### PR TITLE
Restore main CI Swift file-length budget

### DIFF
--- a/Sources/AgentChatActionInFlightGate.swift
+++ b/Sources/AgentChatActionInFlightGate.swift
@@ -1,0 +1,52 @@
+import CMUXAgentLaunch
+import os
+
+nonisolated struct AgentChatActionInFlightGate {
+    private struct State {
+        var isRunning = false
+        var ownedServerSession: AgentChatOwnedServerSession?
+        var sidecarStateFileStore = AgentChatSidecarStateFileStore.live()
+    }
+
+    // Synchronous action entry and theme callbacks require one atomic state transition without Task scheduling.
+    private nonisolated static let lock = OSAllocatedUnfairLock(initialState: State())
+
+    static func begin() -> Bool {
+        lock.withLock { state in
+            guard !state.isRunning else { return false }
+            state.isRunning = true
+            return true
+        }
+    }
+
+    static func end() {
+        lock.withLock { state in
+            state.isRunning = false
+        }
+    }
+
+    static func ownedServerSession() -> AgentChatOwnedServerSession? {
+        lock.withLock { state in
+            state.ownedServerSession
+        }
+    }
+
+    static func updateOwnedServerSession(_ session: AgentChatOwnedServerSession) {
+        lock.withLock { state in
+            state.ownedServerSession = session
+        }
+    }
+
+    static func clearOwnedServerSession(matching candidate: AgentChatOwnedServerSession? = nil) {
+        lock.withLock { state in
+            if let candidate, state.ownedServerSession != candidate { return }
+            state.ownedServerSession = nil
+        }
+    }
+
+    static func sidecarStateFileStore() -> AgentChatSidecarStateFileStore? {
+        lock.withLock { state in
+            state.sidecarStateFileStore
+        }
+    }
+}

--- a/Sources/AppDelegate+AgentChat.swift
+++ b/Sources/AppDelegate+AgentChat.swift
@@ -1,57 +1,7 @@
 import AppKit
 import CMUXAgentLaunch
 import Foundation
-import os
 import Security
-
-nonisolated struct AgentChatActionInFlightGate {
-    private struct State {
-        var isRunning = false
-        var ownedServerSession: AgentChatOwnedServerSession?
-        var sidecarStateFileStore = AgentChatSidecarStateFileStore.live()
-    }
-
-    private nonisolated static let lock = OSAllocatedUnfairLock(initialState: State())
-
-    static func begin() -> Bool {
-        lock.withLock { state in
-            guard !state.isRunning else { return false }
-            state.isRunning = true
-            return true
-        }
-    }
-
-    static func end() {
-        lock.withLock { state in
-            state.isRunning = false
-        }
-    }
-
-    static func ownedServerSession() -> AgentChatOwnedServerSession? {
-        lock.withLock { state in
-            state.ownedServerSession
-        }
-    }
-
-    static func updateOwnedServerSession(_ session: AgentChatOwnedServerSession) {
-        lock.withLock { state in
-            state.ownedServerSession = session
-        }
-    }
-
-    static func clearOwnedServerSession(matching candidate: AgentChatOwnedServerSession? = nil) {
-        lock.withLock { state in
-            if let candidate, state.ownedServerSession != candidate { return }
-            state.ownedServerSession = nil
-        }
-    }
-
-    static func sidecarStateFileStore() -> AgentChatSidecarStateFileStore? {
-        lock.withLock { state in
-            state.sidecarStateFileStore
-        }
-    }
-}
 
 struct AgentChatServerAvailability: Sendable {
     var isReachable: Bool

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		A9E020000000000000000006 /* agent-session-react in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000006 /* agent-session-react */; };
 		A9E020000000000000000007 /* agent-session-solid in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000007 /* agent-session-solid */; };
+		34A78C4AEA9E40109FA99F2D /* AgentChatActionInFlightGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E31FB642AEA46C48540214F /* AgentChatActionInFlightGate.swift */; };
 		C7A52E000000000000000002 /* AgentChatEndedTranscriptListabilityCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A52E000000000000000001 /* AgentChatEndedTranscriptListabilityCache.swift */; };
 		ACA7C4A70000000000000003 /* AgentChatHookSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A70000000000000004 /* AgentChatHookSessionStore.swift */; };
 		C7A531000000000000000002 /* AgentChatObservationHandle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A531000000000000000001 /* AgentChatObservationHandle.swift */; };
@@ -1697,6 +1698,7 @@
 /* Begin PBXFileReference section */
 		A9E010000000000000000006 /* agent-session-react */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-react"; sourceTree = "<group>"; };
 		A9E010000000000000000007 /* agent-session-solid */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-solid"; sourceTree = "<group>"; };
+		1E31FB642AEA46C48540214F /* AgentChatActionInFlightGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatActionInFlightGate.swift; sourceTree = "<group>"; };
 		C7A52E000000000000000001 /* AgentChatEndedTranscriptListabilityCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatEndedTranscriptListabilityCache.swift"; sourceTree = "<group>"; };
 		ACA7C4A70000000000000004 /* AgentChatHookSessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatHookSessionStore.swift"; sourceTree = "<group>"; };
 		C7A531000000000000000001 /* AgentChatObservationHandle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatObservationHandle.swift"; sourceTree = "<group>"; };
@@ -4008,6 +4010,7 @@
 				F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */,
 				D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */,
 				A5001090 /* AppDelegate.swift */,
+				1E31FB642AEA46C48540214F /* AgentChatActionInFlightGate.swift */,
 				C0DE45AC0000000000000002 /* AppDelegate+AgentChat.swift */,
 				C0DE71A00000000000000002 /* AgentChatThemeSync.swift */,
 				B1F0C0080000000000000002 /* AppDelegateDetachedInspectorClose.swift */,
@@ -5403,6 +5406,7 @@
 			buildActionMask = 2147483647;
 			files = (
 
+				34A78C4AEA9E40109FA99F2D /* AgentChatActionInFlightGate.swift in Sources */,
 					C7A52E000000000000000002 /* AgentChatEndedTranscriptListabilityCache.swift in Sources */,
 				ACA7C4A70000000000000003 /* AgentChatHookSessionStore.swift in Sources */,
 				C7A531000000000000000002 /* AgentChatObservationHandle.swift in Sources */,


### PR DESCRIPTION
## Summary
- extract the shared Agent Chat action gate into its own source file
- keep the AppDelegate Agent Chat extension below the 500-line architecture threshold
- preserve the existing gate implementation and tests instead of raising the debt budget

## Testing
- `python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv --base-ref origin/main`
- `./scripts/check-pbxproj.sh`
- tagged macOS cloud build: https://github.com/manaflow-ai/cmux/actions/runs/29054022292

## Context
- Repairs the main CI failure: https://github.com/manaflow-ai/cmux/actions/runs/29053497915/job/86239890287

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7756"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786227729&installation_id=133855650&pr_number=7756&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7756&signature=f524e62eeab88a7a629397fa6e9ae46e20f43b109c10234eababb6c139d17344"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 57dac1a8816829acf8a38f7151a0e04f2c08de8d. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores main CI by bringing the Swift file-length back under the 500-line budget. Extracts the Agent Chat action in-flight gate into its own file with no behavior changes.

- **Refactors**
  - Moved AgentChatActionInFlightGate from AppDelegate+AgentChat.swift to AgentChatActionInFlightGate.swift.
  - Preserved gate semantics and existing tests; no logic changes.
  - Updated cmux.xcodeproj to include the new source file.

<sup>Written for commit 57dac1a8816829acf8a38f7151a0e04f2c08de8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7756?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when starting and completing Agent Chat actions.
  * Prevented overlapping Agent Chat actions from running simultaneously.
  * Preserved active session and sidecar state safely during synchronous callbacks.
  * Removed an invalid import that could interfere with project builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->