### PR TITLE
Split agent-chat notification helper below the file-length tracking threshold

### DIFF
--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -205,50 +205,6 @@ extension AppDelegate {
         return tabManager.tabs.first { !beforeIds.contains($0.id) } ?? tabManager.selectedWorkspace
     }
 
-    private func postAgentChatServerUnavailableNotification(
-        workspace: Workspace?,
-        agentChat: CmuxAgentChatConfiguration
-    ) {
-        let body: String
-        if let startCommand = agentChat.startCommand {
-            let format = String(
-                localized: "notification.agentChat.serverUnavailable.bodyWithCommand",
-                defaultValue: "cmux couldn't reach %@. Start it with: %@"
-            )
-            body = String(format: format, agentChat.url.absoluteString, startCommand)
-        } else {
-            let format = String(
-                localized: "notification.agentChat.serverUnavailable.bodyDefault",
-                defaultValue: "cmux couldn't reach %@. Start the server with cmux-chat or configure agentChat.startCommand in cmux.json."
-            )
-            body = String(format: format, agentChat.url.absoluteString)
-        }
-        // No workspace = owned launch failed; anchor to the focused workspace.
-        guard let anchorTabId = workspace?.id ?? activeTabManagerForCommands(preferredWindow: nil)?.selectedTabId else {
-            return
-        }
-        let subtitle = workspace == nil
-            ? String(
-                localized: "notification.agentChat.serverUnavailable.subtitleLaunchFailed",
-                defaultValue: "Could not start Agent Chat"
-            )
-            : String(
-                localized: "notification.agentChat.serverUnavailable.subtitle",
-                defaultValue: "Opened Agent Chat"
-            )
-        TerminalNotificationStore.shared.addNotification(
-            tabId: anchorTabId,
-            surfaceId: workspace?.focusedPanelId,
-            title: String(
-                localized: "notification.agentChat.serverUnavailable.title",
-                defaultValue: "Agent chat server isn't running"
-            ),
-            subtitle: subtitle,
-            body: body,
-            cooldownKey: "agent-chat-server-unavailable.\(agentChat.url.absoluteString)",
-            cooldownInterval: 30
-        )
-    }
 
     private func ensureAgentChatServerAvailable(
         _ agentChat: CmuxAgentChatConfiguration,

--- a/Sources/AppDelegate+AgentChatNotifications.swift
+++ b/Sources/AppDelegate+AgentChatNotifications.swift
@@ -1,0 +1,51 @@
+import AppKit
+import Foundation
+
+// Split from AppDelegate+AgentChat.swift to keep that file under the
+// 500-line tracking threshold after concurrent merges grew it.
+extension AppDelegate {
+    func postAgentChatServerUnavailableNotification(
+        workspace: Workspace?,
+        agentChat: CmuxAgentChatConfiguration
+    ) {
+        let body: String
+        if let startCommand = agentChat.startCommand {
+            let format = String(
+                localized: "notification.agentChat.serverUnavailable.bodyWithCommand",
+                defaultValue: "cmux couldn't reach %@. Start it with: %@"
+            )
+            body = String(format: format, agentChat.url.absoluteString, startCommand)
+        } else {
+            let format = String(
+                localized: "notification.agentChat.serverUnavailable.bodyDefault",
+                defaultValue: "cmux couldn't reach %@. Start the server with cmux-chat or configure agentChat.startCommand in cmux.json."
+            )
+            body = String(format: format, agentChat.url.absoluteString)
+        }
+        // No workspace = owned launch failed; anchor to the focused workspace.
+        guard let anchorTabId = workspace?.id ?? activeTabManagerForCommands(preferredWindow: nil)?.selectedTabId else {
+            return
+        }
+        let subtitle = workspace == nil
+            ? String(
+                localized: "notification.agentChat.serverUnavailable.subtitleLaunchFailed",
+                defaultValue: "Could not start Agent Chat"
+            )
+            : String(
+                localized: "notification.agentChat.serverUnavailable.subtitle",
+                defaultValue: "Opened Agent Chat"
+            )
+        TerminalNotificationStore.shared.addNotification(
+            tabId: anchorTabId,
+            surfaceId: workspace?.focusedPanelId,
+            title: String(
+                localized: "notification.agentChat.serverUnavailable.title",
+                defaultValue: "Agent chat server isn't running"
+            ),
+            subtitle: subtitle,
+            body: body,
+            cooldownKey: "agent-chat-server-unavailable.\(agentChat.url.absoluteString)",
+            cooldownInterval: 30
+        )
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -80,6 +80,7 @@
 		F4350A110000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */; };
 		F4350A120000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */; };
 		C0DE45AC0000000000000001 /* AppDelegate+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE45AC0000000000000002 /* AppDelegate+AgentChat.swift */; };
+C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */; };
 		C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */; };
 		C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */; };
 		C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */; };
@@ -1762,6 +1763,7 @@
 		A115C0DE0000000000000001 /* AllShortcutsPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AllShortcutsPopover.swift; sourceTree = "<group>"; };
 		F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AppBundleIconPersistencePolicy.swift; sourceTree = "<group>"; };
 		C0DE45AC0000000000000002 /* AppDelegate+AgentChat.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+AgentChat.swift"; sourceTree = "<group>"; };
+C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+AgentChatNotifications.swift"; sourceTree = "<group>"; };
 		C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CanvasShortcutRouting.swift"; sourceTree = "<group>"; };
 		C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ClosedItemHistory.swift"; sourceTree = "<group>"; };
 		C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxNavigationDeepLinks.swift"; sourceTree = "<group>"; };
@@ -4004,6 +4006,7 @@
 				A5001090 /* AppDelegate.swift */,
 				C0DE45AC0000000000000002 /* AppDelegate+AgentChat.swift */,
 				C0DE71A00000000000000002 /* AgentChatThemeSync.swift */,
+				C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */,
 				B1F0C0080000000000000002 /* AppDelegateDetachedInspectorClose.swift */,
 				B1F0C0010000000000000002 /* BrowserInspectorFocusHandoff.swift */,
 				B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */,
@@ -5445,6 +5448,7 @@
 				A115C0DE0000000000000002 /* AllShortcutsPopover.swift in Sources */,
 				F4350A110000000000000001 /* AppBundleIconPersistencePolicy.swift in Sources */,
 				C0DE45AC0000000000000001 /* AppDelegate+AgentChat.swift in Sources */,
+				C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources */,
 				C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */,
 				C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */,
 				C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */,


### PR DESCRIPTION
Unblocks the repo: the squash merges of https://github.com/manaflow-ai/cmux/pull/7216 and https://github.com/manaflow-ai/cmux/pull/7723 each touched Sources/AppDelegate+AgentChat.swift and combined it to 511 lines — past the 500-line tracking threshold with no budget entry — so workflow-guard-tests fails the merge preview of every open PR. Mechanical extraction of postAgentChatServerUnavailableNotification into AppDelegate+AgentChatNotifications.swift (467 + 51 lines, both untracked), pbxproj wired and normalized.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7755"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786226715&installation_id=133855650&pr_number=7755&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7755&signature=ddd0bebe084f379ad2f3d824e43de82ab85c3ad072e0eff30a443c0d1085258d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure file split and Xcode wiring; notification logic and call sites are unchanged.
> 
> **Overview**
> Moves **`postAgentChatServerUnavailableNotification`** out of `AppDelegate+AgentChat.swift` into new **`AppDelegate+AgentChatNotifications.swift`** so the main agent-chat delegate file stays under the repo’s **500-line** tracking limit (after recent merges pushed it to 511). The helper is unchanged; **`cmux.xcodeproj`** is updated to compile the new source file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf523ce1e8b24f07650b03d3e05c755f3cce3d82. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split the agent-chat notification helper into a new file to bring `AppDelegate+AgentChat.swift` under the 500-line tracking threshold. This unblocks merge previews and workflow guards with no behavior changes.

- **Refactors**
  - Moved `postAgentChatServerUnavailableNotification` to `AppDelegate+AgentChatNotifications.swift`; reduced the original file size.
  - Updated `cmux.xcodeproj` to include the new source file.

<sup>Written for commit cf523ce1e8b24f07650b03d3e05c755f3cce3d82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7755?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved notifications when Agent Chat can’t start or the server becomes unavailable.
  * Messages now include clearer localized details, and may show the launch command when available.
  * Notifications are rate-limited to avoid repeated alerts in a short period.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->