### PR TITLE
Install asc in App Store workflow

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -56,6 +56,23 @@ jobs:
       - name: Provision GhosttyKit
         run: ./scripts/ensure-ghosttykit.sh
 
+      - name: Install asc CLI
+        run: |
+          set -euo pipefail
+          BREW_BIN="$(command -v brew || true)"
+          if [ -z "$BREW_BIN" ] && [ -x /opt/homebrew/bin/brew ]; then
+            BREW_BIN=/opt/homebrew/bin/brew
+          fi
+          if [ -z "$BREW_BIN" ] && [ -x /usr/local/bin/brew ]; then
+            BREW_BIN=/usr/local/bin/brew
+          fi
+          if [ -z "$BREW_BIN" ]; then
+            echo "Homebrew is required to install asc CLI" >&2
+            exit 1
+          fi
+          "$BREW_BIN" list asc >/dev/null 2>&1 || "$BREW_BIN" install asc
+          echo "$(dirname "$BREW_BIN")" >> "$GITHUB_PATH"
+
       - name: Verify asc CLI
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- install the Homebrew asc CLI in the iOS App Store workflow before verification
- keep the existing verify step so missing or broken asc fails clearly

## Verification
- ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-app-store.yml"); puts "yaml ok"'\n- production dry run before this PR failed at Verify asc CLI because asc was absent: https://github.com/manaflow-ai/cmux/actions/runs/29055348870

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow change with no app runtime, signing, or secret-handling logic modified.
> 
> **Overview**
> Adds an **Install asc CLI** step to the production iOS App Store workflow so `asc` is present before the existing **Verify asc CLI** check.
> 
> The step resolves Homebrew on Apple Silicon or Intel, fails clearly if brew is missing, runs `brew install asc` only when the formula is not already installed, and appends brew’s `bin` directory to `GITHUB_PATH` so later steps can invoke `asc`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit def18f642643222b204c9fabefda3f35718e9026. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7764"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229548&installation_id=133855650&pr_number=7764&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7764&signature=1c5713e56c19dcb6ee7cd8aa540f64d380dc9c9b342b939b6bea1a9c3d005d93"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Install the `asc` CLI via Homebrew in the iOS App Store workflow before the verify step to prevent failures when `asc` isn’t present. Keep the verify step so it fails clearly if `asc` is missing or broken.

<sup>Written for commit def18f642643222b204c9fabefda3f35718e9026. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the iOS App Store release workflow by automatically installing and configuring the required App Store Connect command-line tool.
  * Added support for locating Homebrew on both Intel and Apple Silicon macOS environments.
  * Added verification to confirm the tool is available before publishing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->