### PR TITLE
Restore manual App Store signing profile setup

### DIFF
--- a/.github/scripts/install-app-store-provisioning-profile.sh
+++ b/.github/scripts/install-app-store-provisioning-profile.sh
@@ -1,0 +1,272 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+die() {
+  printf 'install-app-store-provisioning-profile: %s\n' "$*" >&2
+  exit 1
+}
+
+note() {
+  printf 'install-app-store-provisioning-profile: %s\n' "$*" >&2
+}
+
+TEAM_ID="${IOS_APPSTORE_TEAM_ID:-7WLXT3NR37}"
+BUNDLE_IDENTIFIER="${IOS_APPSTORE_BUNDLE_IDENTIFIER:-com.cmuxterm.app}"
+EXPECTED_APP_ID="${TEAM_ID}.${BUNDLE_IDENTIFIER}"
+KEYCHAIN_NAME="${IOS_APPSTORE_KEYCHAIN_NAME:-ios-app-store.keychain}"
+TMP_ROOT="${RUNNER_TEMP:-${TMPDIR:-/tmp}}"
+TMP_PROFILE="$TMP_ROOT/cmux-appstore.mobileprovision"
+TMP_PLIST="$TMP_ROOT/cmux-appstore-profile.plist"
+PROFILE_DIR="$HOME/Library/MobileDevice/Provisioning Profiles"
+RESOLVED_PROFILE_NAME=""
+RESOLVED_PROFILE_UUID=""
+
+validate_profile() {
+  local profile_path="$1"
+  local plist_path="$2"
+  local label="$3"
+  local strict="$4"
+
+  if ! security cms -D -i "$profile_path" > "$plist_path"; then
+    if [ "$strict" = "true" ]; then
+      die "$label is not a readable provisioning profile"
+    fi
+    note "$label is not a readable provisioning profile; ignoring"
+    return 1
+  fi
+
+  local app_id
+  app_id="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$plist_path" 2>/dev/null || true)"
+  if [ "$app_id" != "$EXPECTED_APP_ID" ]; then
+    if [ "$strict" = "true" ]; then
+      die "$label targets unexpected app ID: ${app_id:-<absent>} (expected $EXPECTED_APP_ID)"
+    fi
+    note "$label targets ${app_id:-<absent>}, expected $EXPECTED_APP_ID; ignoring"
+    return 1
+  fi
+
+  local aps_environment
+  aps_environment="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:aps-environment" "$plist_path" 2>/dev/null || true)"
+  if [ "$aps_environment" != "production" ]; then
+    if [ "$strict" = "true" ]; then
+      die "$label aps-environment is '${aps_environment:-<absent>}', expected 'production'"
+    fi
+    note "$label aps-environment is '${aps_environment:-<absent>}', expected 'production'; ignoring"
+    return 1
+  fi
+
+  local apple_sign_in
+  apple_sign_in="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:com.apple.developer.applesignin:0" "$plist_path" 2>/dev/null || true)"
+  if [ "$apple_sign_in" != "Default" ]; then
+    if [ "$strict" = "true" ]; then
+      die "$label com.apple.developer.applesignin is '${apple_sign_in:-<absent>}', expected 'Default'"
+    fi
+    note "$label com.apple.developer.applesignin is '${apple_sign_in:-<absent>}', expected 'Default'; ignoring"
+    return 1
+  fi
+
+  RESOLVED_PROFILE_NAME="$(/usr/libexec/PlistBuddy -c "Print :Name" "$plist_path")"
+  RESOLVED_PROFILE_UUID="$(/usr/libexec/PlistBuddy -c "Print :UUID" "$plist_path")"
+  return 0
+}
+
+install_profile() {
+  mkdir -p "$PROFILE_DIR"
+  cp "$TMP_PROFILE" "$PROFILE_DIR/$RESOLVED_PROFILE_UUID.mobileprovision"
+  echo "IOS_APPSTORE_PROVISIONING_PROFILE_NAME=$RESOLVED_PROFILE_NAME" >> "$GITHUB_ENV"
+  note "installed App Store profile '$RESOLVED_PROFILE_NAME'"
+}
+
+try_secret_profile() {
+  local label="$1"
+  local value="$2"
+  local strict="$3"
+
+  if [ -z "$value" ]; then
+    return 1
+  fi
+
+  printf '%s' "$value" | base64 --decode > "$TMP_PROFILE"
+  if validate_profile "$TMP_PROFILE" "$TMP_PLIST" "$label" "$strict"; then
+    install_profile
+    return 0
+  fi
+  return 1
+}
+
+json_id_by_bundle_identifier() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path, identifier = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else body
+for item in data if isinstance(data, list) else []:
+    if item.get("attributes", {}).get("identifier") == identifier:
+        print(item.get("id", ""))
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+json_certificate_id_by_serial() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+def norm(value):
+    return "".join(ch for ch in str(value).upper() if ch.isalnum())
+
+path, serial = sys.argv[1], norm(sys.argv[2])
+with open(path, "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else body
+for item in data if isinstance(data, list) else []:
+    if norm(item.get("attributes", {}).get("serialNumber", "")) == serial:
+        print(item.get("id", ""))
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+print_certificate_summary() {
+  python3 - "$1" <<'PY' >&2
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else body
+items = data if isinstance(data, list) else []
+if not items:
+    print("install-app-store-provisioning-profile: no distribution certificates returned by ASC")
+    raise SystemExit(0)
+print("install-app-store-provisioning-profile: ASC distribution certificate candidates:")
+for item in items:
+    attrs = item.get("attributes", {})
+    serial = str(attrs.get("serialNumber", ""))
+    suffix = serial[-8:] if serial else "<absent>"
+    cert_type = attrs.get("certificateType", "<unknown>")
+    display = attrs.get("displayName") or attrs.get("name") or "<unnamed>"
+    print(f"install-app-store-provisioning-profile: - {cert_type} {display} serial_suffix={suffix}")
+PY
+}
+
+json_profile_id_by_name() {
+  python3 - "$1" "$2" <<'PY'
+import json
+import sys
+
+path, name = sys.argv[1], sys.argv[2]
+with open(path, "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else body
+for item in data if isinstance(data, list) else []:
+    if item.get("attributes", {}).get("name") == name:
+        print(item.get("id", ""))
+        raise SystemExit(0)
+raise SystemExit(1)
+PY
+}
+
+json_single_id() {
+  python3 - "$1" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], "r", encoding="utf-8") as handle:
+    body = json.load(handle)
+data = body.get("data", body) if isinstance(body, dict) else None
+if isinstance(data, dict):
+    print(data.get("id", ""))
+elif isinstance(data, list) and data:
+    print(data[0].get("id", ""))
+else:
+    raise SystemExit(1)
+PY
+}
+
+download_profile_from_asc() {
+  command -v asc >/dev/null || die "asc CLI is required"
+  command -v python3 >/dev/null || die "python3 is required"
+  command -v openssl >/dev/null || die "openssl is required"
+
+  export ASC_KEY_ID="${ASC_KEY_ID:-${ASC_API_KEY_ID:-}}"
+  export ASC_ISSUER_ID="${ASC_ISSUER_ID:-${ASC_API_ISSUER_ID:-}}"
+  export ASC_PRIVATE_KEY_PATH="${ASC_PRIVATE_KEY_PATH:-${ASC_API_KEY_PATH:-}}"
+  if [ -z "${ASC_KEY_ID:-}" ] || [ -z "${ASC_ISSUER_ID:-}" ] || [ -z "${ASC_PRIVATE_KEY_PATH:-}" ]; then
+    die "ASC_KEY_ID, ASC_ISSUER_ID, and ASC_PRIVATE_KEY_PATH are required to fetch a profile"
+  fi
+
+  if [ -z "${IOS_DISTRIBUTION_IDENTITY:-}" ]; then
+    die "IOS_DISTRIBUTION_IDENTITY is required to resolve the matching certificate"
+  fi
+
+  local cert_pem cert_serial
+  cert_pem="$TMP_ROOT/ios-distribution-cert.pem"
+  security find-certificate -c "$IOS_DISTRIBUTION_IDENTITY" -p "$KEYCHAIN_NAME" > "$cert_pem" ||
+    die "could not read imported distribution certificate from $KEYCHAIN_NAME"
+  cert_serial="$(openssl x509 -in "$cert_pem" -noout -serial | sed 's/^serial=//' | tr '[:lower:]' '[:upper:]')"
+  cert_serial="$(printf '%s' "$cert_serial" | tr -cd '[:alnum:]')"
+  [ -n "$cert_serial" ] || die "could not resolve imported distribution certificate serial"
+
+  local bundles_json certs_json profiles_json created_json bundle_id certificate_id profile_id profile_name profile_suffix
+  bundles_json="$TMP_ROOT/asc-bundle-ids.json"
+  certs_json="$TMP_ROOT/asc-certificates.json"
+  profiles_json="$TMP_ROOT/asc-profiles.json"
+  created_json="$TMP_ROOT/asc-created-profile.json"
+
+  asc bundle-ids list --paginate --output json > "$bundles_json"
+  bundle_id="$(json_id_by_bundle_identifier "$bundles_json" "$BUNDLE_IDENTIFIER")" ||
+    die "App Store Connect bundle id not found for $BUNDLE_IDENTIFIER"
+
+  asc certificates list --certificate-type IOS_DISTRIBUTION,DISTRIBUTION --paginate --output json > "$certs_json"
+  certificate_id="$(json_certificate_id_by_serial "$certs_json" "$cert_serial" || true)"
+  if [ -z "$certificate_id" ]; then
+    print_certificate_summary "$certs_json"
+    die "App Store Connect certificate not found for imported distribution certificate serial suffix ${cert_serial: -8}"
+  fi
+
+  profile_suffix="${cert_serial: -8}"
+  profile_name="cmuxterm App Store CI $profile_suffix"
+  asc profiles list --profile-type IOS_APP_STORE --paginate --output json > "$profiles_json"
+  profile_id="$(json_profile_id_by_name "$profiles_json" "$profile_name" || true)"
+  if [ -z "$profile_id" ]; then
+    note "creating App Store profile '$profile_name'"
+    asc profiles create \
+      --name "$profile_name" \
+      --profile-type IOS_APP_STORE \
+      --bundle "$bundle_id" \
+      --certificate "$certificate_id" \
+      --output json > "$created_json"
+    profile_id="$(json_single_id "$created_json")" ||
+      die "could not read created profile id"
+  else
+    note "reusing App Store profile '$profile_name'"
+  fi
+
+  asc profiles download --id "$profile_id" --output "$TMP_PROFILE" >/dev/null
+  validate_profile "$TMP_PROFILE" "$TMP_PLIST" "ASC profile '$profile_name'" "true"
+  install_profile
+}
+
+if try_secret_profile "IOS_APPSTORE_PROVISIONING_PROFILE_BASE64" "${IOS_APPSTORE_PROVISIONING_PROFILE_BASE64:-}" "true"; then
+  exit 0
+fi
+
+for candidate in \
+  "IOS_PROD_PROVISIONING_PROFILE_BASE64:${IOS_PROD_PROVISIONING_PROFILE_BASE64:-}" \
+  "IOS_BETA_PROVISIONING_PROFILE_BASE64:${IOS_BETA_PROVISIONING_PROFILE_BASE64:-}" \
+  "APPLE_RELEASE_PROVISIONING_PROFILE_BASE64:${APPLE_RELEASE_PROVISIONING_PROFILE_BASE64:-}" \
+  "APPLE_NIGHTLY_PROVISIONING_PROFILE_BASE64:${APPLE_NIGHTLY_PROVISIONING_PROFILE_BASE64:-}"
+do
+  label="${candidate%%:*}"
+  value="${candidate#*:}"
+  if try_secret_profile "$label" "$value" "false"; then
+    exit 0
+  fi
+done
+
+download_profile_from_asc

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -100,13 +100,59 @@ jobs:
           echo "ASC_ISSUER_ID=$ASC_API_ISSUER_ID" >> "$GITHUB_ENV"
           echo "ASC_PRIVATE_KEY_PATH=$KEY_PATH" >> "$GITHUB_ENV"
 
+      - name: Import iOS distribution signing cert
+        env:
+          IOS_DISTRIBUTION_CERTIFICATE_BASE64: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_BASE64 }}
+          IOS_DISTRIBUTION_CERTIFICATE_PASSWORD: ${{ secrets.IOS_DISTRIBUTION_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          if [ -z "${IOS_DISTRIBUTION_CERTIFICATE_BASE64:-}" ]; then
+            echo "Missing IOS_DISTRIBUTION_CERTIFICATE_BASE64 secret" >&2
+            exit 1
+          fi
+          if [ -z "${IOS_DISTRIBUTION_CERTIFICATE_PASSWORD:-}" ]; then
+            echo "Missing IOS_DISTRIBUTION_CERTIFICATE_PASSWORD secret" >&2
+            exit 1
+          fi
+
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          KEYCHAIN_NAME="ios-app-store.keychain"
+          CERT_PATH="$RUNNER_TEMP/ios-distribution.p12"
+          printf '%s' "$IOS_DISTRIBUTION_CERTIFICATE_BASE64" | base64 --decode > "$CERT_PATH"
+          security delete-keychain "$KEYCHAIN_NAME" >/dev/null 2>&1 || true
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_NAME"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security import "$CERT_PATH" -k "$KEYCHAIN_NAME" -P "$IOS_DISTRIBUTION_CERTIFICATE_PASSWORD" -T /usr/bin/codesign -T /usr/bin/security
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_NAME"
+          security list-keychains -d user -s "$KEYCHAIN_NAME"
+          IOS_DISTRIBUTION_IDENTITY="$(
+            security find-identity -v -p codesigning "$KEYCHAIN_NAME" |
+              sed -n 's/.*"\(Apple Distribution: .* (7WLXT3NR37)\)".*/\1/p' |
+              head -n 1
+          )"
+          if [ -z "$IOS_DISTRIBUTION_IDENTITY" ]; then
+            echo "No Apple Distribution identity for team 7WLXT3NR37 was found in the imported certificate" >&2
+            exit 1
+          fi
+          echo "IOS_DISTRIBUTION_IDENTITY=$IOS_DISTRIBUTION_IDENTITY" >> "$GITHUB_ENV"
+
+      - name: Install App Store provisioning profile
+        env:
+          IOS_APPSTORE_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_APPSTORE_PROVISIONING_PROFILE_BASE64 }}
+          IOS_PROD_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_PROD_PROVISIONING_PROFILE_BASE64 }}
+          IOS_BETA_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_BETA_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_RELEASE_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_RELEASE_PROVISIONING_PROFILE_BASE64 }}
+          APPLE_NIGHTLY_PROVISIONING_PROFILE_BASE64: ${{ secrets.APPLE_NIGHTLY_PROVISIONING_PROFILE_BASE64 }}
+        run: ./.github/scripts/install-app-store-provisioning-profile.sh
+
       - name: Archive, export, and upload production build
         id: upload
         env:
           CMUX_BUILD_NUMBER_OUT_FILE: ${{ runner.temp }}/cmux-final-appstore-build-number.txt
         run: |
           set -euo pipefail
-          ARGS=(--signing automatic)
+          ARGS=(--signing manual)
           if [ -n "${INPUT_BUILD_NUMBER:-}" ]; then
             ARGS+=(--build-number "$INPUT_BUILD_NUMBER")
           fi
@@ -155,12 +201,13 @@ jobs:
             echo "### iOS App Store production"
             echo
             echo "- lane: \`appstore\` (bundle id \`com.cmuxterm.app\`)"
-            echo "- signing: automatic (Xcode-managed via App Store Connect API key)"
+            echo "- signing: manual (CI-imported iOS distribution cert + App Store profile)"
             echo "- build number (CFBundleVersion): \`${FINAL_BUILD_NUMBER}\`"
             echo "- submit for review: \`${INPUT_SUBMIT_FOR_REVIEW}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - name: Cleanup App Store Connect key
+      - name: Cleanup signing material
         if: always()
         run: |
           rm -f "${ASC_API_KEY_PATH:-}"
+          security delete-keychain ios-app-store.keychain >/dev/null 2>&1 || true


### PR DESCRIPTION
## Summary
- restore manual signing for the production App Store workflow
- import the existing iOS distribution p12 in CI
- install a matching App Store provisioning profile from existing secrets when available
- otherwise create/download the profile through `asc`, searching both `IOS_DISTRIBUTION` and `DISTRIBUTION` cert types

## Why
The automatic signing dry runs proved that path is not viable for this runner/account state:
- https://github.com/manaflow-ai/cmux/actions/runs/29062732167 failed because the automatic archive command applied `CODE_SIGN_ENTITLEMENTS` to every SwiftPM target and forced a conflicting identity.
- https://github.com/manaflow-ai/cmux/actions/runs/29063146842 got past that script bug, then Xcode tried development signing for `com.cmuxterm.app` and failed because the Apple account has reached the certificate limit and has no matching development profile.

Manual signing avoids the dev-certificate path entirely. The previous manual helper only searched `IOS_DISTRIBUTION`; this version also searches `DISTRIBUTION`, and it checks all existing profile secrets before creating a new profile.

## Verification
- `bash -n .github/scripts/install-app-store-provisioning-profile.sh ios/scripts/upload-testflight.sh ios/scripts/upload-app-store.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ios-app-store.yml"); puts "yaml ok"'`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786240497&installation_id=133855650&pr_number=7784&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7784&signature=a80a7091c782b08476394d88cd0497f3207a02968a5630da8c3c5f74f744f214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches release signing and secrets handling and can create App Store Connect provisioning profiles via API; mistakes could break production uploads or mis-associate certs/profiles.
> 
> **Overview**
> Switches the **production App Store** GitHub workflow from **automatic** to **manual** signing so CI uses an imported **Apple Distribution** certificate instead of Xcode-managed dev signing (which was failing under certificate limits).
> 
> The workflow gains steps to **import the distribution p12** into a dedicated keychain, **install an App Store provisioning profile** via a new `install-app-store-provisioning-profile.sh` helper, and **delete that keychain** on cleanup. The upload step now passes `--signing manual` to `upload-app-store.sh`.
> 
> The new script **decodes and validates** profiles (bundle id, production push, Sign in with Apple), prefers `IOS_APPSTORE_PROVISIONING_PROFILE_BASE64`, then **non-strictly** tries several legacy profile secrets; if none work it uses **`asc`** to match the imported cert serial (including **`IOS_DISTRIBUTION` and `DISTRIBUTION`** cert types), **reuse or create** a named App Store profile, download it, and export `IOS_APPSTORE_PROVISIONING_PROFILE_NAME` for later steps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0c6b4ab53ae4c72672fb7ba2d542f1be699e2808. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores manual App Store signing in iOS CI by importing the distribution certificate and installing a matching provisioning profile. This fixes the automatic signing failures and unblocks production builds.

- **Bug Fixes**
  - Set `--signing manual` in `ios-app-store.yml` and import the iOS Distribution `.p12` into a temporary keychain.
  - Add script to install an App Store provisioning profile: prefer existing base64 secrets; otherwise use `asc` to find/create an `IOS_APP_STORE` profile using either `IOS_DISTRIBUTION` or `DISTRIBUTION` cert types, matched by serial.
  - Validate profile (bundle id `com.cmuxterm.app`, production APNs, Apple Sign In Default), install it, export `IOS_APPSTORE_PROVISIONING_PROFILE_NAME`, and clean up the keychain.

<sup>Written for commit 0c6b4ab53ae4c72672fb7ba2d542f1be699e2808. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * iOS App Store builds now use consistent manual signing during production uploads.
  * Provisioning profiles can be securely validated and installed automatically, with fallback handling when a preferred profile is unavailable.
  * CI signing credentials and temporary keychain data are cleaned up after each build for improved security and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->