### PR TITLE
Fetch App Store profile in workflow

### DIFF
--- a/.github/scripts/install-app-store-provisioning-profile.sh
+++ b/.github/scripts/install-app-store-provisioning-profile.sh
@@ -1,0 +1,237 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'install-app-store-provisioning-profile: %s\n' "$*" >&2
+  exit 1
+}
+
+note() {
+  printf 'install-app-store-provisioning-profile: %s\n' "$*" >&2
+}
+
+TEAM_ID="${IOS_APPSTORE_TEAM_ID:-7WLXT3NR37}"
+BUNDLE_IDENTIFIER="${IOS_APPSTORE_BUNDLE_IDENTIFIER:-com.cmuxterm.app}"
+EXPECTED_APP_ID="${TEAM_ID}.${BUNDLE_IDENTIFIER}"
+KEYCHAIN_NAME="${IOS_APPSTORE_KEYCHAIN_NAME:-ios-app-store.keychain}"
+TMP_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+TMP_PROFILE="$TMP_ROOT/cmux-appstore.mobileprovision"
+TMP_PLIST="$TMP_ROOT/cmux-appstore-profile.plist"
+PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+RESOLVED_PROFILE_NAME=""
+RESOLVED_PROFILE_UUID=""
+
+validate_profile() {
+  local profile_path="$1"
+  local plist_path="$2"
+  local label="$3"
+  local strict="$4"
+
+  if ! security cms -D -i "$profile_path" > "$plist_path"; then
+    if [ "$strict" = "true" ]; then
+      die "$label is not a readable provisioning profile"
+    fi
+    note "$label is not a readable provisioning profile; ignoring"
+    return 1
+  fi
+
+  local app_id
+  app_id="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$plist_path" 2>/dev/null || true)"
+  if [ "$app_id" != "$EXPECTED_APP_ID" ]; then
+    if [ "$strict" = "true" ]; then
+      die "$label targets unexpected app ID: ${app_id:-<absent>} (expected $EXPECTED_APP_ID)"
+    fi
+    note "$label targets $app_id, expected $EXPECTED_APP_ID; ignoring"
+    return 1
+  fi
+
+  local aps_environment
+  aps_environment="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:aps-environment" "$plist_path" 2>/dev/null || true)"
+  if [ "$aps_environment" != "production" ]; then
+    if [ "$strict" = "true" ]; then
+      die "$label aps-environment is '${aps_environment:-<absent>}', expected 'production'"
+    fi
+    note "$label aps-environment is '${aps_environment:-<absent>}', expected 'production'; ignoring"
+    return 1
+  fi
+
+  local apple_sign_in
+  apple_sign_in="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.applesignin:0" "$plist_path" 2>/dev/null || true)"
+  if [ "$apple_sign_in" != "Default" ]; then
+    if [ "$strict" = "true" ]; then
+      die "$label com.apple.developer.applesignin is '${apple_sign_in:-<absent>}', expected 'Default'"
+    fi
+    note "$label com.apple.developer.applesignin is '${apple_sign_in:-<absent>}', expected 'Default'; ignoring"
+    return 1
+  fi
+
+  RESOLVED_PROFILE_NAME="$(/usr/libexec/PlistBuddy -c "Print :Name" "$plist_path")"
+  RESOLVED_PROFILE_UUID="$(/usr/libexec/PlistBuddy -c "Print :UUID" "$plist_path")"
+  return 0
+}
+
+install_profile() {
+  mkdir -p "$PROFILE_DIR"
+  cp "$TMP_PROFILE" "$PROFILE_DIR/$RESOLVED_PROFILE_UUID.mobileprovision"
+  echo "IOS_APPSTORE_PROVISIONING_PROFILE_NAME=$RESOLVED_PROFILE_NAME" >> "$GITHUB_ENV"
+  note "installed App Store profile '$RESOLVED_PROFILE_NAME'"
+}
+
+try_secret_profile() {
+  local label="$1"
+  local value="$2"
+  local strict="$3"
+
+  if [ -z "$value" ]; then
+    return 1
+  fi
+
+  printf '%s' "$value" | base64 --decode > "$TMP_PROFILE"
+  if validate_profile "$TMP_PROFILE" "$TMP_PLIST" "$label" "$strict"; then
+    install_profile
+    return 0
+  fi
+  return 1
+}
+
+json_id_by_bundle_identifier() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path, identifier = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else body
+for item in data if isinstance(data, list) else []:
+    if item.get("attributes", {}).get("identifier") == identifier:
+        print(item.get("id", ""))
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+json_certificate_id_by_serial() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+def norm(value):
+    return "".join(ch for ch in str(value).upper() if ch.isalnum())
+
+path, serial = sys.argv[1], norm(sys.argv[2])
+with open(path, "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else body
+for item in data if isinstance(data, list) else []:
+    if norm(item.get("attributes", {}).get("serialNumber", "")) == serial:
+        print(item.get("id", ""))
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+json_profile_id_by_name() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path, name = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else body
+for item in data if isinstance(data, list) else []:
+    if item.get("attributes", {}).get("name") == name:
+        print(item.get("id", ""))
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+json_single_id() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else None
+if isinstance(data, dict):
+    print(data.get("id", ""))
+elif isinstance(data, list) and data:
+    print(data[0].get("id", ""))
+else:
+    raise SystemExit(1)
+PY
+}
+
+download_profile_from_asc() {
+  command -v asc >/dev/null || die "asc CLI is required"
+  command -v python3 >/dev/null || die "python3 is required"
+  command -v openssl >/dev/null || die "openssl is required"
+
+  export ASC_KEY_ID="${ASC_KEY_ID:-${ASC_API_KEY_ID:-}}"
+  export ASC_ISSUER_ID="${ASC_ISSUER_ID:-${ASC_API_ISSUER_ID:-}}"
+  export ASC_PRIVATE_KEY_PATH="${ASC_PRIVATE_KEY_PATH:-${ASC_API_KEY_PATH:-}}"
+  if [ -z "${ASC_KEY_ID:-}" ] || [ -z "${ASC_ISSUER_ID:-}" ] || [ -z "${ASC_PRIVATE_KEY_PATH:-}" ]; then
+    die "ASC_KEY_ID, ASC_ISSUER_ID, and ASC_PRIVATE_KEY_PATH are required to fetch a profile"
+  fi
+
+  if [ -z "${IOS_DISTRIBUTION_IDENTITY:-}" ]; then
+    die "IOS_DISTRIBUTION_IDENTITY is required to resolve the matching certificate"
+  fi
+
+  local cert_pem cert_serial
+  cert_pem="$TMP_ROOT/ios-distribution-cert.pem"
+  security find-certificate -c "$IOS_DISTRIBUTION_IDENTITY" -p "$KEYCHAIN_NAME" > "$cert_pem" ||
+    die "could not read imported distribution certificate from $KEYCHAIN_NAME"
+  cert_serial="$(openssl x509 -in "$cert_pem" -noout -serial | sed 's/^serial=//' | tr '[:lower:]' '[:upper:]')"
+  cert_serial="$(printf '%s' "$cert_serial" | tr -cd '[:alnum:]')"
+  [ -n "$cert_serial" ] || die "could not resolve imported distribution certificate serial"
+
+  local bundles_json certs_json profiles_json created_json bundle_id certificate_id profile_id profile_name profile_suffix
+  bundles_json="$TMP_ROOT/asc-bundle-ids.json"
+  certs_json="$TMP_ROOT/asc-certificates.json"
+  profiles_json="$TMP_ROOT/asc-profiles.json"
+  created_json="$TMP_ROOT/asc-created-profile.json"
+
+  asc bundle-ids list --paginate --output json > "$bundles_json"
+  bundle_id="$(json_id_by_bundle_identifier "$bundles_json" "$BUNDLE_IDENTIFIER")" ||
+    die "App Store Connect bundle id not found for $BUNDLE_IDENTIFIER"
+
+  asc certificates list --certificate-type IOS_DISTRIBUTION --paginate --output json > "$certs_json"
+  certificate_id="$(json_certificate_id_by_serial "$certs_json" "$cert_serial")" ||
+    die "App Store Connect certificate not found for imported distribution certificate serial $cert_serial"
+
+  profile_suffix="${cert_serial: -8}"
+  profile_name="cmuxterm App Store CI $profile_suffix"
+  asc profiles list --profile-type IOS_APP_STORE --paginate --output json > "$profiles_json"
+  profile_id="$(json_profile_id_by_name "$profiles_json" "$profile_name" || true)"
+  if [ -z "$profile_id" ]; then
+    note "creating App Store profile '$profile_name'"
+    asc profiles create \
+      --name "$profile_name" \
+      --profile-type IOS_APP_STORE \
+      --bundle "$bundle_id" \
+      --certificate "$certificate_id" \
+      --output json > "$created_json"
+    profile_id="$(json_single_id "$created_json")" ||
+      die "could not read created profile id"
+  else
+    note "reusing App Store profile '$profile_name'"
+  fi
+
+  asc profiles download --id "$profile_id" --output "$TMP_PROFILE" >/dev/null
+  validate_profile "$TMP_PROFILE" "$TMP_PLIST" "ASC profile '$profile_name'" "true"
+  install_profile
+}
+
+if try_secret_profile "IOS_APPSTORE_PROVISIONING_PROFILE_BASE64" "${IOS_APPSTORE_PROVISIONING_PROFILE_BASE64:-}" "true"; then
+  exit 0
+fi
+
+if try_secret_profile "IOS_PROD_PROVISIONING_PROFILE_BASE64" "${IOS_PROD_PROVISIONING_PROFILE_BASE64:-}" "false"; then
+  exit 0
+fi
+
+download_profile_from_asc

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -96,6 +96,9 @@ jobs:
           printf '%s' "$ASC_API_KEY_P8_BASE64" | base64 --decode > "$KEY_PATH"
           chmod 600 "$KEY_PATH"
           echo "ASC_API_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
+          echo "ASC_KEY_ID=$ASC_API_KEY_ID" >> "$GITHUB_ENV"
+          echo "ASC_ISSUER_ID=$ASC_API_ISSUER_ID" >> "$GITHUB_ENV"
+          echo "ASC_PRIVATE_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
       - name: Import iOS distribution signing cert
         env:
@@ -136,39 +139,9 @@ jobs:
 
       - name: Install App Store provisioning profile
         env:
-          IOS_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 || secrets.IOS_PROD_PROVISIONING_PROFILE_BASE64 }}
-        run: |
-          set -euo pipefail
-          if [ -z "${IOS_APPSTORE_PROVISIONING_PROFILE_BASE64:-}" ]; then
-            echo "Missing App Store production provisioning profile secret" >&2
-            exit 1
-          fi
-
-          TMP_PROFILE="$RUNNER_TEMP/cmux-appstore.mobileprovision"
-          TMP_PLIST="$RUNNER_TEMP/cmux-appstore-profile.plist"
-          printf '%s' "$IOS_APPSTORE_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$TMP_PROFILE"
-          security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
-
-          APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$TMP_PLIST")"
-          if [ "$APP_ID" != "7WLXT3NR37.com.cmuxterm.app" ]; then
-            echo "App Store provisioning profile targets unexpected app ID: $APP_ID" >&2
-            exit 1
-          fi
-          APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:aps-environment" "$TMP_PLIST" 2>/dev/null || true)"
-          if [ "$APS_ENVIRONMENT" != "production" ]; then
-            echo "App Store provisioning profile aps-environment is '$APS_ENVIRONMENT', expected 'production'" >&2
-            exit 1
-          fi
-          APPLE_SIGN_IN="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.applesignin:0" "$TMP_PLIST" 2>/dev/null || true)"
-          if [ "$APPLE_SIGN_IN" != "Default" ]; then
-            echo "App Store provisioning profile com.apple.developer.applesignin is '${APPLE_SIGN_IN:-<absent>}', expected 'Default'" >&2
-            exit 1
-          fi
-          PROFILE_NAME="$(/usr/libexec/PlistBuddy -c "Print :Name" "$TMP_PLIST")"
-          PROFILE_UUID="$(/usr/libexec/PlistBuddy -c "Print :UUID" "$TMP_PLIST")"
-          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
-          cp "$TMP_PROFILE" "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
-          echo "IOS_APPSTORE_PROVISIONING_PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
+          IOS_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 }}
+          IOS_PROD_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROD_PROVISIONING_PROFILE_BASE64 }}
+        run: ./.github/scripts/install-app-store-provisioning-profile.sh
 
       - name: Archive, export, and upload production build
         id: upload


### PR DESCRIPTION
## Summary
- stop using the existing prod provisioning profile as a blind App Store fallback because it targets `com.cmux.app`
- add an App Store profile helper that validates an explicit secret when present, ignores the old prod profile if it targets the wrong bundle, and otherwise resolves/creates/downloads a reusable `com.cmuxterm.app` App Store profile from ASC
- export the `ASC_KEY_ID`/`ASC_ISSUER_ID`/`ASC_PRIVATE_KEY_PATH` env names expected by the `asc` CLI while preserving existing `ASC_API_*` env for xcodebuild scripts

## Verification
- `bash -n ios/scripts/install-app-store-provisioning-profile.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-app-store.yml"); puts "yaml ok"'`\n- non-submit production dry run reached profile validation and proved the old fallback targets `7WLXT3NR37.com.cmux.app`: https://github.com/manaflow-ai/cmux/actions/runs/29057496973

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7773"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232380&installation_id=133855650&pr_number=7773&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7773&signature=f0765a3d40912db481c26af45f48c0691ea9eb4f758f840f169721195fc7d47e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production iOS signing and can create App Store Connect profiles via API when secrets are missing; misconfiguration could break releases or create duplicate ASC resources.
> 
> **Overview**
> **App Store CI** no longer treats the legacy prod provisioning secret as an unconditional fallback (it targeted `com.cmux.app`). Profile installation moves into `install-app-store-provisioning-profile.sh`, which enforces `com.cmuxterm.app`, production APS, and Apple Sign In entitlements.
> 
> The helper tries `IOS_APPSTORE_PROVISIONING_PROFILE_BASE64` first (strict), optionally accepts `IOS_PROD_PROVISIONING_PROFILE_BASE64` only when validation passes (non-strict), then uses the `asc` CLI to find or create a certificate-specific App Store profile and download it. The workflow exports `ASC_KEY_ID`, `ASC_ISSUER_ID`, and `ASC_PRIVATE_KEY_PATH` for `asc` while keeping existing `ASC_API_*` variables for xcodebuild scripts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c1b3df1573c565a1e978b6c380222f68b12d9cc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fetch and install the correct App Store provisioning profile for com.cmuxterm.app in CI, replacing the old fallback that targeted com.cmux.app. Adds a script that validates secrets or resolves/creates the profile via `asc`, enforcing the expected app ID and entitlements.

- **New Features**
  - Added `.github/scripts/install-app-store-provisioning-profile.sh` and updated the workflow to run it.
  - Strictly validates `IOS_APPSTORE_PROVISIONING_PROFILE_BASE64`; if absent, tries `IOS_PROD_PROVISIONING_PROFILE_BASE64` only when it matches `7WLXT3NR37.com.cmuxterm.app` with required entitlements; otherwise resolves/creates and downloads a reusable profile via `asc` tied to the imported distribution cert.
  - Sets `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY_PATH` for `asc` (mapped from existing `ASC_API_*`), installs the profile, and exports `IOS_APPSTORE_PROVISIONING_PROFILE_NAME`.

<sup>Written for commit 9c1b3df1573c565a1e978b6c380222f68b12d9cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS App Store build reliability by validating provisioning profiles before installation.
  * Added fallback handling to retrieve or create a compatible provisioning profile when stored credentials are unavailable.
  * Ensured required App Store Connect signing details are available to subsequent build steps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->