### PR TITLE
Add recent agent files to the right sidebar

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Parsing/CodexApplyPatchParser.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Parsing/CodexApplyPatchParser.swift
@@ -1,0 +1,90 @@
+import Foundation
+
+/// Converts Codex `apply_patch` input into one file-edit value per patch section.
+struct CodexApplyPatchParser: Sendable {
+    private let budget: TranscriptTextBudget
+
+    /// Creates a parser using the transcript-wide text budget.
+    ///
+    /// - Parameter budget: Limit applied to captured per-file patch text.
+    init(budget: TranscriptTextBudget) {
+        self.budget = budget
+    }
+
+    /// Extracts every file operation from a Codex patch payload.
+    ///
+    /// - Parameter patch: The raw `*** Begin Patch` payload.
+    /// - Returns: File edits in patch order.
+    func fileEdits(in patch: String) -> [ChatFileEdit] {
+        var edits: [ChatFileEdit] = []
+        var current: Section?
+
+        for line in patch.components(separatedBy: "\n") {
+            if let header = sectionHeader(from: line) {
+                if let current {
+                    edits.append(fileEdit(from: current))
+                }
+                current = header
+                continue
+            }
+            guard var section = current else { continue }
+            if let movedPath = movedPath(from: line) {
+                section.filePath = movedPath
+            } else if line != "*** End Patch" {
+                section.lines.append(line)
+            }
+            current = section
+        }
+
+        if let current {
+            edits.append(fileEdit(from: current))
+        }
+        return edits
+    }
+
+    private func sectionHeader(from line: String) -> Section? {
+        let prefixes: [(String, ChatFileEdit.Operation)] = [
+            ("*** Update File: ", .edit),
+            ("*** Add File: ", .write),
+            ("*** Delete File: ", .delete),
+        ]
+        for (prefix, operation) in prefixes where line.hasPrefix(prefix) {
+            let path = String(line.dropFirst(prefix.count))
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !path.isEmpty else { return nil }
+            return Section(filePath: path, operation: operation)
+        }
+        return nil
+    }
+
+    private func movedPath(from line: String) -> String? {
+        let prefix = "*** Move to: "
+        guard line.hasPrefix(prefix) else { return nil }
+        let path = String(line.dropFirst(prefix.count))
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return path.isEmpty ? nil : path
+    }
+
+    private func fileEdit(from section: Section) -> ChatFileEdit {
+        let additions = section.lines.count { line in
+            line.hasPrefix("+") && !line.hasPrefix("+++")
+        }
+        let deletions = section.lines.count { line in
+            line.hasPrefix("-") && !line.hasPrefix("---")
+        }
+        let diff = section.lines.joined(separator: "\n")
+        return ChatFileEdit(
+            filePath: section.filePath,
+            operation: section.operation,
+            additions: additions,
+            deletions: deletions,
+            unifiedDiff: diff.isEmpty ? nil : budget.body(diff)
+        )
+    }
+
+    private struct Section: Sendable {
+        var filePath: String
+        let operation: ChatFileEdit.Operation
+        var lines: [String] = []
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Parsing/CodexTranscriptParser.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Parsing/CodexTranscriptParser.swift
@@ -284,9 +284,24 @@ public struct CodexTranscriptParser: Sendable {
         guard let name = payload["name"]?.string else { return }
         let callID = payload["call_id"]?.string
         let input = payload["input"]?.string ?? ""
-        var summary = name
-        if name == "apply_patch", let path = firstPatchedFile(in: input) {
-            summary = "\(name) \(budget.summaryArgument(path))"
+        if name == "apply_patch" {
+            let edits = CodexApplyPatchParser(budget: budget).fileEdits(in: input)
+            if !edits.isEmpty {
+                let baseID = callID ?? "line-\(seq)"
+                for (index, edit) in edits.enumerated() {
+                    assembler.append(
+                        ChatMessage(
+                            id: index == 0 ? baseID : "\(baseID)-file-\(index)",
+                            seq: seq,
+                            role: .agent,
+                            timestamp: timestamp,
+                            kind: .fileEdit(edit)
+                        ),
+                        pendingKey: callID
+                    )
+                }
+                return
+            }
         }
         assembler.append(
             ChatMessage(
@@ -297,7 +312,7 @@ public struct CodexTranscriptParser: Sendable {
                 kind: .toolUse(
                     ChatToolUse(
                         toolName: name,
-                        summary: summary,
+                        summary: name,
                         inputDetail: input.isEmpty ? nil : budget.inputDetail(input)
                     )
                 )
@@ -375,15 +390,6 @@ public struct CodexTranscriptParser: Sendable {
             return strings[2...].joined(separator: " ")
         }
         return strings.joined(separator: " ")
-    }
-
-    private func firstPatchedFile(in patch: String) -> String? {
-        guard
-            let match = patch.firstMatch(
-                of: /\*\*\* (?:Update|Add|Delete) File: (.+)/
-            )
-        else { return nil }
-        return String(match.1)
     }
 
     // MARK: - Tool outputs

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/CodexTranscriptParserTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/CodexTranscriptParserTests.swift
@@ -217,9 +217,21 @@ struct CodexTranscriptParserTests {
         #expect(tool.inputDetail?.contains("plan") == true)
     }
 
-    @Test("custom_tool_call apply_patch maps to toolUse with the first patched file in the summary")
+    @Test("custom_tool_call apply_patch maps every patched file to a fileEdit")
     func applyPatch() {
-        let patch = "*** Begin Patch\n*** Update File: /repo/Sources/App.swift\n@@\n-old\n+new\n*** End Patch"
+        let patch = """
+        *** Begin Patch
+        *** Update File: /repo/Sources/App.swift
+        @@
+        -old
+        +new
+        *** Add File: /repo/Sources/New.swift
+        +first
+        +second
+        *** Delete File: /repo/Sources/Old.swift
+        -obsolete
+        *** End Patch
+        """
         let lines = [
             line(type: "response_item", payload: [
                 "type": "custom_tool_call", "status": "completed",
@@ -231,13 +243,52 @@ struct CodexTranscriptParserTests {
             ]),
         ]
         let result = parser.parse(lines: lines, startingSeq: 0)
-        guard case .toolUse(let tool) = result.messages[0].kind else {
-            Issue.record("expected toolUse kind")
+        #expect(result.messages.count == 3)
+        guard case .fileEdit(let updated) = result.messages[0].kind,
+              case .fileEdit(let added) = result.messages[1].kind,
+              case .fileEdit(let deleted) = result.messages[2].kind else {
+            Issue.record("expected fileEdit kinds")
             return
         }
-        #expect(tool.toolName == "apply_patch")
-        #expect(tool.summary == "apply_patch /repo/Sources/App.swift")
-        #expect(tool.status == .succeeded)
+        #expect(updated.filePath == "/repo/Sources/App.swift")
+        #expect(updated.operation == .edit)
+        #expect(updated.additions == 1)
+        #expect(updated.deletions == 1)
+        #expect(added.filePath == "/repo/Sources/New.swift")
+        #expect(added.operation == .write)
+        #expect(added.additions == 2)
+        #expect(added.deletions == 0)
+        #expect(deleted.filePath == "/repo/Sources/Old.swift")
+        #expect(deleted.operation == .delete)
+        #expect(deleted.additions == 0)
+        #expect(deleted.deletions == 1)
+        #expect(result.messages.map(\.id) == ["call_ap", "call_ap-file-1", "call_ap-file-2"])
+        #expect(result.state.pendingToolUses.isEmpty)
+    }
+
+    @Test("apply_patch move reports the destination path")
+    func applyPatchMove() {
+        let patch = """
+        *** Begin Patch
+        *** Update File: /repo/Old.swift
+        *** Move to: /repo/New.swift
+        @@
+        -old
+        +new
+        *** End Patch
+        """
+        let result = parser.parse(lines: [
+            line(type: "response_item", payload: [
+                "type": "custom_tool_call", "status": "completed",
+                "call_id": "call_move", "name": "apply_patch", "input": patch,
+            ]),
+        ], startingSeq: 0)
+        guard case .fileEdit(let edit) = result.messages.first?.kind else {
+            Issue.record("expected fileEdit kind")
+            return
+        }
+        #expect(edit.filePath == "/repo/New.swift")
+        #expect(edit.operation == .edit)
     }
 
     // MARK: - Robustness

--- a/Sources/AgentChatTranscriptService+RecentFiles.swift
+++ b/Sources/AgentChatTranscriptService+RecentFiles.swift
@@ -1,0 +1,138 @@
+import CmuxAgentChat
+import Foundation
+
+extension AgentChatTranscriptService: AgentRecentFileProviding {
+    func recentFiles(in scope: AgentRecentFileScope, limit: Int) async -> [AgentRecentFile] {
+        guard limit > 0 else { return [] }
+        let records = registry.sessions(workspaceID: nil)
+            .filter { supportsRecentFiles(agentKind: $0.agentKind) && session($0, belongsTo: scope) }
+            .prefix(16)
+        var latestByPath: [String: AgentRecentFile] = [:]
+
+        for record in records {
+            for message in await recentFileMessages(for: record) {
+                guard case .fileEdit(let edit) = message.kind,
+                      edit.operation != .delete,
+                      let file = recentFile(edit: edit, message: message, record: record, scope: scope) else {
+                    continue
+                }
+                if let existing = latestByPath[file.path], existing.modifiedAt > file.modifiedAt {
+                    continue
+                }
+                latestByPath[file.path] = file
+            }
+        }
+
+        return Array(
+            latestByPath.values
+                .sorted {
+                    if $0.modifiedAt != $1.modifiedAt { return $0.modifiedAt > $1.modifiedAt }
+                    return $0.relativePath.localizedStandardCompare($1.relativePath) == .orderedAscending
+                }
+                .prefix(limit)
+        )
+    }
+
+    private func recentFileMessages(for record: AgentChatSessionRecord) async -> [ChatMessage] {
+        if case .ended = record.state {
+            guard let path = resolver.transcriptPath(for: record) else { return [] }
+            let tailer = AgentChatTranscriptTailer(
+                sessionID: record.sessionID,
+                agentKind: record.agentKind,
+                path: path,
+                onBatch: { _ in }
+            )
+            await tailer.loadSnapshot()
+            return await tailer.history(beforeSeq: nil, limit: 1_000).messages
+        }
+        return await history(sessionID: record.sessionID, beforeSeq: nil, limit: 1_000)?.messages ?? []
+    }
+
+    func changes() -> AsyncStream<Void> {
+        let id = UUID()
+        return AsyncStream { continuation in
+            recentFileChangeContinuations[id] = continuation
+            continuation.onTermination = { [weak self] _ in
+                Task { @MainActor [weak self] in
+                    self?.recentFileChangeContinuations[id] = nil
+                }
+            }
+        }
+    }
+
+    func yieldRecentAgentFileChanges() {
+        for continuation in recentFileChangeContinuations.values {
+            continuation.yield(())
+        }
+    }
+
+    private func supportsRecentFiles(agentKind: ChatAgentKind) -> Bool {
+        switch agentKind {
+        case .claude, .codex:
+            return true
+        case .other:
+            return false
+        }
+    }
+
+    private func session(_ record: AgentChatSessionRecord, belongsTo scope: AgentRecentFileScope) -> Bool {
+        if let workspaceID = scope.workspaceID, record.workspaceID == workspaceID {
+            return true
+        }
+        guard let root = scope.rootDirectory,
+              let workingDirectory = record.workingDirectory else {
+            return false
+        }
+        return path(normalizedPath(workingDirectory), isWithin: normalizedPath(root))
+    }
+
+    private func recentFile(
+        edit: ChatFileEdit,
+        message: ChatMessage,
+        record: AgentChatSessionRecord,
+        scope: AgentRecentFileScope
+    ) -> AgentRecentFile? {
+        let rawPath = edit.filePath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !rawPath.isEmpty else { return nil }
+        let resolvedPath: String
+        if rawPath.hasPrefix("/") {
+            resolvedPath = normalizedPath(rawPath)
+        } else if let base = record.workingDirectory ?? scope.rootDirectory {
+            resolvedPath = normalizedPath((normalizedPath(base) as NSString).appendingPathComponent(rawPath))
+        } else {
+            return nil
+        }
+
+        let relativePath: String
+        if let rootDirectory = scope.rootDirectory {
+            let root = normalizedPath(rootDirectory)
+            guard path(resolvedPath, isWithin: root) else { return nil }
+            relativePath = pathRelativeToRoot(resolvedPath, root: root)
+        } else {
+            relativePath = rawPath.hasPrefix("/") ? resolvedPath : rawPath
+        }
+        guard !relativePath.isEmpty else { return nil }
+        return AgentRecentFile(
+            path: resolvedPath,
+            relativePath: relativePath,
+            agentKind: record.agentKind,
+            operation: edit.operation,
+            modifiedAt: message.timestamp
+        )
+    }
+
+    private func normalizedPath(_ path: String) -> String {
+        (path as NSString).standardizingPath
+    }
+
+    private func path(_ candidate: String, isWithin root: String) -> Bool {
+        if root == "/" { return candidate.hasPrefix("/") }
+        return candidate == root || candidate.hasPrefix(root + "/")
+    }
+
+    private func pathRelativeToRoot(_ path: String, root: String) -> String {
+        if path == root { return (path as NSString).lastPathComponent }
+        if root == "/" { return String(path.dropFirst()) }
+        return String(path.dropFirst(root.count + 1))
+    }
+}

--- a/Sources/AgentRecentFile.swift
+++ b/Sources/AgentRecentFile.swift
@@ -1,0 +1,33 @@
+import CmuxAgentChat
+import Foundation
+
+/// Immutable row data for one recently changed agent-owned file.
+struct AgentRecentFile: Identifiable, Sendable, Equatable {
+    let path: String
+    let relativePath: String
+    let agentKind: ChatAgentKind
+    let operation: ChatFileEdit.Operation
+    let modifiedAt: Date
+
+    var id: String { path }
+
+    var fileName: String {
+        (relativePath as NSString).lastPathComponent
+    }
+
+    var directoryPath: String {
+        let directory = (relativePath as NSString).deletingLastPathComponent
+        return directory == "." ? "" : directory
+    }
+
+    var symbolName: String {
+        switch operation {
+        case .edit:
+            return "doc.text"
+        case .write:
+            return "doc.badge.plus"
+        case .delete:
+            return "doc.badge.minus"
+        }
+    }
+}

--- a/Sources/AgentRecentFileProviding.swift
+++ b/Sources/AgentRecentFileProviding.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Supplies recent transcript-derived file edits and invalidation events.
+@MainActor
+protocol AgentRecentFileProviding: AnyObject {
+    func recentFiles(in scope: AgentRecentFileScope, limit: Int) async -> [AgentRecentFile]
+    func changes() -> AsyncStream<Void>
+}

--- a/Sources/AgentRecentFileScope.swift
+++ b/Sources/AgentRecentFileScope.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// Workspace identity and root used to select and relativize agent file edits.
+struct AgentRecentFileScope: Hashable, Sendable {
+    let workspaceID: String?
+    let rootDirectory: String?
+
+    init(workspaceID: UUID?, rootDirectory: String?) {
+        self.workspaceID = workspaceID?.uuidString
+        let root = rootDirectory?.trimmingCharacters(in: .whitespacesAndNewlines)
+        self.rootDirectory = root?.isEmpty == false ? root : nil
+    }
+}

--- a/Sources/AgentRecentFilesModel.swift
+++ b/Sources/AgentRecentFilesModel.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Observation
+
+/// Main-actor projection of recent agent file edits for the active workspace.
+@MainActor
+@Observable
+final class AgentRecentFilesModel {
+    private(set) var files: [AgentRecentFile] = []
+    private(set) var isLoading = false
+
+    private let provider: any AgentRecentFileProviding
+    @ObservationIgnored private var activeScope: AgentRecentFileScope?
+    @ObservationIgnored private var observationTask: Task<Void, Never>?
+
+    init(provider: any AgentRecentFileProviding) {
+        self.provider = provider
+    }
+
+    deinit {
+        observationTask?.cancel()
+    }
+
+    func activate(scope: AgentRecentFileScope) {
+        guard activeScope != scope || observationTask == nil else { return }
+        observationTask?.cancel()
+        activeScope = scope
+        files = []
+        isLoading = true
+
+        let changes = provider.changes()
+        observationTask = Task { [weak self] in
+            await self?.reload(scope: scope)
+            for await _ in changes {
+                guard !Task.isCancelled else { return }
+                await self?.reload(scope: scope)
+            }
+        }
+    }
+
+    func deactivate(scope: AgentRecentFileScope) {
+        guard activeScope == scope else { return }
+        observationTask?.cancel()
+        observationTask = nil
+        activeScope = nil
+        isLoading = false
+    }
+
+    private func reload(scope: AgentRecentFileScope) async {
+        let nextFiles = await provider.recentFiles(in: scope, limit: 24)
+        guard !Task.isCancelled, activeScope == scope else { return }
+        files = nextFiles
+        isLoading = false
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8725,6 +8725,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 #endif
 
+        let agentRecentFilesModel = AgentRecentFilesModel(provider: agentChatTranscriptService)
         let root = ContentView(updateViewModel: updateViewModel, windowId: windowId)
             .environmentObject(tabManager)
             .environmentObject(notificationStore)
@@ -8733,6 +8734,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             .environmentObject(sidebarSelectionState)
             .environmentObject(fileExplorerState)
             .environmentObject(cmuxConfigStore)
+            .environment(\.agentRecentFilesModel, agentRecentFilesModel)
             // AppKit hosts this ContentView in its own NSHostingView, which does
             // not inherit the App scene's SwiftUI environment. Inject the
             // settings runtime so `@LiveSetting` can resolve the stores it

--- a/Sources/EnvironmentValues+AgentRecentFilesModel.swift
+++ b/Sources/EnvironmentValues+AgentRecentFilesModel.swift
@@ -1,0 +1,12 @@
+import SwiftUI
+
+private struct AgentRecentFilesModelEnvironmentKey: EnvironmentKey {
+    static let defaultValue: AgentRecentFilesModel? = nil
+}
+
+extension EnvironmentValues {
+    var agentRecentFilesModel: AgentRecentFilesModel? {
+        get { self[AgentRecentFilesModelEnvironmentKey.self] }
+        set { self[AgentRecentFilesModelEnvironmentKey.self] = newValue }
+    }
+}

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptService.swift
@@ -14,6 +14,7 @@ final class AgentChatTranscriptService {
     let registry: AgentChatSessionRegistry
     let resolver: AgentChatTranscriptResolver
     private var tailers: [String: AgentChatTranscriptTailer] = [:]
+    var recentFileChangeContinuations: [UUID: AsyncStream<Void>.Continuation] = [:]
     private let hasEventSubscribers: @MainActor () -> Bool
     private let emitEventPayload: @MainActor ([String: Any]) -> Void
     private let now: () -> Date
@@ -402,6 +403,12 @@ final class AgentChatTranscriptService {
         if !batch.updated.isEmpty {
             emit(frame: ChatSessionEventFrame(sessionID: sessionID, event: .updated(batch.updated)))
         }
+        if (batch.appended + batch.updated).contains(where: { message in
+            if case .fileEdit = message.kind { return true }
+            return false
+        }) {
+            yieldRecentAgentFileChanges()
+        }
         if let completedAt = Self.completedAssistantTurnTimestamp(in: batch.appended) {
             registry.noteAssistantTurnCompleted(sessionID: sessionID, at: completedAt)
         }
@@ -436,6 +443,12 @@ final class AgentChatTranscriptService {
     }
 
     private func handleRecordChange(_ record: AgentChatSessionRecord, previous: AgentChatSessionRecord?) {
+        if previous == nil
+            || previous?.workspaceID != record.workspaceID
+            || previous?.workingDirectory != record.workingDirectory
+            || previous?.transcriptPath != record.transcriptPath {
+            yieldRecentAgentFileChanges()
+        }
         let endedRecordIsListable: Bool
         if record.state == .ended {
             endedRecordIsListable = record.agentKind == .codex
@@ -484,6 +497,7 @@ final class AgentChatTranscriptService {
         }
         failedResolutions.remove(record.sessionID)
         endedListability.remove(sessionID: record.sessionID)
+        yieldRecentAgentFileChanges()
         guard hasEventSubscribers() else { return }
         emit(frame: ChatSessionEventFrame(sessionID: record.sessionID, event: .sessionRemoved(version: record.version)))
     }

--- a/Sources/Mobile/AgentChat/AgentChatTranscriptTailer.swift
+++ b/Sources/Mobile/AgentChat/AgentChatTranscriptTailer.swift
@@ -45,6 +45,7 @@ actor AgentChatTranscriptTailer {
     private var watchTask: Task<Void, Never>?
     private var watcher: FileWatcher?
     private var started = false
+    private var loadedInitialSnapshot = false
     private var reportedTitle = false
 
     /// Creates a tailer.
@@ -77,7 +78,7 @@ actor AgentChatTranscriptTailer {
     func start() async {
         guard !started else { return }
         started = true
-        loadInitialTail()
+        loadSnapshot()
         let watcher = FileWatcher(path: path, throttle: .milliseconds(200))
         self.watcher = watcher
         watchTask = Task { [weak self] in
@@ -86,6 +87,16 @@ actor AgentChatTranscriptTailer {
                 await self.drainNewContent()
             }
         }
+    }
+
+    /// Loads bounded transcript history without starting a filesystem watcher.
+    ///
+    /// Used for ended sessions whose history is immutable and should not retain
+    /// background resources after a one-shot sidebar or history projection.
+    func loadSnapshot() {
+        guard !loadedInitialSnapshot else { return }
+        loadedInitialSnapshot = true
+        loadInitialTail()
     }
 
     /// Stops watching and releases resources.

--- a/Sources/RecentAgentFilesContainerView.swift
+++ b/Sources/RecentAgentFilesContainerView.swift
@@ -1,0 +1,37 @@
+import SwiftUI
+
+/// Connects the per-window recent-file model to the current sidebar workspace.
+struct RecentAgentFilesContainerView: View {
+    @Environment(\.agentRecentFilesModel) private var model
+
+    let workspaceID: UUID?
+    let rootDirectory: String?
+    let isActive: Bool
+    let onOpenFilePreview: (String) -> Void
+
+    private var scope: AgentRecentFileScope {
+        AgentRecentFileScope(workspaceID: workspaceID, rootDirectory: rootDirectory)
+    }
+
+    var body: some View {
+        Group {
+            if let model {
+                RecentAgentFilesSnapshotView(
+                    files: model.files,
+                    isLoading: model.isLoading,
+                    onOpenFilePreview: onOpenFilePreview
+                )
+            }
+        }
+        .task(id: isActive ? scope : nil) {
+            if isActive {
+                model?.activate(scope: scope)
+            } else {
+                model?.deactivate(scope: scope)
+            }
+        }
+        .onDisappear {
+            model?.deactivate(scope: scope)
+        }
+    }
+}

--- a/Sources/RecentAgentFilesSnapshotView.swift
+++ b/Sources/RecentAgentFilesSnapshotView.swift
@@ -1,0 +1,134 @@
+import CmuxAgentChat
+import SwiftUI
+
+/// Snapshot-only recent-file list mounted above the right-sidebar file tree.
+struct RecentAgentFilesSnapshotView: View {
+    let files: [AgentRecentFile]
+    let isLoading: Bool
+    let onOpenFilePreview: (String) -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            if files.isEmpty {
+                emptyState
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 0) {
+                        ForEach(files) { file in
+                            fileButton(file)
+                        }
+                    }
+                }
+                .frame(maxHeight: 210)
+            }
+        }
+        .background(Color.primary.opacity(0.025))
+        .overlay(alignment: .bottom) {
+            Divider()
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("RightSidebar.recentAgentFiles")
+    }
+
+    private var header: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "wand.and.stars")
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+                .offset(x: 0.5)
+                .accessibilityHidden(true)
+            Text(String(localized: "rightSidebar.recentAgentFiles.title", defaultValue: "Recent Agent Files"))
+                .font(.system(size: 11, weight: .semibold))
+                .foregroundStyle(.secondary)
+            Spacer(minLength: 0)
+            if isLoading {
+                ProgressView()
+                    .controlSize(.mini)
+                    .accessibilityLabel(
+                        String(localized: "rightSidebar.recentAgentFiles.loading", defaultValue: "Loading recent agent files")
+                    )
+            }
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 28)
+    }
+
+    private var emptyState: some View {
+        Text(
+            isLoading
+                ? String(
+                    localized: "rightSidebar.recentAgentFiles.loading",
+                    defaultValue: "Loading recent agent files"
+                )
+                : String(
+                    localized: "rightSidebar.recentAgentFiles.empty",
+                    defaultValue: "No recent Codex or Claude file changes"
+                )
+        )
+        .font(.system(size: 11))
+        .foregroundStyle(.tertiary)
+        .multilineTextAlignment(.center)
+        .padding(.horizontal, 12)
+        .padding(.bottom, 10)
+    }
+
+    private func fileButton(_ file: AgentRecentFile) -> some View {
+        Button {
+            onOpenFilePreview(file.path)
+        } label: {
+            HStack(spacing: 7) {
+                Image(systemName: file.symbolName)
+                    .font(.system(size: 12))
+                    .foregroundStyle(.secondary)
+                    .frame(width: 15)
+                    .accessibilityHidden(true)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(file.fileName)
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(.primary)
+                        .lineLimit(1)
+                    Text(directoryLabel(for: file))
+                        .font(.system(size: 9.5, design: .monospaced))
+                        .foregroundStyle(.tertiary)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer(minLength: 4)
+                VStack(alignment: .trailing, spacing: 1) {
+                    Text(file.agentKind.displayName)
+                        .font(.system(size: 9.5, weight: .medium))
+                        .foregroundStyle(.secondary)
+                    Text(file.modifiedAt, style: .relative)
+                        .font(.system(size: 9))
+                        .monospacedDigit()
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.horizontal, 9)
+            .frame(minHeight: 40)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .help(file.path)
+        .accessibilityLabel(accessibilityLabel(for: file))
+    }
+
+    private func directoryLabel(for file: AgentRecentFile) -> String {
+        guard !file.directoryPath.isEmpty else {
+            return String(localized: "rightSidebar.recentAgentFiles.workspaceRoot", defaultValue: "Workspace root")
+        }
+        return file.directoryPath
+    }
+
+    private func accessibilityLabel(for file: AgentRecentFile) -> String {
+        String.localizedStringWithFormat(
+            String(
+                localized: "rightSidebar.recentAgentFiles.openAccessibility",
+                defaultValue: "Open %@, changed by %@"
+            ),
+            file.fileName,
+            file.agentKind.displayName
+        )
+    }
+}

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -379,12 +379,20 @@ struct RightSidebarPanelView: View {
         if RightSidebarContentMountPolicy.shouldMountContent(isRightSidebarVisible: fileExplorerState.isVisible, hasMountedContent: hasMountedRightSidebarContent) {
             switch fileExplorerState.mode {
             case .files:
-                FileExplorerPanelView(
-                    store: fileExplorerStore,
-                    state: fileExplorerState,
-                    onOpenFilePreview: onOpenFilePreview,
-                    presentation: .files
-                )
+                VStack(spacing: 0) {
+                    RecentAgentFilesContainerView(
+                        workspaceID: workspaceId,
+                        rootDirectory: fileExplorerStore.rootPath,
+                        isActive: fileExplorerState.isVisible,
+                        onOpenFilePreview: onOpenFilePreview
+                    )
+                    FileExplorerPanelView(
+                        store: fileExplorerStore,
+                        state: fileExplorerState,
+                        onOpenFilePreview: onOpenFilePreview,
+                        presentation: .files
+                    )
+                }
             case .find:
                 FileExplorerPanelView(
                     store: fileExplorerStore,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -29,6 +29,7 @@
 		C7A51D000000000000000002 /* AgentChatSessionRegistryObservationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A51D000000000000000001 /* AgentChatSessionRegistryObservationTests.swift */; };
 		C0DE71A00000000000000001 /* AgentChatThemeSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE71A00000000000000002 /* AgentChatThemeSync.swift */; };
 		ACA7C4A70000000000000005 /* AgentChatTranscriptResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A70000000000000006 /* AgentChatTranscriptResolver.swift */; };
+		A6F100000000000000000009 /* AgentChatTranscriptService+RecentFiles.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F10000000000000000000A /* AgentChatTranscriptService+RecentFiles.swift */; };
 		C7A52F000000000000000002 /* AgentChatTranscriptService+Wire.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A52F000000000000000001 /* AgentChatTranscriptService+Wire.swift */; };
 		ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */; };
 		ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */; };
@@ -47,6 +48,10 @@
 		A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */; };
 		A5D41230A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */; };
 		C3744E030000000000000001 /* AgentPIDProcessIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */; };
+		A6F100000000000000000001 /* AgentRecentFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F100000000000000000002 /* AgentRecentFile.swift */; };
+		A6F100000000000000000005 /* AgentRecentFileProviding.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F100000000000000000006 /* AgentRecentFileProviding.swift */; };
+		A6F100000000000000000003 /* AgentRecentFileScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F100000000000000000004 /* AgentRecentFileScope.swift */; };
+		A6F100000000000000000007 /* AgentRecentFilesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F100000000000000000008 /* AgentRecentFilesModel.swift */; };
 		D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */; };
 		D3610B020000000000000001 /* AgentSessionAutoResumeSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */; };
 		A9E020000000000000000008 /* AgentSessionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000008 /* AgentSessionBridge.swift */; };
@@ -608,6 +613,7 @@
 		D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */; };
 		D75280040000000000000001 /* DynamicTracingSignpostInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */; };
 		D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */; };
+		A6F10000000000000000000B /* EnvironmentValues+AgentRecentFilesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F10000000000000000000C /* EnvironmentValues+AgentRecentFilesModel.swift */; };
 		5732A0095732A0095732A009 /* EnvironmentValues+MinimalModeInvalidationProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5732B0095732B0095732B009 /* EnvironmentValues+MinimalModeInvalidationProbe.swift */; };
 		5732A0135732A0135732A013 /* EnvironmentValues+SidebarLazyContractProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5732B0135732B0135732B013 /* EnvironmentValues+SidebarLazyContractProbe.swift */; };
 		E4C001000000000000000001 /* ExtensionSidebarWorkspaceRowView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */; };
@@ -957,6 +963,8 @@
 		A64610010000000000000001 /* QuitConfirmationAlertPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64610010000000000000002 /* QuitConfirmationAlertPresenter.swift */; };
 		A64610020000000000000001 /* QuitConfirmationAlertPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A64610020000000000000002 /* QuitConfirmationAlertPresenterTests.swift */; };
 		A500RG01 /* ReactGrab.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500RG00 /* ReactGrab.swift */; };
+		A6F10000000000000000000D /* RecentAgentFilesContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F10000000000000000000E /* RecentAgentFilesContainerView.swift */; };
+		A6F10000000000000000000F /* RecentAgentFilesSnapshotView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6F100000000000000000010 /* RecentAgentFilesSnapshotView.swift */; };
 		A6D1F0000000000000000002 /* ReleasingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D1F0000000000000000001 /* ReleasingWindowController.swift */; };
 		A6D1F0400000000000000002 /* ReleasingWindowControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6D1F0400000000000000001 /* ReleasingWindowControllerTests.swift */; };
 		EE30D5000000000000000002 /* RemoteDaemonStrings+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30D5000000000000000001 /* RemoteDaemonStrings+App.swift */; };
@@ -1686,6 +1694,7 @@
 		C7A51D000000000000000001 /* AgentChatSessionRegistryObservationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatSessionRegistryObservationTests.swift; sourceTree = "<group>"; };
 		C0DE71A00000000000000002 /* AgentChatThemeSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatThemeSync.swift; sourceTree = "<group>"; };
 		ACA7C4A70000000000000006 /* AgentChatTranscriptResolver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptResolver.swift"; sourceTree = "<group>"; };
+		A6F10000000000000000000A /* AgentChatTranscriptService+RecentFiles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService+RecentFiles.swift"; sourceTree = "<group>"; };
 		C7A52F000000000000000001 /* AgentChatTranscriptService+Wire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService+Wire.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000C /* AgentChatTranscriptService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptService.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000A /* AgentChatTranscriptTailer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatTranscriptTailer.swift"; sourceTree = "<group>"; };
@@ -1702,6 +1711,10 @@
 		A5D41235A1B2C3D4E5F60718 /* AgentNotificationGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGate.swift; sourceTree = "<group>"; };
 		A5D41231A1B2C3D4E5F60718 /* AgentNotificationGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentNotificationGateTests.swift; sourceTree = "<group>"; };
 		C3744E040000000000000001 /* AgentPIDProcessIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPIDProcessIdentity.swift; sourceTree = "<group>"; };
+		A6F100000000000000000002 /* AgentRecentFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRecentFile.swift; sourceTree = "<group>"; };
+		A6F100000000000000000006 /* AgentRecentFileProviding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRecentFileProviding.swift; sourceTree = "<group>"; };
+		A6F100000000000000000004 /* AgentRecentFileScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRecentFileScope.swift; sourceTree = "<group>"; };
+		A6F100000000000000000008 /* AgentRecentFilesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRecentFilesModel.swift; sourceTree = "<group>"; };
 		D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionAutoResumeSettingsTests.swift; sourceTree = "<group>"; };
 		D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionAutoResumeSwiftTests.swift; sourceTree = "<group>"; };
 		A9E010000000000000000008 /* AgentSessionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionBridge.swift; sourceTree = "<group>"; };
@@ -2209,6 +2222,7 @@
 		D0B10015A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOverlayRoutingPolicy.swift; sourceTree = "<group>"; };
 		D75280040000000000000002 /* DynamicTracingSignpostInterval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicTracingSignpostInterval.swift; sourceTree = "<group>"; };
 		D3622101A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditableTextViewArrowKeyForwardingTests.swift; sourceTree = "<group>"; };
+		A6F10000000000000000000C /* EnvironmentValues+AgentRecentFilesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EnvironmentValues+AgentRecentFilesModel.swift"; sourceTree = "<group>"; };
 		5732B0095732B0095732B009 /* EnvironmentValues+MinimalModeInvalidationProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Debug/EnvironmentValues+MinimalModeInvalidationProbe.swift"; sourceTree = "<group>"; };
 		5732B0135732B0135732B013 /* EnvironmentValues+SidebarLazyContractProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Debug/EnvironmentValues+SidebarLazyContractProbe.swift"; sourceTree = "<group>"; };
 		E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionSidebarWorkspaceRowView.swift; sourceTree = "<group>"; };
@@ -2553,6 +2567,8 @@
 		A64610010000000000000002 /* QuitConfirmationAlertPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitConfirmationAlertPresenter.swift; sourceTree = "<group>"; };
 		A64610020000000000000002 /* QuitConfirmationAlertPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuitConfirmationAlertPresenterTests.swift; sourceTree = "<group>"; };
 		A500RG00 /* ReactGrab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ReactGrab.swift; sourceTree = "<group>"; };
+		A6F10000000000000000000E /* RecentAgentFilesContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentAgentFilesContainerView.swift; sourceTree = "<group>"; };
+		A6F100000000000000000010 /* RecentAgentFilesSnapshotView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RecentAgentFilesSnapshotView.swift; sourceTree = "<group>"; };
 		A6D1F0000000000000000001 /* ReleasingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/ReleasingWindowController.swift; sourceTree = "<group>"; };
 		A6D1F0400000000000000001 /* ReleasingWindowControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReleasingWindowControllerTests.swift; sourceTree = "<group>"; };
 		EE30D5000000000000000001 /* RemoteDaemonStrings+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "RemoteDaemonStrings+App.swift"; sourceTree = "<group>"; };
@@ -4329,6 +4345,14 @@
 				B37A00000000000000000004 /* RightSidebarMode+Availability.swift */,
 				B37A0000000000000000000E /* RightSidebarRemoteCommand.swift */,
 				FE003003 /* RightSidebarPanelView.swift */,
+				A6F100000000000000000002 /* AgentRecentFile.swift */,
+				A6F100000000000000000004 /* AgentRecentFileScope.swift */,
+				A6F100000000000000000006 /* AgentRecentFileProviding.swift */,
+				A6F100000000000000000008 /* AgentRecentFilesModel.swift */,
+				A6F10000000000000000000A /* AgentChatTranscriptService+RecentFiles.swift */,
+				A6F10000000000000000000C /* EnvironmentValues+AgentRecentFilesModel.swift */,
+				A6F10000000000000000000E /* RecentAgentFilesContainerView.swift */,
+				A6F100000000000000000010 /* RecentAgentFilesSnapshotView.swift */,
 				FE0030A3 /* RightSidebarToolPanel.swift */,
 				DCDC1000000000000000B002 /* DockConfigurationLoadResult.swift */,
 				DCDC1000000000000000B004 /* DockConfigFile.swift */,
@@ -5323,6 +5347,7 @@
 					ACA7C4A70000000000000007 /* AgentChatSessionRegistry.swift in Sources */,
 				C0DE71A00000000000000001 /* AgentChatThemeSync.swift in Sources */,
 				ACA7C4A70000000000000005 /* AgentChatTranscriptResolver.swift in Sources */,
+				A6F100000000000000000009 /* AgentChatTranscriptService+RecentFiles.swift in Sources */,
 				C7A52F000000000000000002 /* AgentChatTranscriptService+Wire.swift in Sources */,
 				ACA7C4A7000000000000000B /* AgentChatTranscriptService.swift in Sources */,
 				ACA7C4A70000000000000009 /* AgentChatTranscriptTailer.swift in Sources */,
@@ -5333,6 +5358,10 @@
 				D36A00030000000000000001 /* AgentHibernationLifecycleState.swift in Sources */,
 				A5D41234A1B2C3D4E5F60718 /* AgentNotificationGate.swift in Sources */,
 				C3744E030000000000000001 /* AgentPIDProcessIdentity.swift in Sources */,
+				A6F100000000000000000001 /* AgentRecentFile.swift in Sources */,
+				A6F100000000000000000005 /* AgentRecentFileProviding.swift in Sources */,
+				A6F100000000000000000003 /* AgentRecentFileScope.swift in Sources */,
+				A6F100000000000000000007 /* AgentRecentFilesModel.swift in Sources */,
 				A9E020000000000000000008 /* AgentSessionBridge.swift in Sources */,
 				A9F20000000000000000000B /* AgentSessionBridgeError.swift in Sources */,
 				A9F20000000000000000000C /* AgentSessionBridgeRequest.swift in Sources */,
@@ -5618,6 +5647,7 @@
 				DCDC1000000000000000B00F /* DockTrustRequest.swift in Sources */,
 				D0B10014A1B2C3D4E5F60001 /* DragOverlayRoutingPolicy.swift in Sources */,
 				D75280040000000000000001 /* DynamicTracingSignpostInterval.swift in Sources */,
+				A6F10000000000000000000B /* EnvironmentValues+AgentRecentFilesModel.swift in Sources */,
 					5732A0095732A0095732A009 /* EnvironmentValues+MinimalModeInvalidationProbe.swift in Sources */,
 					5732A0135732A0135732A013 /* EnvironmentValues+SidebarLazyContractProbe.swift in Sources */,
 				E4C001000000000000000001 /* ExtensionSidebarWorkspaceRowView.swift in Sources */,
@@ -5852,6 +5882,8 @@
 					A5C0DE0000000000000000B8 /* ProjectTargetsTabView.swift in Sources */,
 					A64610010000000000000001 /* QuitConfirmationAlertPresenter.swift in Sources */,
 				A500RG01 /* ReactGrab.swift in Sources */,
+				A6F10000000000000000000D /* RecentAgentFilesContainerView.swift in Sources */,
+				A6F10000000000000000000F /* RecentAgentFilesSnapshotView.swift in Sources */,
 				A6D1F0000000000000000002 /* ReleasingWindowController.swift in Sources */,
 				EE30D5000000000000000002 /* RemoteDaemonStrings+App.swift in Sources */,
 				E30780000000000000000016 /* RemoteDropUploadError+LocalizedError.swift in Sources */,

--- a/cmuxTests/AgentChatSessionRegistryLifecycleTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryLifecycleTests.swift
@@ -464,6 +464,78 @@ struct AgentChatSessionRegistryLifecycleTests {
         #expect(service.hasBoundedReadableTranscript(record))
     }
 
+    @MainActor
+    @Test func recentAgentFilesAreScopedDeduplicatedAndSortedFromTranscriptHistory() async throws {
+        let home = try temporaryHomeDirectory()
+        let project = home.appendingPathComponent("project", isDirectory: true)
+        let transcript = home.appendingPathComponent("session.jsonl")
+        let workspaceID = UUID()
+        let sessionID = UUID().uuidString
+        let surfaceID = UUID().uuidString
+        let appFile = project.appendingPathComponent("Sources/App.swift").path
+        let guideFile = project.appendingPathComponent("Docs/Guide.md").path
+        let lines = [
+            try claudeFileToolLine(
+                filePath: appFile,
+                toolName: "Edit",
+                timestamp: "2026-07-09T10:00:00.000Z"
+            ),
+            try claudeFileToolLine(
+                filePath: home.appendingPathComponent("outside.txt").path,
+                toolName: "Write",
+                timestamp: "2026-07-09T10:30:00.000Z"
+            ),
+            try claudeFileToolLine(
+                filePath: guideFile,
+                toolName: "Edit",
+                timestamp: "2026-07-09T10:45:00.000Z"
+            ),
+            try claudeFileToolLine(
+                filePath: appFile,
+                toolName: "Write",
+                timestamp: "2026-07-09T11:00:00.000Z"
+            ),
+        ]
+        try (lines.joined(separator: "\n") + "\n")
+            .write(to: transcript, atomically: true, encoding: .utf8)
+
+        let service = AgentChatTranscriptService(
+            registry: AgentChatSessionRegistry(),
+            resolver: AgentChatTranscriptResolver(homeDirectory: home, environment: [:])
+        )
+        service.noteHookEvent(WorkstreamEvent(
+            sessionId: sessionID,
+            hookEventName: .sessionStart,
+            source: "claude",
+            workspaceId: workspaceID.uuidString,
+            surfaceId: surfaceID,
+            transcriptPath: transcript.path,
+            cwd: project.path,
+            receivedAt: Date(timeIntervalSince1970: 100)
+        ))
+        service.noteHookEvent(WorkstreamEvent(
+            sessionId: sessionID,
+            hookEventName: .sessionEnd,
+            source: "claude",
+            workspaceId: workspaceID.uuidString,
+            surfaceId: surfaceID,
+            transcriptPath: transcript.path,
+            cwd: project.path,
+            receivedAt: Date(timeIntervalSince1970: 110)
+        ))
+
+        let files = await service.recentFiles(
+            in: AgentRecentFileScope(workspaceID: workspaceID, rootDirectory: project.path),
+            limit: 10
+        )
+
+        #expect(files.count == 2)
+        #expect(files.map(\.path) == [appFile, guideFile])
+        #expect(files.map(\.relativePath) == ["Sources/App.swift", "Docs/Guide.md"])
+        #expect(files.first?.agentKind == .claude)
+        #expect(files.first?.operation == .write)
+    }
+
     private func temporaryHomeDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-agent-chat-\(UUID().uuidString)", isDirectory: true)
@@ -495,5 +567,33 @@ struct AgentChatSessionRegistryLifecycleTests {
         ]
         let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
         try data.write(to: directory.appendingPathComponent("claude-hook-sessions.json"))
+    }
+
+    private func claudeFileToolLine(filePath: String, toolName: String, timestamp: String) throws -> String {
+        let input: [String: Any]
+        if toolName == "Write" {
+            input = ["file_path": filePath, "content": "new content"]
+        } else {
+            input = ["file_path": filePath, "old_string": "old", "new_string": "new"]
+        }
+        let payload: [String: Any] = [
+            "parentUuid": "user",
+            "isSidechain": false,
+            "type": "assistant",
+            "message": [
+                "role": "assistant",
+                "content": [[
+                    "type": "tool_use",
+                    "id": UUID().uuidString,
+                    "name": toolName,
+                    "input": input,
+                ]],
+            ],
+            "uuid": UUID().uuidString,
+            "timestamp": timestamp,
+            "sessionId": UUID().uuidString,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: payload, options: [.sortedKeys])
+        return String(decoding: data, as: UTF8.self)
     }
 }


### PR DESCRIPTION
## Summary
- show recent Codex and Claude file edits above the right-sidebar file tree
- scope, deduplicate, and sort transcript-derived edits for the active workspace
- parse multi-file Codex apply_patch calls into canonical file-edit records
- avoid persistent watchers for ended session transcripts

## Validation
- swift test --package-path Packages/Shared/CmuxAgentChat (177 tests)
- focused cmux-unit recent-agent-files behavior test (1 test, passed)
- ./scripts/reload.sh --tag recent-agent-files
- localization catalog parsed; new keys verified in English and Japanese
- pbxproj, test wiring, workspace package grouping, and Package.resolved policy guards passed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7726"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786214224&installation_id=133855650&pr_number=7726&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7726&signature=99d1a58dc950f800585ca4ef405931e025eed1adc0fcc58bd66ae7cea0289934"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Codex transcript mapping for apply_patch and adds sidebar file-open paths derived from agent transcripts; incorrect path scoping could open wrong files, but scope is UI plus read-only transcript projection.
> 
> **Overview**
> Adds a **Recent Agent Files** section above the right-sidebar file tree so users can jump to files Codex or Claude recently edited in the active workspace.
> 
> Transcript handling now drives that list: **`AgentChatTranscriptService`** implements **`AgentRecentFileProviding`**, scans Claude/Codex sessions in scope, deduplicates by path (newest wins), excludes deletes, and reloads when file-edit messages arrive or session metadata changes. Ended sessions use **`loadSnapshot()`** on the tailer so history is read once without keeping a file watcher alive.
> 
> Codex **`apply_patch`** no longer surfaces as a single **`toolUse`** with one path in the summary. A new **`CodexApplyPatchParser`** turns each patch section into **`fileEdit`** messages (update/add/delete, including **Move to** destination paths), which both improves chat rendering and feeds the recent-files pipeline.
> 
> SwiftUI wiring: per-window **`AgentRecentFilesModel`** in the environment, container/snapshot views, and integration in **`RightSidebarPanelView`** Files mode with localized strings and a unit test for scoped aggregation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c72cdc48954a1007a14add9e470872db87d640f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Recent Agent Files panel above the right-sidebar file tree to surface the latest Codex and Claude file changes for the active workspace. Also parses multi-file Codex apply_patch calls into per-file edits and updates the list live.

- New Features
  - Recent Agent Files panel with file name, relative path/root, agent, and relative time; click opens preview.
  - Scoped to the active workspace/root; deduped by path; sorted by last modified; delete ops are hidden.
  - Live updates on file edits and session changes; strings localized (EN/JA).

- Refactors
  - apply_patch now emits per-file fileEdit messages with move support and addition/deletion counts.
  - Added a Codex patch parser plus model/provider to fetch recent edits; ended sessions use snapshot loading (no persistent watchers).

<sup>Written for commit 3c72cdc48954a1007a14add9e470872db87d640f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Recent Agent Files” panel in the right sidebar to show recently changed files from agent activity.
  * Users can now open recent files directly from the sidebar, with loading and empty states.

* **Bug Fixes**
  * Recent files are now deduplicated, scoped correctly to the current workspace, and shown in a stable order.
  * File moves and multi-file patch changes are now reflected accurately in recent activity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->