### PR TITLE
Disable the workspace agent spinner behind a flag

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10077,7 +10077,6 @@ struct VerticalTabsSidebar: View {
     @LiveSetting(\.customSidebars.renderer) private var customSidebarRenderer
     @LiveSetting(\.shortcuts.showModifierHoldHints) private var showModifierHoldHints
     @LiveSetting(\.sidebar.showAgentActivity) private var showAgentActivity
-    private let featureFlags = CmuxFeatureFlags.shared
 #if DEBUG
     @Environment(\.minimalModeInvalidationProbe) private var minimalModeInvalidationProbe
 #endif
@@ -12430,7 +12429,7 @@ struct VerticalTabsSidebar: View {
             accessibilityWorkspaceCount: renderContext.workspaceCount,
             unreadCount: liveUnreadCount,
             latestNotificationText: liveLatestNotificationText,
-            showsAgentActivity: showAgentActivity && featureFlags.isSidebarWorkspaceAgentSpinnerEnabled,
+            showsAgentActivity: showAgentActivity && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled,
             rowSpacing: tabRowSpacing,
             setSelectionToTabs: { selection = .tabs },
             selectedTabIds: $selectedTabIds,
@@ -13980,11 +13979,7 @@ struct TabItemView: View, Equatable {
             guard !Task.isCancelled, workspaceFinderDirectoryOpenRequest == request else { return }
             workspaceFinderDirectoryOpenRequest = nil
         }
-        .sidebarAgentRuntimeObservation(
-            id: tab.id,
-            enabled: showsAgentActivity,
-            model: tab.sidebarAgentRuntimeObservation
-        ) { refreshWorkspaceSnapshot() }
+        .sidebarAgentRuntimeObservation(id: tab.id, model: tab.sidebarAgentRuntimeObservation) { refreshWorkspaceSnapshot() }
         .onReceive(
             tab.sidebarImmediateObservationPublisher
                 .receive(on: RunLoop.main)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10358,9 +10358,7 @@ struct VerticalTabsSidebar: View {
 
     struct WorkspaceListRenderContext {
         let tabs: [Workspace]
-        /// Stored snapshot of `tabs.map(\.id)` so per-row predicates that need
-        /// it (e.g. `SidebarTabDropIndicatorPredicate.topVisible`) don't pay
-        /// O(n) per row.
+        /// Stored `tabs.map(\.id)` snapshot so row predicates avoid O(n) work.
         let tabIds: [UUID]
         /// Drag-scope row ids shared by every visible row for this render pass.
         let sidebarReorderIds: [UUID]
@@ -10368,6 +10366,7 @@ struct VerticalTabsSidebar: View {
         let canCloseWorkspace: Bool
         let workspaceNumberShortcut: StoredShortcut
         let tabItemSettings: SidebarTabItemSettingsSnapshot
+        let showsAgentActivity: Bool
         let pinResolutionContext: WorkspaceActionDispatcher.PinResolutionContext
         let tabIndexById: [UUID: Int]
         let workspaceById: [UUID: Workspace]
@@ -10446,6 +10445,7 @@ struct VerticalTabsSidebar: View {
             canCloseWorkspace: canCloseWorkspace,
             workspaceNumberShortcut: workspaceNumberShortcut,
             tabItemSettings: tabItemSettings,
+            showsAgentActivity: showAgentActivity && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled,
             pinResolutionContext: pinResolutionContext,
             tabIndexById: tabIndexById,
             workspaceById: workspaceById,
@@ -12429,7 +12429,7 @@ struct VerticalTabsSidebar: View {
             accessibilityWorkspaceCount: renderContext.workspaceCount,
             unreadCount: liveUnreadCount,
             latestNotificationText: liveLatestNotificationText,
-            showsAgentActivity: showAgentActivity && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled,
+            showsAgentActivity: renderContext.showsAgentActivity,
             rowSpacing: tabRowSpacing,
             setSelectionToTabs: { selection = .tabs },
             selectedTabIds: $selectedTabIds,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -10077,6 +10077,7 @@ struct VerticalTabsSidebar: View {
     @LiveSetting(\.customSidebars.renderer) private var customSidebarRenderer
     @LiveSetting(\.shortcuts.showModifierHoldHints) private var showModifierHoldHints
     @LiveSetting(\.sidebar.showAgentActivity) private var showAgentActivity
+    private let featureFlags = CmuxFeatureFlags.shared
 #if DEBUG
     @Environment(\.minimalModeInvalidationProbe) private var minimalModeInvalidationProbe
 #endif
@@ -12429,7 +12430,7 @@ struct VerticalTabsSidebar: View {
             accessibilityWorkspaceCount: renderContext.workspaceCount,
             unreadCount: liveUnreadCount,
             latestNotificationText: liveLatestNotificationText,
-            showsAgentActivity: showAgentActivity,
+            showsAgentActivity: showAgentActivity && featureFlags.isSidebarWorkspaceAgentSpinnerEnabled,
             rowSpacing: tabRowSpacing,
             setSelectionToTabs: { selection = .tabs },
             selectedTabIds: $selectedTabIds,
@@ -13979,7 +13980,11 @@ struct TabItemView: View, Equatable {
             guard !Task.isCancelled, workspaceFinderDirectoryOpenRequest == request else { return }
             workspaceFinderDirectoryOpenRequest = nil
         }
-        .sidebarAgentRuntimeObservation(id: tab.id, model: tab.sidebarAgentRuntimeObservation) { refreshWorkspaceSnapshot() }
+        .sidebarAgentRuntimeObservation(
+            id: tab.id,
+            enabled: showsAgentActivity,
+            model: tab.sidebarAgentRuntimeObservation
+        ) { refreshWorkspaceSnapshot() }
         .onReceive(
             tab.sidebarImmediateObservationPublisher
                 .receive(on: RunLoop.main)

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -66,7 +66,7 @@ final class CmuxFeatureFlags {
                     localized: "featureFlags.proUpgrade.description",
                     defaultValue: "Shows Pro upgrade entrypoints in the sidebar, Settings, command palette, and Help menu."
                 ),
-                defaultWhenUnavailable: Self.proUpgradeUIDefault
+                defaultWhenUnavailable: CmuxFeatureFlags.proUpgradeUIDefault
             ),
 
             // FLAG(key: mobile-connect-button-enabled-release, owner: lawrencecchen,
@@ -81,7 +81,7 @@ final class CmuxFeatureFlags {
                     localized: "featureFlags.mobileConnect.description",
                     defaultValue: "Shows the iPhone button that opens the Mobile Connect pairing window."
                 ),
-                defaultWhenUnavailable: Self.mobileConnectButtonDefault
+                defaultWhenUnavailable: CmuxFeatureFlags.mobileConnectButtonDefault
             ),
 
             // FLAG(key: cloud-vm-ui-enabled-release, owner: lawrencecchen,
@@ -98,7 +98,7 @@ final class CmuxFeatureFlags {
                     localized: "featureFlags.cloudVM.description",
                     defaultValue: "Shows Cloud VM entrypoints in the new-workspace dropdown and command palette."
                 ),
-                defaultWhenUnavailable: Self.cloudVMUIDefault
+                defaultWhenUnavailable: CmuxFeatureFlags.cloudVMUIDefault
             ),
 
             // FLAG(key: agent-chat-ui-enabled-release, owner: lawrencecchen,
@@ -113,7 +113,7 @@ final class CmuxFeatureFlags {
                     localized: "featureFlags.agentChat.description",
                     defaultValue: "Shows Agent Chat entrypoints in the new-workspace dropdown, command palette, and surface tab bar."
                 ),
-                defaultWhenUnavailable: Self.agentChatUIDefault
+                defaultWhenUnavailable: CmuxFeatureFlags.agentChatUIDefault
             ),
 
             // FLAG(key: sidebar-workspace-agent-spinner-experiment, owner: lawrencecchen,
@@ -130,7 +130,7 @@ final class CmuxFeatureFlags {
                     localized: "featureFlags.sidebarWorkspaceAgentSpinner.description",
                     defaultValue: "Shows a spinner in workspace rows while coding agents are running."
                 ),
-                defaultWhenUnavailable: Self.sidebarWorkspaceAgentSpinnerDefault
+                defaultWhenUnavailable: CmuxFeatureFlags.sidebarWorkspaceAgentSpinnerDefault
             ),
         ]
     }()

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -45,6 +45,7 @@ final class CmuxFeatureFlags {
     private static let cloudVMUIDefault = false
     #endif
     private static let agentChatUIDefault = false
+    private static let sidebarWorkspaceAgentSpinnerDefault = false
 
     private static let overrideKeyPrefix = "cmux.flags.override."
 
@@ -114,6 +115,23 @@ final class CmuxFeatureFlags {
                 ),
                 defaultWhenUnavailable: Self.agentChatUIDefault
             ),
+
+            // FLAG(key: sidebar-workspace-agent-spinner-experiment, owner: lawrencecchen,
+            //      reviewBy: 2026-10-01, defaultWhenUnavailable: false)
+            // Shows the coding-agent activity spinner in workspace rows. Hidden
+            // by default while multi-agent lifecycle edge cases are investigated.
+            CmuxFeatureFlagDefinition(
+                key: "sidebar-workspace-agent-spinner-experiment",
+                title: String(
+                    localized: "featureFlags.sidebarWorkspaceAgentSpinner.title",
+                    defaultValue: "Workspace agent spinner"
+                ),
+                flagDescription: String(
+                    localized: "featureFlags.sidebarWorkspaceAgentSpinner.description",
+                    defaultValue: "Shows a spinner in workspace rows while coding agents are running."
+                ),
+                defaultWhenUnavailable: Self.sidebarWorkspaceAgentSpinnerDefault
+            ),
         ]
     }
 
@@ -131,6 +149,10 @@ final class CmuxFeatureFlags {
 
     var isAgentChatUIEnabled: Bool {
         effectiveValue(for: Self.allFlags[3])
+    }
+
+    var isSidebarWorkspaceAgentSpinnerEnabled: Bool {
+        effectiveValue(for: Self.allFlags[4])
     }
 
     @ObservationIgnored

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -52,7 +52,7 @@ final class CmuxFeatureFlags {
     // Order is load-bearing for the typed accessors below. A keyed lookup would
     // repeat flag-key literals and violate the feature-flag lint's single
     // evaluation-site rule.
-    static var allFlags: [CmuxFeatureFlagDefinition] {
+    static let allFlags: [CmuxFeatureFlagDefinition] = {
         [
             // FLAG(key: pro-upgrade-ui-enabled-release, owner: lawrencecchen,
             //      reviewBy: 2026-10-01, defaultWhenUnavailable: false)
@@ -133,7 +133,7 @@ final class CmuxFeatureFlags {
                 defaultWhenUnavailable: Self.sidebarWorkspaceAgentSpinnerDefault
             ),
         ]
-    }
+    }()
 
     var isProUpgradeUIEnabled: Bool {
         effectiveValue(for: Self.allFlags[0])

--- a/Sources/SidebarAgentActivitySummary.swift
+++ b/Sources/SidebarAgentActivitySummary.swift
@@ -3,10 +3,10 @@ import Foundation
 enum SidebarAgentActivitySummary {
     static func visibleActiveCodingAgentCount(
         showsAgentActivity: Bool,
-        statesByPanelId: [UUID: [String: AgentHibernationLifecycleState]]
+        statesByPanelId: @autoclosure () -> [UUID: [String: AgentHibernationLifecycleState]]
     ) -> Int {
         guard showsAgentActivity else { return 0 }
-        return activeCodingAgentCount(statesByPanelId: statesByPanelId)
+        return activeCodingAgentCount(statesByPanelId: statesByPanelId())
     }
 
     static func activeCodingAgentCount(

--- a/Sources/WorkspaceSidebarObservation.swift
+++ b/Sources/WorkspaceSidebarObservation.swift
@@ -16,12 +16,10 @@ private struct SidebarPanelObservationState: Equatable {
 extension View {
     func sidebarAgentRuntimeObservation(
         id: UUID,
-        enabled: Bool,
         model: WorkspaceSidebarAgentRuntimeObservationModel,
         onChange: @MainActor @escaping () -> Void
     ) -> some View {
-        task(id: enabled ? id : nil) { @MainActor in
-            guard enabled else { return }
+        task(id: id) { @MainActor in
             for await _ in model.changes() {
                 if Task.isCancelled { break }
                 onChange()

--- a/Sources/WorkspaceSidebarObservation.swift
+++ b/Sources/WorkspaceSidebarObservation.swift
@@ -16,10 +16,12 @@ private struct SidebarPanelObservationState: Equatable {
 extension View {
     func sidebarAgentRuntimeObservation(
         id: UUID,
+        enabled: Bool,
         model: WorkspaceSidebarAgentRuntimeObservationModel,
         onChange: @MainActor @escaping () -> Void
     ) -> some View {
-        task(id: id) { @MainActor in
+        task(id: enabled ? id : nil) { @MainActor in
+            guard enabled else { return }
             for await _ in model.changes() {
                 if Task.isCancelled { break }
                 onChange()

--- a/cmuxTests/SidebarWorkspaceSnapshotAgentActivityTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotAgentActivityTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import CmuxSidebar
 import Testing
 
@@ -8,6 +9,22 @@ import Testing
 #endif
 
 extension SidebarWorkspaceSnapshotRefreshPolicyTests {
+    @MainActor
+    @Test func workspaceAgentSpinnerFeatureFlagDefaultsOff() throws {
+        let definition = try #require(CmuxFeatureFlags.allFlags.first {
+            $0.key == "sidebar-workspace-agent-spinner-experiment"
+        })
+        let suiteName = "cmux.feature.flags.sidebar-workspace-agent-spinner.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer {
+            defaults.removePersistentDomain(forName: suiteName)
+        }
+
+        let flags = CmuxFeatureFlags(defaults: defaults, remoteFlagValueProvider: { _ in nil })
+
+        #expect(!flags.effectiveValue(for: definition))
+    }
+
     @Test func contextMenuAgentActivityChangeUpdatesDisplayedSpinnerImmediately() {
         let current = Self.snapshot(
             latestConversationMessage: "old message",
@@ -38,5 +55,26 @@ extension SidebarWorkspaceSnapshotRefreshPolicyTests {
         #expect(hidden != visible)
         #expect(!hidden.showsAgentActivity)
         #expect(visible.showsAgentActivity)
+    }
+
+    @Test func disabledSpinnerDoesNotReadAgentLifecycleStates() {
+        var didReadAgentLifecycleStates = false
+        let agentLifecycleStates: () -> [UUID: [String: AgentHibernationLifecycleState]] = {
+            didReadAgentLifecycleStates = true
+            return [
+                UUID(): [
+                    "codex": .running,
+                    "claude_code": .running,
+                ],
+            ]
+        }
+
+        let count = SidebarAgentActivitySummary.visibleActiveCodingAgentCount(
+            showsAgentActivity: false,
+            statesByPanelId: agentLifecycleStates()
+        )
+
+        #expect(count == 0)
+        #expect(!didReadAgentLifecycleStates)
     }
 }


### PR DESCRIPTION
## Summary
- add a PostHog-backed workspace agent spinner experiment flag that defaults off
- stop row lifecycle observation and state reads while the spinner is disabled
- keep the existing sidebar activity setting ready for later re-enablement

## Testing
- `python3 scripts/lint-feature-flags.py`
- parsed `Resources/Localizable.xcstrings` and verified English/Japanese entries
- cloud tagged build: `./scripts/reload-cloud.sh --tag spnff`
- tagged socket preflight with two workspace loading IDs active and no spinner rendered
- focused test execution deferred to CI because the repository guard blocks local test hosts

## Task
- User report: the workspace sidebar spinner is buggy, especially with multiple agents running concurrently.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7774"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786232730&installation_id=133855650&pr_number=7774&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7774&signature=9b6ffbc423b27325c85b784f1defda037b7e858ae6d24e8b9e9e987e27ed71a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI gating behind a flag defaulting off; no auth, data, or payment paths touched.
> 
> **Overview**
> Turns off the workspace sidebar **coding-agent spinner** by default via a new PostHog flag, `sidebar-workspace-agent-spinner-experiment`, while keeping the existing `sidebar.showAgentActivity` setting in place for when the experiment is re-enabled.
> 
> Spinner visibility is now computed once per sidebar render pass as `showAgentActivity && isSidebarWorkspaceAgentSpinnerEnabled` and passed through `WorkspaceListRenderContext` to each row. **`SidebarAgentActivitySummary`** uses an `@autoclosure` so agent lifecycle maps are not read when activity display is off. Localization and tests cover default-off behavior and skipped lifecycle reads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 697e5e870e6c25ab39d077a85a70f2200628e616. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disables the workspace sidebar agent spinner behind a PostHog feature flag that defaults off, and defers agent lifecycle reads unless visible to avoid multi‑agent glitches and extra work. Also fixes stale flag values on CI by making the flag registry static.

- **New Features**
  - Added `sidebar-workspace-agent-spinner-experiment` flag (default off) with localized title/description.
  - Gated spinner rendering and lifecycle access behind the flag and `sidebar.showAgentActivity`, with visibility snapshotted in the sidebar render context.
  - Added tests for default-off behavior and lazy lifecycle reads; fixed CI flag caching to ensure correct defaults.

<sup>Written for commit 697e5e870e6c25ab39d077a85a70f2200628e616. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a feature flag to control the coding-agent activity spinner in workspace rows.
  * Added English and Japanese localization for the new setting.

* **Bug Fixes**
  * Agent activity monitoring now runs only when the activity display is enabled.
  * Disabled activity indicators no longer evaluate unnecessary agent state data.

* **Tests**
  * Added coverage for the feature flag’s default-off behavior and disabled spinner handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->