### PR TITLE
Fix attached Web Inspector resize: bottom-dock divider, small-pane minimum-size policy, WebKit size sync

### DIFF
--- a/Sources/App/HostedInspectorDockControlScript.swift
+++ b/Sources/App/HostedInspectorDockControlScript.swift
@@ -42,7 +42,15 @@ struct HostedInspectorDockControlScript {
                     return true;
                 return String(configuration).toLowerCase() === literal;
             }
+            function disableFrontendDockedResizer() {
+                if (typeof document === "undefined" || !document.getElementById)
+                    return;
+                const dockedResizer = document.getElementById("docked-resizer");
+                if (dockedResizer && dockedResizer.style)
+                    dockedResizer.style.pointerEvents = "none";
+            }
             function enforceDockControls() {
+                disableFrontendDockedResizer();
                 const disallowSideDock = !WI.__cmuxAllowSideDock;
                 const dockConfiguration = WI.DockConfiguration || {};
                 const dockedLeft = dockMatches(dockConfiguration.Left, "left");

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -122,7 +122,6 @@ final class WindowBrowserHostView: NSView {
     private var activeDividerCursorKind: DividerCursorKind?
     private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
     private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
-    private var lastSyncedHostedInspectorDragExtent: Int?
     private let hostedInspectorDragFrameSilencer = HostedInspectorDragFrameNotificationSilencer()
     private var lastHostedInspectorLayoutBoundsSize: NSSize?
 
@@ -132,6 +131,7 @@ final class WindowBrowserHostView: NSView {
             removeTrackingArea(trackingArea)
         }
         clearActiveDividerCursor(restoreArrow: false)
+        // hostedInspectorDragFrameSilencer restores in its own deinit.
     }
 
 #if DEBUG
@@ -409,7 +409,6 @@ final class WindowBrowserHostView: NSView {
             return
         }
         cachedHostedInspectorDividerHit = nil
-        lastSyncedHostedInspectorDragExtent = nil
 
         hostedInspectorHit.slotView.isHostedInspectorDividerDragActive = true
         hostedInspectorDragFrameSilencer.begin(hostedInspectorHit.pageView)
@@ -484,9 +483,12 @@ final class WindowBrowserHostView: NSView {
             ),
             reason: "drag"
         )
-        // Keep WebKit's stored attachment size tracking the live drag so its
-        // relayout can't re-apply the stale pre-drag size mid-drag.
-        syncAttachedSizeDuringDrag(extent: inspectorExtent, dockSide: dragState.dockSide, slotView: dragState.slotView)
+        // Do NOT sync the attachment size to WebKit per drag event: the
+        // frontend's JS queue backs up during fast scrubs and every queued
+        // setAttachedWindow* call echoes back as a stale WebKit frame apply
+        // (verified in the debug log), yanking the divider backwards. The
+        // frame-notification silencer keeps WebKit passive; one sync on
+        // mouseUp reconciles it.
         updateDividerCursor(
             at: convert(event.locationInWindow, from: nil),
             dividerHit: nil,
@@ -516,7 +518,11 @@ final class WindowBrowserHostView: NSView {
                 inspectorFrame: dragState.inspectorView.frame,
                 in: dragState.containerView.bounds
             )
-            syncAttachedSizeDuringDrag(extent: finalExtent, dockSide: dragState.dockSide, slotView: dragState.slotView)
+            HostedInspectorAttachedSizeSync.sync(
+                pageWebView: dragState.slotView.hostedInspectorPageWebViewForAttachedSizeSync,
+                dockSide: dragState.dockSide,
+                extent: finalExtent
+            )
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.manualInspectorDrag stage=end slot=\(browserPortalDebugToken(dragState.slotView)) " +
@@ -745,17 +751,6 @@ final class WindowBrowserHostView: NSView {
         }
 
         return nil
-    }
-
-    private func syncAttachedSizeDuringDrag(extent: CGFloat, dockSide: HostedInspectorDockSide, slotView: WindowBrowserSlotView) {
-        let roundedExtent = max(0, Int(extent.rounded()))
-        guard roundedExtent != lastSyncedHostedInspectorDragExtent else { return }
-        lastSyncedHostedInspectorDragExtent = roundedExtent
-        HostedInspectorAttachedSizeSync.sync(
-            pageWebView: slotView.hostedInspectorPageWebViewForAttachedSizeSync,
-            dockSide: dockSide,
-            extent: extent
-        )
     }
 
     private func cacheHostedInspectorDividerHit(_ hit: HostedInspectorDividerHit, at point: NSPoint) {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -131,7 +131,6 @@ final class WindowBrowserHostView: NSView {
             removeTrackingArea(trackingArea)
         }
         clearActiveDividerCursor(restoreArrow: false)
-        // hostedInspectorDragFrameSilencer restores in its own deinit.
     }
 
 #if DEBUG
@@ -484,12 +483,9 @@ final class WindowBrowserHostView: NSView {
             ),
             reason: "drag"
         )
-        // Do NOT sync the attachment size to WebKit per drag event: the
-        // frontend's JS queue backs up during fast scrubs and every queued
-        // setAttachedWindow* call echoes back as a stale WebKit frame apply
-        // (verified in the debug log), yanking the divider backwards. The
-        // frame-notification silencer keeps WebKit passive; one sync on
-        // mouseUp reconciles it.
+        // Do not sync the attachment size to WebKit per drag event: queued
+        // setAttachedWindow* calls echo back as stale WebKit frame applies
+        // during fast scrubs. One sync on mouseUp reconciles WebKit.
         updateDividerCursor(
             at: convert(event.locationInWindow, from: nil),
             dividerHit: nil,
@@ -521,8 +517,7 @@ final class WindowBrowserHostView: NSView {
             )
             HostedInspectorAttachedSizeSync.sync(
                 pageWebView: dragState.slotView.hostedInspectorPageWebViewForAttachedSizeSync,
-                dockSide: dragState.dockSide,
-                extent: finalExtent
+                dockSide: dragState.dockSide, extent: finalExtent
             )
 #if DEBUG
             cmuxDebugLog(
@@ -912,10 +907,7 @@ final class WindowBrowserHostView: NSView {
     fileprivate func reapplyHostedInspectorDividerIfNeeded(in slot: WindowBrowserSlotView, reason: String) -> Bool {
         guard !slot.isHostedInspectorDividerDragActive else {
 #if DEBUG
-            cmuxDebugLog(
-                "browser.portal.manualInspectorDrag stage=skipReapply slot=\(browserPortalDebugToken(slot)) " +
-                "reason=\(reason)"
-            )
+            cmuxDebugLog("browser.portal.manualInspectorDrag stage=skipReapply slot=\(browserPortalDebugToken(slot)) reason=\(reason)")
 #endif
             return false
         }
@@ -923,7 +915,15 @@ final class WindowBrowserHostView: NSView {
         guard let preferredExtent = slot.resolvedPreferredHostedInspectorExtent(
             dockSide: hit.dockSide,
             in: hit.containerView.bounds
-        ) else { return false }
+        ) else {
+            // A stored extent for the other dock axis (post-redock) must not
+            // block adopting this axis's current layout as its preference.
+            let currentExtent = hit.dockSide.inspectorExtent(inspectorFrame: hit.inspectorView.frame, in: hit.containerView.bounds)
+            if currentExtent > 1 {
+                slot.recordPreferredHostedInspectorExtent(currentExtent, dockSide: hit.dockSide, containerBounds: hit.containerView.bounds)
+            }
+            return false
+        }
         let oldPageFrame = hit.pageView.frame
         let oldInspectorFrame = hit.inspectorView.frame
         _ = applyHostedInspectorDividerExtent(

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -522,6 +522,7 @@ final class WindowBrowserHostView: NSView {
             scheduleHostedInspectorDividerReapply(in: dragState.slotView, reason: "dragEndAsync")
         }
         hostedInspectorDividerDrag = nil
+        cachedHostedInspectorDividerHit = nil
         updateDividerCursor(at: convert(event.locationInWindow, from: nil))
         super.mouseUp(with: event)
     }

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -123,6 +123,7 @@ final class WindowBrowserHostView: NSView {
     private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
     private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
     private var lastSyncedHostedInspectorDragExtent: Int?
+    private let hostedInspectorDragFrameSilencer = HostedInspectorDragFrameNotificationSilencer()
     private var lastHostedInspectorLayoutBoundsSize: NSSize?
 
     deinit {
@@ -411,6 +412,7 @@ final class WindowBrowserHostView: NSView {
         lastSyncedHostedInspectorDragExtent = nil
 
         hostedInspectorHit.slotView.isHostedInspectorDividerDragActive = true
+        hostedInspectorDragFrameSilencer.begin(hostedInspectorHit.pageView)
         hostedInspectorDividerDrag = HostedInspectorDividerDragState(
             slotView: hostedInspectorHit.slotView,
             containerView: hostedInspectorHit.containerView,
@@ -440,6 +442,7 @@ final class WindowBrowserHostView: NSView {
         guard dragState.slotView.window === window else {
             dragState.slotView.isHostedInspectorDividerDragActive = false
             hostedInspectorDividerDrag = nil
+            hostedInspectorDragFrameSilencer.end()
             super.mouseDragged(with: event)
             return
         }
@@ -508,6 +511,7 @@ final class WindowBrowserHostView: NSView {
     override func mouseUp(with event: NSEvent) {
         if let dragState = hostedInspectorDividerDrag {
             dragState.slotView.isHostedInspectorDividerDragActive = false
+            hostedInspectorDragFrameSilencer.end()
             let finalExtent = dragState.dockSide.inspectorExtent(
                 inspectorFrame: dragState.inspectorView.frame,
                 in: dragState.containerView.bounds

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -179,6 +179,7 @@ final class WindowBrowserHostView: NSView {
         super.viewDidMoveToWindow()
         if window == nil {
             clearActiveDividerCursor(restoreArrow: false)
+            cancelHostedInspectorDividerDragForTeardown()
         }
         updateSplitDividerResizeObserver()
         invalidateSplitDividerRegionCache()
@@ -751,6 +752,14 @@ final class WindowBrowserHostView: NSView {
         }
 
         return nil
+    }
+
+    private func cancelHostedInspectorDividerDragForTeardown() {
+        guard let dragState = hostedInspectorDividerDrag else { return }
+        dragState.slotView.isHostedInspectorDividerDragActive = false
+        hostedInspectorDividerDrag = nil
+        cachedHostedInspectorDividerHit = nil
+        hostedInspectorDragFrameSilencer.end()
     }
 
     private func cacheHostedInspectorDividerHit(_ hit: HostedInspectorDividerHit, at point: NSPoint) {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -122,6 +122,7 @@ final class WindowBrowserHostView: NSView {
     private var activeDividerCursorKind: DividerCursorKind?
     private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
     private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
+    private var lastSyncedHostedInspectorDragExtent: Int?
     private var lastHostedInspectorLayoutBoundsSize: NSSize?
 
     deinit {
@@ -407,6 +408,7 @@ final class WindowBrowserHostView: NSView {
             return
         }
         cachedHostedInspectorDividerHit = nil
+        lastSyncedHostedInspectorDragExtent = nil
 
         hostedInspectorHit.slotView.isHostedInspectorDividerDragActive = true
         hostedInspectorDividerDrag = HostedInspectorDividerDragState(
@@ -479,6 +481,9 @@ final class WindowBrowserHostView: NSView {
             ),
             reason: "drag"
         )
+        // Keep WebKit's stored attachment size tracking the live drag so its
+        // relayout can't re-apply the stale pre-drag size mid-drag.
+        syncAttachedSizeDuringDrag(extent: inspectorExtent, dockSide: dragState.dockSide, slotView: dragState.slotView)
         updateDividerCursor(
             at: convert(event.locationInWindow, from: nil),
             dividerHit: nil,
@@ -507,11 +512,7 @@ final class WindowBrowserHostView: NSView {
                 inspectorFrame: dragState.inspectorView.frame,
                 in: dragState.containerView.bounds
             )
-            HostedInspectorAttachedSizeSync.sync(
-                pageWebView: dragState.slotView.hostedInspectorPageWebViewForAttachedSizeSync,
-                dockSide: dragState.dockSide,
-                extent: finalExtent
-            )
+            syncAttachedSizeDuringDrag(extent: finalExtent, dockSide: dragState.dockSide, slotView: dragState.slotView)
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.manualInspectorDrag stage=end slot=\(browserPortalDebugToken(dragState.slotView)) " +
@@ -740,6 +741,17 @@ final class WindowBrowserHostView: NSView {
         }
 
         return nil
+    }
+
+    private func syncAttachedSizeDuringDrag(extent: CGFloat, dockSide: HostedInspectorDockSide, slotView: WindowBrowserSlotView) {
+        let roundedExtent = max(0, Int(extent.rounded()))
+        guard roundedExtent != lastSyncedHostedInspectorDragExtent else { return }
+        lastSyncedHostedInspectorDragExtent = roundedExtent
+        HostedInspectorAttachedSizeSync.sync(
+            pageWebView: slotView.hostedInspectorPageWebViewForAttachedSizeSync,
+            dockSide: dockSide,
+            extent: extent
+        )
     }
 
     private func cacheHostedInspectorDividerHit(_ hit: HostedInspectorDividerHit, at point: NSPoint) {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -62,132 +62,6 @@ private extension NSWindow {
     }
 }
 
-enum HostedInspectorDockSide {
-    case leading
-    case trailing
-
-    static func resolve(
-        pageFrame: NSRect,
-        inspectorFrame: NSRect,
-        epsilon: CGFloat = 1
-    ) -> Self? {
-        if pageFrame.maxX <= inspectorFrame.minX + epsilon {
-            return .trailing
-        }
-        if inspectorFrame.maxX <= pageFrame.minX + epsilon {
-            return .leading
-        }
-        return nil
-    }
-
-    func dividerX(pageFrame: NSRect, inspectorFrame: NSRect) -> CGFloat {
-        switch self {
-        case .leading:
-            return inspectorFrame.maxX
-        case .trailing:
-            return inspectorFrame.minX
-        }
-    }
-
-    func dividerHitRect(
-        in bounds: NSRect,
-        pageFrame: NSRect,
-        inspectorFrame: NSRect,
-        expansion: CGFloat
-    ) -> NSRect {
-        return NSRect(
-            x: dividerX(pageFrame: pageFrame, inspectorFrame: inspectorFrame) - expansion,
-            y: bounds.minY,
-            width: expansion * 2,
-            height: max(0, bounds.height)
-        )
-    }
-
-    func clampedDividerX(
-        _ proposedDividerX: CGFloat,
-        containerBounds: NSRect,
-        pageFrame: NSRect,
-        minimumInspectorWidth: CGFloat
-    ) -> CGFloat {
-        switch self {
-        case .leading:
-            let minDividerX = min(containerBounds.maxX, containerBounds.minX + minimumInspectorWidth)
-            let maxDividerX = max(minDividerX, min(containerBounds.maxX, pageFrame.maxX))
-            return max(minDividerX, min(maxDividerX, proposedDividerX))
-        case .trailing:
-            let minDividerX = max(containerBounds.minX, pageFrame.minX)
-            let maxDividerX = max(minDividerX, containerBounds.maxX - minimumInspectorWidth)
-            return max(minDividerX, min(maxDividerX, proposedDividerX))
-        }
-    }
-
-    func inspectorWidth(forDividerX dividerX: CGFloat, in containerBounds: NSRect) -> CGFloat {
-        switch self {
-        case .leading:
-            return max(0, dividerX - containerBounds.minX)
-        case .trailing:
-            return max(0, containerBounds.maxX - dividerX)
-        }
-    }
-
-    func resizedFrames(
-        preferredWidth: CGFloat,
-        in containerBounds: NSRect,
-        pageFrame: NSRect,
-        inspectorFrame: NSRect,
-        minimumInspectorWidth: CGFloat
-    ) -> (pageFrame: NSRect, inspectorFrame: NSRect) {
-        let normalizedMinY = containerBounds.minY
-        let normalizedHeight = max(0, containerBounds.height)
-
-        switch self {
-        case .leading:
-            let maximumInspectorWidth = max(0, containerBounds.width)
-            let clampedMinimumInspectorWidth = min(maximumInspectorWidth, max(0, minimumInspectorWidth))
-            let clampedInspectorWidth = min(
-                maximumInspectorWidth,
-                max(clampedMinimumInspectorWidth, preferredWidth)
-            )
-            let dividerX = min(containerBounds.maxX, containerBounds.minX + clampedInspectorWidth)
-
-            var nextPageFrame = pageFrame
-            nextPageFrame.origin.x = dividerX
-            nextPageFrame.origin.y = normalizedMinY
-            nextPageFrame.size.width = max(0, containerBounds.maxX - dividerX)
-            nextPageFrame.size.height = normalizedHeight
-
-            var nextInspectorFrame = inspectorFrame
-            nextInspectorFrame.origin.x = containerBounds.minX
-            nextInspectorFrame.origin.y = normalizedMinY
-            nextInspectorFrame.size.width = max(0, dividerX - containerBounds.minX)
-            nextInspectorFrame.size.height = normalizedHeight
-            return (pageFrame: nextPageFrame, inspectorFrame: nextInspectorFrame)
-
-        case .trailing:
-            let maximumInspectorWidth = max(0, containerBounds.width)
-            let clampedMinimumInspectorWidth = min(maximumInspectorWidth, max(0, minimumInspectorWidth))
-            let clampedInspectorWidth = min(
-                maximumInspectorWidth,
-                max(clampedMinimumInspectorWidth, preferredWidth)
-            )
-            let dividerX = max(containerBounds.minX, containerBounds.maxX - clampedInspectorWidth)
-
-            var nextPageFrame = pageFrame
-            nextPageFrame.origin.x = containerBounds.minX
-            nextPageFrame.origin.y = normalizedMinY
-            nextPageFrame.size.width = max(0, dividerX - containerBounds.minX)
-            nextPageFrame.size.height = normalizedHeight
-
-            var nextInspectorFrame = inspectorFrame
-            nextInspectorFrame.origin.x = dividerX
-            nextInspectorFrame.origin.y = normalizedMinY
-            nextInspectorFrame.size.width = max(0, containerBounds.maxX - dividerX)
-            nextInspectorFrame.size.height = normalizedHeight
-            return (pageFrame: nextPageFrame, inspectorFrame: nextInspectorFrame)
-        }
-    }
-}
-
 final class WindowBrowserHostView: NSView {
     private typealias DividerRegion = PortalSplitDividerRegion
 
@@ -210,9 +84,15 @@ final class WindowBrowserHostView: NSView {
         let pageView: NSView
         let inspectorView: NSView
         let dockSide: HostedInspectorDockSide
-        let initialWindowX: CGFloat
+        let initialWindowPoint: NSPoint
         let initialPageFrame: NSRect
         let initialInspectorFrame: NSRect
+    }
+
+    private struct CachedHostedInspectorDividerHit {
+        let point: NSPoint
+        let hit: HostedInspectorDividerHit
+        let timestamp: TimeInterval
     }
 
     private enum DividerCursorKind: Equatable {
@@ -231,7 +111,7 @@ final class WindowBrowserHostView: NSView {
     private static let sidebarLeadingEdgeEpsilon: CGFloat = 1
     private static let minimumVisibleLeadingContentWidth: CGFloat = 24
     private static let hostedInspectorDividerHitExpansion: CGFloat = 6
-    private static let minimumHostedInspectorWidth: CGFloat = 120
+    private static let hostedInspectorHitCacheLifetime: TimeInterval = 0.1
     private var cachedSidebarDividerX: CGFloat?
     private var sidebarDividerMissCount = 0
     private var cachedSplitDividerRegions: [DividerRegion]?
@@ -241,6 +121,7 @@ final class WindowBrowserHostView: NSView {
     private var trackingArea: NSTrackingArea?
     private var activeDividerCursorKind: DividerCursorKind?
     private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
+    private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
     private var lastHostedInspectorLayoutBoundsSize: NSSize?
 
     deinit {
@@ -478,7 +359,9 @@ final class WindowBrowserHostView: NSView {
         }
 
         if let hostedInspectorHit {
-            if let nativeHit = nativeHostedInspectorHit(at: point, hostedInspectorHit: hostedInspectorHit) {
+            cacheHostedInspectorDividerHit(hostedInspectorHit, at: point)
+            if !hostedInspectorHit.dockSide.isHorizontalDivider,
+               let nativeHit = nativeHostedInspectorHit(at: point, hostedInspectorHit: hostedInspectorHit) {
 #if DEBUG
                 debugLogPointerRouting(
                     stage: "hitTest.hostedInspectorNative",
@@ -519,10 +402,11 @@ final class WindowBrowserHostView: NSView {
 
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
-        guard let hostedInspectorHit = hostedInspectorDividerHit(at: point) else {
+        guard let hostedInspectorHit = hostedInspectorDividerHit(at: point) ?? cachedHostedInspectorDividerHit(at: point) else {
             super.mouseDown(with: event)
             return
         }
+        cachedHostedInspectorDividerHit = nil
 
         hostedInspectorHit.slotView.isHostedInspectorDividerDragActive = true
         hostedInspectorDividerDrag = HostedInspectorDividerDragState(
@@ -531,7 +415,7 @@ final class WindowBrowserHostView: NSView {
             pageView: hostedInspectorHit.pageView,
             inspectorView: hostedInspectorHit.inspectorView,
             dockSide: hostedInspectorHit.dockSide,
-            initialWindowX: event.locationInWindow.x,
+            initialWindowPoint: event.locationInWindow,
             initialPageFrame: hostedInspectorHit.pageView.frame,
             initialInspectorFrame: hostedInspectorHit.inspectorView.frame
         )
@@ -559,29 +443,33 @@ final class WindowBrowserHostView: NSView {
         }
 
         let containerBounds = dragState.containerView.bounds
-        let minimumInspectorWidth = min(
-            Self.minimumHostedInspectorWidth,
-            max(60, dragState.initialInspectorFrame.width)
-        )
-        let initialDividerX = dragState.dockSide.dividerX(
+        let initialDividerPosition = dragState.dockSide.dividerPosition(
             pageFrame: dragState.initialPageFrame,
             inspectorFrame: dragState.initialInspectorFrame
         )
-        let proposedDividerX = initialDividerX + (event.locationInWindow.x - dragState.initialWindowX)
-        let clampedDividerX = dragState.dockSide.clampedDividerX(
-            proposedDividerX,
+        let windowDeltaX = event.locationInWindow.x - dragState.initialWindowPoint.x
+        let windowDeltaY = event.locationInWindow.y - dragState.initialWindowPoint.y
+        let proposedDividerPosition = initialDividerPosition +
+            (dragState.dockSide.isHorizontalDivider ? windowDeltaY : windowDeltaX)
+        let clampedDividerPosition = dragState.dockSide.clampedDividerPosition(
+            proposedDividerPosition,
             containerBounds: containerBounds,
             pageFrame: dragState.initialPageFrame,
-            minimumInspectorWidth: minimumInspectorWidth
+            inspectorFrame: dragState.initialInspectorFrame,
+            policy: HostedInspectorMinimumSizePolicy(dockSide: dragState.dockSide)
         )
-        let inspectorWidth = dragState.dockSide.inspectorWidth(
-            forDividerX: clampedDividerX,
+        let inspectorExtent = dragState.dockSide.inspectorExtent(
+            forDividerPosition: clampedDividerPosition,
             in: containerBounds
         )
 
-        dragState.slotView.recordPreferredHostedInspectorWidth(inspectorWidth, containerBounds: containerBounds)
-        let appliedFrames = applyHostedInspectorDividerWidth(
-            inspectorWidth,
+        dragState.slotView.recordPreferredHostedInspectorExtent(
+            inspectorExtent,
+            dockSide: dragState.dockSide,
+            containerBounds: containerBounds
+        )
+        let appliedFrames = applyHostedInspectorDividerExtent(
+            inspectorExtent,
             to: HostedInspectorDividerHit(
                 slotView: dragState.slotView,
                 containerView: dragState.containerView,
@@ -589,7 +477,6 @@ final class WindowBrowserHostView: NSView {
                 inspectorView: dragState.inspectorView,
                 dockSide: dragState.dockSide
             ),
-            minimumInspectorWidth: Self.minimumHostedInspectorWidth,
             reason: "drag"
         )
         updateDividerCursor(
@@ -606,7 +493,7 @@ final class WindowBrowserHostView: NSView {
 #if DEBUG
         cmuxDebugLog(
             "browser.portal.manualInspectorDrag stage=update slot=\(browserPortalDebugToken(dragState.slotView)) " +
-            "dividerX=\(String(format: "%.1f", clampedDividerX)) " +
+            "divider=\(String(format: "%.1f", clampedDividerPosition)) " +
             "pageFrame=\(browserPortalDebugFrame(appliedFrames.pageFrame)) " +
             "inspectorFrame=\(browserPortalDebugFrame(appliedFrames.inspectorFrame))"
         )
@@ -616,6 +503,15 @@ final class WindowBrowserHostView: NSView {
     override func mouseUp(with event: NSEvent) {
         if let dragState = hostedInspectorDividerDrag {
             dragState.slotView.isHostedInspectorDividerDragActive = false
+            let finalExtent = dragState.dockSide.inspectorExtent(
+                inspectorFrame: dragState.inspectorView.frame,
+                in: dragState.containerView.bounds
+            )
+            HostedInspectorAttachedSizeSync.sync(
+                pageWebView: dragState.slotView.hostedInspectorPageWebViewForAttachedSizeSync,
+                dockSide: dragState.dockSide,
+                extent: finalExtent
+            )
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.manualInspectorDrag stage=end slot=\(browserPortalDebugToken(dragState.slotView)) " +
@@ -763,7 +659,9 @@ final class WindowBrowserHostView: NSView {
             return
         }
 
-        let nextKind = resolvedDividerHit?.kind ?? (resolvedHostedInspectorHit == nil ? nil : .vertical)
+        let nextKind = resolvedDividerHit?.kind ?? resolvedHostedInspectorHit.map {
+            $0.dockSide.isHorizontalDivider ? .horizontal : .vertical
+        }
         guard let nextKind else {
             clearActiveDividerCursor(restoreArrow: true)
             return
@@ -843,6 +741,30 @@ final class WindowBrowserHostView: NSView {
         return nil
     }
 
+    private func cacheHostedInspectorDividerHit(_ hit: HostedInspectorDividerHit, at point: NSPoint) {
+        cachedHostedInspectorDividerHit = CachedHostedInspectorDividerHit(
+            point: point,
+            hit: hit,
+            timestamp: ProcessInfo.processInfo.systemUptime
+        )
+    }
+
+    private func cachedHostedInspectorDividerHit(at point: NSPoint) -> HostedInspectorDividerHit? {
+        guard let cachedHostedInspectorDividerHit else { return nil }
+        let age = ProcessInfo.processInfo.systemUptime - cachedHostedInspectorDividerHit.timestamp
+        guard age <= Self.hostedInspectorHitCacheLifetime else {
+            self.cachedHostedInspectorDividerHit = nil
+            return nil
+        }
+        let dx = abs(point.x - cachedHostedInspectorDividerHit.point.x)
+        let dy = abs(point.y - cachedHostedInspectorDividerHit.point.y)
+        guard dx <= Self.hostedInspectorDividerHitExpansion,
+              dy <= Self.hostedInspectorDividerHitExpansion else {
+            return nil
+        }
+        return cachedHostedInspectorDividerHit.hit
+    }
+
     private func hostedInspectorDividerCandidate(in slot: WindowBrowserSlotView) -> HostedInspectorDividerHit? {
         let inspectorCandidates = Self.visibleDescendants(in: slot)
             .filter { Self.isVisibleHostedInspectorCandidate($0) && Self.isInspectorView($0) }
@@ -882,21 +804,23 @@ final class WindowBrowserHostView: NSView {
             let pageCandidates = containerView.subviews.compactMap { candidate -> (view: NSView, dockSide: HostedInspectorDockSide)? in
                 guard Self.isVisibleHostedInspectorSiblingCandidate(candidate) else { return nil }
                 guard candidate !== inspectorView else { return nil }
-                guard Self.verticalOverlap(between: candidate.frame, and: inspectorView.frame) > 8 else {
-                    return nil
-                }
                 guard let dockSide = HostedInspectorDockSide.resolve(
                     pageFrame: candidate.frame,
                     inspectorFrame: inspectorView.frame
                 ) else {
                     return nil
                 }
+                guard dockSide.hasSufficientCrossAxisOverlap(
+                    pageFrame: candidate.frame,
+                    inspectorFrame: inspectorView.frame,
+                    containerBounds: containerView.bounds
+                ) else { return nil }
                 return (view: candidate, dockSide: dockSide)
             }
 
             if let pageCandidate = pageCandidates.max(by: {
-                hostedInspectorPageCandidateScore($0.view, inspectorView: inspectorView)
-                    < hostedInspectorPageCandidateScore($1.view, inspectorView: inspectorView)
+                hostedInspectorPageCandidateScore($0.view, inspectorView: inspectorView, dockSide: $0.dockSide)
+                    < hostedInspectorPageCandidateScore($1.view, inspectorView: inspectorView, dockSide: $1.dockSide)
             }) {
                 bestHit = HostedInspectorDividerHit(
                     slotView: slot,
@@ -928,15 +852,23 @@ final class WindowBrowserHostView: NSView {
     private func hostedInspectorDividerCandidateScore(_ hit: HostedInspectorDividerHit) -> CGFloat {
         let pageFrame = hit.slotView.convert(hit.pageView.bounds, from: hit.pageView)
         let inspectorFrame = hit.slotView.convert(hit.inspectorView.bounds, from: hit.inspectorView)
-        let overlap = Self.verticalOverlap(between: pageFrame, and: inspectorFrame)
-        let coverageWidth = max(pageFrame.maxX, inspectorFrame.maxX) - min(pageFrame.minX, inspectorFrame.minX)
-        return (overlap * 1_000) + coverageWidth + pageFrame.width
+        let overlap = hit.dockSide.crossAxisOverlap(pageFrame: pageFrame, inspectorFrame: inspectorFrame)
+        let coverage = hit.dockSide.isHorizontalDivider
+            ? max(pageFrame.maxY, inspectorFrame.maxY) - min(pageFrame.minY, inspectorFrame.minY)
+            : max(pageFrame.maxX, inspectorFrame.maxX) - min(pageFrame.minX, inspectorFrame.minX)
+        return (overlap * 1_000) + coverage + hit.dockSide.pageExtent(pageFrame: pageFrame)
     }
 
-    private func hostedInspectorPageCandidateScore(_ pageView: NSView, inspectorView: NSView) -> CGFloat {
-        let overlap = Self.verticalOverlap(between: pageView.frame, and: inspectorView.frame)
-        let coverageWidth = max(pageView.frame.maxX, inspectorView.frame.maxX) - min(pageView.frame.minX, inspectorView.frame.minX)
-        return (overlap * 1_000) + coverageWidth + pageView.frame.width
+    private func hostedInspectorPageCandidateScore(
+        _ pageView: NSView,
+        inspectorView: NSView,
+        dockSide: HostedInspectorDockSide
+    ) -> CGFloat {
+        let overlap = dockSide.crossAxisOverlap(pageFrame: pageView.frame, inspectorFrame: inspectorView.frame)
+        let coverage = dockSide.isHorizontalDivider
+            ? max(pageView.frame.maxY, inspectorView.frame.maxY) - min(pageView.frame.minY, inspectorView.frame.minY)
+            : max(pageView.frame.maxX, inspectorView.frame.maxX) - min(pageView.frame.minX, inspectorView.frame.minX)
+        return (overlap * 1_000) + coverage + dockSide.pageExtent(pageFrame: pageView.frame)
     }
 
     private func reapplyHostedInspectorDividersIfNeeded(reason: String) {
@@ -948,7 +880,7 @@ final class WindowBrowserHostView: NSView {
     }
 
     private func scheduleHostedInspectorDividerReapply(in slot: WindowBrowserSlotView, reason: String) {
-        guard slot.preferredHostedInspectorWidth != nil else { return }
+        guard slot.hasPreferredHostedInspectorExtent else { return }
         DispatchQueue.main.async { [weak self, weak slot] in
             guard let self, let slot, slot.isDescendant(of: self) else { return }
             self.reapplyHostedInspectorDividerIfNeeded(in: slot, reason: reason)
@@ -966,14 +898,16 @@ final class WindowBrowserHostView: NSView {
 #endif
             return false
         }
-        guard let preferredWidth = slot.resolvedPreferredHostedInspectorWidth(in: slot.bounds) else { return false }
         guard let hit = hostedInspectorDividerCandidate(in: slot) else { return false }
+        guard let preferredExtent = slot.resolvedPreferredHostedInspectorExtent(
+            dockSide: hit.dockSide,
+            in: hit.containerView.bounds
+        ) else { return false }
         let oldPageFrame = hit.pageView.frame
         let oldInspectorFrame = hit.inspectorView.frame
-        _ = applyHostedInspectorDividerWidth(
-            preferredWidth,
+        _ = applyHostedInspectorDividerExtent(
+            preferredExtent,
             to: hit,
-            minimumInspectorWidth: Self.minimumHostedInspectorWidth,
             reason: reason
         )
         return !Self.rectApproximatelyEqual(oldPageFrame, hit.pageView.frame, epsilon: 0.5) ||
@@ -981,19 +915,18 @@ final class WindowBrowserHostView: NSView {
     }
 
     @discardableResult
-    private func applyHostedInspectorDividerWidth(
-        _ preferredWidth: CGFloat,
+    private func applyHostedInspectorDividerExtent(
+        _ preferredExtent: CGFloat,
         to hit: HostedInspectorDividerHit,
-        minimumInspectorWidth: CGFloat,
         reason: String
     ) -> (pageFrame: NSRect, inspectorFrame: NSRect) {
         let containerBounds = hit.containerView.bounds
         let nextFrames = hit.dockSide.resizedFrames(
-            preferredWidth: preferredWidth,
+            preferredExtent: preferredExtent,
             in: containerBounds,
             pageFrame: hit.pageView.frame,
             inspectorFrame: hit.inspectorView.frame,
-            minimumInspectorWidth: minimumInspectorWidth
+            policy: HostedInspectorMinimumSizePolicy(dockSide: hit.dockSide)
         )
         let pageFrame = nextFrames.pageFrame
         let inspectorFrame = nextFrames.inspectorFrame
@@ -1027,7 +960,7 @@ final class WindowBrowserHostView: NSView {
         cmuxDebugLog(
             "browser.portal.manualInspectorDrag stage=reapply slot=\(browserPortalDebugToken(hit.slotView)) " +
             "container=\(browserPortalDebugToken(hit.containerView)) reason=\(reason) " +
-            "preferredWidth=\(String(format: "%.1f", preferredWidth)) " +
+            "preferredExtent=\(String(format: "%.1f", preferredExtent)) " +
             "liveDrag=\(isLiveDrag ? 1 : 0) " +
             "pageChanged=\(pageChanged ? 1 : 0) inspectorChanged=\(inspectorChanged ? 1 : 0) " +
             "oldPageFrame=\(browserPortalDebugFrame(oldPageFrame)) oldInspectorFrame=\(browserPortalDebugFrame(oldInspectorFrame)) " +
@@ -1089,10 +1022,6 @@ final class WindowBrowserHostView: NSView {
             }
         }
         return nil
-    }
-
-    private static func verticalOverlap(between lhs: NSRect, and rhs: NSRect) -> CGFloat {
-        max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
     }
 
     private static func rectApproximatelyEqual(_ lhs: NSRect, _ rhs: NSRect, epsilon: CGFloat = 0.01) -> Bool {
@@ -1183,6 +1112,8 @@ final class WindowBrowserSlotView: NSView {
     private var paneTopChromeHeight: CGFloat = 0
     var preferredHostedInspectorWidth: CGFloat?
     private var preferredHostedInspectorWidthFraction: CGFloat?
+    var preferredHostedInspectorHeight: CGFloat?
+    private var preferredHostedInspectorHeightFraction: CGFloat?
     fileprivate var isRightSidebarDockSlot = false
     fileprivate var isHostedInspectorDividerDragActive = false
     var onHostedInspectorLayout: ((WindowBrowserSlotView) -> Void)?
@@ -1238,7 +1169,28 @@ final class WindowBrowserSlotView: NSView {
         applyResolvedDropZoneOverlay()
     }
 
-    func recordPreferredHostedInspectorWidth(_ width: CGFloat, containerBounds: NSRect) {
+    fileprivate var hostedInspectorPageWebViewForAttachedSizeSync: WKWebView? { hostedWebView }
+
+    var hasPreferredHostedInspectorExtent: Bool {
+        preferredHostedInspectorWidth != nil ||
+            preferredHostedInspectorWidthFraction != nil ||
+            preferredHostedInspectorHeight != nil ||
+            preferredHostedInspectorHeightFraction != nil
+    }
+
+    func recordPreferredHostedInspectorExtent(
+        _ extent: CGFloat,
+        dockSide: HostedInspectorDockSide,
+        containerBounds: NSRect
+    ) {
+        if dockSide.isHorizontalDivider {
+            recordPreferredHostedInspectorHeight(extent, containerBounds: containerBounds)
+        } else {
+            recordPreferredHostedInspectorWidth(extent, containerBounds: containerBounds)
+        }
+    }
+
+    private func recordPreferredHostedInspectorWidth(_ width: CGFloat, containerBounds: NSRect) {
         preferredHostedInspectorWidth = width
         guard containerBounds.width > 0 else {
             preferredHostedInspectorWidthFraction = nil
@@ -1247,11 +1199,37 @@ final class WindowBrowserSlotView: NSView {
         preferredHostedInspectorWidthFraction = width / containerBounds.width
     }
 
-    func resolvedPreferredHostedInspectorWidth(in containerBounds: NSRect) -> CGFloat? {
+    private func recordPreferredHostedInspectorHeight(_ height: CGFloat, containerBounds: NSRect) {
+        preferredHostedInspectorHeight = height
+        guard containerBounds.height > 0 else {
+            preferredHostedInspectorHeightFraction = nil
+            return
+        }
+        preferredHostedInspectorHeightFraction = height / containerBounds.height
+    }
+
+    func resolvedPreferredHostedInspectorExtent(
+        dockSide: HostedInspectorDockSide,
+        in containerBounds: NSRect
+    ) -> CGFloat? {
+        if dockSide.isHorizontalDivider {
+            return resolvedPreferredHostedInspectorHeight(in: containerBounds)
+        }
+        return resolvedPreferredHostedInspectorWidth(in: containerBounds)
+    }
+
+    private func resolvedPreferredHostedInspectorWidth(in containerBounds: NSRect) -> CGFloat? {
         if let preferredHostedInspectorWidthFraction, containerBounds.width > 0 {
             return max(0, containerBounds.width * preferredHostedInspectorWidthFraction)
         }
         return preferredHostedInspectorWidth
+    }
+
+    private func resolvedPreferredHostedInspectorHeight(in containerBounds: NSRect) -> CGFloat? {
+        if let preferredHostedInspectorHeightFraction, containerBounds.height > 0 {
+            return max(0, containerBounds.height * preferredHostedInspectorHeightFraction)
+        }
+        return preferredHostedInspectorHeight
     }
 
     private static func sizeApproximatelyEqual(_ lhs: NSSize, _ rhs: NSSize, epsilon: CGFloat = 0.5) -> Bool {
@@ -3441,6 +3419,7 @@ final class WindowBrowserPortal: NSObject {
         let inspectorSubviews = Self.inspectorSubviewCount(in: containerView)
 #endif
         if containerOwnsWebView,
+           !containerView.isHostedInspectorDividerDragActive,
            let repairedBottomDockFrame = Self.repairedBottomDockedPageFrame(
                in: containerView,
                primaryWebView: webView

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6260,6 +6260,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             if window == nil {
                 notifyHostedWebKitHidden(reason: "viewDidMoveToWindow")
                 clearActiveDividerCursor(restoreArrow: false)
+                cancelHostedInspectorDividerDragForTeardown()
             } else {
                 scheduleHostedInspectorDividerReapply(reason: "viewDidMoveToWindow")
                 scheduleHostedInspectorDockConfigurationSync(reason: "viewDidMoveToWindow")
@@ -6680,6 +6681,13 @@ struct WebViewRepresentable: NSViewRepresentable {
                 return nil
             }
             return hit
+        }
+        private func cancelHostedInspectorDividerDragForTeardown() {
+            guard hostedInspectorDividerDrag != nil else { return }
+            hostedInspectorDividerDrag = nil
+            cachedHostedInspectorDividerHit = nil
+            isHostedInspectorDividerDragActive = false
+            hostedInspectorDragFrameSilencer.end()
         }
         private func cacheHostedInspectorDividerHit(_ hit: HostedInspectorDividerHit, at point: NSPoint) {
             cachedHostedInspectorDividerHit = CachedHostedInspectorDividerHit(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5511,6 +5511,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         private var activeDividerCursorKind: DividerCursorKind?
         private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
         private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
+        private var lastSyncedHostedInspectorDragExtent: Int?
         private var preferredHostedInspectorWidth: CGFloat?
         private var preferredHostedInspectorWidthFraction: CGFloat?
         private var preferredHostedInspectorHeight: CGFloat?
@@ -6144,13 +6145,13 @@ struct WebViewRepresentable: NSViewRepresentable {
         }
         private func shouldForceHostedInspectorBottomDock(using hit: HostedInspectorDividerHit) -> Bool {
             guard !hit.dockSide.isHorizontalDivider else { return false }
+            // Decide from container capacity, not live frame widths: a user drag
+            // that leaves the page below the side-dock threshold must not yank
+            // the inspector to the bottom right after mouseUp.
             let containerWidth = max(0, hit.containerView.bounds.width)
             guard containerWidth > 1 else { return false }
-            let currentInspectorWidth = max(0, hit.inspectorView.frame.width)
-            let currentPageWidth = max(0, hit.pageView.frame.width)
-            let remainingPageWidth = max(0, containerWidth - max(Self.minimumHostedInspectorWidth, currentInspectorWidth))
-            let effectivePageWidth = min(currentPageWidth, remainingPageWidth)
-            return effectivePageWidth < Self.minimumHostedInspectorPageWidthForSideDock
+            let remainingPageWidth = max(0, containerWidth - Self.minimumHostedInspectorWidth)
+            return remainingPageWidth < Self.minimumHostedInspectorPageWidthForSideDock
         }
         @discardableResult
         private func requestAdaptiveHostedInspectorBottomDock(reason: String) -> Bool {
@@ -6433,6 +6434,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 return
             }
             cachedHostedInspectorDividerHit = nil
+            lastSyncedHostedInspectorDragExtent = nil
             hostedInspectorReapplyWorkItem?.cancel()
             isHostedInspectorDividerDragActive = true
             hostedInspectorDividerDrag = HostedInspectorDividerDragState(
@@ -6488,6 +6490,11 @@ struct WebViewRepresentable: NSViewRepresentable {
                 ),
                 reason: "drag"
             )
+            // Keep WebKit's stored attachment size tracking the live drag: its
+            // inspectedViewFrameDidChange relayout otherwise re-applies the
+            // stale pre-drag size between our frame writes and the divider
+            // visibly fights the cursor.
+            syncAttachedSizeDuringDrag(extent: inspectorExtent, dockSide: dragState.dockSide)
 #if DEBUG
             debugLogHostedInspectorFrames(
                 stage: "drag.update",
@@ -6521,11 +6528,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                     inspectorFrame: finalDragState.inspectorView.frame,
                     in: finalDragState.containerView.bounds
                 )
-                HostedInspectorAttachedSizeSync.sync(
-                    frontendWebView: hostedInspectorFrontendWebView,
-                    dockSide: finalDragState.dockSide,
-                    extent: finalExtent
-                )
+                syncAttachedSizeDuringDrag(extent: finalExtent, dockSide: finalDragState.dockSide)
 #if DEBUG
                 debugLogHostedInspectorFrames(
                     stage: "drag.end",
@@ -6541,6 +6544,16 @@ struct WebViewRepresentable: NSViewRepresentable {
                 reapplyHostedInspectorDividerToStoredExtentIfNeeded(reason: "drag.end")
             }
             super.mouseUp(with: event)
+        }
+        private func syncAttachedSizeDuringDrag(extent: CGFloat, dockSide: HostedInspectorDockSide) {
+            let roundedExtent = max(0, Int(extent.rounded()))
+            guard roundedExtent != lastSyncedHostedInspectorDragExtent else { return }
+            lastSyncedHostedInspectorDragExtent = roundedExtent
+            HostedInspectorAttachedSizeSync.sync(
+                frontendWebView: hostedInspectorFrontendWebView,
+                dockSide: dockSide,
+                extent: extent
+            )
         }
         private func shouldPassThroughToSidebarResizer(
             at point: NSPoint,

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5511,7 +5511,6 @@ struct WebViewRepresentable: NSViewRepresentable {
         private var activeDividerCursorKind: DividerCursorKind?
         private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
         private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
-        private var lastSyncedHostedInspectorDragExtent: Int?
         private let hostedInspectorDragFrameSilencer = HostedInspectorDragFrameNotificationSilencer()
         private var preferredHostedInspectorWidth: CGFloat?
         private var preferredHostedInspectorWidthFraction: CGFloat?
@@ -5544,6 +5543,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 removeTrackingArea(trackingArea)
             }
             clearActiveDividerCursor(restoreArrow: false)
+            // hostedInspectorDragFrameSilencer restores in its own deinit.
         }
         private func recordPreferredHostedInspectorWidth(_ width: CGFloat, containerBounds: NSRect) {
             preferredHostedInspectorWidth = width
@@ -6435,7 +6435,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 return
             }
             cachedHostedInspectorDividerHit = nil
-            lastSyncedHostedInspectorDragExtent = nil
             hostedInspectorReapplyWorkItem?.cancel()
             isHostedInspectorDividerDragActive = true
             hostedInspectorDragFrameSilencer.begin(hostedInspectorHit.pageView)
@@ -6492,11 +6491,11 @@ struct WebViewRepresentable: NSViewRepresentable {
                 ),
                 reason: "drag"
             )
-            // Keep WebKit's stored attachment size tracking the live drag: its
-            // inspectedViewFrameDidChange relayout otherwise re-applies the
-            // stale pre-drag size between our frame writes and the divider
-            // visibly fights the cursor.
-            syncAttachedSizeDuringDrag(extent: inspectorExtent, dockSide: dragState.dockSide)
+            // Do NOT sync the attachment size to WebKit per drag event: the
+            // frontend's JS queue backs up during fast scrubs and every queued
+            // setAttachedWindow* call echoes back as a stale WebKit frame
+            // apply, yanking the divider backwards. The frame-notification
+            // silencer keeps WebKit passive; one sync on mouseUp reconciles it.
 #if DEBUG
             debugLogHostedInspectorFrames(
                 stage: "drag.update",
@@ -6531,7 +6530,11 @@ struct WebViewRepresentable: NSViewRepresentable {
                     inspectorFrame: finalDragState.inspectorView.frame,
                     in: finalDragState.containerView.bounds
                 )
-                syncAttachedSizeDuringDrag(extent: finalExtent, dockSide: finalDragState.dockSide)
+                HostedInspectorAttachedSizeSync.sync(
+                    frontendWebView: hostedInspectorFrontendWebView,
+                    dockSide: finalDragState.dockSide,
+                    extent: finalExtent
+                )
 #if DEBUG
                 debugLogHostedInspectorFrames(
                     stage: "drag.end",
@@ -6547,16 +6550,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 reapplyHostedInspectorDividerToStoredExtentIfNeeded(reason: "drag.end")
             }
             super.mouseUp(with: event)
-        }
-        private func syncAttachedSizeDuringDrag(extent: CGFloat, dockSide: HostedInspectorDockSide) {
-            let roundedExtent = max(0, Int(extent.rounded()))
-            guard roundedExtent != lastSyncedHostedInspectorDragExtent else { return }
-            lastSyncedHostedInspectorDragExtent = roundedExtent
-            HostedInspectorAttachedSizeSync.sync(
-                frontendWebView: hostedInspectorFrontendWebView,
-                dockSide: dockSide,
-                extent: extent
-            )
         }
         private func shouldPassThroughToSidebarResizer(
             at point: NSPoint,

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5512,6 +5512,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
         private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
         private var lastSyncedHostedInspectorDragExtent: Int?
+        private let hostedInspectorDragFrameSilencer = HostedInspectorDragFrameNotificationSilencer()
         private var preferredHostedInspectorWidth: CGFloat?
         private var preferredHostedInspectorWidthFraction: CGFloat?
         private var preferredHostedInspectorHeight: CGFloat?
@@ -6437,6 +6438,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             lastSyncedHostedInspectorDragExtent = nil
             hostedInspectorReapplyWorkItem?.cancel()
             isHostedInspectorDividerDragActive = true
+            hostedInspectorDragFrameSilencer.begin(hostedInspectorHit.pageView)
             hostedInspectorDividerDrag = HostedInspectorDividerDragState(
                 containerView: hostedInspectorHit.containerView,
                 pageView: hostedInspectorHit.pageView,
@@ -6522,6 +6524,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             hostedInspectorDividerDrag = nil
             cachedHostedInspectorDividerHit = nil
             isHostedInspectorDividerDragActive = false
+            hostedInspectorDragFrameSilencer.end()
             updateDividerCursor(at: convert(event.locationInWindow, from: nil))
             if let finalDragState {
                 let finalExtent = finalDragState.dockSide.inspectorExtent(
@@ -6925,6 +6928,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                 dockSide: hit.dockSide,
                 in: hit.containerView.bounds
             ) else {
+                // A stored extent for the other dock axis (e.g. side-dock width
+                // after redocking to bottom) must not block adopting the current
+                // layout as this axis's preference.
+                captureHostedInspectorPreferredWidthFromCurrentLayout(reason: "\(reason).captureOtherAxis")
                 return
             }
             let currentInspectorExtent = hit.dockSide.inspectorExtent(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6399,7 +6399,8 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             if let hostedInspectorHit {
                 cacheHostedInspectorDividerHit(hostedInspectorHit, at: point)
-                if let nativeHit = nativeHostedInspectorHit(at: point, hostedInspectorHit: hostedInspectorHit) {
+                if !hostedInspectorHit.dockSide.isHorizontalDivider,
+                   let nativeHit = nativeHostedInspectorHit(at: point, hostedInspectorHit: hostedInspectorHit) {
 #if DEBUG
                     debugLogHitTest(stage: "hitTest.hostedInspectorNative", point: point, passThrough: false, hitView: nativeHit)
 #endif
@@ -6511,6 +6512,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         override func mouseUp(with event: NSEvent) {
             let finalDragState = hostedInspectorDividerDrag
             hostedInspectorDividerDrag = nil
+            cachedHostedInspectorDividerHit = nil
             isHostedInspectorDividerDragActive = false
             updateDividerCursor(at: convert(event.locationInWindow, from: nil))
             if let finalDragState {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6143,6 +6143,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
         }
         private func shouldForceHostedInspectorBottomDock(using hit: HostedInspectorDividerHit) -> Bool {
+            guard !hit.dockSide.isHorizontalDivider else { return false }
             let containerWidth = max(0, hit.containerView.bounds.width)
             guard containerWidth > 1 else { return false }
             let currentInspectorWidth = max(0, hit.inspectorView.frame.width)

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5443,21 +5443,17 @@ struct WebViewRepresentable: NSViewRepresentable {
                 wantsLayer = true
                 layer?.masksToBounds = true
             }
-
             @available(*, unavailable)
             required init?(coder: NSCoder) {
                 nil
             }
-
             override var isOpaque: Bool { false }
-
             override func resizeSubviews(withOldSize oldSize: NSSize) {
                 // Managed side-docked DevTools use explicit frame updates from the host.
                 // Letting AppKit autoresize the WK siblings here makes them snap back to
                 // stale widths while the divider drag or pane resize is in flight.
             }
         }
-
         var onDidMoveToWindow: (() -> Void)?
         var onGeometryChanged: (() -> Void)?
         private(set) var geometryRevision: UInt64 = 0
@@ -5476,39 +5472,49 @@ struct WebViewRepresentable: NSViewRepresentable {
             let inspectorView: NSView
             let dockSide: HostedInspectorDockSide
         }
-
         private struct GeometryState: Equatable {
             let frame: CGRect
             let bounds: CGRect
             let windowNumber: Int?
             let superviewID: ObjectIdentifier?
         }
-
         private struct HostedInspectorDividerDragState {
             let containerView: NSView
             let pageView: NSView
             let inspectorView: NSView
             let dockSide: HostedInspectorDockSide
-            let initialWindowX: CGFloat
+            let initialWindowPoint: NSPoint
             let initialPageFrame: NSRect
             let initialInspectorFrame: NSRect
         }
-
+        private struct CachedHostedInspectorDividerHit {
+            let point: NSPoint
+            let hit: HostedInspectorDividerHit
+            let timestamp: TimeInterval
+        }
         private enum DividerCursorKind: Equatable {
             case vertical
-
-            var cursor: NSCursor { .resizeLeftRight }
+            case horizontal
+            var cursor: NSCursor {
+                switch self {
+                case .vertical: return .resizeLeftRight
+                case .horizontal: return .resizeUpDown
+                }
+            }
         }
-
         private static let hostedInspectorDividerHitExpansion: CGFloat = 10
         private static let minimumHostedInspectorWidth: CGFloat = 120
         private static let minimumHostedInspectorPageWidthForSideDock: CGFloat = 240
         private static let adaptiveBottomDockRequestCooldown: TimeInterval = 0.25
+        private static let hostedInspectorHitCacheLifetime: TimeInterval = 0.1
         private var trackingArea: NSTrackingArea?
         private var activeDividerCursorKind: DividerCursorKind?
         private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
+        private var cachedHostedInspectorDividerHit: CachedHostedInspectorDividerHit?
         private var preferredHostedInspectorWidth: CGFloat?
         private var preferredHostedInspectorWidthFraction: CGFloat?
+        private var preferredHostedInspectorHeight: CGFloat?
+        private var preferredHostedInspectorHeightFraction: CGFloat?
         var onPreferredHostedInspectorWidthChanged: ((CGFloat, CGFloat?) -> Void)?
         private weak var hostedInspectorSideDockPageView: NSView?
         private weak var hostedInspectorSideDockInspectorView: NSView?
@@ -5528,7 +5534,6 @@ struct WebViewRepresentable: NSViewRepresentable {
         private var lastLoggedHostedInspectorFrames: (page: NSRect, inspector: NSRect)?
         private var hasLoggedMissingHostedInspectorCandidate = false
 #endif
-
         deinit {
             hostedInspectorReapplyWorkItem?.cancel()
             hostedInspectorDockConfigurationSyncWorkItem?.cancel()
@@ -5538,7 +5543,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             clearActiveDividerCursor(restoreArrow: false)
         }
-
         private func recordPreferredHostedInspectorWidth(_ width: CGFloat, containerBounds: NSRect) {
             preferredHostedInspectorWidth = width
             guard containerBounds.width > 0 else {
@@ -5549,24 +5553,48 @@ struct WebViewRepresentable: NSViewRepresentable {
             preferredHostedInspectorWidthFraction = width / containerBounds.width
             onPreferredHostedInspectorWidthChanged?(width, preferredHostedInspectorWidthFraction)
         }
-
         private func resolvedPreferredHostedInspectorWidth(in containerBounds: NSRect) -> CGFloat? {
             if let preferredHostedInspectorWidthFraction, containerBounds.width > 0 {
                 return max(0, containerBounds.width * preferredHostedInspectorWidthFraction)
             }
             return preferredHostedInspectorWidth
         }
-
+        private func recordPreferredHostedInspectorHeight(_ height: CGFloat, containerBounds: NSRect) {
+            preferredHostedInspectorHeight = height
+            guard containerBounds.height > 0 else {
+                preferredHostedInspectorHeightFraction = nil
+                return
+            }
+            preferredHostedInspectorHeightFraction = height / containerBounds.height
+        }
+        private func recordPreferredHostedInspectorExtent(_ extent: CGFloat, dockSide: HostedInspectorDockSide, containerBounds: NSRect) {
+            if dockSide.isHorizontalDivider {
+                recordPreferredHostedInspectorHeight(extent, containerBounds: containerBounds)
+            } else {
+                recordPreferredHostedInspectorWidth(extent, containerBounds: containerBounds)
+            }
+        }
+        private func resolvedPreferredHostedInspectorHeight(in containerBounds: NSRect) -> CGFloat? {
+            if let preferredHostedInspectorHeightFraction, containerBounds.height > 0 {
+                return max(0, containerBounds.height * preferredHostedInspectorHeightFraction)
+            }
+            return preferredHostedInspectorHeight
+        }
+        private func resolvedPreferredHostedInspectorExtent(dockSide: HostedInspectorDockSide, in containerBounds: NSRect) -> CGFloat? {
+            dockSide.isHorizontalDivider
+                ? resolvedPreferredHostedInspectorHeight(in: containerBounds)
+                : resolvedPreferredHostedInspectorWidth(in: containerBounds)
+        }
         func setPreferredHostedInspectorWidth(width: CGFloat?, widthFraction: CGFloat?) {
             preferredHostedInspectorWidth = width
             preferredHostedInspectorWidthFraction = widthFraction
+            preferredHostedInspectorHeight = nil
+            preferredHostedInspectorHeightFraction = nil
         }
-
         private func recordHostedInspectorSideDockWidth(_ width: CGFloat) {
             guard width > 1 else { return }
             recordedHostedInspectorSideDockWidth = max(Self.minimumHostedInspectorWidth, width)
         }
-
         private func shouldAllowHostedInspectorManualSideDock() -> Bool {
             let containerWidth = max(0, bounds.width)
             guard containerWidth > 1 else { return true }
@@ -5576,14 +5604,12 @@ struct WebViewRepresentable: NSViewRepresentable {
             )
             return containerWidth - baselineWidth >= Self.minimumHostedInspectorPageWidthForSideDock
         }
-
         private func updateHostedInspectorDockControlAvailabilityIfNeeded(reason: String) {
             guard let hostedInspectorFrontendWebView else {
                 lastHostedInspectorManualSideDockAllowed = nil
                 lastHostedInspectorDetachedFromHostWindow = nil
                 return
             }
-
             let sideDockAllowed = shouldAllowHostedInspectorManualSideDock()
             let detachedFromHostWindow =
                 hostedInspectorFrontendWebView.window != nil &&
@@ -5592,7 +5618,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 lastHostedInspectorDetachedFromHostWindow != detachedFromHostWindow else {
                 return
             }
-
 #if DEBUG
             let recordedWidthDesc = recordedHostedInspectorSideDockWidth.map {
                 String(format: "%.1f", $0)
@@ -5624,7 +5649,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 }
             )
         }
-
         func containsManagedLocalInlineContent(_ view: NSView) -> Bool {
             if let localInlineSlotView,
                view === localInlineSlotView || view.isDescendant(of: localInlineSlotView) {
@@ -5636,7 +5660,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return false
         }
-
         func currentHostedWebViewContainer(preferredSlotView: WindowBrowserSlotView) -> NSView {
             if let hostedInspectorSideDockContainerView,
                let hostedInspectorSideDockPageView,
@@ -5646,18 +5669,18 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return preferredSlotView
         }
-
         func setHostedInspectorFrontendWebView(_ webView: WKWebView?) {
             hostedInspectorFrontendWebView = webView
             lastHostedInspectorManualSideDockAllowed = nil
             lastHostedInspectorDetachedFromHostWindow = nil
             updateHostedInspectorDockControlAvailabilityIfNeeded(reason: "setHostedInspectorFrontendWebView")
         }
-
         private var hasStoredHostedInspectorWidthPreference: Bool {
-            preferredHostedInspectorWidth != nil || preferredHostedInspectorWidthFraction != nil
+            preferredHostedInspectorWidth != nil ||
+                preferredHostedInspectorWidthFraction != nil ||
+                preferredHostedInspectorHeight != nil ||
+                preferredHostedInspectorHeightFraction != nil
         }
-
 #if DEBUG
         private static func shouldLogPointerEvent(_ event: NSEvent?) -> Bool {
             switch event?.type {
@@ -5667,11 +5690,9 @@ struct WebViewRepresentable: NSViewRepresentable {
                 return false
             }
         }
-
         private func debugLogHitTest(stage: String, point: NSPoint, passThrough: Bool, hitView: NSView?) {
             let event = NSApp.currentEvent
             guard Self.shouldLogPointerEvent(event) else { return }
-
             let hitDesc: String = {
                 guard let hitView else { return "nil" }
                 let token = Unmanaged.passUnretained(hitView).toOpaque()
@@ -5688,16 +5709,13 @@ struct WebViewRepresentable: NSViewRepresentable {
                 "hit=\(hitDesc)"
             )
         }
-
         private static func debugObjectID(_ object: AnyObject?) -> String {
             guard let object else { return "nil" }
             return String(describing: Unmanaged.passUnretained(object).toOpaque())
         }
-
         private static func debugRect(_ rect: NSRect) -> String {
             String(format: "%.1f,%.1f %.1fx%.1f", rect.origin.x, rect.origin.y, rect.width, rect.height)
         }
-
         private func debugLogHostedInspectorFrames(
             stage: String,
             point: NSPoint? = nil,
@@ -5716,7 +5734,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 "inspectorFrame=\(Self.debugRect(hit.inspectorView.frame))"
             )
         }
-
         private func debugLogHostedInspectorLayoutIfNeeded(reason: String) {
             guard let hit = hostedInspectorDividerCandidate() else {
                 if !hasLoggedMissingHostedInspectorCandidate,
@@ -5734,31 +5751,26 @@ struct WebViewRepresentable: NSViewRepresentable {
                 return
             }
             hasLoggedMissingHostedInspectorCandidate = false
-
             let nextFrames = (page: hit.pageView.frame, inspector: hit.inspectorView.frame)
             if let lastLoggedHostedInspectorFrames,
                Self.rectApproximatelyEqual(lastLoggedHostedInspectorFrames.page, nextFrames.page),
                Self.rectApproximatelyEqual(lastLoggedHostedInspectorFrames.inspector, nextFrames.inspector) {
                 return
             }
-
             lastLoggedHostedInspectorFrames = nextFrames
             debugLogHostedInspectorFrames(stage: "\(reason).layout", hit: hit)
         }
 #endif
-
         private static func rectApproximatelyEqual(_ lhs: NSRect, _ rhs: NSRect, epsilon: CGFloat = 0.5) -> Bool {
             abs(lhs.origin.x - rhs.origin.x) <= epsilon &&
                 abs(lhs.origin.y - rhs.origin.y) <= epsilon &&
                 abs(lhs.width - rhs.width) <= epsilon &&
                 abs(lhs.height - rhs.height) <= epsilon
         }
-
         private static func sizeApproximatelyEqual(_ lhs: NSSize, _ rhs: NSSize, epsilon: CGFloat = 0.5) -> Bool {
             abs(lhs.width - rhs.width) <= epsilon &&
                 abs(lhs.height - rhs.height) <= epsilon
         }
-
         private func currentGeometryState() -> GeometryState {
             GeometryState(
                 frame: frame,
@@ -5767,7 +5779,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 superviewID: superview.map(ObjectIdentifier.init)
             )
         }
-
         /// Record that geometry changed without firing the callback immediately.
         /// `setFrameOrigin`/`setFrameSize` can fire multiple times before `layout()`;
         /// deferring avoids redundant portal-sync cascades during divider drag.
@@ -5784,7 +5795,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 self?.notifyGeometryChangedIfNeeded()
             }
         }
-
         /// Check for geometry changes and fire the callback. Also flushes any pending
         /// dirty state from `markGeometryDirtyIfNeeded` so `layout()` supersedes the
         /// async fallback.  Only updates `lastReportedGeometryState` / `geometryRevision`
@@ -5798,13 +5808,11 @@ struct WebViewRepresentable: NSViewRepresentable {
             geometryRevision &+= 1
             onGeometryChanged?()
         }
-
         func ensureLocalInlineSlotView() -> WindowBrowserSlotView {
             if let localInlineSlotView, localInlineSlotView.superview === self {
                 localInlineSlotView.isHidden = false
                 return localInlineSlotView
             }
-
             let slotView = WindowBrowserSlotView(frame: bounds)
             slotView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(slotView, positioned: .above, relativeTo: nil)
@@ -5818,25 +5826,21 @@ struct WebViewRepresentable: NSViewRepresentable {
             localInlineSlotView = slotView
             return slotView
         }
-
 #if DEBUG
         func localInlineSlotViewForDebug() -> WindowBrowserSlotView? {
             localInlineSlotView
         }
 #endif
-
         func setLocalInlineSlotHidden(_ hidden: Bool) {
             localInlineSlotView?.isHidden = hidden
             if hidden {
                 notifyHostedWebKitHidden(reason: "slotHidden")
             }
         }
-
         func clearLocalInlineCallbacks() {
             onPreferredHostedInspectorWidthChanged = nil
             localInlineSlotView?.onHostedInspectorLayout = nil
         }
-
         private func appendHostedWebKitSubviews(
             in root: NSView,
             to result: inout [WKWebView],
@@ -5853,11 +5857,9 @@ struct WebViewRepresentable: NSViewRepresentable {
                 appendHostedWebKitSubviews(in: subview, to: &result, seen: &seen)
             }
         }
-
         private var hostedWebKitSubviews: [WKWebView] {
             var result: [WKWebView] = []
             var seen = Set<ObjectIdentifier>()
-
             func append(_ webView: WKWebView?) {
                 guard let webView else { return }
                 guard !webView.cmuxBrowserPanelIsInspectorFrontend else { return }
@@ -5865,18 +5867,15 @@ struct WebViewRepresentable: NSViewRepresentable {
                 guard seen.insert(id).inserted else { return }
                 result.append(webView)
             }
-
             append(hostedWebView)
             appendHostedWebKitSubviews(in: self, to: &result, seen: &seen)
             return result
         }
-
         private func notifyHostedWebKitHidden(reason: String) {
             for webView in hostedWebKitSubviews {
                 webView.cmuxBrowserPanelNotifyHidden(reason: reason)
             }
         }
-
         func refreshHostedWebKitPresentation(
             reason: String,
             forceLifecycleRefresh: Bool = false
@@ -5885,15 +5884,12 @@ struct WebViewRepresentable: NSViewRepresentable {
             guard !localInlineSlotView.isHidden else { return }
             let hostedWebKitSubviews = hostedWebKitSubviews
             guard !hostedWebKitSubviews.isEmpty else { return }
-
             localInlineSlotView.needsLayout = true
             localInlineSlotView.needsDisplay = true
             localInlineSlotView.setNeedsDisplay(localInlineSlotView.bounds)
-
             needsLayout = true
             needsDisplay = true
             setNeedsDisplay(bounds)
-
             for webView in hostedWebKitSubviews {
                 if let scrollView = webView.enclosingScrollView {
                     scrollView.needsLayout = true
@@ -5906,10 +5902,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                 webView.needsDisplay = true
                 webView.setNeedsDisplay(webView.bounds)
             }
-
             localInlineSlotView.layoutSubtreeIfNeeded()
             layoutSubtreeIfNeeded()
-
             for webView in hostedWebKitSubviews {
                 if let scrollView = webView.enclosingScrollView {
                     scrollView.layoutSubtreeIfNeeded()
@@ -5924,12 +5918,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                 }
                 webView.displayIfNeeded()
             }
-
             localInlineSlotView.displayIfNeeded()
             displayIfNeeded()
             window?.displayIfNeeded()
         }
-
         func prepareForWindowPortalHosting() {
             hostedInspectorDockConfigurationSyncWorkItem?.cancel()
             hostedInspectorDockConfigurationSyncWorkItem = nil
@@ -5939,7 +5931,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             lastHostedInspectorManualSideDockAllowed = nil
             lastHostedInspectorDetachedFromHostWindow = nil
         }
-
         func clearStaleHostedInspectorOwnershipState() {
             hostedInspectorDockConfigurationSyncWorkItem?.cancel()
             hostedInspectorDockConfigurationSyncWorkItem = nil
@@ -5947,16 +5938,13 @@ struct WebViewRepresentable: NSViewRepresentable {
             lastHostedInspectorManualSideDockAllowed = nil
             lastHostedInspectorDetachedFromHostWindow = nil
         }
-
         func releaseHostedWebViewConstraints() {
             NSLayoutConstraint.deactivate(hostedWebViewConstraints)
             hostedWebViewConstraints = []
             hostedWebView = nil
         }
-
         func pinHostedWebView(_ webView: WKWebView, in container: NSView) {
             guard webView.superview === container || webView.isDescendant(of: container) else { return }
-
             let hasCompanionWKSubviews = Self.hasWebKitCompanionSubview(
                 in: container,
                 primaryWebView: webView
@@ -5976,11 +5964,9 @@ struct WebViewRepresentable: NSViewRepresentable {
                 layoutSubtreeIfNeeded()
                 return
             }
-
             NSLayoutConstraint.deactivate(hostedWebViewConstraints)
             hostedWebViewConstraints = []
             hostedWebView = webView
-
             // WebKit's attached inspector does not reliably dock into a constraint-managed
             // WKWebView hierarchy on macOS. Host the moved webview with autoresizing and
             // preserve WebKit-managed split frames when docked DevTools siblings exist.
@@ -5992,14 +5978,12 @@ struct WebViewRepresentable: NSViewRepresentable {
             needsLayout = true
             layoutSubtreeIfNeeded()
         }
-
         private static func frameDiffersFromBounds(_ frame: NSRect, bounds: NSRect, epsilon: CGFloat = 0.5) -> Bool {
             abs(frame.minX - bounds.minX) > epsilon ||
                 abs(frame.minY - bounds.minY) > epsilon ||
                 abs(frame.width - bounds.width) > epsilon ||
                 abs(frame.height - bounds.height) > epsilon
         }
-
         private static func hasWebKitCompanionSubview(in host: NSView, primaryWebView: WKWebView) -> Bool {
             var stack = host.subviews.filter { $0 !== primaryWebView }
             while let current = stack.popLast() {
@@ -6021,14 +6005,12 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return false
         }
-
         private func ensureHostedInspectorSideDockContainerView() -> HostedInspectorSideDockContainerView {
             if let hostedInspectorSideDockContainerView,
                hostedInspectorSideDockContainerView.superview === self {
                 hostedInspectorSideDockContainerView.isHidden = false
                 return hostedInspectorSideDockContainerView
             }
-
             let containerView = HostedInspectorSideDockContainerView(frame: bounds)
             containerView.translatesAutoresizingMaskIntoConstraints = false
             addSubview(containerView, positioned: .above, relativeTo: localInlineSlotView)
@@ -6042,7 +6024,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             hostedInspectorSideDockContainerView = containerView
             return containerView
         }
-
         private func moveHostedInspectorSubviewIfNeeded(_ view: NSView, to container: NSView) {
             guard view.superview !== container else { return }
             let frameInWindow = view.superview?.convert(view.frame, to: nil) ?? convert(view.frame, to: nil)
@@ -6050,7 +6031,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             container.addSubview(view, positioned: .above, relativeTo: nil)
             view.frame = container.convert(frameInWindow, from: nil)
         }
-
         private func isHostedInspectorSideDockActive() -> Bool {
             guard let hostedInspectorSideDockContainerView,
                   let hostedInspectorSideDockPageView,
@@ -6060,12 +6040,10 @@ struct WebViewRepresentable: NSViewRepresentable {
             return hostedInspectorSideDockPageView.superview === hostedInspectorSideDockContainerView &&
                 hostedInspectorSideDockInspectorView.superview === hostedInspectorSideDockContainerView
         }
-
         private func isHostedInspectorSideDockHit(_ hit: HostedInspectorDividerHit) -> Bool {
             guard let hostedInspectorSideDockContainerView else { return false }
             return hit.containerView === hostedInspectorSideDockContainerView
         }
-
         private func activateHostedInspectorSideDockIfNeeded(using hit: HostedInspectorDividerHit) {
             let containerView = ensureHostedInspectorSideDockContainerView()
             moveHostedInspectorSubviewIfNeeded(hit.pageView, to: containerView)
@@ -6075,7 +6053,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             hostedInspectorSideDockDockSide = hit.dockSide
             layoutHostedInspectorSideDockIfNeeded(reason: "sideDock.activate")
         }
-
         @discardableResult
         func promoteHostedInspectorSideDockFromCurrentLayoutIfNeeded() -> Bool {
             guard !isHostedInspectorSideDockActive(),
@@ -6083,7 +6060,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                   let hit = hostedInspectorDividerCandidateUsingKnownWebViews(in: slotView) else {
                 return false
             }
-
             // The inspector frontend sometimes reports its dock configuration a tick
             // late after local-inline reattach. Promote the visible left/right split
             // immediately so drag routing stays symmetric on both dock sides. Adaptive
@@ -6092,7 +6068,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             activateHostedInspectorSideDockIfNeeded(using: hit)
             return isHostedInspectorSideDockActive()
         }
-
         /// Schedules `promoteHostedInspectorSideDockFromCurrentLayoutIfNeeded`
         /// for the next runloop tick when a promotion is actually pending, so the
         /// hierarchy mutation it performs never runs inside the `layout()` pass
@@ -6119,7 +6094,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             hostedInspectorSideDockPromotionTask = task
         }
-
         private func deactivateHostedInspectorSideDockIfNeeded(reparentTo slotView: WindowBrowserSlotView?) {
             guard let slotView,
                   let pageView = hostedInspectorSideDockPageView,
@@ -6130,7 +6104,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 hostedInspectorSideDockContainerView?.isHidden = true
                 return
             }
-
             moveHostedInspectorSubviewIfNeeded(pageView, to: slotView)
             moveHostedInspectorSubviewIfNeeded(inspectorView, to: slotView)
             hostedInspectorSideDockPageView = nil
@@ -6138,7 +6111,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             hostedInspectorSideDockDockSide = nil
             hostedInspectorSideDockContainerView?.isHidden = true
         }
-
         private func layoutHostedInspectorSideDockIfNeeded(reason: String) {
             guard let containerView = hostedInspectorSideDockContainerView,
                   let pageView = hostedInspectorSideDockPageView,
@@ -6146,20 +6118,19 @@ struct WebViewRepresentable: NSViewRepresentable {
                   let dockSide = hostedInspectorSideDockDockSide else {
                 return
             }
-            let preferredWidth = resolvedPreferredHostedInspectorWidth(in: containerView.bounds) ?? max(0, inspectorView.frame.width)
-            _ = applyHostedInspectorDividerWidth(
-                preferredWidth,
+            let preferredExtent = resolvedPreferredHostedInspectorExtent(dockSide: dockSide, in: containerView.bounds)
+                ?? dockSide.inspectorExtent(inspectorFrame: inspectorView.frame, in: containerView.bounds)
+            _ = applyHostedInspectorDividerExtent(
+                preferredExtent,
                 to: HostedInspectorDividerHit(
                     containerView: containerView,
                     pageView: pageView,
                     inspectorView: inspectorView,
                     dockSide: dockSide
                 ),
-                minimumInspectorWidth: Self.minimumHostedInspectorWidth,
                 reason: reason
             )
         }
-
         func normalizeHostedInspectorLayoutIfNeeded(reason: String) {
             if enforceAdaptiveBottomDockIfNeeded(reason: "\(reason).adaptive") {
                 return
@@ -6171,27 +6142,23 @@ struct WebViewRepresentable: NSViewRepresentable {
                 captureHostedInspectorPreferredWidthFromCurrentLayout(reason: reason)
             }
         }
-
         private func shouldForceHostedInspectorBottomDock(using hit: HostedInspectorDividerHit) -> Bool {
             let containerWidth = max(0, hit.containerView.bounds.width)
             guard containerWidth > 1 else { return false }
-
             let currentInspectorWidth = max(0, hit.inspectorView.frame.width)
             let currentPageWidth = max(0, hit.pageView.frame.width)
             let remainingPageWidth = max(0, containerWidth - max(Self.minimumHostedInspectorWidth, currentInspectorWidth))
             let effectivePageWidth = min(currentPageWidth, remainingPageWidth)
-
             return effectivePageWidth < Self.minimumHostedInspectorPageWidthForSideDock
         }
-
         @discardableResult
         private func requestAdaptiveHostedInspectorBottomDock(reason: String) -> Bool {
+            guard !isHostedInspectorDividerDragActive else { return false }
             let now = Date()
             if let adaptiveBottomDockRequestCooldownDeadline, adaptiveBottomDockRequestCooldownDeadline > now {
                 return true
             }
             guard let hostedInspectorFrontendWebView else { return false }
-
             adaptiveBottomDockRequestCooldownDeadline = now.addingTimeInterval(Self.adaptiveBottomDockRequestCooldown)
             updateHostedInspectorDockControlAvailabilityIfNeeded(reason: reason)
 #if DEBUG
@@ -6209,9 +6176,9 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return true
         }
-
         @discardableResult
         private func enforceAdaptiveBottomDockIfNeeded(reason: String) -> Bool {
+            guard !isHostedInspectorDividerDragActive else { return false }
             guard let hit = hostedInspectorDividerCandidate(),
                   shouldForceHostedInspectorBottomDock(using: hit) else {
                 return false
@@ -6219,7 +6186,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             recordHostedInspectorSideDockWidth(hit.inspectorView.frame.width)
             return requestAdaptiveHostedInspectorBottomDock(reason: reason)
         }
-
         fileprivate func scheduleHostedInspectorDockConfigurationSync(reason: String) {
             hostedInspectorDockConfigurationSyncWorkItem?.cancel()
             guard hostedInspectorFrontendWebView != nil else { return }
@@ -6229,7 +6195,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             hostedInspectorDockConfigurationSyncWorkItem = workItem
             DispatchQueue.main.async(execute: workItem)
         }
-
         private func syncHostedInspectorDockConfiguration(reason: String) {
             hostedInspectorDockConfigurationSyncWorkItem = nil
             guard let hostedInspectorFrontendWebView else { return }
@@ -6239,7 +6204,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 self?.applyHostedInspectorDockConfiguration(result as? String, reason: reason)
             }
         }
-
         private func applyHostedInspectorDockConfiguration(_ dockConfiguration: String?, reason: String) {
             switch dockConfiguration {
             case "left":
@@ -6288,7 +6252,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             updateHostedInspectorDockControlAvailabilityIfNeeded(reason: "\(reason).dockConfiguration")
         }
-
         override func viewDidMoveToWindow() {
             super.viewDidMoveToWindow()
             if window == nil {
@@ -6309,7 +6272,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             debugLogHostedInspectorLayoutIfNeeded(reason: "viewDidMoveToWindow")
 #endif
         }
-
         override func viewDidMoveToSuperview() {
             super.viewDidMoveToSuperview()
             scheduleHostedInspectorDividerReapply(reason: "viewDidMoveToSuperview")
@@ -6319,7 +6281,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             debugLogHostedInspectorLayoutIfNeeded(reason: "viewDidMoveToSuperview")
 #endif
         }
-
         override func layout() {
             super.layout()
             if enforceAdaptiveBottomDockIfNeeded(reason: "host.layout") {
@@ -6339,7 +6300,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 // WebKit's own dock layout and shows up as visible flicker.
                 if !isHostedInspectorDividerDragActive {
                     if hasStoredHostedInspectorWidthPreference {
-                        reapplyHostedInspectorDividerToStoredWidthIfNeeded(reason: "host.layout.sameSize")
+                        reapplyHostedInspectorDividerToStoredExtentIfNeeded(reason: "host.layout.sameSize")
                     } else if !isHostedInspectorSideDockActive() {
                         captureHostedInspectorPreferredWidthFromCurrentLayout(reason: "host.layout.sameSize")
                     }
@@ -6355,7 +6316,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             if isHostedInspectorSideDockActive() {
                 layoutHostedInspectorSideDockIfNeeded(reason: "host.layout.sideDock")
             } else if hasStoredHostedInspectorWidthPreference {
-                reapplyHostedInspectorDividerToStoredWidthIfNeeded(reason: "host.layout")
+                reapplyHostedInspectorDividerToStoredExtentIfNeeded(reason: "host.layout")
             } else {
                 captureHostedInspectorPreferredWidthFromCurrentLayout(reason: "host.layout")
             }
@@ -6366,7 +6327,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             debugLogHostedInspectorLayoutIfNeeded(reason: "layout")
 #endif
         }
-
         override func setFrameOrigin(_ newOrigin: NSPoint) {
             super.setFrameOrigin(newOrigin)
             window?.invalidateCursorRects(for: self)
@@ -6376,7 +6336,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             debugLogHostedInspectorLayoutIfNeeded(reason: "setFrameOrigin")
 #endif
         }
-
         override func setFrameSize(_ newSize: NSSize) {
             super.setFrameSize(newSize)
             window?.invalidateCursorRects(for: self)
@@ -6386,15 +6345,16 @@ struct WebViewRepresentable: NSViewRepresentable {
             debugLogHostedInspectorLayoutIfNeeded(reason: "setFrameSize")
 #endif
         }
-
         override func resetCursorRects() {
             super.resetCursorRects()
             guard let hostedInspectorHit = hostedInspectorDividerCandidate() else { return }
             let clipped = hostedInspectorDividerHitRect(for: hostedInspectorHit).intersection(bounds)
             guard !clipped.isNull, clipped.width > 0, clipped.height > 0 else { return }
-            addCursorRect(clipped, cursor: NSCursor.resizeLeftRight)
+            addCursorRect(
+                clipped,
+                cursor: hostedInspectorHit.dockSide.isHorizontalDivider ? .resizeUpDown : .resizeLeftRight
+            )
         }
-
         override func updateTrackingAreas() {
             if let trackingArea {
                 removeTrackingArea(trackingArea)
@@ -6412,19 +6372,15 @@ struct WebViewRepresentable: NSViewRepresentable {
             trackingArea = next
             super.updateTrackingAreas()
         }
-
         override func cursorUpdate(with event: NSEvent) {
             updateDividerCursor(at: convert(event.locationInWindow, from: nil))
         }
-
         override func mouseMoved(with event: NSEvent) {
             updateDividerCursor(at: convert(event.locationInWindow, from: nil))
         }
-
         override func mouseExited(with event: NSEvent) {
             clearActiveDividerCursor(restoreArrow: true)
         }
-
         override func hitTest(_ point: NSPoint) -> NSView? {
             let hostedInspectorHit = hostedInspectorDividerHit(at: point)
             updateDividerCursor(at: point, hostedInspectorHit: hostedInspectorHit)
@@ -6442,6 +6398,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 return nil
             }
             if let hostedInspectorHit {
+                cacheHostedInspectorDividerHit(hostedInspectorHit, at: point)
                 if let nativeHit = nativeHostedInspectorHit(at: point, hostedInspectorHit: hostedInspectorHit) {
 #if DEBUG
                     debugLogHitTest(stage: "hitTest.hostedInspectorNative", point: point, passThrough: false, hitView: nativeHit)
@@ -6467,14 +6424,13 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
             return hit
         }
-
         override func mouseDown(with event: NSEvent) {
             let point = convert(event.locationInWindow, from: nil)
-            guard let hostedInspectorHit = hostedInspectorDividerHit(at: point) else {
+            guard let hostedInspectorHit = hostedInspectorDividerHit(at: point) ?? cachedHostedInspectorDividerHit(at: point) else {
                 super.mouseDown(with: event)
                 return
             }
-
+            cachedHostedInspectorDividerHit = nil
             hostedInspectorReapplyWorkItem?.cancel()
             isHostedInspectorDividerDragActive = true
             hostedInspectorDividerDrag = HostedInspectorDividerDragState(
@@ -6482,7 +6438,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 pageView: hostedInspectorHit.pageView,
                 inspectorView: hostedInspectorHit.inspectorView,
                 dockSide: hostedInspectorHit.dockSide,
-                initialWindowX: event.locationInWindow.x,
+                initialWindowPoint: event.locationInWindow,
                 initialPageFrame: hostedInspectorHit.pageView.frame,
                 initialInspectorFrame: hostedInspectorHit.inspectorView.frame
             )
@@ -6490,40 +6446,44 @@ struct WebViewRepresentable: NSViewRepresentable {
             debugLogHostedInspectorFrames(stage: "drag.start", point: point, hit: hostedInspectorHit)
 #endif
         }
-
         override func mouseDragged(with event: NSEvent) {
             guard let dragState = hostedInspectorDividerDrag else {
                 super.mouseDragged(with: event)
                 return
             }
-
             let containerBounds = dragState.containerView.bounds
-            let minimumInspectorWidth = Self.minimumHostedInspectorWidth
-            let initialDividerX = dragState.dockSide.dividerX(
+            let initialDividerPosition = dragState.dockSide.dividerPosition(
                 pageFrame: dragState.initialPageFrame,
                 inspectorFrame: dragState.initialInspectorFrame
             )
-            let proposedDividerX = initialDividerX + (event.locationInWindow.x - dragState.initialWindowX)
-            let clampedDividerX = dragState.dockSide.clampedDividerX(
-                proposedDividerX,
+            let windowDeltaX = event.locationInWindow.x - dragState.initialWindowPoint.x
+            let windowDeltaY = event.locationInWindow.y - dragState.initialWindowPoint.y
+            let proposedDividerPosition = initialDividerPosition +
+                (dragState.dockSide.isHorizontalDivider ? windowDeltaY : windowDeltaX)
+            let clampedDividerPosition = dragState.dockSide.clampedDividerPosition(
+                proposedDividerPosition,
                 containerBounds: containerBounds,
                 pageFrame: dragState.initialPageFrame,
-                minimumInspectorWidth: minimumInspectorWidth
+                inspectorFrame: dragState.initialInspectorFrame,
+                policy: HostedInspectorMinimumSizePolicy(dockSide: dragState.dockSide)
             )
-            let inspectorWidth = dragState.dockSide.inspectorWidth(
-                forDividerX: clampedDividerX,
+            let inspectorExtent = dragState.dockSide.inspectorExtent(
+                forDividerPosition: clampedDividerPosition,
                 in: containerBounds
             )
-            recordPreferredHostedInspectorWidth(inspectorWidth, containerBounds: containerBounds)
-            _ = applyHostedInspectorDividerWidth(
-                inspectorWidth,
+            recordPreferredHostedInspectorExtent(
+                inspectorExtent,
+                dockSide: dragState.dockSide,
+                containerBounds: containerBounds
+            )
+            _ = applyHostedInspectorDividerExtent(
+                inspectorExtent,
                 to: HostedInspectorDividerHit(
                     containerView: dragState.containerView,
                     pageView: dragState.pageView,
                     inspectorView: dragState.inspectorView,
                     dockSide: dragState.dockSide
                 ),
-                minimumInspectorWidth: Self.minimumHostedInspectorWidth,
                 reason: "drag"
             )
 #if DEBUG
@@ -6548,13 +6508,21 @@ struct WebViewRepresentable: NSViewRepresentable {
                 )
             )
         }
-
         override func mouseUp(with event: NSEvent) {
             let finalDragState = hostedInspectorDividerDrag
             hostedInspectorDividerDrag = nil
             isHostedInspectorDividerDragActive = false
             updateDividerCursor(at: convert(event.locationInWindow, from: nil))
             if let finalDragState {
+                let finalExtent = finalDragState.dockSide.inspectorExtent(
+                    inspectorFrame: finalDragState.inspectorView.frame,
+                    in: finalDragState.containerView.bounds
+                )
+                HostedInspectorAttachedSizeSync.sync(
+                    frontendWebView: hostedInspectorFrontendWebView,
+                    dockSide: finalDragState.dockSide,
+                    extent: finalExtent
+                )
 #if DEBUG
                 debugLogHostedInspectorFrames(
                     stage: "drag.end",
@@ -6567,11 +6535,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                     )
                 )
 #endif
-                reapplyHostedInspectorDividerToStoredWidthIfNeeded(reason: "drag.end")
+                reapplyHostedInspectorDividerToStoredExtentIfNeeded(reason: "drag.end")
             }
             super.mouseUp(with: event)
         }
-
         private func shouldPassThroughToSidebarResizer(
             at point: NSPoint,
             hostedInspectorHit: HostedInspectorDividerHit? = nil
@@ -6597,7 +6564,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return contentView.bounds.maxX - hostRectInContent.maxX > 24
         }
-
         private func shouldPassThroughToExternalSplitDivider(
             at point: NSPoint,
             hostedInspectorHit: HostedInspectorDividerHit? = nil
@@ -6605,7 +6571,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             guard hostedInspectorHit == nil else { return false }
             guard isNearPaneEdge(point) else { return false }
             guard window != nil else { return false }
-
             let windowPoint = convert(point, to: nil)
             var ancestor = superview
             while let currentAncestor = ancestor {
@@ -6624,7 +6589,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return false
         }
-
         private func externalSplitDividerHit(
             at windowPoint: NSPoint,
             in splitView: NSSplitView,
@@ -6640,7 +6604,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return hitRect.contains(windowPoint)
         }
-
         private func isNearPaneEdge(_ point: NSPoint) -> Bool {
             // hitTest and cursor tracking call this with points in this view's bounds coordinates.
             guard bounds.contains(point) else { return false }
@@ -6651,7 +6614,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 point.y >= bounds.maxY - expansion
             return nearVerticalEdge || nearHorizontalEdge
         }
-
         private func updateDividerCursor(
             at point: NSPoint,
             hostedInspectorHit: HostedInspectorDividerHit? = nil
@@ -6669,10 +6631,10 @@ struct WebViewRepresentable: NSViewRepresentable {
                 clearActiveDividerCursor(restoreArrow: true)
                 return
             }
-            activeDividerCursorKind = .vertical
-            NSCursor.resizeLeftRight.set()
+            let kind: DividerCursorKind = resolvedHostedInspectorHit?.dockSide.isHorizontalDivider == true ? .horizontal : .vertical
+            activeDividerCursorKind = kind
+            kind.cursor.set()
         }
-
         private func clearActiveDividerCursor(restoreArrow: Bool) {
             guard activeDividerCursorKind != nil else { return }
             window?.invalidateCursorRects(for: self)
@@ -6681,7 +6643,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 NSCursor.arrow.set()
             }
         }
-
         private func nativeHostedInspectorHit(
             at point: NSPoint,
             hostedInspectorHit: HostedInspectorDividerHit
@@ -6701,7 +6662,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return nil
         }
-
         private func hostedInspectorDividerHit(at point: NSPoint) -> HostedInspectorDividerHit? {
             guard let hit = hostedInspectorDividerCandidate(),
                   hostedInspectorDividerHitRect(for: hit).contains(point) else {
@@ -6709,16 +6669,35 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return hit
         }
-
+        private func cacheHostedInspectorDividerHit(_ hit: HostedInspectorDividerHit, at point: NSPoint) {
+            cachedHostedInspectorDividerHit = CachedHostedInspectorDividerHit(
+                point: point,
+                hit: hit,
+                timestamp: ProcessInfo.processInfo.systemUptime
+            )
+        }
+        private func cachedHostedInspectorDividerHit(at point: NSPoint) -> HostedInspectorDividerHit? {
+            guard let cachedHostedInspectorDividerHit else { return nil }
+            let age = ProcessInfo.processInfo.systemUptime - cachedHostedInspectorDividerHit.timestamp
+            guard age <= Self.hostedInspectorHitCacheLifetime else {
+                self.cachedHostedInspectorDividerHit = nil
+                return nil
+            }
+            let dx = abs(point.x - cachedHostedInspectorDividerHit.point.x)
+            let dy = abs(point.y - cachedHostedInspectorDividerHit.point.y)
+            guard dx <= Self.hostedInspectorDividerHitExpansion,
+                  dy <= Self.hostedInspectorDividerHitExpansion else {
+                return nil
+            }
+            return cachedHostedInspectorDividerHit.hit
+        }
         private func hostedInspectorDividerCandidate() -> HostedInspectorDividerHit? {
             hostedInspectorDividerCandidate(in: self)
         }
-
         private func hostedInspectorDividerCandidate(in root: NSView) -> HostedInspectorDividerHit? {
             if let preferredHit = hostedInspectorDividerCandidateUsingKnownWebViews(in: root) {
                 return preferredHit
             }
-
             let inspectorCandidates = Self.visibleDescendants(in: root)
                 .filter { Self.isVisibleHostedInspectorCandidate($0) && Self.isInspectorView($0) }
                 .sorted { lhs, rhs in
@@ -6726,10 +6705,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     let rhsFrame = root.convert(rhs.bounds, from: rhs)
                     return lhsFrame.minX < rhsFrame.minX
                 }
-
             var bestHit: HostedInspectorDividerHit?
             var bestScore = -CGFloat.greatestFiniteMagnitude
-
             for inspectorCandidate in inspectorCandidates {
                 guard let candidate = hostedInspectorDividerCandidate(in: root, startingAt: inspectorCandidate) else {
                     continue
@@ -6740,10 +6717,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     bestHit = candidate
                 }
             }
-
             return bestHit
         }
-
         private func hostedInspectorDividerCandidateUsingKnownWebViews(in root: NSView) -> HostedInspectorDividerHit? {
             guard let pageLeaf = hostedWebView,
                   let inspectorLeaf = hostedInspectorFrontendWebView,
@@ -6758,14 +6733,12 @@ struct WebViewRepresentable: NSViewRepresentable {
                 inspectorLeaf: inspectorLeaf
             )
         }
-
         private func hostedInspectorDividerCandidate(
             in root: NSView,
             pageLeaf: NSView,
             inspectorLeaf: NSView
         ) -> HostedInspectorDividerHit? {
             var currentInspector: NSView? = inspectorLeaf
-
             while let inspectorView = currentInspector, inspectorView !== root {
                 guard let containerView = inspectorView.superview else { break }
                 guard containerView === root || containerView.isDescendant(of: root) else {
@@ -6778,10 +6751,14 @@ struct WebViewRepresentable: NSViewRepresentable {
                 }
                 guard pageView !== inspectorView,
                       Self.isVisibleHostedInspectorSiblingCandidate(pageView),
-                      Self.verticalOverlap(between: pageView.frame, and: inspectorView.frame) > 8,
                       let dockSide = HostedInspectorDockSide.resolve(
                           pageFrame: pageView.frame,
                           inspectorFrame: inspectorView.frame
+                      ),
+                      dockSide.hasSufficientCrossAxisOverlap(
+                          pageFrame: pageView.frame,
+                          inspectorFrame: inspectorView.frame,
+                          containerBounds: containerView.bounds
                       ) else {
                     currentInspector = containerView
                     continue
@@ -6793,10 +6770,8 @@ struct WebViewRepresentable: NSViewRepresentable {
                     dockSide: dockSide
                 )
             }
-
             return nil
         }
-
         private func hostedInspectorDividerHitRect(for hit: HostedInspectorDividerHit) -> NSRect {
             let pageFrame = convert(hit.pageView.bounds, from: hit.pageView)
             let inspectorFrame = convert(hit.inspectorView.bounds, from: hit.inspectorView)
@@ -6807,32 +6782,30 @@ struct WebViewRepresentable: NSViewRepresentable {
                 expansion: Self.hostedInspectorDividerHitExpansion
             )
         }
-
         private func hostedInspectorDividerCandidate(in root: NSView, startingAt inspectorLeaf: NSView) -> HostedInspectorDividerHit? {
             var current: NSView? = inspectorLeaf
             var bestHit: HostedInspectorDividerHit?
-
             while let inspectorView = current, inspectorView !== root {
                 guard let containerView = inspectorView.superview else { break }
-
                 let pageCandidates = containerView.subviews.compactMap { candidate -> (view: NSView, dockSide: HostedInspectorDockSide)? in
                     guard Self.isVisibleHostedInspectorSiblingCandidate(candidate) else { return nil }
                     guard candidate !== inspectorView else { return nil }
-                    guard Self.verticalOverlap(between: candidate.frame, and: inspectorView.frame) > 8 else {
-                        return nil
-                    }
                     guard let dockSide = HostedInspectorDockSide.resolve(
                         pageFrame: candidate.frame,
                         inspectorFrame: inspectorView.frame
                     ) else {
                         return nil
                     }
+                    guard dockSide.hasSufficientCrossAxisOverlap(
+                        pageFrame: candidate.frame,
+                        inspectorFrame: inspectorView.frame,
+                        containerBounds: containerView.bounds
+                    ) else { return nil }
                     return (view: candidate, dockSide: dockSide)
                 }
-
                 if let pageCandidate = pageCandidates.max(by: {
-                    hostedInspectorPageCandidateScore($0.view, inspectorView: inspectorView)
-                        < hostedInspectorPageCandidateScore($1.view, inspectorView: inspectorView)
+                    hostedInspectorPageCandidateScore($0.view, inspectorView: inspectorView, dockSide: $0.dockSide)
+                        < hostedInspectorPageCandidateScore($1.view, inspectorView: inspectorView, dockSide: $1.dockSide)
                 }) {
                     bestHit = HostedInspectorDividerHit(
                         containerView: containerView,
@@ -6841,27 +6814,26 @@ struct WebViewRepresentable: NSViewRepresentable {
                         dockSide: pageCandidate.dockSide
                     )
                 }
-
                 current = containerView
             }
-
             return bestHit
         }
-
         private func hostedInspectorDividerCandidateScore(_ hit: HostedInspectorDividerHit) -> CGFloat {
             let pageFrame = convert(hit.pageView.bounds, from: hit.pageView)
             let inspectorFrame = convert(hit.inspectorView.bounds, from: hit.inspectorView)
-            let overlap = Self.verticalOverlap(between: pageFrame, and: inspectorFrame)
-            let coverageWidth = max(pageFrame.maxX, inspectorFrame.maxX) - min(pageFrame.minX, inspectorFrame.minX)
-            return (overlap * 1_000) + coverageWidth + pageFrame.width
+            let overlap = hit.dockSide.crossAxisOverlap(pageFrame: pageFrame, inspectorFrame: inspectorFrame)
+            let coverage = hit.dockSide.isHorizontalDivider
+                ? max(pageFrame.maxY, inspectorFrame.maxY) - min(pageFrame.minY, inspectorFrame.minY)
+                : max(pageFrame.maxX, inspectorFrame.maxX) - min(pageFrame.minX, inspectorFrame.minX)
+            return (overlap * 1_000) + coverage + hit.dockSide.pageExtent(pageFrame: pageFrame)
         }
-
-        private func hostedInspectorPageCandidateScore(_ pageView: NSView, inspectorView: NSView) -> CGFloat {
-            let overlap = Self.verticalOverlap(between: pageView.frame, and: inspectorView.frame)
-            let coverageWidth = max(pageView.frame.maxX, inspectorView.frame.maxX) - min(pageView.frame.minX, inspectorView.frame.minX)
-            return (overlap * 1_000) + coverageWidth + pageView.frame.width
+        private func hostedInspectorPageCandidateScore(_ pageView: NSView, inspectorView: NSView, dockSide: HostedInspectorDockSide) -> CGFloat {
+            let overlap = dockSide.crossAxisOverlap(pageFrame: pageView.frame, inspectorFrame: inspectorView.frame)
+            let coverage = dockSide.isHorizontalDivider
+                ? max(pageView.frame.maxY, inspectorView.frame.maxY) - min(pageView.frame.minY, inspectorView.frame.minY)
+                : max(pageView.frame.maxX, inspectorView.frame.maxX) - min(pageView.frame.minX, inspectorView.frame.minX)
+            return (overlap * 1_000) + coverage + dockSide.pageExtent(pageFrame: pageView.frame)
         }
-
         fileprivate func scheduleHostedInspectorDividerReapply(reason: String) {
             hostedInspectorReapplyWorkItem?.cancel()
             let workItem = DispatchWorkItem { [weak self] in
@@ -6869,7 +6841,7 @@ struct WebViewRepresentable: NSViewRepresentable {
                 self.hostedInspectorReapplyWorkItem = nil
                 _ = self.promoteHostedInspectorSideDockFromCurrentLayoutIfNeeded()
                 if self.hasStoredHostedInspectorWidthPreference {
-                    self.reapplyHostedInspectorDividerToStoredWidthIfNeeded(reason: reason)
+                    self.reapplyHostedInspectorDividerToStoredExtentIfNeeded(reason: reason)
                 } else {
                     self.captureHostedInspectorPreferredWidthFromCurrentLayout(reason: reason)
                 }
@@ -6877,7 +6849,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             hostedInspectorReapplyWorkItem = workItem
             DispatchQueue.main.async(execute: workItem)
         }
-
         private func captureHostedInspectorPreferredWidthFromCurrentLayout(reason: String) {
             guard !isApplyingHostedInspectorLayout else { return }
             guard !isHostedInspectorDividerDragActive else { return }
@@ -6896,19 +6867,23 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
                 return
             }
-
-            let inspectorWidth = max(0, hit.inspectorView.frame.width)
-            guard inspectorWidth > 1 else { return }
-            recordHostedInspectorSideDockWidth(inspectorWidth)
+            let inspectorExtent = hit.dockSide.inspectorExtent(inspectorFrame: hit.inspectorView.frame, in: hit.containerView.bounds)
+            guard inspectorExtent > 1 else { return }
+            if !hit.dockSide.isHorizontalDivider {
+                recordHostedInspectorSideDockWidth(inspectorExtent)
+            }
             let currentFraction: CGFloat? = {
-                guard hit.containerView.bounds.width > 0 else { return nil }
-                return inspectorWidth / hit.containerView.bounds.width
+                let containerExtent = hit.dockSide.isHorizontalDivider ? hit.containerView.bounds.height : hit.containerView.bounds.width
+                guard containerExtent > 0 else { return nil }
+                return inspectorExtent / containerExtent
             }()
-            let widthMatches = preferredHostedInspectorWidth.map {
-                abs($0 - inspectorWidth) <= 0.5
+            let storedExtent = hit.dockSide.isHorizontalDivider ? preferredHostedInspectorHeight : preferredHostedInspectorWidth
+            let storedFraction = hit.dockSide.isHorizontalDivider ? preferredHostedInspectorHeightFraction : preferredHostedInspectorWidthFraction
+            let extentMatches = storedExtent.map {
+                abs($0 - inspectorExtent) <= 0.5
             } ?? false
             let fractionMatches: Bool = {
-                switch (preferredHostedInspectorWidthFraction, currentFraction) {
+                switch (storedFraction, currentFraction) {
                 case (nil, nil):
                     return true
                 case let (lhs?, rhs?):
@@ -6917,51 +6892,52 @@ struct WebViewRepresentable: NSViewRepresentable {
                     return false
                 }
             }()
-            guard !(widthMatches && fractionMatches) else { return }
-
+            guard !(extentMatches && fractionMatches) else { return }
 #if DEBUG
             hasLoggedMissingHostedInspectorCandidate = false
 #endif
-            recordPreferredHostedInspectorWidth(
-                inspectorWidth,
+            recordPreferredHostedInspectorExtent(
+                inspectorExtent,
+                dockSide: hit.dockSide,
                 containerBounds: hit.containerView.bounds
             )
         }
-
-        private func reapplyHostedInspectorDividerToStoredWidthIfNeeded(reason: String) {
+        private func reapplyHostedInspectorDividerToStoredExtentIfNeeded(reason: String) {
             guard !isApplyingHostedInspectorLayout else { return }
             guard let hit = hostedInspectorDividerCandidate() else { return }
-            guard let preferredWidth = resolvedPreferredHostedInspectorWidth(in: hit.containerView.bounds) else {
+            guard let preferredExtent = resolvedPreferredHostedInspectorExtent(
+                dockSide: hit.dockSide,
+                in: hit.containerView.bounds
+            ) else {
                 return
             }
-            let currentInspectorWidth = max(0, hit.inspectorView.frame.width)
-            guard abs(currentInspectorWidth - preferredWidth) > 0.5 else { return }
-            _ = applyHostedInspectorDividerWidth(
-                preferredWidth,
+            let currentInspectorExtent = hit.dockSide.inspectorExtent(
+                inspectorFrame: hit.inspectorView.frame,
+                in: hit.containerView.bounds
+            )
+            guard abs(currentInspectorExtent - preferredExtent) > 0.5 else { return }
+            _ = applyHostedInspectorDividerExtent(
+                preferredExtent,
                 to: hit,
-                minimumInspectorWidth: Self.minimumHostedInspectorWidth,
                 reason: reason
             )
         }
-
         @discardableResult
-        private func applyHostedInspectorDividerWidth(
-            _ preferredWidth: CGFloat,
+        private func applyHostedInspectorDividerExtent(
+            _ preferredExtent: CGFloat,
             to hit: HostedInspectorDividerHit,
-            minimumInspectorWidth: CGFloat,
             reason: String
         ) -> (pageFrame: NSRect, inspectorFrame: NSRect) {
             let containerBounds = hit.containerView.bounds
             let nextFrames = hit.dockSide.resizedFrames(
-                preferredWidth: preferredWidth,
+                preferredExtent: preferredExtent,
                 in: containerBounds,
                 pageFrame: hit.pageView.frame,
                 inspectorFrame: hit.inspectorView.frame,
-                minimumInspectorWidth: minimumInspectorWidth
+                policy: HostedInspectorMinimumSizePolicy(dockSide: hit.dockSide)
             )
             let pageFrame = nextFrames.pageFrame
             let inspectorFrame = nextFrames.inspectorFrame
-
             let oldPageFrame = hit.pageView.frame
             let oldInspectorFrame = hit.inspectorView.frame
             let pageChanged = !Self.rectApproximatelyEqual(pageFrame, oldPageFrame, epsilon: 0.5)
@@ -6969,8 +6945,9 @@ struct WebViewRepresentable: NSViewRepresentable {
             guard pageChanged || inspectorChanged else {
                 return (pageFrame, inspectorFrame)
             }
-            recordHostedInspectorSideDockWidth(inspectorFrame.width)
-
+            if !hit.dockSide.isHorizontalDivider {
+                recordHostedInspectorSideDockWidth(inspectorFrame.width)
+            }
             isApplyingHostedInspectorLayout = true
             CATransaction.begin()
             CATransaction.setDisableActions(true)
@@ -6978,7 +6955,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             hit.inspectorView.frame = inspectorFrame
             CATransaction.commit()
             isApplyingHostedInspectorLayout = false
-
             hit.pageView.needsDisplay = true
             hit.pageView.setNeedsDisplay(hit.pageView.bounds)
             hit.inspectorView.needsDisplay = true
@@ -6991,12 +6967,11 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             needsDisplay = true
             setNeedsDisplay(bounds)
-
             let isLiveDrag = reason == "drag"
 #if DEBUG
             cmuxDebugLog(
                 "browser.panel.hostedInspector stage=\(reason).reapply " +
-                "host=\(Self.debugObjectID(self)) preferredWidth=\(String(format: "%.1f", preferredWidth)) " +
+                "host=\(Self.debugObjectID(self)) preferredExtent=\(String(format: "%.1f", preferredExtent)) " +
                 "liveDrag=\(isLiveDrag ? 1 : 0) " +
                 "pageChanged=\(pageChanged ? 1 : 0) inspectorChanged=\(inspectorChanged ? 1 : 0) " +
                 "oldPage=\(Self.debugRect(oldPageFrame)) oldInspector=\(Self.debugRect(oldInspectorFrame)) " +
@@ -7006,7 +6981,6 @@ struct WebViewRepresentable: NSViewRepresentable {
 #endif
             return (pageFrame, inspectorFrame)
         }
-
         private static func visibleDescendants(in root: NSView) -> [NSView] {
             var descendants: [NSView] = []
             var stack = Array(root.subviews.reversed())
@@ -7016,7 +6990,6 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             return descendants
         }
-
         private static func directChild(of container: NSView, containing descendant: NSView) -> NSView? {
             var current: NSView? = descendant
             var directChild: NSView?
@@ -7027,29 +7000,21 @@ struct WebViewRepresentable: NSViewRepresentable {
             guard current === container else { return nil }
             return directChild
         }
-
         fileprivate static func isInspectorView(_ view: NSView) -> Bool {
             cmuxIsWebInspectorObject(view)
         }
-
         fileprivate static func isVisibleHostedInspectorCandidate(_ view: NSView) -> Bool {
             !view.isHidden &&
                 view.alphaValue > 0 &&
                 view.frame.width > 1 &&
                 view.frame.height > 1
         }
-
         private static func isVisibleHostedInspectorSiblingCandidate(_ view: NSView) -> Bool {
             !view.isHidden &&
                 view.alphaValue > 0 &&
                 view.frame.height > 1
         }
-
-        private static func verticalOverlap(between lhs: NSRect, and rhs: NSRect) -> CGFloat {
-            max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
-        }
     }
-
     #if DEBUG
     private static func logDevToolsState(
         _ panel: BrowserPanel,

--- a/Sources/Panels/HostedInspectorAttachedSizeSync.swift
+++ b/Sources/Panels/HostedInspectorAttachedSizeSync.swift
@@ -4,11 +4,26 @@ import WebKit
 @MainActor
 struct HostedInspectorAttachedSizeSync {
     static func sync(frontendWebView: WKWebView?, dockSide: HostedInspectorDockSide, extent: CGFloat) {
-        guard let frontendWebView else { return }
+        guard let frontendWebView else {
+#if DEBUG
+            cmuxDebugLog("browser.inspector.attachedSizeSync skip=nilFrontend dock=\(dockSide) extent=\(String(format: "%.1f", extent))")
+#endif
+            return
+        }
+#if DEBUG
+        let script = javaScript(dockSide: dockSide, extent: extent)
+        frontendWebView.evaluateJavaScript(script) { result, error in
+            cmuxDebugLog(
+                "browser.inspector.attachedSizeSync dock=\(dockSide) extent=\(String(format: "%.1f", extent)) " +
+                "result=\(String(describing: result)) error=\(error.map { String(describing: $0) } ?? "nil")"
+            )
+        }
+#else
         frontendWebView.evaluateJavaScript(
             javaScript(dockSide: dockSide, extent: extent),
             completionHandler: nil
         )
+#endif
     }
 
     static func sync(pageWebView: WKWebView?, dockSide: HostedInspectorDockSide, extent: CGFloat) {

--- a/Sources/Panels/HostedInspectorAttachedSizeSync.swift
+++ b/Sources/Panels/HostedInspectorAttachedSizeSync.swift
@@ -1,0 +1,34 @@
+import AppKit
+import WebKit
+
+@MainActor
+struct HostedInspectorAttachedSizeSync {
+    static func sync(frontendWebView: WKWebView?, dockSide: HostedInspectorDockSide, extent: CGFloat) {
+        guard let frontendWebView else { return }
+        frontendWebView.evaluateJavaScript(
+            javaScript(dockSide: dockSide, extent: extent),
+            completionHandler: nil
+        )
+    }
+
+    static func sync(pageWebView: WKWebView?, dockSide: HostedInspectorDockSide, extent: CGFloat) {
+        sync(
+            frontendWebView: pageWebView?.cmuxInspectorFrontendWebView(),
+            dockSide: dockSide,
+            extent: extent
+        )
+    }
+
+    nonisolated static func javaScript(dockSide: HostedInspectorDockSide, extent: CGFloat) -> String {
+        let method = dockSide.isHorizontalDivider ? "setAttachedWindowHeight" : "setAttachedWindowWidth"
+        let roundedExtent = max(0, Int(extent.rounded()))
+        return """
+        (() => {
+            if (typeof InspectorFrontendHost === "undefined") { return false; }
+            if (typeof InspectorFrontendHost.\(method) !== "function") { return false; }
+            InspectorFrontendHost.\(method)(\(roundedExtent));
+            return true;
+        })();
+        """
+    }
+}

--- a/Sources/Panels/HostedInspectorResizeGeometry.swift
+++ b/Sources/Panels/HostedInspectorResizeGeometry.swift
@@ -32,6 +32,32 @@ struct HostedInspectorMinimumSizePolicy: Equatable {
     }
 }
 
+/// WebKit's WebInspectorUIProxy observes the inspected webview's frame-change
+/// notifications and asynchronously re-applies its stored attachment size.
+/// During a cmux divider drag that stored size is stale, so every one of our
+/// per-event frame writes triggered a reset to the pre-drag layout (verified
+/// via the browser.portal.manualInspectorDrag debug log: oldPageFrame kept
+/// reverting between events). Silence the inspected view's frame notifications
+/// for exactly the drag's duration so cmux is the only layout writer.
+@MainActor
+final class HostedInspectorDragFrameNotificationSilencer {
+    private var restore: (() -> Void)?
+
+    func begin(_ inspectedView: NSView) {
+        end()
+        let postedFrameChangedNotifications = inspectedView.postsFrameChangedNotifications
+        inspectedView.postsFrameChangedNotifications = false
+        restore = { [weak inspectedView] in
+            inspectedView?.postsFrameChangedNotifications = postedFrameChangedNotifications
+        }
+    }
+
+    func end() {
+        restore?()
+        restore = nil
+    }
+}
+
 enum HostedInspectorDockSide {
     case leading
     case trailing

--- a/Sources/Panels/HostedInspectorResizeGeometry.swift
+++ b/Sources/Panels/HostedInspectorResizeGeometry.swift
@@ -1,0 +1,260 @@
+import AppKit
+
+struct HostedInspectorMinimumSizePolicy: Equatable {
+    let minimumInspectorExtent: CGFloat
+    let minimumPageExtent: CGFloat
+
+    static let sideDock = HostedInspectorMinimumSizePolicy(
+        minimumInspectorExtent: 120,
+        minimumPageExtent: 120
+    )
+
+    static let bottomDock = HostedInspectorMinimumSizePolicy(
+        minimumInspectorExtent: 100,
+        minimumPageExtent: 80
+    )
+
+    init(minimumInspectorExtent: CGFloat, minimumPageExtent: CGFloat) {
+        self.minimumInspectorExtent = max(0, minimumInspectorExtent)
+        self.minimumPageExtent = max(0, minimumPageExtent)
+    }
+
+    init(dockSide: HostedInspectorDockSide) {
+        self = dockSide == .bottom ? .bottomDock : .sideDock
+    }
+
+    func clampedInspectorExtent(_ proposedExtent: CGFloat, containerExtent: CGFloat) -> CGFloat {
+        let extent = max(0, containerExtent)
+        let effectiveMinInspector = min(minimumInspectorExtent, extent / 2)
+        let effectiveMinPage = min(minimumPageExtent, extent / 2)
+        let maxInspector = max(effectiveMinInspector, extent - effectiveMinPage)
+        return min(maxInspector, max(effectiveMinInspector, proposedExtent))
+    }
+}
+
+enum HostedInspectorDockSide {
+    case leading
+    case trailing
+    case bottom
+
+    static func resolve(
+        pageFrame: NSRect,
+        inspectorFrame: NSRect,
+        epsilon: CGFloat = 4
+    ) -> Self? {
+        let verticalOverlap = verticalOverlap(between: pageFrame, and: inspectorFrame)
+        let horizontalOverlap = horizontalOverlap(between: pageFrame, and: inspectorFrame)
+        if verticalOverlap > 0, pageFrame.maxX <= inspectorFrame.minX + epsilon {
+            return .trailing
+        }
+        if verticalOverlap > 0, inspectorFrame.maxX <= pageFrame.minX + epsilon {
+            return .leading
+        }
+        if horizontalOverlap > 0, inspectorFrame.maxY <= pageFrame.minY + epsilon {
+            return .bottom
+        }
+        return nil
+    }
+
+    var isHorizontalDivider: Bool {
+        self == .bottom
+    }
+
+    func dividerPosition(pageFrame: NSRect, inspectorFrame: NSRect) -> CGFloat {
+        switch self {
+        case .leading:
+            return inspectorFrame.maxX
+        case .trailing:
+            return inspectorFrame.minX
+        case .bottom:
+            return inspectorFrame.maxY
+        }
+    }
+
+    func dividerHitRect(
+        in bounds: NSRect,
+        pageFrame: NSRect,
+        inspectorFrame: NSRect,
+        expansion: CGFloat
+    ) -> NSRect {
+        let position = dividerPosition(pageFrame: pageFrame, inspectorFrame: inspectorFrame)
+        switch self {
+        case .leading, .trailing:
+            return NSRect(
+                x: position - expansion,
+                y: bounds.minY,
+                width: expansion * 2,
+                height: max(0, bounds.height)
+            )
+        case .bottom:
+            return NSRect(
+                x: bounds.minX,
+                y: position - expansion,
+                width: max(0, bounds.width),
+                height: expansion * 2
+            )
+        }
+    }
+
+    func clampedDividerPosition(
+        _ proposedDividerPosition: CGFloat,
+        containerBounds: NSRect,
+        pageFrame: NSRect,
+        inspectorFrame: NSRect,
+        policy: HostedInspectorMinimumSizePolicy
+    ) -> CGFloat {
+        let proposedExtent = inspectorExtent(
+            forDividerPosition: proposedDividerPosition,
+            in: containerBounds
+        )
+        let clampedExtent = policy.clampedInspectorExtent(
+            proposedExtent,
+            containerExtent: containerExtent(in: containerBounds)
+        )
+        return dividerPosition(forInspectorExtent: clampedExtent, in: containerBounds)
+    }
+
+    func inspectorExtent(forDividerPosition dividerPosition: CGFloat, in containerBounds: NSRect) -> CGFloat {
+        switch self {
+        case .leading:
+            return max(0, dividerPosition - containerBounds.minX)
+        case .trailing:
+            return max(0, containerBounds.maxX - dividerPosition)
+        case .bottom:
+            return max(0, dividerPosition - containerBounds.minY)
+        }
+    }
+
+    func inspectorExtent(inspectorFrame: NSRect, in containerBounds: NSRect) -> CGFloat {
+        switch self {
+        case .leading, .trailing:
+            return min(max(0, containerBounds.width), max(0, inspectorFrame.width))
+        case .bottom:
+            return min(max(0, containerBounds.height), max(0, inspectorFrame.height))
+        }
+    }
+
+    func resizedFrames(
+        preferredExtent: CGFloat,
+        in containerBounds: NSRect,
+        pageFrame: NSRect,
+        inspectorFrame: NSRect,
+        policy: HostedInspectorMinimumSizePolicy
+    ) -> (pageFrame: NSRect, inspectorFrame: NSRect) {
+        let clampedExtent = policy.clampedInspectorExtent(
+            preferredExtent,
+            containerExtent: containerExtent(in: containerBounds)
+        )
+        let dividerPosition = dividerPosition(forInspectorExtent: clampedExtent, in: containerBounds)
+        switch self {
+        case .leading:
+            return horizontalFrames(
+                dividerX: dividerPosition,
+                containerBounds: containerBounds,
+                pageFrame: pageFrame,
+                inspectorFrame: inspectorFrame,
+                inspectorOnLeadingEdge: true
+            )
+        case .trailing:
+            return horizontalFrames(
+                dividerX: dividerPosition,
+                containerBounds: containerBounds,
+                pageFrame: pageFrame,
+                inspectorFrame: inspectorFrame,
+                inspectorOnLeadingEdge: false
+            )
+        case .bottom:
+            var nextPageFrame = pageFrame
+            nextPageFrame.origin.x = containerBounds.minX
+            nextPageFrame.origin.y = dividerPosition
+            nextPageFrame.size.width = max(0, containerBounds.width)
+            nextPageFrame.size.height = max(0, containerBounds.maxY - dividerPosition)
+
+            var nextInspectorFrame = inspectorFrame
+            nextInspectorFrame.origin.x = containerBounds.minX
+            nextInspectorFrame.origin.y = containerBounds.minY
+            nextInspectorFrame.size.width = max(0, containerBounds.width)
+            nextInspectorFrame.size.height = max(0, dividerPosition - containerBounds.minY)
+            return (pageFrame: nextPageFrame, inspectorFrame: nextInspectorFrame)
+        }
+    }
+
+    func hasSufficientCrossAxisOverlap(
+        pageFrame: NSRect,
+        inspectorFrame: NSRect,
+        containerBounds: NSRect
+    ) -> Bool {
+        let overlap = crossAxisOverlap(pageFrame: pageFrame, inspectorFrame: inspectorFrame)
+        let containerCrossExtent = isHorizontalDivider ? containerBounds.width : containerBounds.height
+        return overlap > min(8, max(0, containerCrossExtent) * 0.25)
+    }
+
+    func crossAxisOverlap(pageFrame: NSRect, inspectorFrame: NSRect) -> CGFloat {
+        switch self {
+        case .leading, .trailing:
+            return Self.verticalOverlap(between: pageFrame, and: inspectorFrame)
+        case .bottom:
+            return Self.horizontalOverlap(between: pageFrame, and: inspectorFrame)
+        }
+    }
+
+    func pageExtent(pageFrame: NSRect) -> CGFloat {
+        switch self {
+        case .leading, .trailing:
+            return max(0, pageFrame.width)
+        case .bottom:
+            return max(0, pageFrame.height)
+        }
+    }
+
+    private func containerExtent(in bounds: NSRect) -> CGFloat {
+        isHorizontalDivider ? bounds.height : bounds.width
+    }
+
+    private func dividerPosition(forInspectorExtent inspectorExtent: CGFloat, in bounds: NSRect) -> CGFloat {
+        switch self {
+        case .leading:
+            return bounds.minX + inspectorExtent
+        case .trailing:
+            return bounds.maxX - inspectorExtent
+        case .bottom:
+            return bounds.minY + inspectorExtent
+        }
+    }
+
+    private func horizontalFrames(
+        dividerX: CGFloat,
+        containerBounds: NSRect,
+        pageFrame: NSRect,
+        inspectorFrame: NSRect,
+        inspectorOnLeadingEdge: Bool
+    ) -> (pageFrame: NSRect, inspectorFrame: NSRect) {
+        var nextPageFrame = pageFrame
+        var nextInspectorFrame = inspectorFrame
+        nextPageFrame.origin.y = containerBounds.minY
+        nextPageFrame.size.height = max(0, containerBounds.height)
+        nextInspectorFrame.origin.y = containerBounds.minY
+        nextInspectorFrame.size.height = max(0, containerBounds.height)
+
+        if inspectorOnLeadingEdge {
+            nextInspectorFrame.origin.x = containerBounds.minX
+            nextInspectorFrame.size.width = max(0, dividerX - containerBounds.minX)
+            nextPageFrame.origin.x = dividerX
+            nextPageFrame.size.width = max(0, containerBounds.maxX - dividerX)
+        } else {
+            nextPageFrame.origin.x = containerBounds.minX
+            nextPageFrame.size.width = max(0, dividerX - containerBounds.minX)
+            nextInspectorFrame.origin.x = dividerX
+            nextInspectorFrame.size.width = max(0, containerBounds.maxX - dividerX)
+        }
+        return (pageFrame: nextPageFrame, inspectorFrame: nextInspectorFrame)
+    }
+
+    private static func verticalOverlap(between lhs: NSRect, and rhs: NSRect) -> CGFloat {
+        max(0, min(lhs.maxY, rhs.maxY) - max(lhs.minY, rhs.minY))
+    }
+
+    private static func horizontalOverlap(between lhs: NSRect, and rhs: NSRect) -> CGFloat {
+        max(0, min(lhs.maxX, rhs.maxX) - max(lhs.minX, rhs.minX))
+    }
+}

--- a/Sources/Panels/HostedInspectorResizeGeometry.swift
+++ b/Sources/Panels/HostedInspectorResizeGeometry.swift
@@ -41,20 +41,47 @@ struct HostedInspectorMinimumSizePolicy: Equatable {
 /// for exactly the drag's duration so cmux is the only layout writer.
 @MainActor
 final class HostedInspectorDragFrameNotificationSilencer {
-    private var restore: (() -> Void)?
+    /// Deinit-safe restore token: the silencer's owner is an NSView whose
+    /// deinit is nonisolated, so restoration must not require MainActor
+    /// isolation proof at the call site.
+    private final class Restore: @unchecked Sendable {
+        private weak var view: NSView?
+        private let value: Bool
 
-    func begin(_ inspectedView: NSView) {
-        end()
-        let postedFrameChangedNotifications = inspectedView.postsFrameChangedNotifications
-        inspectedView.postsFrameChangedNotifications = false
-        restore = { [weak inspectedView] in
-            inspectedView?.postsFrameChangedNotifications = postedFrameChangedNotifications
+        @MainActor
+        init(view: NSView) {
+            self.view = view
+            self.value = view.postsFrameChangedNotifications
+        }
+
+        func run() {
+            if Thread.isMainThread {
+                MainActor.assumeIsolated { view?.postsFrameChangedNotifications = value }
+            } else {
+                DispatchQueue.main.async { [self] in
+                    MainActor.assumeIsolated { view?.postsFrameChangedNotifications = value }
+                }
+            }
         }
     }
 
+    private var restore: Restore?
+
+    func begin(_ inspectedView: NSView) {
+        end()
+        restore = Restore(view: inspectedView)
+        inspectedView.postsFrameChangedNotifications = false
+    }
+
     func end() {
-        restore?()
+        restore?.run()
         restore = nil
+    }
+
+    deinit {
+        // A drag that never sees mouseUp (owner torn down mid-drag) must not
+        // leave WebKit's inspector layout observer permanently deaf.
+        restore?.run()
     }
 }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -749,6 +749,7 @@
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
+		B77620000000000000000006 /* HostedInspectorBottomDockDividerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77620000000000000000005 /* HostedInspectorBottomDockDividerTests.swift */; };
 		B1F0C0030000000000000001 /* HostedInspectorDockControlScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */; };
 		B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */; };
 		CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */; };
@@ -2384,6 +2385,7 @@
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
 		4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenRightSidebarContentMountingTests.swift; sourceTree = "<group>"; };
 		CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostAccountFlow.swift; sourceTree = "<group>"; };
+		B77620000000000000000005 /* HostedInspectorBottomDockDividerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedInspectorBottomDockDividerTests.swift; sourceTree = "<group>"; };
 		B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/HostedInspectorDockControlScript.swift; sourceTree = "<group>"; };
 		B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedInspectorDockControlScriptTests.swift; sourceTree = "<group>"; };
 		CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostSettingsActions.swift; sourceTree = "<group>"; };
@@ -4699,6 +4701,7 @@
 				B1F0C0060000000000000002 /* BrowserDeveloperToolsDockControlNormalizerTests.swift */,
 				B1F0C0020000000000000002 /* BrowserInspectorFocusHandoffTests.swift */,
 				B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */,
+				B77620000000000000000005 /* HostedInspectorBottomDockDividerTests.swift */,
 				D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */,
 				BABA25000000000000000006 /* BrowserHTTPBasicAuthPromptCoordinatorTests.swift */,
 				BABA25000000000000000004 /* BrowserHTTPBasicAuthPromptTests.swift */,
@@ -6752,6 +6755,7 @@
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */,
 				4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */,
+				B77620000000000000000006 /* HostedInspectorBottomDockDividerTests.swift in Sources */,
 				B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */,
 				F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */,
 				C34670050000000000000001 /* KeyboardShortcutContextSwiftTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -749,9 +749,12 @@
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
+		B77620000000000000000004 /* HostedInspectorAttachedSizeSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77620000000000000000003 /* HostedInspectorAttachedSizeSync.swift */; };
 		B77620000000000000000006 /* HostedInspectorBottomDockDividerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77620000000000000000005 /* HostedInspectorBottomDockDividerTests.swift */; };
 		B1F0C0030000000000000001 /* HostedInspectorDockControlScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */; };
 		B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */; };
+		B77620000000000000000002 /* HostedInspectorResizeGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77620000000000000000001 /* HostedInspectorResizeGeometry.swift */; };
+		B77620000000000000000008 /* HostedInspectorResizeGeometryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B77620000000000000000007 /* HostedInspectorResizeGeometryTests.swift */; };
 		CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */; };
 		F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
@@ -2385,9 +2388,12 @@
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
 		4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenRightSidebarContentMountingTests.swift; sourceTree = "<group>"; };
 		CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostAccountFlow.swift; sourceTree = "<group>"; };
+		B77620000000000000000003 /* HostedInspectorAttachedSizeSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/HostedInspectorAttachedSizeSync.swift; sourceTree = "<group>"; };
 		B77620000000000000000005 /* HostedInspectorBottomDockDividerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedInspectorBottomDockDividerTests.swift; sourceTree = "<group>"; };
 		B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/HostedInspectorDockControlScript.swift; sourceTree = "<group>"; };
 		B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedInspectorDockControlScriptTests.swift; sourceTree = "<group>"; };
+		B77620000000000000000001 /* HostedInspectorResizeGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/HostedInspectorResizeGeometry.swift; sourceTree = "<group>"; };
+		B77620000000000000000007 /* HostedInspectorResizeGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedInspectorResizeGeometryTests.swift; sourceTree = "<group>"; };
 		CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostSettingsActions.swift; sourceTree = "<group>"; };
 		F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivePaneFirstClickFocusTests.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
@@ -4162,6 +4168,8 @@
 				109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */,
 				326E7A5E13C6DF650B9F8971 /* BrowserSystemProxyWatcher.swift */,
 				A5001414 /* BrowserPanelView.swift */,
+				B77620000000000000000003 /* HostedInspectorAttachedSizeSync.swift */,
+				B77620000000000000000001 /* HostedInspectorResizeGeometry.swift */,
 				C67540070000000000000002 /* BrowserPDFDocumentToolbarButtons.swift */,
 				C42660010000000000000002 /* BrowserPDFPreviewActionUIDelegate.swift */,
 				C42660020000000000000002 /* BrowserPDFPrintOperationRunner.swift */,
@@ -4702,6 +4710,7 @@
 				B1F0C0020000000000000002 /* BrowserInspectorFocusHandoffTests.swift */,
 				B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */,
 				B77620000000000000000005 /* HostedInspectorBottomDockDividerTests.swift */,
+				B77620000000000000000007 /* HostedInspectorResizeGeometryTests.swift */,
 				D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */,
 				BABA25000000000000000006 /* BrowserHTTPBasicAuthPromptCoordinatorTests.swift */,
 				BABA25000000000000000004 /* BrowserHTTPBasicAuthPromptTests.swift */,
@@ -5816,7 +5825,9 @@
 					A6AC72020000000000000001 /* GPUSpinnerStyle.swift in Sources */,
 					F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */,
 				CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */,
+				B77620000000000000000004 /* HostedInspectorAttachedSizeSync.swift in Sources */,
 				B1F0C0030000000000000001 /* HostedInspectorDockControlScript.swift in Sources */,
+				B77620000000000000000002 /* HostedInspectorResizeGeometry.swift in Sources */,
 				CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */,
 				C0DEA7720000000000000001 /* InternalFlagsWindow.swift in Sources */,
 				4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */,
@@ -6757,6 +6768,7 @@
 				4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */,
 				B77620000000000000000006 /* HostedInspectorBottomDockDividerTests.swift in Sources */,
 				B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */,
+				B77620000000000000000008 /* HostedInspectorResizeGeometryTests.swift in Sources */,
 				F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */,
 				C34670050000000000000001 /* KeyboardShortcutContextSwiftTests.swift in Sources */,
 				C34670020000000000000001 /* KeyboardShortcutContextTests.swift in Sources */,

--- a/cmuxTests/BrowserPanelTests.swift
+++ b/cmuxTests/BrowserPanelTests.swift
@@ -2411,7 +2411,7 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
 
     func testBrowserPanelHostAllowsRightDockedInspectorToExpandLeftAfterPromotion() {
         let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 260),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
@@ -2422,14 +2422,14 @@ final class BrowserPanelHostContainerViewTests: XCTestCase {
             return
         }
 
-        let host = WebViewRepresentable.HostContainerView(frame: NSRect(x: 180, y: 0, width: 240, height: contentView.bounds.height))
+        let host = WebViewRepresentable.HostContainerView(frame: NSRect(x: 180, y: 0, width: 420, height: contentView.bounds.height))
         host.autoresizingMask = [.minXMargin, .height]
         contentView.addSubview(host)
 
         let slotView = host.ensureLocalInlineSlotView()
-        let pageView = WKWebView(frame: NSRect(x: 0, y: 0, width: 92, height: host.bounds.height))
+        let pageView = WKWebView(frame: NSRect(x: 0, y: 0, width: 272, height: host.bounds.height))
         let inspectorView = WKWebView(
-            frame: NSRect(x: 92, y: 0, width: slotView.bounds.width - 92, height: host.bounds.height)
+            frame: NSRect(x: 272, y: 0, width: slotView.bounds.width - 272, height: host.bounds.height)
         )
         slotView.addSubview(pageView)
         slotView.addSubview(inspectorView)

--- a/cmuxTests/HostedInspectorBottomDockDividerTests.swift
+++ b/cmuxTests/HostedInspectorBottomDockDividerTests.swift
@@ -1,0 +1,158 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Hosted inspector bottom dock divider")
+struct HostedInspectorBottomDockDividerTests {
+    private final class PrimaryPageProbeView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            bounds.contains(point) ? self : nil
+        }
+    }
+
+    private final class WKInspectorProbeView: NSView {
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            bounds.contains(point) ? self : nil
+        }
+    }
+
+    @Test func portalHostClaimsBottomDockSeam() throws {
+        let fixture = try makePortalFixture()
+        defer { fixture.window.orderOut(nil) }
+
+        let seamInSlot = NSPoint(x: fixture.slot.bounds.midX, y: fixture.inspectorView.frame.maxY)
+        let seamInHost = fixture.host.convert(fixture.slot.convert(seamInSlot, to: nil), from: nil)
+
+        #expect(fixture.host.hitTest(seamInHost) === fixture.host)
+    }
+
+    @Test func portalHostBottomDockDragResizesComplementaryFrames() throws {
+        let fixture = try makePortalFixture()
+        defer { fixture.window.orderOut(nil) }
+        let initialHeight = fixture.inspectorView.frame.height
+        let seamInWindow = fixture.slot.convert(
+            NSPoint(x: fixture.slot.bounds.midX, y: fixture.inspectorView.frame.maxY),
+            to: nil
+        )
+
+        fixture.host.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: seamInWindow, window: fixture.window))
+        let drag = makeMouseEvent(
+            type: .leftMouseDragged,
+            location: NSPoint(x: seamInWindow.x, y: seamInWindow.y + 36),
+            window: fixture.window
+        )
+        fixture.host.mouseDragged(with: drag)
+        fixture.host.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: drag.locationInWindow, window: fixture.window))
+
+        #expect(fixture.inspectorView.frame.height > initialHeight)
+        #expect(abs(fixture.pageView.frame.minY - fixture.inspectorView.frame.maxY) <= 0.5)
+        #expect(abs(fixture.pageView.frame.maxY - fixture.slot.bounds.maxY) <= 0.5)
+    }
+
+    @Test func localInlineHostClaimsBottomDockSeam() throws {
+        let fixture = try makeLocalFixture()
+        defer { fixture.window.orderOut(nil) }
+
+        let seam = NSPoint(x: fixture.host.bounds.midX, y: fixture.inspectorView.frame.maxY)
+        #expect(fixture.host.hitTest(seam) === fixture.host)
+    }
+
+    @Test func smallPaneSideDockDragMovesIntoDegradedRange() throws {
+        let fixture = try makeLocalFixture(width: 160, pageFrame: NSRect(x: 0, y: 0, width: 100, height: 220), inspectorFrame: NSRect(x: 100, y: 0, width: 60, height: 220))
+        defer { fixture.window.orderOut(nil) }
+        let seam = NSPoint(x: fixture.inspectorView.frame.minX, y: fixture.host.bounds.midY)
+        let seamInWindow = fixture.host.convert(seam, to: nil)
+
+        fixture.host.mouseDown(with: makeMouseEvent(type: .leftMouseDown, location: seamInWindow, window: fixture.window))
+        let drag = makeMouseEvent(
+            type: .leftMouseDragged,
+            location: NSPoint(x: seamInWindow.x - 30, y: seamInWindow.y),
+            window: fixture.window
+        )
+        fixture.host.mouseDragged(with: drag)
+        fixture.host.mouseUp(with: makeMouseEvent(type: .leftMouseUp, location: drag.locationInWindow, window: fixture.window))
+
+        #expect(fixture.inspectorView.frame.width > 60)
+        #expect(abs(fixture.pageView.frame.maxX - fixture.inspectorView.frame.minX) <= 0.5)
+    }
+
+    private struct PortalFixture {
+        let window: NSWindow
+        let host: WindowBrowserHostView
+        let slot: WindowBrowserSlotView
+        let pageView: NSView
+        let inspectorView: NSView
+    }
+
+    private struct LocalFixture {
+        let window: NSWindow
+        let host: WebViewRepresentable.HostContainerView
+        let pageView: NSView
+        let inspectorView: NSView
+    }
+
+    private func makePortalFixture() throws -> PortalFixture {
+        let window = makeWindow()
+        let contentView = try #require(window.contentView)
+        let container = try #require(contentView.superview)
+        let host = WindowBrowserHostView(frame: container.convert(contentView.bounds, from: contentView))
+        container.addSubview(host, positioned: .above, relativeTo: contentView)
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 80, y: 0, width: 280, height: 220))
+        host.addSubview(slot)
+        let inspectorView = WKInspectorProbeView(frame: NSRect(x: 0, y: 0, width: slot.bounds.width, height: 90))
+        let pageView = PrimaryPageProbeView(frame: NSRect(x: 0, y: 90, width: slot.bounds.width, height: slot.bounds.height - 90))
+        slot.addSubview(pageView)
+        slot.addSubview(inspectorView)
+        contentView.layoutSubtreeIfNeeded()
+        return PortalFixture(window: window, host: host, slot: slot, pageView: pageView, inspectorView: inspectorView)
+    }
+
+    private func makeLocalFixture(
+        width: CGFloat = 280,
+        pageFrame: NSRect = NSRect(x: 0, y: 90, width: 280, height: 130),
+        inspectorFrame: NSRect = NSRect(x: 0, y: 0, width: 280, height: 90)
+    ) throws -> LocalFixture {
+        let window = makeWindow()
+        let contentView = try #require(window.contentView)
+        let host = WebViewRepresentable.HostContainerView(frame: NSRect(x: 80, y: 0, width: width, height: 220))
+        contentView.addSubview(host)
+        let pageView = PrimaryPageProbeView(frame: pageFrame)
+        let inspectorView = WKInspectorProbeView(frame: inspectorFrame)
+        host.addSubview(pageView)
+        host.addSubview(inspectorView)
+        contentView.layoutSubtreeIfNeeded()
+        return LocalFixture(window: window, host: host, pageView: pageView, inspectorView: inspectorView)
+    }
+
+    private func makeWindow() -> NSWindow {
+        NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 260),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+    }
+
+    private func makeMouseEvent(type: NSEvent.EventType, location: NSPoint, window: NSWindow) -> NSEvent {
+        guard let event = NSEvent.mouseEvent(
+            with: type,
+            location: location,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: 1
+        ) else {
+            fatalError("Failed to create mouse event")
+        }
+        return event
+    }
+}

--- a/cmuxTests/HostedInspectorDockControlScriptTests.swift
+++ b/cmuxTests/HostedInspectorDockControlScriptTests.swift
@@ -130,14 +130,11 @@ struct HostedInspectorDockControlScriptTests {
         let context = try makeDockControlContext(dockConfiguration: "bottom")
         context.evaluateScript(
             """
+            var dockedResizer = { style: {} };
             var document = {
                 getElementById: function(id) {
-                    return id === "docked-resizer" ? { style: {} } : null;
+                    return id === "docked-resizer" ? dockedResizer : null;
                 }
-            };
-            var dockedResizer = document.getElementById("docked-resizer");
-            document.getElementById = function(id) {
-                return id === "docked-resizer" ? dockedResizer : null;
             };
             """
         )

--- a/cmuxTests/HostedInspectorDockControlScriptTests.swift
+++ b/cmuxTests/HostedInspectorDockControlScriptTests.swift
@@ -126,6 +126,35 @@ struct HostedInspectorDockControlScriptTests {
         #expect(context.evaluateScript("updateCount").toInt32() == 2)
     }
 
+    @Test func disablesFrontendDockedResizerSoCmuxOwnsAttachedResize() throws {
+        let context = try makeDockControlContext(dockConfiguration: "bottom")
+        context.evaluateScript(
+            """
+            var document = {
+                getElementById: function(id) {
+                    return id === "docked-resizer" ? { style: {} } : null;
+                }
+            };
+            var dockedResizer = document.getElementById("docked-resizer");
+            document.getElementById = function(id) {
+                return id === "docked-resizer" ? dockedResizer : null;
+            };
+            """
+        )
+
+        context.evaluateScript(
+            HostedInspectorDockControlScript(
+                allowSideDock: true,
+                detachedFromHostWindow: false
+            ).source
+        )
+
+        #expect(
+            context.evaluateScript("dockedResizer.style.pointerEvents").toString() == "none",
+            "The inspector frontend's own docked resizer must be inert so every attached resize goes through cmux's clamped divider"
+        )
+    }
+
     private func makeDockControlContext(dockConfiguration: String) throws -> JSContext {
         let context = try #require(JSContext())
         context.evaluateScript(

--- a/cmuxTests/HostedInspectorResizeGeometryTests.swift
+++ b/cmuxTests/HostedInspectorResizeGeometryTests.swift
@@ -1,0 +1,98 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Hosted inspector resize geometry")
+struct HostedInspectorResizeGeometryTests {
+    @Test func resolvesBottomDockWithTolerantEpsilon() {
+        let page = NSRect(x: 0, y: 100, width: 300, height: 200)
+        let inspector = NSRect(x: 0, y: 0, width: 300, height: 102)
+
+        #expect(HostedInspectorDockSide.resolve(pageFrame: page, inspectorFrame: inspector) == .bottom)
+    }
+
+    @Test func resolvesSideDockWithSmallJitter() {
+        let page = NSRect(x: 0, y: 0, width: 180, height: 220)
+        let inspector = NSRect(x: 182, y: 0, width: 118, height: 220)
+
+        #expect(HostedInspectorDockSide.resolve(pageFrame: page, inspectorFrame: inspector) == .trailing)
+    }
+
+    @Test func dividerHitRectsFollowDividerOrientation() {
+        let bounds = NSRect(x: 0, y: 0, width: 300, height: 220)
+        let page = NSRect(x: 0, y: 90, width: 300, height: 130)
+        let bottomInspector = NSRect(x: 0, y: 0, width: 300, height: 90)
+        let sideInspector = NSRect(x: 180, y: 0, width: 120, height: 220)
+
+        let bottom = HostedInspectorDockSide.bottom.dividerHitRect(
+            in: bounds,
+            pageFrame: page,
+            inspectorFrame: bottomInspector,
+            expansion: 6
+        )
+        let trailing = HostedInspectorDockSide.trailing.dividerHitRect(
+            in: bounds,
+            pageFrame: NSRect(x: 0, y: 0, width: 180, height: 220),
+            inspectorFrame: sideInspector,
+            expansion: 6
+        )
+
+        #expect(bottom.width == 300)
+        #expect(bottom.height == 12)
+        #expect(trailing.width == 12)
+        #expect(trailing.height == 220)
+    }
+
+    @Test func proportionalClampNeverCreatesEmptyRangeForTinyContainers() {
+        let policy = HostedInspectorMinimumSizePolicy(minimumInspectorExtent: 120, minimumPageExtent: 120)
+
+        #expect(policy.clampedInspectorExtent(0, containerExtent: 80) == 40)
+        #expect(policy.clampedInspectorExtent(200, containerExtent: 80) == 40)
+        #expect(policy.clampedInspectorExtent(40, containerExtent: 320) == 120)
+        #expect(policy.clampedInspectorExtent(280, containerExtent: 320) == 200)
+    }
+
+    @Test func resizedBottomFramesTileContainer() {
+        let bounds = NSRect(x: 0, y: 0, width: 300, height: 220)
+        let frames = HostedInspectorDockSide.bottom.resizedFrames(
+            preferredExtent: 110,
+            in: bounds,
+            pageFrame: NSRect(x: 0, y: 90, width: 300, height: 130),
+            inspectorFrame: NSRect(x: 0, y: 0, width: 300, height: 90),
+            policy: HostedInspectorMinimumSizePolicy(dockSide: .bottom)
+        )
+
+        #expect(frames.inspectorFrame == NSRect(x: 0, y: 0, width: 300, height: 110))
+        #expect(frames.pageFrame == NSRect(x: 0, y: 110, width: 300, height: 110))
+    }
+
+    @Test func resizedSideFramesTileContainer() {
+        let bounds = NSRect(x: 0, y: 0, width: 300, height: 220)
+        let frames = HostedInspectorDockSide.trailing.resizedFrames(
+            preferredExtent: 130,
+            in: bounds,
+            pageFrame: NSRect(x: 0, y: 0, width: 180, height: 220),
+            inspectorFrame: NSRect(x: 180, y: 0, width: 120, height: 220),
+            policy: HostedInspectorMinimumSizePolicy(dockSide: .trailing)
+        )
+
+        #expect(frames.pageFrame == NSRect(x: 0, y: 0, width: 170, height: 220))
+        #expect(frames.inspectorFrame == NSRect(x: 170, y: 0, width: 130, height: 220))
+    }
+
+    @Test func attachedSizeSyncJavaScriptUsesGuardedIntegerHeightAndWidth() {
+        let height = HostedInspectorAttachedSizeSync.javaScript(dockSide: .bottom, extent: 120.6)
+        let width = HostedInspectorAttachedSizeSync.javaScript(dockSide: .trailing, extent: 119.4)
+
+        #expect(height.contains("typeof InspectorFrontendHost"))
+        #expect(height.contains("setAttachedWindowHeight"))
+        #expect(height.contains("121"))
+        #expect(width.contains("setAttachedWindowWidth"))
+        #expect(width.contains("119"))
+    }
+}


### PR DESCRIPTION
Fixes #7762. Fixes #663. Related: #2933 (item 2 tracks this same symptom), #7037 (same hit-swallowing failure family — prior art for the pass-through/claim approach), #617.

## Problem

Resizing the attached Web Inspector was unreliable: the divider was intermittently dead to drag, glitchy when it did work, and much worse in small panes / on small displays.

Root causes:

1. **Bottom dock had no cmux-owned divider at all.** `HostedInspectorDockSide` only modeled `.leading`/`.trailing`. Bottom-dock resize relied on WebKit's tiny in-content resizer inside the inspector frontend, which cmux's portal hit-testing routes around/swallows → #663's completely dead divider.
2. **Small panes are forced into bottom dock.** The local-inline host auto-redocks to bottom when a side dock would leave < 240pt of page width — landing small panes exactly in the dock mode with no divider. That's why the issue is worst on small panes/displays.
3. **Brittle candidate detection.** Side-dock resolution used a 1pt epsilon and a fixed `overlap > 8` guard, and `mouseDown` re-resolved the divider independently of `hitTest`, so transient WebKit layout churn silently dropped drags.
4. **Frame fighting.** cmux wrote inspector/page frames directly but never told WebKit the user-chosen size, so WebKit's attachment relayout could snap the divider back after/on relayout → glitchy resize.

## Fix

- **New `Sources/Panels/HostedInspectorResizeGeometry.swift`** (pure, unit-tested): `HostedInspectorDockSide` moved out of `BrowserWindowPortal.swift`, gains `.bottom`, axis-generic divider position/hit-rect/clamp/frame math, tolerant resolve epsilon (4pt), container-scaled cross-axis overlap guard.
- **Explicit minimum-size policy** (`HostedInspectorMinimumSizePolicy`): side dock keeps a 120pt inspector / 120pt page minimum; bottom dock 100pt inspector / 80pt page. When the pane can't fit both minimums, each minimum degrades to half the container, so the allowed divider range is **never empty** — the divider clamps gracefully instead of locking up.
- **Bottom-dock divider drag in both hosts** (window-portal `WindowBrowserHostView` and local-inline `WebViewRepresentable.HostContainerView`): hitTest claims the seam band (±6pt portal / ±10pt inline) so neither the page WKWebView nor the inspector's own web content swallows the drag; `resizeUpDown` cursor; Y-axis drag; preferred-height record/reapply with the same fraction-of-container semantics as width.
- **New `Sources/Panels/HostedInspectorAttachedSizeSync.swift`**: on mouseUp, pushes the final size into WebKit via `InspectorFrontendHost.setAttachedWindowHeight/Width` on the inspector *frontend* webview (typeof-guarded JS, nil-safe), so WebKit's attachment manager agrees with the user-chosen size and stops fighting cmux's layout.
- **Drag-vs-relayout races closed**: adaptive bottom-dock redock and the portal-sync bottom-dock frame repair no longer run while a divider drag is active; `mouseDown` falls back to the hit cached by `hitTest` (0.1s lifetime, ±hit-band distance) so event-to-event layout churn can't lose the drag.

## Commit structure (red/green)

- Commit 1 (`4275c014ab`) adds `cmuxTests/HostedInspectorBottomDockDividerTests.swift` only — expected **red**: both hosts fail to claim the bottom-dock seam and the portal drag doesn't resize. Proof run on that SHA: [test-e2e run — **failed** on exactly the three bottom-dock expectations](https://github.com/manaflow-ai/cmux/actions/runs/29058552563). (`smallPaneSideDockDragMovesIntoDegradedRange` is a guard test for the clamp policy and may already pass on commit 1.)
- Commit 2 (`5efa87918c`) is the fix plus `cmuxTests/HostedInspectorResizeGeometryTests.swift` (pure geometry: `.bottom` resolve, hit-rect bands, never-empty clamp range, frame complementarity, size-sync JS shape). Same filter on the fixed code: [test-e2e run — **passed**](https://github.com/manaflow-ai/cmux/actions/runs/29058556310) (run @ e793f50e3a, which also carries the review fixes: bottom-dock seam guard in the local-inline host, widened pinned test fixture; c69020621d additionally stops already-bottom-docked layouts from re-triggering the adaptive `WI._dockBottom()` redock).

## Test coverage honesty

Deterministic coverage: divider hit-testing/claiming in both hosts, drag→frame application, small-pane clamp policy, and the pure geometry — all via cmuxTests. **Not covered by automated tests:** the live feel of a real drag against a real WKWebView-hosted inspector (WebKit's actual attachment relayout timing, `InspectorFrontendHost` sync round-trip) — that needs manual dogfood: open a browser pane → open DevTools (attached, bottom and side dock) → drag the divider, including with the pane narrowed below ~240pt so the adaptive bottom dock engages.

## Localization audit

No user-facing strings were added or changed (divider/cursor interaction only); no `Localizable.xcstrings` changes needed.

Swift file budgets: `BrowserWindowPortal.swift` 3960/3981, `BrowserPanelView.swift` 7924/7959 — both shrank; no TSV changes; new files are 260/34/158/98 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7771"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786231853&installation_id=133855650&pr_number=7771&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7771&signature=f24a94a39f6ff1e753b45a8b12672ff7875f02f4617c602a9adb51e66668dacb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches pointer routing, live NSView frame layout, and WebKit inspector attachment JS across portal and browser panel hosts; behavior is heavily unit-tested but real WKWebView drag feel still needs manual verification.
> 
> **Overview**
> Attached Web Inspector resizing is reworked so cmux owns the divider in **bottom dock** as well as side dock, with clamping that still works in narrow panes and without fighting WebKit during drags.
> 
> **Geometry and policy** — `HostedInspectorDockSide` moves into `HostedInspectorResizeGeometry.swift` and gains `.bottom`, axis-generic divider math, and `HostedInspectorMinimumSizePolicy` so side/bottom docks clamp inspector vs page size without an empty drag range on tiny containers.
> 
> **Hosts (portal + local inline)** — Divider hit-testing claims the seam (vertical or horizontal cursor), drags use extent (width or height) with stored fractions, a short-lived hit cache bridges `hitTest` → `mouseDown`, and adaptive bottom-dock / frame repair are skipped while dragging. `HostedInspectorDragFrameNotificationSilencer` suppresses inspected-view frame notifications during drag; **one** `InspectorFrontendHost.setAttachedWindowWidth/Height` sync runs on mouseUp via new `HostedInspectorAttachedSizeSync`.
> 
> **Frontend** — `HostedInspectorDockControlScript` disables the in-page `#docked-resizer` so WebKit’s built-in handle doesn’t compete with cmux.
> 
> Tests cover bottom-dock claiming/drag, geometry, dock-control script, and a widened side-dock panel test fixture.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 61aea050a6d720fca15520be528fd503f8914dd4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dock-side–aware Web Inspector divider resizing using preferred extents (including bottom-docked behavior) with improved clamping and minimum-size handling.
  * Added attached inspector window size synchronization during divider drags.
  * Enhanced dock control behavior by disabling the frontend’s docked resizer when cmux owns resizing.
* **Bug Fixes**
  * Stabilized hosted divider hit-testing/cursor routing and reduced unnecessary frame updates; improved hosted rendering refresh and teardown safety.
  * Prevented background “webframe repair” while a hosted inspector divider drag is active.
* **Tests**
  * Added coverage for bottom-dock divider interactions and hosted inspector resize geometry (including JS generation).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->