### PR TITLE
Fix typed window handles in CLI window commands

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4306,8 +4306,8 @@ struct CMUXCLI {
             guard let target = optionValue(commandArgs, name: "--window"), let windowID = try normalizeWindowHandle(target, client: client) else {
                 throw CLIError(message: "close-window requires --window")
             }
-            let payload = try client.sendV2(method: "window.close", params: ["window_id": windowID])
-            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: []))
+            let response = try sendV1Command("close_window \(windowID)", client: client)
+            print(response)
 
         case "move-workspace-to-window":
             guard let workspaceRaw = optionValue(commandArgs, name: "--workspace") else {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4299,8 +4299,8 @@ struct CMUXCLI {
             guard let target = optionValue(commandArgs, name: "--window"), let windowID = try normalizeWindowHandle(target, client: client) else {
                 throw CLIError(message: "focus-window requires --window")
             }
-            let payload = try client.sendV2(method: "window.focus", params: ["window_id": windowID])
-            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: []))
+            let response = try sendV1Command("focus_window \(windowID)", client: client)
+            print(response)
 
         case "close-window":
             guard let target = optionValue(commandArgs, name: "--window"), let windowID = try normalizeWindowHandle(target, client: client) else {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4296,18 +4296,18 @@ struct CMUXCLI {
             print(response)
 
         case "focus-window":
-            guard let target = optionValue(commandArgs, name: "--window") else {
+            guard let target = optionValue(commandArgs, name: "--window"), let windowID = try normalizeWindowHandle(target, client: client) else {
                 throw CLIError(message: "focus-window requires --window")
             }
-            let response = try sendV1Command("focus_window \(target)", client: client)
-            print(response)
+            let payload = try client.sendV2(method: "window.focus", params: ["window_id": windowID])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: []))
 
         case "close-window":
-            guard let target = optionValue(commandArgs, name: "--window") else {
+            guard let target = optionValue(commandArgs, name: "--window"), let windowID = try normalizeWindowHandle(target, client: client) else {
                 throw CLIError(message: "close-window requires --window")
             }
-            let response = try sendV1Command("close_window \(target)", client: client)
-            print(response)
+            let payload = try client.sendV2(method: "window.close", params: ["window_id": windowID])
+            printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: []))
 
         case "move-workspace-to-window":
             guard let workspaceRaw = optionValue(commandArgs, name: "--workspace") else {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -326,6 +326,8 @@
 		6379A0016379A0016379A001 /* CLISSHPTYResizeInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */; };
 		C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */; };
 		B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */; };
+		773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000002 /* CLIWindowCommandMockServer.swift */; };
+		773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */; };
 		C10D51700000000000000002 /* ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C10D51700000000000000001 /* ClosedItemHistory.swift */; };
 		7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */; };
 		B9000025A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */; };
@@ -1980,6 +1982,8 @@
 		6379A0026379A0026379A002 /* CLISSHPTYResizeInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLISSHPTYResizeInputTests.swift; sourceTree = "<group>"; };
 		C12984000000000000000003 /* CLIStdioSIGPIPERegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIStdioSIGPIPERegressionTests.swift; sourceTree = "<group>"; };
 		B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLITmuxCompatRemoteSplitTests.swift; sourceTree = "<group>"; };
+		773600000000000000000002 /* CLIWindowCommandMockServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowCommandMockServer.swift; sourceTree = "<group>"; };
+		773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIWindowHandleRoutingTests.swift; sourceTree = "<group>"; };
 		C10D51700000000000000001 /* ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedItemHistory.swift; sourceTree = "<group>"; };
 		7375A0047375A0047375A004 /* ClosedMainWindowRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClosedMainWindowRoutingTests.swift; sourceTree = "<group>"; };
 		B9000026A1B2C3D4E5F60719 /* CloseWindowConfirmDialogUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CloseWindowConfirmDialogUITests.swift; sourceTree = "<group>"; };
@@ -4684,6 +4688,8 @@
 						A6AC72080000000000000002 /* CMUXWorkspaceLoadingCLIRegressionTests.swift */,
 						C0DE31390000000000000112 /* CMUXOpenHTMLFocusTests.swift */,
 					1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */,
+					773600000000000000000002 /* CLIWindowCommandMockServer.swift */,
+					773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */,
 					CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */,
 					C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
 					C0DE64950000000000000006 /* CMUXCLISessionsListTests.swift */,
@@ -6524,6 +6530,8 @@
 				6379A0016379A0016379A001 /* CLISSHPTYResizeInputTests.swift in Sources */,
 				C12984000000000000000004 /* CLIStdioSIGPIPERegressionTests.swift in Sources */,
 				B05553B10000000000000001 /* CLITmuxCompatRemoteSplitTests.swift in Sources */,
+					773600000000000000000001 /* CLIWindowCommandMockServer.swift in Sources */,
+					773600000000000000000003 /* CLIWindowHandleRoutingTests.swift in Sources */,
 				7375A0037375A0037375A003 /* ClosedMainWindowRoutingTests.swift in Sources */,
 				C75740010000000000000001 /* CloudVMMenuItemMetricsTests.swift in Sources */,
 				C0DE43000000000000000009 /* CmuxAgentChatConfigTests.swift in Sources */,

--- a/cmuxTests/CLIWindowCommandMockServer.swift
+++ b/cmuxTests/CLIWindowCommandMockServer.swift
@@ -241,8 +241,11 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
     }
 
     private func response(for line: String) -> String {
-        if line == "focus_window \(targetWindowID)" {
+        if line == "focus_window \(targetWindowID)" || line == "close_window \(targetWindowID)" {
             return "OK"
+        }
+        if line.hasPrefix("close_window ") {
+            return "ERROR: Window not found"
         }
 
         guard let data = line.data(using: .utf8),
@@ -263,15 +266,6 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
                         "ref": targetWindowRef,
                         "index": 2,
                     ]],
-                ]
-            )
-        case "window.close":
-            return v2Response(
-                id: id,
-                ok: true,
-                result: [
-                    "window_id": targetWindowID,
-                    "window_ref": targetWindowRef,
                 ]
             )
         default:

--- a/cmuxTests/CLIWindowCommandMockServer.swift
+++ b/cmuxTests/CLIWindowCommandMockServer.swift
@@ -125,9 +125,15 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
                 let lineData = pending.subdata(in: 0..<newline.lowerBound)
                 pending.removeSubrange(0...newline.lowerBound)
                 guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                record(line)
-                let response = response(for: line) + "\n"
-                _ = response.withCString { pointer in
+                let response: String
+                if line.hasPrefix("auth ") {
+                    response = "OK: Authenticated"
+                } else {
+                    record(line)
+                    response = self.response(for: line)
+                }
+                let responseLine = response + "\n"
+                _ = responseLine.withCString { pointer in
                     Darwin.write(clientFD, pointer, strlen(pointer))
                 }
             }

--- a/cmuxTests/CLIWindowCommandMockServer.swift
+++ b/cmuxTests/CLIWindowCommandMockServer.swift
@@ -79,9 +79,10 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
     }
 
     func requestObjects() throws -> [[String: Any]] {
-        try receivedLinesSnapshot().compactMap { line in
+        receivedLinesSnapshot().compactMap { line in
             guard let data = line.data(using: .utf8),
-                  let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                  let value = try? JSONSerialization.jsonObject(with: data),
+                  let object = value as? [String: Any] else {
                 return nil
             }
             return object

--- a/cmuxTests/CLIWindowCommandMockServer.swift
+++ b/cmuxTests/CLIWindowCommandMockServer.swift
@@ -1,15 +1,18 @@
 import Darwin
 import Foundation
 
-// The socket loop runs on a private queue; the lock only protects test captures read by the test thread.
+// The socket loop runs on a private queue; the lock protects captures and descriptor lifecycle state.
 final class CLIWindowCommandMockServer: @unchecked Sendable {
     private let socketPath: String
     private let targetWindowID: String
     private let targetWindowRef: String
     private let queue = DispatchQueue(label: "com.cmux.tests.cli-window-command-server")
-    private let finished = DispatchSemaphore(value: 0)
+    private let finished = DispatchGroup()
     private let lock = NSLock()
     private var listenerFD: Int32 = -1
+    private var clientFD: Int32 = -1
+    private var started = false
+    private var stopping = false
     private var receivedLines: [String] = []
 
     init(socketPath: String, targetWindowID: String, targetWindowRef: String) throws {
@@ -63,6 +66,15 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
     }
 
     func start() {
+        lock.lock()
+        guard !started, !stopping else {
+            lock.unlock()
+            return
+        }
+        started = true
+        finished.enter()
+        lock.unlock()
+
         queue.async { [self] in
             serveOneConnection()
         }
@@ -90,15 +102,49 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
     }
 
     func stop() {
-        if listenerFD >= 0 {
-            Darwin.close(listenerFD)
+        var listenerToClose: Int32 = -1
+        var shouldWakeListener = false
+        var shouldWait = false
+
+        lock.lock()
+        guard !stopping else {
+            lock.unlock()
+            return
+        }
+        stopping = true
+        shouldWait = started
+        if !started {
+            listenerToClose = listenerFD
             listenerFD = -1
+        } else if clientFD >= 0 {
+            _ = Darwin.shutdown(clientFD, SHUT_RDWR)
+        } else {
+            shouldWakeListener = listenerFD >= 0
+        }
+        lock.unlock()
+
+        if listenerToClose >= 0 {
+            Darwin.close(listenerToClose)
+        }
+        if shouldWakeListener {
+            wakeListener()
+        }
+        if shouldWait {
+            finished.wait()
         }
         unlink(socketPath)
     }
 
     private func serveOneConnection() {
-        defer { finished.signal() }
+        defer {
+            closeListener()
+            finished.leave()
+        }
+
+        lock.lock()
+        let listenerFD = self.listenerFD
+        lock.unlock()
+        guard listenerFD >= 0 else { return }
 
         var clientAddress = sockaddr_un()
         var clientAddressLength = socklen_t(MemoryLayout<sockaddr_un>.size)
@@ -108,7 +154,15 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
             }
         }
         guard clientFD >= 0 else { return }
-        defer { Darwin.close(clientFD) }
+        lock.lock()
+        guard !stopping else {
+            lock.unlock()
+            Darwin.close(clientFD)
+            return
+        }
+        self.clientFD = clientFD
+        lock.unlock()
+        defer { closeClient(clientFD) }
 
         var pending = Data()
         var buffer = [UInt8](repeating: 0, count: 4096)
@@ -136,6 +190,46 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
                 _ = responseLine.withCString { pointer in
                     Darwin.write(clientFD, pointer, strlen(pointer))
                 }
+            }
+        }
+    }
+
+    private func closeClient(_ descriptor: Int32) {
+        lock.lock()
+        if clientFD == descriptor {
+            clientFD = -1
+        }
+        lock.unlock()
+        Darwin.close(descriptor)
+    }
+
+    private func closeListener() {
+        lock.lock()
+        let descriptor = listenerFD
+        listenerFD = -1
+        lock.unlock()
+        if descriptor >= 0 {
+            Darwin.close(descriptor)
+        }
+    }
+
+    private func wakeListener() {
+        let descriptor = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard descriptor >= 0 else { return }
+        defer { Darwin.close(descriptor) }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: address.sun_path)
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                let buffer = UnsafeMutableRawPointer(destination).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, source, maxPathLength - 1)
+            }
+        }
+        _ = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.connect(descriptor, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
             }
         }
     }

--- a/cmuxTests/CLIWindowCommandMockServer.swift
+++ b/cmuxTests/CLIWindowCommandMockServer.swift
@@ -1,0 +1,204 @@
+import Darwin
+import Foundation
+
+// The socket loop runs on a private queue; the lock only protects test captures read by the test thread.
+final class CLIWindowCommandMockServer: @unchecked Sendable {
+    private let socketPath: String
+    private let targetWindowID: String
+    private let targetWindowRef: String
+    private let queue = DispatchQueue(label: "com.cmux.tests.cli-window-command-server")
+    private let finished = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var listenerFD: Int32 = -1
+    private var receivedLines: [String] = []
+
+    init(socketPath: String, targetWindowID: String, targetWindowRef: String) throws {
+        self.socketPath = socketPath
+        self.targetWindowID = targetWindowID
+        self.targetWindowRef = targetWindowRef
+
+        unlink(socketPath)
+        listenerFD = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard listenerFD >= 0 else {
+            throw Self.posixError("socket")
+        }
+
+        var address = sockaddr_un()
+        address.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: address.sun_path)
+        guard socketPath.utf8.count < maxPathLength else {
+            stop()
+            throw NSError(
+                domain: NSPOSIXErrorDomain,
+                code: Int(ENAMETOOLONG),
+                userInfo: [NSLocalizedDescriptionKey: "Unix socket path is too long: \(socketPath)"]
+            )
+        }
+        socketPath.withCString { source in
+            withUnsafeMutablePointer(to: &address.sun_path) { destination in
+                let buffer = UnsafeMutableRawPointer(destination).assumingMemoryBound(to: CChar.self)
+                strncpy(buffer, source, maxPathLength - 1)
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &address) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.bind(listenerFD, socketPointer, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            let error = Self.posixError("bind")
+            stop()
+            throw error
+        }
+        guard Darwin.listen(listenerFD, 1) == 0 else {
+            let error = Self.posixError("listen")
+            stop()
+            throw error
+        }
+    }
+
+    deinit {
+        stop()
+    }
+
+    func start() {
+        queue.async { [self] in
+            serveOneConnection()
+        }
+    }
+
+    func waitUntilFinished(timeout: TimeInterval) -> Bool {
+        finished.wait(timeout: .now() + timeout) == .success
+    }
+
+    func receivedLinesSnapshot() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return receivedLines
+    }
+
+    func requestObjects() throws -> [[String: Any]] {
+        try receivedLinesSnapshot().compactMap { line in
+            guard let data = line.data(using: .utf8),
+                  let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+                return nil
+            }
+            return object
+        }
+    }
+
+    func stop() {
+        if listenerFD >= 0 {
+            Darwin.close(listenerFD)
+            listenerFD = -1
+        }
+        unlink(socketPath)
+    }
+
+    private func serveOneConnection() {
+        defer { finished.signal() }
+
+        var clientAddress = sockaddr_un()
+        var clientAddressLength = socklen_t(MemoryLayout<sockaddr_un>.size)
+        let clientFD = withUnsafeMutablePointer(to: &clientAddress) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { socketPointer in
+                Darwin.accept(listenerFD, socketPointer, &clientAddressLength)
+            }
+        }
+        guard clientFD >= 0 else { return }
+        defer { Darwin.close(clientFD) }
+
+        var pending = Data()
+        var buffer = [UInt8](repeating: 0, count: 4096)
+        while true {
+            let count = Darwin.read(clientFD, &buffer, buffer.count)
+            if count < 0 {
+                if errno == EINTR { continue }
+                return
+            }
+            if count == 0 { return }
+            pending.append(buffer, count: count)
+
+            while let newline = pending.firstRange(of: Data([0x0A])) {
+                let lineData = pending.subdata(in: 0..<newline.lowerBound)
+                pending.removeSubrange(0...newline.lowerBound)
+                guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                record(line)
+                let response = response(for: line) + "\n"
+                _ = response.withCString { pointer in
+                    Darwin.write(clientFD, pointer, strlen(pointer))
+                }
+            }
+        }
+    }
+
+    private func record(_ line: String) {
+        lock.lock()
+        receivedLines.append(line)
+        lock.unlock()
+    }
+
+    private func response(for line: String) -> String {
+        guard let data = line.data(using: .utf8),
+              let request = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let id = request["id"] as? String,
+              let method = request["method"] as? String else {
+            return "ERROR: Invalid window id"
+        }
+
+        switch method {
+        case "window.list":
+            return v2Response(
+                id: id,
+                ok: true,
+                result: [
+                    "windows": [[
+                        "id": targetWindowID,
+                        "ref": targetWindowRef,
+                        "index": 2,
+                    ]],
+                ]
+            )
+        case "window.close", "window.focus":
+            return v2Response(
+                id: id,
+                ok: true,
+                result: [
+                    "window_id": targetWindowID,
+                    "window_ref": targetWindowRef,
+                ]
+            )
+        default:
+            return v2Response(
+                id: id,
+                ok: false,
+                error: ["code": "unexpected_method", "message": method]
+            )
+        }
+    }
+
+    private func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        guard let data = try? JSONSerialization.data(withJSONObject: payload),
+              let response = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return response
+    }
+
+    private static func posixError(_ operation: String) -> NSError {
+        NSError(
+            domain: NSPOSIXErrorDomain,
+            code: Int(errno),
+            userInfo: [NSLocalizedDescriptionKey: "\(operation) failed: \(String(cString: strerror(errno)))"]
+        )
+    }
+}

--- a/cmuxTests/CLIWindowCommandMockServer.swift
+++ b/cmuxTests/CLIWindowCommandMockServer.swift
@@ -140,6 +140,10 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
     }
 
     private func response(for line: String) -> String {
+        if line == "focus_window \(targetWindowID)" {
+            return "OK"
+        }
+
         guard let data = line.data(using: .utf8),
               let request = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
               let id = request["id"] as? String,
@@ -160,7 +164,7 @@ final class CLIWindowCommandMockServer: @unchecked Sendable {
                     ]],
                 ]
             )
-        case "window.close", "window.focus":
+        case "window.close":
             return v2Response(
                 id: id,
                 ok: true,

--- a/cmuxTests/CLIWindowHandleRoutingTests.swift
+++ b/cmuxTests/CLIWindowHandleRoutingTests.swift
@@ -88,17 +88,17 @@ struct CLIWindowHandleRoutingTests {
         process.standardOutput = outputPipe
         process.standardError = outputPipe
 
+        let exited = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in
+            exited.signal()
+        }
+
         do {
             try process.run()
         } catch {
             return ProcessResult(status: -1, output: String(describing: error), timedOut: false)
         }
 
-        let exited = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            process.waitUntilExit()
-            exited.signal()
-        }
         let timedOut = exited.wait(timeout: .now() + 5) == .timedOut
         if timedOut {
             process.terminate()

--- a/cmuxTests/CLIWindowHandleRoutingTests.swift
+++ b/cmuxTests/CLIWindowHandleRoutingTests.swift
@@ -4,15 +4,40 @@ import Testing
 
 @Suite(.serialized)
 struct CLIWindowHandleRoutingTests {
-    @Test func closeWindowResolvesTypedHandleThroughV2() throws {
-        try assertTypedHandleRoutes(command: "close-window", expectedMutation: .v2(method: "window.close"))
+    @Test func closeWindowResolvesTypedHandleBeforeLegacyMutation() throws {
+        try assertTypedHandleRoutes(
+            command: "close-window",
+            expectedMutationLine: "close_window \(Self.targetWindowID)"
+        )
     }
 
     @Test func focusWindowResolvesTypedHandleBeforeLegacyMutation() throws {
         try assertTypedHandleRoutes(
             command: "focus-window",
-            expectedMutation: .v1(line: "focus_window \(Self.targetWindowID)")
+            expectedMutationLine: "focus_window \(Self.targetWindowID)"
         )
+    }
+
+    @Test func closeWindowPreservesLegacyNotFoundError() throws {
+        let socketPath = Self.makeSocketPath("missing")
+        let server = try CLIWindowCommandMockServer(
+            socketPath: socketPath,
+            targetWindowID: Self.targetWindowID,
+            targetWindowRef: Self.targetWindowRef
+        )
+        server.start()
+        defer { server.stop() }
+
+        let result = try Self.runCLI(
+            arguments: ["close-window", "--window", Self.missingWindowID],
+            socketPath: socketPath
+        )
+
+        #expect(server.waitUntilFinished(timeout: 5))
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 1, Comment(rawValue: result.output))
+        #expect(result.output == "Error: ERROR: Window not found\n")
+        #expect(server.receivedLinesSnapshot() == ["close_window \(Self.missingWindowID)"])
     }
 
     @Test func closeWindowRejectsMalformedTypedHandleBeforeMutation() throws {
@@ -42,7 +67,7 @@ struct CLIWindowHandleRoutingTests {
         #expect(server.receivedLinesSnapshot().isEmpty)
     }
 
-    private func assertTypedHandleRoutes(command: String, expectedMutation: ExpectedMutation) throws {
+    private func assertTypedHandleRoutes(command: String, expectedMutationLine: String) throws {
         let socketPath = Self.makeSocketPath(command)
         let server = try CLIWindowCommandMockServer(
             socketPath: socketPath,
@@ -62,20 +87,11 @@ struct CLIWindowHandleRoutingTests {
         #expect(result.status == 0, Comment(rawValue: result.output))
         #expect(result.output.trimmingCharacters(in: .whitespacesAndNewlines) == "OK")
 
-        switch expectedMutation {
-        case let .v2(method):
-            let requests = try server.requestObjects()
-            #expect(requests.compactMap { $0["method"] as? String } == ["window.list", method])
-            let mutation = try #require(requests.last)
-            let params = try #require(mutation["params"] as? [String: Any])
-            #expect(params["window_id"] as? String == Self.targetWindowID)
-        case let .v1(line):
-            let receivedLines = server.receivedLinesSnapshot()
-            #expect(receivedLines.count == 2)
-            #expect(receivedLines.last == line)
-            let requests = try server.requestObjects()
-            #expect(requests.compactMap { $0["method"] as? String } == ["window.list"])
-        }
+        let receivedLines = server.receivedLinesSnapshot()
+        #expect(receivedLines.count == 2)
+        #expect(receivedLines.last == expectedMutationLine)
+        let requests = try server.requestObjects()
+        #expect(requests.compactMap { $0["method"] as? String } == ["window.list"])
     }
 
     private static func runCLI(arguments: [String], socketPath: String) throws -> ProcessResult {
@@ -142,13 +158,9 @@ struct CLIWindowHandleRoutingTests {
 
     private static let targetWindowID = "22222222-2222-2222-2222-222222222222"
     private static let targetWindowRef = "window:2"
+    private static let missingWindowID = "33333333-3333-3333-3333-333333333333"
 
     private final class BundleToken {}
-
-    private enum ExpectedMutation {
-        case v1(line: String)
-        case v2(method: String)
-    }
 
     private struct ProcessResult {
         let status: Int32

--- a/cmuxTests/CLIWindowHandleRoutingTests.swift
+++ b/cmuxTests/CLIWindowHandleRoutingTests.swift
@@ -1,0 +1,141 @@
+import Darwin
+import Foundation
+import Testing
+
+@Suite(.serialized)
+struct CLIWindowHandleRoutingTests {
+    @Test func closeWindowResolvesTypedHandleThroughV2() throws {
+        try assertTypedHandleRoutes(command: "close-window", expectedMethod: "window.close")
+    }
+
+    @Test func focusWindowResolvesTypedHandleThroughV2() throws {
+        try assertTypedHandleRoutes(command: "focus-window", expectedMethod: "window.focus")
+    }
+
+    @Test func closeWindowRejectsMalformedTypedHandleBeforeMutation() throws {
+        let socketPath = Self.makeSocketPath("invalid")
+        let server = try CLIWindowCommandMockServer(
+            socketPath: socketPath,
+            targetWindowID: Self.targetWindowID,
+            targetWindowRef: Self.targetWindowRef
+        )
+        server.start()
+        defer { server.stop() }
+
+        let result = try Self.runCLI(
+            arguments: ["close-window", "--window", "window:not-a-number"],
+            socketPath: socketPath
+        )
+
+        #expect(server.waitUntilFinished(timeout: 5))
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 1, Comment(rawValue: result.output))
+        #expect(
+            result.output.contains(
+                "Invalid window handle: window:not-a-number (expected UUID, ref like window:1, or index)"
+            ),
+            Comment(rawValue: result.output)
+        )
+        #expect(server.receivedLinesSnapshot().isEmpty)
+    }
+
+    private func assertTypedHandleRoutes(command: String, expectedMethod: String) throws {
+        let socketPath = Self.makeSocketPath(command)
+        let server = try CLIWindowCommandMockServer(
+            socketPath: socketPath,
+            targetWindowID: Self.targetWindowID,
+            targetWindowRef: Self.targetWindowRef
+        )
+        server.start()
+        defer { server.stop() }
+
+        let result = try Self.runCLI(
+            arguments: [command, "--window", Self.targetWindowRef],
+            socketPath: socketPath
+        )
+
+        #expect(server.waitUntilFinished(timeout: 5))
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(result.output.trimmingCharacters(in: .whitespacesAndNewlines) == "OK")
+
+        let requests = try server.requestObjects()
+        #expect(requests.compactMap { $0["method"] as? String } == ["window.list", expectedMethod])
+        let mutation = try #require(requests.last)
+        let params = try #require(mutation["params"] as? [String: Any])
+        #expect(params["window_id"] as? String == Self.targetWindowID)
+    }
+
+    private static func runCLI(arguments: [String], socketPath: String) throws -> ProcessResult {
+        let process = Process()
+        let outputPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: try bundledCLIPath())
+        process.arguments = arguments
+        process.environment = cliEnvironment(socketPath: socketPath)
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = outputPipe
+        process.standardError = outputPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessResult(status: -1, output: String(describing: error), timedOut: false)
+        }
+
+        let exited = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exited.signal()
+        }
+        let timedOut = exited.wait(timeout: .now() + 5) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exited.wait(timeout: .now() + 1) == .timedOut, process.isRunning {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exited.wait(timeout: .now() + 1)
+            }
+        }
+
+        return ProcessResult(
+            status: process.terminationStatus,
+            output: String(
+                data: outputPipe.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+            ) ?? "",
+            timedOut: timedOut
+        )
+    }
+
+    private static func bundledCLIPath() throws -> String {
+        try BundledCLITestSupport.bundledCLIPath(for: BundleToken.self)
+    }
+
+    private static func cliEnvironment(socketPath: String) -> [String: String] {
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_SOCKET_PATH"] = socketPath
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment["CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC"] = "2"
+        return environment
+    }
+
+    private static func makeSocketPath(_ label: String) -> String {
+        let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-window-\(label.prefix(5))-\(suffix).sock")
+            .path
+    }
+
+    private static let targetWindowID = "22222222-2222-2222-2222-222222222222"
+    private static let targetWindowRef = "window:2"
+
+    private final class BundleToken {}
+
+    private struct ProcessResult {
+        let status: Int32
+        let output: String
+        let timedOut: Bool
+    }
+}

--- a/cmuxTests/CLIWindowHandleRoutingTests.swift
+++ b/cmuxTests/CLIWindowHandleRoutingTests.swift
@@ -5,11 +5,14 @@ import Testing
 @Suite(.serialized)
 struct CLIWindowHandleRoutingTests {
     @Test func closeWindowResolvesTypedHandleThroughV2() throws {
-        try assertTypedHandleRoutes(command: "close-window", expectedMethod: "window.close")
+        try assertTypedHandleRoutes(command: "close-window", expectedMutation: .v2(method: "window.close"))
     }
 
-    @Test func focusWindowResolvesTypedHandleThroughV2() throws {
-        try assertTypedHandleRoutes(command: "focus-window", expectedMethod: "window.focus")
+    @Test func focusWindowResolvesTypedHandleBeforeLegacyMutation() throws {
+        try assertTypedHandleRoutes(
+            command: "focus-window",
+            expectedMutation: .v1(line: "focus_window \(Self.targetWindowID)")
+        )
     }
 
     @Test func closeWindowRejectsMalformedTypedHandleBeforeMutation() throws {
@@ -39,7 +42,7 @@ struct CLIWindowHandleRoutingTests {
         #expect(server.receivedLinesSnapshot().isEmpty)
     }
 
-    private func assertTypedHandleRoutes(command: String, expectedMethod: String) throws {
+    private func assertTypedHandleRoutes(command: String, expectedMutation: ExpectedMutation) throws {
         let socketPath = Self.makeSocketPath(command)
         let server = try CLIWindowCommandMockServer(
             socketPath: socketPath,
@@ -59,11 +62,20 @@ struct CLIWindowHandleRoutingTests {
         #expect(result.status == 0, Comment(rawValue: result.output))
         #expect(result.output.trimmingCharacters(in: .whitespacesAndNewlines) == "OK")
 
-        let requests = try server.requestObjects()
-        #expect(requests.compactMap { $0["method"] as? String } == ["window.list", expectedMethod])
-        let mutation = try #require(requests.last)
-        let params = try #require(mutation["params"] as? [String: Any])
-        #expect(params["window_id"] as? String == Self.targetWindowID)
+        switch expectedMutation {
+        case let .v2(method):
+            let requests = try server.requestObjects()
+            #expect(requests.compactMap { $0["method"] as? String } == ["window.list", method])
+            let mutation = try #require(requests.last)
+            let params = try #require(mutation["params"] as? [String: Any])
+            #expect(params["window_id"] as? String == Self.targetWindowID)
+        case let .v1(line):
+            let receivedLines = server.receivedLinesSnapshot()
+            #expect(receivedLines.count == 2)
+            #expect(receivedLines.last == line)
+            let requests = try server.requestObjects()
+            #expect(requests.compactMap { $0["method"] as? String } == ["window.list"])
+        }
     }
 
     private static func runCLI(arguments: [String], socketPath: String) throws -> ProcessResult {
@@ -132,6 +144,11 @@ struct CLIWindowHandleRoutingTests {
     private static let targetWindowRef = "window:2"
 
     private final class BundleToken {}
+
+    private enum ExpectedMutation {
+        case v1(line: String)
+        case v2(method: String)
+    }
 
     private struct ProcessResult {
         let status: Int32


### PR DESCRIPTION
Closes #7736

## Root cause

The bundled Swift CLI passed focus-window and close-window arguments directly to legacy v1 text commands. Those app-side handlers parse only raw UUIDs, bypassing the shared CLI handle normalization used by other window-taking commands.

## Fix

Route both affected commands through normalizeWindowHandle, which resolves UUID, window:N ref, and numeric index forms through window.list.

After resolution, close-window calls the existing window.close v2 coordinator method. Focus-window sends the canonical resolved UUID through its existing v1 focus mutation because that path also updates TerminalController active TabManager state; the current v2 window.focus context only focuses the AppKit window and switching to it would regress command routing after focus.

The adjacent window-taking-command audit found no other bypasses. Commands such as move-workspace-to-window and the window namespace already normalize their window argument; list/current/new-window do not accept a target window argument.

## Regression coverage

The first commit adds bundled-CLI socket integration tests proving that window:2 resolves to the correct UUID, the intended mutation receives that UUID, and malformed typed handles fail before mutation. A pinned CI run of the test-only commit recorded the expected failure: the old CLI returned ERROR: Invalid window id and never emitted a normalized mutation request. The current CI wrapper masks Swift Testing failures when the terminal XCTest summary contains zero unexpected XCTest failures, so that historical job badge remained green even though the failure is present in its logs.

The second commit implements shared resolution and v2 close routing. The third preserves focus-window active-manager semantics after review identified the v1/v2 behavioral difference.

## Separate issue

#4579 is not the same root cause. Both legacy and v2 close paths ultimately call AppDelegate.closeMainWindow, which returns success immediately after performClose. This PR changes handle resolution and command routing only; it does not change close-lifecycle acknowledgement.

## Verification

- Bundled CLI integration regression compiled and executed in GitHub Actions on the test-only commit
- Canonical autoreview clean: merge-conflict gate and cmux policy clean, zero actionable findings
- Test project wiring lint passed
- Test determinism guard passed
- pbxproj normalization check passed
- Package.resolved policy check passed
- Swift parser validation passed
- Diff-aware Swift file-length budget passed; CLI/cmux.swift remains line-neutral at 35,398 lines
- No new product-facing strings; localization catalogs are unchanged
- Required current-HEAD CI pending

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow CLI argument routing change with regression tests; behavior change is limited to how window targets are resolved before existing focus/close paths run.
> 
> **Overview**
> **`focus-window`** and **`close-window`** now resolve `--window` through **`normalizeWindowHandle`** (UUID, `window:N` refs, numeric index via **`window.list`**) before issuing legacy **`focus_window`** / **`close_window`** mutations, matching other window-taking CLI commands instead of passing raw strings that only worked for UUIDs.
> 
> Adds bundled-CLI socket integration coverage: a mock server plus routing tests that typed refs like **`window:2`** map to the canonical UUID, malformed handles fail before any mutation, and missing windows still surface the legacy not-found error.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3760b7b839619fdf1ab62f18c519470dac5ecdba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `focus-window` handling by requiring `--window`, normalizing the provided handle, and producing consistent `focus_window <windowID>` output.
  * Updated `close-window` to require `--window`, normalize the handle, and use the newer structured mutation API for its results.
* **Tests**
  * Added a mock CLI socket server to simulate window listing and focus/close requests.
  * Added routing tests to verify correct request sequencing for typed window handles and proper error messaging for malformed handles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->