### PR TITLE
iOS: sync checked-in MARKETING_VERSION to 1.0.4

### DIFF
--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -42,6 +42,33 @@ The top entry's version MUST equal the checked-in `MARKETING_VERSION` in
 
 ---
 
+## [1.0.4] - 2026-07-09
+
+### Internal
+
+- Version-sync bump: checked-in `MARKETING_VERSION` catches up to `1.0.4`, the version already live to external founders (an earlier upload under that version shipped stale, pre-#7636 code; the CI reship on 2026-07-09 replaced it with current `main`).
+- Fix iOS surface-teardown deadlock behind external-beta watchdog kills (#7666).
+- Add iOS account deletion and legal links (#7645).
+- iOS: terminal connection/render resilience, fail-open delivery gates, route iteration, persistent terminal surface (#7675).
+- Add iOS crash telemetry via Sentry + MetricKit (#7649).
+- iOS: dismissable alt-screen sizing notice in terminal toolbar (#7669).
+- iOS: render exactly one workspace-list connection surface (#7659).
+- iOS: persist debug log to a file and capture crashes in it (#7652).
+- Treat unreadable token storage as transient during iOS session restore, fixing spurious sign-outs on update (#7667).
+- iOS: native drag & drop in workspace list + create workspace in group (#7384).
+- iOS: enable multi-Mac workspace aggregation by default; re-aggregate on network recovery.
+- Workspaces as todos: inferred status lifecycle + per-workspace checklist (#7216) — merged but not yet dogfood-confirmed on this version; hold out of External until confirmed.
+- Dogfood focus: confirm the app launches straight to current UI (not the old stale build), sign-in survives an app relaunch, terminal connections recover after backgrounding, and multi-Mac workspaces list correctly.
+
+### External
+
+- Fixed an issue where the app could freeze or crash in the background.
+- Fixed an issue that could sign you out unexpectedly after updating.
+- Terminal connections recover more reliably after switching apps or losing network.
+- Added account deletion in Settings.
+- See workspaces from all your paired Macs in one list, with automatic recovery after network drops.
+- Drag and drop to reorder workspaces, and create new workspaces inside a group.
+
 ## [1.0.3] - 2026-06-13
 
 ### Internal

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -13,7 +13,7 @@ PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.ios
 // release with ios/scripts/bump-ios-version.sh. Keep this human-meaningful and
 // tellable; CFBundleVersion (CURRENT_PROJECT_VERSION) is the monotonic build id
 // (a UTC timestamp stamped by ios/scripts/upload-testflight.sh on TestFlight).
-MARKETING_VERSION = 1.0.1
+MARKETING_VERSION = 1.0.4
 CURRENT_PROJECT_VERSION = 1
 
 // Dev-build identity, surfaced in-app (Settings > About) so a DEBUG dogfood


### PR DESCRIPTION
## Summary
- External TestFlight was already approved and live on `1.0.4`, but the checked-in `MARKETING_VERSION` in `ios/Config/Shared.xcconfig` was still `1.0.1`, and an earlier upload under `1.0.4` shipped stale `main` code.
- Emergency reship already ran directly against App Store Connect via `workflow_dispatch` with `marketing_version_override=1.0.4` (https://github.com/manaflow-ai/cmux/actions/runs/29057777931), so this PR does not itself ship anything new to testers.
- This PR just syncs the repo's checked-in version to match reality, so the scheduled `ios-testflight.yml` beta lane (which reuses the checked-in `MARKETING_VERSION`) keeps publishing under the already-approved `1.0.4` instead of drifting back to `1.0.1`.
- Backfills `ios/CHANGELOG.md` with a `[1.0.4]` entry summarizing what shipped since `1.0.3` (2026-06-13).

## Test plan
- [x] `ios/scripts/bump-ios-version.sh 1.0.4` updated `ios/Config/Shared.xcconfig` cleanly
- [ ] CI green
- No runtime/app behavior change; this is a metadata-only version-string sync, not a code change

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7772"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232347&installation_id=133855650&pr_number=7772&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7772&signature=ca2ce7441e94a949857b8e285b2f5eb23895a84f02a34907409edcd7d6228857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit d9861ce782131f0cd12a30e7722427445310c127. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sync iOS MARKETING_VERSION to 1.0.4 to match the already-approved TestFlight build and keep scheduled betas from reverting to 1.0.1. Backfills ios/CHANGELOG.md with a 1.0.4 entry; no code changes or new distribution.

<sup>Written for commit d9861ce782131f0cd12a30e7722427445310c127. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added account deletion and legal links in Settings.
  * Added cross-device workspace viewing with improved recovery after network interruptions.
  * Added drag-and-drop workspace reordering and creation.

* **Bug Fixes**
  * Improved reliability for terminal reconnection and session restoration.
  * Fixed background freezes, crashes, and unexpected sign-outs.
  * Improved workspace connection and terminal rendering behavior.

* **Release**
  * Updated the iOS app version to 1.0.4.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->