### PR TITLE
Fix automatic iOS archive signing settings

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -581,9 +581,10 @@ if [[ -z "$ARCHIVE_PATH" ]]; then
   ARCHIVE_PATH="$OUT_DIR/cmux.xcarchive"
   if [[ "$SIGNING" == "automatic" ]]; then
     # Automatic signing must archive a signed app so Xcode has the requested
-    # Release entitlements to preserve during App Store Connect export. An
-    # unsigned archive exports with only the profile baseline and drops
-    # aps-environment, which the gate below correctly refuses to upload.
+    # Release entitlements to preserve during App Store Connect export. The
+    # iOS app target gets those entitlements from Config/Release.xcconfig; do
+    # not pass CODE_SIGN_ENTITLEMENTS here because command-line build settings
+    # apply to every SwiftPM target in the workspace.
     xcodebuild archive \
       -workspace "$WORKSPACE" \
       -scheme "$SCHEME" \
@@ -599,8 +600,6 @@ if [[ -z "$ARCHIVE_PATH" ]]; then
       CURRENT_PROJECT_VERSION="$BUILD_NUMBER" \
       ${MARKETING_VERSION_ARGS[@]+"${MARKETING_VERSION_ARGS[@]}"} \
       CODE_SIGN_STYLE=Automatic \
-      CODE_SIGN_ENTITLEMENTS="Config/cmux-release.entitlements" \
-      CODE_SIGN_IDENTITY="Apple Distribution" \
       CODE_SIGNING_ALLOWED=YES \
       CODE_SIGNING_REQUIRED=YES \
       | tee "$OUT_DIR/archive.log"


### PR DESCRIPTION
## Summary
- stop passing `CODE_SIGN_ENTITLEMENTS` globally for automatic iOS archive builds
- stop passing `CODE_SIGN_IDENTITY=Apple Distribution` globally in automatic signing mode
- leave the existing post-export IPA entitlement gate in place

## Why
The non-submit App Store workflow run https://github.com/manaflow-ai/cmux/actions/runs/29062732167 reached `Archive, export, and upload production build` with the ASC API key materialized, then failed with Xcode exit 65. The automatic archive command applied `CODE_SIGN_ENTITLEMENTS=Config/cmux-release.entitlements` to every SwiftPM target, making dependencies look for nonexistent `Config/cmux-release.entitlements` files. Xcode also reported a manual identity conflict because `CODE_SIGN_IDENTITY=Apple Distribution` was forced while the target was automatically signed.

`ios/Config/Release.xcconfig` already supplies `CODE_SIGN_ENTITLEMENTS = Config/cmux-release.entitlements` for the iOS app target.

## Verification
- `bash -n ios/scripts/upload-testflight.sh ios/scripts/upload-app-store.sh`
- `git diff --check`
- `./scripts/ensure-ghosttykit.sh`
- `xcodebuild -workspace ios/cmux.xcworkspace -scheme cmux-ios -configuration Release -destination 'generic/platform=iOS' -showBuildSettings` confirmed the app target sees `CODE_SIGN_ENTITLEMENTS = Config/cmux-release.entitlements`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow change to automatic archive CLI flags in one script; release entitlements remain on the app via xcconfig and upload safety checks are unchanged.
> 
> **Overview**
> Fixes CI **automatic** `xcodebuild archive` failures (Xcode exit 65) by no longer passing workspace-wide `CODE_SIGN_ENTITLEMENTS` or `CODE_SIGN_IDENTITY=Apple Distribution` on the command line in `upload-testflight.sh`.
> 
> Those CLI settings apply to **every** SwiftPM target, so dependencies tried to sign with a nonexistent `Config/cmux-release.entitlements` and automatic signing conflicted with a forced distribution identity. Release entitlements for the iOS app still come from `Config/Release.xcconfig`; the existing post-export IPA entitlement gate is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b8831133a654fe099d9d320895e9109b9442573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7782"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786239761&installation_id=133855650&pr_number=7782&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7782&signature=8e0c896181d9b6c7ff77b6c32c2e1bf03b2a2a8774b776a4fa097e28d4f99e3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Xcode exit 65 during automatic iOS App Store archives by removing global signing flags and relying on the app’s xcconfig for entitlements.

- **Bug Fixes**
  - Stop passing `CODE_SIGN_ENTITLEMENTS` and `CODE_SIGN_IDENTITY="Apple Distribution"` to `xcodebuild archive` when `SIGNING=automatic`; keep `CODE_SIGN_STYLE=Automatic`.
  - Use entitlements from `ios/Config/Release.xcconfig` so only the app target receives `Config/cmux-release.entitlements` (avoids SwiftPM target errors).
  - Keep the post-export IPA entitlements gate to ensure `aps-environment` is preserved.

<sup>Written for commit 0b8831133a654fe099d9d320895e9109b9442573. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved automatic signing during TestFlight archive uploads by using the app’s release configuration.
  * Prevented signing settings from being incorrectly applied to package targets during builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->