### PR TITLE
Fix ssh PTY input loss and reordering at reconnect and backpressure seams

### DIFF
--- a/CLI/SSHPTYAttachReconnectInputFilter.swift
+++ b/CLI/SSHPTYAttachReconnectInputFilter.swift
@@ -78,6 +78,9 @@ final class SSHPTYAttachReconnectInputFilter {
                 Darwin.close(stopSignalFDs[1])
                 throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
             }
+            // Read ends can close mid-write: writers get EPIPE, never SIGPIPE.
+            _ = fcntl(stopSignalFDs[1], F_SETNOSIGPIPE, 1)
+            _ = fcntl(stopAcknowledgementFDs[1], F_SETNOSIGPIPE, 1)
             filterControl = SSHPTYAttachReconnectInputFilterControl(
                 stopSignalWriteFD: stopSignalFDs[1],
                 stopAcknowledgementReadFD: stopAcknowledgementFDs[0]

--- a/CLI/SSHPTYAttachReconnectInputFilter.swift
+++ b/CLI/SSHPTYAttachReconnectInputFilter.swift
@@ -13,17 +13,28 @@ final class SSHPTYAttachReconnectInputFilter {
     private static let maxPendingProbeBytes = 512
     // Terminal ESC disambiguation: bounded so a literal Escape key is not held indefinitely.
     private static let pendingProbeContinuationTimeoutMilliseconds: Int32 = 25
+    private static let reconnectProbeDeadlineMilliseconds: Int64 = 2_000
 
     private var isFiltering: Bool
     private var pending = [UInt8]()
+    private let deadlineReached: (@Sendable () -> Bool)?
+    private let remainingDeadline: (@Sendable () -> Int64?)?
 
-    init(enabled: Bool) {
+    init(
+        enabled: Bool,
+        deadlineReached: (@Sendable () -> Bool)? = nil,
+        remainingDeadlineMilliseconds: (@Sendable () -> Int64?)? = nil
+    ) {
         isFiltering = enabled
+        self.deadlineReached = deadlineReached
+        remainingDeadline = remainingDeadlineMilliseconds
     }
 
     private init(state: SSHPTYAttachReconnectInputFilterState) {
         isFiltering = state.isFiltering
         pending = state.pending
+        deadlineReached = state.deadlineReached
+        remainingDeadline = state.remainingDeadlineMilliseconds
     }
 
     @discardableResult
@@ -31,10 +42,23 @@ final class SSHPTYAttachReconnectInputFilter {
         fd: Int32,
         inputFD: Int32 = STDIN_FILENO,
         filterEnabled: Bool,
+        monotonicNowMilliseconds: (@Sendable () -> Int64)? = nil,
         beforeForwardingInput: (@Sendable () async -> Void)? = nil
     ) throws -> SSHPTYAttachReconnectInputFilterControl? {
+        let now = monotonicNowMilliseconds ?? {
+            Int64(DispatchTime.now().uptimeNanoseconds / 1_000_000)
+        }
+        let deadline = filterEnabled ? now() + reconnectProbeDeadlineMilliseconds : nil
         let filterState = filterEnabled
-            ? SSHPTYAttachReconnectInputFilterState(isFiltering: true, pending: [])
+            ? SSHPTYAttachReconnectInputFilterState(
+                isFiltering: true,
+                pending: [],
+                deadlineReached: { deadline.map { now() >= $0 } ?? false },
+                remainingDeadlineMilliseconds: {
+                    guard let deadline else { return nil }
+                    return max(0, deadline - now())
+                }
+            )
             : nil
         var stopSignalFDs = [Int32](repeating: -1, count: 2)
         let filterControl: SSHPTYAttachReconnectInputFilterControl?
@@ -153,16 +177,37 @@ final class SSHPTYAttachReconnectInputFilter {
             return true
         }
 
+        func flushPendingThenShutdown() async {
+            if let filter = reconnectInputFilter, filter.hasPendingInput {
+                _ = await writeOrShutdown(filter.flushPendingInput())
+            }
+            _ = shutdown(fd, SHUT_WR)
+        }
+
+        func stopReconnectFilteringAtDeadline() async -> Bool {
+            guard let filter = reconnectInputFilter else { return true }
+            guard await writeOrShutdown(filter.stopFiltering()) else { return false }
+            return stopReconnectFiltering()
+        }
+
         while true {
-            let timeoutMilliseconds = reconnectInputFilter?.hasPendingInput == true
+            if reconnectInputFilter?.isDeadlineReached == true {
+                guard await stopReconnectFilteringAtDeadline() else { return }
+                continue
+            }
+            var timeoutMilliseconds = reconnectInputFilter?.hasPendingInput == true
                 ? pendingProbeContinuationTimeoutMilliseconds
                 : -1
+            if let remaining = reconnectInputFilter?.remainingDeadlineMilliseconds {
+                let capped = Int32(min(Int64(Int32.max), remaining))
+                timeoutMilliseconds = timeoutMilliseconds < 0 ? capped : min(timeoutMilliseconds, capped)
+            }
             guard var readiness = pollStdinPump(
                 inputFD: inputFD,
                 stopSignalFD: stopSignalFD,
                 timeoutMilliseconds: timeoutMilliseconds
             ) else {
-                _ = shutdown(fd, SHUT_WR)
+                await flushPendingThenShutdown()
                 return
             }
 
@@ -174,7 +219,7 @@ final class SSHPTYAttachReconnectInputFilter {
                     stopSignalFD: nil,
                     timeoutMilliseconds: pendingProbeContinuationTimeoutMilliseconds
                 ) else {
-                    _ = shutdown(fd, SHUT_WR)
+                    await flushPendingThenShutdown()
                     return
                 }
                 if pendingReadiness.inputReady {
@@ -225,10 +270,10 @@ final class SSHPTYAttachReconnectInputFilter {
                     }
                 }
             } else if count == 0 {
-                _ = shutdown(fd, SHUT_WR)
+                await flushPendingThenShutdown()
                 return
             } else if errno != EINTR {
-                _ = shutdown(fd, SHUT_WR)
+                await flushPendingThenShutdown()
                 return
             }
         }
@@ -237,6 +282,11 @@ final class SSHPTYAttachReconnectInputFilter {
     func filter(_ data: Data) -> Data {
         guard isFiltering, !data.isEmpty else {
             return data
+        }
+        if isDeadlineReached {
+            var output = stopFiltering()
+            output.append(data)
+            return output
         }
 
         var bytes = pending
@@ -299,6 +349,15 @@ final class SSHPTYAttachReconnectInputFilter {
 
     var isFilteringActive: Bool {
         isFiltering
+    }
+
+    var isDeadlineReached: Bool {
+        isFiltering && (deadlineReached?() == true)
+    }
+
+    var remainingDeadlineMilliseconds: Int64? {
+        guard isFiltering else { return nil }
+        return remainingDeadline?()
     }
 
     func flushPendingInput() -> Data {
@@ -434,53 +493,4 @@ final class SSHPTYAttachReconnectInputFilter {
         }
     }
 
-    private static func writeAll(fd: Int32, data: Data) throws {
-        try data.withUnsafeBytes { rawBuffer in
-            guard let base = rawBuffer.bindMemory(to: UInt8.self).baseAddress else { return }
-            var remaining = rawBuffer.count
-            var cursor = base
-            while remaining > 0 {
-                let written = Darwin.write(fd, cursor, remaining)
-                if written > 0 {
-                    remaining -= written
-                    cursor = cursor.advanced(by: written)
-                } else if written < 0 && errno == EINTR {
-                    continue
-                } else {
-                    throw POSIXError(.EIO)
-                }
-            }
-        }
-    }
-
-    private static func pollStdinPump(
-        inputFD: Int32,
-        stopSignalFD: Int32?,
-        timeoutMilliseconds: Int32
-    ) -> (inputReady: Bool, stopRequested: Bool)? {
-        let inputEvents = Int16(POLLIN | POLLHUP | POLLERR | POLLNVAL)
-        let stopEvents = Int16(POLLIN | POLLHUP | POLLERR | POLLNVAL)
-        var pollFDs = [pollfd(fd: inputFD, events: Int16(POLLIN), revents: 0)]
-        if let stopSignalFD {
-            pollFDs.append(pollfd(fd: stopSignalFD, events: Int16(POLLIN), revents: 0))
-        }
-
-        while true {
-            let result = pollFDs.withUnsafeMutableBufferPointer { buffer in
-                Darwin.poll(buffer.baseAddress, nfds_t(buffer.count), timeoutMilliseconds)
-            }
-            if result > 0 {
-                let inputReady = (pollFDs[0].revents & inputEvents) != 0
-                let stopRequested = pollFDs.count > 1 && (pollFDs[1].revents & stopEvents) != 0
-                return (inputReady: inputReady, stopRequested: stopRequested)
-            }
-            if result == 0 {
-                return (inputReady: false, stopRequested: false)
-            }
-            if errno == EINTR {
-                continue
-            }
-            return nil
-        }
-    }
 }

--- a/CLI/SSHPTYAttachReconnectInputFilterPumpIO.swift
+++ b/CLI/SSHPTYAttachReconnectInputFilterPumpIO.swift
@@ -33,9 +33,16 @@ extension SSHPTYAttachReconnectInputFilter {
             pollFDs.append(pollfd(fd: stopSignalFD, events: Int16(POLLIN), revents: 0))
         }
 
+        // Anchor the timeout to an absolute monotonic deadline so EINTR
+        // retries cannot extend the caller's window (e.g. the reconnect
+        // filter deadline) under repeated signal delivery.
+        let deadline: DispatchTime? = timeoutMilliseconds >= 0
+            ? .now() + .milliseconds(Int(timeoutMilliseconds))
+            : nil
+        var remainingTimeout = timeoutMilliseconds
         while true {
             let result = pollFDs.withUnsafeMutableBufferPointer { buffer in
-                Darwin.poll(buffer.baseAddress, nfds_t(buffer.count), timeoutMilliseconds)
+                Darwin.poll(buffer.baseAddress, nfds_t(buffer.count), remainingTimeout)
             }
             if result > 0 {
                 let inputReady = (pollFDs[0].revents & inputEvents) != 0
@@ -46,6 +53,14 @@ extension SSHPTYAttachReconnectInputFilter {
                 return (inputReady: false, stopRequested: false)
             }
             if errno == EINTR {
+                if let deadline {
+                    let now = DispatchTime.now()
+                    guard now < deadline else {
+                        return (inputReady: false, stopRequested: false)
+                    }
+                    let remainingNanos = deadline.uptimeNanoseconds - now.uptimeNanoseconds
+                    remainingTimeout = Int32(min(Int64(Int32.max), Int64(remainingNanos / 1_000_000) + 1))
+                }
                 continue
             }
             return nil

--- a/CLI/SSHPTYAttachReconnectInputFilterPumpIO.swift
+++ b/CLI/SSHPTYAttachReconnectInputFilterPumpIO.swift
@@ -1,0 +1,54 @@
+import Darwin
+import Foundation
+
+extension SSHPTYAttachReconnectInputFilter {
+    static func writeAll(fd: Int32, data: Data) throws {
+        try data.withUnsafeBytes { rawBuffer in
+            guard let base = rawBuffer.bindMemory(to: UInt8.self).baseAddress else { return }
+            var remaining = rawBuffer.count
+            var cursor = base
+            while remaining > 0 {
+                let written = Darwin.write(fd, cursor, remaining)
+                if written > 0 {
+                    remaining -= written
+                    cursor = cursor.advanced(by: written)
+                } else if written < 0 && errno == EINTR {
+                    continue
+                } else {
+                    throw POSIXError(.EIO)
+                }
+            }
+        }
+    }
+
+    static func pollStdinPump(
+        inputFD: Int32,
+        stopSignalFD: Int32?,
+        timeoutMilliseconds: Int32
+    ) -> (inputReady: Bool, stopRequested: Bool)? {
+        let inputEvents = Int16(POLLIN | POLLHUP | POLLERR | POLLNVAL)
+        let stopEvents = Int16(POLLIN | POLLHUP | POLLERR | POLLNVAL)
+        var pollFDs = [pollfd(fd: inputFD, events: Int16(POLLIN), revents: 0)]
+        if let stopSignalFD {
+            pollFDs.append(pollfd(fd: stopSignalFD, events: Int16(POLLIN), revents: 0))
+        }
+
+        while true {
+            let result = pollFDs.withUnsafeMutableBufferPointer { buffer in
+                Darwin.poll(buffer.baseAddress, nfds_t(buffer.count), timeoutMilliseconds)
+            }
+            if result > 0 {
+                let inputReady = (pollFDs[0].revents & inputEvents) != 0
+                let stopRequested = pollFDs.count > 1 && (pollFDs[1].revents & stopEvents) != 0
+                return (inputReady: inputReady, stopRequested: stopRequested)
+            }
+            if result == 0 {
+                return (inputReady: false, stopRequested: false)
+            }
+            if errno == EINTR {
+                continue
+            }
+            return nil
+        }
+    }
+}

--- a/CLI/SSHPTYAttachReconnectInputFilterState.swift
+++ b/CLI/SSHPTYAttachReconnectInputFilterState.swift
@@ -1,4 +1,6 @@
 struct SSHPTYAttachReconnectInputFilterState: Sendable {
     let isFiltering: Bool
     let pending: [UInt8]
+    let deadlineReached: @Sendable () -> Bool
+    let remainingDeadlineMilliseconds: @Sendable () -> Int64?
 }

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Capabilities/RemoteDaemonCapability.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Capabilities/RemoteDaemonCapability.swift
@@ -16,6 +16,8 @@ public enum RemoteDaemonCapability: String, Sendable, CaseIterable {
     case ptyWriteNotification = "pty.write.notification"
     /// Resize notifications (`pty.resize.notification`).
     case ptyResizeNotification = "pty.resize.notification"
+    /// Sequenced, cumulatively acknowledged PTY input (`pty.input.seq_ack`).
+    case ptyInputSeqAck = "pty.input.seq_ack"
 
     /// The capability family backing persistent SSH PTY sessions; missing any
     /// of these yields the persistent-PTY reconnect message.

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonPTYEvent.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonPTYEvent.swift
@@ -10,6 +10,8 @@ public enum RemoteDaemonPTYEvent: Sendable {
     case ready
     /// A chunk of PTY output bytes (`pty.data`).
     case data(Data)
+    /// Cumulative ack for sequenced PTY input (`pty.input_ack`).
+    case inputAck(seq: UInt64)
     /// The remote PTY exited; no further events follow (`pty.exit`).
     case exit
     /// The attachment failed; payload is the daemon's error text

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+Events.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+Events.swift
@@ -268,7 +268,7 @@ extension RemoteDaemonRPCClient {
 
         case "pty.input_ack":
             subscription = ptySubscriptions[key] ?? ptySubscriptions[legacyKey]
-            event = .inputAck(seq: Self.uint64Value(payload["seq"]))
+            event = .inputAck(seq: rpcEventUInt64Value(payload["seq"]))
 
         case "pty.exit":
             subscription = ptySubscriptions.removeValue(forKey: key)
@@ -291,19 +291,6 @@ extension RemoteDaemonRPCClient {
             subscription.handler(event)
         }
         return true
-    }
-
-    private static func uint64Value(_ value: Any?) -> UInt64 {
-        switch value {
-        case let number as UInt64:
-            return number
-        case let number as Int:
-            return number > 0 ? UInt64(number) : 0
-        case let number as NSNumber:
-            return number.uint64Value
-        default:
-            return 0
-        }
     }
 
     func sendCLIResponse(requestID: String, data: Data?, error: String?) {
@@ -394,5 +381,18 @@ extension RemoteDaemonRPCClient {
             attachmentID.trimmingCharacters(in: .whitespacesAndNewlines),
             token,
         ].joined(separator: "\u{1f}")
+    }
+}
+
+private func rpcEventUInt64Value(_ value: Any?) -> UInt64 {
+    switch value {
+    case let number as UInt64:
+        return number
+    case let number as Int:
+        return number > 0 ? UInt64(number) : 0
+    case let number as NSNumber:
+        return number.uint64Value
+    default:
+        return 0
     }
 }

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+Events.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+Events.swift
@@ -266,6 +266,10 @@ extension RemoteDaemonRPCClient {
             subscription = ptySubscriptions[key] ?? ptySubscriptions[legacyKey]
             event = .data(Self.decodeBase64Data(payload["data_base64"]))
 
+        case "pty.input_ack":
+            subscription = ptySubscriptions[key] ?? ptySubscriptions[legacyKey]
+            event = .inputAck(seq: Self.uint64Value(payload["seq"]))
+
         case "pty.exit":
             subscription = ptySubscriptions.removeValue(forKey: key)
                 ?? ptySubscriptions.removeValue(forKey: legacyKey)
@@ -287,6 +291,19 @@ extension RemoteDaemonRPCClient {
             subscription.handler(event)
         }
         return true
+    }
+
+    private static func uint64Value(_ value: Any?) -> UInt64 {
+        switch value {
+        case let number as UInt64:
+            return number
+        case let number as Int:
+            return number > 0 ? UInt64(number) : 0
+        case let number as NSNumber:
+            return number.uint64Value
+        default:
+            return 0
+        }
     }
 
     func sendCLIResponse(requestID: String, data: Data?, error: String?) {

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RPC.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RPC.swift
@@ -106,6 +106,7 @@ extension RemoteDaemonRPCClient {
         rows: Int,
         command: String?,
         requireExisting: Bool,
+        inputSeqAck: Bool = false,
         queue: DispatchQueue,
         onEvent: @escaping (RemoteDaemonPTYEvent) -> Void
     ) throws -> RemotePTYBridgeAttachment {
@@ -146,6 +147,9 @@ extension RemoteDaemonRPCClient {
         if requireExisting {
             params["require_existing"] = true
         }
+        if inputSeqAck {
+            params["input_seq_ack"] = true
+        }
 
         do {
             let result = try call(method: "pty.attach", params: params, timeout: 12.0)
@@ -176,17 +180,22 @@ extension RemoteDaemonRPCClient {
         attachmentID: String,
         attachmentToken: String,
         data: Data,
+        seq: UInt64? = nil,
         completion: @escaping ((any Error)?) -> Void
     ) {
+        var params: [String: Any] = [
+            "session_id": sessionID,
+            "attachment_id": attachmentID,
+            "client_attachment_token": attachmentToken,
+            "data_base64": data.base64EncodedString(),
+        ]
+        if let seq {
+            params["seq"] = seq
+        }
         do {
             try notify(
                 method: "pty.write",
-                params: [
-                    "session_id": sessionID,
-                    "attachment_id": attachmentID,
-                    "client_attachment_token": attachmentToken,
-                    "data_base64": data.base64EncodedString(),
-                ]
+                params: params
             )
             completion(nil)
         } catch {

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RemotePTYBridgeRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RemotePTYBridgeRPCClient.swift
@@ -6,6 +6,8 @@ public import Foundation
 /// ``RemoteDaemonPTYEvent`` to ``RemotePTYBridgeEvent`` case-for-case,
 /// exactly like the legacy `WorkspaceRemotePTYBridgeRPCClient` extension.
 extension RemoteDaemonRPCClient: RemotePTYBridgeRPCClient {
+    /// Whether the connected daemon advertised the optional
+    /// ``RemoteDaemonCapability/ptyInputSeqAck`` capability in its hello.
     public var supportsInputSeqAck: Bool {
         stateQueue.sync {
             advertisedCapabilities.contains(Self.optionalPTYInputSeqAckCapability)

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RemotePTYBridgeRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient+RemotePTYBridgeRPCClient.swift
@@ -6,6 +6,12 @@ public import Foundation
 /// ``RemoteDaemonPTYEvent`` to ``RemotePTYBridgeEvent`` case-for-case,
 /// exactly like the legacy `WorkspaceRemotePTYBridgeRPCClient` extension.
 extension RemoteDaemonRPCClient: RemotePTYBridgeRPCClient {
+    public var supportsInputSeqAck: Bool {
+        stateQueue.sync {
+            advertisedCapabilities.contains(Self.optionalPTYInputSeqAckCapability)
+        }
+    }
+
     /// Attaches via ``attachPTY(sessionID:attachmentID:cols:rows:command:requireExisting:queue:onEvent:)``,
     /// translating each PTY event into its bridge equivalent on `queue`.
     public func attachBridgePTY(
@@ -15,6 +21,7 @@ extension RemoteDaemonRPCClient: RemotePTYBridgeRPCClient {
         rows: Int,
         command: String?,
         requireExisting: Bool,
+        inputSeqAck: Bool,
         queue: DispatchQueue,
         onEvent: @escaping (RemotePTYBridgeEvent) -> Void
     ) throws -> RemotePTYBridgeAttachment {
@@ -25,6 +32,7 @@ extension RemoteDaemonRPCClient: RemotePTYBridgeRPCClient {
             rows: rows,
             command: command,
             requireExisting: requireExisting,
+            inputSeqAck: inputSeqAck,
             queue: queue
         ) { event in
             switch event {
@@ -32,6 +40,8 @@ extension RemoteDaemonRPCClient: RemotePTYBridgeRPCClient {
                 onEvent(.ready)
             case .data(let data):
                 onEvent(.data(data))
+            case .inputAck(let seq):
+                onEvent(.inputAck(seq: seq))
             case .exit:
                 onEvent(.exit)
             case .error(let detail):

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/Client/RemoteDaemonRPCClient.swift
@@ -59,6 +59,12 @@ public final class RemoteDaemonRPCClient: @unchecked Sendable {
     /// Wire capability required for resize notifications
     /// (`pty.resize.notification`; value is test-pinned, do not change).
     public static let requiredPTYResizeNotificationCapability = RemoteDaemonCapability.ptyResizeNotification.rawValue
+    /// Optional wire capability for sequenced, acked PTY input
+    /// (`pty.input.seq_ack`; value is test-pinned, do not change).
+    public static let optionalPTYInputSeqAckCapability = RemoteDaemonCapability.ptyInputSeqAck.rawValue
+    /// Wire-pinned rpc error code the daemon returns for a sequenced
+    /// `pty.write` whose seq is not exactly last+1.
+    public static let ptyInputSeqGapErrorCode = "pty_input_seq_gap"
     static let maxCloudCLIRequestsInFlight = 4
 
     // Subscription records pair the caller's delivery queue with its handler.
@@ -119,6 +125,7 @@ public final class RemoteDaemonRPCClient: @unchecked Sendable {
     var streamSubscriptions: [String: StreamSubscription] = [:]
     var ptySubscriptions: [String: PTYSubscription] = [:]
     var cliRequestsInFlight = 0
+    var advertisedCapabilities: Set<String> = []
 
     /// Creates a client for one daemon transport.
     ///
@@ -168,6 +175,9 @@ public final class RemoteDaemonRPCClient: @unchecked Sendable {
         do {
             let hello = try call(method: "hello", params: [:], timeout: 8.0)
             let capabilities = (hello["capabilities"] as? [String]) ?? []
+            stateQueue.sync {
+                advertisedCapabilities = Set(capabilities)
+            }
             let missingCapabilities = Self.missingRequiredCapabilities(
                 Self.requiredCapabilities(for: configuration),
                 in: capabilities
@@ -229,6 +239,7 @@ public final class RemoteDaemonRPCClient: @unchecked Sendable {
         stderrBuffer = ""
         streamSubscriptions.removeAll(keepingCapacity: false)
         ptySubscriptions.removeAll(keepingCapacity: false)
+        advertisedCapabilities.removeAll(keepingCapacity: false)
     }
 
     func failPTYSubscriptionsLocked(_ detail: String) {

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/PTYBridge/RemotePTYBridgeEvent.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/PTYBridge/RemotePTYBridgeEvent.swift
@@ -7,6 +7,8 @@ public enum RemotePTYBridgeEvent: Sendable {
     case ready
     /// A chunk of PTY output bytes.
     case data(Data)
+    /// Cumulative ack for sequenced PTY input.
+    case inputAck(seq: UInt64)
     /// The remote PTY exited; no further events follow.
     case exit
     /// The attachment failed; the payload is the daemon's error text.

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/PTYBridge/RemotePTYBridgeRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/PTYBridge/RemotePTYBridgeRPCClient.swift
@@ -11,8 +11,14 @@ public import Foundation
 /// because clients cross queue boundaries by contract (the bridge server
 /// calls it from its own rpc queue).
 public protocol RemotePTYBridgeRPCClient: AnyObject, Sendable {
+    /// Whether the daemon attachment path supports sequenced input acks.
+    var supportsInputSeqAck: Bool { get }
+
     /// Attaches to (or creates) a remote PTY session and starts streaming
     /// events to `onEvent` on `queue`. Throws when the attach handshake fails.
+    /// `inputSeqAck` is the caller's one-time seq-ack decision; conformers
+    /// must not re-derive it so the attach opt-in and the sender's window
+    /// accounting can never diverge.
     func attachBridgePTY(
         sessionID: String,
         attachmentID: String,
@@ -20,6 +26,7 @@ public protocol RemotePTYBridgeRPCClient: AnyObject, Sendable {
         rows: Int,
         command: String?,
         requireExisting: Bool,
+        inputSeqAck: Bool,
         queue: DispatchQueue,
         onEvent: @escaping (RemotePTYBridgeEvent) -> Void
     ) throws -> RemotePTYBridgeAttachment
@@ -31,9 +38,15 @@ public protocol RemotePTYBridgeRPCClient: AnyObject, Sendable {
         attachmentID: String,
         attachmentToken: String,
         data: Data,
+        seq: UInt64?,
         completion: @escaping ((any Error)?) -> Void
     )
 
     /// Detaches an attachment; fire-and-forget like the legacy client.
     func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String)
+}
+
+public extension RemotePTYBridgeRPCClient {
+    /// Legacy clients do not opt into sequenced PTY input.
+    var supportsInputSeqAck: Bool { false }
 }

--- a/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/PTYBridge/RemotePTYBridgeRPCClient.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Sources/CmuxRemoteDaemon/PTYBridge/RemotePTYBridgeRPCClient.swift
@@ -46,6 +46,7 @@ public protocol RemotePTYBridgeRPCClient: AnyObject, Sendable {
     func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String)
 }
 
+/// Default for conformers predating sequenced input.
 public extension RemotePTYBridgeRPCClient {
     /// Legacy clients do not opt into sequenced PTY input.
     var supportsInputSeqAck: Bool { false }

--- a/Packages/macOS/CmuxRemoteDaemon/Tests/CmuxRemoteDaemonTests/RemoteDaemonRPCClientCapabilityTests.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Tests/CmuxRemoteDaemonTests/RemoteDaemonRPCClientCapabilityTests.swift
@@ -32,6 +32,8 @@ struct RemoteDaemonRPCClientCapabilityTests {
         #expect(RemoteDaemonRPCClient.requiredPTYPersistentDaemonCapability == "pty.session.persistent_daemon")
         #expect(RemoteDaemonRPCClient.requiredPTYWriteNotificationCapability == "pty.write.notification")
         #expect(RemoteDaemonRPCClient.requiredPTYResizeNotificationCapability == "pty.resize.notification")
+        #expect(RemoteDaemonRPCClient.optionalPTYInputSeqAckCapability == "pty.input.seq_ack")
+        #expect(RemoteDaemonRPCClient.ptyInputSeqGapErrorCode == "pty_input_seq_gap")
     }
 
     @Test("a base configuration only requires proxy streaming")
@@ -74,6 +76,14 @@ struct RemoteDaemonRPCClientCapabilityTests {
                 "pty.session.persistent_daemon",
             ]
         )
+    }
+
+    @Test("seq-ack is optional and never required for transport startup")
+    func seqAckCapabilityIsOptional() {
+        #expect(!RemoteDaemonRPCClient.requiredCapabilities(for: configuration()).contains("pty.input.seq_ack"))
+        #expect(!RemoteDaemonRPCClient.requiredCapabilities(
+            for: configuration(preserveAfterTerminalExit: true, persistentDaemonSlot: "slot")
+        ).contains("pty.input.seq_ack"))
     }
 
     @Test("missingRequiredCapabilities filters advertised capabilities preserving order")

--- a/Packages/macOS/CmuxRemoteDaemon/Tests/CmuxRemoteDaemonTests/RemoteDaemonStringsTests.swift
+++ b/Packages/macOS/CmuxRemoteDaemon/Tests/CmuxRemoteDaemonTests/RemoteDaemonStringsTests.swift
@@ -11,6 +11,7 @@ struct RemoteDaemonCapabilityTests {
         #expect(RemoteDaemonCapability.ptyPersistentDaemon.rawValue == "pty.session.persistent_daemon")
         #expect(RemoteDaemonCapability.ptyWriteNotification.rawValue == "pty.write.notification")
         #expect(RemoteDaemonCapability.ptyResizeNotification.rawValue == "pty.resize.notification")
+        #expect(RemoteDaemonCapability.ptyInputSeqAck.rawValue == "pty.input.seq_ack")
     }
 
     @Test("the persistent PTY family is the PTY capability set")

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeInputFlow.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeInputFlow.swift
@@ -22,6 +22,7 @@ final class RemotePTYBridgeInputFlow {
     private let lowWatermarkWrites: Int
     private let lowWatermarkBytes: Int
     private let seqAckEnabled: Bool
+    private let maxWriteBytes: Int
 
     private var nextSeq: UInt64 = 1
     private var pendingWrites: [PendingWrite] = []
@@ -30,28 +31,47 @@ final class RemotePTYBridgeInputFlow {
     private var bufferedBytes = 0
     private(set) var isPaused = false
 
-    init(maxPendingWrites: Int, maxPendingBytes: Int, seqAckEnabled: Bool) {
+    /// `maxWriteBytes` bounds a single `pty.write`: the daemon rejects RPC
+    /// frames over 4 MiB before it can parse attachment identity, so a write
+    /// must stay well under that after base64 (~4/3x) plus JSON overhead.
+    init(
+        maxPendingWrites: Int,
+        maxPendingBytes: Int,
+        seqAckEnabled: Bool,
+        maxWriteBytes: Int = 256 * 1024
+    ) {
         self.maxPendingWrites = max(1, maxPendingWrites)
         self.maxPendingBytes = max(1, maxPendingBytes)
         lowWatermarkWrites = max(0, maxPendingWrites / 2)
         lowWatermarkBytes = max(0, maxPendingBytes / 2)
         self.seqAckEnabled = seqAckEnabled
+        self.maxWriteBytes = max(1, maxWriteBytes)
     }
 
     func enqueue(_ data: Data) -> DrainResult? {
         guard !data.isEmpty else {
             return DrainResult(writes: [], shouldResumeReads: false)
         }
-        if let write = reserveWrite(for: data) {
-            return DrainResult(writes: [write], shouldResumeReads: false)
+        var writes: [Write] = []
+        var offset = data.startIndex
+        while offset < data.endIndex {
+            let end = data.index(offset, offsetBy: maxWriteBytes, limitedBy: data.endIndex) ?? data.endIndex
+            let piece = Data(data[offset..<end])
+            offset = end
+            // Once a piece buffers, every later piece must buffer too or
+            // bytes would reorder around the window boundary.
+            if bufferedInput.isEmpty, let write = reserveWrite(for: piece) {
+                writes.append(write)
+                continue
+            }
+            guard bufferedBytes <= maxPendingBytes - piece.count else {
+                return nil
+            }
+            bufferedInput.append(piece)
+            bufferedBytes += piece.count
+            isPaused = true
         }
-        guard bufferedBytes <= maxPendingBytes - data.count else {
-            return nil
-        }
-        bufferedInput.append(data)
-        bufferedBytes += data.count
-        isPaused = true
-        return DrainResult(writes: [], shouldResumeReads: false)
+        return DrainResult(writes: writes, shouldResumeReads: false)
     }
 
     func complete(_ write: Write, error: (any Error)?) -> DrainResult? {

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeInputFlow.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeInputFlow.swift
@@ -69,6 +69,11 @@ final class RemotePTYBridgeInputFlow {
         guard seqAckEnabled else {
             return DrainResult(writes: [], shouldResumeReads: false)
         }
+        // An ack for a seq that was never sent is a protocol violation;
+        // nil tells the session to tear down visibly instead of trusting it.
+        guard seq < nextSeq else {
+            return nil
+        }
         while let first = pendingWrites.first,
               let pendingSeq = first.seq,
               pendingSeq <= seq {

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeInputFlow.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeInputFlow.swift
@@ -1,0 +1,128 @@
+internal import Foundation
+
+/// Queue-confined PTY input flow control for one bridge attachment.
+final class RemotePTYBridgeInputFlow {
+    struct Write {
+        let data: Data
+        let seq: UInt64?
+    }
+
+    struct DrainResult {
+        let writes: [Write]
+        let shouldResumeReads: Bool
+    }
+
+    private struct PendingWrite {
+        let seq: UInt64?
+        let bytes: Int
+    }
+
+    private let maxPendingWrites: Int
+    private let maxPendingBytes: Int
+    private let lowWatermarkWrites: Int
+    private let lowWatermarkBytes: Int
+    private let seqAckEnabled: Bool
+
+    private var nextSeq: UInt64 = 1
+    private var pendingWrites: [PendingWrite] = []
+    private var pendingBytes = 0
+    private var bufferedInput: [Data] = []
+    private var bufferedBytes = 0
+    private(set) var isPaused = false
+
+    init(maxPendingWrites: Int, maxPendingBytes: Int, seqAckEnabled: Bool) {
+        self.maxPendingWrites = max(1, maxPendingWrites)
+        self.maxPendingBytes = max(1, maxPendingBytes)
+        lowWatermarkWrites = max(0, maxPendingWrites / 2)
+        lowWatermarkBytes = max(0, maxPendingBytes / 2)
+        self.seqAckEnabled = seqAckEnabled
+    }
+
+    func enqueue(_ data: Data) -> DrainResult? {
+        guard !data.isEmpty else {
+            return DrainResult(writes: [], shouldResumeReads: false)
+        }
+        if let write = reserveWrite(for: data) {
+            return DrainResult(writes: [write], shouldResumeReads: false)
+        }
+        guard bufferedBytes <= maxPendingBytes - data.count else {
+            return nil
+        }
+        bufferedInput.append(data)
+        bufferedBytes += data.count
+        isPaused = true
+        return DrainResult(writes: [], shouldResumeReads: false)
+    }
+
+    func complete(_ write: Write, error: (any Error)?) -> DrainResult? {
+        if error != nil {
+            return nil
+        }
+        guard !seqAckEnabled else {
+            return DrainResult(writes: [], shouldResumeReads: false)
+        }
+        drainCompletedWrite(seq: write.seq, bytes: write.data.count)
+        return flushBufferedInput()
+    }
+
+    func acknowledge(upTo seq: UInt64) -> DrainResult? {
+        guard seqAckEnabled else {
+            return DrainResult(writes: [], shouldResumeReads: false)
+        }
+        while let first = pendingWrites.first,
+              let pendingSeq = first.seq,
+              pendingSeq <= seq {
+            pendingBytes = max(0, pendingBytes - first.bytes)
+            pendingWrites.removeFirst()
+        }
+        return flushBufferedInput()
+    }
+
+    func reset() {
+        pendingWrites.removeAll(keepingCapacity: false)
+        pendingBytes = 0
+        bufferedInput.removeAll(keepingCapacity: false)
+        bufferedBytes = 0
+        isPaused = false
+    }
+
+    private func reserveWrite(for data: Data) -> Write? {
+        guard pendingWrites.count < maxPendingWrites,
+              pendingBytes <= maxPendingBytes - data.count else {
+            return nil
+        }
+        let seq = seqAckEnabled ? nextSeq : nil
+        if seqAckEnabled {
+            nextSeq += 1
+        }
+        pendingWrites.append(PendingWrite(seq: seq, bytes: data.count))
+        pendingBytes += data.count
+        return Write(data: data, seq: seq)
+    }
+
+    private func drainCompletedWrite(seq: UInt64?, bytes: Int) {
+        if let index = pendingWrites.firstIndex(where: { $0.seq == seq && $0.bytes == bytes }) {
+            pendingWrites.remove(at: index)
+        } else if !pendingWrites.isEmpty {
+            pendingWrites.removeFirst()
+        }
+        pendingBytes = max(0, pendingBytes - bytes)
+    }
+
+    private func flushBufferedInput() -> DrainResult {
+        var writes: [Write] = []
+        while let first = bufferedInput.first,
+              let write = reserveWrite(for: first) {
+            bufferedInput.removeFirst()
+            bufferedBytes = max(0, bufferedBytes - first.count)
+            writes.append(write)
+        }
+        let belowLowWatermark = pendingWrites.count <= lowWatermarkWrites &&
+            pendingBytes <= lowWatermarkBytes
+        let shouldResume = isPaused && bufferedInput.isEmpty && belowLowWatermark
+        if shouldResume {
+            isPaused = false
+        }
+        return DrainResult(writes: writes, shouldResumeReads: shouldResume)
+    }
+}

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession+Input.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession+Input.swift
@@ -1,0 +1,82 @@
+internal import CmuxRemoteDaemon
+internal import Foundation
+
+extension RemotePTYBridgeServer.Session {
+    fileprivate typealias InputWrite = RemotePTYBridgeInputFlow.Write
+
+    func forwardInput(_ data: Data) {
+        guard !data.isEmpty else { return }
+        guard let remoteAttachment else {
+            close(detach: true)
+            return
+        }
+        guard let drain = inputFlow.enqueue(data) else {
+            close(detach: true)
+            return
+        }
+        sendInputWrites(drain.writes, remoteAttachment: remoteAttachment)
+    }
+
+    func handleInputAck(seq: UInt64) {
+        guard let drain = inputFlow.acknowledge(upTo: seq) else {
+            close(detach: true)
+            return
+        }
+        drainInputFlow(drain)
+    }
+
+    private func sendInputWrites(
+        _ writes: [InputWrite],
+        remoteAttachment: RemotePTYBridgeAttachment
+    ) {
+        for write in writes {
+            sendInputWrite(write, remoteAttachment: remoteAttachment)
+        }
+    }
+
+    private func sendInputWrite(
+        _ write: InputWrite,
+        remoteAttachment: RemotePTYBridgeAttachment
+    ) {
+        let currentSessionID = sessionID
+        rpcQueue.async { [weak self, write, remoteAttachment] in
+            guard let self else { return }
+            let shouldWrite = self.queue.sync { !self.isClosed }
+            guard shouldWrite else {
+                self.queue.async {
+                    self.handleInputWriteFinished(write: write, error: nil)
+                }
+                return
+            }
+            self.rpcClient.writePTY(
+                sessionID: currentSessionID,
+                attachmentID: remoteAttachment.attachmentID,
+                attachmentToken: remoteAttachment.token,
+                data: write.data,
+                seq: write.seq
+            ) { [weak self] writeError in
+                guard let self else { return }
+                self.queue.async {
+                    self.handleInputWriteFinished(write: write, error: writeError)
+                }
+            }
+        }
+    }
+
+    private func handleInputWriteFinished(write: InputWrite, error: (any Error)?) {
+        guard let drain = inputFlow.complete(write, error: error) else {
+            close(detach: true)
+            return
+        }
+        drainInputFlow(drain)
+    }
+
+    private func drainInputFlow(_ drain: RemotePTYBridgeInputFlow.DrainResult) {
+        if let remoteAttachment {
+            sendInputWrites(drain.writes, remoteAttachment: remoteAttachment)
+        }
+        if drain.shouldResumeReads, !clientInputDidComplete {
+            receiveNext()
+        }
+    }
+}

--- a/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession.swift
@@ -24,33 +24,33 @@ extension RemotePTYBridgeServer {
         private static let maxPendingInputBytes = 4 * 1024 * 1024
 
         private let connection: NWConnection
-        private let rpcClient: any RemotePTYBridgeRPCClient
-        private let sessionID: String
+        let rpcClient: any RemotePTYBridgeRPCClient
+        let sessionID: String
         private let attachmentID: String
         private let command: String?
         private let requireExisting: Bool
         private let token: String
-        private let queue: DispatchQueue
-        private let rpcQueue = DispatchQueue(label: "com.cmux.remote-ssh.pty-bridge.rpc.\(UUID().uuidString)", qos: .userInitiated)
+        let queue: DispatchQueue
+        let rpcQueue = DispatchQueue(label: "com.cmux.remote-ssh.pty-bridge.rpc.\(UUID().uuidString)", qos: .userInitiated)
         let strings: any RemotePTYBridgeStrings
         private let clock: any RemoteProxyRetryClock
         private let onClose: () -> Void
+        let inputFlow: RemotePTYBridgeInputFlow
+        private let inputSeqAckEnabled: Bool
 
-        private var isClosed = false
+        var isClosed = false
         private var isAttaching = false
         private var isAttached = false
         private var handshakeBuffer = Data()
         private var pendingInputBeforeAttach = Data()
-        private var pendingInputWrites = 0
-        private var pendingInputBytes = 0
         private var pendingOutputSends = 0
         private var pendingOutputBytes = 0
-        private var clientInputDidComplete = false
+        var clientInputDidComplete = false
         private var pendingPTYEventsBeforeReady: [RemotePTYBridgeEvent] = []
         private var pendingPTYEventBytesBeforeReady = 0
         private var closeWhenOutputFlushes: (detach: Bool, gracefulOutputClose: Bool)?
         private var handshakeTimeoutTask: Task<Void, Never>?
-        private var remoteAttachment: RemotePTYBridgeAttachment?
+        var remoteAttachment: RemotePTYBridgeAttachment?
         private var clientPID: pid_t?
         private var clientProcessExitSource: (any DispatchSourceProcess)?
 
@@ -78,6 +78,16 @@ extension RemotePTYBridgeServer {
             self.strings = strings
             self.clock = clock
             self.onClose = onClose
+            // One-time seq-ack decision: the attach opt-in and the input
+            // window accounting must read the same value, or the daemon and
+            // sender disagree about who drains the window.
+            let seqAckEnabled = rpcClient.supportsInputSeqAck
+            inputSeqAckEnabled = seqAckEnabled
+            inputFlow = RemotePTYBridgeInputFlow(
+                maxPendingWrites: Self.maxPendingInputWrites,
+                maxPendingBytes: Self.maxPendingInputBytes,
+                seqAckEnabled: seqAckEnabled
+            )
         }
 
         func start() {
@@ -99,7 +109,7 @@ extension RemotePTYBridgeServer {
             close(detach: true)
         }
 
-        private func receiveNext() {
+        func receiveNext() {
             guard !isClosed else { return }
             connection.receive(minimumIncompleteLength: 1, maximumLength: 32768) { [weak self] data, _, isComplete, error in
                 guard let self, !self.isClosed else { return }
@@ -130,7 +140,9 @@ extension RemotePTYBridgeServer {
                     self.close(detach: true)
                     return
                 }
-                self.receiveNext()
+                if !self.inputFlow.isPaused {
+                    self.receiveNext()
+                }
             }
         }
 
@@ -178,6 +190,7 @@ extension RemotePTYBridgeServer {
                         rows: rows,
                         command: self.command,
                         requireExisting: self.requireExisting,
+                        inputSeqAck: self.inputSeqAckEnabled,
                         queue: self.queue
                     ) { [weak self] event in
                         self?.handlePTYEvent(event)
@@ -251,51 +264,6 @@ extension RemotePTYBridgeServer {
             pendingInputBeforeAttach.append(data)
         }
 
-        private func forwardInput(_ data: Data) {
-            guard !data.isEmpty else { return }
-            guard let remoteAttachment else {
-                close(detach: true)
-                return
-            }
-            guard pendingInputWrites < Self.maxPendingInputWrites,
-                  pendingInputBytes <= Self.maxPendingInputBytes - data.count else {
-                close(detach: true)
-                return
-            }
-            pendingInputWrites += 1
-            pendingInputBytes += data.count
-            let currentSessionID = sessionID
-            rpcQueue.async { [weak self, data, remoteAttachment] in
-                guard let self else { return }
-                let shouldWrite = self.queue.sync { !self.isClosed }
-                guard shouldWrite else {
-                    self.queue.async {
-                        self.handleInputWriteFinished(bytes: data.count, error: nil)
-                    }
-                    return
-                }
-                self.rpcClient.writePTY(
-                    sessionID: currentSessionID,
-                    attachmentID: remoteAttachment.attachmentID,
-                    attachmentToken: remoteAttachment.token,
-                    data: data
-                ) { [weak self] writeError in
-                    guard let self else { return }
-                    self.queue.async {
-                        self.handleInputWriteFinished(bytes: data.count, error: writeError)
-                    }
-                }
-            }
-        }
-
-        private func handleInputWriteFinished(bytes: Int, error: (any Error)?) {
-            pendingInputWrites = max(0, pendingInputWrites - 1)
-            pendingInputBytes = max(0, pendingInputBytes - bytes)
-            if error != nil {
-                close(detach: true)
-            }
-        }
-
         private func detachRemoteAttachment(_ attachment: RemotePTYBridgeAttachment) {
             rpcQueue.async { [rpcClient, sessionID] in
                 rpcClient.detachPTY(
@@ -328,6 +296,8 @@ extension RemotePTYBridgeServer {
                 }
                 pendingPTYEventBytesBeforeReady += data.count
                 pendingPTYEventsBeforeReady.append(event)
+            case .inputAck:
+                return
             case .exit, .error:
                 guard pendingPTYEventsBeforeReady.count < Self.maxPendingOutputSends else {
                     close(detach: true)
@@ -345,6 +315,8 @@ extension RemotePTYBridgeServer {
             case .data(let data):
                 guard !data.isEmpty else { return }
                 sendBufferedOutput(data, detachOnOverflow: true)
+            case .inputAck(let seq):
+                handleInputAck(seq: seq)
             case .exit, .error:
                 closeAfterOutputFlush(detach: false, gracefulOutputClose: true)
             }
@@ -425,13 +397,14 @@ extension RemotePTYBridgeServer {
             })
         }
 
-        private func close(detach: Bool, gracefulOutputClose: Bool = false) {
+        func close(detach: Bool, gracefulOutputClose: Bool = false) {
             guard !isClosed else { return }
             isClosed = true
             handshakeTimeoutTask?.cancel()
             handshakeTimeoutTask = nil
             isAttaching = false
             pendingInputBeforeAttach.removeAll(keepingCapacity: false)
+            inputFlow.reset()
             pendingPTYEventsBeforeReady.removeAll(keepingCapacity: false)
             pendingPTYEventBytesBeforeReady = 0
             clientProcessExitSource?.cancel()

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeInputFlowTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeInputFlowTests.swift
@@ -1,0 +1,39 @@
+import Foundation
+import Testing
+@testable import CmuxRemoteWorkspace
+
+@Suite("RemotePTYBridgeInputFlow")
+struct RemotePTYBridgeInputFlowTests {
+    @Test("an ack for a seq that was never sent is a protocol violation")
+    func ackForUnsentSeqReturnsNil() {
+        let flow = RemotePTYBridgeInputFlow(
+            maxPendingWrites: 4,
+            maxPendingBytes: 1024,
+            seqAckEnabled: true
+        )
+        // Nothing sent yet: any positive ack is out of range.
+        #expect(flow.acknowledge(upTo: 1) == nil)
+
+        guard let enqueued = flow.enqueue(Data("a".utf8)), let write = enqueued.writes.first else {
+            Issue.record("expected an immediate write")
+            return
+        }
+        #expect(write.seq == 1)
+        // Acking the sent seq drains; acking past it is rejected.
+        #expect(flow.acknowledge(upTo: 2) == nil)
+        #expect(flow.acknowledge(upTo: 1) != nil)
+    }
+
+    @Test("legacy mode ignores acks without draining or failing")
+    func legacyModeIgnoresAcks() {
+        let flow = RemotePTYBridgeInputFlow(
+            maxPendingWrites: 4,
+            maxPendingBytes: 1024,
+            seqAckEnabled: false
+        )
+        let result = flow.acknowledge(upTo: 99)
+        #expect(result != nil)
+        #expect(result?.writes.isEmpty == true)
+        #expect(result?.shouldResumeReads == false)
+    }
+}

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeInputFlowTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeInputFlowTests.swift
@@ -24,6 +24,47 @@ struct RemotePTYBridgeInputFlowTests {
         #expect(flow.acknowledge(upTo: 1) != nil)
     }
 
+    @Test("oversized input splits into bounded, ordered, seq-contiguous writes")
+    func oversizedInputSplitsIntoBoundedWrites() {
+        let flow = RemotePTYBridgeInputFlow(
+            maxPendingWrites: 256,
+            maxPendingBytes: 1024,
+            seqAckEnabled: true,
+            maxWriteBytes: 16
+        )
+        let input = Data((0..<100).map { UInt8($0) })
+        guard let drain = flow.enqueue(input) else {
+            Issue.record("enqueue should not overflow")
+            return
+        }
+        #expect(drain.writes.allSatisfy { $0.data.count <= 16 })
+        #expect(drain.writes.map(\.data).reduce(Data(), +) == input)
+        #expect(drain.writes.compactMap(\.seq) == (1...UInt64(drain.writes.count)).map { $0 })
+    }
+
+    @Test("pieces past the window buffer in order and drain on ack")
+    func windowBoundaryBuffersInOrder() {
+        let flow = RemotePTYBridgeInputFlow(
+            maxPendingWrites: 2,
+            maxPendingBytes: 1024,
+            seqAckEnabled: true,
+            maxWriteBytes: 4
+        )
+        let input = Data("abcdefghij".utf8)
+        guard let drain = flow.enqueue(input) else {
+            Issue.record("enqueue should not overflow")
+            return
+        }
+        // Window fits two 4-byte writes; the tail buffers and pauses reads.
+        #expect(drain.writes.map(\.data) == [Data("abcd".utf8), Data("efgh".utf8)])
+        #expect(flow.isPaused)
+        guard let acked = flow.acknowledge(upTo: 2) else {
+            Issue.record("ack of sent seqs should drain")
+            return
+        }
+        #expect(acked.writes.map(\.data) == [Data("ij".utf8)])
+    }
+
     @Test("legacy mode ignores acks without draining or failing")
     func legacyModeIgnoresAcks() {
         let flow = RemotePTYBridgeInputFlow(

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeServerTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeServerTests.swift
@@ -61,6 +61,64 @@ final class RecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClient, @unchecked Se
     func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {}
 }
 
+
+private final class DeferredRecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _writes: [Data] = []
+    private var completions: [((any Error)?) -> Void] = []
+    private var _onEvent: ((RemotePTYBridgeEvent) -> Void)?
+    private var _eventQueue: DispatchQueue?
+
+    var writes: [Data] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _writes
+    }
+
+    func attachBridgePTY(
+        sessionID: String,
+        attachmentID: String,
+        cols: Int,
+        rows: Int,
+        command: String?,
+        requireExisting: Bool,
+        queue: DispatchQueue,
+        onEvent: @escaping (RemotePTYBridgeEvent) -> Void
+    ) throws -> RemotePTYBridgeAttachment {
+        lock.lock()
+        _onEvent = onEvent
+        _eventQueue = queue
+        lock.unlock()
+        return RemotePTYBridgeAttachment(attachmentID: attachmentID, token: "deferred-token")
+    }
+
+    func writePTY(
+        sessionID: String,
+        attachmentID: String,
+        attachmentToken: String,
+        data: Data,
+        completion: @escaping ((any Error)?) -> Void
+    ) {
+        lock.lock()
+        _writes.append(data)
+        completions.append(completion)
+        lock.unlock()
+    }
+
+    func completePendingWrites() {
+        let pending: [((any Error)?) -> Void]
+        lock.lock()
+        pending = completions
+        completions.removeAll(keepingCapacity: true)
+        lock.unlock()
+        for completion in pending {
+            completion(nil)
+        }
+    }
+
+    func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {}
+}
+
 struct TestPTYBridgeStrings: RemotePTYBridgeStrings {
     var missingPersistentPTYCapability: String { "test-missing-capability" }
     var sessionEnded: String { "test-session-ended" }
@@ -119,6 +177,12 @@ private final class BridgeTestClient: @unchecked Sendable {
         return false
     }
 
+    var isClosed: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return closed
+    }
+
     func cancel() {
         connection.cancel()
     }
@@ -127,7 +191,7 @@ private final class BridgeTestClient: @unchecked Sendable {
 @Suite("RemotePTYBridgeServer")
 struct RemotePTYBridgeServerTests {
     private func makeServer(
-        client: RecordingPTYBridgeRPCClient,
+        client: any RemotePTYBridgeRPCClient,
         onStop: @escaping () -> Void = {}
     ) -> RemotePTYBridgeServer {
         RemotePTYBridgeServer(
@@ -139,6 +203,71 @@ struct RemotePTYBridgeServerTests {
             strings: TestPTYBridgeStrings(),
             onStop: onStop
         )
+    }
+
+    private func patternedInput(byteCount: Int) -> Data {
+        var data = Data()
+        data.reserveCapacity(byteCount)
+        for index in 0..<byteCount {
+            data.append(UInt8(index % 251))
+        }
+        return data
+    }
+
+    private func waitUntil(timeout: TimeInterval = 5.0, _ predicate: () -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if predicate() { return true }
+            usleep(20_000)
+        }
+        return predicate()
+    }
+
+    // Regression test for https://github.com/manaflow-ai/cmux/issues/7708:
+    // input-window overflow must never close the bridge session or drop
+    // accepted bytes; it must backpressure and eventually deliver every
+    // byte to writePTY in order.
+    @Test("legacy input overflow pauses instead of closing and preserves order")
+    func legacyInputOverflowPausesAndPreservesOrder() throws {
+        let rpc = DeferredRecordingPTYBridgeRPCClient()
+        let server = makeServer(client: rpc)
+        defer { server.stop() }
+        let endpoint = try server.start()
+
+        let client = BridgeTestClient(endpoint: endpoint)
+        defer { client.cancel() }
+        client.send(Data("{\"token\":\"\(endpoint.token)\",\"cols\":120,\"rows\":40}\n".utf8))
+        #expect(client.waitForReceived { data, _ in
+            String(decoding: data, as: UTF8.self).contains("\"attachment_token\":\"deferred-token\"")
+        })
+
+        let input = patternedInput(byteCount: 5 * 1024 * 1024)
+        client.send(input)
+
+        // Phase 1: with no write completions the input window must fill and
+        // the session must backpressure (pause socket reads) — never close.
+        let windowFillTarget = 3 * 1024 * 1024
+        #expect(waitUntil(timeout: 10.0) {
+            rpc.writes.reduce(0) { $0 + $1.count } >= windowFillTarget || client.isClosed
+        })
+        #expect(!client.isClosed)
+
+        // Phase 2: draining completions must deliver every accepted byte,
+        // in order, with the connection still open.
+        let drainDeadline = Date().addingTimeInterval(15.0)
+        while rpc.writes.reduce(0, { $0 + $1.count }) < input.count,
+              Date() < drainDeadline {
+            rpc.completePendingWrites()
+            usleep(20_000)
+        }
+        rpc.completePendingWrites()
+        // Compare via a Bool: on mismatch Swift Testing would otherwise try
+        // to render a byte-level diff of two multi-megabyte Data values.
+        let delivered = rpc.writes.reduce(Data(), +)
+        #expect(delivered.count == input.count)
+        let deliveredMatchesInput = delivered == input
+        #expect(deliveredMatchesInput)
+        #expect(!client.isClosed)
     }
 
     @Test("start binds a loopback endpoint with a fresh token")

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeServerTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeServerTests.swift
@@ -8,23 +8,38 @@ import Testing
 /// bridge calls it from its rpc queue while the test thread inspects it.
 final class RecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClient, @unchecked Sendable {
     private let lock = NSLock()
-    private var _writes: [Data] = []
+    private var _writes: [(data: Data, seq: UInt64?)] = []
     private var _onEvent: ((RemotePTYBridgeEvent) -> Void)?
     private var _eventQueue: DispatchQueue?
     var attachError: (any Error)?
+    var supportsInputSeqAck = false
 
     var writes: [Data] {
         lock.lock()
         defer { lock.unlock() }
-        return _writes
+        return _writes.map(\.data)
+    }
+
+    var writeSeqs: [UInt64?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _writes.map(\.seq)
     }
 
     func emit(_ event: RemotePTYBridgeEvent) {
         lock.lock()
-        let onEvent = _onEvent
         let queue = _eventQueue
         lock.unlock()
-        queue?.async { onEvent?(event) }
+        queue?.async { [weak self] in
+            self?.deliver(event)
+        }
+    }
+
+    private func deliver(_ event: RemotePTYBridgeEvent) {
+        lock.lock()
+        let onEvent = _onEvent
+        lock.unlock()
+        onEvent?(event)
     }
 
     func attachBridgePTY(
@@ -34,6 +49,7 @@ final class RecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClient, @unchecked Se
         rows: Int,
         command: String?,
         requireExisting: Bool,
+        inputSeqAck: Bool,
         queue: DispatchQueue,
         onEvent: @escaping (RemotePTYBridgeEvent) -> Void
     ) throws -> RemotePTYBridgeAttachment {
@@ -50,10 +66,11 @@ final class RecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClient, @unchecked Se
         attachmentID: String,
         attachmentToken: String,
         data: Data,
+        seq: UInt64?,
         completion: @escaping ((any Error)?) -> Void
     ) {
         lock.lock()
-        _writes.append(data)
+        _writes.append((data, seq))
         lock.unlock()
         completion(nil)
     }
@@ -61,18 +78,44 @@ final class RecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClient, @unchecked Se
     func detachPTY(sessionID: String, attachmentID: String, attachmentToken: String) {}
 }
 
-
 private final class DeferredRecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClient, @unchecked Sendable {
     private let lock = NSLock()
-    private var _writes: [Data] = []
+    private var _writes: [(data: Data, seq: UInt64?)] = []
     private var completions: [((any Error)?) -> Void] = []
     private var _onEvent: ((RemotePTYBridgeEvent) -> Void)?
     private var _eventQueue: DispatchQueue?
+    let supportsInputSeqAck: Bool
+
+    init(supportsInputSeqAck: Bool) {
+        self.supportsInputSeqAck = supportsInputSeqAck
+    }
 
     var writes: [Data] {
         lock.lock()
         defer { lock.unlock() }
-        return _writes
+        return _writes.map(\.data)
+    }
+
+    var writeSeqs: [UInt64?] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _writes.map(\.seq)
+    }
+
+    func emit(_ event: RemotePTYBridgeEvent) {
+        lock.lock()
+        let queue = _eventQueue
+        lock.unlock()
+        queue?.async { [weak self] in
+            self?.deliver(event)
+        }
+    }
+
+    private func deliver(_ event: RemotePTYBridgeEvent) {
+        lock.lock()
+        let onEvent = _onEvent
+        lock.unlock()
+        onEvent?(event)
     }
 
     func attachBridgePTY(
@@ -82,6 +125,7 @@ private final class DeferredRecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClien
         rows: Int,
         command: String?,
         requireExisting: Bool,
+        inputSeqAck: Bool,
         queue: DispatchQueue,
         onEvent: @escaping (RemotePTYBridgeEvent) -> Void
     ) throws -> RemotePTYBridgeAttachment {
@@ -97,12 +141,18 @@ private final class DeferredRecordingPTYBridgeRPCClient: RemotePTYBridgeRPCClien
         attachmentID: String,
         attachmentToken: String,
         data: Data,
+        seq: UInt64?,
         completion: @escaping ((any Error)?) -> Void
     ) {
         lock.lock()
-        _writes.append(data)
-        completions.append(completion)
-        lock.unlock()
+        _writes.append((data, seq))
+        if supportsInputSeqAck {
+            lock.unlock()
+            completion(nil)
+        } else {
+            completions.append(completion)
+            lock.unlock()
+        }
     }
 
     func completePendingWrites() {
@@ -162,6 +212,14 @@ private final class BridgeTestClient: @unchecked Sendable {
         connection.send(content: data, completion: .contentProcessed { _ in })
     }
 
+    func sendBlocking(_ data: Data, timeout: TimeInterval = 5.0) -> Bool {
+        let semaphore = DispatchSemaphore(value: 0)
+        connection.send(content: data, completion: .contentProcessed { _ in
+            semaphore.signal()
+        })
+        return semaphore.wait(timeout: .now() + timeout) == .success
+    }
+
     /// Polls until `predicate` over the received bytes holds or the deadline
     /// passes (generous upper bound only; the happy path returns quickly).
     func waitForReceived(timeout: TimeInterval = 5.0, _ predicate: (Data, Bool) -> Bool) -> Bool {
@@ -206,12 +264,7 @@ struct RemotePTYBridgeServerTests {
     }
 
     private func patternedInput(byteCount: Int) -> Data {
-        var data = Data()
-        data.reserveCapacity(byteCount)
-        for index in 0..<byteCount {
-            data.append(UInt8(index % 251))
-        }
-        return data
+        Data((0..<byteCount).map { UInt8($0 % 251) })
     }
 
     private func waitUntil(timeout: TimeInterval = 5.0, _ predicate: () -> Bool) -> Bool {
@@ -221,53 +274,6 @@ struct RemotePTYBridgeServerTests {
             usleep(20_000)
         }
         return predicate()
-    }
-
-    // Regression test for https://github.com/manaflow-ai/cmux/issues/7708:
-    // input-window overflow must never close the bridge session or drop
-    // accepted bytes; it must backpressure and eventually deliver every
-    // byte to writePTY in order.
-    @Test("legacy input overflow pauses instead of closing and preserves order")
-    func legacyInputOverflowPausesAndPreservesOrder() throws {
-        let rpc = DeferredRecordingPTYBridgeRPCClient()
-        let server = makeServer(client: rpc)
-        defer { server.stop() }
-        let endpoint = try server.start()
-
-        let client = BridgeTestClient(endpoint: endpoint)
-        defer { client.cancel() }
-        client.send(Data("{\"token\":\"\(endpoint.token)\",\"cols\":120,\"rows\":40}\n".utf8))
-        #expect(client.waitForReceived { data, _ in
-            String(decoding: data, as: UTF8.self).contains("\"attachment_token\":\"deferred-token\"")
-        })
-
-        let input = patternedInput(byteCount: 5 * 1024 * 1024)
-        client.send(input)
-
-        // Phase 1: with no write completions the input window must fill and
-        // the session must backpressure (pause socket reads) — never close.
-        let windowFillTarget = 3 * 1024 * 1024
-        #expect(waitUntil(timeout: 10.0) {
-            rpc.writes.reduce(0) { $0 + $1.count } >= windowFillTarget || client.isClosed
-        })
-        #expect(!client.isClosed)
-
-        // Phase 2: draining completions must deliver every accepted byte,
-        // in order, with the connection still open.
-        let drainDeadline = Date().addingTimeInterval(15.0)
-        while rpc.writes.reduce(0, { $0 + $1.count }) < input.count,
-              Date() < drainDeadline {
-            rpc.completePendingWrites()
-            usleep(20_000)
-        }
-        rpc.completePendingWrites()
-        // Compare via a Bool: on mismatch Swift Testing would otherwise try
-        // to render a byte-level diff of two multi-megabyte Data values.
-        let delivered = rpc.writes.reduce(Data(), +)
-        #expect(delivered.count == input.count)
-        let deliveredMatchesInput = delivered == input
-        #expect(deliveredMatchesInput)
-        #expect(!client.isClosed)
     }
 
     @Test("start binds a loopback endpoint with a fresh token")
@@ -311,6 +317,119 @@ struct RemotePTYBridgeServerTests {
         rpc.emit(.data(Data("OUTPUT".utf8)))
         #expect(client.waitForReceived { data, _ in
             String(decoding: data, as: UTF8.self).contains("OUTPUT")
+        })
+    }
+
+    @Test("legacy input overflow pauses instead of closing and preserves order")
+    func legacyInputOverflowPausesAndPreservesOrder() throws {
+        let rpc = DeferredRecordingPTYBridgeRPCClient(supportsInputSeqAck: false)
+        let server = makeServer(client: rpc)
+        defer { server.stop() }
+        let endpoint = try server.start()
+
+        let client = BridgeTestClient(endpoint: endpoint)
+        defer { client.cancel() }
+        client.send(Data("{\"token\":\"\(endpoint.token)\",\"cols\":120,\"rows\":40}\n".utf8))
+        #expect(client.waitForReceived { data, _ in
+            String(decoding: data, as: UTF8.self).contains("\"attachment_token\":\"deferred-token\"")
+        })
+
+        let input = patternedInput(byteCount: 5 * 1024 * 1024)
+        client.send(input)
+
+        // Phase 1: with no write completions the input window must fill and
+        // the session must backpressure (pause socket reads) — never close.
+        let windowFillTarget = 3 * 1024 * 1024
+        #expect(waitUntil(timeout: 10.0) {
+            rpc.writes.reduce(0) { $0 + $1.count } >= windowFillTarget || client.isClosed
+        })
+        #expect(!client.isClosed)
+
+        // Phase 2: draining completions must deliver every accepted byte,
+        // in order, with the connection still open.
+        let drainDeadline = Date().addingTimeInterval(15.0)
+        while rpc.writes.reduce(0, { $0 + $1.count }) < input.count,
+              Date() < drainDeadline {
+            rpc.completePendingWrites()
+            usleep(20_000)
+        }
+        rpc.completePendingWrites()
+        // Bool compare: a failed Data #expect would render a huge byte diff.
+        let delivered = rpc.writes.reduce(Data(), +)
+        #expect(delivered.count == input.count)
+        let deliveredMatchesInput = delivered == input
+        #expect(deliveredMatchesInput)
+        #expect(!client.isClosed)
+    }
+
+    @Test("acked input mode drains only on cumulative ack and preserves seq order")
+    func ackedInputModeDrainsOnAck() throws {
+        let rpc = DeferredRecordingPTYBridgeRPCClient(supportsInputSeqAck: true)
+        let server = makeServer(client: rpc)
+        defer { server.stop() }
+        let endpoint = try server.start()
+
+        let client = BridgeTestClient(endpoint: endpoint)
+        defer { client.cancel() }
+        client.send(Data("{\"token\":\"\(endpoint.token)\",\"cols\":120,\"rows\":40}\n".utf8))
+        #expect(client.waitForReceived { data, _ in
+            String(decoding: data, as: UTF8.self).contains("\"attachment_token\":\"deferred-token\"")
+        })
+
+        let input = patternedInput(byteCount: 5 * 1024 * 1024)
+        #expect(client.sendBlocking(input))
+
+        // No acks: the window must fill and pause, bounding delivery.
+        let windowFillTarget = 3 * 1024 * 1024
+        #expect(waitUntil(timeout: 10.0) {
+            rpc.writes.reduce(0) { $0 + $1.count } >= windowFillTarget || client.isClosed
+        })
+        let firstSeqs = rpc.writeSeqs.compactMap { $0 }
+        #expect(firstSeqs == firstSeqs.indices.map { UInt64($0 + 1) })
+        #expect(!client.isClosed)
+        #expect(rpc.writes.reduce(0) { $0 + $1.count } <= 4 * 1024 * 1024)
+
+        let ackDeadline = Date().addingTimeInterval(10.0)
+        while rpc.writes.reduce(0, { $0 + $1.count }) < input.count,
+              Date() < ackDeadline {
+            let seqs = rpc.writeSeqs.compactMap { $0 }
+            if let last = seqs.last {
+                rpc.emit(.inputAck(seq: last))
+            }
+            usleep(20_000)
+        }
+        let seqs = rpc.writeSeqs.compactMap { $0 }
+        #expect(seqs == seqs.indices.map { UInt64($0 + 1) })
+        let delivered = rpc.writes.reduce(Data(), +)
+        #expect(delivered.count == input.count)
+        let deliveredMatchesInput = delivered == input
+        #expect(deliveredMatchesInput)
+        #expect(!client.isClosed)
+    }
+
+    @Test("a pty.error mid-stream closes the session")
+    func ptyErrorMidStreamClosesSession() throws {
+        let rpc = DeferredRecordingPTYBridgeRPCClient(supportsInputSeqAck: true)
+        let server = makeServer(client: rpc)
+        defer { server.stop() }
+        let endpoint = try server.start()
+
+        let client = BridgeTestClient(endpoint: endpoint)
+        defer { client.cancel() }
+        client.send(Data("{\"token\":\"\(endpoint.token)\",\"cols\":120,\"rows\":40}\n".utf8))
+        #expect(client.waitForReceived { data, _ in
+            String(decoding: data, as: UTF8.self).contains("\"attachment_token\":\"deferred-token\"")
+        })
+
+        client.send(Data("echo hi\n".utf8))
+        #expect(waitUntil {
+            !rpc.writes.isEmpty
+        })
+        #expect(!client.isClosed)
+
+        rpc.emit(.error("PTY input sequence gap: got 3, want 2"))
+        #expect(waitUntil {
+            client.isClosed
         })
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1258,6 +1258,8 @@
 			B816E948EC5E42AF967648AC /* SSHPTYAttachReconnectInputFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E4DB33FA55F1B13C60EFFC8 /* SSHPTYAttachReconnectInputFilter.swift */; };
 			E60610200000000000000002 /* SSHPTYAttachReconnectInputFilterControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */; };
 			E60610200000000000000003 /* SSHPTYAttachReconnectInputFilterControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */; };
+			E60610400000000000000002 /* SSHPTYAttachReconnectInputFilterPumpIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610400000000000000001 /* SSHPTYAttachReconnectInputFilterPumpIO.swift */; };
+			E60610400000000000000003 /* SSHPTYAttachReconnectInputFilterPumpIO.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610400000000000000001 /* SSHPTYAttachReconnectInputFilterPumpIO.swift */; };
 			E60610100000000000000002 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */; };
 			E60610100000000000000003 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */; };
 			E60610300000000000000002 /* SSHPTYAttachReconnectInputFilterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E60610300000000000000001 /* SSHPTYAttachReconnectInputFilterState.swift */; };
@@ -2828,6 +2830,7 @@
 		F6724601A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHConfiguredRemoteCommandHostTests.swift; sourceTree = "<group>"; };
 			1E4DB33FA55F1B13C60EFFC8 /* SSHPTYAttachReconnectInputFilter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilter.swift; sourceTree = "<group>"; };
 			E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilterControl.swift; sourceTree = "<group>"; };
+			E60610400000000000000001 /* SSHPTYAttachReconnectInputFilterPumpIO.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilterPumpIO.swift; sourceTree = "<group>"; };
 			E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilterSequenceMatch.swift; sourceTree = "<group>"; };
 			E60610300000000000000001 /* SSHPTYAttachReconnectInputFilterState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilterState.swift; sourceTree = "<group>"; };
 			0C4AD348F196FBBEE52D53A7 /* SSHPTYAttachReconnectInputFilterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachReconnectInputFilterTests.swift; sourceTree = "<group>"; };
@@ -4365,6 +4368,7 @@
 				E60610200000000000000001 /* SSHPTYAttachReconnectInputFilterControl.swift */,
 				E60610100000000000000001 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift */,
 				E60610300000000000000001 /* SSHPTYAttachReconnectInputFilterState.swift */,
+				E60610400000000000000001 /* SSHPTYAttachReconnectInputFilterPumpIO.swift */,
 				C0DECAFE0000000000000002 /* CodexTeamsApprovalBridge.swift */,
 				A76110010000000000000002 /* AgentHookNotificationPolicy.swift */,
 				FEEDC1A50000000000000002 /* FeedEventClassifier.swift */,
@@ -6296,6 +6300,7 @@
 				C510C1E00000000000000002 /* SocketOperationTelemetry.swift in Sources */,
 				B816E948EC5E42AF967648AC /* SSHPTYAttachReconnectInputFilter.swift in Sources */,
 				E60610200000000000000002 /* SSHPTYAttachReconnectInputFilterControl.swift in Sources */,
+				E60610400000000000000002 /* SSHPTYAttachReconnectInputFilterPumpIO.swift in Sources */,
 				E60610100000000000000002 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift in Sources */,
 				E60610300000000000000002 /* SSHPTYAttachReconnectInputFilterState.swift in Sources */,
 				6379A0046379A0046379A004 /* SSHPTYResizeMonitor.swift in Sources */,
@@ -6695,6 +6700,7 @@
 				F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */,
 						6E8B6A69A468EF938B9AD8C2 /* SSHPTYAttachReconnectInputFilter.swift in Sources */,
 						E60610200000000000000003 /* SSHPTYAttachReconnectInputFilterControl.swift in Sources */,
+						E60610400000000000000003 /* SSHPTYAttachReconnectInputFilterPumpIO.swift in Sources */,
 						E60610100000000000000003 /* SSHPTYAttachReconnectInputFilterSequenceMatch.swift in Sources */,
 						E60610300000000000000003 /* SSHPTYAttachReconnectInputFilterState.swift in Sources */,
 						B6285B71BA6F82AF8F945E00 /* SSHPTYAttachReconnectInputFilterTests.swift in Sources */,

--- a/cmuxTests/SSHPTYAttachReconnectInputFilterTests.swift
+++ b/cmuxTests/SSHPTYAttachReconnectInputFilterTests.swift
@@ -85,6 +85,84 @@ import Testing
         #expect(filter.filter(keyInput) == keyInput)
     }
 
+    @Test func deadlineFlushesPendingAndStopsStripping() {
+        var expired = false
+        let filter = SSHPTYAttachReconnectInputFilter(
+            enabled: true,
+            deadlineReached: { expired }
+        )
+        let escape = Data([0x1B])
+        #expect(filter.filter(escape) == Data())
+        expired = true
+
+        let probeReply = Data("\u{1B}[1;1R".utf8)
+        #expect(filter.filter(probeReply) == escape + probeReply)
+        #expect(filter.filter(Data("\u{1B}]11;rgb:e5e5/e9e9/f0f0\u{07}".utf8)) == Data("\u{1B}]11;rgb:e5e5/e9e9/f0f0\u{07}".utf8))
+    }
+
+    @Test func seededSplitFuzzPreservesNonProbeBytes() {
+        var seed: UInt64 = 0x7708
+        let probes = [
+            Data("\u{1B}[1;1R".utf8),
+            Data("\u{1B}[?1;2c".utf8),
+            Data("\u{1B}[?0u".utf8),
+            Data("\u{1B}[4$y".utf8),
+            Data("\u{1B}]10;rgb:ffff/ffff/ffff\u{07}".utf8),
+            Data("\u{1B}]11;rgb:e5e5/e9e9/f0f0\u{1B}\\".utf8),
+        ]
+        let keys = [
+            Data("plain text\n".utf8),
+            Data("\u{1B}[A".utf8),
+            Data("\u{1B}x".utf8),
+            Data("\u{1B}[13;2u".utf8),
+            Data("\u{1B}[200~paste\u{1B}[201~".utf8),
+            Data([0x1B]),
+        ]
+
+        // Keys are inserted before, between, and after probe replies. The
+        // oracle mirrors the prefix-safety contract: probes are stripped only
+        // while every byte seen so far belonged to a probe reply; the first
+        // key byte ends stripping and everything after it (probes included)
+        // must reach the output verbatim, in order.
+        for index in 0..<128 {
+            let filter = SSHPTYAttachReconnectInputFilter(enabled: true)
+            var segments: [(data: Data, isKey: Bool)] = []
+            for _ in 0..<(1 + Int(nextRandom(&seed) % 4)) {
+                segments.append((probes[Int(nextRandom(&seed) % UInt64(probes.count))], false))
+            }
+            for _ in 0..<(1 + Int(nextRandom(&seed) % 2)) {
+                let key = keys[Int(nextRandom(&seed) % UInt64(keys.count))]
+                let position = Int(nextRandom(&seed) % UInt64(segments.count + 1))
+                segments.insert((key, true), at: position)
+            }
+
+            var input = Data()
+            var expected = Data()
+            var stripping = true
+            for segment in segments {
+                input.append(segment.data)
+                if segment.isKey {
+                    stripping = false
+                }
+                if !segment.isKey && stripping {
+                    continue
+                }
+                expected.append(segment.data)
+            }
+
+            var output = Data()
+            var cursor = 0
+            while cursor < input.count {
+                let remaining = input.count - cursor
+                let step = 1 + Int(nextRandom(&seed) % UInt64(min(7, remaining)))
+                output.append(filter.filter(Data(input[cursor..<(cursor + step)])))
+                cursor += step
+            }
+            output.append(filter.finish())
+            #expect(output == expected, "seed 0x7708 case \(index)")
+        }
+    }
+
     @Test func stdinPumpKeepsFilteringLateProbeRepliesAfterInitialDrain() throws {
         var inputPipe = [Int32](repeating: -1, count: 2)
         try makePipe(&inputPipe)
@@ -271,5 +349,10 @@ import Testing
             return
         }
         Darwin.close(fd)
+    }
+
+    private func nextRandom(_ seed: inout UInt64) -> UInt64 {
+        seed = seed &* 6364136223846793005 &+ 1442695040888963407
+        return seed
     }
 }

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -3657,7 +3657,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             cols: Int,
             rows: Int,
             command: String?,
-            requireExisting: Bool,
+            requireExisting: Bool, inputSeqAck: Bool,
             queue: DispatchQueue,
             onEvent: @escaping (RemotePTYBridgeEvent) -> Void
         ) throws -> RemotePTYBridgeAttachment {
@@ -3679,7 +3679,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             sessionID: String,
             attachmentID: String,
             attachmentToken: String,
-            data: Data,
+            data: Data, seq: UInt64?,
             completion: @escaping (Error?) -> Void
         ) {
             completion(nil)
@@ -3694,7 +3694,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             cols: Int,
             rows: Int,
             command: String?,
-            requireExisting: Bool,
+            requireExisting: Bool, inputSeqAck: Bool,
             queue: DispatchQueue,
             onEvent: @escaping (RemotePTYBridgeEvent) -> Void
         ) throws -> RemotePTYBridgeAttachment {
@@ -3709,7 +3709,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             sessionID: String,
             attachmentID: String,
             attachmentToken: String,
-            data: Data,
+            data: Data, seq: UInt64?,
             completion: @escaping (Error?) -> Void
         ) {
             completion(nil)
@@ -3726,7 +3726,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             cols: Int,
             rows: Int,
             command: String?,
-            requireExisting: Bool,
+            requireExisting: Bool, inputSeqAck: Bool,
             queue: DispatchQueue,
             onEvent: @escaping (RemotePTYBridgeEvent) -> Void
         ) throws -> RemotePTYBridgeAttachment {
@@ -3743,7 +3743,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             sessionID: String,
             attachmentID: String,
             attachmentToken: String,
-            data: Data,
+            data: Data, seq: UInt64?,
             completion: @escaping (Error?) -> Void
         ) {
             completion(nil)
@@ -3775,7 +3775,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             cols: Int,
             rows: Int,
             command: String?,
-            requireExisting: Bool,
+            requireExisting: Bool, inputSeqAck: Bool,
             queue: DispatchQueue,
             onEvent: @escaping (RemotePTYBridgeEvent) -> Void
         ) throws -> RemotePTYBridgeAttachment {
@@ -3794,7 +3794,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             sessionID: String,
             attachmentID: String,
             attachmentToken: String,
-            data: Data,
+            data: Data, seq: UInt64?,
             completion: @escaping (Error?) -> Void
         ) {
             guard String(data: data, encoding: .utf8)?.contains("after-half-close-input") == true else {
@@ -3840,7 +3840,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             cols: Int,
             rows: Int,
             command: String?,
-            requireExisting: Bool,
+            requireExisting: Bool, inputSeqAck: Bool,
             queue: DispatchQueue,
             onEvent: @escaping (RemotePTYBridgeEvent) -> Void
         ) throws -> RemotePTYBridgeAttachment {
@@ -3851,7 +3851,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
             sessionID: String,
             attachmentID: String,
             attachmentToken: String,
-            data: Data,
+            data: Data, seq: UInt64?,
             completion: @escaping (Error?) -> Void
         ) {
             let writeCount: Int

--- a/daemon/remote/.gitignore
+++ b/daemon/remote/.gitignore
@@ -1,0 +1,1 @@
+/cmuxd-remote

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -1439,7 +1439,8 @@ func (s *rpcServer) handleNotificationResponse(req rpcRequest, resp rpcResponse)
 		Error:           detail,
 		Message:         detail,
 	})
-	if req.Method == "pty.write" && resp.Error != nil && resp.Error.Code == "pty_input_queue_full" && s.ptyHub != nil {
+	if req.Method == "pty.write" && resp.Error != nil && s.ptyHub != nil &&
+		(resp.Error.Code == "pty_input_queue_full" || resp.Error.Code == "pty_input_seq_gap") {
 		s.ptyHub.detachByID(sessionID, attachmentID, attachmentToken)
 	}
 	return err

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -2066,7 +2066,18 @@ func (s *rpcServer) handlePTYWrite(req rpcRequest) rpcResponse {
 	writeStatus := wsPTYInputWriteNotFound
 	var seq uint64
 	var hasSeq bool
-	if parsedSeq, ok := getIntParam(req.Params, "seq"); ok && parsedSeq >= 0 {
+	if _, provided := req.Params["seq"]; provided {
+		parsedSeq, ok := getIntParam(req.Params, "seq")
+		if !ok || parsedSeq < 0 {
+			return rpcResponse{
+				ID: req.ID,
+				OK: false,
+				Error: &rpcError{
+					Code:    "invalid_params",
+					Message: "seq must be a non-negative integer",
+				},
+			}
+		}
 		seq = uint64(parsedSeq)
 		hasSeq = true
 	}

--- a/daemon/remote/cmd/cmuxd-remote/main.go
+++ b/daemon/remote/cmd/cmuxd-remote/main.go
@@ -81,6 +81,7 @@ type rpcEvent struct {
 	DataBase64      string `json:"data_base64,omitempty"`
 	Message         string `json:"message,omitempty"`
 	Error           string `json:"error,omitempty"`
+	Seq             uint64 `json:"seq,omitempty"`
 }
 
 type rpcFrameWriter interface {
@@ -1322,6 +1323,7 @@ func (s *rpcServer) handleRequest(req rpcRequest) rpcResponse {
 					"pty.session.persistent_daemon",
 					"pty.write.notification",
 					"pty.resize.notification",
+					"pty.input.seq_ack",
 					"cli.bridge",
 				},
 			},
@@ -1975,6 +1977,7 @@ func (s *rpcServer) handlePTYAttach(req rpcRequest) rpcResponse {
 	}
 	command, _ := getStringParam(req.Params, "command")
 	requireExisting, _ := getBoolParam(req.Params, "require_existing")
+	inputSeqAck, _ := getBoolParam(req.Params, "input_seq_ack")
 
 	hub := s.ptyHub
 	if hub == nil {
@@ -1996,6 +1999,7 @@ func (s *rpcServer) handlePTYAttach(req rpcRequest) rpcResponse {
 		command,
 		attachmentToken,
 		requireExisting,
+		inputSeqAck,
 	)
 	if err != nil {
 		return rpcResponse{
@@ -2060,8 +2064,26 @@ func (s *rpcServer) handlePTYWrite(req rpcRequest) rpcResponse {
 		}
 	}
 	writeStatus := wsPTYInputWriteNotFound
+	var seq uint64
+	var hasSeq bool
+	if parsedSeq, ok := getIntParam(req.Params, "seq"); ok && parsedSeq >= 0 {
+		seq = uint64(parsedSeq)
+		hasSeq = true
+	}
+	writeResult := wsPTYInputWriteResult{status: wsPTYInputWriteNotFound}
 	if s.ptyHub != nil {
-		writeStatus = s.ptyHub.writeInputByID(sessionID, attachmentID, attachmentToken, payload)
+		writeResult = s.ptyHub.writeInputByIDWithSeq(sessionID, attachmentID, attachmentToken, payload, seq, hasSeq)
+		writeStatus = writeResult.status
+	}
+	if writeStatus == wsPTYInputWriteSeqGap {
+		return rpcResponse{
+			ID: req.ID,
+			OK: false,
+			Error: &rpcError{
+				Code:    "pty_input_seq_gap",
+				Message: fmt.Sprintf("PTY input sequence gap: got %d, want %d", writeResult.got, writeResult.want),
+			},
+		}
 	}
 	if writeStatus == wsPTYInputWriteQueueFull {
 		return rpcResponse{

--- a/daemon/remote/cmd/cmuxd-remote/main_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/main_test.go
@@ -361,6 +361,16 @@ func TestRunStdioHelloAndPing(t *testing.T) {
 	if !sawPTYResizeNotificationCapability {
 		t.Fatalf("hello should advertise pty.resize.notification: %v", firstResult)
 	}
+	sawPTYInputSeqAckCapability := false
+	for _, capability := range capabilities {
+		if capability == "pty.input.seq_ack" {
+			sawPTYInputSeqAckCapability = true
+			break
+		}
+	}
+	if !sawPTYInputSeqAckCapability {
+		t.Fatalf("hello should advertise pty.input.seq_ack: %v", firstResult)
+	}
 
 	var second map[string]any
 	if err := json.Unmarshal([]byte(lines[1]), &second); err != nil {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -1662,6 +1662,12 @@ func (h *wsPTYHub) writeInputChunkLocked(session *wsPTYSession, chunk wsPTYInput
 	session.ptyWriteMu.Lock()
 	defer session.ptyWriteMu.Unlock()
 
+	// Deliberately session-scoped, not attachment-scoped: once writeInput
+	// accepted bytes they belong to the persistent session and are written
+	// even if their attachment has since detached (tmux semantics — input
+	// sent before detach still executes). Discarding queued accepted bytes
+	// on detach is the silent-loss bug class this path exists to prevent;
+	// writeInput still rejects NEW writes from detached attachments.
 	h.mu.Lock()
 	current := h.sessions[session.key] == session && !session.closed
 	ptyFile := session.ptyFile

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -1647,6 +1647,18 @@ func (h *wsPTYHub) writeInputLoop(session *wsPTYSession) {
 }
 
 func (h *wsPTYHub) writeInputChunk(session *wsPTYSession, chunk wsPTYInputChunk) bool {
+	written, ackOK := h.writeInputChunkLocked(session, chunk)
+	if !ackOK {
+		// enqueueInputAck canceled the attachment because its send queue
+		// was saturated; finish the cleanup like the output path does.
+		// Must run outside ptyWriteMu: dropAttachment can resize via
+		// applyCurrentPTYSize, which takes ptyWriteMu.
+		h.dropAttachment(chunk.attachment)
+	}
+	return written
+}
+
+func (h *wsPTYHub) writeInputChunkLocked(session *wsPTYSession, chunk wsPTYInputChunk) (written bool, ackOK bool) {
 	session.ptyWriteMu.Lock()
 	defer session.ptyWriteMu.Unlock()
 
@@ -1655,12 +1667,12 @@ func (h *wsPTYHub) writeInputChunk(session *wsPTYSession, chunk wsPTYInputChunk)
 	ptyFile := session.ptyFile
 	h.mu.Unlock()
 	if !current || ptyFile == nil {
-		return false
+		return false, true
 	}
 	return h.writeInputChunkWithPTYFile(ptyFile, chunk)
 }
 
-func (h *wsPTYHub) writeInputChunkWithPTYFile(ptyFile *os.File, chunk wsPTYInputChunk) bool {
+func (h *wsPTYHub) writeInputChunkWithPTYFile(ptyFile *os.File, chunk wsPTYInputChunk) (written bool, ackOK bool) {
 	total := 0
 	for total < len(chunk.payload) {
 		n, err := ptyFile.Write(chunk.payload[total:])
@@ -1668,21 +1680,20 @@ func (h *wsPTYHub) writeInputChunkWithPTYFile(ptyFile *os.File, chunk wsPTYInput
 			total += n
 		}
 		if err != nil {
-			return false
+			return false, true
 		}
 		if n == 0 {
-			return false
+			return false, true
 		}
 	}
-	h.ackInputChunk(chunk)
-	return true
+	return true, h.ackInputChunk(chunk)
 }
 
-func (h *wsPTYHub) ackInputChunk(chunk wsPTYInputChunk) {
+func (h *wsPTYHub) ackInputChunk(chunk wsPTYInputChunk) bool {
 	if !chunk.finalSeqChunk || chunk.attachment == nil || !chunk.attachment.inputSeqAck {
-		return
+		return true
 	}
-	chunk.attachment.enqueueInputAck(chunk.seq)
+	return chunk.attachment.enqueueInputAck(chunk.seq)
 }
 
 func (h *wsPTYHub) sessionForAttachment(sessionKey wsPTYSessionKey) *wsPTYSession {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -120,9 +120,6 @@ type wsPTYInputChunk struct {
 	payload       []byte
 	seq           uint64
 	finalSeqChunk bool
-	// flushDone marks a barrier sentinel: the input loop closes it once every
-	// chunk enqueued before it has been written to the PTY. No payload.
-	flushDone chan struct{}
 }
 
 type wsPTYInputWriteStatus uint8
@@ -828,33 +825,19 @@ func (h *wsPTYHub) prepareAttachment(
 		attachmentID = fmt.Sprintf("att-%d", h.nextAttachmentID)
 		h.nextAttachmentID++
 	}
-	// Supersede any existing attachment with this id, quiescing its accepted
-	// input before the replacement may enqueue. Waiting on the flush barrier
-	// drops h.mu, so re-check the slot afterwards: a concurrent attach for the
-	// same id may have registered in the window and must be superseded too,
-	// never silently overwritten.
-	var superseded []*wsPTYAttachment
-	closeSuperseded := func() {
-		for _, old := range superseded {
-			old.closeNow()
-		}
-	}
-	for {
-		old := session.attachments[attachmentID]
-		if old == nil {
-			break
-		}
+	// Supersede any existing attachment with this id. Input the old
+	// attachment already had accepted stays queued and reaches the PTY
+	// ahead of anything the replacement enqueues: session.input is FIFO
+	// with writeInputLoop as its only consumer, whole writes enqueue
+	// atomically under inputEnqueueMu, and writeInputChunk deliberately
+	// does not require the chunk's attachment to still be registered.
+	// Never wait on that drain here — a wedged PTY (reader stopped) must
+	// not turn reattach into an indefinite hang.
+	var superseded *wsPTYAttachment
+	if old := session.attachments[attachmentID]; old != nil {
 		old.cancel()
 		delete(session.attachments, attachmentID)
-		superseded = append(superseded, old)
-		h.mu.Unlock()
-		h.flushAcceptedInput(session)
-		h.mu.Lock()
-		if h.sessions[sessionKey] != session || session.closed {
-			h.mu.Unlock()
-			closeSuperseded()
-			return nil, nil, nil, fmt.Errorf("persistent PTY session %q is not running", sessionID)
-		}
+		superseded = old
 	}
 
 	attachmentCtx, cancel := context.WithCancel(ctx)
@@ -875,13 +858,17 @@ func (h *wsPTYHub) prepareAttachment(
 	if ok := attachment.enqueueReady(sessionID); !ok {
 		cancel()
 		h.mu.Unlock()
-		closeSuperseded()
+		if superseded != nil {
+			superseded.closeNow()
+		}
 		return nil, nil, nil, errors.New("failed to queue ready frame")
 	}
 	if ok := enqueuePTYReplay(attachment, replay); !ok {
 		cancel()
 		h.mu.Unlock()
-		closeSuperseded()
+		if superseded != nil {
+			superseded.closeNow()
+		}
 		return nil, nil, nil, errors.New("failed to queue replay frame")
 	}
 	session.attachments[attachmentID] = attachment
@@ -889,7 +876,9 @@ func (h *wsPTYHub) prepareAttachment(
 	sessionDone := session.done
 	h.mu.Unlock()
 
-	closeSuperseded()
+	if superseded != nil {
+		superseded.closeNow()
+	}
 	if shouldApplySize {
 		h.applyCurrentPTYSize(session)
 	}
@@ -1658,10 +1647,6 @@ func (h *wsPTYHub) writeInputLoop(session *wsPTYSession) {
 }
 
 func (h *wsPTYHub) writeInputChunk(session *wsPTYSession, chunk wsPTYInputChunk) bool {
-	if chunk.flushDone != nil {
-		close(chunk.flushDone)
-		return true
-	}
 	session.ptyWriteMu.Lock()
 	defer session.ptyWriteMu.Unlock()
 
@@ -1691,27 +1676,6 @@ func (h *wsPTYHub) writeInputChunkWithPTYFile(ptyFile *os.File, chunk wsPTYInput
 	}
 	h.ackInputChunk(chunk)
 	return true
-}
-
-// flushAcceptedInput blocks until every input chunk enqueued before the call
-// has been written to the PTY. writeInputLoop stays the sole consumer of
-// session.input (a second consumer could reorder a chunk the loop already
-// dequeued but has not yet written); the barrier sentinel is enqueued under
-// inputEnqueueMu so no concurrent write can slip in ahead of it.
-func (h *wsPTYHub) flushAcceptedInput(session *wsPTYSession) {
-	session.inputEnqueueMu.Lock()
-	flushDone := make(chan struct{})
-	select {
-	case session.input <- wsPTYInputChunk{flushDone: flushDone}:
-	case <-session.done:
-		session.inputEnqueueMu.Unlock()
-		return
-	}
-	session.inputEnqueueMu.Unlock()
-	select {
-	case <-flushDone:
-	case <-session.done:
-	}
 }
 
 func (h *wsPTYHub) ackInputChunk(chunk wsPTYInputChunk) {

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty.go
@@ -111,12 +111,18 @@ const (
 type wsPTYOutgoingFrame struct {
 	messageType websocket.MessageType
 	payload     []byte
+	inputAck    bool
 }
 
 type wsPTYInputChunk struct {
-	attachmentID string
-	attachment   *wsPTYAttachment
-	payload      []byte
+	attachmentID  string
+	attachment    *wsPTYAttachment
+	payload       []byte
+	seq           uint64
+	finalSeqChunk bool
+	// flushDone marks a barrier sentinel: the input loop closes it once every
+	// chunk enqueued before it has been written to the PTY. No payload.
+	flushDone chan struct{}
 }
 
 type wsPTYInputWriteStatus uint8
@@ -125,18 +131,24 @@ const (
 	wsPTYInputWriteOK wsPTYInputWriteStatus = iota
 	wsPTYInputWriteNotFound
 	wsPTYInputWriteQueueFull
+	wsPTYInputWriteSeqGap
 )
 
 type wsPTYAttachment struct {
-	sessionKey  wsPTYSessionKey
-	id          string
-	clientToken string
-	cols        int
-	rows        int
-	send        chan wsPTYOutgoingFrame
-	cancel      context.CancelFunc
-	conn        *websocket.Conn
-	persistent  bool
+	sessionKey      wsPTYSessionKey
+	id              string
+	clientToken     string
+	cols            int
+	rows            int
+	send            chan wsPTYOutgoingFrame
+	cancel          context.CancelFunc
+	conn            *websocket.Conn
+	persistent      bool
+	inputSeqAck     bool
+	lastAcceptedSeq uint64
+	ackMu           sync.Mutex
+	ackQueued       bool
+	ackSeq          uint64
 }
 
 type wsPTYSessionKey struct {
@@ -748,6 +760,7 @@ func (h *wsPTYHub) attach(ctx context.Context, conn *websocket.Conn, auth wsAuth
 		"",
 		"",
 		false,
+		false,
 	)
 	if err != nil {
 		return nil, err
@@ -765,6 +778,7 @@ func (h *wsPTYHub) attachRPC(
 	command string,
 	clientToken string,
 	requireExisting bool,
+	inputSeqAck bool,
 ) (*wsPTYAttachment, context.Context, <-chan struct{}, error) {
 	sessionID = strings.TrimSpace(sessionID)
 	if sessionID == "" {
@@ -772,7 +786,7 @@ func (h *wsPTYHub) attachRPC(
 	}
 	attachmentID = strings.TrimSpace(attachmentID)
 	cols, rows = normalizePTYSize(cols, rows)
-	return h.prepareAttachment(ctx, nil, sessionID, attachmentID, cols, rows, true, command, clientToken, requireExisting)
+	return h.prepareAttachment(ctx, nil, sessionID, attachmentID, cols, rows, true, command, clientToken, requireExisting, inputSeqAck)
 }
 
 func (h *wsPTYHub) prepareAttachment(
@@ -786,6 +800,7 @@ func (h *wsPTYHub) prepareAttachment(
 	command string,
 	clientToken string,
 	requireExisting bool,
+	inputSeqAck bool,
 ) (*wsPTYAttachment, context.Context, <-chan struct{}, error) {
 	h.mu.Lock()
 
@@ -813,11 +828,33 @@ func (h *wsPTYHub) prepareAttachment(
 		attachmentID = fmt.Sprintf("att-%d", h.nextAttachmentID)
 		h.nextAttachmentID++
 	}
-	var superseded *wsPTYAttachment
-	if old := session.attachments[attachmentID]; old != nil {
+	// Supersede any existing attachment with this id, quiescing its accepted
+	// input before the replacement may enqueue. Waiting on the flush barrier
+	// drops h.mu, so re-check the slot afterwards: a concurrent attach for the
+	// same id may have registered in the window and must be superseded too,
+	// never silently overwritten.
+	var superseded []*wsPTYAttachment
+	closeSuperseded := func() {
+		for _, old := range superseded {
+			old.closeNow()
+		}
+	}
+	for {
+		old := session.attachments[attachmentID]
+		if old == nil {
+			break
+		}
 		old.cancel()
 		delete(session.attachments, attachmentID)
-		superseded = old
+		superseded = append(superseded, old)
+		h.mu.Unlock()
+		h.flushAcceptedInput(session)
+		h.mu.Lock()
+		if h.sessions[sessionKey] != session || session.closed {
+			h.mu.Unlock()
+			closeSuperseded()
+			return nil, nil, nil, fmt.Errorf("persistent PTY session %q is not running", sessionID)
+		}
 	}
 
 	attachmentCtx, cancel := context.WithCancel(ctx)
@@ -832,22 +869,19 @@ func (h *wsPTYHub) prepareAttachment(
 		cancel:      cancel,
 		conn:        conn,
 		persistent:  persistent,
+		inputSeqAck: inputSeqAck,
 	}
 	replay := append([]byte(nil), session.scrollback...)
 	if ok := attachment.enqueueReady(sessionID); !ok {
 		cancel()
 		h.mu.Unlock()
-		if superseded != nil {
-			superseded.closeNow()
-		}
+		closeSuperseded()
 		return nil, nil, nil, errors.New("failed to queue ready frame")
 	}
 	if ok := enqueuePTYReplay(attachment, replay); !ok {
 		cancel()
 		h.mu.Unlock()
-		if superseded != nil {
-			superseded.closeNow()
-		}
+		closeSuperseded()
 		return nil, nil, nil, errors.New("failed to queue replay frame")
 	}
 	session.attachments[attachmentID] = attachment
@@ -855,9 +889,7 @@ func (h *wsPTYHub) prepareAttachment(
 	sessionDone := session.done
 	h.mu.Unlock()
 
-	if superseded != nil {
-		superseded.closeNow()
-	}
+	closeSuperseded()
 	if shouldApplySize {
 		h.applyCurrentPTYSize(session)
 	}
@@ -1137,12 +1169,22 @@ func (h *wsPTYHub) closeAll() {
 	}
 }
 
+type wsPTYInputWriteResult struct {
+	status wsPTYInputWriteStatus
+	got    uint64
+	want   uint64
+}
+
 func (h *wsPTYHub) writeInputByID(sessionID string, attachmentID string, attachmentToken string, payload []byte) wsPTYInputWriteStatus {
+	return h.writeInputByIDWithSeq(sessionID, attachmentID, attachmentToken, payload, 0, false).status
+}
+
+func (h *wsPTYHub) writeInputByIDWithSeq(sessionID string, attachmentID string, attachmentToken string, payload []byte, seq uint64, hasSeq bool) wsPTYInputWriteResult {
 	attachment := h.attachmentByID(sessionID, attachmentID, attachmentToken)
 	if attachment == nil {
-		return wsPTYInputWriteNotFound
+		return wsPTYInputWriteResult{status: wsPTYInputWriteNotFound}
 	}
-	return h.writeInput(attachment, payload)
+	return h.writeInput(attachment, payload, seq, hasSeq)
 }
 
 func (h *wsPTYHub) resizeByID(sessionID string, attachmentID string, attachmentToken string, cols int, rows int) bool {
@@ -1520,13 +1562,13 @@ func (h *wsPTYHub) applyPTYSizeWithWriteLock(session *wsPTYSession, cols int, ro
 	return false
 }
 
-func (h *wsPTYHub) writeInput(attachment *wsPTYAttachment, payload []byte) wsPTYInputWriteStatus {
+func (h *wsPTYHub) writeInput(attachment *wsPTYAttachment, payload []byte, seq uint64, hasSeq bool) wsPTYInputWriteResult {
 	session := h.sessionForAttachment(attachment.sessionKey)
 	if session == nil {
-		return wsPTYInputWriteNotFound
+		return wsPTYInputWriteResult{status: wsPTYInputWriteNotFound}
 	}
 	if len(payload) == 0 {
-		return wsPTYInputWriteOK
+		return wsPTYInputWriteResult{status: wsPTYInputWriteOK}
 	}
 
 	h.mu.Lock()
@@ -1536,19 +1578,23 @@ func (h *wsPTYHub) writeInput(attachment *wsPTYAttachment, payload []byte) wsPTY
 		session.input != nil
 	h.mu.Unlock()
 	if !current {
-		return wsPTYInputWriteNotFound
+		return wsPTYInputWriteResult{status: wsPTYInputWriteNotFound}
 	}
 
 	chunks := make([]wsPTYInputChunk, 0, (len(payload)+defaultPTYInputChunkBytes-1)/defaultPTYInputChunkBytes)
+	remaining := len(payload)
 	for len(payload) > 0 {
 		chunkLen := len(payload)
 		if chunkLen > defaultPTYInputChunkBytes {
 			chunkLen = defaultPTYInputChunkBytes
 		}
+		remaining -= chunkLen
 		chunks = append(chunks, wsPTYInputChunk{
-			attachmentID: attachment.id,
-			attachment:   attachment,
-			payload:      append([]byte(nil), payload[:chunkLen]...),
+			attachmentID:  attachment.id,
+			attachment:    attachment,
+			payload:       append([]byte(nil), payload[:chunkLen]...),
+			seq:           seq,
+			finalSeqChunk: attachment.inputSeqAck && remaining == 0,
 		})
 		payload = payload[chunkLen:]
 	}
@@ -1561,24 +1607,43 @@ func (h *wsPTYHub) writeInput(attachment *wsPTYAttachment, payload []byte) wsPTY
 		!session.closed &&
 		session.attachments[attachment.id] == attachment &&
 		session.input != nil
+	if current && attachment.inputSeqAck {
+		want := attachment.lastAcceptedSeq + 1
+		if !hasSeq || seq != want {
+			h.mu.Unlock()
+			return wsPTYInputWriteResult{status: wsPTYInputWriteSeqGap, got: seq, want: want}
+		}
+	}
 	h.mu.Unlock()
 	if !current {
-		return wsPTYInputWriteNotFound
+		return wsPTYInputWriteResult{status: wsPTYInputWriteNotFound}
 	}
 	if len(chunks) > cap(session.input)-len(session.input) {
 		if h.stderr != nil {
 			_, _ = fmt.Fprintf(h.stderr, "ws pty input queue full session=%s attachment=%s\n", session.id, attachment.id)
 		}
-		return wsPTYInputWriteQueueFull
+		return wsPTYInputWriteResult{status: wsPTYInputWriteQueueFull}
+	}
+	if attachment.inputSeqAck {
+		h.mu.Lock()
+		if h.sessions[attachment.sessionKey] != session ||
+			session.closed ||
+			session.attachments[attachment.id] != attachment ||
+			session.input == nil {
+			h.mu.Unlock()
+			return wsPTYInputWriteResult{status: wsPTYInputWriteNotFound}
+		}
+		attachment.lastAcceptedSeq = seq
+		h.mu.Unlock()
 	}
 	for _, chunk := range chunks {
 		select {
 		case session.input <- chunk:
 		case <-session.done:
-			return wsPTYInputWriteNotFound
+			return wsPTYInputWriteResult{status: wsPTYInputWriteNotFound}
 		}
 	}
-	return wsPTYInputWriteOK
+	return wsPTYInputWriteResult{status: wsPTYInputWriteOK}
 }
 
 func (h *wsPTYHub) writeInputLoop(session *wsPTYSession) {
@@ -1593,18 +1658,24 @@ func (h *wsPTYHub) writeInputLoop(session *wsPTYSession) {
 }
 
 func (h *wsPTYHub) writeInputChunk(session *wsPTYSession, chunk wsPTYInputChunk) bool {
+	if chunk.flushDone != nil {
+		close(chunk.flushDone)
+		return true
+	}
 	session.ptyWriteMu.Lock()
 	defer session.ptyWriteMu.Unlock()
 
 	h.mu.Lock()
-	current := h.sessions[session.key] == session &&
-		!session.closed &&
-		session.attachments[chunk.attachmentID] == chunk.attachment
+	current := h.sessions[session.key] == session && !session.closed
 	ptyFile := session.ptyFile
 	h.mu.Unlock()
 	if !current || ptyFile == nil {
 		return false
 	}
+	return h.writeInputChunkWithPTYFile(ptyFile, chunk)
+}
+
+func (h *wsPTYHub) writeInputChunkWithPTYFile(ptyFile *os.File, chunk wsPTYInputChunk) bool {
 	total := 0
 	for total < len(chunk.payload) {
 		n, err := ptyFile.Write(chunk.payload[total:])
@@ -1618,7 +1689,36 @@ func (h *wsPTYHub) writeInputChunk(session *wsPTYSession, chunk wsPTYInputChunk)
 			return false
 		}
 	}
+	h.ackInputChunk(chunk)
 	return true
+}
+
+// flushAcceptedInput blocks until every input chunk enqueued before the call
+// has been written to the PTY. writeInputLoop stays the sole consumer of
+// session.input (a second consumer could reorder a chunk the loop already
+// dequeued but has not yet written); the barrier sentinel is enqueued under
+// inputEnqueueMu so no concurrent write can slip in ahead of it.
+func (h *wsPTYHub) flushAcceptedInput(session *wsPTYSession) {
+	session.inputEnqueueMu.Lock()
+	flushDone := make(chan struct{})
+	select {
+	case session.input <- wsPTYInputChunk{flushDone: flushDone}:
+	case <-session.done:
+		session.inputEnqueueMu.Unlock()
+		return
+	}
+	session.inputEnqueueMu.Unlock()
+	select {
+	case <-flushDone:
+	case <-session.done:
+	}
+}
+
+func (h *wsPTYHub) ackInputChunk(chunk wsPTYInputChunk) {
+	if !chunk.finalSeqChunk || chunk.attachment == nil || !chunk.attachment.inputSeqAck {
+		return
+	}
+	chunk.attachment.enqueueInputAck(chunk.seq)
 }
 
 func (h *wsPTYHub) sessionForAttachment(sessionKey wsPTYSessionKey) *wsPTYSession {
@@ -1706,6 +1806,38 @@ func (a *wsPTYAttachment) enqueue(messageType websocket.MessageType, payload []b
 	}
 }
 
+func (a *wsPTYAttachment) enqueueInputAck(seq uint64) bool {
+	a.ackMu.Lock()
+	if seq > a.ackSeq {
+		a.ackSeq = seq
+	}
+	if a.ackQueued {
+		a.ackMu.Unlock()
+		return true
+	}
+	a.ackQueued = true
+	a.ackMu.Unlock()
+
+	select {
+	case a.send <- wsPTYOutgoingFrame{inputAck: true}:
+		return true
+	default:
+		a.ackMu.Lock()
+		a.ackQueued = false
+		a.ackMu.Unlock()
+		a.cancel()
+		return false
+	}
+}
+
+func (a *wsPTYAttachment) consumeInputAck() uint64 {
+	a.ackMu.Lock()
+	defer a.ackMu.Unlock()
+	seq := a.ackSeq
+	a.ackQueued = false
+	return seq
+}
+
 func (a *wsPTYAttachment) writeLoop(ctx context.Context, conn *websocket.Conn, sessionDone <-chan struct{}) {
 	for {
 		select {
@@ -1753,6 +1885,15 @@ func (a *wsPTYAttachment) writeFrame(ctx context.Context, conn *websocket.Conn, 
 }
 
 func rpcPTYEventForFrame(attachment *wsPTYAttachment, frame wsPTYOutgoingFrame) rpcEvent {
+	if frame.inputAck {
+		return rpcEvent{
+			Event:           "pty.input_ack",
+			SessionID:       attachment.sessionKey.sessionID,
+			AttachmentID:    attachment.id,
+			AttachmentToken: attachment.clientToken,
+			Seq:             attachment.consumeInputAck(),
+		}
+	}
 	event := rpcEvent{
 		Event:           "pty.data",
 		SessionID:       attachment.sessionKey.sessionID,
@@ -1805,7 +1946,7 @@ func pumpWebSocketToPTY(ctx context.Context, hub *wsPTYHub, attachment *wsPTYAtt
 		}
 		switch msgType {
 		case websocket.MessageBinary:
-			if status := hub.writeInput(attachment, payload); status != wsPTYInputWriteOK {
+			if status := hub.writeInput(attachment, payload, 0, false).status; status != wsPTYInputWriteOK {
 				return
 			}
 		case websocket.MessageText:

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -65,7 +65,7 @@ func TestAttachRPCSurfacesPTYAllocationFailure(t *testing.T) {
 		return nil, nil, denied
 	}
 
-	_, _, _, err := hub.attachRPC(context.Background(), "sess-1", "att-1", 80, 24, "", "", false)
+	_, _, _, err := hub.attachRPC(context.Background(), "sess-1", "att-1", 80, 24, "", "", false, false)
 	if err == nil {
 		t.Fatalf("expected attachRPC to fail when PTY allocation is denied")
 	}
@@ -429,6 +429,182 @@ func TestWebSocketPTYReplacedAttachmentCannotWriteInput(t *testing.T) {
 	}
 	waitForNormalCloseWithOutput(t, ctx, newConn, 5*time.Second, output)
 	waitForHubSessionCount(t, hub, 0, 5*time.Second)
+}
+
+func TestWebSocketPTYReattachWritesAcceptedOldInputBeforeNew(t *testing.T) {
+	hub, session, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-reattach-seam", "same", false)
+	defer close(done)
+	defer readFile.Close()
+	defer writeFile.Close()
+
+	go hub.writeInputLoop(session)
+	session.ptyWriteMu.Lock()
+	if status := hub.writeInputByID(session.id, attachment.id, attachment.clientToken, []byte("OLD")); status != wsPTYInputWriteOK {
+		session.ptyWriteMu.Unlock()
+		t.Fatalf("old write status = %v, want ok", status)
+	}
+
+	attachDone := make(chan *wsPTYAttachment, 1)
+	go func() {
+		newAttachment, _, _, err := hub.prepareAttachment(
+			context.Background(),
+			nil,
+			session.id,
+			attachment.id,
+			80,
+			24,
+			true,
+			"",
+			"new-token",
+			true,
+			false,
+		)
+		if err != nil {
+			t.Errorf("prepare replacement attachment: %v", err)
+			attachDone <- nil
+			return
+		}
+		attachDone <- newAttachment
+	}()
+
+	session.ptyWriteMu.Unlock()
+	newAttachment := <-attachDone
+	if newAttachment == nil {
+		t.Fatal("replacement attachment was not created")
+	}
+	if status := hub.writeInputByID(session.id, newAttachment.id, newAttachment.clientToken, []byte("NEW")); status != wsPTYInputWriteOK {
+		t.Fatalf("new write status = %v, want ok", status)
+	}
+	if got := readExactlyFromFile(t, readFile, 6, 5*time.Second); string(got) != "OLDNEW" {
+		t.Fatalf("PTY input = %q, want OLDNEW", string(got))
+	}
+}
+
+func TestWebSocketPTYInputSeqEnforcement(t *testing.T) {
+	hub, session, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-seq", "seq-att", true)
+	defer close(done)
+	defer readFile.Close()
+	defer writeFile.Close()
+	attachment.inputSeqAck = true
+
+	go hub.writeInputLoop(session)
+	if result := hub.writeInputByIDWithSeq(session.id, attachment.id, attachment.clientToken, []byte("A"), 1, true); result.status != wsPTYInputWriteOK {
+		t.Fatalf("seq 1 status = %v, want ok", result.status)
+	}
+	if result := hub.writeInputByIDWithSeq(session.id, attachment.id, attachment.clientToken, []byte("B"), 2, true); result.status != wsPTYInputWriteOK {
+		t.Fatalf("seq 2 status = %v, want ok", result.status)
+	}
+	if result := hub.writeInputByIDWithSeq(session.id, attachment.id, attachment.clientToken, []byte("D"), 4, true); result.status != wsPTYInputWriteSeqGap || result.got != 4 || result.want != 3 {
+		t.Fatalf("seq 4 result = %+v, want gap got=4 want=3", result)
+	}
+	if got := readExactlyFromFile(t, readFile, 2, 5*time.Second); string(got) != "AB" {
+		t.Fatalf("PTY input = %q, want AB", string(got))
+	}
+
+	replacement, _, _, err := hub.prepareAttachment(context.Background(), nil, session.id, attachment.id, 80, 24, true, "", "seq-token-2", true, true)
+	if err != nil {
+		t.Fatalf("prepare replacement attachment: %v", err)
+	}
+	if result := hub.writeInputByIDWithSeq(session.id, replacement.id, replacement.clientToken, []byte("C"), 1, true); result.status != wsPTYInputWriteOK {
+		t.Fatalf("fresh attachment seq 1 status = %v, want ok", result.status)
+	}
+	if got := readExactlyFromFile(t, readFile, 1, 5*time.Second); string(got) != "C" {
+		t.Fatalf("fresh PTY input = %q, want C", string(got))
+	}
+}
+
+func TestWebSocketPTYInputSeqGapNotificationEmitsPTYError(t *testing.T) {
+	hub, _, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-seq-event", "seq-att", true)
+	defer close(done)
+	defer readFile.Close()
+	defer writeFile.Close()
+	attachment.inputSeqAck = true
+
+	writer := &captureRPCFrameWriter{}
+	server := &rpcServer{ptyHub: hub, frameWriter: writer}
+	req := rpcRequest{
+		Method: "pty.write",
+		Params: map[string]any{
+			"session_id":              "sess-seq-event",
+			"attachment_id":           "seq-att",
+			"client_attachment_token": "token-1",
+			"data_base64":             base64.StdEncoding.EncodeToString([]byte("gap")),
+			"seq":                     2,
+		},
+	}
+	resp := server.handlePTYWrite(req)
+	if resp.OK || resp.Error == nil || resp.Error.Code != "pty_input_seq_gap" {
+		t.Fatalf("gapped write response = %+v, want pty_input_seq_gap", resp)
+	}
+	if err := server.handleNotificationResponse(req, resp); err != nil {
+		t.Fatalf("handle notification response: %v", err)
+	}
+	if len(writer.events) != 1 {
+		t.Fatalf("events = %d, want 1", len(writer.events))
+	}
+	event := writer.events[0]
+	if event.Event != "pty.error" || !strings.Contains(event.Message, "got 2, want 1") {
+		t.Fatalf("event = %+v, want visible seq gap pty.error", event)
+	}
+}
+
+func TestWebSocketPTYInputAckEmission(t *testing.T) {
+	hub, session, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-ack", "ack-att", true)
+	defer close(done)
+	defer readFile.Close()
+	defer writeFile.Close()
+	attachment.inputSeqAck = true
+
+	for seq := uint64(1); seq <= 10; seq++ {
+		chunk := wsPTYInputChunk{
+			attachmentID:  attachment.id,
+			attachment:    attachment,
+			payload:       []byte("x"),
+			seq:           seq,
+			finalSeqChunk: true,
+		}
+		if !hub.writeInputChunk(session, chunk) {
+			t.Fatalf("write seq %d failed", seq)
+		}
+	}
+	frame := <-attachment.send
+	event := rpcPTYEventForFrame(attachment, frame)
+	if event.Event != "pty.input_ack" || event.Seq != 10 {
+		t.Fatalf("ack event = %+v, want cumulative seq 10", event)
+	}
+	select {
+	case extra := <-attachment.send:
+		t.Fatalf("ack was not coalesced; extra frame=%+v", extra)
+	default:
+	}
+
+	legacyAttachment := &wsPTYAttachment{
+		sessionKey:  session.key,
+		id:          "legacy-att",
+		clientToken: "legacy-token",
+		send:        make(chan wsPTYOutgoingFrame, defaultWebSocketWriteQueueCap),
+		cancel:      func() {},
+		persistent:  true,
+		inputSeqAck: false,
+	}
+	hub.mu.Lock()
+	session.attachments[legacyAttachment.id] = legacyAttachment
+	hub.mu.Unlock()
+	chunk := wsPTYInputChunk{
+		attachmentID:  legacyAttachment.id,
+		attachment:    legacyAttachment,
+		payload:       []byte("y"),
+		seq:           1,
+		finalSeqChunk: true,
+	}
+	if !hub.writeInputChunk(session, chunk) {
+		t.Fatal("legacy write failed")
+	}
+	select {
+	case frame := <-legacyAttachment.send:
+		t.Fatalf("legacy attachment received unexpected ack frame=%+v", frame)
+	default:
+	}
 }
 
 func TestWebSocketPTYMultiAttachUsesSmallestResize(t *testing.T) {
@@ -902,6 +1078,84 @@ func TestWebSocketPTYInputBackpressureRejectsWholePayload(t *testing.T) {
 	}
 }
 
+func newTestPTYInputSession(t *testing.T, sessionID string, attachmentID string, inputSeqAck bool) (*wsPTYHub, *wsPTYSession, *wsPTYAttachment, *os.File, *os.File, chan struct{}) {
+	t.Helper()
+	readFile, writeFile, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	hub := newWebSocketPTYHub(wsPTYServerConfig{
+		Shell:           "/bin/sh",
+		ScrollbackLimit: 4096,
+	}, &bytes.Buffer{})
+	sessionKey := persistentPTYSessionKey(sessionID)
+	done := make(chan struct{})
+	attachment := &wsPTYAttachment{
+		sessionKey:  sessionKey,
+		id:          attachmentID,
+		clientToken: "token-1",
+		cols:        80,
+		rows:        24,
+		send:        make(chan wsPTYOutgoingFrame, defaultWebSocketWriteQueueCap),
+		cancel:      func() {},
+		persistent:  true,
+		inputSeqAck: inputSeqAck,
+	}
+	session := &wsPTYSession{
+		id:            sessionID,
+		key:           sessionKey,
+		ptyFile:       writeFile,
+		attachments:   map[string]*wsPTYAttachment{attachment.id: attachment},
+		effectiveCols: 80,
+		effectiveRows: 24,
+		lastKnownCols: 80,
+		lastKnownRows: 24,
+		input:         make(chan wsPTYInputChunk, defaultPTYInputQueueCap),
+		done:          done,
+	}
+	hub.mu.Lock()
+	hub.sessions[session.key] = session
+	hub.mu.Unlock()
+	return hub, session, attachment, readFile, writeFile, done
+}
+
+func readExactlyFromFile(t *testing.T, file *os.File, count int, timeout time.Duration) []byte {
+	t.Helper()
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	resultCh := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, count)
+		_, err := io.ReadFull(file, buf)
+		resultCh <- readResult{data: buf, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("read PTY input: %v", result.err)
+		}
+		return result.data
+	case <-time.After(timeout):
+		t.Fatalf("timed out reading %d PTY bytes", count)
+		return nil
+	}
+}
+
+type captureRPCFrameWriter struct {
+	events []rpcEvent
+}
+
+func (w *captureRPCFrameWriter) writeResponse(rpcResponse) error {
+	return nil
+}
+
+func (w *captureRPCFrameWriter) writeEvent(event rpcEvent) error {
+	w.events = append(w.events, event)
+	return nil
+}
+
 func TestWebSocketPTYReapsDetachedIdleSession(t *testing.T) {
 	leasePath := filepath.Join(t.TempDir(), "lease.json")
 	stderr := &bytes.Buffer{}
@@ -1235,119 +1489,4 @@ func (h *wsPTYHub) sessionPTYSize(sessionID string) (cols int, rows int, ok bool
 		return 0, 0, true, err
 	}
 	return int(size.Cols), int(size.Rows), true, nil
-}
-
-func newTestPTYInputSession(t *testing.T, sessionID string, attachmentID string) (*wsPTYHub, *wsPTYSession, *wsPTYAttachment, *os.File, *os.File, chan struct{}) {
-	t.Helper()
-	readFile, writeFile, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create pipe: %v", err)
-	}
-	hub := newWebSocketPTYHub(wsPTYServerConfig{
-		Shell:           "/bin/sh",
-		ScrollbackLimit: 4096,
-	}, &bytes.Buffer{})
-	sessionKey := persistentPTYSessionKey(sessionID)
-	done := make(chan struct{})
-	attachment := &wsPTYAttachment{
-		sessionKey:  sessionKey,
-		id:          attachmentID,
-		clientToken: "token-1",
-		cols:        80,
-		rows:        24,
-		send:        make(chan wsPTYOutgoingFrame, defaultWebSocketWriteQueueCap),
-		cancel:      func() {},
-		persistent:  true,
-	}
-	session := &wsPTYSession{
-		id:            sessionID,
-		key:           sessionKey,
-		ptyFile:       writeFile,
-		attachments:   map[string]*wsPTYAttachment{attachment.id: attachment},
-		effectiveCols: 80,
-		effectiveRows: 24,
-		lastKnownCols: 80,
-		lastKnownRows: 24,
-		input:         make(chan wsPTYInputChunk, defaultPTYInputQueueCap),
-		done:          done,
-	}
-	hub.mu.Lock()
-	hub.sessions[session.key] = session
-	hub.mu.Unlock()
-	return hub, session, attachment, readFile, writeFile, done
-}
-
-func readExactlyFromFile(t *testing.T, file *os.File, count int, timeout time.Duration) []byte {
-	t.Helper()
-	type readResult struct {
-		data []byte
-		err  error
-	}
-	resultCh := make(chan readResult, 1)
-	go func() {
-		buf := make([]byte, count)
-		_, err := io.ReadFull(file, buf)
-		resultCh <- readResult{data: buf, err: err}
-	}()
-	select {
-	case result := <-resultCh:
-		if result.err != nil {
-			t.Fatalf("read PTY input: %v", result.err)
-		}
-		return result.data
-	case <-time.After(timeout):
-		t.Fatalf("timed out reading %d PTY bytes", count)
-		return nil
-	}
-}
-
-// Regression test for https://github.com/manaflow-ai/cmux/issues/7708:
-// input accepted by a superseded attachment must reach the PTY, in order,
-// before input from the replacement attachment.
-func TestWebSocketPTYReattachWritesAcceptedOldInputBeforeNew(t *testing.T) {
-	hub, session, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-reattach-seam", "same")
-	defer close(done)
-	defer readFile.Close()
-	defer writeFile.Close()
-
-	go hub.writeInputLoop(session)
-	session.ptyWriteMu.Lock()
-	if status := hub.writeInputByID(session.id, attachment.id, attachment.clientToken, []byte("OLD")); status != wsPTYInputWriteOK {
-		session.ptyWriteMu.Unlock()
-		t.Fatalf("old write status = %v, want ok", status)
-	}
-
-	attachDone := make(chan *wsPTYAttachment, 1)
-	go func() {
-		newAttachment, _, _, err := hub.prepareAttachment(
-			context.Background(),
-			nil,
-			session.id,
-			attachment.id,
-			80,
-			24,
-			true,
-			"",
-			"new-token",
-			true,
-		)
-		if err != nil {
-			t.Errorf("prepare replacement attachment: %v", err)
-			attachDone <- nil
-			return
-		}
-		attachDone <- newAttachment
-	}()
-
-	session.ptyWriteMu.Unlock()
-	newAttachment := <-attachDone
-	if newAttachment == nil {
-		t.Fatal("replacement attachment was not created")
-	}
-	if status := hub.writeInputByID(session.id, newAttachment.id, newAttachment.clientToken, []byte("NEW")); status != wsPTYInputWriteOK {
-		t.Fatalf("new write status = %v, want ok", status)
-	}
-	if got := readExactlyFromFile(t, readFile, 6, 5*time.Second); string(got) != "OLDNEW" {
-		t.Fatalf("PTY input = %q, want OLDNEW", string(got))
-	}
 }

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -513,6 +513,32 @@ func TestWebSocketPTYInputSeqEnforcement(t *testing.T) {
 	}
 }
 
+func TestWebSocketPTYWriteRejectsMalformedSeq(t *testing.T) {
+	hub, _, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-seq-invalid", "seq-att", true)
+	defer close(done)
+	defer readFile.Close()
+	defer writeFile.Close()
+	attachment.inputSeqAck = true
+
+	server := &rpcServer{ptyHub: hub, frameWriter: &captureRPCFrameWriter{}}
+	for _, badSeq := range []any{"not-a-number", -1, 1.5} {
+		req := rpcRequest{
+			Method: "pty.write",
+			Params: map[string]any{
+				"session_id":              "sess-seq-invalid",
+				"attachment_id":           "seq-att",
+				"client_attachment_token": "token-1",
+				"data_base64":             base64.StdEncoding.EncodeToString([]byte("x")),
+				"seq":                     badSeq,
+			},
+		}
+		resp := server.handlePTYWrite(req)
+		if resp.OK || resp.Error == nil || resp.Error.Code != "invalid_params" {
+			t.Fatalf("seq=%v response = %+v, want invalid_params", badSeq, resp)
+		}
+	}
+}
+
 func TestWebSocketPTYInputSeqGapNotificationEmitsPTYError(t *testing.T) {
 	hub, _, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-seq-event", "seq-att", true)
 	defer close(done)

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -467,14 +467,24 @@ func TestWebSocketPTYReattachWritesAcceptedOldInputBeforeNew(t *testing.T) {
 		attachDone <- newAttachment
 	}()
 
-	session.ptyWriteMu.Unlock()
-	newAttachment := <-attachDone
+	// Reattach must complete while the PTY writer is still stalled — a
+	// wedged reader must never turn reattach into an indefinite hang.
+	var newAttachment *wsPTYAttachment
+	select {
+	case newAttachment = <-attachDone:
+	case <-time.After(5 * time.Second):
+		session.ptyWriteMu.Unlock()
+		t.Fatal("reattach blocked behind a stalled PTY writer")
+	}
 	if newAttachment == nil {
+		session.ptyWriteMu.Unlock()
 		t.Fatal("replacement attachment was not created")
 	}
 	if status := hub.writeInputByID(session.id, newAttachment.id, newAttachment.clientToken, []byte("NEW")); status != wsPTYInputWriteOK {
+		session.ptyWriteMu.Unlock()
 		t.Fatalf("new write status = %v, want ok", status)
 	}
+	session.ptyWriteMu.Unlock()
 	if got := readExactlyFromFile(t, readFile, 6, 5*time.Second); string(got) != "OLDNEW" {
 		t.Fatalf("PTY input = %q, want OLDNEW", string(got))
 	}
@@ -571,6 +581,12 @@ func TestWebSocketPTYInputSeqGapNotificationEmitsPTYError(t *testing.T) {
 	event := writer.events[0]
 	if event.Event != "pty.error" || !strings.Contains(event.Message, "got 2, want 1") {
 		t.Fatalf("event = %+v, want visible seq gap pty.error", event)
+	}
+	hub.mu.Lock()
+	_, stillAttached := hub.sessions[persistentPTYSessionKey("sess-seq-event")].attachments["seq-att"]
+	hub.mu.Unlock()
+	if stillAttached {
+		t.Fatal("seq-gap error should detach the attachment, not leave it registered")
 	}
 }
 

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -1234,4 +1235,119 @@ func (h *wsPTYHub) sessionPTYSize(sessionID string) (cols int, rows int, ok bool
 		return 0, 0, true, err
 	}
 	return int(size.Cols), int(size.Rows), true, nil
+}
+
+func newTestPTYInputSession(t *testing.T, sessionID string, attachmentID string) (*wsPTYHub, *wsPTYSession, *wsPTYAttachment, *os.File, *os.File, chan struct{}) {
+	t.Helper()
+	readFile, writeFile, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	hub := newWebSocketPTYHub(wsPTYServerConfig{
+		Shell:           "/bin/sh",
+		ScrollbackLimit: 4096,
+	}, &bytes.Buffer{})
+	sessionKey := persistentPTYSessionKey(sessionID)
+	done := make(chan struct{})
+	attachment := &wsPTYAttachment{
+		sessionKey:  sessionKey,
+		id:          attachmentID,
+		clientToken: "token-1",
+		cols:        80,
+		rows:        24,
+		send:        make(chan wsPTYOutgoingFrame, defaultWebSocketWriteQueueCap),
+		cancel:      func() {},
+		persistent:  true,
+	}
+	session := &wsPTYSession{
+		id:            sessionID,
+		key:           sessionKey,
+		ptyFile:       writeFile,
+		attachments:   map[string]*wsPTYAttachment{attachment.id: attachment},
+		effectiveCols: 80,
+		effectiveRows: 24,
+		lastKnownCols: 80,
+		lastKnownRows: 24,
+		input:         make(chan wsPTYInputChunk, defaultPTYInputQueueCap),
+		done:          done,
+	}
+	hub.mu.Lock()
+	hub.sessions[session.key] = session
+	hub.mu.Unlock()
+	return hub, session, attachment, readFile, writeFile, done
+}
+
+func readExactlyFromFile(t *testing.T, file *os.File, count int, timeout time.Duration) []byte {
+	t.Helper()
+	type readResult struct {
+		data []byte
+		err  error
+	}
+	resultCh := make(chan readResult, 1)
+	go func() {
+		buf := make([]byte, count)
+		_, err := io.ReadFull(file, buf)
+		resultCh <- readResult{data: buf, err: err}
+	}()
+	select {
+	case result := <-resultCh:
+		if result.err != nil {
+			t.Fatalf("read PTY input: %v", result.err)
+		}
+		return result.data
+	case <-time.After(timeout):
+		t.Fatalf("timed out reading %d PTY bytes", count)
+		return nil
+	}
+}
+
+// Regression test for https://github.com/manaflow-ai/cmux/issues/7708:
+// input accepted by a superseded attachment must reach the PTY, in order,
+// before input from the replacement attachment.
+func TestWebSocketPTYReattachWritesAcceptedOldInputBeforeNew(t *testing.T) {
+	hub, session, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-reattach-seam", "same")
+	defer close(done)
+	defer readFile.Close()
+	defer writeFile.Close()
+
+	go hub.writeInputLoop(session)
+	session.ptyWriteMu.Lock()
+	if status := hub.writeInputByID(session.id, attachment.id, attachment.clientToken, []byte("OLD")); status != wsPTYInputWriteOK {
+		session.ptyWriteMu.Unlock()
+		t.Fatalf("old write status = %v, want ok", status)
+	}
+
+	attachDone := make(chan *wsPTYAttachment, 1)
+	go func() {
+		newAttachment, _, _, err := hub.prepareAttachment(
+			context.Background(),
+			nil,
+			session.id,
+			attachment.id,
+			80,
+			24,
+			true,
+			"",
+			"new-token",
+			true,
+		)
+		if err != nil {
+			t.Errorf("prepare replacement attachment: %v", err)
+			attachDone <- nil
+			return
+		}
+		attachDone <- newAttachment
+	}()
+
+	session.ptyWriteMu.Unlock()
+	newAttachment := <-attachDone
+	if newAttachment == nil {
+		t.Fatal("replacement attachment was not created")
+	}
+	if status := hub.writeInputByID(session.id, newAttachment.id, newAttachment.clientToken, []byte("NEW")); status != wsPTYInputWriteOK {
+		t.Fatalf("new write status = %v, want ok", status)
+	}
+	if got := readExactlyFromFile(t, readFile, 6, 5*time.Second); string(got) != "OLDNEW" {
+		t.Fatalf("PTY input = %q, want OLDNEW", string(got))
+	}
 }

--- a/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
+++ b/daemon/remote/cmd/cmuxd-remote/ws_pty_test.go
@@ -523,6 +523,38 @@ func TestWebSocketPTYInputSeqEnforcement(t *testing.T) {
 	}
 }
 
+func TestWebSocketPTYSaturatedAckQueueDropsAttachment(t *testing.T) {
+	hub, session, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-ack-full", "ack-att", true)
+	defer close(done)
+	defer readFile.Close()
+	defer writeFile.Close()
+	attachment.inputSeqAck = true
+
+	// Saturate the send queue so the coalesced ack frame cannot be queued.
+	for i := 0; i < cap(attachment.send); i++ {
+		attachment.send <- wsPTYOutgoingFrame{}
+	}
+	chunk := wsPTYInputChunk{
+		attachmentID:  attachment.id,
+		attachment:    attachment,
+		payload:       []byte("x"),
+		seq:           1,
+		finalSeqChunk: true,
+	}
+	if !hub.writeInputChunk(session, chunk) {
+		t.Fatal("payload write should still succeed")
+	}
+	if got := readExactlyFromFile(t, readFile, 1, 5*time.Second); string(got) != "x" {
+		t.Fatalf("PTY input = %q, want x", string(got))
+	}
+	hub.mu.Lock()
+	_, stillAttached := session.attachments[attachment.id]
+	hub.mu.Unlock()
+	if stillAttached {
+		t.Fatal("attachment with a saturated ack queue should be dropped, not leaked")
+	}
+}
+
 func TestWebSocketPTYWriteRejectsMalformedSeq(t *testing.T) {
 	hub, _, attachment, readFile, writeFile, done := newTestPTYInputSession(t, "sess-seq-invalid", "seq-att", true)
 	defer close(done)


### PR DESCRIPTION
Fixes #7708

## Problem

`cmux ssh` keystrokes could be garbled, reordered, or silently lost at reconnect and backpressure seams. The rendering-side bug was fixed in #6831; this PR closes the **input** direction, where `pty.write` had no sequencing, no acks, and no loss surfacing. Four root causes, all present on main:

1. **Reconnect input filter over-stripping** (`CLI/SSHPTYAttachReconnectInputFilter.swift`): the post-reattach probe-reply filter window was unbounded until first output, so real ESC-prefixed keystrokes (arrows, alt-combos, bracketed paste) typed in that window could be eaten (prior bugs: #6070, #5989).
2. **Reattach seam drop/interleave** (`daemon/remote/cmd/cmuxd-remote/ws_pty.go`): input chunks queued by a superseded attachment were silently dropped at reattach — bytes typed just before a disconnect vanished, and the seam was not quiesced.
3. **Silent overflow loss**: the daemon atomically rejected a whole `pty.write` on queue overflow after the bytes were already consumed from local stdin, and the app-side `RemotePTYBridgeSession` closed the whole session on window overflow — accepted bytes lost either way.
4. **Structural enabler**: `pty.write` was fire-and-forget — nothing could detect a gap or reorder.

## Fix

Sequenced, cumulatively-acked `pty.write` with sender-side windowed flow control, capability-gated for mixed versions:

- **Wire protocol (all additive)**: daemon `hello` advertises `pty.input.seq_ack`; `pty.attach` takes optional `input_seq_ack`; `pty.write` takes optional `seq` (strictly `last+1` per attachment, gaps rejected with wire-pinned `pty_input_seq_gap` → visible `pty.error` + daemon-side detach, never a silent write; a present-but-malformed `seq` is rejected with `invalid_params`); new coalesced cumulative `pty.input_ack` event emitted only to opted-in attachments after bytes hit the PTY fd, with out-of-range acks treated as a protocol violation by the app. Writes stay async notifications — the typing-latency win from 719a231c73 is preserved.
- **Seam ordering without drops**: input a superseded attachment already had accepted stays queued and reaches the PTY ahead of anything the replacement enqueues — `session.input` is FIFO with `writeInputLoop` as its only consumer, whole writes enqueue atomically under `inputEnqueueMu`, and `writeInputChunk` no longer drops chunks whose attachment was replaced (the original loss bug). Reattach never waits on that drain, so a wedged PTY (stopped foreground process) cannot hang the attach path; the seam test asserts attach completes while the PTY writer is stalled.
- **Backpressure instead of loss**: `RemotePTYBridgeSession` gets a queue-confined flow controller (`RemotePTYBridgeInputFlow`, new file) that pauses socket receives at the window (4 MiB / 256 writes), splits writes to ≤256 KiB so no RPC frame can exceed the daemon's 4 MiB limit, and resumes on drain — cumulative acks in seq_ack mode, write completions in legacy mode. No accepted byte is ever dropped and the session never closes on overflow, in either mode.
- **Bounded filter**: the reconnect input filter self-disables at a monotonic deadline (injectable clock; poll timeout capped by the remaining deadline, EINTR retries anchored to an absolute deadline) and flushes pending bytes on every pump exit (EOF, read error, poll failure) — it can only strip exact probe-reply sequences, never prefix bytes of real key sequences.

**Compatibility**: the capability is optional (not part of the required handshake set). New app ↔ old daemon falls back to legacy completion-drained windowing; old app ↔ new daemon sees no enforcement and no acks; raw `/terminal` websocket clients never see ack frames.

## Two-commit structure (regression policy)

- **Commit 1** (`test:`) adds only the two RED regression tests, written against main's APIs. Verified failing on main:
  - Go `TestWebSocketPTYReattachWritesAcceptedOldInputBeforeNew`: times out — "OLD" bytes dropped at the seam.
  - Swift `legacy input overflow pauses instead of closing and preserves order`: session closes, 4,182,004 of 5,242,880 bytes delivered.
- **Commit 2** (`fix:`) adds the fix plus the GREEN tests (seq enforcement, seq-gap → `pty.error`, cumulative/coalesced ack emission, acked-mode flow control, `pty.error` mid-stream teardown, filter deadline + seeded fuzz with keys before/between/after probe replies including lone ESC, capability/error-code pinning on both sides) and mechanically updates the RED tests to the new signatures.

## Verification

- `cd daemon/remote && go test ./cmd/cmuxd-remote/ -count=1` ✅ (and `go vet ./...`; new tests also pass with `-race`; the one `-race` failure, `TestPersistentDaemonPTYReattachSurvivesClientDisconnect`, reproduces on unmodified main — pre-existing writer-lifetime race, not introduced here)
- `swift test --package-path Packages/macOS/CmuxRemoteWorkspace` ✅ 51/51
- `swift test --package-path Packages/macOS/CmuxRemoteDaemon` ✅ 20/20
- `python3 scripts/swift_file_length_budget.py`: no TSV touched; all touched files at/under budget (`RemotePTYBridgeSession.swift` 479/506, filter 496/<500, `WorkspaceRemoteConnectionTests.swift` 7312/7312 line-neutral, `cmux.swift` untouched); remaining script failures are pre-existing files this PR does not modify
- `./scripts/lint-pbxproj-test-wiring.sh` ✅ (new `SSHPTYAttachReconnectInputFilterPumpIO.swift` wired into both targets)
- Localization audit: no user-facing strings added — only wire identifiers (`pty.input.seq_ack`, `pty_input_seq_gap`, `pty.input_ack`); errors surface through the existing localized `RemotePTYBridgeStrings` path. No `Localizable.xcstrings` changes needed.

Related (not closed by this PR): #2969, #6082, #6821.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches live SSH stdin forwarding, persistent PTY reconnect semantics, and daemon input ordering—bugs could garble, reorder, or lose keystrokes or hang reattach.
> 
> **Overview**
> Adds **optional, capability-gated sequenced PTY input** end-to-end: daemon advertises `pty.input.seq_ack`, attach can opt in with `input_seq_ack`, `pty.write` may carry monotonic `seq` (gaps → `pty_input_seq_gap`, visible `pty.error`, detach), and **`pty.input_ack`** reports cumulative progress after bytes hit the PTY. Swift RPC/bridge layers plumb `inputAck`, `supportsInputSeqAck`, and optional `seq` on writes.
> 
> On the **daemon**, reattach no longer drops input already accepted from a superseded attachment—`writeInputChunk` is session-scoped so queued FIFO input still reaches the PTY (without blocking reattach on a wedged writer). **App-side** `RemotePTYBridgeInputFlow` replaces naive pending-write counters with windowed flow control: pause socket reads at the cap, split large payloads, resume on write completion (legacy) or cumulative acks (seq mode).
> 
> **SSH reconnect stdin filtering** gets a **2s monotonic deadline** (poll timeouts capped; EINTR-safe absolute deadlines in extracted pump I/O), flushes pending bytes on pump exit, and `F_SETNOSIGPIPE` on stop pipes.
> 
> Regression tests cover seam ordering, seq enforcement/acks, overflow pause vs close, filter deadline/fuzz, and capability pinning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 79aa8e8505d7378054574c028045455af1854e68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->