### PR TITLE
agent-chat: dynamic-port + path-token serving, app-owned sidecar launch

### DIFF
--- a/Sources/AgentChatThemeSync.swift
+++ b/Sources/AgentChatThemeSync.swift
@@ -135,7 +135,7 @@ enum AgentChatThemeSync {
     @MainActor
     static func syncNow(agentChat: CmuxAgentChatConfiguration) {
         guard isEnabled else { return }
-        let url = themeURL(for: agentChat.url)
+        let url = themeURL(for: agentChat)
         Task { @MainActor in
             await postResolvedTheme(to: url)
         }
@@ -185,9 +185,19 @@ enum AgentChatThemeSync {
     }
 
     @MainActor
+    static func themeURL(for agentChat: CmuxAgentChatConfiguration) -> URL {
+        if !agentChat.hasExplicitURL,
+           agentChat.startCommand != nil,
+           let session = AgentChatOwnedServerRuntime.shared.session {
+            return session.themeURL
+        }
+        return themeURL(for: agentChat.url)
+    }
+
+    @MainActor
     private static func currentThemeURL() -> URL {
         if let store = AppDelegate.shared?.mainWindowContexts.values.compactMap(\.cmuxConfigStore).first {
-            return themeURL(for: store.agentChat.url)
+            return themeURL(for: store.agentChat)
         }
         return themeURL(for: CmuxAgentChatConfiguration.default.url)
     }

--- a/Sources/AgentChatThemeSync.swift
+++ b/Sources/AgentChatThemeSync.swift
@@ -188,7 +188,7 @@ enum AgentChatThemeSync {
     static func themeURL(for agentChat: CmuxAgentChatConfiguration) -> URL {
         if !agentChat.hasExplicitURL,
            agentChat.startCommand != nil,
-           let session = AgentChatOwnedServerRuntime.shared.session {
+           let session = AgentChatActionInFlightGate.ownedServerSession() {
             return session.themeURL
         }
         return themeURL(for: agentChat.url)

--- a/Sources/AgentChatThemeSync.swift
+++ b/Sources/AgentChatThemeSync.swift
@@ -226,9 +226,34 @@ enum AgentChatThemeSync {
                 )
             }
         } catch {
-            agentChatThemeSyncLogger.error(
-                "failed to sync theme: \(String(describing: error), privacy: .public)"
-            )
+            await handleThemePostFailure(error, url: url)
+        }
+    }
+
+    static func handleThemePostFailure(_ error: Error, url: URL) async {
+        agentChatThemeSyncLogger.error(
+            "failed to sync theme: \(String(describing: error), privacy: .public)"
+        )
+        guard shouldClearOwnedSessionAfterThemePostFailure(error) else { return }
+        await MainActor.run {
+            guard let session = AgentChatActionInFlightGate.ownedServerSession(),
+                  session.themeURL == url else { return }
+            AgentChatActionInFlightGate.clearOwnedServerSession(matching: session)
+        }
+    }
+
+    static func shouldClearOwnedSessionAfterThemePostFailure(_ error: Error) -> Bool {
+        guard let urlError = error as? URLError else { return false }
+        switch urlError.code {
+        case .cannotConnectToHost,
+             .cannotFindHost,
+             .dnsLookupFailed,
+             .networkConnectionLost,
+             .notConnectedToInternet,
+             .timedOut:
+            return true
+        default:
+            return false
         }
     }
 }

--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -7,6 +7,7 @@ nonisolated struct AgentChatActionInFlightGate {
     private struct State {
         var isRunning = false
         var ownedServerSession: AgentChatOwnedServerSession?
+        var sidecarStateFileStore = AgentChatSidecarStateFileStore.live()
     }
 
     private nonisolated static let lock = OSAllocatedUnfairLock(initialState: State())
@@ -41,6 +42,12 @@ nonisolated struct AgentChatActionInFlightGate {
         lock.withLock { state in
             if let candidate, state.ownedServerSession != candidate { return }
             state.ownedServerSession = nil
+        }
+    }
+
+    static func sidecarStateFileStore() -> AgentChatSidecarStateFileStore? {
+        lock.withLock { state in
+            state.sidecarStateFileStore
         }
     }
 }
@@ -292,11 +299,16 @@ extension AppDelegate {
                 return AgentChatServerAvailability(isReachable: true, browserURL: session.browserURL)
             }
             AgentChatActionInFlightGate.clearOwnedServerSession(matching: session)
-            await AgentChatSidecarStateFileStore.removeStateFile()
+            await AgentChatActionInFlightGate.sidecarStateFileStore()?.removeStateFile()
         }
 
         guard let token = Self.generateAgentChatToken(),
-              let stateFileURL = await AgentChatSidecarStateFileStore.prepareStateFileURL() else {
+              let launchId = Self.generateAgentChatLaunchID(),
+              let stateFileStore = AgentChatActionInFlightGate.sidecarStateFileStore() else {
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+        }
+        let launchDate = Date()
+        guard let stateFileURL = await stateFileStore.prepareStateFileURL(launchDate: launchDate) else {
             return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
 
@@ -315,14 +327,16 @@ extension AppDelegate {
                 "CMUX_AGENT_CHAT_TOKEN": token,
                 "CMUX_AGENT_CHAT_PORT": "0",
                 "CMUX_AGENT_CHAT_STATE_FILE": stateFileURL.path,
+                "CMUX_AGENT_CHAT_LAUNCH_ID": launchId,
             ]
         ) else {
             return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
 
-        guard let session = await AgentChatSidecarStateFileStore.waitForSession(
-            stateFileURL: stateFileURL,
-            token: token
+        guard let session = await stateFileStore.waitForSession(
+            token: token,
+            launchId: launchId,
+            launchDate: launchDate
         ) else {
             return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
@@ -456,6 +470,10 @@ extension AppDelegate {
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
+    }
+
+    nonisolated private static func generateAgentChatLaunchID() -> String? {
+        UUID().uuidString
     }
 
 }

--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -126,7 +126,6 @@ extension AppDelegate {
             AgentChatThemeSync.syncNow(agentChat: agentChat)
             guard let tabManager else { return }
             guard let browserURL = availability.browserURL else {
-                // Owned launch failed: never fall back to the legacy URL.
                 NSSound.beep()
                 self.postAgentChatServerUnavailableNotification(
                     workspace: nil,
@@ -211,8 +210,7 @@ extension AppDelegate {
             )
             body = String(format: format, agentChat.url.absoluteString)
         }
-        // With no workspace (owned launch failed, nothing opened) anchor the
-        // notification to the focused workspace so the failure is still visible.
+        // No workspace = owned launch failed; anchor to the focused workspace.
         guard let anchorTabId = workspace?.id ?? activeTabManagerForCommands(preferredWindow: nil)?.selectedTabId else {
             return
         }

--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -322,14 +322,17 @@ extension AppDelegate {
             await AgentChatActionInFlightGate.sidecarStateFileStore()?.removeStateFile()
         }
 
+        let launchId = UUID().uuidString
         guard let token = Self.generateAgentChatToken(),
-              let launchId = Self.generateAgentChatLaunchID(),
               let stateFileStore = AgentChatActionInFlightGate.sidecarStateFileStore() else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
         let launchDate = Date()
-        guard let stateFileURL = await stateFileStore.prepareStateFileURL(launchDate: launchDate) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
+        guard let stateFileURL = await stateFileStore.prepareStateFileURL(
+            launchId: launchId,
+            launchDate: launchDate
+        ) else {
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
 
         guard await authorizeAgentChatStartCommandIfNeeded(
@@ -338,7 +341,7 @@ extension AppDelegate {
             globalConfigPath: globalConfigPath,
             preferredWindow: preferredWindow
         ) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
         guard Self.launchDetachedAgentChatStartCommand(
             startCommand,
@@ -350,7 +353,7 @@ extension AppDelegate {
                 "CMUX_AGENT_CHAT_LAUNCH_ID": launchId,
             ]
         ) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
 
         guard let session = await stateFileStore.waitForSession(
@@ -358,7 +361,7 @@ extension AppDelegate {
             launchId: launchId,
             launchDate: launchDate
         ) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
         AgentChatActionInFlightGate.updateOwnedServerSession(session)
         let isHealthy = await Self.agentChatServerIsHealthy(healthURL: session.healthURL, timeout: 1.5)
@@ -490,10 +493,6 @@ extension AppDelegate {
             .replacingOccurrences(of: "+", with: "-")
             .replacingOccurrences(of: "/", with: "_")
             .replacingOccurrences(of: "=", with: "")
-    }
-
-    nonisolated private static func generateAgentChatLaunchID() -> String? {
-        UUID().uuidString
     }
 
 }

--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -6,6 +6,7 @@ import Security
 nonisolated struct AgentChatActionInFlightGate {
     private struct State {
         var isRunning = false
+        var ownedServerSession: AgentChatOwnedServerSession?
     }
 
     private nonisolated static let lock = OSAllocatedUnfairLock(initialState: State())
@@ -23,25 +24,24 @@ nonisolated struct AgentChatActionInFlightGate {
             state.isRunning = false
         }
     }
-}
 
-@MainActor
-final class AgentChatOwnedServerRuntime {
-    static let shared = AgentChatOwnedServerRuntime()
-
-    private(set) var session: AgentChatOwnedServerSession?
-
-    func update(session: AgentChatOwnedServerSession) {
-        self.session = session
+    static func ownedServerSession() -> AgentChatOwnedServerSession? {
+        lock.withLock { state in
+            state.ownedServerSession
+        }
     }
 
-    func clearSession(matching candidate: AgentChatOwnedServerSession) {
-        guard session == candidate else { return }
-        session = nil
+    static func updateOwnedServerSession(_ session: AgentChatOwnedServerSession) {
+        lock.withLock { state in
+            state.ownedServerSession = session
+        }
     }
 
-    func resetForTesting() {
-        session = nil
+    static func clearOwnedServerSession(matching candidate: AgentChatOwnedServerSession? = nil) {
+        lock.withLock { state in
+            if let candidate, state.ownedServerSession != candidate { return }
+            state.ownedServerSession = nil
+        }
     }
 }
 
@@ -215,35 +215,41 @@ extension AppDelegate {
         globalConfigPath: String?,
         preferredWindow: NSWindow?
     ) async -> AgentChatServerAvailability {
-        if await Self.agentChatServerIsHealthy(healthURL: agentChat.healthURL, timeout: 1.5) {
-            return AgentChatServerAvailability(isReachable: true, browserURL: agentChat.url)
-        }
-        guard let startCommand = agentChat.startCommand else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
-        }
-        if agentChat.hasExplicitURL {
+        switch agentChat.serverMode {
+        case .explicitURL:
             return await ensureExplicitAgentChatServerAvailable(
+                agentChat,
+                startCommand: agentChat.startCommand,
+                globalConfigPath: globalConfigPath,
+                preferredWindow: preferredWindow
+            )
+        case .appOwned:
+            guard let startCommand = agentChat.startCommand else {
+                return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+            }
+            return await ensureOwnedAgentChatServerAvailable(
                 agentChat,
                 startCommand: startCommand,
                 globalConfigPath: globalConfigPath,
                 preferredWindow: preferredWindow
             )
+        case .legacyDefaultURL:
+            let isHealthy = await Self.agentChatServerIsHealthy(healthURL: agentChat.healthURL, timeout: 1.5)
+            return AgentChatServerAvailability(isReachable: isHealthy, browserURL: agentChat.url)
         }
-        return await ensureOwnedAgentChatServerAvailable(
-            agentChat,
-            startCommand: startCommand,
-            globalConfigPath: globalConfigPath,
-            preferredWindow: preferredWindow
-        )
     }
 
     private func ensureExplicitAgentChatServerAvailable(
         _ agentChat: CmuxAgentChatConfiguration,
-        startCommand: String,
+        startCommand: String?,
         globalConfigPath: String?,
         preferredWindow: NSWindow?
     ) async -> AgentChatServerAvailability {
+        if await Self.agentChatServerIsHealthy(healthURL: agentChat.healthURL, timeout: 1.5) {
+            return AgentChatServerAvailability(isReachable: true, browserURL: agentChat.url)
+        }
         let unavailable = AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+        guard let startCommand else { return unavailable }
         guard await authorizeAgentChatStartCommandIfNeeded(
             agentChat,
             command: startCommand,
@@ -281,22 +287,18 @@ extension AppDelegate {
         globalConfigPath: String?,
         preferredWindow: NSWindow?
     ) async -> AgentChatServerAvailability {
-        if let session = AgentChatOwnedServerRuntime.shared.session {
+        if let session = AgentChatActionInFlightGate.ownedServerSession() {
             if await Self.agentChatServerIsHealthy(healthURL: session.healthURL, timeout: 1.5) {
                 return AgentChatServerAvailability(isReachable: true, browserURL: session.browserURL)
             }
-            AgentChatOwnedServerRuntime.shared.clearSession(matching: session)
+            AgentChatActionInFlightGate.clearOwnedServerSession(matching: session)
+            await AgentChatSidecarStateFileStore.removeStateFile()
         }
 
         guard let token = Self.generateAgentChatToken(),
-              let stateFileURL = Self.agentChatStateFileURL() else {
+              let stateFileURL = await AgentChatSidecarStateFileStore.prepareStateFileURL() else {
             return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
-        try? FileManager.default.removeItem(at: stateFileURL)
-        try? FileManager.default.createDirectory(
-            at: stateFileURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
 
         guard await authorizeAgentChatStartCommandIfNeeded(
             agentChat,
@@ -318,13 +320,13 @@ extension AppDelegate {
             return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
 
-        guard let session = await Self.waitForOwnedAgentChatSession(
+        guard let session = await AgentChatSidecarStateFileStore.waitForSession(
             stateFileURL: stateFileURL,
             token: token
         ) else {
             return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
-        AgentChatOwnedServerRuntime.shared.update(session: session)
+        AgentChatActionInFlightGate.updateOwnedServerSession(session)
         let isHealthy = await Self.agentChatServerIsHealthy(healthURL: session.healthURL, timeout: 1.5)
         return AgentChatServerAvailability(isReachable: isHealthy, browserURL: session.browserURL)
     }
@@ -456,38 +458,4 @@ extension AppDelegate {
             .replacingOccurrences(of: "=", with: "")
     }
 
-    nonisolated private static func agentChatStateFileURL() -> URL? {
-        guard let appSupport = FileManager.default.urls(
-            for: .applicationSupportDirectory,
-            in: .userDomainMask
-        ).first else {
-            return nil
-        }
-        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
-        return appSupport
-            .appendingPathComponent(bundleIdentifier, isDirectory: true)
-            .appendingPathComponent("AgentChat", isDirectory: true)
-            .appendingPathComponent("sidecar-\(UUID().uuidString).json")
-    }
-
-    nonisolated private static func waitForOwnedAgentChatSession(
-        stateFileURL: URL,
-        token: String
-    ) async -> AgentChatOwnedServerSession? {
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(10))
-        while !Task.isCancelled, clock.now < deadline {
-            if let data = try? Data(contentsOf: stateFileURL),
-               let session = try? AgentChatSidecarStateFile.parse(data, token: token) {
-                return session
-            }
-            do {
-                // Bounded, cancellable polling for the sidecar readiness state file.
-                try await clock.sleep(for: .milliseconds(250))
-            } catch {
-                return nil
-            }
-        }
-        return nil
-    }
 }

--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -54,7 +54,9 @@ nonisolated struct AgentChatActionInFlightGate {
 
 struct AgentChatServerAvailability: Sendable {
     var isReachable: Bool
-    var browserURL: URL
+    /// nil means the owned launch failed and nothing safe exists to open;
+    /// the action must fail instead of falling back to the legacy URL.
+    var browserURL: URL?
 }
 
 extension AppDelegate {
@@ -123,9 +125,18 @@ extension AppDelegate {
             )
             AgentChatThemeSync.syncNow(agentChat: agentChat)
             guard let tabManager else { return }
+            guard let browserURL = availability.browserURL else {
+                // Owned launch failed: never fall back to the legacy URL.
+                NSSound.beep()
+                self.postAgentChatServerUnavailableNotification(
+                    workspace: nil,
+                    agentChat: agentChat
+                )
+                return
+            }
             guard let workspace = self.openAgentChatWorkspace(
                 tabManager: tabManager,
-                url: availability.browserURL
+                url: browserURL
             ) else {
                 NSSound.beep()
                 return
@@ -183,7 +194,7 @@ extension AppDelegate {
     }
 
     private func postAgentChatServerUnavailableNotification(
-        workspace: Workspace,
+        workspace: Workspace?,
         agentChat: CmuxAgentChatConfiguration
     ) {
         let body: String
@@ -200,17 +211,28 @@ extension AppDelegate {
             )
             body = String(format: format, agentChat.url.absoluteString)
         }
+        // With no workspace (owned launch failed, nothing opened) anchor the
+        // notification to the focused workspace so the failure is still visible.
+        guard let anchorTabId = workspace?.id ?? activeTabManagerForCommands(preferredWindow: nil)?.selectedTabId else {
+            return
+        }
+        let subtitle = workspace == nil
+            ? String(
+                localized: "notification.agentChat.serverUnavailable.subtitleLaunchFailed",
+                defaultValue: "Could not start Agent Chat"
+            )
+            : String(
+                localized: "notification.agentChat.serverUnavailable.subtitle",
+                defaultValue: "Opened Agent Chat"
+            )
         TerminalNotificationStore.shared.addNotification(
-            tabId: workspace.id,
-            surfaceId: workspace.focusedPanelId,
+            tabId: anchorTabId,
+            surfaceId: workspace?.focusedPanelId,
             title: String(
                 localized: "notification.agentChat.serverUnavailable.title",
                 defaultValue: "Agent chat server isn't running"
             ),
-            subtitle: String(
-                localized: "notification.agentChat.serverUnavailable.subtitle",
-                defaultValue: "Opened Agent Chat"
-            ),
+            subtitle: subtitle,
             body: body,
             cooldownKey: "agent-chat-server-unavailable.\(agentChat.url.absoluteString)",
             cooldownInterval: 30
@@ -305,11 +327,11 @@ extension AppDelegate {
         guard let token = Self.generateAgentChatToken(),
               let launchId = Self.generateAgentChatLaunchID(),
               let stateFileStore = AgentChatActionInFlightGate.sidecarStateFileStore() else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
         }
         let launchDate = Date()
         guard let stateFileURL = await stateFileStore.prepareStateFileURL(launchDate: launchDate) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
         }
 
         guard await authorizeAgentChatStartCommandIfNeeded(
@@ -318,7 +340,7 @@ extension AppDelegate {
             globalConfigPath: globalConfigPath,
             preferredWindow: preferredWindow
         ) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
         }
         guard Self.launchDetachedAgentChatStartCommand(
             startCommand,
@@ -330,7 +352,7 @@ extension AppDelegate {
                 "CMUX_AGENT_CHAT_LAUNCH_ID": launchId,
             ]
         ) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
         }
 
         guard let session = await stateFileStore.waitForSession(
@@ -338,7 +360,7 @@ extension AppDelegate {
             launchId: launchId,
             launchDate: launchDate
         ) else {
-            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+            return AgentChatServerAvailability(isReachable: false, browserURL: nil)
         }
         AgentChatActionInFlightGate.updateOwnedServerSession(session)
         let isHealthy = await Self.agentChatServerIsHealthy(healthURL: session.healthURL, timeout: 1.5)

--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import os
+import Security
 
 nonisolated struct AgentChatActionInFlightGate {
     private struct State {
@@ -22,6 +23,31 @@ nonisolated struct AgentChatActionInFlightGate {
             state.isRunning = false
         }
     }
+}
+
+@MainActor
+final class AgentChatOwnedServerRuntime {
+    static let shared = AgentChatOwnedServerRuntime()
+
+    private(set) var session: AgentChatOwnedServerSession?
+
+    func update(session: AgentChatOwnedServerSession) {
+        self.session = session
+    }
+
+    func clearSession(matching candidate: AgentChatOwnedServerSession) {
+        guard session == candidate else { return }
+        session = nil
+    }
+
+    func resetForTesting() {
+        session = nil
+    }
+}
+
+struct AgentChatServerAvailability: Sendable {
+    var isReachable: Bool
+    var browserURL: URL
 }
 
 extension AppDelegate {
@@ -83,7 +109,7 @@ extension AppDelegate {
         Task { @MainActor [weak self, weak tabManager] in
             defer { AgentChatActionInFlightGate.end() }
             guard let self else { return }
-            let isReachable = await self.ensureAgentChatServerAvailable(
+            let availability = await self.ensureAgentChatServerAvailable(
                 agentChat,
                 globalConfigPath: globalConfigPath,
                 preferredWindow: preferredWindow
@@ -92,12 +118,12 @@ extension AppDelegate {
             guard let tabManager else { return }
             guard let workspace = self.openAgentChatWorkspace(
                 tabManager: tabManager,
-                agentChat: agentChat
+                url: availability.browserURL
             ) else {
                 NSSound.beep()
                 return
             }
-            if !isReachable {
+            if !availability.isReachable {
                 self.postAgentChatServerUnavailableNotification(
                     workspace: workspace,
                     agentChat: agentChat
@@ -111,7 +137,7 @@ extension AppDelegate {
     @discardableResult
     private func openAgentChatWorkspace(
         tabManager: TabManager,
-        agentChat: CmuxAgentChatConfiguration
+        url: URL
     ) -> Workspace? {
         let beforeIds = Set(tabManager.tabs.map(\.id))
         let workspaceName = String(
@@ -127,7 +153,7 @@ extension AppDelegate {
                     command: nil,
                     cwd: nil,
                     env: nil,
-                    url: agentChat.url.absoluteString,
+                    url: url.absoluteString,
                     focus: true
                 ),
             ]))
@@ -188,41 +214,119 @@ extension AppDelegate {
         _ agentChat: CmuxAgentChatConfiguration,
         globalConfigPath: String?,
         preferredWindow: NSWindow?
-    ) async -> Bool {
+    ) async -> AgentChatServerAvailability {
         if await Self.agentChatServerIsHealthy(healthURL: agentChat.healthURL, timeout: 1.5) {
-            return true
+            return AgentChatServerAvailability(isReachable: true, browserURL: agentChat.url)
         }
         guard let startCommand = agentChat.startCommand else {
-            return false
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         }
+        if agentChat.hasExplicitURL {
+            return await ensureExplicitAgentChatServerAvailable(
+                agentChat,
+                startCommand: startCommand,
+                globalConfigPath: globalConfigPath,
+                preferredWindow: preferredWindow
+            )
+        }
+        return await ensureOwnedAgentChatServerAvailable(
+            agentChat,
+            startCommand: startCommand,
+            globalConfigPath: globalConfigPath,
+            preferredWindow: preferredWindow
+        )
+    }
+
+    private func ensureExplicitAgentChatServerAvailable(
+        _ agentChat: CmuxAgentChatConfiguration,
+        startCommand: String,
+        globalConfigPath: String?,
+        preferredWindow: NSWindow?
+    ) async -> AgentChatServerAvailability {
+        let unavailable = AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
         guard await authorizeAgentChatStartCommandIfNeeded(
             agentChat,
             command: startCommand,
             globalConfigPath: globalConfigPath,
             preferredWindow: preferredWindow
         ) else {
-            return false
+            return unavailable
         }
         guard Self.launchDetachedAgentChatStartCommand(
             startCommand,
-            currentDirectoryURL: Self.agentChatStartCommandDirectoryURL(for: agentChat)
+            currentDirectoryURL: Self.agentChatStartCommandDirectoryURL(for: agentChat),
+            environmentOverrides: [:]
         ) else {
-            return false
+            return unavailable
         }
         let clock = ContinuousClock()
         let deadline = clock.now.advanced(by: .seconds(10))
         while !Task.isCancelled, clock.now < deadline {
             if await Self.agentChatServerIsHealthy(healthURL: agentChat.healthURL, timeout: 1.5) {
-                return true
+                return AgentChatServerAvailability(isReachable: true, browserURL: agentChat.url)
             }
             do {
                 // Bounded, cancellable health polling after a configured server start.
                 try await clock.sleep(for: .milliseconds(250))
             } catch {
-                return false
+                return unavailable
             }
         }
-        return false
+        return unavailable
+    }
+
+    private func ensureOwnedAgentChatServerAvailable(
+        _ agentChat: CmuxAgentChatConfiguration,
+        startCommand: String,
+        globalConfigPath: String?,
+        preferredWindow: NSWindow?
+    ) async -> AgentChatServerAvailability {
+        if let session = AgentChatOwnedServerRuntime.shared.session {
+            if await Self.agentChatServerIsHealthy(healthURL: session.healthURL, timeout: 1.5) {
+                return AgentChatServerAvailability(isReachable: true, browserURL: session.browserURL)
+            }
+            AgentChatOwnedServerRuntime.shared.clearSession(matching: session)
+        }
+
+        guard let token = Self.generateAgentChatToken(),
+              let stateFileURL = Self.agentChatStateFileURL() else {
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+        }
+        try? FileManager.default.removeItem(at: stateFileURL)
+        try? FileManager.default.createDirectory(
+            at: stateFileURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+
+        guard await authorizeAgentChatStartCommandIfNeeded(
+            agentChat,
+            command: startCommand,
+            globalConfigPath: globalConfigPath,
+            preferredWindow: preferredWindow
+        ) else {
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+        }
+        guard Self.launchDetachedAgentChatStartCommand(
+            startCommand,
+            currentDirectoryURL: Self.agentChatStartCommandDirectoryURL(for: agentChat),
+            environmentOverrides: [
+                "CMUX_AGENT_CHAT_TOKEN": token,
+                "CMUX_AGENT_CHAT_PORT": "0",
+                "CMUX_AGENT_CHAT_STATE_FILE": stateFileURL.path,
+            ]
+        ) else {
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+        }
+
+        guard let session = await Self.waitForOwnedAgentChatSession(
+            stateFileURL: stateFileURL,
+            token: token
+        ) else {
+            return AgentChatServerAvailability(isReachable: false, browserURL: agentChat.url)
+        }
+        AgentChatOwnedServerRuntime.shared.update(session: session)
+        let isHealthy = await Self.agentChatServerIsHealthy(healthURL: session.healthURL, timeout: 1.5)
+        return AgentChatServerAvailability(isReachable: isHealthy, browserURL: session.browserURL)
     }
 
     private func authorizeAgentChatStartCommandIfNeeded(
@@ -308,7 +412,8 @@ extension AppDelegate {
 
     nonisolated private static func launchDetachedAgentChatStartCommand(
         _ command: String,
-        currentDirectoryURL: URL
+        currentDirectoryURL: URL,
+        environmentOverrides: [String: String]
     ) -> Bool {
         let trimmedCommand = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedCommand.isEmpty else { return false }
@@ -322,6 +427,7 @@ extension AppDelegate {
         process.executableURL = URL(fileURLWithPath: shellPath)
         process.arguments = ["-lc", trimmedCommand]
         process.currentDirectoryURL = currentDirectoryURL
+        process.environment = environment.merging(environmentOverrides) { _, override in override }
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
@@ -336,5 +442,52 @@ extension AppDelegate {
 
     nonisolated private static func canonicalAgentChatPath(_ path: String) -> String {
         URL(fileURLWithPath: path).standardizedFileURL.path
+    }
+
+    nonisolated private static func generateAgentChatToken(byteCount: Int = 32) -> String? {
+        var bytes = [UInt8](repeating: 0, count: byteCount)
+        guard SecRandomCopyBytes(kSecRandomDefault, bytes.count, &bytes) == errSecSuccess else {
+            return nil
+        }
+        return Data(bytes)
+            .base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    nonisolated private static func agentChatStateFileURL() -> URL? {
+        guard let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
+        return appSupport
+            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+            .appendingPathComponent("AgentChat", isDirectory: true)
+            .appendingPathComponent("sidecar-\(UUID().uuidString).json")
+    }
+
+    nonisolated private static func waitForOwnedAgentChatSession(
+        stateFileURL: URL,
+        token: String
+    ) async -> AgentChatOwnedServerSession? {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(10))
+        while !Task.isCancelled, clock.now < deadline {
+            if let data = try? Data(contentsOf: stateFileURL),
+               let session = try? AgentChatSidecarStateFile.parse(data, token: token) {
+                return session
+            }
+            do {
+                // Bounded, cancellable polling for the sidecar readiness state file.
+                try await clock.sleep(for: .milliseconds(250))
+            } catch {
+                return nil
+            }
+        }
+        return nil
     }
 }

--- a/Sources/CmuxAgentChatConfig.swift
+++ b/Sources/CmuxAgentChatConfig.swift
@@ -198,19 +198,38 @@ struct AgentChatOwnedServerSession: Sendable, Hashable {
 struct AgentChatSidecarStateFile: Decodable, Sendable, Hashable {
     var port: Int
     var pid: Int
+    var launchId: String?
 
-    func session(token: String) -> AgentChatOwnedServerSession? {
+    func session(token: String, launchId expectedLaunchId: String) -> AgentChatOwnedServerSession? {
+        guard launchId == expectedLaunchId else { return nil }
         guard (1...65_535).contains(port), pid > 0 else { return nil }
         return AgentChatOwnedServerSession(port: port, pid: pid, token: token)
     }
 
-    static func parse(_ data: Data, token: String) throws -> AgentChatOwnedServerSession? {
-        try JSONDecoder().decode(Self.self, from: data).session(token: token)
+    static func parse(
+        _ data: Data,
+        token: String,
+        launchId: String
+    ) throws -> AgentChatOwnedServerSession? {
+        try JSONDecoder().decode(Self.self, from: data).session(token: token, launchId: launchId)
     }
 }
 
-enum AgentChatSidecarStateFileStore {
-    static func stateFileURL() -> URL? {
+// FileManager is thread-safe for independent file operations; the wrapper is
+// captured by detached utility tasks so the store can keep injected I/O.
+final class AgentChatSidecarFileSystem: @unchecked Sendable {
+    let fileManager: FileManager
+
+    init(fileManager: FileManager = .default) {
+        self.fileManager = fileManager
+    }
+}
+
+struct AgentChatSidecarStateFileStore: Sendable {
+    var stateFileURL: URL
+    var fileSystem: AgentChatSidecarFileSystem
+
+    static func live() -> AgentChatSidecarStateFileStore? {
         guard let appSupport = FileManager.default.urls(
             for: .applicationSupportDirectory,
             in: .userDomainMask
@@ -218,20 +237,29 @@ enum AgentChatSidecarStateFileStore {
             return nil
         }
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
-        return appSupport
+        return AgentChatSidecarStateFileStore(
+            stateFileURL: appSupport
             .appendingPathComponent(bundleIdentifier, isDirectory: true)
             .appendingPathComponent("agent-chat", isDirectory: true)
-            .appendingPathComponent("state.json")
+                .appendingPathComponent("state.json"),
+            fileSystem: AgentChatSidecarFileSystem()
+        )
     }
 
-    static func prepareStateFileURL() async -> URL? {
+    func prepareStateFileURL(launchDate: Date) async -> URL? {
+        let stateFileURL = stateFileURL
+        let fileSystem = fileSystem
         await Task.detached(priority: .utility) {
-            guard let stateFileURL = Self.stateFileURL() else { return nil }
             let directoryURL = stateFileURL.deletingLastPathComponent()
-            let fileManager = FileManager.default
+            let fileManager = fileSystem.fileManager
             do {
                 try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
-                try Self.sweepStaleStateFiles(in: directoryURL, keeping: stateFileURL)
+                try Self.sweepStaleStateFiles(
+                    in: directoryURL,
+                    keeping: stateFileURL,
+                    olderThan: launchDate,
+                    fileManager: fileManager
+                )
                 try? fileManager.removeItem(at: stateFileURL)
                 _ = fileManager.createFile(atPath: stateFileURL.path, contents: nil)
                 return stateFileURL
@@ -241,24 +269,35 @@ enum AgentChatSidecarStateFileStore {
         }.value
     }
 
-    static func removeStateFile() async {
+    func removeStateFile() async {
+        let stateFileURL = stateFileURL
+        let fileSystem = fileSystem
         await Task.detached(priority: .utility) {
-            guard let stateFileURL = Self.stateFileURL() else { return }
-            try? FileManager.default.removeItem(at: stateFileURL)
+            try? fileSystem.fileManager.removeItem(at: stateFileURL)
         }.value
     }
 
-    static func waitForSession(
-        stateFileURL: URL,
-        token: String
+    func waitForSession(
+        token: String,
+        launchId: String,
+        launchDate: Date
     ) async -> AgentChatOwnedServerSession? {
+        let stateFileURL = stateFileURL
+        let fileSystem = fileSystem
         await Task.detached(priority: .utility) {
+            let fileManager = fileSystem.fileManager
             let clock = ContinuousClock()
             let deadline = clock.now.advanced(by: .seconds(10))
             while !Task.isCancelled, clock.now < deadline {
                 if let data = try? Data(contentsOf: stateFileURL),
-                   let session = try? AgentChatSidecarStateFile.parse(data, token: token) {
-                    return session
+                   let stateFile = try? JSONDecoder().decode(AgentChatSidecarStateFile.self, from: data) {
+                    if let session = stateFile.session(token: token, launchId: launchId) {
+                        return session
+                    }
+                    let values = try? stateFileURL.resourceValues(forKeys: [.contentModificationDateKey])
+                    if (values?.contentModificationDate ?? .distantPast) < launchDate {
+                        try? fileManager.removeItem(at: stateFileURL)
+                    }
                 }
                 do {
                     // Bounded, cancellable polling for the sidecar readiness state file.
@@ -273,10 +312,10 @@ enum AgentChatSidecarStateFileStore {
 
     private static func sweepStaleStateFiles(
         in directoryURL: URL,
-        keeping currentStateFileURL: URL
+        keeping currentStateFileURL: URL,
+        olderThan cutoff: Date,
+        fileManager: FileManager
     ) throws {
-        let fileManager = FileManager.default
-        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
         let stateFiles = try fileManager.contentsOfDirectory(
             at: directoryURL,
             includingPropertiesForKeys: [.contentModificationDateKey],

--- a/Sources/CmuxAgentChatConfig.swift
+++ b/Sources/CmuxAgentChatConfig.swift
@@ -275,7 +275,7 @@ struct AgentChatSidecarStateFileStore: Sendable {
     }
 
     func removeStateFile(launchId: String? = nil) async {
-        let stateFileURL = launchId.map { stateFileURL(launchId: $0) }
+        let stateFileURL = launchId.map { self.stateFileURL(launchId: $0) }
         let directoryURL = directoryURL
         let fileSystem = fileSystem
         await Task.detached(priority: .utility) {
@@ -297,7 +297,7 @@ struct AgentChatSidecarStateFileStore: Sendable {
         launchId: String,
         launchDate: Date
     ) async -> AgentChatOwnedServerSession? {
-        let stateFileURL = stateFileURL
+        let stateFileURL = stateFileURL(launchId: launchId)
         let fileSystem = fileSystem
         return await Task.detached(priority: .utility) { () -> AgentChatOwnedServerSession? in
             let fileManager = fileSystem.fileManager

--- a/Sources/CmuxAgentChatConfig.swift
+++ b/Sources/CmuxAgentChatConfig.swift
@@ -226,7 +226,7 @@ final class AgentChatSidecarFileSystem: @unchecked Sendable {
 }
 
 struct AgentChatSidecarStateFileStore: Sendable {
-    var stateFileURL: URL
+    var directoryURL: URL
     var fileSystem: AgentChatSidecarFileSystem
 
     static func live() -> AgentChatSidecarStateFileStore? {
@@ -238,16 +238,19 @@ struct AgentChatSidecarStateFileStore: Sendable {
         }
         let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
         return AgentChatSidecarStateFileStore(
-            stateFileURL: appSupport
+            directoryURL: appSupport
             .appendingPathComponent(bundleIdentifier, isDirectory: true)
-            .appendingPathComponent("agent-chat", isDirectory: true)
-                .appendingPathComponent("state.json"),
+            .appendingPathComponent("agent-chat", isDirectory: true),
             fileSystem: AgentChatSidecarFileSystem()
         )
     }
 
-    func prepareStateFileURL(launchDate: Date) async -> URL? {
-        let stateFileURL = stateFileURL
+    func stateFileURL(launchId: String) -> URL {
+        directoryURL.appendingPathComponent("state-\(launchId).json")
+    }
+
+    func prepareStateFileURL(launchId: String, launchDate: Date) async -> URL? {
+        let stateFileURL = stateFileURL(launchId: launchId)
         let fileSystem = fileSystem
         return await Task.detached(priority: .utility) { () -> URL? in
             let directoryURL = stateFileURL.deletingLastPathComponent()
@@ -271,11 +274,21 @@ struct AgentChatSidecarStateFileStore: Sendable {
         }.value
     }
 
-    func removeStateFile() async {
-        let stateFileURL = stateFileURL
+    func removeStateFile(launchId: String? = nil) async {
+        let stateFileURL = launchId.map { stateFileURL(launchId: $0) }
+        let directoryURL = directoryURL
         let fileSystem = fileSystem
         await Task.detached(priority: .utility) {
-            try? fileSystem.fileManager.removeItem(at: stateFileURL)
+            if let stateFileURL {
+                try? fileSystem.fileManager.removeItem(at: stateFileURL)
+            } else if let files = try? fileSystem.fileManager.contentsOfDirectory(
+                at: directoryURL,
+                includingPropertiesForKeys: nil
+            ) {
+                for fileURL in files where Self.isStateFile(fileURL) {
+                    try? fileSystem.fileManager.removeItem(at: fileURL)
+                }
+            }
         }.value
     }
 
@@ -294,6 +307,7 @@ struct AgentChatSidecarStateFileStore: Sendable {
                 if let data = try? Data(contentsOf: stateFileURL),
                    let stateFile = try? JSONDecoder().decode(AgentChatSidecarStateFile.self, from: data) {
                     if let session = stateFile.session(token: token, launchId: launchId) {
+                        try? fileManager.removeItem(at: stateFileURL)
                         return session
                     }
                     let values = try? stateFileURL.resourceValues(forKeys: [.contentModificationDateKey])
@@ -324,11 +338,16 @@ struct AgentChatSidecarStateFileStore: Sendable {
             options: [.skipsHiddenFiles]
         )
         for fileURL in stateFiles where fileURL != currentStateFileURL {
-            guard fileURL.pathExtension == "json" else { continue }
+            guard isStateFile(fileURL) else { continue }
             let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey])
             if (values?.contentModificationDate ?? .distantPast) < cutoff {
                 try? fileManager.removeItem(at: fileURL)
             }
         }
+    }
+
+    private static func isStateFile(_ fileURL: URL) -> Bool {
+        let name = fileURL.lastPathComponent
+        return name.hasPrefix("state-") && name.hasSuffix(".json")
     }
 }

--- a/Sources/CmuxAgentChatConfig.swift
+++ b/Sources/CmuxAgentChatConfig.swift
@@ -89,12 +89,14 @@ struct CmuxAgentChatConfiguration: Sendable, Hashable {
     static let `default` = CmuxAgentChatConfiguration(
         url: URL(string: defaultURLString)!,
         startCommand: nil,
-        source: .defaults
+        source: .defaults,
+        hasExplicitURL: false
     )
 
     var url: URL
     var startCommand: String?
     var source: CmuxAgentChatConfigurationSource
+    var hasExplicitURL: Bool
 
     var startCommandRequiresTrust: Bool {
         source.isLocal && startCommand != nil
@@ -142,7 +144,51 @@ struct CmuxAgentChatConfiguration: Sendable, Hashable {
         return CmuxAgentChatConfiguration(
             url: URL(string: rawURL) ?? Self.default.url,
             startCommand: definition?.startCommand,
-            source: source
+            source: source,
+            hasExplicitURL: definition?.url != nil
         )
+    }
+}
+
+struct AgentChatOwnedServerSession: Sendable, Hashable {
+    var port: Int
+    var pid: Int
+    var token: String
+
+    var baseURL: URL {
+        URL(string: "http://127.0.0.1:\(port)")!
+    }
+
+    var healthURL: URL {
+        baseURL.appendingPathComponent("healthz")
+    }
+
+    var browserURL: URL {
+        Self.browserURL(port: port, token: token)
+    }
+
+    var themeURL: URL {
+        baseURL
+            .appendingPathComponent(token, isDirectory: true)
+            .appendingPathComponent("api", isDirectory: true)
+            .appendingPathComponent("theme")
+    }
+
+    static func browserURL(port: Int, token: String) -> URL {
+        URL(string: "http://127.0.0.1:\(port)/\(token)/")!
+    }
+}
+
+struct AgentChatSidecarStateFile: Decodable, Sendable, Hashable {
+    var port: Int
+    var pid: Int
+
+    func session(token: String) -> AgentChatOwnedServerSession? {
+        guard (1...65_535).contains(port), pid > 0 else { return nil }
+        return AgentChatOwnedServerSession(port: port, pid: pid, token: token)
+    }
+
+    static func parse(_ data: Data, token: String) throws -> AgentChatOwnedServerSession? {
+        try JSONDecoder().decode(Self.self, from: data).session(token: token)
     }
 }

--- a/Sources/CmuxAgentChatConfig.swift
+++ b/Sources/CmuxAgentChatConfig.swift
@@ -195,7 +195,7 @@ struct AgentChatOwnedServerSession: Sendable, Hashable {
     }
 }
 
-struct AgentChatSidecarStateFile: Decodable, Sendable, Hashable {
+nonisolated struct AgentChatSidecarStateFile: Decodable, Sendable, Hashable {
     var port: Int
     var pid: Int
     var launchId: String?
@@ -261,7 +261,9 @@ struct AgentChatSidecarStateFileStore: Sendable {
                     fileManager: fileManager
                 )
                 try? fileManager.removeItem(at: stateFileURL)
-                _ = fileManager.createFile(atPath: stateFileURL.path, contents: nil)
+                guard fileManager.createFile(atPath: stateFileURL.path, contents: nil) else {
+                    return nil
+                }
                 return stateFileURL
             } catch {
                 return nil

--- a/Sources/CmuxAgentChatConfig.swift
+++ b/Sources/CmuxAgentChatConfig.swift
@@ -249,7 +249,7 @@ struct AgentChatSidecarStateFileStore: Sendable {
     func prepareStateFileURL(launchDate: Date) async -> URL? {
         let stateFileURL = stateFileURL
         let fileSystem = fileSystem
-        await Task.detached(priority: .utility) {
+        return await Task.detached(priority: .utility) { () -> URL? in
             let directoryURL = stateFileURL.deletingLastPathComponent()
             let fileManager = fileSystem.fileManager
             do {
@@ -284,7 +284,7 @@ struct AgentChatSidecarStateFileStore: Sendable {
     ) async -> AgentChatOwnedServerSession? {
         let stateFileURL = stateFileURL
         let fileSystem = fileSystem
-        await Task.detached(priority: .utility) {
+        return await Task.detached(priority: .utility) { () -> AgentChatOwnedServerSession? in
             let fileManager = fileSystem.fileManager
             let clock = ContinuousClock()
             let deadline = clock.now.advanced(by: .seconds(10))

--- a/Sources/CmuxAgentChatConfig.swift
+++ b/Sources/CmuxAgentChatConfig.swift
@@ -84,6 +84,12 @@ enum CmuxAgentChatConfigurationSource: Sendable, Hashable {
     }
 }
 
+enum AgentChatServerMode: Sendable, Hashable {
+    case explicitURL
+    case appOwned
+    case legacyDefaultURL
+}
+
 struct CmuxAgentChatConfiguration: Sendable, Hashable {
     static let defaultURLString = "http://127.0.0.1:7739"
     static let `default` = CmuxAgentChatConfiguration(
@@ -100,6 +106,16 @@ struct CmuxAgentChatConfiguration: Sendable, Hashable {
 
     var startCommandRequiresTrust: Bool {
         source.isLocal && startCommand != nil
+    }
+
+    var serverMode: AgentChatServerMode {
+        if hasExplicitURL {
+            return .explicitURL
+        }
+        if startCommand != nil {
+            return .appOwned
+        }
+        return .legacyDefaultURL
     }
 
     var healthURL: URL {
@@ -190,5 +206,88 @@ struct AgentChatSidecarStateFile: Decodable, Sendable, Hashable {
 
     static func parse(_ data: Data, token: String) throws -> AgentChatOwnedServerSession? {
         try JSONDecoder().decode(Self.self, from: data).session(token: token)
+    }
+}
+
+enum AgentChatSidecarStateFileStore {
+    static func stateFileURL() -> URL? {
+        guard let appSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else {
+            return nil
+        }
+        let bundleIdentifier = Bundle.main.bundleIdentifier ?? "com.cmuxterm.app"
+        return appSupport
+            .appendingPathComponent(bundleIdentifier, isDirectory: true)
+            .appendingPathComponent("agent-chat", isDirectory: true)
+            .appendingPathComponent("state.json")
+    }
+
+    static func prepareStateFileURL() async -> URL? {
+        await Task.detached(priority: .utility) {
+            guard let stateFileURL = Self.stateFileURL() else { return nil }
+            let directoryURL = stateFileURL.deletingLastPathComponent()
+            let fileManager = FileManager.default
+            do {
+                try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+                try Self.sweepStaleStateFiles(in: directoryURL, keeping: stateFileURL)
+                try? fileManager.removeItem(at: stateFileURL)
+                _ = fileManager.createFile(atPath: stateFileURL.path, contents: nil)
+                return stateFileURL
+            } catch {
+                return nil
+            }
+        }.value
+    }
+
+    static func removeStateFile() async {
+        await Task.detached(priority: .utility) {
+            guard let stateFileURL = Self.stateFileURL() else { return }
+            try? FileManager.default.removeItem(at: stateFileURL)
+        }.value
+    }
+
+    static func waitForSession(
+        stateFileURL: URL,
+        token: String
+    ) async -> AgentChatOwnedServerSession? {
+        await Task.detached(priority: .utility) {
+            let clock = ContinuousClock()
+            let deadline = clock.now.advanced(by: .seconds(10))
+            while !Task.isCancelled, clock.now < deadline {
+                if let data = try? Data(contentsOf: stateFileURL),
+                   let session = try? AgentChatSidecarStateFile.parse(data, token: token) {
+                    return session
+                }
+                do {
+                    // Bounded, cancellable polling for the sidecar readiness state file.
+                    try await clock.sleep(for: .milliseconds(250))
+                } catch {
+                    return nil
+                }
+            }
+            return nil
+        }.value
+    }
+
+    private static func sweepStaleStateFiles(
+        in directoryURL: URL,
+        keeping currentStateFileURL: URL
+    ) throws {
+        let fileManager = FileManager.default
+        let cutoff = Date().addingTimeInterval(-24 * 60 * 60)
+        let stateFiles = try fileManager.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles]
+        )
+        for fileURL in stateFiles where fileURL != currentStateFileURL {
+            guard fileURL.pathExtension == "json" else { continue }
+            let values = try? fileURL.resourceValues(forKeys: [.contentModificationDateKey])
+            if (values?.contentModificationDate ?? .distantPast) < cutoff {
+                try? fileManager.removeItem(at: fileURL)
+            }
+        }
     }
 }

--- a/agent-chat/README.md
+++ b/agent-chat/README.md
@@ -1,6 +1,6 @@
 # cmux-agent-ui
 
-MVP of the "UI mode" for cmux: a web chat surface (initial composer + chat view) rendered in cmux's existing browser surface, backed by any coding agent CLI. No Swift changes; the app side is just `cmux browser open http://127.0.0.1:7739`.
+MVP of the "UI mode" for cmux: a web chat surface (initial composer + chat view) rendered in cmux's existing browser surface, backed by any coding agent CLI. In production cmux launches the sidecar on a discovered loopback port and opens the unguessable token-prefixed URL it reports.
 
 ## Run
 
@@ -8,9 +8,9 @@ Three entrypoints, all landing on the same server:
 
 - **CLI** (`cmux-chat`, symlinked into `~/.local/bin`): `cmux-chat` opens a composer as a new workspace tab; `cmux-chat -p codex fix the tests` starts the chat immediately; `--split` opens in the current workspace instead; `--no-open` prints the URL. It auto-starts the server if needed.
 - **Command palette**: `Cmd+Shift+P` → "New Agent Chat". Wired via `~/.config/cmux/cmux.json` (`actions.agent-chat` → `workspaceCommand` "Agent Chat" with a browser-surface layout), cmux's designed extension point, so no app build. When this productizes it becomes a built-in palette command in the cmux repo.
-- **Server** runs under launchd (`~/Library/LaunchAgents/com.cmux.agent-ui.plist`, KeepAlive) on http://127.0.0.1:7739. Remove with `launchctl bootout gui/501/com.cmux.agent-ui && rm ~/Library/LaunchAgents/com.cmux.agent-ui.plist`. Manual run: `bun server.ts`.
+- **Server** runs as a cmux sidecar. Manual dev run: `bun server.ts` (defaults to `http://127.0.0.1:7739` with no token). Production launchers set `CMUX_AGENT_CHAT_PORT=0`, `CMUX_AGENT_CHAT_TOKEN=<unguessable>`, and `CMUX_AGENT_CHAT_STATE_FILE=<path>`; after bind the server atomically writes `{"port":..., "pid":..., "protocolVersion":1}` so cmux can open `http://127.0.0.1:<port>/<token>/`.
 
-One page = one session: `/` is the composer, `/s/<id>` a chat. There is deliberately no in-page session list or header; each chat is its own cmux workspace tab (page title = first prompt), so cmux's sidebar is the session list.
+One page = one session: `/` is the composer, `/s/<id>` a chat. When `CMUX_AGENT_CHAT_TOKEN` or `--token` is configured, every HTTP route, static asset, API route, and WebSocket upgrade except `/healthz` must be under `/<token>/...`; missing or wrong tokens return 404. There is deliberately no in-page session list or header; each chat is its own cmux workspace tab (page title = first prompt), so cmux's sidebar is the session list.
 
 ## Theming
 
@@ -49,7 +49,7 @@ picker and `Popover` for the working-directory editor and overflow menus.
 Base UI ships unstyled, so every part is themed with the resolved Ghostty
 colors. The server bundles `src/main.tsx` with `Bun.build` on startup and
 serves it as `/app.js`; the HTML shell injects the theme CSS variables and
-loads `/app.css`.
+loads `app.css` relative to the current sidecar prefix.
 
 ```
 browser surface (React app: src/*.tsx + Base UI)

--- a/agent-chat/cmux-chat
+++ b/agent-chat/cmux-chat
@@ -17,6 +17,11 @@ PORT="${CMUX_AGENT_UI_PORT:-7739}"
 BASE="http://127.0.0.1:${PORT}"
 BUN="${BUN_BIN:-$HOME/.bun/bin/bun}"
 
+if [ -n "${CMUX_AGENT_CHAT_STATE_FILE:-}" ]; then
+  cd "$HERE"
+  exec "$BUN" server.ts
+fi
+
 provider="claude" cwd="" open_mode="tab" auto_approve=true no_open=false
 prompt=()
 while [ $# -gt 0 ]; do

--- a/agent-chat/server.ts
+++ b/agent-chat/server.ts
@@ -89,7 +89,11 @@ async function writeStateFilePath(path: string, port: number) {
   const dir = dirname(path);
   await mkdir(dir, { recursive: true });
   const tmp = join(dir, `${pathBasename(path)}.${process.pid}.tmp`);
-  await writeFile(tmp, JSON.stringify({ port, pid: process.pid, protocolVersion: 1 }) + "\n", "utf8");
+  // launchId lets the app match the file to ITS launch: with a stable state
+  // path, a stale file from a previous sidecar (different token) must never
+  // satisfy a new launch's discovery.
+  const launchId = process.env.CMUX_AGENT_CHAT_LAUNCH_ID ?? null;
+  await writeFile(tmp, JSON.stringify({ port, pid: process.pid, protocolVersion: 1, launchId }) + "\n", "utf8");
   await rename(tmp, path);
 }
 

--- a/agent-chat/server.ts
+++ b/agent-chat/server.ts
@@ -17,21 +17,37 @@ import { piAdapter } from "./adapters/pi";
 import { makeAcpAdapter } from "./adapters/acp";
 import { pickAccentColor, resolveGhosttyTheme, resolveGhosttyThemeAsync, type GhosttyTheme } from "./theme";
 import { existsSync, readFileSync, statSync, watch, type FSWatcher } from "node:fs";
-import { readdir, stat } from "node:fs/promises";
+import { mkdir, readdir, rename, stat, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
-import { basename as pathBasename, extname, isAbsolute, join, relative, resolve } from "node:path";
+import { basename as pathBasename, dirname, extname, isAbsolute, join, relative, resolve } from "node:path";
 
-const PORT = Number(process.env.CMUX_AGENT_UI_PORT ?? 7739);
+function argValue(name: string): string | undefined {
+  const eq = Bun.argv.find((arg) => arg.startsWith(`${name}=`));
+  if (eq) return eq.slice(name.length + 1);
+  const i = Bun.argv.indexOf(name);
+  return i >= 0 ? Bun.argv[i + 1] : undefined;
+}
+
+const PORT = Number(argValue("--port") ?? process.env.CMUX_AGENT_CHAT_PORT ?? process.env.CMUX_AGENT_UI_PORT ?? 7739);
+const AUTH_TOKEN = argValue("--token") ?? process.env.CMUX_AGENT_CHAT_TOKEN ?? "";
+if (AUTH_TOKEN.includes("/")) throw new Error("CMUX_AGENT_CHAT_TOKEN must be a single path segment");
+const AUTH_PREFIX = AUTH_TOKEN ? `/${encodeURIComponent(AUTH_TOKEN)}` : "";
+const STATE_FILE = process.env.CMUX_AGENT_CHAT_STATE_FILE ?? "";
 
 // The sidecar binds loopback only, but browsers can still reach loopback from
 // arbitrary web origins (CSRF against the WS control plane) and DNS rebinding
-// can defeat a bind-address check alone. Require a loopback Host header and,
+// can defeat a bind-address check alone. Require a loopback Host header and
 // for browser-originated requests, a same-origin Origin header. Requests
 // without an Origin header (CLI curl, Bun's WebSocket client) are trusted.
-const ALLOWED_HOSTS = new Set([`127.0.0.1:${PORT}`, `localhost:${PORT}`, `[::1]:${PORT}`]);
+const LOOPBACK_HOSTS = new Set(["127.0.0.1", "localhost", "::1", "[::1]"]);
 
 function hasTrustedHost(req: Request): boolean {
-  return ALLOWED_HOSTS.has(req.headers.get("host") ?? "");
+  const host = req.headers.get("host") ?? "";
+  try {
+    return LOOPBACK_HOSTS.has(new URL(`http://${host}`).hostname);
+  } catch {
+    return false;
+  }
 }
 
 function hasTrustedOrigin(req: Request): boolean {
@@ -39,10 +55,50 @@ function hasTrustedOrigin(req: Request): boolean {
   if (origin === null) return true;
   try {
     const u = new URL(origin);
-    return u.protocol === "http:" && ALLOWED_HOSTS.has(u.host);
+    return u.protocol === "http:" && LOOPBACK_HOSTS.has(u.hostname) && u.host === (req.headers.get("host") ?? "");
   } catch {
     return false;
   }
+}
+
+function stripAuthPrefixWithToken(url: URL, token: string): URL | null {
+  const prefix = token ? `/${encodeURIComponent(token)}` : "";
+  if (!prefix) return url;
+  if (url.pathname === "/healthz") return url;
+  if (url.pathname !== prefix && !url.pathname.startsWith(`${prefix}/`)) return null;
+  const next = new URL(url);
+  next.pathname = url.pathname.slice(prefix.length) || "/";
+  return next;
+}
+
+function stripAuthPrefix(url: URL): URL | null {
+  return stripAuthPrefixWithToken(url, AUTH_TOKEN);
+}
+
+export function stripAuthPrefixForTest(path: string, token: string): string | null {
+  const stripped = stripAuthPrefixWithToken(new URL(`http://127.0.0.1${path}`), token);
+  return stripped?.pathname ?? null;
+}
+
+function prefixedPath(path: string): string {
+  return `${AUTH_PREFIX}${path}`;
+}
+
+async function writeStateFilePath(path: string, port: number) {
+  if (!path) return;
+  const dir = dirname(path);
+  await mkdir(dir, { recursive: true });
+  const tmp = join(dir, `${pathBasename(path)}.${process.pid}.tmp`);
+  await writeFile(tmp, JSON.stringify({ port, pid: process.pid, protocolVersion: 1 }) + "\n", "utf8");
+  await rename(tmp, path);
+}
+
+async function writeStateFile(port: number) {
+  await writeStateFilePath(STATE_FILE, port);
+}
+
+export async function writeStateFileForTest(path: string, port: number) {
+  await writeStateFilePath(path, port);
 }
 
 // Under launchd the PATH is minimal; make sure the agent CLIs resolve.
@@ -1170,8 +1226,8 @@ function iconResponse(url: URL): Response {
 }
 
 const providerIconInfo = new Map(PROVIDERS.map((p) => {
-  const iconUrl = iconFile(p.id, false) ? `/icons/${p.id}` : undefined;
-  const iconDarkUrl = p.id === "codex" && iconFile(p.id, true) ? `/icons/${p.id}?dark=1` : undefined;
+  const iconUrl = iconFile(p.id, false) ? prefixedPath(`/icons/${p.id}`) : undefined;
+  const iconDarkUrl = p.id === "codex" && iconFile(p.id, true) ? `${prefixedPath(`/icons/${p.id}`)}?dark=1` : undefined;
   return [p.id, { ...(iconUrl ? { iconUrl } : {}), ...(iconDarkUrl ? { iconDarkUrl } : {}) }];
 }));
 
@@ -1438,7 +1494,7 @@ export function themeMessageForTest(theme: GhosttyTheme): string {
 // appended by openers that created the browser surface with
 // transparent_background, so only genuinely transparent surfaces get an alpha
 // body; `?opacity=` is a dogfood override.
-function renderPage(url: URL): string {
+function renderPage(url: URL, prefix = AUTH_PREFIX): string {
   if (!cmuxThemeOverride) {
     fileTheme = resolveGhosttyTheme();
     currentTheme = fileTheme;
@@ -1452,18 +1508,25 @@ function renderPage(url: URL): string {
   const css = `:root { ${themeCssVars(currentTheme, { transparent, opacity: Number.isNaN(override) ? undefined : override })} }`;
   // Shell: theme vars first (so the first paint is the terminal bg), the
   // static stylesheet, a mount point, and the bundled React app (Base UI).
-  const script = url.pathname === "/gallery" ? "/gallery.js" : "/app.js";
+  const script = url.pathname === "/gallery" ? "gallery.js" : "app.js";
+  const base = prefix ? `${prefix}/` : "/";
   return `<!doctype html>
 <html lang="en"><head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <title>cmux agent</title>
-<link rel="stylesheet" href="/app.css">
+<base href="${base}">
+<script>window.__AGENT_CHAT_BASE__=${JSON.stringify(prefix)};</script>
+<link rel="stylesheet" href="app.css">
 <style>${css}</style>
 </head><body>
 <div id="root"></div>
 <script type="module" src="${script}"></script>
 </body></html>`;
+}
+
+export function renderPageForTest(pathname: string, prefix = ""): string {
+  return renderPage(new URL(`http://127.0.0.1${pathname}`), prefix);
 }
 
 interface StaticAsset {
@@ -1598,15 +1661,17 @@ function startServer() {
     port: PORT,
     hostname: "127.0.0.1",
     async fetch(req, srv) {
-    const url = new URL(req.url);
+    const originalUrl = new URL(req.url);
     if (!hasTrustedHost(req)) return new Response("forbidden", { status: 403 });
+    if (originalUrl.pathname === "/healthz") return new Response("ok");
+    const url = stripAuthPrefix(originalUrl);
+    if (!url) return new Response("not found", { status: 404 });
     if (url.pathname === "/ws") {
       if (!hasTrustedOrigin(req)) return new Response("forbidden", { status: 403 });
       return srv.upgrade(req, { data: { subscribed: null } })
         ? undefined
         : new Response("upgrade failed", { status: 400 });
     }
-    if (url.pathname === "/healthz") return new Response("ok");
     if (url.pathname.startsWith("/icons/")) return iconResponse(url);
     if (url.pathname === "/app.js" || url.pathname === "/gallery.js" || /^\/chunk-[\w-]+\.js$/.test(url.pathname)) {
       try {
@@ -1665,7 +1730,7 @@ function startServer() {
       }
       refreshSession(sess);
       if (prompt) sendPrompt(sess, prompt);
-      return Response.json({ id: sess.id, url: `http://127.0.0.1:${PORT}/s/${sess.id}` });
+      return Response.json({ id: sess.id, url: `http://127.0.0.1:${server.port}${prefixedPath(`/s/${sess.id}`)}` });
     }
     if (url.pathname === "/api/sessions" && req.method === "GET") {
       return Response.json([...sessions.values()].sort((a, b) => b.createdAt - a.createdAt).map(sessionSummary));
@@ -1721,6 +1786,7 @@ function startServer() {
     });
   }
   startThemeWatcher();
+  writeStateFile(server.port).catch((err) => console.error(`failed to write agent-chat state file: ${String(err)}`));
 
   console.log(`cmux-agent-ui listening on http://127.0.0.1:${server.port}`);
 }

--- a/agent-chat/src/session.ts
+++ b/agent-chat/src/session.ts
@@ -170,7 +170,10 @@ function basePrefix(): string {
 function routePath(): string {
   if (typeof location === "undefined") return "/";
   const base = basePrefix();
-  return base && location.pathname.startsWith(base + "/") ? location.pathname.slice(base.length) : location.pathname;
+  if (!base) return location.pathname;
+  // Bare /<token> (no trailing slash) is the app root.
+  if (location.pathname === base) return "/";
+  return location.pathname.startsWith(base + "/") ? location.pathname.slice(base.length) : location.pathname;
 }
 
 function appPath(path: string): string {

--- a/agent-chat/src/session.ts
+++ b/agent-chat/src/session.ts
@@ -158,7 +158,26 @@ export interface SessionState {
   clearError(): void;
 }
 
-const routedSessionId = (location.pathname.match(/^\/s\/([\w-]+)/) || [])[1] || null;
+declare global {
+  interface Window { __AGENT_CHAT_BASE__?: string }
+}
+
+function basePrefix(): string {
+  const base = typeof window === "undefined" ? "" : window.__AGENT_CHAT_BASE__ ?? "";
+  return base && base !== "/" ? base.replace(/\/$/, "") : "";
+}
+
+function routePath(): string {
+  if (typeof location === "undefined") return "/";
+  const base = basePrefix();
+  return base && location.pathname.startsWith(base + "/") ? location.pathname.slice(base.length) : location.pathname;
+}
+
+function appPath(path: string): string {
+  return `${basePrefix()}${path}`;
+}
+
+const routedSessionId = (routePath().match(/^\/s\/([\w-]+)/) || [])[1] || null;
 export const composerDraftKey = "agentui.draft";
 const PENDING_START_TIMEOUT_MS = 30_000;
 
@@ -219,7 +238,7 @@ export function useSession(): SessionState {
     clearPendingStartTimeout();
     pendingStartRef.current = null;
     restoreComposerDraft(sessionStorage, pending.prompt);
-    history.replaceState(null, "", "/");
+    history.replaceState(null, "", appPath("/"));
     document.title = "cmux agent";
     sessionIdRef.current = null;
     optimisticUsersRef.current = [];
@@ -253,7 +272,7 @@ export function useSession(): SessionState {
   useEffect(() => {
     let closed = false;
     const connect = () => {
-      const ws = new WebSocket((location.protocol === "https:" ? "wss://" : "ws://") + location.host + "/ws");
+      const ws = new WebSocket((location.protocol === "https:" ? "wss://" : "ws://") + location.host + appPath("/ws"));
       wsRef.current = ws;
       ws.onopen = () => {
         const pending = pendingStartRef.current;
@@ -278,7 +297,7 @@ export function useSession(): SessionState {
           }
           case "session-created":
             sessionIdRef.current = msg.session.id;
-            history.replaceState(null, "", "/s/" + msg.session.id);
+            history.replaceState(null, "", appPath("/s/" + msg.session.id));
             document.title = msg.session.title || "cmux agent";
             if (msg.requestId && pendingStartRef.current?.requestId === msg.requestId) {
               const queuedReplies = pendingStartRef.current.queuedReplies;
@@ -314,7 +333,7 @@ export function useSession(): SessionState {
             setPhase("chat");
             break;
           case "no-session":
-            history.replaceState(null, "", "/");
+            history.replaceState(null, "", appPath("/"));
             sessionIdRef.current = null;
             setSession(null);
             setOptions([]);
@@ -345,7 +364,7 @@ export function useSession(): SessionState {
             break;
           case "session-forked":
             setForkPending(false);
-            window.open("/s/" + msg.session.id, "_blank");
+            window.open(appPath("/s/" + msg.session.id), "_blank");
             break;
           case "options-list":
             setProviderOptions((m) => ({ ...m, [msg.provider]: msg.options ?? [] }));
@@ -408,7 +427,7 @@ export function useSession(): SessionState {
     armPendingStartTimeout();
     optimisticUsersRef.current = [opts.prompt];
     sessionIdRef.current = null;
-    history.replaceState(null, "", "/");
+    history.replaceState(null, "", appPath("/"));
     document.title = opts.prompt.length > 64 ? opts.prompt.slice(0, 64) + "…" : opts.prompt;
     setLastError("");
     setSession({
@@ -430,7 +449,7 @@ export function useSession(): SessionState {
   const compose = useCallback(() => {
     clearPendingStartTimeout();
     pendingStartRef.current = null;
-    history.replaceState(null, "", "/");
+    history.replaceState(null, "", appPath("/"));
     document.title = "cmux agent";
     sessionIdRef.current = null;
     setSession(null);

--- a/agent-chat/test/server-utils.test.ts
+++ b/agent-chat/test/server-utils.test.ts
@@ -16,9 +16,11 @@ import {
   recordFilesChangedForTest,
   recordTurnBaselineForTest,
   rebuildFileDiffAllowlistForTest,
+  renderPageForTest,
   resetAssetCachesForTest,
   resolveFileDiffPath,
   sendPromptForTest,
+  stripAuthPrefixForTest,
   themeCssVars,
   themeMtimesChangedForTest,
   themeMessageForTest,
@@ -28,10 +30,11 @@ import {
   turnBaselineCountForTest,
   turnBaselineKeysForTest,
   validateCmuxThemePayload,
+  writeStateFileForTest,
 } from "../server";
 import { applyManagedThemeOverrideForTest, pickAccentColor, resolveThemeNameForTest, type GhosttyTheme } from "../theme";
 import type { Adapter, AgentEvent, SessionCtx, SessionStatus } from "../types";
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 
 function assert(cond: unknown, msg: string): asserts cond {
@@ -56,6 +59,21 @@ try {
 }
 
 const cwd = "/tmp/agent-chat-path-test";
+assert(stripAuthPrefixForTest("/secret/app.js", "secret") === "/app.js", "token-prefixed route should be accepted and stripped");
+assert(stripAuthPrefixForTest("/secret", "secret") === "/", "bare token route should map to app root");
+assert(stripAuthPrefixForTest("/wrong/app.js", "secret") === null, "wrong token route should be hidden");
+assert(stripAuthPrefixForTest("/app.js", "secret") === null, "untokened route should be hidden when token is configured");
+assert(stripAuthPrefixForTest("/healthz", "secret") === "/healthz", "healthz should remain tokenless");
+const tokenHtml = renderPageForTest("/gallery", "/secret");
+assert(tokenHtml.includes('<base href="/secret/">'), "tokened HTML should inject the token base path");
+assert(tokenHtml.includes('src="gallery.js"') && tokenHtml.includes('href="app.css"'), "tokened HTML should use relative asset URLs");
+assert(!tokenHtml.includes('src="/app.js"') && !tokenHtml.includes('href="/app.css"'), "tokened HTML should not use root-absolute asset URLs");
+const statePath = join(import.meta.dir, "..", "scratch", "agent-chat-state-test.json");
+await rm(statePath, { force: true });
+await writeStateFileForTest(statePath, 54321);
+const state = JSON.parse(await readFile(statePath, "utf8"));
+assert(state.port === 54321 && state.pid === process.pid && state.protocolVersion === 1, `state file should contain discovery JSON: ${JSON.stringify(state)}`);
+
 assert(resolveFileDiffPath(cwd, "src/../file.ts") === "file.ts", "normal in-cwd paths should normalize");
 for (const path of ["src/../../x", "../x", "..", "a\0b"]) {
   let rejected = false;

--- a/cmuxTests/CmuxAgentChatConfigTests.swift
+++ b/cmuxTests/CmuxAgentChatConfigTests.swift
@@ -214,10 +214,14 @@ struct CmuxAgentChatConfigTests {
 
     @Test func agentChatStateFileParsesValidPortAndPID() throws {
         let data = try #require("""
-        {"port":43123,"pid":9876}
+        {"port":43123,"pid":9876,"launchId":"launch-1"}
         """.data(using: .utf8))
 
-        let session = try #require(try AgentChatSidecarStateFile.parse(data, token: "token_123"))
+        let session = try #require(try AgentChatSidecarStateFile.parse(
+            data,
+            token: "token_123",
+            launchId: "launch-1"
+        ))
 
         #expect(session.port == 43123)
         #expect(session.pid == 9876)
@@ -227,14 +231,26 @@ struct CmuxAgentChatConfigTests {
 
     @Test func agentChatStateFileRejectsInvalidPortOrPID() throws {
         let badPort = try #require("""
-        {"port":0,"pid":9876}
+        {"port":0,"pid":9876,"launchId":"launch-1"}
         """.data(using: .utf8))
         let badPID = try #require("""
-        {"port":43123,"pid":0}
+        {"port":43123,"pid":0,"launchId":"launch-1"}
         """.data(using: .utf8))
 
-        #expect(try AgentChatSidecarStateFile.parse(badPort, token: "token") == nil)
-        #expect(try AgentChatSidecarStateFile.parse(badPID, token: "token") == nil)
+        #expect(try AgentChatSidecarStateFile.parse(badPort, token: "token", launchId: "launch-1") == nil)
+        #expect(try AgentChatSidecarStateFile.parse(badPID, token: "token", launchId: "launch-1") == nil)
+    }
+
+    @Test func agentChatStateFileRequiresMatchingLaunchID() throws {
+        let missing = try #require("""
+        {"port":43123,"pid":9876}
+        """.data(using: .utf8))
+        let mismatched = try #require("""
+        {"port":43123,"pid":9876,"launchId":"old-launch"}
+        """.data(using: .utf8))
+
+        #expect(try AgentChatSidecarStateFile.parse(missing, token: "token", launchId: "new-launch") == nil)
+        #expect(try AgentChatSidecarStateFile.parse(mismatched, token: "token", launchId: "new-launch") == nil)
     }
 
     @Test func agentChatOwnedServerBuildsTokenedURLs() {

--- a/cmuxTests/CmuxAgentChatConfigTests.swift
+++ b/cmuxTests/CmuxAgentChatConfigTests.swift
@@ -56,6 +56,7 @@ struct CmuxAgentChatConfigTests {
         #expect(config.agentChat?.url == "http://127.0.0.1:8777/chat")
         #expect(config.agentChat?.startCommand == "cmux-chat --port 8777")
         let resolved = CmuxAgentChatConfiguration.resolved(local: config.agentChat, global: nil)
+        #expect(resolved.hasExplicitURL)
         #expect(resolved.healthURL.absoluteString == "http://127.0.0.1:8777/healthz")
     }
 
@@ -106,6 +107,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.startCommand == nil)
         #expect(resolved.source == .local(path: localPath))
         #expect(resolved.source.sourcePath == localPath)
+        #expect(resolved.hasExplicitURL)
         #expect(!resolved.startCommandRequiresTrust)
     }
 
@@ -133,6 +135,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.url.absoluteString == "http://127.0.0.1:9000")
         #expect(resolved.startCommand == "cmux-chat --port 9000")
         #expect(resolved.source == .global(path: globalPath))
+        #expect(resolved.hasExplicitURL)
         #expect(!resolved.startCommandRequiresTrust)
     }
 
@@ -151,6 +154,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.url.absoluteString == CmuxAgentChatConfiguration.defaultURLString)
         #expect(resolved.startCommand == "cmux-chat --port 9010")
         #expect(resolved.source == .local(path: localPath))
+        #expect(!resolved.hasExplicitURL)
         #expect(resolved.startCommandRequiresTrust)
     }
 
@@ -169,6 +173,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.url.absoluteString == "http://127.0.0.1:9000")
         #expect(resolved.startCommand == "cmux-chat --port 9000")
         #expect(resolved.source == .global(path: globalPath))
+        #expect(resolved.hasExplicitURL)
         #expect(!resolved.startCommandRequiresTrust)
     }
 
@@ -179,7 +184,41 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.startCommand == nil)
         #expect(resolved.source == .defaults)
         #expect(resolved.source.sourcePath == nil)
+        #expect(!resolved.hasExplicitURL)
         #expect(!resolved.startCommandRequiresTrust)
+    }
+
+    @Test func agentChatStateFileParsesValidPortAndPID() throws {
+        let data = try #require("""
+        {"port":43123,"pid":9876}
+        """.data(using: .utf8))
+
+        let session = try #require(try AgentChatSidecarStateFile.parse(data, token: "token_123"))
+
+        #expect(session.port == 43123)
+        #expect(session.pid == 9876)
+        #expect(session.token == "token_123")
+        #expect(session.healthURL.absoluteString == "http://127.0.0.1:43123/healthz")
+    }
+
+    @Test func agentChatStateFileRejectsInvalidPortOrPID() throws {
+        let badPort = try #require("""
+        {"port":0,"pid":9876}
+        """.data(using: .utf8))
+        let badPID = try #require("""
+        {"port":43123,"pid":0}
+        """.data(using: .utf8))
+
+        #expect(try AgentChatSidecarStateFile.parse(badPort, token: "token") == nil)
+        #expect(try AgentChatSidecarStateFile.parse(badPID, token: "token") == nil)
+    }
+
+    @Test func agentChatOwnedServerBuildsTokenedURLs() {
+        let session = AgentChatOwnedServerSession(port: 43123, pid: 9876, token: "abc-DEF_123")
+
+        #expect(session.browserURL.absoluteString == "http://127.0.0.1:43123/abc-DEF_123/")
+        #expect(session.themeURL.absoluteString == "http://127.0.0.1:43123/abc-DEF_123/api/theme")
+        #expect(AgentChatOwnedServerSession.browserURL(port: 43123, token: "abc").absoluteString == "http://127.0.0.1:43123/abc/")
     }
 
     @Test func newAgentChatInFlightGateRejectsDuplicatesUntilCleared() {
@@ -235,6 +274,35 @@ struct CmuxAgentChatConfigTests {
     @Test func agentChatThemeEndpointIsRootAnchoredLikeHealthURL() throws {
         let url = try #require(URL(string: "http://127.0.0.1:7739/chat?ignored=1"))
         #expect(AgentChatThemeSync.themeURL(for: url).absoluteString == "http://127.0.0.1:7739/api/theme")
+    }
+
+    @MainActor
+    @Test func agentChatThemeURLUsesTokenedOwnedServerWhenAvailable() {
+        let session = AgentChatOwnedServerSession(port: 43123, pid: 9876, token: "theme-token")
+        AgentChatOwnedServerRuntime.shared.update(session: session)
+        defer { AgentChatOwnedServerRuntime.shared.resetForTesting() }
+        let agentChat = CmuxAgentChatConfiguration.resolved(
+            local: CmuxAgentChatConfigDefinition(startCommand: "cmux-chat"),
+            global: nil
+        )
+
+        #expect(AgentChatThemeSync.themeURL(for: agentChat).absoluteString == "http://127.0.0.1:43123/theme-token/api/theme")
+    }
+
+    @MainActor
+    @Test func explicitAgentChatThemeURLIgnoresOwnedServer() {
+        let session = AgentChatOwnedServerSession(port: 43123, pid: 9876, token: "theme-token")
+        AgentChatOwnedServerRuntime.shared.update(session: session)
+        defer { AgentChatOwnedServerRuntime.shared.resetForTesting() }
+        let agentChat = CmuxAgentChatConfiguration.resolved(
+            local: CmuxAgentChatConfigDefinition(
+                url: "http://127.0.0.1:9000/chat",
+                startCommand: "cmux-chat"
+            ),
+            global: nil
+        )
+
+        #expect(AgentChatThemeSync.themeURL(for: agentChat).absoluteString == "http://127.0.0.1:9000/api/theme")
     }
 
     @Test func agentChatThemePayloadEncodesNullNullableFields() throws {

--- a/cmuxTests/CmuxAgentChatConfigTests.swift
+++ b/cmuxTests/CmuxAgentChatConfigTests.swift
@@ -261,6 +261,51 @@ struct CmuxAgentChatConfigTests {
         #expect(AgentChatOwnedServerSession.browserURL(port: 43123, token: "abc").absoluteString == "http://127.0.0.1:43123/abc/")
     }
 
+    @Test func agentChatStateFileStoreBuildsPerLaunchPaths() {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-agent-chat-state-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        let store = AgentChatSidecarStateFileStore(
+            directoryURL: root,
+            fileSystem: AgentChatSidecarFileSystem()
+        )
+
+        #expect(store.stateFileURL(launchId: "launch-a").lastPathComponent == "state-launch-a.json")
+        #expect(store.stateFileURL(launchId: "launch-b").lastPathComponent == "state-launch-b.json")
+    }
+
+    @Test func agentChatStateFileStoreSweepsPatternedStaleFiles() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-agent-chat-state-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? fileManager.removeItem(at: root) }
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        let stale = root.appendingPathComponent("state-old.json")
+        let unrelated = root.appendingPathComponent("other.json")
+        try Data("old".utf8).write(to: stale)
+        try Data("keep".utf8).write(to: unrelated)
+        let oldDate = Date(timeIntervalSinceNow: -120)
+        try fileManager.setAttributes([.modificationDate: oldDate], ofItemAtPath: stale.path)
+        try fileManager.setAttributes([.modificationDate: oldDate], ofItemAtPath: unrelated.path)
+        let store = AgentChatSidecarStateFileStore(
+            directoryURL: root,
+            fileSystem: AgentChatSidecarFileSystem(fileManager: fileManager)
+        )
+
+        let prepared = try #require(await store.prepareStateFileURL(
+            launchId: "new",
+            launchDate: Date()
+        ))
+
+        #expect(prepared.lastPathComponent == "state-new.json")
+        #expect(fileManager.fileExists(atPath: prepared.path))
+        #expect(!fileManager.fileExists(atPath: stale.path))
+        #expect(fileManager.fileExists(atPath: unrelated.path))
+    }
+
     @Test func newAgentChatInFlightGateRejectsDuplicatesUntilCleared() {
         let firstBegin = AgentChatActionInFlightGate.begin()
         #expect(firstBegin)
@@ -343,6 +388,34 @@ struct CmuxAgentChatConfigTests {
         )
 
         #expect(AgentChatThemeSync.themeURL(for: agentChat).absoluteString == "http://127.0.0.1:9000/api/theme")
+    }
+
+    @MainActor
+    @Test func agentChatThemeConnectionFailureClearsMatchingOwnedSession() async {
+        let session = AgentChatOwnedServerSession(port: 43123, pid: 9876, token: "theme-token")
+        AgentChatActionInFlightGate.updateOwnedServerSession(session)
+        defer { AgentChatActionInFlightGate.clearOwnedServerSession() }
+
+        await AgentChatThemeSync.handleThemePostFailure(
+            URLError(.cannotConnectToHost),
+            url: session.themeURL
+        )
+
+        #expect(AgentChatActionInFlightGate.ownedServerSession() == nil)
+    }
+
+    @MainActor
+    @Test func agentChatThemeNonConnectionFailureKeepsOwnedSession() async {
+        let session = AgentChatOwnedServerSession(port: 43123, pid: 9876, token: "theme-token")
+        AgentChatActionInFlightGate.updateOwnedServerSession(session)
+        defer { AgentChatActionInFlightGate.clearOwnedServerSession() }
+
+        await AgentChatThemeSync.handleThemePostFailure(
+            URLError(.badURL),
+            url: session.themeURL
+        )
+
+        #expect(AgentChatActionInFlightGate.ownedServerSession() == session)
     }
 
     @Test func agentChatThemePayloadEncodesNullNullableFields() throws {

--- a/cmuxTests/CmuxAgentChatConfigTests.swift
+++ b/cmuxTests/CmuxAgentChatConfigTests.swift
@@ -108,6 +108,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.source == .local(path: localPath))
         #expect(resolved.source.sourcePath == localPath)
         #expect(resolved.hasExplicitURL)
+        #expect(resolved.serverMode == .explicitURL)
         #expect(!resolved.startCommandRequiresTrust)
     }
 
@@ -136,6 +137,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.startCommand == "cmux-chat --port 9000")
         #expect(resolved.source == .global(path: globalPath))
         #expect(resolved.hasExplicitURL)
+        #expect(resolved.serverMode == .explicitURL)
         #expect(!resolved.startCommandRequiresTrust)
     }
 
@@ -155,6 +157,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.startCommand == "cmux-chat --port 9010")
         #expect(resolved.source == .local(path: localPath))
         #expect(!resolved.hasExplicitURL)
+        #expect(resolved.serverMode == .appOwned)
         #expect(resolved.startCommandRequiresTrust)
     }
 
@@ -174,6 +177,7 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.startCommand == "cmux-chat --port 9000")
         #expect(resolved.source == .global(path: globalPath))
         #expect(resolved.hasExplicitURL)
+        #expect(resolved.serverMode == .explicitURL)
         #expect(!resolved.startCommandRequiresTrust)
     }
 
@@ -185,7 +189,27 @@ struct CmuxAgentChatConfigTests {
         #expect(resolved.source == .defaults)
         #expect(resolved.source.sourcePath == nil)
         #expect(!resolved.hasExplicitURL)
+        #expect(resolved.serverMode == .legacyDefaultURL)
         #expect(!resolved.startCommandRequiresTrust)
+    }
+
+    @Test func agentChatServerModeSelectsTheThreeURLStrategies() {
+        let explicit = CmuxAgentChatConfiguration.resolved(
+            local: CmuxAgentChatConfigDefinition(url: "http://127.0.0.1:9000/chat"),
+            global: nil
+        )
+        let owned = CmuxAgentChatConfiguration.resolved(
+            local: CmuxAgentChatConfigDefinition(startCommand: "cmux-chat"),
+            global: nil
+        )
+        let legacy = CmuxAgentChatConfiguration.resolved(local: nil, global: nil)
+
+        #expect(explicit.serverMode == .explicitURL)
+        #expect(explicit.url.absoluteString == "http://127.0.0.1:9000/chat")
+        #expect(owned.serverMode == .appOwned)
+        #expect(owned.url.absoluteString == CmuxAgentChatConfiguration.defaultURLString)
+        #expect(legacy.serverMode == .legacyDefaultURL)
+        #expect(legacy.url.absoluteString == CmuxAgentChatConfiguration.defaultURLString)
     }
 
     @Test func agentChatStateFileParsesValidPortAndPID() throws {
@@ -279,8 +303,8 @@ struct CmuxAgentChatConfigTests {
     @MainActor
     @Test func agentChatThemeURLUsesTokenedOwnedServerWhenAvailable() {
         let session = AgentChatOwnedServerSession(port: 43123, pid: 9876, token: "theme-token")
-        AgentChatOwnedServerRuntime.shared.update(session: session)
-        defer { AgentChatOwnedServerRuntime.shared.resetForTesting() }
+        AgentChatActionInFlightGate.updateOwnedServerSession(session)
+        defer { AgentChatActionInFlightGate.clearOwnedServerSession() }
         let agentChat = CmuxAgentChatConfiguration.resolved(
             local: CmuxAgentChatConfigDefinition(startCommand: "cmux-chat"),
             global: nil
@@ -292,8 +316,8 @@ struct CmuxAgentChatConfigTests {
     @MainActor
     @Test func explicitAgentChatThemeURLIgnoresOwnedServer() {
         let session = AgentChatOwnedServerSession(port: 43123, pid: 9876, token: "theme-token")
-        AgentChatOwnedServerRuntime.shared.update(session: session)
-        defer { AgentChatOwnedServerRuntime.shared.resetForTesting() }
+        AgentChatActionInFlightGate.updateOwnedServerSession(session)
+        defer { AgentChatActionInFlightGate.clearOwnedServerSession() }
         let agentChat = CmuxAgentChatConfiguration.resolved(
             local: CmuxAgentChatConfigDefinition(
                 url: "http://127.0.0.1:9000/chat",


### PR DESCRIPTION
Moves the agent-chat sidecar off the fixed public localhost:7739 onto the diff-viewer serving contract. Sidecar: CMUX_AGENT_CHAT_TOKEN gates every route and the WebSocket as a leading path segment (missing/wrong token 404s, /healthz stays tokenless), CMUX_AGENT_CHAT_PORT=0 binds an ephemeral port and writes {port,pid,protocolVersion} atomically to CMUX_AGENT_CHAT_STATE_FILE, and all asset/WS URLs are prefix-relative. App (behind isAgentChatUIEnabled): generates a per-launch 128-bit token, injects the env into the existing trusted startCommand launch, discovers the port from the state file, health-checks, opens the tokened URL, and theme pushes target the tokened base. An explicitly configured agentChat.url keeps current behavior as the advanced escape hatch. Follow-up direction on record: converge the backend into the native AgentSessionProcessStore + webviews bridge so no local server exists at all.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7723"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786200139&installation_id=133855650&pr_number=7723&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7723&signature=8c2c51a6f0b0d1061d97c0718ae8e771b08c28c6a93a1076d9e0df13ca5f6d04"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches local process launch, loopback security boundaries, and browser URL opening; mistakes could open the wrong endpoint or leave stale sidecar state, but scope stays on localhost with tokens and launch-id matching.
> 
> **Overview**
> Replaces the fixed **127.0.0.1:7739** agent-chat contract with an **app-owned sidecar** when config has a `startCommand` but no explicit `agentChat.url`. cmux generates a per-launch **unguessable token** and **launch ID**, starts the trusted `startCommand` with `CMUX_AGENT_CHAT_PORT=0`, token, state-file, and launch-id env vars, **polls an atomic state file** for `{port, pid, launchId}`, health-checks, then opens **`http://127.0.0.1:<port>/<token>/`** instead of the legacy URL. **`AgentChatServerMode`** splits **explicit URL**, **app-owned**, and **legacy default** behavior; theme pushes target the **token-prefixed** `/api/theme` on the owned session, and **connection failures** can clear a stale owned session.
> 
> The **Bun sidecar** gates every route and WebSocket (except **`/healthz`**) behind a leading **path token**, binds an **ephemeral loopback port**, writes discovery JSON to the state file, and serves HTML with **`<base>`** plus **`__AGENT_CHAT_BASE__`** so assets and the React client use **prefix-relative** URLs. Loopback **Host/Origin** checks work with dynamic ports. **`cmux-chat`** **execs** `server.ts` when `CMUX_AGENT_CHAT_STATE_FILE` is set (cmux-driven launch).
> 
> Owned launch failures surface **“Could not start Agent Chat”** (no workspace opened) instead of only the older unreachable-server copy; explicit `agentChat.url` keeps the previous fixed-URL + optional `startCommand` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bbd2fdd92534ef62ba12eda4160293e2b25365d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves Agent Chat to an app-owned sidecar on a per-launch loopback port with an unguessable path token; the app discovers it via a per‑launch state file and opens the tokened URL. Owned launches never fall back to the legacy URL; failures beep and show a focused “Could not start Agent Chat” notification.

- New Features
  - Dynamic port + token: set `CMUX_AGENT_CHAT_PORT=0` and `CMUX_AGENT_CHAT_TOKEN`; all HTTP and WebSocket routes require the leading token; `/healthz` stays tokenless; HTML injects `<base>` and `__AGENT_CHAT_BASE__`; assets and WS use prefix‑relative URLs.
  - App-owned launch: the app generates a 128‑bit token and `launchId`, launches the trusted `startCommand` with `CMUX_AGENT_CHAT_*`, the sidecar writes `{"port","pid","protocolVersion","launchId"}` atomically to a per‑launch `state-<launchId>.json`, the app validates `launchId`, reuses a healthy session, opens `http://127.0.0.1:<port>/<token>/`, and sends theme updates to that session’s tokened `/api/theme` (explicit `agentChat.url` keeps fixed‑URL behavior).
  - Owned‑mode wrapper: `cmux-chat` execs the sidecar when `CMUX_AGENT_CHAT_STATE_FILE` is set so env flows through; no fixed‑port probe or URL opening.

- Bug Fixes
  - Hardened serving: strict loopback Host and same‑origin Origin checks; wrong/missing tokens 404; owned mode never probes or opens legacy `127.0.0.1:7739`; on failure we beep and post an anchored notification.
  - Theme sync treats connection‑level errors as dead sessions and clears the owned session so the next action relaunches.

<sup>Written for commit 2bbd2fdd92534ef62ba12eda4160293e2b25365d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Agent Chat now supports session-specific, token-prefixed routing with a persisted state file for startup, theming, and navigation.
  * Added configuration-aware theme URL selection (prefers owned-session theme when available; otherwise uses the configured URL).
* **Bug Fixes**
  * Improved server availability handling across server modes with more reliable “server unavailable” notifications.
  * Strengthened loopback/origin trust checks for both HTTP and WebSocket requests.
* **Documentation**
  * Updated run instructions and asset/theme path guidance to match token-prefixed routing.
* **Tests**
  * Expanded coverage for auth-prefix handling, token-aware rendering, state-file persistence, and theme URL selection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->