### PR TITLE
fix: preserve pinned workspace cwd for terminals

### DIFF
--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1766,6 +1766,7 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var customDescription: String?
     var customColor: String?
     var isPinned: Bool
+    var pinnedWorkingDirectory: String? = nil
     var groupId: UUID? = nil
     var isManuallyUnread: Bool? = nil
     var hasUnreadIndicator: Bool? = nil

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -1725,16 +1725,25 @@ class TabManager: ObservableObject {
     }
 
     func togglePin(tabId: UUID) {
-        workspaceReordering.togglePin(tabId: tabId)
+        guard let tab = tabs.first(where: { $0.id == tabId }) else { return }
+        setPinned(tab, pinned: !tab.isPinned)
     }
 
     func setPinned(_ tab: Workspace, pinned: Bool) {
+        let wasPinned = tab.isPinned
         workspaceReordering.setPinned(tab, pinned: pinned)
+        if wasPinned != tab.isPinned {
+            tab.updatePinnedWorkingDirectoryForCurrentState()
+        }
     }
 
     @discardableResult
     func setPinned(workspaceIds: [UUID], pinned: Bool) -> [UUID] {
-        workspaceReordering.setPinned(workspaceIds: workspaceIds, pinned: pinned)
+        let changedWorkspaceIds = workspaceReordering.setPinned(workspaceIds: workspaceIds, pinned: pinned)
+        for workspaceId in changedWorkspaceIds {
+            tabs.first { $0.id == workspaceId }?.updatePinnedWorkingDirectoryForCurrentState()
+        }
+        return changedWorkspaceIds
     }
 
     // MARK: - Workspace Groups (WorkspaceGroupCoordinator, CmuxWorkspaces)
@@ -5575,6 +5584,7 @@ extension TabManager {
             hasher.combine(workspace.customDescription ?? "")
             hasher.combine(workspace.customColor ?? "")
             hasher.combine(workspace.isPinned)
+            hasher.combine(workspace.pinnedWorkingDirectory ?? "")
             hasher.combine(workspace.panels.count)
             hasher.combine(workspace.statusEntries.count)
             hasher.combine(workspace.metadataBlocks.count)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -128,6 +128,7 @@ extension Workspace {
             customDescription: customDescription,
             customColor: customColor,
             isPinned: isPinned,
+            pinnedWorkingDirectory: pinnedWorkingDirectory,
             groupId: groupId,
             isManuallyUnread: isWorkspaceManuallyUnread,
             hasUnreadIndicator: hasWorkspaceUnreadIndicator,
@@ -230,6 +231,12 @@ extension Workspace {
         setCustomDescription(snapshot.customDescription)
         setCustomColor(snapshot.customColor)
         isPinned = snapshot.isPinned
+        pinnedWorkingDirectory = isPinned
+            ? Self.normalizedTerminalWorkingDirectory(snapshot.pinnedWorkingDirectory)
+            : nil
+        if isPinned, pinnedWorkingDirectory == nil {
+            updatePinnedWorkingDirectoryForCurrentState()
+        }
         groupId = snapshot.groupId
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
@@ -1957,6 +1964,7 @@ final class Workspace: Identifiable, ObservableObject {
     @Published var customTitleSource: CustomTitleSource?
     @Published var customDescription: String?
     @Published var isPinned: Bool = false
+    @Published var pinnedWorkingDirectory: String?
     /// Identifier of the WorkspaceGroup this workspace belongs to, or nil if ungrouped.
     /// The group entity itself lives in `TabManager.workspaceGroups`.
     @Published var groupId: UUID?
@@ -3839,6 +3847,12 @@ final class Workspace: Identifiable, ObservableObject {
             }
         }
         return nil
+    }
+
+    func updatePinnedWorkingDirectoryForCurrentState() {
+        pinnedWorkingDirectory = isPinned
+            ? resolvedWorkingDirectory().flatMap(Self.normalizedTerminalWorkingDirectory)
+            : nil
     }
 
     private func surfaceKind(for panel: any Panel) -> String {
@@ -6843,6 +6857,9 @@ final class Workspace: Identifiable, ObservableObject {
     ) -> String? {
         if let requested = Self.normalizedTerminalWorkingDirectory(requestedWorkingDirectory) {
             return requested
+        }
+        if isPinned, let pinnedWorkingDirectory = Self.normalizedTerminalWorkingDirectory(pinnedWorkingDirectory) {
+            return pinnedWorkingDirectory
         }
         if let sourcePanelId,
            let rescued = resumedAgentPaneWorkingDirectoryRescue(panelId: sourcePanelId) {
@@ -10143,7 +10160,7 @@ final class Workspace: Identifiable, ObservableObject {
 
     /// Create a new terminal panel (used when replacing the last panel)
     @discardableResult
-    func createReplacementTerminalPanel() -> TerminalPanel {
+    func createReplacementTerminalPanel(workingDirectory: String? = nil) -> TerminalPanel {
         var replacementConfig = inheritedTerminalConfig(
             preferredPanelId: focusedPanelId,
             inPane: bonsplitController.focusedPaneId
@@ -10165,6 +10182,7 @@ final class Workspace: Identifiable, ObservableObject {
             workspaceId: id,
             context: GHOSTTY_SURFACE_CONTEXT_TAB,
             configTemplate: replacementConfig,
+            workingDirectory: workingDirectory,
             portOrdinal: portOrdinal,
             initialCommand: replacementInitialCommand,
             additionalEnvironment: startupEnvironmentMergingWorkspaceEnvironment([:])
@@ -12378,6 +12396,13 @@ extension Workspace: BonsplitDelegate {
             }
         }
 
+        let replacementWorkingDirectory = [
+            isPinned ? pinnedWorkingDirectory : nil,
+            (panel as? TerminalPanel)?.requestedWorkingDirectory,
+            panelDirectories[panelId],
+            currentDirectory,
+        ].lazy.compactMap(Self.normalizedTerminalWorkingDirectory).first
+
         let closedRemoteCleanupConfiguration = discardClosedPanelLifecycleState(
             panelId: panelId,
             tabId: tabId,
@@ -12421,7 +12446,7 @@ extension Workspace: BonsplitDelegate {
             #if DEBUG
             dlog("replacement.remoteDisconnect.fire target=\(pendingRemoteDisconnectReplacement?.target ?? "nil")")
             #endif
-            let replacement = createReplacementTerminalPanel()
+            let replacement = createReplacementTerminalPanel(workingDirectory: replacementWorkingDirectory)
             if let replacementTabId = surfaceIdFromPanelId(replacement.id),
                let replacementPane = bonsplitController.allPaneIds.first {
                 bonsplitController.focusPane(replacementPane)

--- a/cmuxTests/LastSurfaceClosePreferenceTests.swift
+++ b/cmuxTests/LastSurfaceClosePreferenceTests.swift
@@ -63,6 +63,68 @@ struct LastSurfaceClosePreferenceTests {
     }
 
     @Test
+    func tabCloseButtonReplacementKeepsClosedTerminalWorkingDirectory() throws {
+        try withManager(closeWorkspaceOnLastSurface: false) { manager in
+            let workspace = manager.addWorkspace(
+                workingDirectory: "/Users/cmux/project",
+                inheritWorkingDirectory: false
+            )
+            manager.selectWorkspace(workspace)
+
+            let closingPanelId = try #require(workspace.focusedPanelId)
+            let closingSurfaceId = try #require(workspace.surfaceIdFromPanelId(closingPanelId))
+            workspace.panelDirectories[closingPanelId] = "/tmp/elsewhere"
+            workspace.currentDirectory = "/Users/cmux/fallback"
+
+            var didClose = false
+            workspace.withClosedPanelHistorySuppressed {
+                workspace.markTabCloseButtonClose(surfaceId: closingSurfaceId)
+                didClose = workspace.closePanel(closingPanelId)
+            }
+            #expect(didClose)
+            drainMainQueue()
+            drainMainQueue()
+
+            let replacementPanelId = try #require(workspace.focusedPanelId)
+            let replacementPanel = try #require(workspace.terminalPanel(for: replacementPanelId))
+            #expect(replacementPanelId != closingPanelId)
+            #expect(replacementPanel.requestedWorkingDirectory == "/Users/cmux/project")
+        }
+    }
+
+    @Test
+    func tabCloseButtonReplacementUsesDirectoryCapturedWhenWorkspaceWasPinned() throws {
+        try withManager(closeWorkspaceOnLastSurface: false) { manager in
+            let workspace = manager.addWorkspace()
+            manager.selectWorkspace(workspace)
+
+            let closingPanelId = try #require(workspace.focusedPanelId)
+            let closingSurfaceId = try #require(workspace.surfaceIdFromPanelId(closingPanelId))
+            workspace.panelDirectories[closingPanelId] = "/Users/cmux/project"
+            workspace.currentDirectory = "/Users/cmux/project"
+            manager.setPinned(workspace, pinned: true)
+            #expect(workspace.pinnedWorkingDirectory == "/Users/cmux/project")
+
+            workspace.panelDirectories[closingPanelId] = "/tmp/elsewhere"
+            workspace.currentDirectory = "/tmp/elsewhere"
+
+            var didClose = false
+            workspace.withClosedPanelHistorySuppressed {
+                workspace.markTabCloseButtonClose(surfaceId: closingSurfaceId)
+                didClose = workspace.closePanel(closingPanelId)
+            }
+            #expect(didClose)
+            drainMainQueue()
+            drainMainQueue()
+
+            let replacementPanelId = try #require(workspace.focusedPanelId)
+            let replacementPanel = try #require(workspace.terminalPanel(for: replacementPanelId))
+            #expect(replacementPanelId != closingPanelId)
+            #expect(replacementPanel.requestedWorkingDirectory == "/Users/cmux/project")
+        }
+    }
+
+    @Test
     func middleClickClosesWorkspaceWhenKeepWorkspaceOpenPreferenceIsDisabled() throws {
         try withManager(closeWorkspaceOnLastSurface: true) { manager in
             let firstWorkspace = manager.tabs[0]

--- a/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
+++ b/cmuxTests/WorkspaceTerminalWorkingDirectoryFallbackTests.swift
@@ -47,4 +47,26 @@ import Testing
             "Expected new terminal tab to inherit the selected source terminal's requested cwd when no reported cwd exists yet"
         )
     }
+
+    @Test func newTerminalSurfaceUsesPinnedWorkingDirectoryCapturedAtPinTime() throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.tabs.first)
+        manager.selectWorkspace(workspace)
+        let sourcePanelId = try #require(workspace.focusedPanelId)
+
+        workspace.panelDirectories[sourcePanelId] = "/Users/cmux/project"
+        workspace.currentDirectory = "/Users/cmux/project"
+        manager.setPinned(workspace, pinned: true)
+        #expect(workspace.pinnedWorkingDirectory == "/Users/cmux/project")
+
+        workspace.panelDirectories[sourcePanelId] = "/tmp/elsewhere"
+        workspace.currentDirectory = "/tmp/elsewhere"
+
+        let newTabPanel = try #require(
+            workspace.newTerminalSurfaceInFocusedPane(focus: false),
+            "Expected new terminal tab panel to be created"
+        )
+
+        #expect(newTabPanel.requestedWorkingDirectory == "/Users/cmux/project")
+    }
 }


### PR DESCRIPTION
## Summary

Fixes #7721.

Pinned workspaces now keep a stable project working directory for terminal launches. When a workspace becomes pinned, cmux captures the workspace's resolved working directory, stores it in the session snapshot, and prefers that value when creating new or replacement terminal surfaces inside the pinned workspace.

## Changes

- Add `pinnedWorkingDirectory` to `Workspace` and persist it through `SessionWorkspaceSnapshot`.
- Capture or clear the pinned cwd when workspace pin state changes through single or batch pin actions.
- Prefer the pinned cwd when resolving startup cwd for new terminal surfaces in pinned workspaces.
- Pass an explicit cwd into the replacement terminal created when the last surface is closed but the workspace is kept open.
- Add regression tests for replacement terminals and pinned-workspace terminal startup cwd.

## Notes

This is intentionally narrower than persistent workspace profiles (#6093). It does not add config-defined workspace profiles or a new CLI `set-cwd`; it only makes the existing pinned-workspace behavior stable for new/replacement terminal launches.

Related: #7704, #6093, #4155.

## Verified

- `CMUX_SKIP_ZIG_BUILD=1 COPYFILE_DISABLE=1 xcodebuild test -project cmux.xcodeproj -scheme cmux-unit -destination 'platform=macOS,arch=arm64' -derivedDataPath /tmp/cmux-pr-pinned-cwd-pr-test -parallel-testing-enabled NO -only-testing:cmuxTests/LastSurfaceClosePreferenceTests`
- Local manual check on patched Nightly: create workspace, `cd <project-dir>`, pin, `cd /tmp`, close last terminal with Cmd+W; replacement terminal starts in `<project-dir>`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786199160&installation_id=133855650&pr_number=7722&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7722&signature=d01116cec443db842d2dd291ec14a76e95aa0db0e8d6b3e1882ed594baa3b682"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pinned workspaces now always start new and replacement terminals in the project directory. We capture the cwd at pin time, persist it, and prefer it when launching terminals so they don’t drift to home or the last shell PWD.

- **Bug Fixes**
  - Added `pinnedWorkingDirectory` to `Workspace` and `SessionWorkspaceSnapshot`, restored on load.
  - Capture or clear the pinned cwd when pin state changes (single and batch).
  - Prefer the pinned cwd for terminal startup; pass it to replacement terminals when the last surface closes.
  - Added tests for replacement terminals and new terminals honoring the pinned cwd.

<sup>Written for commit 6522869fb5fdaafee5facd1e78a2a0b1531aec7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7722?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

