### PR TITLE
Make Settings open structurally reliable: AppKit-owned window lifecycle

### DIFF
--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemMisc.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemMisc.swift
@@ -30,10 +30,16 @@ extension ControlCommandCoordinator {
     func settingsOpen(_ params: [String: JSONValue]) -> ControlCallResult {
         let targetRaw = string(params, "target")
         let requestedActivate = bool(params, "activate") ?? true
-        let resolution = systemContext?.controlSettingsOpen(
+        guard let systemContext else {
+            // Fail closed: without the app context no window can have been
+            // presented, and `opened` must mean a window actually exists
+            // (https://github.com/manaflow-ai/cmux/issues/7775).
+            return .err(code: "unavailable", message: "Settings context not attached", data: nil)
+        }
+        let resolution = systemContext.controlSettingsOpen(
             targetRaw: targetRaw,
             requestedActivate: requestedActivate
-        ) ?? .opened(target: targetRaw ?? "general")
+        )
         switch resolution {
         case .invalidTarget:
             return .err(

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemMisc.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlCommandCoordinator+SystemMisc.swift
@@ -46,6 +46,12 @@ extension ControlCommandCoordinator {
                 "opened": .bool(true),
                 "target": .string(target),
             ]))
+        case .failed(let message):
+            return .err(
+                code: "unavailable",
+                message: message,
+                data: .object(["target": orNull(targetRaw)])
+            )
         }
     }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSettingsOpenResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/System/ControlSettingsOpenResolution.swift
@@ -1,10 +1,15 @@
 /// The outcome of `settings.open` (the legacy `v2SettingsOpen` body): the app
 /// validates the target against its `SettingsNavigationTarget` enum and
-/// schedules the window presentation.
+/// presents the window before replying, so `opened` means a window actually
+/// materialized (https://github.com/manaflow-ai/cmux/issues/7775).
 public enum ControlSettingsOpenResolution: Sendable, Equatable {
     /// The `target` param did not name a known settings pane.
     case invalidTarget
-    /// The settings window presentation was scheduled. Carries the resolved
-    /// target raw value (`"general"` when no target was given).
+    /// The settings window was presented (or ordered front under a hidden
+    /// app). Carries the resolved target raw value (`"general"` when no
+    /// target was given).
     case opened(target: String)
+    /// The app could not make a settings window visible. `message` carries
+    /// the diagnostic reason from the window presenter.
+    case failed(message: String)
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -116,6 +116,12 @@ public struct SettingsWindowRoot: View {
         .onReceive(NotificationCenter.default.publisher(for: Self.navigationRequestName)) { notification in
             applyNavigationRequest(notification)
         }
+        .onReceive(NotificationCenter.default.publisher(for: Self.sidebarToggleRequestName)) { _ in
+            // AppKit hosts this window, so SwiftUI's SidebarCommands cannot
+            // reach the split view; the host app routes its sidebar-toggle
+            // menu command here when the Settings window is key.
+            columnVisibility = columnVisibility == .detailOnly ? .all : .detailOnly
+        }
         .onChange(of: searchText) { _, newValue in
             // Legacy SettingsRootView resyncs the sidebar entry to the
             // section row whenever the search text is cleared, so
@@ -127,6 +133,7 @@ public struct SettingsWindowRoot: View {
     }
 
     public static let navigationRequestName = Notification.Name("cmux.settings.navigate")
+    public static let sidebarToggleRequestName = Notification.Name("cmux.settings.toggleSidebar")
 
     /// Legacy `SettingsRootView.onReceive` only updates the selection
     /// state (sidebar entry + section pane) in response to an external

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -1,36 +1,15 @@
 import CmuxSettings
 import SwiftUI
 
-/// The settings window SwiftUI `Scene`.
+/// Root view of the settings window, hosted in an AppKit-owned
+/// `NSWindow` by the app's `SettingsWindowFactory` (cmux issue
+/// #7777; a SwiftUI `Window` scene's `openWindow(id:)` could
+/// silently no-op and strand the open path).
 ///
 /// Composes a single tall `ScrollView` of stacked sections — the
 /// legacy in-app layout — with a left sidebar that scrolls to a
-/// section's anchor on click. This mirrors what cmux's settings
-/// window has historically looked like; using a `NavigationSplitView`
-/// with one-pane-at-a-time selection was a previous (now reverted)
-/// architecture choice.
-@MainActor
-public struct SettingsWindowScene: Scene {
-    private let runtime: SettingsRuntime
-
-    public init(runtime: SettingsRuntime) {
-        self.runtime = runtime
-    }
-
-    public var body: some Scene {
-        WindowGroup(String(localized: "settings.title", defaultValue: "Settings"), id: "cmux.settings") {
-            SettingsWindowRoot(runtime: runtime)
-                .settingsRuntime(runtime)
-        }
-        .defaultSize(width: 980, height: 680)
-        .windowResizability(.contentMinSize)
-        .commands { SidebarCommands() }
-    }
-}
-
-/// Root view of the settings window. Owns the search query, the
-/// scroll proxy, and the section anchors. Renders sidebar + tall
-/// scrolling content side-by-side.
+/// section's anchor on click. Owns the search query, the scroll
+/// proxy, and the section anchors.
 @MainActor
 public struct SettingsWindowRoot: View {
     private let runtime: SettingsRuntime
@@ -50,8 +29,10 @@ public struct SettingsWindowRoot: View {
     // because under search the user can click an individual setting
     // hit and we still want the section pane to follow, but two
     // sibling hits inside one section must each be selectable.
-    @SceneStorage("selectedSettingsSection") private var selectedSectionRaw: String = SettingsSectionID.account.rawValue
-    @SceneStorage("selectedSettingsSidebarEntry") private var selectedSidebarEntryID: String = "section:\(SettingsSectionID.account.rawValue)"
+    // @AppStorage (not @SceneStorage): the window is AppKit-hosted, so
+    // there is no SwiftUI scene to store into (cmux issue #7777).
+    @AppStorage("selectedSettingsSection") private var selectedSectionRaw: String = SettingsSectionID.account.rawValue
+    @AppStorage("selectedSettingsSidebarEntry") private var selectedSidebarEntryID: String = "section:\(SettingsSectionID.account.rawValue)"
     // Legacy `SettingsRootView` binds `NavigationSplitView`'s
     // `columnVisibility` so the user can collapse the sidebar via the
     // toolbar button (or the SidebarCommands menu) and have that state

--- a/Sources/App/AppDelegateSettingsPresentation.swift
+++ b/Sources/App/AppDelegateSettingsPresentation.swift
@@ -1,0 +1,44 @@
+import AppKit
+
+/// The Settings-open entrypoints shared by the app menu, ⌘,, the command
+/// palette, help commands, and the menu-bar extra. Split out of
+/// `AppDelegate.swift` (file-length budget) alongside the AppKit-owned
+/// Settings window lifecycle (https://github.com/manaflow-ai/cmux/issues/7777).
+extension AppDelegate {
+    @MainActor
+    static func presentPreferencesWindow(
+        navigationTarget: SettingsNavigationTarget? = nil,
+        showFallbackSettingsWindow: (@MainActor (SettingsNavigationTarget?) -> Void)? = nil,
+        activateApplication: @MainActor () -> Void = {
+            NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+        }
+    ) {
+#if DEBUG
+        cmuxDebugLog("settings.open.present path=appkitWindow")
+#endif
+        if let showFallbackSettingsWindow {
+            showFallbackSettingsWindow(navigationTarget)
+        } else if case .failed = SettingsWindowPresenter.show(navigationTarget: navigationTarget) {
+            // The presenter already logged the loud failure diagnostics;
+            // surface the failed menu/⌘, action instead of silently activating.
+            NSSound.beep()
+            return
+        }
+        activateApplication()
+#if DEBUG
+        cmuxDebugLog("settings.open.present activate=1")
+#endif
+    }
+
+    @MainActor
+    func openPreferencesWindow(debugSource: String, navigationTarget: SettingsNavigationTarget? = nil) {
+#if DEBUG
+        cmuxDebugLog("settings.open.request source=\(debugSource)")
+#endif
+        Self.presentPreferencesWindow(navigationTarget: navigationTarget)
+    }
+
+    @objc func openPreferencesWindow() {
+        openPreferencesWindow(debugSource: "appDelegate")
+    }
+}

--- a/Sources/App/AppDelegateSettingsPresentation.swift
+++ b/Sources/App/AppDelegateSettingsPresentation.swift
@@ -9,8 +9,11 @@ extension AppDelegate {
     static func presentPreferencesWindow(
         navigationTarget: SettingsNavigationTarget? = nil,
         showFallbackSettingsWindow: (@MainActor (SettingsNavigationTarget?) -> Void)? = nil,
+        // The legacy body also passed .activateIgnoringOtherApps; the option
+        // is deprecated and documented as a no-op on macOS 14+ (this target's
+        // minimum), so dropping it is behavior-neutral.
         activateApplication: @MainActor () -> Void = {
-            NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
+            NSRunningApplication.current.activate(options: [.activateAllWindows])
         }
     ) {
 #if DEBUG

--- a/Sources/App/SettingsWindowFactory.swift
+++ b/Sources/App/SettingsWindowFactory.swift
@@ -33,6 +33,20 @@ enum SettingsWindowFactory {
     }
 }
 
+extension SettingsWindowPresenter {
+    /// Routes the app's sidebar-toggle menu command (Toggle Left Sidebar) to
+    /// the Settings split view when the Settings window is key. The AppKit-
+    /// hosted window gets no SwiftUI `SidebarCommands`, so without this the
+    /// command would toggle a terminal window's sidebar instead.
+    static func handleSidebarToggleIfSettingsWindowIsKey(
+        keyWindow: NSWindow? = NSApp.keyWindow
+    ) -> Bool {
+        guard keyWindow?.identifier?.rawValue == windowIdentifier else { return false }
+        NotificationCenter.default.post(name: SettingsWindowRoot.sidebarToggleRequestName, object: nil)
+        return true
+    }
+}
+
 /// Settings window class that records the moment close teardown begins, so
 /// ``SettingsWindowPresenter`` can deterministically refuse to reuse a dying
 /// window even when a foreign `willClose` observer re-enters `show()` before
@@ -61,14 +75,10 @@ struct SettingsWindowHostRoot: View {
             .cmuxFontMagnificationEnvironment()
             .cmuxAppearanceColorScheme(appearanceMode)
             .onAppear {
-                guard let target = SettingsWindowPresenter.consumePendingNavigationTarget() else {
-                    return
-                }
-                // One main-actor hop so the content's own notification
-                // subscriptions are in place before the request posts.
-                Task { @MainActor in
-                    SettingsNavigationRequest.post(target)
-                }
+                // The presenter defers the post one main-actor hop (so the
+                // content's restore navigation cannot clobber it) and guards
+                // it against being superseded by a newer targeted show.
+                SettingsWindowPresenter.deliverPendingNavigationAfterContentAppears()
             }
     }
 

--- a/Sources/App/SettingsWindowFactory.swift
+++ b/Sources/App/SettingsWindowFactory.swift
@@ -25,11 +25,25 @@ enum SettingsWindowFactory {
         // Bridge SwiftUI's navigation title, the sidebar toggle, and the
         // search field into the AppKit window's titlebar/toolbar.
         hostingController.sceneBridgingOptions = [.toolbars, .title]
-        let window = NSWindow(contentViewController: hostingController)
+        let window = SettingsHostWindow(contentViewController: hostingController)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
         window.title = String(localized: "settings.title", defaultValue: "Settings")
         window.setContentSize(NSSize(width: 980, height: 680))
         return window
+    }
+}
+
+/// Settings window class that records the moment close teardown begins, so
+/// ``SettingsWindowPresenter`` can deterministically refuse to reuse a dying
+/// window even when a foreign `willClose` observer re-enters `show()` before
+/// the presenter's own observer runs (notification-observer order is not a
+/// lifecycle invariant).
+class SettingsHostWindow: NSWindow {
+    private(set) var isClosingSettingsWindow = false
+
+    override func close() {
+        isClosingSettingsWindow = true
+        super.close()
     }
 }
 

--- a/Sources/App/SettingsWindowFactory.swift
+++ b/Sources/App/SettingsWindowFactory.swift
@@ -1,0 +1,81 @@
+import AppKit
+import CmuxFoundation
+import CmuxSettingsUI
+import SwiftUI
+import os
+
+/// Builds the AppKit-owned Settings window
+/// (https://github.com/manaflow-ai/cmux/issues/7777).
+///
+/// Construction is synchronous and infallible: unlike the previous SwiftUI
+/// `Window` scene + `openWindow(id:)` path, a call here always returns a real
+/// `NSWindow`, so ``SettingsWindowPresenter`` can guarantee an open request
+/// ends with a visible window. SwiftUI is used only for the window's content.
+@MainActor
+enum SettingsWindowFactory {
+    private nonisolated static let log = Logger(subsystem: "com.cmuxterm.app", category: "Settings")
+
+    static func makeSettingsWindow() -> NSWindow {
+        if AppDelegate.shared?.settingsRuntime == nil {
+            // ``SettingsWindowHostRoot`` presents a visible, localized error
+            // in this state — loud, never a silent no-op (issue #7777).
+            log.fault("settings.window.factory settingsRuntime unavailable; presenting fallback content")
+        }
+        let hostingController = NSHostingController(rootView: SettingsWindowHostRoot())
+        // Bridge SwiftUI's navigation title, the sidebar toggle, and the
+        // search field into the AppKit window's titlebar/toolbar.
+        hostingController.sceneBridgingOptions = [.toolbars, .title]
+        let window = NSWindow(contentViewController: hostingController)
+        window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+        window.title = String(localized: "settings.title", defaultValue: "Settings")
+        window.setContentSize(NSSize(width: 980, height: 680))
+        return window
+    }
+}
+
+/// Root SwiftUI content of the AppKit-hosted Settings window. Applies the
+/// environment the removed `Window` scene used to apply (settings runtime,
+/// font magnification, appearance override) — an AppKit-hosted view does not
+/// inherit the App scene's SwiftUI environment — and delivers any pending
+/// navigation target once the content is live.
+struct SettingsWindowHostRoot: View {
+    @AppStorage(AppearanceSettings.appearanceModeKey)
+    private var appearanceMode = AppearanceSettings.defaultMode.rawValue
+
+    var body: some View {
+        content
+            .cmuxFontMagnificationEnvironment()
+            .cmuxAppearanceColorScheme(appearanceMode)
+            .onAppear {
+                guard let target = SettingsWindowPresenter.consumePendingNavigationTarget() else {
+                    return
+                }
+                // One main-actor hop so the content's own notification
+                // subscriptions are in place before the request posts.
+                Task { @MainActor in
+                    SettingsNavigationRequest.post(target)
+                }
+            }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if let runtime = AppDelegate.shared?.settingsRuntime {
+            SettingsWindowRoot(runtime: runtime)
+                .settingsRuntime(runtime)
+        } else {
+            // Unreachable in a normally-launched app (the runtime is created
+            // in cmuxApp.init before any UI); kept so a lifecycle regression
+            // surfaces as a visible message instead of a silent no-op.
+            Text(String(
+                localized: "settings.window.runtimeUnavailable",
+                defaultValue: "Settings could not load. Please restart cmux and report this issue."
+            ))
+            .padding(40)
+            .frame(
+                minWidth: SettingsWindowPresenter.minimumSize.width,
+                minHeight: SettingsWindowPresenter.minimumSize.height
+            )
+        }
+    }
+}

--- a/Sources/App/SettingsWindowFactory.swift
+++ b/Sources/App/SettingsWindowFactory.swift
@@ -37,10 +37,10 @@ extension SettingsWindowPresenter {
     /// Routes the app's sidebar-toggle menu command (Toggle Left Sidebar) to
     /// the Settings split view when the Settings window is key. The AppKit-
     /// hosted window gets no SwiftUI `SidebarCommands`, so without this the
-    /// command would toggle a terminal window's sidebar instead.
-    static func handleSidebarToggleIfSettingsWindowIsKey(
-        keyWindow: NSWindow? = NSApp.keyWindow
-    ) -> Bool {
+    /// command would toggle a terminal window's sidebar instead. Callers pass
+    /// `NSApp.keyWindow`; a default argument would be evaluated outside the
+    /// main actor and warn under strict concurrency.
+    static func handleSidebarToggleIfSettingsWindowIsKey(keyWindow: NSWindow?) -> Bool {
         guard keyWindow?.identifier?.rawValue == windowIdentifier else { return false }
         NotificationCenter.default.post(name: SettingsWindowRoot.sidebarToggleRequestName, object: nil)
         return true

--- a/Sources/App/SettingsWindowGeometry.swift
+++ b/Sources/App/SettingsWindowGeometry.swift
@@ -1,0 +1,75 @@
+import AppKit
+
+/// Pure multi-monitor recovery geometry for the Settings window, split out of
+/// `SettingsWindowPresenter` (which stays under the Swift file-length budget)
+/// and kept as extensions so call sites and tests address one type.
+extension SettingsWindowPresenter {
+    /// Pure selection of the visible-screen frame the settings window should be
+    /// clamped into. When the window's saved frame is off every active screen
+    /// (e.g. restored onto a now-disconnected display in a multi-monitor setup)
+    /// it recovers onto the screen under the cursor, then the main/first screen.
+    /// Cursor hit-testing uses each screen's *full* frame: `visibleFrame`
+    /// excludes the menu bar and Dock strips, and the cursor sits exactly there
+    /// when Settings is opened from the menu bar, which would misroute the
+    /// recovery to the main screen. The returned rect is always a visible
+    /// frame. Factored out so multi-monitor recovery is unit-testable.
+    static func targetVisibleFrame(
+        windowFrame: NSRect,
+        screens: [(frame: NSRect, visibleFrame: NSRect)],
+        mouseLocation: NSPoint?,
+        fallbackVisibleFrame: NSRect?
+    ) -> NSRect? {
+        guard !screens.isEmpty else { return fallbackVisibleFrame }
+
+        // Prefer the screen the window already overlaps the most so a window
+        // that is mostly visible stays where the user put it.
+        var bestFrame: NSRect?
+        var bestArea: CGFloat = 0
+        for screen in screens {
+            let intersection = screen.visibleFrame.intersection(windowFrame)
+            let area = intersection.isNull ? 0 : intersection.width * intersection.height
+            if area > bestArea {
+                bestArea = area
+                bestFrame = screen.visibleFrame
+            }
+        }
+        if let bestFrame, bestArea > 0 {
+            return bestFrame
+        }
+
+        // The window is off every active screen. Recover onto the screen under
+        // the cursor when possible so Settings appears where the user is looking.
+        if let mouseLocation,
+           let mouseScreen = screens.first(where: { $0.frame.contains(mouseLocation) }) {
+            return mouseScreen.visibleFrame
+        }
+        return fallbackVisibleFrame ?? screens.first?.visibleFrame
+    }
+
+    /// Pure clamp geometry: fit `frame` within `visibleFrame` (honoring `inset`
+    /// and a minimum size). Factored out of `clampToVisibleAreaIfNeeded` so the
+    /// geometry is unit-testable independent of `NSWindow`/`NSScreen`.
+    static func clampedFrame(
+        _ frame: NSRect,
+        minimumSize: NSSize,
+        into visibleFrame: NSRect,
+        inset: CGFloat
+    ) -> NSRect {
+        var result = frame
+        let maxVisibleSize = NSSize(
+            width: max(minimumSize.width, visibleFrame.width - 2 * inset),
+            height: max(minimumSize.height, visibleFrame.height - 2 * inset)
+        )
+        result.size.width = min(result.size.width, maxVisibleSize.width)
+        result.size.height = min(result.size.height, maxVisibleSize.height)
+        let minX = visibleFrame.minX + inset
+        let minY = visibleFrame.minY + inset
+        let maxX = max(minX, visibleFrame.maxX - inset - result.width)
+        let maxY = max(minY, visibleFrame.maxY - inset - result.height)
+        result.origin = NSPoint(
+            x: min(max(result.origin.x, minX), maxX),
+            y: min(max(result.origin.y, minY), maxY)
+        )
+        return result
+    }
+}

--- a/Sources/App/SettingsWindowGeometry.swift
+++ b/Sources/App/SettingsWindowGeometry.swift
@@ -1,9 +1,25 @@
 import AppKit
 
-/// Pure multi-monitor recovery geometry for the Settings window, split out of
-/// `SettingsWindowPresenter` (which stays under the Swift file-length budget)
-/// and kept as extensions so call sites and tests address one type.
+/// Pure multi-monitor recovery geometry and window-usability policy for the
+/// Settings window, split out of `SettingsWindowPresenter` (which stays under
+/// the Swift file-length budget) and kept as extensions so call sites and
+/// tests address one type.
 extension SettingsWindowPresenter {
+    /// Pure usability policy so the self-healing decision is unit-testable.
+    static func unusableWindowReason(
+        hasContent: Bool,
+        frame: NSRect,
+        minimumSize: NSSize
+    ) -> String? {
+        if !hasContent {
+            return "window has no content (deallocated or unloaded content view)"
+        }
+        if frame.width < minimumSize.width / 2 || frame.height < minimumSize.height / 2 {
+            return "window frame is degenerate (\(Int(frame.width))x\(Int(frame.height)))"
+        }
+        return nil
+    }
+
     /// Pure selection of the visible-screen frame the settings window should be
     /// clamped into. When the window's saved frame is off every active screen
     /// (e.g. restored onto a now-disconnected display in a multi-monitor setup)

--- a/Sources/App/SettingsWindowOpenOutcome.swift
+++ b/Sources/App/SettingsWindowOpenOutcome.swift
@@ -1,6 +1,0 @@
-/// Recovery decision after a settings-window open request reaches its verification deadline.
-enum SettingsWindowOpenOutcome: Equatable {
-    case materialized
-    case retry
-    case giveUp
-}

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -58,6 +58,10 @@ final class SettingsWindowPresenter: NSObject {
     /// a closed window can never absorb a future open request.
     private var settingsWindow: NSWindow?
     private var pendingNavigationTarget: SettingsNavigationTarget?
+    /// Monotonic delivery token: bumped on every posted navigation so a
+    /// queued fresh-window delivery can detect it was superseded by a newer
+    /// targeted show and stay silent instead of navigating backwards.
+    private var navigationDeliveryGeneration = 0
 
     override convenience init() {
         self.init(windowFactory: { SettingsWindowFactory.makeSettingsWindow() })
@@ -324,12 +328,35 @@ final class SettingsWindowPresenter: NSObject {
     }
 
     /// Existing live content receives the navigation immediately; a freshly
-    /// created window keeps it pending, and ``SettingsWindowHostRoot``
-    /// consumes it once the content's notification subscriptions exist.
+    /// created window keeps it pending, and ``SettingsWindowHostRoot`` calls
+    /// `deliverPendingNavigationAfterContentAppears()` once the content's
+    /// notification subscriptions exist.
     private func deliverNavigation(reusedExistingWindow: Bool) {
         guard let target = pendingNavigationTarget else { return }
         if reusedExistingWindow {
             pendingNavigationTarget = nil
+            navigationDeliveryGeneration &+= 1
+            SettingsNavigationRequest.post(target)
+        }
+    }
+
+    static func deliverPendingNavigationAfterContentAppears() {
+        shared.deliverPendingNavigationAfterContentAppears()
+    }
+
+    /// Delivers a fresh window's pending target once its content is live. The
+    /// post is deferred one main-actor hop so the content's own restore
+    /// navigation (posted from a descendant `onAppear`) cannot clobber it, and
+    /// it is generation-guarded: a newer targeted `show()` that delivered in
+    /// the meantime supersedes this queued post instead of being overridden by
+    /// it.
+    func deliverPendingNavigationAfterContentAppears() {
+        guard let target = pendingNavigationTarget else { return }
+        pendingNavigationTarget = nil
+        navigationDeliveryGeneration &+= 1
+        let generation = navigationDeliveryGeneration
+        Task { @MainActor in
+            guard self.navigationDeliveryGeneration == generation else { return }
             SettingsNavigationRequest.post(target)
         }
     }

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -187,6 +187,15 @@ final class SettingsWindowPresenter: NSObject {
             $0.identifier?.rawValue == Self.windowIdentifier
         }
         guard let candidate else { return nil }
+        if let hostWindow = candidate as? SettingsHostWindow, hostWindow.isClosingSettingsWindow {
+            // Deterministic mid-close rejection: the dying window must not
+            // absorb this open request, regardless of whether the presenter's
+            // own willClose observer has run yet. It is already closing, so
+            // strip identity but do not close it again.
+            Self.log.notice("settings.window.show candidate is mid-close; building a fresh window")
+            strip(candidate)
+            return nil
+        }
         if let reason = Self.unusableWindowReason(
             hasContent: candidate.contentViewController != nil || candidate.contentView != nil,
             frame: candidate.frame,
@@ -274,6 +283,13 @@ final class SettingsWindowPresenter: NSObject {
         }
         window.adoptCmuxPeerWindowLevel()
         clampToVisibleAreaIfNeeded(window)
+        guard activateApp else {
+            // Socket no-focus-steal contract (`settings.open --activate=false`):
+            // make the window visible without keying it, raising other cmux
+            // windows, or activating/unhiding the app.
+            window.orderFrontRegardless()
+            return
+        }
         // Surface the preferred main window first so Settings opens layered
         // above it — the standard "Settings in front of its app" presentation.
         // Both windows are ordered front *as peers*, never via
@@ -287,10 +303,8 @@ final class SettingsWindowPresenter: NSObject {
             }
             parentWindow.orderFront(nil)
         }
-        if activateApp {
-            NSApp.unhide(nil)
-            NSRunningApplication.current.activate(options: [.activateAllWindows])
-        }
+        NSApp.unhide(nil)
+        NSRunningApplication.current.activate(options: [.activateAllWindows])
         window.makeKeyAndOrderFront(nil)
         window.orderFrontRegardless()
     }
@@ -324,6 +338,16 @@ final class SettingsWindowPresenter: NSObject {
 
     /// Fully retires a window that must never satisfy an open request again.
     private func demolish(_ window: NSWindow) {
+        strip(window)
+        window.orderOut(nil)
+        window.close()
+        window.contentViewController = nil
+        window.contentView = nil
+    }
+
+    /// Removes the window's settings identity and the presenter's tracking,
+    /// without closing it (used for windows that are already mid-close).
+    private func strip(_ window: NSWindow) {
         NotificationCenter.default.removeObserver(
             self,
             name: NSWindow.willCloseNotification,
@@ -333,10 +357,6 @@ final class SettingsWindowPresenter: NSObject {
         if settingsWindow === window {
             settingsWindow = nil
         }
-        window.orderOut(nil)
-        window.close()
-        window.contentViewController = nil
-        window.contentView = nil
     }
 
     @objc
@@ -413,72 +433,4 @@ final class SettingsWindowPresenter: NSObject {
         }
     }
 
-    /// Pure selection of the visible-screen frame the settings window should be
-    /// clamped into. When the window's saved frame is off every active screen
-    /// (e.g. restored onto a now-disconnected display in a multi-monitor setup)
-    /// it recovers onto the screen under the cursor, then the main/first screen.
-    /// Cursor hit-testing uses each screen's *full* frame: `visibleFrame`
-    /// excludes the menu bar and Dock strips, and the cursor sits exactly there
-    /// when Settings is opened from the menu bar, which would misroute the
-    /// recovery to the main screen. The returned rect is always a visible
-    /// frame. Factored out so multi-monitor recovery is unit-testable.
-    static func targetVisibleFrame(
-        windowFrame: NSRect,
-        screens: [(frame: NSRect, visibleFrame: NSRect)],
-        mouseLocation: NSPoint?,
-        fallbackVisibleFrame: NSRect?
-    ) -> NSRect? {
-        guard !screens.isEmpty else { return fallbackVisibleFrame }
-
-        // Prefer the screen the window already overlaps the most so a window
-        // that is mostly visible stays where the user put it.
-        var bestFrame: NSRect?
-        var bestArea: CGFloat = 0
-        for screen in screens {
-            let intersection = screen.visibleFrame.intersection(windowFrame)
-            let area = intersection.isNull ? 0 : intersection.width * intersection.height
-            if area > bestArea {
-                bestArea = area
-                bestFrame = screen.visibleFrame
-            }
-        }
-        if let bestFrame, bestArea > 0 {
-            return bestFrame
-        }
-
-        // The window is off every active screen. Recover onto the screen under
-        // the cursor when possible so Settings appears where the user is looking.
-        if let mouseLocation,
-           let mouseScreen = screens.first(where: { $0.frame.contains(mouseLocation) }) {
-            return mouseScreen.visibleFrame
-        }
-        return fallbackVisibleFrame ?? screens.first?.visibleFrame
-    }
-
-    /// Pure clamp geometry: fit `frame` within `visibleFrame` (honoring `inset`
-    /// and a minimum size). Factored out of `clampToVisibleAreaIfNeeded` so the
-    /// geometry is unit-testable independent of `NSWindow`/`NSScreen`.
-    static func clampedFrame(
-        _ frame: NSRect,
-        minimumSize: NSSize,
-        into visibleFrame: NSRect,
-        inset: CGFloat
-    ) -> NSRect {
-        var result = frame
-        let maxVisibleSize = NSSize(
-            width: max(minimumSize.width, visibleFrame.width - 2 * inset),
-            height: max(minimumSize.height, visibleFrame.height - 2 * inset)
-        )
-        result.size.width = min(result.size.width, maxVisibleSize.width)
-        result.size.height = min(result.size.height, maxVisibleSize.height)
-        let minX = visibleFrame.minX + inset
-        let minY = visibleFrame.minY + inset
-        let maxX = max(minX, visibleFrame.maxX - inset - result.width)
-        let maxY = max(minY, visibleFrame.maxY - inset - result.height)
-        result.origin = NSPoint(
-            x: min(max(result.origin.x, minX), maxX),
-            y: min(max(result.origin.y, minY), maxY)
-        )
-        return result
-    }
 }

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -62,6 +62,11 @@ final class SettingsWindowPresenter: NSObject {
     /// queued fresh-window delivery can detect it was superseded by a newer
     /// targeted show and stay silent instead of navigating backwards.
     private var navigationDeliveryGeneration = 0
+    /// Whether the current window's SwiftUI content has signaled (via the
+    /// host root's `onAppear`) that its navigation consumer is installed. An
+    /// `NSWindow` existing is not enough: posting before this is set would
+    /// drop the navigation on the floor.
+    private var isContentReadyForNavigation = false
 
     override convenience init() {
         self.init(windowFactory: { SettingsWindowFactory.makeSettingsWindow() })
@@ -276,6 +281,7 @@ final class SettingsWindowPresenter: NSObject {
             object: window
         )
         settingsWindow = window
+        isContentReadyForNavigation = false
         return window
     }
 
@@ -327,13 +333,14 @@ final class SettingsWindowPresenter: NSObject {
         """
     }
 
-    /// Existing live content receives the navigation immediately; a freshly
-    /// created window keeps it pending, and ``SettingsWindowHostRoot`` calls
-    /// `deliverPendingNavigationAfterContentAppears()` once the content's
-    /// notification subscriptions exist.
+    /// Ready live content receives the navigation immediately. Until the
+    /// content signals readiness (a window can exist before its navigation
+    /// consumer is installed — fresh creation, hidden app), the target stays
+    /// pending and ``SettingsWindowHostRoot`` delivers it from `onAppear` via
+    /// `deliverPendingNavigationAfterContentAppears()`.
     private func deliverNavigation(reusedExistingWindow: Bool) {
         guard let target = pendingNavigationTarget else { return }
-        if reusedExistingWindow {
+        if reusedExistingWindow && isContentReadyForNavigation {
             pendingNavigationTarget = nil
             navigationDeliveryGeneration &+= 1
             SettingsNavigationRequest.post(target)
@@ -344,13 +351,13 @@ final class SettingsWindowPresenter: NSObject {
         shared.deliverPendingNavigationAfterContentAppears()
     }
 
-    /// Delivers a fresh window's pending target once its content is live. The
-    /// post is deferred one main-actor hop so the content's own restore
-    /// navigation (posted from a descendant `onAppear`) cannot clobber it, and
-    /// it is generation-guarded: a newer targeted `show()` that delivered in
-    /// the meantime supersedes this queued post instead of being overridden by
-    /// it.
+    /// Marks the content ready and delivers any pending target. The post is
+    /// deferred one main-actor hop so the content's own restore navigation
+    /// (posted from a descendant `onAppear`) cannot clobber it, and it is
+    /// generation-guarded: a newer targeted `show()` that delivered in the
+    /// meantime supersedes this queued post instead of being overridden by it.
     func deliverPendingNavigationAfterContentAppears() {
+        isContentReadyForNavigation = true
         guard let target = pendingNavigationTarget else { return }
         pendingNavigationTarget = nil
         navigationDeliveryGeneration &+= 1
@@ -383,6 +390,7 @@ final class SettingsWindowPresenter: NSObject {
         window.identifier = nil
         if settingsWindow === window {
             settingsWindow = nil
+            isContentReadyForNavigation = false
         }
     }
 
@@ -403,6 +411,7 @@ final class SettingsWindowPresenter: NSObject {
         // classes). The next show() builds a fresh window from scratch.
         window.identifier = nil
         settingsWindow = nil
+        isContentReadyForNavigation = false
         window.contentViewController = nil
         window.contentView = nil
     }

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -94,13 +94,31 @@ final class SettingsWindowPresenter: NSObject {
     ) -> SettingsWindowShowResult {
 #if DEBUG
         cmuxDebugLog("settings.window.show path=appkitWindow")
+#endif
+        let result = performShow(navigationTarget: navigationTarget, activateApp: activateApp)
+#if DEBUG
+        // Recorded from the verified outcome, not the request, so UI-test
+        // captures cannot claim an open that never presented.
+        let presented: Bool
+        if case .failed = result {
+            presented = false
+        } else {
+            presented = true
+        }
         _ = UITestCaptureSink().mutateJSONObjectIfConfigured(
             envKey: "CMUX_UI_TEST_SETTINGS_OPEN_CAPTURE_PATH"
         ) { payload in
-            payload["opened"] = true
+            payload["opened"] = presented
             payload["target"] = navigationTarget?.rawValue ?? ""
         }
 #endif
+        return result
+    }
+
+    private func performShow(
+        navigationTarget: SettingsNavigationTarget?,
+        activateApp: Bool
+    ) -> SettingsWindowShowResult {
         pendingNavigationTarget = navigationTarget
 
         var failureReason = "settings window was never presented"
@@ -125,7 +143,11 @@ final class SettingsWindowPresenter: NSObject {
             }
             if NSApp.isHidden && !activateApp {
                 // Ordering front succeeded as far as AppKit allows without
-                // unhiding the app; the window appears on unhide.
+                // unhiding the app; the window appears on unhide. Reused live
+                // content still receives the navigation now — its notification
+                // subscriptions outlive visibility, and the host root's
+                // onAppear consumer only runs for fresh windows.
+                deliverNavigation(reusedExistingWindow: reusedExisting)
                 Self.log.notice(
                     "settings.window.show ordered front while app is hidden; deferring visibility to unhide"
                 )

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -128,7 +128,13 @@ final class SettingsWindowPresenter: NSObject {
         navigationTarget: SettingsNavigationTarget?,
         activateApp: Bool
     ) -> SettingsWindowShowResult {
-        pendingNavigationTarget = navigationTarget
+        // Only a targeted show may replace the pending target. An untargeted
+        // show expresses no pane preference and must not erase a still-
+        // undelivered targeted request (e.g. CLI `settings open account`
+        // followed by a menu open before the content appeared).
+        if let navigationTarget {
+            pendingNavigationTarget = navigationTarget
+        }
 
         var failureReason = "settings window was never presented"
         for attempt in 1...Self.maxPresentAttempts {

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -45,6 +45,9 @@ final class SettingsWindowPresenter: NSObject {
     /// is synchronous, so more attempts cannot help: if two consecutive fresh
     /// windows refuse to order in, AppKit itself is wedged and we fail loudly.
     static let maxPresentAttempts = 2
+    /// Maximum re-entrant `show()` depth reached through close-triggered
+    /// observers before the presenter fails loudly instead of recursing.
+    static let maxReentrantShowDepth = 3
 
     static let shared = SettingsWindowPresenter()
     /// Release-safe diagnostics so intermittent "Settings won't open" reports
@@ -58,6 +61,9 @@ final class SettingsWindowPresenter: NSObject {
     /// a closed window can never absorb a future open request.
     private var settingsWindow: NSWindow?
     private var pendingNavigationTarget: SettingsNavigationTarget?
+    /// Current re-entrant depth of `performShow` (close-triggered observers
+    /// may re-enter). Bounded by `maxReentrantShowDepth`.
+    private var activeShowDepth = 0
     /// Monotonic delivery token: bumped on every posted navigation so a
     /// queued fresh-window delivery can detect it was superseded by a newer
     /// targeted show and stay silent instead of navigating backwards.
@@ -136,11 +142,29 @@ final class SettingsWindowPresenter: NSObject {
             pendingNavigationTarget = navigationTarget
         }
 
+        // `demolish` closes windows synchronously, and a foreign willClose
+        // observer may re-enter show() from inside that close (a supported
+        // pattern). The depth bound is the safety valve that keeps a
+        // pathological reopen-on-close observer combined with persistent
+        // presentation failure from recursing without limit.
+        activeShowDepth += 1
+        defer { activeShowDepth -= 1 }
+        if activeShowDepth > Self.maxReentrantShowDepth {
+            let reason = "re-entrant settings show exceeded depth \(Self.maxReentrantShowDepth) during teardown recovery"
+            Self.log.fault("settings.window.show \(reason, privacy: .public)")
+            return .failed(reason: reason)
+        }
+
         var failureReason = "settings window was never presented"
         for attempt in 1...Self.maxPresentAttempts {
             let window: NSWindow
             let reusedExisting: Bool
-            if attempt == 1, let existing = usableExistingWindow() {
+            // Checked on every attempt, not just the first: attempt 1's
+            // demolish strips the failed window before closing it, so it can
+            // never be rediscovered here — but a re-entrant show() from that
+            // close may already have created a healthy replacement, which
+            // must be adopted instead of duplicated.
+            if let existing = usableExistingWindow() {
                 Self.logExistingWindowState(existing)
                 adopt(existing)
                 window = existing
@@ -223,21 +247,6 @@ final class SettingsWindowPresenter: NSObject {
             return nil
         }
         return candidate
-    }
-
-    /// Pure usability policy so the self-healing decision is unit-testable.
-    static func unusableWindowReason(
-        hasContent: Bool,
-        frame: NSRect,
-        minimumSize: NSSize
-    ) -> String? {
-        if !hasContent {
-            return "window has no content (deallocated or unloaded content view)"
-        }
-        if frame.width < minimumSize.width / 2 || frame.height < minimumSize.height / 2 {
-            return "window frame is degenerate (\(Int(frame.width))x\(Int(frame.height)))"
-        }
-        return nil
     }
 
     /// Tracks a window discovered by identifier scan (e.g. after presenter

--- a/Sources/App/SettingsWindowPresenter.swift
+++ b/Sources/App/SettingsWindowPresenter.swift
@@ -2,325 +2,343 @@ import AppKit
 import CmuxTestSupport
 import os
 
+/// Outcome of a Settings show request. Every request ends in exactly one of
+/// these; "the request was accepted but nothing happened" is not
+/// representable (https://github.com/manaflow-ai/cmux/issues/7777, #7775).
+enum SettingsWindowShowResult: Equatable {
+    /// The Settings window is visible on screen (ordered in).
+    case presented
+    /// The window was ordered front while the app is hidden, so AppKit defers
+    /// actual visibility until the app unhides. This is the correct outcome
+    /// for non-activating CLI opens, which must not unhide the app
+    /// (socket focus policy).
+    case orderedWhileAppHidden
+    /// No window could be made visible. `reason` carries diagnostic-grade
+    /// window/app state for the failure log and the CLI error payload.
+    case failed(reason: String)
+}
+
+/// Single source of truth for the Settings window lifecycle: create, show,
+/// repair, and close-teardown (https://github.com/manaflow-ai/cmux/issues/7777).
+///
+/// The window is AppKit-owned: `show()` synchronously builds a fresh
+/// `NSWindow` (hosting the SwiftUI settings content via
+/// ``SettingsWindowFactory``) whenever no usable window exists, orders it
+/// front, and verifies visibility before returning. This is the same
+/// ownership model the main window (`AppDelegate.createMainWindow`) and
+/// `TaskManagerWindowController` use.
+///
+/// History: the previous design delegated creation to a SwiftUI single
+/// `Window` scene via `openWindow(id:)`, which has no failure callback and
+/// could wedge permanently (relaunch-while-open, scene mid-teardown), so the
+/// menu, ⌘, and CLI `settings open` all silently no-oped until the app was
+/// restarted (#5770, #4053, #7775). A deferred-verification retry (PR #5806)
+/// reduced but could not eliminate the class; synchronous AppKit construction
+/// removes it by design.
 @MainActor
-struct SettingsWindowPresenter {
-    static let windowID = "settings"
+final class SettingsWindowPresenter: NSObject {
     static let windowIdentifier = "cmux.settings"
     static let minimumSize = NSSize(width: 820, height: 540)
+    private static let frameAutosaveName = "cmux.settings"
     private static let visibleAreaInset: CGFloat = 18
-    private static let sharedPresenter = SettingsWindowPresenter()
+    /// One reuse-or-create pass plus one recreate-from-scratch pass. Creation
+    /// is synchronous, so more attempts cannot help: if two consecutive fresh
+    /// windows refuse to order in, AppKit itself is wedged and we fail loudly.
+    static let maxPresentAttempts = 2
+
+    static let shared = SettingsWindowPresenter()
     /// Release-safe diagnostics so intermittent "Settings won't open" reports
-    /// (https://github.com/manaflow-ai/cmux/issues/5770) become attributable
-    /// from `log show --predicate 'subsystem == "com.cmuxterm.app" && category == "Settings"'`.
+    /// become attributable from
+    /// `log show --predicate 'subsystem == "com.cmuxterm.app" && category == "Settings"'`.
     private nonisolated static let log = Logger(subsystem: "com.cmuxterm.app", category: "Settings")
-    /// Number of times to re-request the SwiftUI window when an open request
-    /// produces no window. The single `Window` scene's `openWindow(id:)` can
-    /// silently no-op mid-teardown, which is the "nothing happens" symptom.
-    static let maxOpenAttempts = 2
 
-    private let openVerificationDelay: Duration
+    private let windowFactory: @MainActor () -> NSWindow
+    /// Strong while open: the presenter owns the window's lifetime. Cleared
+    /// (and the window's identifier removed) in `settingsWindowWillClose` so
+    /// a closed window can never absorb a future open request.
+    private var settingsWindow: NSWindow?
+    private var pendingNavigationTarget: SettingsNavigationTarget?
 
-    private final class State: NSObject {
-        var openWindow: (@MainActor () -> Void)?
-        var parentWindowProvider: (@MainActor () -> NSWindow?)?
-        weak var settingsWindow: NSWindow?
-        var pendingNavigationTarget: SettingsNavigationTarget?
-        var pendingContentNavigationTarget: SettingsNavigationTarget?
-        var shouldOpenWhenConfigured = false
-        var shouldFocusWhenConfigured = false
-        var isOpeningSettingsWindow = false
-        var openVerificationTask: Task<Void, Never>?
+    override convenience init() {
+        self.init(windowFactory: { SettingsWindowFactory.makeSettingsWindow() })
+    }
 
-        deinit {
-            openVerificationTask?.cancel()
-            NotificationCenter.default.removeObserver(self)
+    init(windowFactory: @escaping @MainActor () -> NSWindow) {
+        self.windowFactory = windowFactory
+        super.init()
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @discardableResult
+    static func show(
+        navigationTarget: SettingsNavigationTarget? = nil,
+        activateApp: Bool = true
+    ) -> SettingsWindowShowResult {
+        shared.show(navigationTarget: navigationTarget, activateApp: activateApp)
+    }
+
+    static func consumePendingNavigationTarget() -> SettingsNavigationTarget? {
+        shared.consumePendingNavigationTarget()
+    }
+
+    /// Presents the Settings window, creating it if needed. Synchronous: on
+    /// return the window is visible (or ordered front under a hidden app), or
+    /// the failure has been logged loudly and is carried in the result.
+    @discardableResult
+    func show(
+        navigationTarget: SettingsNavigationTarget? = nil,
+        activateApp: Bool = true
+    ) -> SettingsWindowShowResult {
+#if DEBUG
+        cmuxDebugLog("settings.window.show path=appkitWindow")
+        _ = UITestCaptureSink().mutateJSONObjectIfConfigured(
+            envKey: "CMUX_UI_TEST_SETTINGS_OPEN_CAPTURE_PATH"
+        ) { payload in
+            payload["opened"] = true
+            payload["target"] = navigationTarget?.rawValue ?? ""
         }
+#endif
+        pendingNavigationTarget = navigationTarget
 
-        @MainActor
-        @objc
-        func settingsWindowWillClose(_ notification: Notification) {
-            guard
-                let window = notification.object as? NSWindow,
-                settingsWindow === window
-            else { return }
-            NotificationCenter.default.removeObserver(
-                self,
-                name: NSWindow.willCloseNotification,
-                object: window
+        var failureReason = "settings window was never presented"
+        for attempt in 1...Self.maxPresentAttempts {
+            let window: NSWindow
+            let reusedExisting: Bool
+            if attempt == 1, let existing = usableExistingWindow() {
+                Self.logExistingWindowState(existing)
+                adopt(existing)
+                window = existing
+                reusedExisting = true
+            } else {
+                window = makeConfiguredWindow()
+                reusedExisting = false
+            }
+
+            orderFront(window, activateApp: activateApp)
+
+            if window.isVisible {
+                deliverNavigation(reusedExistingWindow: reusedExisting)
+                return .presented
+            }
+            if NSApp.isHidden && !activateApp {
+                // Ordering front succeeded as far as AppKit allows without
+                // unhiding the app; the window appears on unhide.
+                Self.log.notice(
+                    "settings.window.show ordered front while app is hidden; deferring visibility to unhide"
+                )
+                return .orderedWhileAppHidden
+            }
+
+            failureReason = Self.presentationFailureReason(
+                window: window,
+                attempt: attempt,
+                reusedExisting: reusedExisting
             )
-            // Ordered-out live windows can still be re-fronted through the weak
-            // reference; closed windows must not be rediscovered from NSApp.
-            window.identifier = nil
-            settingsWindow = nil
-            isOpeningSettingsWindow = false
-            openVerificationTask?.cancel()
-            openVerificationTask = nil
+            Self.log.error("settings.window.show \(failureReason, privacy: .public)")
+            demolish(window)
         }
-    }
 
-    private let state: State
-
-    init(openVerificationDelay: Duration = .milliseconds(500)) {
-        self.openVerificationDelay = openVerificationDelay
-        state = State()
-    }
-
-    static func configure(
-        openWindow: @escaping @MainActor () -> Void,
-        parentWindowProvider: @escaping @MainActor () -> NSWindow? = { nil }
-    ) {
-        sharedPresenter.configure(
-            openWindow: openWindow,
-            parentWindowProvider: parentWindowProvider
+        Self.log.fault(
+            "settings.window.show FAILED after \(Self.maxPresentAttempts, privacy: .public) attempts: \(failureReason, privacy: .public)"
         )
+        return .failed(reason: failureReason)
     }
 
-    func configure(
-        openWindow: @escaping @MainActor () -> Void,
-        parentWindowProvider: @escaping @MainActor () -> NSWindow? = { nil }
-    ) {
-        state.openWindow = openWindow
-        state.parentWindowProvider = parentWindowProvider
-        if state.shouldOpenWhenConfigured {
-            state.shouldOpenWhenConfigured = false
-            requestOpen(using: openWindow)
+    func consumePendingNavigationTarget() -> SettingsNavigationTarget? {
+        let target = pendingNavigationTarget
+        pendingNavigationTarget = nil
+        return target
+    }
+
+    // MARK: - Window acquisition
+
+    /// The tracked (or identifier-scanned) settings window, provided it is in
+    /// a presentable state. Any unusable window — torn-down content, a
+    /// degenerate frame — is demolished on the spot so the caller creates a
+    /// fresh one instead of silently re-fronting a husk (issue #7777 goal:
+    /// self-healing open).
+    private func usableExistingWindow() -> NSWindow? {
+        let candidate = settingsWindow ?? NSApp.windows.first {
+            $0.identifier?.rawValue == Self.windowIdentifier
         }
-    }
-
-    static func configure(window: NSWindow) {
-        sharedPresenter.configure(window: window)
-    }
-
-    func configure(window: NSWindow) {
-        // Window materialization is the success signal for issue #5770's
-        // silent-open retry path; a slow SwiftUI scene must not be retried
-        // after it has produced a real window.
-        cancelOpenVerification()
-        let isNewSettingsWindow = state.settingsWindow !== window
-        let shouldFocusAfterConfiguration = isNewSettingsWindow && state.shouldFocusWhenConfigured
-        if shouldFocusAfterConfiguration {
-            state.shouldFocusWhenConfigured = false
+        guard let candidate else { return nil }
+        if let reason = Self.unusableWindowReason(
+            hasContent: candidate.contentViewController != nil || candidate.contentView != nil,
+            frame: candidate.frame,
+            minimumSize: Self.minimumSize
+        ) {
+            Self.log.error(
+                "settings.window.show existing window unusable (\(reason, privacy: .public)); tearing it down"
+            )
+            demolish(candidate)
+            return nil
         }
-        state.settingsWindow = window
-        state.isOpeningSettingsWindow = false
+        return candidate
+    }
+
+    /// Pure usability policy so the self-healing decision is unit-testable.
+    static func unusableWindowReason(
+        hasContent: Bool,
+        frame: NSRect,
+        minimumSize: NSSize
+    ) -> String? {
+        if !hasContent {
+            return "window has no content (deallocated or unloaded content view)"
+        }
+        if frame.width < minimumSize.width / 2 || frame.height < minimumSize.height / 2 {
+            return "window frame is degenerate (\(Int(frame.width))x\(Int(frame.height)))"
+        }
+        return nil
+    }
+
+    /// Tracks a window discovered by identifier scan (e.g. after presenter
+    /// state was lost) so close-teardown ownership is re-established.
+    private func adopt(_ window: NSWindow) {
+        guard settingsWindow !== window else { return }
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.willCloseNotification,
+            object: window
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(settingsWindowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: window
+        )
+        settingsWindow = window
+    }
+
+    private func makeConfiguredWindow() -> NSWindow {
+        let window = windowFactory()
         window.identifier = NSUserInterfaceItemIdentifier(Self.windowIdentifier)
         window.isReleasedWhenClosed = false
         window.isRestorable = false
         window.minSize = Self.minimumSize
         window.contentMinSize = Self.minimumSize
         window.adoptCmuxPeerWindowLevel()
+        if !window.setFrameUsingName(Self.frameAutosaveName) {
+            window.center()
+        }
+        window.setFrameAutosaveName(Self.frameAutosaveName)
+        // A saved frame can be smaller than the current minimum (e.g. written
+        // by an older build); NSWindow.minSize constrains user resizes only,
+        // not programmatic restores.
+        var frame = window.frame
+        if frame.width < Self.minimumSize.width || frame.height < Self.minimumSize.height {
+            frame.size.width = max(frame.width, Self.minimumSize.width)
+            frame.size.height = max(frame.height, Self.minimumSize.height)
+            window.setFrame(frame, display: false)
+        }
         clampToVisibleAreaIfNeeded(window)
-        if isNewSettingsWindow {
-            observeClose(of: window)
-        }
-        if shouldFocusAfterConfiguration {
-            Task { @MainActor in
-                guard state.settingsWindow === window else { return }
-                focus(window)
-            }
-        }
-    }
-
-    static func show(
-        navigationTarget: SettingsNavigationTarget? = nil,
-        openWindowOverride: (@MainActor () -> Void)? = nil
-    ) {
-        sharedPresenter.show(
-            navigationTarget: navigationTarget,
-            openWindowOverride: openWindowOverride
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(settingsWindowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: window
         )
+        settingsWindow = window
+        return window
     }
 
-    func show(
-        navigationTarget: SettingsNavigationTarget? = nil,
-        openWindowOverride: (@MainActor () -> Void)? = nil
-    ) {
-#if DEBUG
-        cmuxDebugLog("settings.window.show path=swiftuiWindow")
-        _ = UITestCaptureSink().mutateJSONObjectIfConfigured(
-            envKey: "CMUX_UI_TEST_SETTINGS_OPEN_CAPTURE_PATH"
-        ) { payload in
-            payload["opened"] = true
-            payload["target"] = navigationTarget?.rawValue ?? ""
-            payload["used_open_window_override"] = openWindowOverride != nil
-        }
-#endif
-        state.pendingNavigationTarget = navigationTarget
-        state.pendingContentNavigationTarget = navigationTarget
+    // MARK: - Presentation
 
-        if let window = existingWindow() {
-            recordMaterializedWindowIfNeeded(window)
-            Self.logExistingWindowState(window)
-            let shouldDeferNavigation = window.isMiniaturized
-            if !shouldDeferNavigation {
-                state.pendingNavigationTarget = nil
-                state.pendingContentNavigationTarget = nil
+    private func orderFront(_ window: NSWindow, activateApp: Bool) {
+        if window.isMiniaturized {
+            window.deminiaturize(nil)
+        }
+        window.adoptCmuxPeerWindowLevel()
+        clampToVisibleAreaIfNeeded(window)
+        // Surface the preferred main window first so Settings opens layered
+        // above it — the standard "Settings in front of its app" presentation.
+        // Both windows are ordered front *as peers*, never via
+        // `addChildWindow`: a child window is pinned above its parent forever
+        // and can never recede when the user clicks the main window
+        // (https://github.com/manaflow-ai/cmux/issues/5081).
+        if let parentWindow = AppDelegate.shared?.preferredMainWindowForSettingsPresentation(),
+           parentWindow !== window {
+            if parentWindow.isMiniaturized {
+                parentWindow.deminiaturize(nil)
             }
-            focus(window)
-            if let navigationTarget, !shouldDeferNavigation {
-                SettingsNavigationRequest.post(navigationTarget)
-            }
-            return
+            parentWindow.orderFront(nil)
         }
-
-        if state.isOpeningSettingsWindow {
-            state.shouldFocusWhenConfigured = true
-            return
+        if activateApp {
+            NSApp.unhide(nil)
+            NSRunningApplication.current.activate(options: [.activateAllWindows])
         }
-
-        if let openWindowOverride {
-            // The override still funnels into SwiftUI's `openWindow(id:)`, which
-            // can hit the same mid-teardown no-op, so it gets the same retry/
-            // logging recovery as the configured opener (issue #5770).
-            Self.log.notice("settings.window.show no existing window; requesting via override")
-            requestOpen(using: openWindowOverride)
-            return
-        }
-
-        guard let openWindow = state.openWindow else {
-            state.shouldOpenWhenConfigured = true
-            state.shouldFocusWhenConfigured = true
-            return
-        }
-        Self.log.notice("settings.window.show no existing window; requesting new settings window")
-        requestOpen(using: openWindow)
+        window.makeKeyAndOrderFront(nil)
+        window.orderFrontRegardless()
     }
 
-    static func consumePendingNavigationTarget() -> SettingsNavigationTarget? {
-        sharedPresenter.consumePendingNavigationTarget()
-    }
-
-    func consumePendingNavigationTarget() -> SettingsNavigationTarget? {
-        let target = state.pendingNavigationTarget
-        state.pendingNavigationTarget = nil
-        return target
-    }
-
-    static func consumePendingContentNavigationTarget() -> SettingsNavigationTarget? {
-        sharedPresenter.consumePendingContentNavigationTarget()
-    }
-
-    func consumePendingContentNavigationTarget() -> SettingsNavigationTarget? {
-        let target = state.pendingContentNavigationTarget
-        state.pendingContentNavigationTarget = nil
-        return target
-    }
-
-    static func refocusIfVisible() {
-        sharedPresenter.refocusIfVisible()
-    }
-
-    func refocusIfVisible() {
-        guard let window = visibleExistingWindow() else { return }
-        focus(window)
-    }
-
-    private func existingWindow() -> NSWindow? {
-        if let settingsWindow = state.settingsWindow {
-            return settingsWindow
-        }
-        return NSApp.windows.first {
-            $0.identifier?.rawValue == Self.windowIdentifier
-        }
-    }
-
-    private func visibleExistingWindow() -> NSWindow? {
-        if let settingsWindow = state.settingsWindow,
-           settingsWindow.isVisible,
-           !settingsWindow.isMiniaturized {
-            return settingsWindow
-        }
-        return NSApp.windows.first {
-            $0.identifier?.rawValue == Self.windowIdentifier &&
-            $0.isVisible &&
-            !$0.isMiniaturized
-        }
-    }
-
-    /// Re-request the window when the previous request silently produced no
-    /// window. `openWindow(id:)` on a single `Window` scene can no-op while the
-    /// scene is mid-teardown, and there is no failure callback, so a deferred
-    /// check is the only way to notice the lost request (issue #5770 / #4053).
-    /// Success is event-driven: `configure(window:)` cancels the pending check
-    /// as soon as the scene materializes a window, so the timer below only ever
-    /// decides the failure case.
-    private func requestOpen(using opener: @escaping @MainActor () -> Void) {
-        state.shouldFocusWhenConfigured = true
-        state.isOpeningSettingsWindow = true
-        opener()
-        if state.isOpeningSettingsWindow {
-            scheduleOpenVerification(attempt: 1, opener: opener)
-        }
-    }
-
-    private func scheduleOpenVerification(
+    private static func presentationFailureReason(
+        window: NSWindow,
         attempt: Int,
-        opener: @escaping @MainActor () -> Void
-    ) {
-        guard state.openVerificationTask == nil else { return }
-        state.openVerificationTask = Task { @MainActor in
-            do {
-                // Intentional bounded deadline; `configure(window:)` cancels it on success.
-                try await ContinuousClock().sleep(for: openVerificationDelay)
-            } catch {
-                return
-            }
-            _ = resolveOpenVerification(attempt: attempt, opener: opener)
+        reusedExisting: Bool
+    ) -> String {
+        """
+        window did not become visible after order front \
+        (attempt \(attempt)/\(maxPresentAttempts), reusedExisting=\(reusedExisting), \
+        appHidden=\(NSApp.isHidden), appActive=\(NSApp.isActive), \
+        miniaturized=\(window.isMiniaturized), screens=\(NSScreen.screens.count), \
+        frame=\(NSStringFromRect(window.frame)))
+        """
+    }
+
+    /// Existing live content receives the navigation immediately; a freshly
+    /// created window keeps it pending, and ``SettingsWindowHostRoot``
+    /// consumes it once the content's notification subscriptions exist.
+    private func deliverNavigation(reusedExistingWindow: Bool) {
+        guard let target = pendingNavigationTarget else { return }
+        if reusedExistingWindow {
+            pendingNavigationTarget = nil
+            SettingsNavigationRequest.post(target)
         }
     }
 
-    @discardableResult
-    func resolveOpenVerification(
-        attempt: Int,
-        opener: @escaping @MainActor () -> Void
-    ) -> SettingsWindowOpenOutcome {
-        cancelOpenVerification()
-        let existingWindow = existingWindow()
-        let outcome = Self.openOutcome(windowExists: existingWindow != nil, attempt: attempt)
-        switch outcome {
-        case .materialized:
-            state.isOpeningSettingsWindow = false
-            if let existingWindow {
-                recordMaterializedWindowIfNeeded(existingWindow)
-            }
-        case .retry:
-            state.isOpeningSettingsWindow = true
-            Self.log.error(
-                "settings.window.open no window after attempt \(attempt, privacy: .public); retrying"
-            )
-            opener()
-            if state.isOpeningSettingsWindow {
-                scheduleOpenVerification(attempt: attempt + 1, opener: opener)
-            }
-        case .giveUp:
-            state.isOpeningSettingsWindow = false
-            Self.log.error(
-                "settings.window.open gave up after \(attempt, privacy: .public) attempts; no window materialized"
-            )
+    // MARK: - Teardown
+
+    /// Fully retires a window that must never satisfy an open request again.
+    private func demolish(_ window: NSWindow) {
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.willCloseNotification,
+            object: window
+        )
+        window.identifier = nil
+        if settingsWindow === window {
+            settingsWindow = nil
         }
-        return outcome
+        window.orderOut(nil)
+        window.close()
+        window.contentViewController = nil
+        window.contentView = nil
     }
 
-    private func recordMaterializedWindowIfNeeded(_ window: NSWindow) {
-        cancelOpenVerification()
-        state.isOpeningSettingsWindow = false
-        if state.settingsWindow !== window {
-            state.settingsWindow = window
-            observeClose(of: window)
-        }
+    @objc
+    private func settingsWindowWillClose(_ notification: Notification) {
+        guard
+            let window = notification.object as? NSWindow,
+            window === settingsWindow
+        else { return }
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.willCloseNotification,
+            object: window
+        )
+        // A closed window must never be rediscovered by an open request, and
+        // its SwiftUI tree must be released with it so it cannot linger
+        // half-alive (the #4964 blank-reopen / #5321 lingering-window
+        // classes). The next show() builds a fresh window from scratch.
+        window.identifier = nil
+        settingsWindow = nil
+        window.contentViewController = nil
+        window.contentView = nil
     }
 
-    private func cancelOpenVerification() {
-        state.openVerificationTask?.cancel()
-        state.openVerificationTask = nil
-    }
-
-    static func openOutcome(windowExists: Bool, attempt: Int) -> SettingsWindowOpenOutcome {
-        if windowExists {
-            return .materialized
-        }
-        return attempt < maxOpenAttempts ? .retry : .giveUp
-    }
+    // MARK: - Diagnostics
 
     private static func logExistingWindowState(_ window: NSWindow) {
         log.notice(
@@ -335,49 +353,7 @@ struct SettingsWindowPresenter {
         )
     }
 
-    private func focus(_ window: NSWindow) {
-        performFocus(window)
-    }
-
-    private func performFocus(_ window: NSWindow) {
-        if window.isMiniaturized {
-            window.deminiaturize(nil)
-        }
-        window.adoptCmuxPeerWindowLevel()
-        clampToVisibleAreaIfNeeded(window)
-        // Surface the preferred main window first so Settings opens layered
-        // above it — the standard "Settings in front of its app" presentation
-        // a global hotkey or app activation expects. We do this by ordering
-        // both windows front *as peers*, never via `addChildWindow`: a child
-        // window is pinned above its parent forever and can never recede when
-        // the user clicks the main window (the bug in
-        // https://github.com/manaflow-ai/cmux/issues/5081). One-time front
-        // ordering gives the same initial layering while leaving normal
-        // click-to-raise window ordering fully intact afterwards.
-        if let parentWindow = state.parentWindowProvider?(), parentWindow !== window {
-            if parentWindow.isMiniaturized {
-                parentWindow.deminiaturize(nil)
-            }
-            parentWindow.orderFront(nil)
-        }
-        NSRunningApplication.current.activate(options: [.activateAllWindows])
-        window.makeKeyAndOrderFront(nil)
-        window.orderFrontRegardless()
-    }
-
-    private func observeClose(of window: NSWindow) {
-        NotificationCenter.default.removeObserver(
-            state,
-            name: NSWindow.willCloseNotification,
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            state,
-            selector: #selector(State.settingsWindowWillClose(_:)),
-            name: NSWindow.willCloseNotification,
-            object: window
-        )
-    }
+    // MARK: - Multi-monitor recovery
 
     private func clampToVisibleAreaIfNeeded(_ window: NSWindow) {
         let screens = NSScreen.screens.map { (frame: $0.frame, visibleFrame: $0.visibleFrame) }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9203,42 +9203,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     }
 
-    @MainActor
-    static func presentPreferencesWindow(
-        navigationTarget: SettingsNavigationTarget? = nil,
-        showFallbackSettingsWindow: (@MainActor (SettingsNavigationTarget?) -> Void)? = nil,
-        activateApplication: @MainActor () -> Void = {
-            NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
-        }
-    ) {
-#if DEBUG
-        cmuxDebugLog("settings.open.present path=appkitWindow")
-#endif
-        if let showFallbackSettingsWindow {
-            showFallbackSettingsWindow(navigationTarget)
-        } else if case .failed = SettingsWindowPresenter.show(navigationTarget: navigationTarget) {
-            // The presenter already logged the loud failure diagnostics;
-            // surface the failed menu/⌘, action instead of silently activating.
-            NSSound.beep()
-            return
-        }
-        activateApplication()
-#if DEBUG
-        cmuxDebugLog("settings.open.present activate=1")
-#endif
-    }
-
-    @MainActor
-    func openPreferencesWindow(debugSource: String, navigationTarget: SettingsNavigationTarget? = nil) {
-#if DEBUG
-        cmuxDebugLog("settings.open.request source=\(debugSource)")
-#endif
-        Self.presentPreferencesWindow(navigationTarget: navigationTarget)
-    }
-
-    @objc func openPreferencesWindow() {
-        openPreferencesWindow(debugSource: "appDelegate")
-    }
+    // presentPreferencesWindow / openPreferencesWindow live in
+    // Sources/App/AppDelegateSettingsPresentation.swift.
 
     func refreshMenuBarExtraForDebug() {
         menuBarExtraController?.refreshForDebugControls()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9206,9 +9206,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     @MainActor
     static func presentPreferencesWindow(
         navigationTarget: SettingsNavigationTarget? = nil,
-        showFallbackSettingsWindow: @MainActor (SettingsNavigationTarget?) -> Void = { target in
-            SettingsWindowPresenter.show(navigationTarget: target)
-        },
+        showFallbackSettingsWindow: (@MainActor (SettingsNavigationTarget?) -> Void)? = nil,
         activateApplication: @MainActor () -> Void = {
             NSRunningApplication.current.activate(options: [.activateAllWindows, .activateIgnoringOtherApps])
         }
@@ -9216,7 +9214,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 #if DEBUG
         cmuxDebugLog("settings.open.present path=appkitWindow")
 #endif
-        showFallbackSettingsWindow(navigationTarget)
+        if let showFallbackSettingsWindow {
+            showFallbackSettingsWindow(navigationTarget)
+        } else if case .failed = SettingsWindowPresenter.show(navigationTarget: navigationTarget) {
+            // The presenter already logged the loud failure diagnostics;
+            // surface the failed menu/⌘, action instead of silently activating.
+            NSSound.beep()
+            return
+        }
         activateApplication()
 #if DEBUG
         cmuxDebugLog("settings.open.present activate=1")

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -9214,7 +9214,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
     ) {
 #if DEBUG
-        cmuxDebugLog("settings.open.present path=swiftuiWindow")
+        cmuxDebugLog("settings.open.present path=appkitWindow")
 #endif
         showFallbackSettingsWindow(navigationTarget)
         activateApplication()

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -2341,7 +2341,9 @@ struct BrowserPanelView: View {
 
     private func openBrowserImportSettings() {
         isBrowserImportHintPopoverPresented = false
-        SettingsWindowPresenter.show(navigationTarget: .browserImport)
+        // Shared entrypoint: surfaces a failed presentation (beep) instead of
+        // silently doing nothing, like the menu/⌘, path.
+        AppDelegate.presentPreferencesWindow(navigationTarget: .browserImport)
     }
 
     private func dismissBrowserImportHint() {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -386,7 +386,6 @@ struct BrowserPanelView: View {
     let paneOwnershipOverride: Bool?
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.cmuxCanvasInlineBrowserHosting) private var canvasInlineBrowserHosting
-    @Environment(\.openWindow) private var openWindow
     @Environment(\.paneDropZone) private var paneDropZone
     /// Held detector instance; the view detects and summarizes installed browsers
     /// through this rather than the former `BrowserInstalledBrowserDetector` static
@@ -2342,11 +2341,7 @@ struct BrowserPanelView: View {
 
     private func openBrowserImportSettings() {
         isBrowserImportHintPopoverPresented = false
-        SettingsWindowPresenter.show(
-            navigationTarget: .browserImport,
-            openWindowOverride: { openWindow(id: SettingsWindowPresenter.windowID) }
-        )
-        NSRunningApplication.current.activate(options: [.activateAllWindows])
+        SettingsWindowPresenter.show(navigationTarget: .browserImport)
     }
 
     private func dismissBrowserImportHint() {

--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -228,14 +228,19 @@ extension TerminalController: ControlSystemContext {
             navigationTarget = nil
         }
 
-        DispatchQueue.main.async {
-            if shouldActivate {
-                AppDelegate.presentPreferencesWindow(navigationTarget: navigationTarget)
-            } else {
-                SettingsWindowPresenter.show(navigationTarget: navigationTarget)
-            }
+        // Present synchronously (this context is @MainActor) so the reply
+        // reflects reality: `opened` if-and-only-if a window materialized.
+        // "OK but nothing happened" was the #7775 failure shape.
+        let result = SettingsWindowPresenter.show(
+            navigationTarget: navigationTarget,
+            activateApp: shouldActivate
+        )
+        switch result {
+        case .presented, .orderedWhileAppHidden:
+            return .opened(target: navigationTarget?.rawValue ?? "general")
+        case .failed(let reason):
+            return .failed(message: reason)
         }
-        return .opened(target: navigationTarget?.rawValue ?? "general")
     }
 
     func controlFeedbackOpen(workspaceID: UUID?, windowID: UUID?, requestedActivate: Bool) {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -887,7 +887,7 @@ struct cmuxApp: App {
                 // The AppKit-hosted Settings window has no SwiftUI
                 // SidebarCommands; route the shared command to its split view
                 // whenever it is key.
-                if SettingsWindowPresenter.handleSidebarToggleIfSettingsWindowIsKey() { return }
+                if SettingsWindowPresenter.handleSidebarToggleIfSettingsWindowIsKey(keyWindow: NSApp.keyWindow) { return }
                 if AppDelegate.shared?.toggleSidebarInActiveMainWindow() != true {
                     sidebarState.toggle()
                 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -65,7 +65,6 @@ struct cmuxApp: App {
     @State private var browserFocusModeMenuRevision = 0
     @StateObject var focusHistoryMenuInvalidator = FocusHistoryMenuInvalidator()
     @NSApplicationDelegateAdaptor(AppDelegate.self) private var appDelegate
-    @Environment(\.openWindow) private var openWindow
     private var browserToolbarAccessorySpacing: Int {
         BrowserToolbarAccessorySpacingDebugSettings.resolved(browserToolbarAccessorySpacingRaw)
     }
@@ -380,14 +379,6 @@ struct cmuxApp: App {
                 .cmuxFontMagnificationEnvironment()
                 .cmuxAppearanceColorScheme(appearanceMode)
                 .onAppear {
-                    SettingsWindowPresenter.configure(
-                        openWindow: {
-                            openWindow(id: SettingsWindowPresenter.windowID)
-                        },
-                        parentWindowProvider: {
-                            AppDelegate.shared?.preferredMainWindowForSettingsPresentation()
-                        }
-                    )
 #if DEBUG
                     if ProcessInfo.processInfo.environment["CMUX_UI_TEST_MODE"] == "1" {
                         AppDelegate.shared?.updateLog.append("ui test: cmuxApp onAppear")
@@ -869,20 +860,10 @@ struct cmuxApp: App {
             windowAndViewCommands
         }
 
-        Window(String(localized: "settings.title", defaultValue: "Settings"), id: SettingsWindowPresenter.windowID) {
-            SettingsWindowRoot(runtime: settingsRuntime)
-                .settingsRuntime(settingsRuntime)
-                .cmuxFontMagnificationEnvironment()
-                .background(WindowAccessor(dedupeByWindow: false) { window in
-                    SettingsWindowPresenter.configure(window: window)
-                })
-                .cmuxAppearanceColorScheme(appearanceMode)
-        }
-        .defaultSize(width: 980, height: 680)
-        .windowResizability(.contentMinSize)
-        .commands {
-            SidebarCommands()
-        }
+        // Settings is an AppKit-owned window (SettingsWindowPresenter /
+        // SettingsWindowFactory), not a SwiftUI Window scene: openWindow(id:)
+        // could silently no-op and leave menu/⌘,/CLI opens dead until app
+        // restart (https://github.com/manaflow-ai/cmux/issues/7777).
 
         Window(String(localized: "settings.config.windowTitle", defaultValue: "Config"), id: ConfigSettingsView.windowID) {
             ConfigSettingsView()

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -884,6 +884,10 @@ struct cmuxApp: App {
         historyCommands
         CommandGroup(after: .toolbar) {
             splitCommandButton(title: String(localized: "menu.view.toggleLeftSidebar", defaultValue: "Toggle Left Sidebar"), shortcut: menuShortcut(for: .toggleSidebar)) {
+                // The AppKit-hosted Settings window has no SwiftUI
+                // SidebarCommands; route the shared command to its split view
+                // whenever it is key.
+                if SettingsWindowPresenter.handleSidebarToggleIfSettingsWindowIsKey() { return }
                 if AppDelegate.shared?.toggleSidebarInActiveMainWindow() != true {
                     sidebarState.toggle()
                 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1157,6 +1157,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D10000000000000000A00010 /* SettingsUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00011 /* SettingsUITestSupport.swift */; };
 		D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090030000000000000002 /* SettingsWindowFactory.swift */; };
 		D37777030000000000000001 /* SettingsWindowGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777030000000000000002 /* SettingsWindowGeometry.swift */; };
+		D37777020000000000000001 /* SettingsWindowNavigationRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777020000000000000002 /* SettingsWindowNavigationRoutingTests.swift */; };
 		D37777010000000000000001 /* SettingsWindowOpenRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */; };
 		D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000002 /* SettingsWindowPresenter.swift */; };
 		D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000004 /* SettingsWindowPresenterTests.swift */; };
@@ -2767,6 +2768,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D10000000000000000A00011 /* SettingsUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITestSupport.swift; sourceTree = "<group>"; };
 		D36090030000000000000002 /* SettingsWindowFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowFactory.swift; sourceTree = "<group>"; };
 		D37777030000000000000002 /* SettingsWindowGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowGeometry.swift; sourceTree = "<group>"; };
+		D37777020000000000000002 /* SettingsWindowNavigationRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowNavigationRoutingTests.swift; sourceTree = "<group>"; };
 		D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowOpenRegressionTests.swift; sourceTree = "<group>"; };
 		D36090010000000000000002 /* SettingsWindowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowPresenter.swift; sourceTree = "<group>"; };
 		D36090010000000000000004 /* SettingsWindowPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowPresenterTests.swift; sourceTree = "<group>"; };
@@ -4647,6 +4649,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEC0DE000000000000F203 /* CommandPaletteNucleoFixtures.swift */,
 				A50019B3 /* SettingsSearchIndexTests.swift */,
 				D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */,
+				D37777020000000000000002 /* SettingsWindowNavigationRoutingTests.swift */,
 				D36090010000000000000004 /* SettingsWindowPresenterTests.swift */,
 				D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */,
 				D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */,
@@ -6802,6 +6805,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 				583A675AA1224E8D82A44883 /* SetAutoTitleSocketTests.swift in Sources */,
 				A50019B2 /* SettingsSearchIndexTests.swift in Sources */,
+				D37777020000000000000001 /* SettingsWindowNavigationRoutingTests.swift in Sources */,
 				D37777010000000000000001 /* SettingsWindowOpenRegressionTests.swift in Sources */,
 				D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */,
 				F0ACC0DF0000000000000001 /* SharedLiveAgentIndexAgentLivenessTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1156,6 +1156,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D10000000000000000A00014 /* SettingsTerminalBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */; };
 		D10000000000000000A00010 /* SettingsUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00011 /* SettingsUITestSupport.swift */; };
 		D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090030000000000000002 /* SettingsWindowFactory.swift */; };
+		D37777030000000000000001 /* SettingsWindowGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777030000000000000002 /* SettingsWindowGeometry.swift */; };
 		D37777010000000000000001 /* SettingsWindowOpenRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */; };
 		D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000002 /* SettingsWindowPresenter.swift */; };
 		D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000004 /* SettingsWindowPresenterTests.swift */; };
@@ -2765,6 +2766,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTerminalBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00011 /* SettingsUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITestSupport.swift; sourceTree = "<group>"; };
 		D36090030000000000000002 /* SettingsWindowFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowFactory.swift; sourceTree = "<group>"; };
+		D37777030000000000000002 /* SettingsWindowGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowGeometry.swift; sourceTree = "<group>"; };
 		D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowOpenRegressionTests.swift; sourceTree = "<group>"; };
 		D36090010000000000000002 /* SettingsWindowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowPresenter.swift; sourceTree = "<group>"; };
 		D36090010000000000000004 /* SettingsWindowPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowPresenterTests.swift; sourceTree = "<group>"; };
@@ -3529,6 +3531,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A50019B1 /* SettingsSearchAliases.swift */,
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
 				D36090030000000000000002 /* SettingsWindowFactory.swift */,
+				D37777030000000000000002 /* SettingsWindowGeometry.swift */,
 				D36090010000000000000002 /* SettingsWindowPresenter.swift */,
 					D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */,
 					C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */,
@@ -6035,6 +6038,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A50019A0 /* SettingsNavigation.swift in Sources */,
 				A50019B0 /* SettingsSearchAliases.swift in Sources */,
 				D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */,
+				D37777030000000000000001 /* SettingsWindowGeometry.swift in Sources */,
 				D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */,
 				F0ACC0DE0000000000000011 /* SharedLiveAgentIndex.swift in Sources */,
 				F0ACC0DE0000000000000007 /* SharedLiveAgentIndexLoader.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1156,6 +1156,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D10000000000000000A00014 /* SettingsTerminalBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */; };
 		D10000000000000000A00010 /* SettingsUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00011 /* SettingsUITestSupport.swift */; };
 		D36090030000000000000001 /* SettingsWindowOpenOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090030000000000000002 /* SettingsWindowOpenOutcome.swift */; };
+		D37777010000000000000001 /* SettingsWindowOpenRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */; };
 		D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000002 /* SettingsWindowPresenter.swift */; };
 		D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000004 /* SettingsWindowPresenterTests.swift */; };
 		D10000000000000000A0001E /* SettingsWorkspaceColorsBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A0001F /* SettingsWorkspaceColorsBehaviorUITests.swift */; };
@@ -2764,6 +2765,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTerminalBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00011 /* SettingsUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITestSupport.swift; sourceTree = "<group>"; };
 		D36090030000000000000002 /* SettingsWindowOpenOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowOpenOutcome.swift; sourceTree = "<group>"; };
+		D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowOpenRegressionTests.swift; sourceTree = "<group>"; };
 		D36090010000000000000002 /* SettingsWindowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowPresenter.swift; sourceTree = "<group>"; };
 		D36090010000000000000004 /* SettingsWindowPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowPresenterTests.swift; sourceTree = "<group>"; };
 		D10000000000000000A0001F /* SettingsWorkspaceColorsBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWorkspaceColorsBehaviorUITests.swift; sourceTree = "<group>"; };
@@ -4641,6 +4643,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEC0DE000000000000F201 /* CommandPaletteNucleoFFILibrarySupport.swift */,
 				C0DEC0DE000000000000F203 /* CommandPaletteNucleoFixtures.swift */,
 				A50019B3 /* SettingsSearchIndexTests.swift */,
+				D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */,
 				D36090010000000000000004 /* SettingsWindowPresenterTests.swift */,
 				D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */,
 				D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */,
@@ -6795,6 +6798,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 				583A675AA1224E8D82A44883 /* SetAutoTitleSocketTests.swift in Sources */,
 				A50019B2 /* SettingsSearchIndexTests.swift in Sources */,
+				D37777010000000000000001 /* SettingsWindowOpenRegressionTests.swift in Sources */,
 				D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */,
 				F0ACC0DF0000000000000001 /* SharedLiveAgentIndexAgentLivenessTests.swift in Sources */,
 				C0F16A000000000000000001 /* ShellStartupMatrixTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -120,6 +120,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7AB0000000000000000000F /* AppDelegateMoveTabToNewWorkspaceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */; };
 		F5588000A1B2C3D4E5F60718 /* AppDelegateOptionDigitShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5588001A1B2C3D4E5F60718 /* AppDelegateOptionDigitShortcutRoutingTests.swift */; };
 		C34670010000000000000001 /* AppDelegateRenameShortcutContextTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */; };
+		D37777040000000000000001 /* AppDelegateSettingsPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777040000000000000002 /* AppDelegateSettingsPresentation.swift */; };
 		6419B0016419B0016419B001 /* AppDelegateShortcutRoutingRepairProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */; };
 		F6000000A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */; };
 		C6711A030000000000000001 /* AppDelegateSurfaceResumeTerminalIdTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6711B030000000000000001 /* AppDelegateSurfaceResumeTerminalIdTests.swift */; };
@@ -1795,6 +1796,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7AB00000000000000000010 /* AppDelegateMoveTabToNewWorkspaceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateMoveTabToNewWorkspaceTests.swift; sourceTree = "<group>"; };
 		F5588001A1B2C3D4E5F60718 /* AppDelegateOptionDigitShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateOptionDigitShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateRenameShortcutContextTests.swift; sourceTree = "<group>"; };
+		D37777040000000000000002 /* AppDelegateSettingsPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/AppDelegateSettingsPresentation.swift; sourceTree = "<group>"; };
 		6419B0026419B0026419B002 /* AppDelegateShortcutRoutingRepairProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingRepairProbe.swift; sourceTree = "<group>"; };
 		F6000001A1B2C3D4E5F60718 /* AppDelegateShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateShortcutRoutingTests.swift; sourceTree = "<group>"; };
 		C6711B030000000000000001 /* AppDelegateSurfaceResumeTerminalIdTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateSurfaceResumeTerminalIdTests.swift; sourceTree = "<group>"; };
@@ -3534,6 +3536,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
 				D36090030000000000000002 /* SettingsWindowFactory.swift */,
 				D37777030000000000000002 /* SettingsWindowGeometry.swift */,
+				D37777040000000000000002 /* AppDelegateSettingsPresentation.swift */,
 				D36090010000000000000002 /* SettingsWindowPresenter.swift */,
 					D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */,
 					C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */,
@@ -5455,6 +5458,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5FB1207 /* AppDelegate+WorkspaceActionSave.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
 				B1F0C0080000000000000001 /* AppDelegateDetachedInspectorClose.swift in Sources */,
+				D37777040000000000000001 /* AppDelegateSettingsPresentation.swift in Sources */,
 				A11EAB000000000000000000 /* AppearanceSettings.swift in Sources */,
 				A5001621 /* AppleScriptSupport.swift in Sources */,
 				A5001A02A1B2C3D4E5F60718 /* AppWindowBackdropControllerDependencies.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1155,7 +1155,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D10000000000000000A00016 /* SettingsSidebarBetaBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00017 /* SettingsSidebarBetaBehaviorUITests.swift */; };
 		D10000000000000000A00014 /* SettingsTerminalBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */; };
 		D10000000000000000A00010 /* SettingsUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00011 /* SettingsUITestSupport.swift */; };
-		D36090030000000000000001 /* SettingsWindowOpenOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090030000000000000002 /* SettingsWindowOpenOutcome.swift */; };
+		D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090030000000000000002 /* SettingsWindowFactory.swift */; };
 		D37777010000000000000001 /* SettingsWindowOpenRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */; };
 		D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000002 /* SettingsWindowPresenter.swift */; };
 		D36090010000000000000003 /* SettingsWindowPresenterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000004 /* SettingsWindowPresenterTests.swift */; };
@@ -2764,7 +2764,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D10000000000000000A00017 /* SettingsSidebarBetaBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarBetaBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTerminalBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00011 /* SettingsUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITestSupport.swift; sourceTree = "<group>"; };
-		D36090030000000000000002 /* SettingsWindowOpenOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowOpenOutcome.swift; sourceTree = "<group>"; };
+		D36090030000000000000002 /* SettingsWindowFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowFactory.swift; sourceTree = "<group>"; };
 		D37777010000000000000002 /* SettingsWindowOpenRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowOpenRegressionTests.swift; sourceTree = "<group>"; };
 		D36090010000000000000002 /* SettingsWindowPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowPresenter.swift; sourceTree = "<group>"; };
 		D36090010000000000000004 /* SettingsWindowPresenterTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowPresenterTests.swift; sourceTree = "<group>"; };
@@ -3528,7 +3528,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D5671402D5671402D5671402 /* SettingsNavigation+TerminalScrollSpeed.swift */,
 				A50019B1 /* SettingsSearchAliases.swift */,
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
-				D36090030000000000000002 /* SettingsWindowOpenOutcome.swift */,
+				D36090030000000000000002 /* SettingsWindowFactory.swift */,
 				D36090010000000000000002 /* SettingsWindowPresenter.swift */,
 					D36090020000000000000002 /* NSWindow+CmuxPeerWindow.swift */,
 					C0DE35860000000000000002 /* BackgroundWorkspacePrimeCoordinator.swift */,
@@ -6034,7 +6034,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D5671401D5671401D5671401 /* SettingsNavigation+TerminalScrollSpeed.swift in Sources */,
 				A50019A0 /* SettingsNavigation.swift in Sources */,
 				A50019B0 /* SettingsSearchAliases.swift in Sources */,
-				D36090030000000000000001 /* SettingsWindowOpenOutcome.swift in Sources */,
+				D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */,
 				D36090010000000000000001 /* SettingsWindowPresenter.swift in Sources */,
 				F0ACC0DE0000000000000011 /* SharedLiveAgentIndex.swift in Sources */,
 				F0ACC0DE0000000000000007 /* SharedLiveAgentIndexLoader.swift in Sources */,

--- a/cmuxTests/SettingsWindowNavigationRoutingTests.swift
+++ b/cmuxTests/SettingsWindowNavigationRoutingTests.swift
@@ -126,6 +126,68 @@ struct SettingsWindowNavigationRoutingTests {
         }
     }
 
+    // MARK: - Re-entrant teardown recovery
+
+    @Test func reentrantReopenDuringTeardownAdoptsReplacementWindow() async {
+        await withCleanSettingsWindows {
+            var buildCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                buildCount += 1
+                let window = makePlainFactoryWindow()
+                // Only the first window refuses to present, forcing a
+                // demolish whose close re-enters show() via the observer.
+                window.refusesToBecomeVisible = buildCount == 1
+                return window
+            })
+            let reopener = ReopenOnSettingsTestWindowClose {
+                _ = presenter.show()
+            }
+
+            let result = presenter.show()
+            reopener.stopObserving()
+
+            // The outer retry must adopt the window the re-entrant show
+            // created, not build a duplicate next to it.
+            #expect(result == .presented)
+            #expect(buildCount == 2)
+            let visibleCount = NSApp.windows.filter {
+                $0.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier && $0.isVisible
+            }.count
+            #expect(visibleCount == 1)
+        }
+    }
+
+    @Test func pathologicalReopenOnCloseFailsLoudlyInsteadOfRecursing() async {
+        await withCleanSettingsWindows {
+            var buildCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                buildCount += 1
+                let window = makePlainFactoryWindow()
+                window.refusesToBecomeVisible = true
+                return window
+            })
+            let reopener = ReopenOnSettingsTestWindowClose {
+                _ = presenter.show()
+            }
+
+            let result = presenter.show()
+            reopener.stopObserving()
+
+            // Every window refuses to present and every close re-enters
+            // show(): the depth bound must convert this into a loud failure
+            // with a bounded number of attempts, never a runaway recursion.
+            guard case .failed = result else {
+                Issue.record("expected .failed, got \(result)")
+                return
+            }
+            #expect(buildCount < 20)
+            let visibleCount = NSApp.windows.filter {
+                $0.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier && $0.isVisible
+            }.count
+            #expect(visibleCount == 0)
+        }
+    }
+
     // MARK: - Helpers
 
     private func visibleSettingsWindow() -> NSWindow? {
@@ -160,8 +222,8 @@ struct SettingsWindowNavigationRoutingTests {
 }
 
 @MainActor
-private func makePlainFactoryWindow() -> SettingsHostWindow {
-    let window = SettingsHostWindow(
+private func makePlainFactoryWindow() -> SettingsTestHostWindow {
+    let window = SettingsTestHostWindow(
         contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
         styleMask: [.titled, .closable, .miniaturizable, .resizable],
         backing: .buffered,
@@ -170,6 +232,53 @@ private func makePlainFactoryWindow() -> SettingsHostWindow {
     window.isReleasedWhenClosed = false
     window.contentViewController = NSViewController()
     return window
+}
+
+@MainActor
+private final class SettingsTestHostWindow: SettingsHostWindow {
+    var refusesToBecomeVisible = false
+
+    override var isVisible: Bool {
+        refusesToBecomeVisible ? false : super.isVisible
+    }
+
+    override func makeKeyAndOrderFront(_ sender: Any?) {
+        guard !refusesToBecomeVisible else { return }
+        super.makeKeyAndOrderFront(sender)
+    }
+
+    override func orderFrontRegardless() {
+        guard !refusesToBecomeVisible else { return }
+        super.orderFrontRegardless()
+    }
+}
+
+/// Re-enters the given closure from any `SettingsTestHostWindow`'s willClose
+/// notification (the presenter's demolish closes windows synchronously).
+@MainActor
+private final class ReopenOnSettingsTestWindowClose: NSObject {
+    private let reopen: () -> Void
+
+    init(reopen: @escaping () -> Void) {
+        self.reopen = reopen
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: nil
+        )
+    }
+
+    func stopObserving() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc
+    private func windowWillClose(_ notification: Notification) {
+        guard notification.object is SettingsTestHostWindow else { return }
+        reopen()
+    }
 }
 
 /// Records `SettingsNavigationRequest` posts on the main actor.

--- a/cmuxTests/SettingsWindowNavigationRoutingTests.swift
+++ b/cmuxTests/SettingsWindowNavigationRoutingTests.swift
@@ -1,0 +1,187 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+#if DEBUG
+/// Navigation-delivery ordering and sidebar-command routing for the
+/// AppKit-hosted Settings window (issue #7777 follow-ups): a queued
+/// fresh-window navigation must deliver exactly once and never override a
+/// newer targeted open, and the shared Toggle Left Sidebar command must reach
+/// the Settings split view when the Settings window is key.
+@MainActor
+@Suite(.serialized)
+struct SettingsWindowNavigationRoutingTests {
+    @Test func queuedFreshWindowNavigationDelivers() async {
+        await withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makePlainFactoryWindow() })
+            let recorder = SettingsNavigationTargetRecorder()
+
+            #expect(presenter.show(navigationTarget: .browserImport) == .presented)
+            presenter.deliverPendingNavigationAfterContentAppears()
+            await drainMainQueue()
+            recorder.stopObserving()
+
+            #expect(recorder.receivedTargets == [.browserImport])
+        }
+    }
+
+    @Test func staleQueuedNavigationIsSupersededByNewerTargetedShow() async {
+        await withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makePlainFactoryWindow() })
+            let recorder = SettingsNavigationTargetRecorder()
+
+            #expect(presenter.show(navigationTarget: .browserImport) == .presented)
+            // Content appears and queues the browserImport post, but a newer
+            // targeted show reuses the window and delivers synchronously
+            // before the queued task runs; the stale post must stay silent.
+            presenter.deliverPendingNavigationAfterContentAppears()
+            #expect(presenter.show(navigationTarget: .keyboardShortcuts) == .presented)
+            await drainMainQueue()
+            recorder.stopObserving()
+
+            #expect(recorder.receivedTargets == [.keyboardShortcuts])
+        }
+    }
+
+    @Test func sidebarToggleRoutesToKeySettingsWindow() async {
+        await withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makePlainFactoryWindow() })
+            #expect(presenter.show() == .presented)
+            let window = visibleSettingsWindow()
+            #expect(window != nil)
+            let recorder = SettingsSidebarToggleRecorder()
+
+            let handled = SettingsWindowPresenter.handleSidebarToggleIfSettingsWindowIsKey(
+                keyWindow: window
+            )
+            recorder.stopObserving()
+
+            #expect(handled)
+            #expect(recorder.receivedCount == 1)
+        }
+    }
+
+    @Test func sidebarToggleIgnoresNonSettingsKeyWindow() async {
+        await withCleanSettingsWindows {
+            let otherWindow = makePlainFactoryWindow()
+            otherWindow.identifier = NSUserInterfaceItemIdentifier("cmux.main.test")
+            defer { otherWindow.close() }
+            let recorder = SettingsSidebarToggleRecorder()
+
+            let handledOther = SettingsWindowPresenter.handleSidebarToggleIfSettingsWindowIsKey(
+                keyWindow: otherWindow
+            )
+            let handledNil = SettingsWindowPresenter.handleSidebarToggleIfSettingsWindowIsKey(
+                keyWindow: nil
+            )
+            recorder.stopObserving()
+
+            #expect(!handledOther)
+            #expect(!handledNil)
+            #expect(recorder.receivedCount == 0)
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func visibleSettingsWindow() -> NSWindow? {
+        NSApp.windows.first {
+            $0.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier && $0.isVisible
+        }
+    }
+
+    private func withCleanSettingsWindows(_ body: () async throws -> Void) async rethrows {
+        closeSettingsWindows()
+        defer { closeSettingsWindows() }
+        try await body()
+    }
+
+    private func closeSettingsWindows() {
+        for window in NSApp.windows
+        where window.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier {
+            window.orderOut(nil)
+            window.identifier = nil
+            window.close()
+        }
+        UserDefaults.standard.removeObject(forKey: "NSWindow Frame cmux.settings")
+    }
+
+    /// Lets already-enqueued main-actor tasks (the deferred navigation post)
+    /// run before assertions.
+    private func drainMainQueue() async {
+        for _ in 0..<20 {
+            await Task.yield()
+        }
+    }
+}
+
+@MainActor
+private func makePlainFactoryWindow() -> SettingsHostWindow {
+    let window = SettingsHostWindow(
+        contentRect: NSRect(x: 0, y: 0, width: 980, height: 680),
+        styleMask: [.titled, .closable, .miniaturizable, .resizable],
+        backing: .buffered,
+        defer: false
+    )
+    window.isReleasedWhenClosed = false
+    window.contentViewController = NSViewController()
+    return window
+}
+
+/// Records `SettingsNavigationRequest` posts on the main actor.
+@MainActor
+private final class SettingsNavigationTargetRecorder: NSObject {
+    private(set) var receivedTargets: [SettingsNavigationTarget] = []
+
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceive(_:)),
+            name: SettingsNavigationRequest.notificationName,
+            object: nil
+        )
+    }
+
+    func stopObserving() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc
+    private func didReceive(_ notification: Notification) {
+        if let target = SettingsNavigationRequest.target(from: notification) {
+            receivedTargets.append(target)
+        }
+    }
+}
+
+/// Counts `SettingsWindowRoot.sidebarToggleRequestName` posts on the main actor.
+@MainActor
+private final class SettingsSidebarToggleRecorder: NSObject {
+    private(set) var receivedCount = 0
+
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceive(_:)),
+            name: SettingsWindowRoot.sidebarToggleRequestName,
+            object: nil
+        )
+    }
+
+    func stopObserving() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc
+    private func didReceive(_ notification: Notification) {
+        receivedCount += 1
+    }
+}
+#endif

--- a/cmuxTests/SettingsWindowNavigationRoutingTests.swift
+++ b/cmuxTests/SettingsWindowNavigationRoutingTests.swift
@@ -48,6 +48,27 @@ struct SettingsWindowNavigationRoutingTests {
         }
     }
 
+    @Test func targetedReuseBeforeContentReadyKeepsNavigationPending() async {
+        await withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makePlainFactoryWindow() })
+            let recorder = SettingsNavigationTargetRecorder()
+
+            // Two targeted opens land before the content ever signals
+            // readiness (e.g. rapid CLI opens while the window is still
+            // mounting). Nothing may be posted into the void; the latest
+            // target must survive until the content appears.
+            #expect(presenter.show(navigationTarget: .browserImport) == .presented)
+            #expect(presenter.show(navigationTarget: .keyboardShortcuts) == .presented)
+            #expect(recorder.receivedTargets.isEmpty)
+
+            presenter.deliverPendingNavigationAfterContentAppears()
+            await drainMainQueue()
+            recorder.stopObserving()
+
+            #expect(recorder.receivedTargets == [.keyboardShortcuts])
+        }
+    }
+
     @Test func sidebarToggleRoutesToKeySettingsWindow() async {
         await withCleanSettingsWindows {
             let presenter = SettingsWindowPresenter(windowFactory: { makePlainFactoryWindow() })

--- a/cmuxTests/SettingsWindowNavigationRoutingTests.swift
+++ b/cmuxTests/SettingsWindowNavigationRoutingTests.swift
@@ -69,6 +69,24 @@ struct SettingsWindowNavigationRoutingTests {
         }
     }
 
+    @Test func untargetedShowDoesNotDropPendingNavigationTarget() async {
+        await withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makePlainFactoryWindow() })
+            let recorder = SettingsNavigationTargetRecorder()
+
+            #expect(presenter.show(navigationTarget: .browserImport) == .presented)
+            // An untargeted open (e.g. a menu click) lands before the content
+            // appears; it must not erase the still-undelivered target.
+            #expect(presenter.show() == .presented)
+
+            presenter.deliverPendingNavigationAfterContentAppears()
+            await drainMainQueue()
+            recorder.stopObserving()
+
+            #expect(recorder.receivedTargets == [.browserImport])
+        }
+    }
+
     @Test func sidebarToggleRoutesToKeySettingsWindow() async {
         await withCleanSettingsWindows {
             let presenter = SettingsWindowPresenter(windowFactory: { makePlainFactoryWindow() })
@@ -181,7 +199,10 @@ private final class SettingsNavigationTargetRecorder: NSObject {
     }
 }
 
-/// Counts `SettingsWindowRoot.sidebarToggleRequestName` posts on the main actor.
+/// Counts settings sidebar-toggle request posts on the main actor. Uses the
+/// raw notification name (the stable contract with CmuxSettingsUI's
+/// `SettingsWindowRoot.sidebarToggleRequestName`) so the test target does not
+/// depend on package-symbol visibility, which differs across toolchains.
 @MainActor
 private final class SettingsSidebarToggleRecorder: NSObject {
     private(set) var receivedCount = 0
@@ -191,7 +212,7 @@ private final class SettingsSidebarToggleRecorder: NSObject {
         NotificationCenter.default.addObserver(
             self,
             selector: #selector(didReceive(_:)),
-            name: SettingsWindowRoot.sidebarToggleRequestName,
+            name: Notification.Name("cmux.settings.toggleSidebar"),
             object: nil
         )
     }

--- a/cmuxTests/SettingsWindowOpenRegressionTests.swift
+++ b/cmuxTests/SettingsWindowOpenRegressionTests.swift
@@ -1,0 +1,169 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+#if DEBUG
+/// End-to-end regression coverage for the "Settings won't open" family
+/// (https://github.com/manaflow-ai/cmux/issues/7777, #7775, #5770, #4053):
+/// every `show()` must end with a *visible* Settings window, synchronously,
+/// from any prior lifecycle state — fresh process, after close, after
+/// open/close churn, while a previous window is mid-close, and after the
+/// window's frame was stranded off every active screen.
+///
+/// These tests intentionally drive the real presenter entry point with no
+/// injected opener: a request that is merely "accepted" (the pre-#7777
+/// behavior of handing the request to SwiftUI's `openWindow(id:)` and hoping
+/// the scene materializes a window) fails them.
+@MainActor
+@Suite(.serialized)
+struct SettingsWindowOpenRegressionTests {
+    @Test func showAlwaysProducesAVisibleSettingsWindow() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter()
+
+            presenter.show()
+
+            #expect(visibleSettingsWindow() != nil)
+        }
+    }
+
+    @Test func showAfterCloseProducesAFreshVisibleSettingsWindow() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter()
+
+            presenter.show()
+            let firstWindow = visibleSettingsWindow()
+            #expect(firstWindow != nil)
+            firstWindow?.close()
+
+            presenter.show()
+            let secondWindow = visibleSettingsWindow()
+
+            #expect(secondWindow != nil)
+            // The reopened window must be a fresh, fully-populated window —
+            // never the half-closed previous one (the #4964 blank-content and
+            // #5321 lingering-window classes).
+            #expect(secondWindow !== firstWindow)
+        }
+    }
+
+    @Test func openCloseChurnNeverWedgesTheOpenPath() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter()
+
+            for _ in 0..<3 {
+                presenter.show()
+                visibleSettingsWindow()?.close()
+            }
+            presenter.show()
+
+            #expect(visibleSettingsWindow() != nil)
+        }
+    }
+
+    @Test func showWhileSettingsWindowIsMidCloseStillProducesAVisibleWindow() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter()
+
+            presenter.show()
+            let firstWindow = visibleSettingsWindow()
+            #expect(firstWindow != nil)
+            guard let firstWindow else { return }
+
+            // Re-request Settings from inside the willClose notification —
+            // the previous window is torn down but still alive. The open
+            // request must not be absorbed by the dying window.
+            let reopener = ReopenSettingsOnWillClose(window: firstWindow) {
+                presenter.show()
+            }
+            firstWindow.close()
+            reopener.stopObserving()
+
+            #expect(visibleSettingsWindow() != nil)
+        }
+    }
+
+    @Test func showRecoversASettingsWindowParkedOffAllScreens() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter()
+
+            presenter.show()
+            let window = visibleSettingsWindow()
+            #expect(window != nil)
+            guard let window else { return }
+            // Strand the window where no active screen can show it (the
+            // saved-frame-on-a-disconnected-display shape from #5770).
+            window.setFrame(
+                NSRect(x: -99_999, y: -99_999, width: 980, height: 680),
+                display: false
+            )
+
+            presenter.show()
+
+            let recoveredFrame = visibleSettingsWindow()?.frame
+            #expect(recoveredFrame != nil)
+            if let recoveredFrame {
+                let intersectsAnyScreen = NSScreen.screens.contains {
+                    $0.visibleFrame.intersects(recoveredFrame)
+                }
+                #expect(intersectsAnyScreen)
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func visibleSettingsWindow() -> NSWindow? {
+        NSApp.windows.first {
+            $0.identifier?.rawValue == "cmux.settings" && $0.isVisible
+        }
+    }
+
+    private func withCleanSettingsWindows(_ body: () -> Void) {
+        closeSettingsWindows()
+        defer { closeSettingsWindows() }
+        body()
+    }
+
+    private func closeSettingsWindows() {
+        for window in NSApp.windows where window.identifier?.rawValue == "cmux.settings" {
+            window.orderOut(nil)
+            window.identifier = nil
+            window.close()
+        }
+    }
+}
+
+/// Invokes `reopen` from inside the observed window's `willClose`
+/// notification, on the main actor (window notifications post on the posting
+/// thread, and `NSWindow.close()` runs on the main thread in these tests).
+@MainActor
+private final class ReopenSettingsOnWillClose: NSObject {
+    private let reopen: () -> Void
+
+    init(window: NSWindow, reopen: @escaping () -> Void) {
+        self.reopen = reopen
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: window
+        )
+    }
+
+    func stopObserving() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc
+    private func windowWillClose(_ notification: Notification) {
+        reopen()
+    }
+}
+#endif

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -8,270 +8,266 @@ import Testing
 #endif
 
 #if DEBUG
+/// Unit coverage for ``SettingsWindowPresenter``'s AppKit-owned lifecycle
+/// (issue #7777) using an injected window factory. End-to-end coverage of the
+/// real factory path lives in `SettingsWindowOpenRegressionTests`.
 @MainActor
 @Suite(.serialized)
 struct SettingsWindowPresenterTests {
-    @Test func configureWindowLeavesPendingNavigationForSettingsViews() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let settingsWindow = makeWindow(identifier: "cmux.unconfiguredSettings.\(UUID().uuidString)")
-            var didOpen = false
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
+    // MARK: - Creation, reuse, and self-healing
+
+    @Test func showCreatesWindowThroughFactoryAndFrontsIt() {
+        withCleanSettingsWindows {
+            var factoryCallCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                factoryCallCount += 1
+                return makeFactoryWindow()
+            })
+
+            let result = presenter.show()
+
+            #expect(result == .presented)
+            #expect(factoryCallCount == 1)
+            let window = visibleSettingsWindow()
+            #expect(window != nil)
+            #expect(window?.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier)
+            #expect(window?.isReleasedWhenClosed == false)
+            #expect(window?.isRestorable == false)
+        }
+    }
+
+    @Test func showReusesUsableExistingWindow() {
+        withCleanSettingsWindows {
+            var factoryCallCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                factoryCallCount += 1
+                return makeFactoryWindow()
+            })
+
+            #expect(presenter.show() == .presented)
+            #expect(presenter.show() == .presented)
+
+            #expect(factoryCallCount == 1)
+        }
+    }
+
+    @Test func showAfterCloseCreatesFreshWindow() {
+        withCleanSettingsWindows {
+            var factoryCallCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                factoryCallCount += 1
+                return makeFactoryWindow()
+            })
+
+            #expect(presenter.show() == .presented)
+            let firstWindow = visibleSettingsWindow()
+            firstWindow?.close()
+
+            #expect(presenter.show() == .presented)
+
+            #expect(factoryCallCount == 2)
+            // The closed window must never satisfy a future open request.
+            #expect(firstWindow?.identifier == nil)
+            let secondWindow = visibleSettingsWindow()
+            #expect(secondWindow != nil)
+            #expect(secondWindow !== firstWindow)
+        }
+    }
+
+    @Test func closingReleasesTheWindowContent() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makeFactoryWindow() })
+
+            #expect(presenter.show() == .presented)
+            let window = visibleSettingsWindow()
+            #expect(window?.contentViewController != nil)
+
+            window?.close()
+
+            // The content tree is released with the window so a closed
+            // Settings cannot linger half-alive (#4964 / #5321 classes).
+            #expect(window?.contentViewController == nil)
+        }
+    }
+
+    @Test func showTearsDownContentlessWindowAndRecreates() {
+        withCleanSettingsWindows {
+            var factoryCallCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                factoryCallCount += 1
+                return makeFactoryWindow()
+            })
+
+            #expect(presenter.show() == .presented)
+            let huskWindow = visibleSettingsWindow()
+            // Simulate a window whose content was torn down without a close
+            // (the "hidden-but-alive" / unloaded-content family).
+            huskWindow?.contentViewController = nil
+            huskWindow?.contentView = nil
+
+            #expect(presenter.show() == .presented)
+
+            #expect(factoryCallCount == 2)
+            #expect(huskWindow?.identifier == nil)
+            let replacement = visibleSettingsWindow()
+            #expect(replacement != nil)
+            #expect(replacement !== huskWindow)
+        }
+    }
+
+    @Test func showDuringWillCloseCreatesFreshWindow() {
+        withCleanSettingsWindows {
+            var factoryCallCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                factoryCallCount += 1
+                return makeFactoryWindow()
+            })
+
+            #expect(presenter.show() == .presented)
+            let firstWindow = visibleSettingsWindow()
+            #expect(firstWindow != nil)
+            guard let firstWindow else { return }
+
+            var midCloseResult: SettingsWindowShowResult?
+            let reopener = ReopenSettingsOnWillClose(window: firstWindow) {
+                midCloseResult = presenter.show()
             }
+            firstWindow.close()
+            reopener.stopObserving()
 
-            presenter.show(
-                navigationTarget: .browserImport,
-                openWindowOverride: { didOpen = true }
+            #expect(midCloseResult == .presented)
+            #expect(factoryCallCount == 2)
+            #expect(visibleSettingsWindow() != nil)
+        }
+    }
+
+    @Test func showFailsLoudlyWhenNoWindowBecomesVisible() {
+        withCleanSettingsWindows {
+            var factoryCallCount = 0
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                factoryCallCount += 1
+                let window = makeFactoryWindow()
+                window.refusesToBecomeVisible = true
+                return window
+            })
+
+            let result = presenter.show()
+
+            // Bounded recreation: one reuse-or-create pass plus one fresh
+            // recreate, then a loud failure — never a silent no-op.
+            #expect(factoryCallCount == SettingsWindowPresenter.maxPresentAttempts)
+            guard case .failed(let reason) = result else {
+                Issue.record("expected .failed, got \(result)")
+                return
+            }
+            #expect(reason.contains("did not become visible"))
+        }
+    }
+
+    // MARK: - Geometry repair on show
+
+    @Test func showEnforcesMinimumSizeOnDegenerateFactoryWindow() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: {
+                makeFactoryWindow(contentRect: NSRect(x: 0, y: 0, width: 500, height: 300))
+            })
+
+            #expect(presenter.show() == .presented)
+
+            let frame = visibleSettingsWindow()?.frame
+            #expect((frame?.width ?? 0) >= SettingsWindowPresenter.minimumSize.width)
+            #expect((frame?.height ?? 0) >= SettingsWindowPresenter.minimumSize.height)
+        }
+    }
+
+    @Test func showClampsOversizedSettingsFrameToVisibleArea() throws {
+        try withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makeFactoryWindow() })
+            let screen = try #require(NSScreen.main)
+            let visibleFrame = screen.visibleFrame
+
+            #expect(presenter.show() == .presented)
+            let window = try #require(visibleSettingsWindow())
+            window.setFrame(
+                NSRect(
+                    x: visibleFrame.minX - 120,
+                    y: visibleFrame.minY - 120,
+                    width: visibleFrame.width * 2,
+                    height: visibleFrame.height * 2
+                ),
+                display: false
             )
-            presenter.configure(window: settingsWindow)
 
-            #expect(didOpen)
-            #expect(presenter.consumePendingNavigationTarget() == .browserImport)
-            #expect(presenter.consumePendingContentNavigationTarget() == .browserImport)
+            #expect(presenter.show() == .presented)
+
+            let inset: CGFloat = 18
+            let availableWidth = max(
+                SettingsWindowPresenter.minimumSize.width,
+                visibleFrame.width - 2 * inset
+            )
+            let availableHeight = max(
+                SettingsWindowPresenter.minimumSize.height,
+                visibleFrame.height - 2 * inset
+            )
+            let frame = window.frame
+            #expect(frame.width <= availableWidth)
+            #expect(frame.height <= availableHeight)
+            #expect(frame.minX >= visibleFrame.minX + inset)
+            #expect(frame.minY >= visibleFrame.minY + inset)
+        }
+    }
+
+    // MARK: - Navigation delivery
+
+    @Test func navigationPostsImmediatelyForExistingVisibleWindow() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makeFactoryWindow() })
+            #expect(presenter.show() == .presented)
+
+            let recorder = SettingsNavigationRecorder()
+            #expect(presenter.show(navigationTarget: .browserImport) == .presented)
+            recorder.stopObserving()
+
+            #expect(recorder.receivedTargets == [.browserImport])
+            // Delivered immediately, so nothing stays pending.
             #expect(presenter.consumePendingNavigationTarget() == nil)
-            #expect(presenter.consumePendingContentNavigationTarget() == nil)
         }
     }
 
-    @Test func repeatedConfigureForSameSettingsWindowDoesNotRefocus() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
+    @Test func navigationStaysPendingForFreshWindowUntilContentConsumesIt() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makeFactoryWindow() })
 
-            presenter.show(openWindowOverride: {})
-            presenter.configure(window: settingsWindow)
-            await Task.yield()
-            presenter.configure(window: settingsWindow)
-            await Task.yield()
+            let recorder = SettingsNavigationRecorder()
+            #expect(presenter.show(navigationTarget: .browserImport) == .presented)
+            recorder.stopObserving()
 
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 1)
-        }
-    }
-
-    @Test func configureWindowWithoutOpenRequestDoesNotFocus() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
-
-            presenter.configure(window: settingsWindow)
-            await Task.yield()
-
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 0)
-            #expect(!settingsWindow.isVisible)
-        }
-    }
-
-    @Test func showPreservesPendingNavigationWhenExistingSettingsWindowIsMiniaturized() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let settingsWindow = makeWindow(
-                identifier: SettingsWindowPresenter.windowIdentifier,
-                forcedMiniaturized: true
-            )
-            var didOpen = false
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
-
-            presenter.configure(window: settingsWindow)
-            await Task.yield()
-
-            presenter.show(
-                navigationTarget: .browserImport,
-                openWindowOverride: { didOpen = true }
-            )
-
-            #expect(!didOpen)
+            // A fresh window's content is not listening yet; the host root
+            // consumes the pending target from its onAppear instead.
+            #expect(recorder.receivedTargets.isEmpty)
             #expect(presenter.consumePendingNavigationTarget() == .browserImport)
-            #expect(presenter.consumePendingContentNavigationTarget() == .browserImport)
+            #expect(presenter.consumePendingNavigationTarget() == nil)
         }
     }
 
-    @Test func closedSettingsWindowReopensThroughSceneInsteadOfRetainingHiddenTree() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            var didOpen = false
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
+    // MARK: - Peer-window behavior
 
-            presenter.show(openWindowOverride: {})
-            presenter.configure(window: settingsWindow)
-            await Task.yield()
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 1)
+    @Test func doesNotAttachSettingsAsChildOfPreferredMainWindow() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makeFactoryWindow() })
 
-            settingsWindow.close()
-            await Task.yield()
+            #expect(presenter.show() == .presented)
 
-            presenter.show(
-                openWindowOverride: { didOpen = true }
-            )
-
-            #expect(didOpen)
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 1)
-            #expect(settingsWindow.identifier == nil)
+            let window = visibleSettingsWindow()
+            #expect(window?.parent == nil)
+            #expect(window?.level == .normal)
         }
     }
 
-    @Test func showReusesTrackedOrderedOutSettingsWindow() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            var didOpen = false
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
-
-            presenter.configure(window: settingsWindow)
-            settingsWindow.orderOut(nil)
-            await Task.yield()
-
-            presenter.show(openWindowOverride: { didOpen = true })
-
-            #expect(!didOpen)
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 1)
-            #expect(settingsWindow.isVisible)
-        }
-    }
-
-    @Test func repeatedShowWhileSettingsSceneIsOpeningCoalescesOpenRequests() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            var openCallCount = 0
-
-            presenter.show(openWindowOverride: { openCallCount += 1 })
-            presenter.show(openWindowOverride: { openCallCount += 1 })
-
-            #expect(openCallCount == 1)
-        }
-    }
-
-    @Test func refocusIfVisibleDoesNotReopenClosedSettingsWindow() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
-
-            presenter.show(openWindowOverride: {})
-            presenter.configure(window: settingsWindow)
-            await Task.yield()
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 1)
-
-            settingsWindow.orderOut(nil)
-            #expect(!settingsWindow.isVisible)
-
-            presenter.refocusIfVisible()
-
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 1)
-            #expect(!settingsWindow.isVisible)
-        }
-    }
-
-    @Test func doesNotAttachSettingsAsChildOfPreferredMainWindow() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            defer {
-                settingsWindow.orderOut(nil)
-                parentWindow.orderOut(nil)
-                settingsWindow.close()
-                parentWindow.close()
-            }
-
-            presenter.configure(
-                openWindow: {},
-                parentWindowProvider: { parentWindow }
-            )
-            presenter.configure(window: settingsWindow)
-
-            #expect(settingsWindow.parent == nil)
-            #expect(!hasChild(parentWindow, settingsWindow))
-            #expect(settingsWindow.level == .normal)
-        }
-    }
-
-    @Test func focusingSettingsKeepsItAsPeerWhenPreferredMainWindowChanges() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let firstParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
-            let secondParent = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            var preferredParent = firstParent
-            defer {
-                settingsWindow.orderOut(nil)
-                firstParent.orderOut(nil)
-                secondParent.orderOut(nil)
-                settingsWindow.close()
-                firstParent.close()
-                secondParent.close()
-            }
-
-            presenter.configure(
-                openWindow: {},
-                parentWindowProvider: { preferredParent }
-            )
-            presenter.configure(window: settingsWindow)
-            #expect(settingsWindow.parent == nil)
-
-            preferredParent = secondParent
-            settingsWindow.orderFront(nil)
-            presenter.refocusIfVisible()
-
-            #expect(settingsWindow.parent == nil)
-            #expect(!hasChild(firstParent, settingsWindow))
-            #expect(!hasChild(secondParent, settingsWindow))
-            #expect(settingsWindow.level == .normal)
-        }
-    }
-
-    @Test func settingsSurvivesPreferredMainWindowCloseAsIndependentPeer() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let parentWindow = makeWindow(identifier: "cmux.main.\(UUID().uuidString)")
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            defer {
-                settingsWindow.orderOut(nil)
-                parentWindow.orderOut(nil)
-                settingsWindow.close()
-                parentWindow.close()
-            }
-
-            presenter.configure(
-                openWindow: {},
-                parentWindowProvider: { parentWindow }
-            )
-            presenter.configure(window: settingsWindow)
-            settingsWindow.orderFront(nil)
-            #expect(settingsWindow.parent == nil)
-
-            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: parentWindow)
-
-            #expect(settingsWindow.parent == nil)
-            #expect(settingsWindow.isVisible)
-        }
-    }
-
-    @Test func adoptCmuxPeerWindowLevelBringsFloatingWindowToNormal() async throws {
-        try await withCleanSettingsWindows {
-            let window = makeWindow(identifier: "cmux.peer.\(UUID().uuidString)")
+    @Test func adoptCmuxPeerWindowLevelBringsFloatingWindowToNormal() {
+        withCleanSettingsWindows {
+            let window = makeFactoryWindow()
+            window.identifier = NSUserInterfaceItemIdentifier("cmux.peer.\(UUID().uuidString)")
             defer {
                 window.orderOut(nil)
                 window.close()
@@ -286,55 +282,33 @@ struct SettingsWindowPresenterTests {
         }
     }
 
-    @Test func configureClampsOversizedSettingsFrameToVisibleArea() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            let screen = try #require(NSScreen.main)
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            let visibleFrame = screen.visibleFrame
-            settingsWindow.setFrame(
-                NSRect(
-                    x: visibleFrame.minX - 120,
-                    y: visibleFrame.minY - 120,
-                    width: visibleFrame.width * 2,
-                    height: visibleFrame.height * 2
-                ),
-                display: false
-            )
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
+    // MARK: - Pure usability policy
 
-            presenter.configure(window: settingsWindow)
-
-            let inset: CGFloat = 18
-            let availableWidth = max(
-                SettingsWindowPresenter.minimumSize.width,
-                visibleFrame.width - 2 * inset
-            )
-            let availableHeight = max(
-                SettingsWindowPresenter.minimumSize.height,
-                visibleFrame.height - 2 * inset
-            )
-            let frame = settingsWindow.frame
-            #expect(frame.width <= availableWidth)
-            #expect(frame.height <= availableHeight)
-            #expect(frame.minX >= visibleFrame.minX + inset)
-            #expect(frame.minY >= visibleFrame.minY + inset)
-            if frame.width <= visibleFrame.width - 2 * inset {
-                #expect(frame.maxX <= visibleFrame.maxX - inset)
-            }
-            if frame.height <= visibleFrame.height - 2 * inset {
-                #expect(frame.maxY <= visibleFrame.maxY - inset)
-            }
-        }
+    @Test func unusableReasonForMissingContent() {
+        let reason = SettingsWindowPresenter.unusableWindowReason(
+            hasContent: false,
+            frame: NSRect(x: 0, y: 0, width: 980, height: 680),
+            minimumSize: SettingsWindowPresenter.minimumSize
+        )
+        #expect(reason != nil)
     }
 
-    private func withCleanSettingsWindows(_ body: () async throws -> Void) async rethrows {
-        closeSettingsWindows()
-        defer { closeSettingsWindows() }
-        try await body()
+    @Test func unusableReasonForDegenerateFrame() {
+        let reason = SettingsWindowPresenter.unusableWindowReason(
+            hasContent: true,
+            frame: NSRect(x: 0, y: 0, width: 40, height: 20),
+            minimumSize: SettingsWindowPresenter.minimumSize
+        )
+        #expect(reason != nil)
+    }
+
+    @Test func usableWindowHasNoUnusableReason() {
+        let reason = SettingsWindowPresenter.unusableWindowReason(
+            hasContent: true,
+            frame: NSRect(x: 0, y: 0, width: 980, height: 680),
+            minimumSize: SettingsWindowPresenter.minimumSize
+        )
+        #expect(reason == nil)
     }
 
     // MARK: - Multi-monitor recovery (issue #5770)
@@ -453,216 +427,116 @@ struct SettingsWindowPresenterTests {
         #expect(clamped.height >= SettingsWindowPresenter.minimumSize.height)
     }
 
-    // MARK: - Silent no-op recovery (issue #5770 / #4053)
+    // MARK: - Helpers
 
-    // The "click Settings and nothing happens" symptom: the open request is
-    // dispatched but no window ever materializes. The presenter must notice
-    // the silently-dropped request and re-request the window, bounded at
-    // exactly one retry by maxOpenAttempts.
-    @Test func showReRequestsWindowWhenOpenRequestSilentlyProducesNoWindow() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            var openRequests = 0
-            presenter.configure(openWindow: { openRequests += 1 })
-
-            presenter.show()
-            #expect(openRequests == 1)
-
-            let outcome = presenter.resolveOpenVerification(
-                attempt: 1,
-                opener: { openRequests += 1 }
-            )
-
-            #expect(outcome == .retry)
-            #expect(openRequests == 2)
+    private func visibleSettingsWindow() -> NSWindow? {
+        NSApp.windows.first {
+            $0.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier && $0.isVisible
         }
     }
 
-    // show() before configure(openWindow:) defers the open request; the
-    // deferred request must get the same lost-request verification as a
-    // direct one instead of being fired blind.
-    @Test func deferredOpenRequestAlsoVerifiesAndRetries() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            var openRequests = 0
-
-            presenter.show()
-            #expect(openRequests == 0)
-
-            presenter.configure(openWindow: { openRequests += 1 })
-            #expect(openRequests == 1)
-
-            let outcome = presenter.resolveOpenVerification(
-                attempt: 1,
-                opener: { openRequests += 1 }
-            )
-
-            #expect(outcome == .retry)
-            #expect(openRequests == 2)
-        }
-    }
-
-    // An override opener (e.g. BrowserPanelView.openBrowserImportSettings still
-    // calls SwiftUI openWindow(id:)) hits the same mid-teardown no-op, so it
-    // must get the same lost-request verification and single retry.
-    @Test func overrideOpenRequestAlsoVerifiesAndRetries() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            var openRequests = 0
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-            #expect(openRequests == 1)
-
-            let outcome = presenter.resolveOpenVerification(
-                attempt: 1,
-                opener: { openRequests += 1 }
-            )
-
-            #expect(outcome == .retry)
-            #expect(openRequests == 2)
-        }
-    }
-
-    @Test func retryKeepsOpeningRequestsCoalescedUntilWindowMaterializes() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            var openRequests = 0
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-            #expect(openRequests == 1)
-
-            let outcome = presenter.resolveOpenVerification(
-                attempt: 1,
-                opener: { openRequests += 1 }
-            )
-            #expect(outcome == .retry)
-            #expect(openRequests == 2)
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-            #expect(openRequests == 2)
-        }
-    }
-
-    @Test func scheduledVerificationCanAdvanceWithoutRealWaiting() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter(openVerificationDelay: .zero)
-            var openRequests = 0
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-            #expect(openRequests == 1)
-
-            for _ in 0..<20 {
-                if openRequests == 2 { break }
-                await Task.yield()
-            }
-
-            #expect(openRequests == 2)
-        }
-    }
-
-    @Test func giveUpClearsOpeningFlagSoNextShowCanRequestAgain() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            var openRequests = 0
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-            #expect(openRequests == 1)
-
-            let outcome = presenter.resolveOpenVerification(
-                attempt: SettingsWindowPresenter.maxOpenAttempts,
-                opener: { openRequests += 1 }
-            )
-            #expect(outcome == .giveUp)
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-            #expect(openRequests == 2)
-        }
-    }
-
-    @Test func materializedVerificationUsesIdentifierScannedWindowAndClearsOpeningFlag() async throws {
-        try await withCleanSettingsWindows {
-            let presenter = SettingsWindowPresenter()
-            var openRequests = 0
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-            #expect(openRequests == 1)
-
-            let settingsWindow = makeWindow(identifier: SettingsWindowPresenter.windowIdentifier)
-            defer {
-                settingsWindow.orderOut(nil)
-                settingsWindow.close()
-            }
-
-            let outcome = presenter.resolveOpenVerification(
-                attempt: 1,
-                opener: { openRequests += 1 }
-            )
-            #expect(outcome == .materialized)
-
-            presenter.show(openWindowOverride: { openRequests += 1 })
-
-            #expect(openRequests == 1)
-            #expect(settingsWindow.makeKeyAndOrderFrontCallCount == 1)
-        }
-    }
-
-    @Test func openOutcomeRetriesWhenWindowDoesNotMaterializeOnFirstAttempt() {
-        #expect(SettingsWindowPresenter.openOutcome(windowExists: false, attempt: 1) == .retry)
-    }
-
-    @Test func openOutcomeGivesUpAfterMaxAttempts() {
-        #expect(
-            SettingsWindowPresenter.openOutcome(
-                windowExists: false,
-                attempt: SettingsWindowPresenter.maxOpenAttempts
-            ) == .giveUp
-        )
-    }
-
-    @Test func openOutcomeIsMaterializedWhenWindowExists() {
-        #expect(SettingsWindowPresenter.openOutcome(windowExists: true, attempt: 1) == .materialized)
-    }
-
-    private func makeWindow(
-        identifier: String,
-        forcedMiniaturized: Bool? = nil
-    ) -> TestSettingsWindow {
-        let window = TestSettingsWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 320, height: 220),
-            styleMask: [.titled, .closable, .miniaturizable, .resizable],
-            backing: .buffered,
-            defer: false
-        )
-        window.forcedMiniaturized = forcedMiniaturized
-        window.isReleasedWhenClosed = false
-        window.identifier = NSUserInterfaceItemIdentifier(identifier)
-        return window
+    private func withCleanSettingsWindows(_ body: () throws -> Void) rethrows {
+        closeSettingsWindows()
+        defer { closeSettingsWindows() }
+        try body()
     }
 
     private func closeSettingsWindows() {
-        for window in NSApp.windows where window.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier {
+        for window in NSApp.windows
+        where window.identifier?.rawValue == SettingsWindowPresenter.windowIdentifier {
             window.orderOut(nil)
             window.identifier = nil
             window.close()
         }
+        // Keep the shared frame-autosave slot from coupling tests together.
+        UserDefaults.standard.removeObject(forKey: "NSWindow Frame cmux.settings")
+    }
+}
+
+@MainActor
+private func makeFactoryWindow(
+    contentRect: NSRect = NSRect(x: 0, y: 0, width: 980, height: 680)
+) -> TestSettingsWindow {
+    let window = TestSettingsWindow(
+        contentRect: contentRect,
+        styleMask: [.titled, .closable, .miniaturizable, .resizable],
+        backing: .buffered,
+        defer: false
+    )
+    window.isReleasedWhenClosed = false
+    window.contentViewController = NSViewController()
+    return window
+}
+
+@MainActor
+private final class TestSettingsWindow: NSWindow {
+    var refusesToBecomeVisible = false
+
+    override var isVisible: Bool {
+        refusesToBecomeVisible ? false : super.isVisible
     }
 
-    private func hasChild(_ parentWindow: NSWindow, _ childWindow: NSWindow) -> Bool {
-        parentWindow.childWindows?.contains { $0 === childWindow } == true
+    override func makeKeyAndOrderFront(_ sender: Any?) {
+        guard !refusesToBecomeVisible else { return }
+        super.makeKeyAndOrderFront(sender)
     }
 
-    private final class TestSettingsWindow: NSWindow {
-        var forcedMiniaturized: Bool?
-        var makeKeyAndOrderFrontCallCount = 0
+    override func orderFrontRegardless() {
+        guard !refusesToBecomeVisible else { return }
+        super.orderFrontRegardless()
+    }
+}
 
-        override var isMiniaturized: Bool {
-            forcedMiniaturized ?? super.isMiniaturized
-        }
+/// Records `SettingsNavigationRequest` posts on the main actor.
+@MainActor
+private final class SettingsNavigationRecorder: NSObject {
+    private(set) var receivedTargets: [SettingsNavigationTarget] = []
 
-        override func makeKeyAndOrderFront(_ sender: Any?) {
-            makeKeyAndOrderFrontCallCount += 1
-            super.makeKeyAndOrderFront(sender)
+    override init() {
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(didReceive(_:)),
+            name: SettingsNavigationRequest.notificationName,
+            object: nil
+        )
+    }
+
+    func stopObserving() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc
+    private func didReceive(_ notification: Notification) {
+        if let target = SettingsNavigationRequest.target(from: notification) {
+            receivedTargets.append(target)
         }
+    }
+}
+
+/// Invokes `reopen` from inside the observed window's `willClose` notification.
+@MainActor
+private final class ReopenSettingsOnWillClose: NSObject {
+    private let reopen: () -> Void
+
+    init(window: NSWindow, reopen: @escaping () -> Void) {
+        self.reopen = reopen
+        super.init()
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowWillClose(_:)),
+            name: NSWindow.willCloseNotification,
+            object: window
+        )
+    }
+
+    func stopObserving() {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc
+    private func windowWillClose(_ notification: Notification) {
+        reopen()
     }
 }
 #endif

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -247,10 +247,12 @@ struct SettingsWindowPresenterTests {
 
     // MARK: - Navigation delivery
 
-    @Test func navigationPostsImmediatelyForExistingVisibleWindow() {
+    @Test func navigationPostsImmediatelyForReadyExistingWindow() {
         withCleanSettingsWindows {
             let presenter = SettingsWindowPresenter(windowFactory: { makeFactoryWindow() })
             #expect(presenter.show() == .presented)
+            // The content signals readiness from the host root's onAppear.
+            presenter.deliverPendingNavigationAfterContentAppears()
 
             let recorder = SettingsNavigationRecorder()
             #expect(presenter.show(navigationTarget: .browserImport) == .presented)

--- a/cmuxTests/SettingsWindowPresenterTests.swift
+++ b/cmuxTests/SettingsWindowPresenterTests.swift
@@ -164,6 +164,34 @@ struct SettingsWindowPresenterTests {
         }
     }
 
+    @Test func showWithoutActivationPresentsWithoutKeyingTheWindow() {
+        withCleanSettingsWindows {
+            let presenter = SettingsWindowPresenter(windowFactory: { makeFactoryWindow() })
+
+            let result = presenter.show(activateApp: false)
+
+            // Socket no-focus-steal contract: the window becomes visible but
+            // is never made key and the app is not activated.
+            #expect(result == .presented)
+            let window = visibleSettingsWindow() as? TestSettingsWindow
+            #expect(window != nil)
+            #expect(window?.makeKeyAndOrderFrontCallCount == 0)
+        }
+    }
+
+    @Test func hostWindowRecordsCloseBeginForMidCloseRejection() {
+        withCleanSettingsWindows {
+            let window = makeFactoryWindow()
+            #expect(!window.isClosingSettingsWindow)
+
+            window.close()
+
+            // The flag is what lets show() deterministically refuse a dying
+            // window regardless of notification-observer order.
+            #expect(window.isClosingSettingsWindow)
+        }
+    }
+
     // MARK: - Geometry repair on show
 
     @Test func showEnforcesMinimumSizeOnDegenerateFactoryWindow() {
@@ -469,14 +497,16 @@ private func makeFactoryWindow(
 }
 
 @MainActor
-private final class TestSettingsWindow: NSWindow {
+private final class TestSettingsWindow: SettingsHostWindow {
     var refusesToBecomeVisible = false
+    var makeKeyAndOrderFrontCallCount = 0
 
     override var isVisible: Bool {
         refusesToBecomeVisible ? false : super.isVisible
     }
 
     override func makeKeyAndOrderFront(_ sender: Any?) {
+        makeKeyAndOrderFrontCallCount += 1
         guard !refusesToBecomeVisible else { return }
         super.makeKeyAndOrderFront(sender)
     }

--- a/cmuxUITests/BrowserImportProfilesUITests.swift
+++ b/cmuxUITests/BrowserImportProfilesUITests.swift
@@ -127,7 +127,6 @@ final class BrowserImportProfilesUITests: XCTestCase {
         let capture = try XCTUnwrap(waitForSettingsOpenCapture(timeout: 5.0))
         XCTAssertEqual(capture["opened"] as? Bool, true)
         XCTAssertEqual(capture["target"] as? String, "browserImport")
-        XCTAssertEqual(capture["used_open_window_override"] as? Bool, true)
     }
 
     func testBlankBrowserImportHintCanBeDismissed() {


### PR DESCRIPTION
Fixes #7777
Fixes #7775
Fixes #4053

## Problem

Settings intermittently cannot be opened at all: **cmux → Settings…**, ⌘,, and CLI `settings open` all silently do nothing, and only an app restart recovers. This has recurred across builds (#5770 → closed, still recurring; #4053; #7775), and the point fix in PR #5806 (deferred verification + one retry) did not hold.

The #7775 capture shows the worst shape: the tag-bound socket returns `OK target=account` while accessibility inspection proves **no Settings window exists at all** — not offscreen, not hidden, never created.

## Root cause

Settings window *creation* was delegated to a SwiftUI single-`Window` scene through `openWindow(id: "settings")`. That call returns nothing, reports nothing, and its internal scene state can wedge permanently (relaunch-while-open per #7775, scene mid-teardown per the live root-cause confirmation on #5770). The presenter could only request-and-hope, so each observed failure mode grew its own patch: an `isOpeningSettingsWindow` flag, a `shouldOpenWhenConfigured` deferral, a 500 ms verification timer, and a bounded retry. When the scene wedged, the retry retried into the same wedged scene and gave up — the exact "accepted but nothing happened" symptom.

## Fix: AppKit-owned window lifecycle, SwiftUI only for content

`SettingsWindowPresenter` is rewritten as the single source of truth for the Settings window lifecycle. It constructs the `NSWindow` itself (`SettingsWindowFactory`: `NSHostingController(SettingsWindowRoot)` with `sceneBridgingOptions = [.toolbars, .title]`), the same ownership model the main window (`AppDelegate.createMainWindow`) and `TaskManagerWindowController` already use. The SwiftUI settings `Window` scene is deleted.

`show()` is now synchronous and self-healing:

1. Reuse the tracked/scanned window only if usable; a window in any unusable state (torn-down content, degenerate frame) is demolished on the spot.
2. Otherwise **build a fresh window synchronously** — creation cannot no-op.
3. Clamp the frame onto a visible screen (multi-monitor recovery kept from #5806, incl. cursor-screen recovery for frames stranded on disconnected displays).
4. Order front and **verify `isVisible` before returning**; on failure, tear down and recreate once, then fail loudly (`Logger` fault with full window/app/screen state).
5. On close, the presenter strips the window's identifier and releases its content tree, so a closed window can never absorb a future open request (the #4964 blank-reopen / #5321 lingering-window classes).

Deleted with the scene: the `openWindow` closures, `configure(openWindow:)`/`configure(window:)` + `WindowAccessor` wiring, `shouldOpenWhenConfigured`, `isOpeningSettingsWindow`, the verification timer, `SettingsWindowOpenOutcome`, and the retry machinery.

**Invariant established:** every open request ends in exactly one of — a visible Settings window, a window ordered front under a hidden app (non-activating CLI opens only), or a loud diagnostic failure carried in the return value. "Returned OK but nothing happened" is unrepresentable.

## CLI truth-telling (#7775)

`ControlSystemContext` is `@MainActor`, so `controlSettingsOpen` now presents synchronously and replies from the actual outcome: `ControlSettingsOpenResolution` gains `.failed(message:)`, mapped to an `unavailable` socket error. `settings.open` returns `opened=true` if-and-only-if a window actually materialized. The `activate` flag now also gates app activation on the shared path (socket focus policy), instead of `show()` unconditionally activating.

Navigation targets are also now delivered on *first* open: previously a fresh window's pending target was never consumed (dead `consumePendingNavigationTarget`); the new `SettingsWindowHostRoot` consumes it once the content is live.

## Why this also closes #4053

#4053 is the same "menu click produces nothing" symptom on a stable build with no deterministic repro. The live root-cause confirmation on #5770 (same symptom family) proved the mechanism: `openPreferencesWindow → show() → openWindow(id:) silently no-ops with no window created`. That entire creation path no longer exists; any wedge inside it is gone by construction, and if AppKit itself ever refused to present, the CLI/log now say so explicitly instead of no-oping.

## Regression tests (two-commit red/green)

**Commit 1** adds `SettingsWindowOpenRegressionTests` — end-to-end, real-factory tests that are red on the old code and unchanged by the fix commit:

- `show()` always produces a visible Settings window (fresh state)
- reopen after close produces a fresh visible window
- open/close churn never wedges the open path
- `show()` while the previous window is **mid-close** still produces a visible window
- `show()` recovers a window parked off every active screen

**Commit 2** (the fix) rewrites `SettingsWindowPresenterTests` for the new lifecycle using an injected window factory: creation/reuse/fresh-after-close, content released on close, contentless-husk teardown + recreation, mid-close reopen, bounded recreate → loud `.failed` when no window becomes visible, min-size + clamp repair on show, immediate vs pending navigation delivery, and the pure usability policy. The multi-monitor recovery and clamp-geometry unit tests are carried over unchanged.

**Interactive-only modes (stated plainly, not faked):** the #7775 relaunch-while-open recipe, real display disconnect/reconnect, and hidden-app CLI opens are not reproducible in unit tests. The relaunch wedge is eliminated structurally (no scene state survives to wedge); display changes are covered by the pure `targetVisibleFrame`/`clampedFrame` tests plus the offscreen-frame end-to-end test; the hidden-app path is covered by the `orderedWhileAppHidden` result mapping.

## Localization audit

- New user-facing string: `settings.window.runtimeUnavailable` (fallback shown only if the settings runtime is missing at window creation — loud instead of silent). Added to `Resources/Localizable.xcstrings` with translations for all 19 catalog locales (ar, bs, da, de, en, es, fr, it, ja, ko, nb, pl, pt-BR, ru, th, tr, uk, zh-Hans, zh-Hant).
- Window title reuses the existing `settings.title` key.
- Removed scene used the same `settings.title` key; no keys were orphaned. All other new strings are `os.Logger`/debug diagnostics (not localized by policy).
- No keyboard shortcuts added or changed.

## Budgets / guards

- `swift_file_length_budget.py` passes with **no TSV changes**: new files `SettingsWindowFactory.swift` (81) and rewritten `SettingsWindowPresenter.swift` (462) are under 500; `SettingsWindowPresenterTests.swift` shrank 668 → 542; `BrowserPanelView.swift`, `cmuxApp.swift`, `SettingsWindowScene.swift` (dead scene struct deleted) all shrank.
- `lint-pbxproj-test-wiring.sh`, `check-workspace-package-groups.py --check`, `check-package-resolved-policy.py` all pass.
- No new keyboard shortcuts; no `swift-warning-budget.tsv` changes.

## Red/green CI proof

Both commits were pushed together, so in addition to the PR checks:

- **Red** (tests-only commit `33313fc`): [e2e run 29063423332](https://github.com/manaflow-ai/cmux/actions/runs/29063423332) — all 5 `SettingsWindowOpenRegressionTests` FAILED with "no visible settings window", proving the tests catch the bug.
- **Green** (fix): [run 29063487727](https://github.com/manaflow-ai/cmux/actions/runs/29063487727) (`SettingsWindowOpenRegressionTests`) and [run 29063489144](https://github.com/manaflow-ai/cmux/actions/runs/29063489144) (`SettingsWindowPresenterTests`) passed; re-runs on the final HEAD: [29064369806](https://github.com/manaflow-ai/cmux/actions/runs/29064369806), [29064371100](https://github.com/manaflow-ai/cmux/actions/runs/29064371100), [29064372539](https://github.com/manaflow-ai/cmux/actions/runs/29064372539) (`SettingsWindowNavigationRoutingTests`).

## Review follow-ups (pushed in `8977ae1`)

- Reused live Settings window now receives the requested navigation target even when the app is hidden and `activate=false` (Cursor medium / Greptile P1).
- `presentPreferencesWindow` consumes the show result: `.failed` beeps instead of silently activating, matching the CLI's error surfacing (Cursor medium).
- The DEBUG UI-test capture records `opened` from the verified outcome, not the request (Cursor low).

## Review follow-ups round 2 (codex structured review, pushed in `ee23c79` and `708080a`)

- `settings.open --activate=false` no longer keys the window, raises the main window, or unhides/activates the app (socket no-focus-steal contract).
- `SettingsHostWindow` records close-begin, so `show()` deterministically refuses to reuse a dying window regardless of notification-observer order.
- `settings.open` with a missing control-system context fails closed (`unavailable`) instead of synthesizing `opened=true`.
- A fresh window's deferred navigation post is generation-guarded so it can't override a newer targeted open.
- The shared **Toggle Left Sidebar** command now routes to the Settings split view when the Settings window is key (the AppKit-hosted window lost SwiftUI `SidebarCommands`); covered by new `SettingsWindowNavigationRoutingTests`.
- Pure geometry statics moved to `SettingsWindowGeometry.swift` to keep the presenter under the 500-line budget threshold.

## Review follow-ups round 3–4 (pushed in `40edeae`, `7788d21`, `43e05e5`)

- `presentPreferencesWindow`/`openPreferencesWindow` moved to `Sources/App/AppDelegateSettingsPresentation.swift` — `AppDelegate.swift` is over the 900-line hard cap and may not grow, which failed `workflow-guard-tests`; it now shrinks 29 lines net.
- Navigation posts only after the Settings content signals readiness via the host root's `onAppear` — an `NSWindow` existing is not enough, so rapid targeted opens can no longer post into a not-yet-subscribed window and lose the pane.
- An untargeted `show()` (menu click) no longer erases a still-undelivered pending navigation target (Cursor findings).
- `openBrowserImportSettings` routes through the shared `AppDelegate.presentPreferencesWindow`, so a failed presentation beeps there too instead of silently no-oping.
- Added the Khmer (`km`) translation for `settings.window.runtimeUnavailable` (the catalog ships `km`; the key now covers all 20 catalog locales).
- Test-side sidebar-toggle recorder observes the raw notification name instead of the package symbol — `@testable import` package-symbol visibility differs across toolchains and broke the CI test compile while local Xcode accepted it.
- Warning budget: dropped the deprecated no-op `activateIgnoringOtherApps` from the moved default closure; the sidebar-toggle helper takes `keyWindow` explicitly (a `NSApp.keyWindow` default argument warns under strict concurrency) (`ebbe77b`).
- Reentrancy-safe teardown recovery (`9526370`): the retry loop re-checks for a usable window on every attempt so a re-entrant `show()` from a willClose observer is adopted instead of duplicated, and a small depth bound turns a pathological reopen-on-close observer plus persistent presentation failure into a loud `.failed` instead of unbounded recursion — both covered by new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
