### PR TITLE
Fix app-host crash-restart storm: test windows default to releasedWhenClosed = false

### DIFF
--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -508,6 +508,7 @@
 		C750500000000000000000A3 /* CmuxTerminal in Frameworks */ = {isa = PBXBuildFile; productRef = C750500000000000000000A2 /* CmuxTerminal */; };
 		C750200000000000000000A3 /* CmuxTerminalCore in Frameworks */ = {isa = PBXBuildFile; productRef = C750200000000000000000A2 /* CmuxTerminalCore */; };
 		CFF12E0000000000000000A3 /* CmuxTestSupport in Frameworks */ = {isa = PBXBuildFile; productRef = CFF12E0000000000000000A2 /* CmuxTestSupport */; };
+		A2977C204AD69CF268D38EE3 /* CmuxTestWindowReleaseGuard.m in Sources */ = {isa = PBXBuildFile; fileRef = EA9B442F20273D64D2BA1FC5 /* CmuxTestWindowReleaseGuard.m */; };
 		C7A510000000000000000002 /* CmuxTopMemoryDiagnostics.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */; };
 		B35750000000000000000004 /* CmuxTopProcessArguments.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000003 /* CmuxTopProcessArguments.swift */; };
 		C7A50C000000000000000003 /* CmuxTopProcessArgumentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */; };
@@ -2143,6 +2144,7 @@
 		C0DE43000000000000000004 /* CmuxSurfaceTabBarBuiltInAction+Codable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CmuxSurfaceTabBarBuiltInAction+Codable.swift"; sourceTree = "<group>"; };
 		C10D00040000000000000004 /* CmuxSurfaceTabBarBuiltInAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxSurfaceTabBarBuiltInAction.swift; sourceTree = "<group>"; };
 		F1000002A1B2C3D4E5F60718 /* cmuxTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = cmuxTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		EA9B442F20273D64D2BA1FC5 /* CmuxTestWindowReleaseGuard.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CmuxTestWindowReleaseGuard.m; sourceTree = "<group>"; };
 		C7A510000000000000000001 /* CmuxTopMemoryDiagnostics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopMemoryDiagnostics.swift; sourceTree = "<group>"; };
 		B35750000000000000000003 /* CmuxTopProcessArguments.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessArguments.swift; sourceTree = "<group>"; };
 		C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessArgumentsTests.swift; sourceTree = "<group>"; };
@@ -4832,6 +4834,7 @@
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
 				B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */,
+				EA9B442F20273D64D2BA1FC5 /* CmuxTestWindowReleaseGuard.m */,
 				9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */,
 				9F007352E96022D7EFBE73C9 /* WorkspaceTodoSidebarModelTests.swift */,
 				C0DE1A080000000000000002 /* SavedLayoutDefinitionTests.swift */,
@@ -6664,6 +6667,7 @@
 					C0DE31390000000000000101 /* CMUXOpenCommandTests.swift in Sources */,
 					C0DE31390000000000000111 /* CMUXOpenHTMLFocusTests.swift in Sources */,
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
+				A2977C204AD69CF268D38EE3 /* CmuxTestWindowReleaseGuard.m in Sources */,
 				C7A50C000000000000000003 /* CmuxTopProcessArgumentsTests.swift in Sources */,
 				C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,
 				C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		F47126CFDAE244988A92E2D0 /* AppDelegateWindowFrameReconcileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD21AD844E5D4D50A6DFC442 /* AppDelegateWindowFrameReconcileTests.swift */; };
 		A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAB000000000000000001 /* AppearanceSettings.swift */; };
 		A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAA000000000000000001 /* AppearanceSettingsTests.swift */; };
+		C8046FF15781CC7E4F8EAEA6 /* AppHostWindowReleaseGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */; };
 		D1320AA0D1320AA0D1320AA1 /* AppIconDockTilePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */; };
 		A5001621 /* AppleScriptSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001620 /* AppleScriptSupport.swift */; };
 		A5001A02A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001A03A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift */; };
@@ -1809,6 +1810,7 @@
 		FD21AD844E5D4D50A6DFC442 /* AppDelegateWindowFrameReconcileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateWindowFrameReconcileTests.swift; sourceTree = "<group>"; };
 		A11EAB000000000000000001 /* AppearanceSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettings.swift; sourceTree = "<group>"; };
 		A11EAA000000000000000001 /* AppearanceSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsTests.swift; sourceTree = "<group>"; };
+		B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppHostWindowReleaseGuardTests.swift; sourceTree = "<group>"; };
 		IC000002 /* AppIcon.icon */ = {isa = PBXFileReference; lastKnownFileType = folder; path = AppIcon.icon; sourceTree = "<group>"; };
 		D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppIconDockTilePlugin.swift; sourceTree = "<group>"; };
 		A5001620 /* AppleScriptSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleScriptSupport.swift; sourceTree = "<group>"; };
@@ -4829,6 +4831,7 @@
 				C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */,
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				B3FAA194471B7BA157FB4660 /* AppHostWindowReleaseGuardTests.swift */,
 				9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */,
 				9F007352E96022D7EFBE73C9 /* WorkspaceTodoSidebarModelTests.swift */,
 				C0DE1A080000000000000002 /* SavedLayoutDefinitionTests.swift */,
@@ -6562,6 +6565,7 @@
 				4E6A6F5C1D2B4980A1234568 /* AppDelegateSurfaceShortcutRoutingTests.swift in Sources */,
 				F47126CFDAE244988A92E2D0 /* AppDelegateWindowFrameReconcileTests.swift in Sources */,
 				A11EAA000000000000000000 /* AppearanceSettingsTests.swift in Sources */,
+				C8046FF15781CC7E4F8EAEA6 /* AppHostWindowReleaseGuardTests.swift in Sources */,
 				A47E00010000000000000001 /* AuthEnvironmentTests.swift in Sources */,
 				FF068325E8A04E51A30AE9BA /* AutoNamingCodexAdapterTests.swift in Sources */,
 				7C592156DCB3419BB95383E5 /* AutoNamingEngineTests.swift in Sources */,

--- a/cmuxTests/AppHostWindowReleaseGuardTests.swift
+++ b/cmuxTests/AppHostWindowReleaseGuardTests.swift
@@ -1,0 +1,41 @@
+import AppKit
+import XCTest
+
+/// Guards the process-wide window-release guard installed by
+/// `CmuxTestWindowReleaseGuard.m`.
+///
+/// AppKit defaults code-created windows to `isReleasedWhenClosed == true`,
+/// which under ARC means `close()` over-releases the window and XCTest's
+/// post-test autorelease-pool drain crashes the shared app host
+/// (EXC_BAD_ACCESS in objc_release, reported by xcodebuild as "Restarting
+/// after unexpected exit"). The guard swizzles NSWindow's designated
+/// initializers so every window created in the test process defaults to
+/// `isReleasedWhenClosed == false`, making test-teardown `close()` calls safe
+/// regardless of whether the individual test remembered to set the flag.
+final class AppHostWindowReleaseGuardTests: XCTestCase {
+    func testCodeCreatedWindowDefaultsToNotReleasedWhenClosed() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        XCTAssertFalse(
+            window.isReleasedWhenClosed,
+            "Test-process windows must not be released on close: ARC already owns them, " +
+            "and the extra release crashes the app host in the post-test pool drain"
+        )
+        window.close()
+    }
+
+    func testPanelInheritsGuardedDefault() {
+        let panel = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 80, height: 60),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        XCTAssertFalse(panel.isReleasedWhenClosed)
+        panel.close()
+    }
+}

--- a/cmuxTests/AppHostWindowReleaseGuardTests.swift
+++ b/cmuxTests/AppHostWindowReleaseGuardTests.swift
@@ -38,4 +38,22 @@ final class AppHostWindowReleaseGuardTests: XCTestCase {
         XCTAssertFalse(panel.isReleasedWhenClosed)
         panel.close()
     }
+
+    func testClosedWindowSurvivesAutoreleasePoolDrain() {
+        weak var weakWindow: NSWindow?
+        autoreleasepool {
+            let window = NSWindow(
+                contentRect: NSRect(x: 0, y: 0, width: 100, height: 100),
+                styleMask: [.titled, .closable],
+                backing: .buffered,
+                defer: false
+            )
+            weakWindow = window
+            window.close()
+            // Without the guard this is the exact over-release shape that
+            // killed the host: close() consumed ARC's +1, and the pool drain
+            // below released a deallocated window.
+        }
+        XCTAssertNil(weakWindow, "window should deallocate exactly once, with no lingering references")
+    }
 }

--- a/cmuxTests/CmuxTestWindowReleaseGuard.m
+++ b/cmuxTests/CmuxTestWindowReleaseGuard.m
@@ -1,0 +1,56 @@
+//  CmuxTestWindowReleaseGuard.m
+//
+//  App-host unit tests create hundreds of NSWindows in Swift and close them in
+//  test teardown. AppKit's default for code-created windows is
+//  releasedWhenClosed == YES, so under ARC every close() sends an extra
+//  release. The window then deallocates while still sitting in the test's
+//  autorelease pool, and XCTest's post-test pool drain (XCTMemoryChecker)
+//  crashes the shared app host with EXC_BAD_ACCESS in objc_release. On CI this
+//  surfaced as dozens of silent "Restarting after unexpected exit" host
+//  relaunches per shard, and cascading failures for whichever suite ran next.
+//
+//  This constructor runs when the test bundle loads and swizzles NSWindow's
+//  designated initializers so every window created in the test process
+//  defaults to releasedWhenClosed == NO, which is the only correct value for
+//  ARC-managed windows. Nothing in cmux sets releasedWhenClosed = YES
+//  deliberately; production code already sets NO defensively at 13 call sites.
+//  Known tradeoff: AppKit-internal self-releasing windows leak instead of
+//  freeing in the test process, which is harmless there.
+//  Guarded by AppHostWindowReleaseGuardTests.
+
+#import <AppKit/AppKit.h>
+#import <objc/runtime.h>
+
+static void CmuxSwizzleWindowInitializer(SEL selector) {
+    Method method = class_getInstanceMethod([NSWindow class], selector);
+    if (method == NULL) {
+        return;
+    }
+    IMP original = method_getImplementation(method);
+    id block;
+    if (selector == @selector(initWithContentRect:styleMask:backing:defer:screen:)) {
+        block = ^NSWindow *(NSWindow *self, NSRect rect, NSWindowStyleMask style,
+                            NSBackingStoreType backing, BOOL defer, NSScreen *screen) {
+            typedef NSWindow *(*Init)(NSWindow *, SEL, NSRect, NSWindowStyleMask,
+                                      NSBackingStoreType, BOOL, NSScreen *);
+            NSWindow *window = ((Init)original)(self, selector, rect, style, backing, defer, screen);
+            window.releasedWhenClosed = NO;
+            return window;
+        };
+    } else {
+        block = ^NSWindow *(NSWindow *self, NSRect rect, NSWindowStyleMask style,
+                            NSBackingStoreType backing, BOOL defer) {
+            typedef NSWindow *(*Init)(NSWindow *, SEL, NSRect, NSWindowStyleMask,
+                                      NSBackingStoreType, BOOL);
+            NSWindow *window = ((Init)original)(self, selector, rect, style, backing, defer);
+            window.releasedWhenClosed = NO;
+            return window;
+        };
+    }
+    method_setImplementation(method, imp_implementationWithBlock(block));
+}
+
+__attribute__((constructor)) static void CmuxInstallTestWindowReleaseGuard(void) {
+    CmuxSwizzleWindowInitializer(@selector(initWithContentRect:styleMask:backing:defer:));
+    CmuxSwizzleWindowInitializer(@selector(initWithContentRect:styleMask:backing:defer:screen:));
+}


### PR DESCRIPTION
Every test in `BrowserDeveloperToolsVisibilityPersistenceTests` silently crash-restarted the shared app host once per run, and main's baseline CI runs carry dozens of the same silent restarts across shards (34 on one shard of run [28984723481](https://github.com/manaflow-ai/cmux/actions/runs/28984723481)). The time-weighted resharding in https://github.com/manaflow-ai/cmux/pull/7687 made the latent bug visible by co-locating the crasher with live-WKWebView suites, which then failed collaterally (worked around there with `SEPARATED_SUITES`).

Root cause, pinned with lldb and NSZombie on the AWS M4 Pro builder: test-created `NSWindow`s keep AppKit's default `releasedWhenClosed == true`. Under ARC, teardown `close()` sends an extra release, and XCTest's post-test autorelease-pool drain then over-releases the deallocated window: `EXC_BAD_ACCESS` in `objc_release` inside `XCTMemoryChecker`, zombie message `-[NSWindow release]: message sent to deallocated instance`. The host exits with code 1 under the debugger, so no crash report is written and xcodebuild logs only 'Restarting after unexpected exit'. 269 of 299 window creations across 61 test files lack the `isReleasedWhenClosed = false` guard.

Fix: a test-bundle constructor (`cmuxTests/CmuxTestWindowReleaseGuard.m`) swizzles NSWindow's designated initializers so every window created in the test process defaults to `releasedWhenClosed = false`, the only correct value for ARC-managed windows. One hook kills all 269 latent sites plus any future ones; production code is untouched (it already sets `false` defensively at its 13 sites). Commit 1 adds the failing guard tests (red), commit 2 the fix (green), per the regression-test policy.

Verified on aws-m4pro-2: the DevTools suite went from 16 host restarts and 21 cascade failures per isolated run to 0 restarts.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7768"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786230658&installation_id=133855650&pr_number=7768&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7768&signature=a3d66211f5a11b3fec750c0755b53a746ffb306b81276689d9e1c33f9df04dff"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are confined to the cmuxTests bundle via constructor swizzling; production app code is untouched, with a documented harmless leak tradeoff for AppKit-internal self-releasing windows in tests only.
> 
> **Overview**
> Stops shared **app-host** XCTest runs from **EXC_BAD_ACCESS** during post-test autorelease-pool drains when tests create `NSWindow`/`NSPanel` and call `close()` without overriding AppKit’s default **`isReleasedWhenClosed == true`** (double-release under ARC).
> 
> Adds a **test-bundle-only** `__attribute__((constructor))` in `CmuxTestWindowReleaseGuard.m` that **swizzles** `NSWindow`’s designated `initWithContentRect:styleMask:backing:defer:` initializers (with and without `screen:`) so new windows default to **`releasedWhenClosed = NO`**, covering existing and future test window creation without touching production. **`AppHostWindowReleaseGuardTests`** asserts the default for windows/panels and that close + pool drain deallocates exactly once.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ec78dc277977ee1f8db2d222b0e5d60e001bf2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes app-host crash-restart storms in CI by defaulting all test-created AppKit windows to not be released on close. Stabilizes DevTools and live WKWebView suites; host restarts drop from 16/run to 0.

- **Bug Fixes**
  - Install a test-bundle constructor that swizzles `NSWindow` initializers to set `isReleasedWhenClosed = false` for all windows created in tests (covers `NSWindow` and `NSPanel`).
  - Add guard tests to verify the default for windows/panels and the close-then-autorelease-pool-drain case that previously crashed.
  - No production changes.

<sup>Written for commit 9ec78dc277977ee1f8db2d222b0e5d60e001bf2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

