### PR TITLE
Temporarily disable clipped alt-screen notice

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -128,14 +128,6 @@ struct MobileSettingsView: View {
                 }
 
                 Section(L10n.string("mobile.settings.terminal", defaultValue: "Terminal")) {
-                    Toggle(isOn: $displaySettings.showAltScreenNotice) {
-                        Text(L10n.string(
-                            "mobile.settings.altScreenNotice",
-                            defaultValue: "Full-Screen Sizing Notice"
-                        ))
-                    }
-                    .accessibilityIdentifier("MobileSettingsAltScreenNoticeToggle")
-
                     Button {
                         showingShortcuts = true
                     } label: {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -33,7 +33,6 @@ struct WorkspaceDetailView: View {
     let backButtonConfiguration: WorkspaceBackButtonConfiguration?
     let signOut: (() -> Void)?
     @Environment(BrowserSurfaceStore.self) var browserStore
-    @Environment(MobileDisplaySettings.self) private var displaySettings
     /// Drives the destructive close-workspace confirmation dialog.
     @State var isConfirmingClose = false
     #if canImport(UIKit)
@@ -138,15 +137,6 @@ struct WorkspaceDetailView: View {
         }
         ToolbarItem(id: "workspace-title", placement: .topBarLeading) {
             workspaceTitleToolbarMenu
-        }
-        if let selectedTerminalID,
-           store.isAlternateScreen(surfaceID: selectedTerminalID),
-           displaySettings.showAltScreenNotice {
-            ToolbarItem(id: "workspace-altscreen-notice", placement: .topBarTrailing) {
-                AltScreenNoticeButton {
-                    displaySettings.showAltScreenNotice = false
-                }
-            }
         }
         ToolbarItem(id: "workspace-trailing", placement: .topBarTrailing) {
             toolbarTrailingCluster


### PR DESCRIPTION
## Summary
- temporarily remove the alternate-screen sizing notice from the workspace toolbar
- hide its Settings toggle while the native popover layout fix is verified
- preserve the notice state, localization, tests, alternate-screen detection, and render-delivery optimization for restoration

## Testing
- `git diff --check`
- tagged `noalt` Mac build started after `./scripts/setup.sh`, then was stopped before completion to open this urgent hotfix PR
- CI pending

## Issues
- Reverts the user-visible behavior introduced by https://github.com/manaflow-ai/cmux/pull/7669
- Follow-up fix: https://github.com/manaflow-ai/cmux/pull/7727

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7766"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786229993&installation_id=133855650&pr_number=7766&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7766&signature=0e1bd634671449a33fa3a0895d8b4a092172db7e56c6c7e236734f5b36c9661b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal of a notice and settings row; no changes to terminal rendering, pairing, or persisted preference keys beyond hiding controls.
> 
> **Overview**
> **Hotfix:** User-facing alternate-screen sizing notice is turned off until the native popover layout fix is verified.
> 
> The workspace toolbar no longer shows the warning button when a terminal is on the alternate screen, and **Settings → Terminal** no longer includes the **Full-Screen Sizing Notice** toggle. `MobileDisplaySettings.showAltScreenNotice`, `AltScreenNoticeButton`, detection, and tests are left in place for a follow-up restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d4ffb276f7505827d8a66ff2d5c432da08852515. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily disable the alt-screen sizing notice and hide its Settings toggle while we verify the native popover layout fix. Removes the toolbar notice and the Settings toggle; underlying state, localization, and detection remain for later restore.

<sup>Written for commit d4ffb276f7505827d8a66ff2d5c432da08852515. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7766?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Changes**
  * Removed the “Full-Screen Sizing Notice” toggle from Terminal settings.
  * Removed the alternate-screen notice from the workspace toolbar.
  * Terminal settings now provide direct access to Terminal Shortcuts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->