### PR TITLE
Re-detect the checked-out branch when resolving workspace PR badges

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -156,6 +156,18 @@ public struct GitMetadataService: Sendable {
         return Self.githubRepositorySlugs(fromGitRemoteVOutput: output)
     }
 
+    /// Reads the current checked-out branch for the repository enclosing `directory`.
+    ///
+    /// - Parameter directory: An absolute path to inspect.
+    /// - Returns: The normalized branch name, or `nil` when `directory` is not
+    ///   inside a repository or `HEAD` is detached.
+    public nonisolated func currentBranchName(forDirectory directory: String) async -> String? {
+        guard let repository = Self.resolveGitRepository(containing: directory) else {
+            return nil
+        }
+        return Self.normalizedBranchName(Self.gitBranchName(repository: repository))
+    }
+
     /// Whether this module's `nonisolated async` methods execute off the calling
     /// thread. A seam for the test that pins the SE-0338 execution contract the
     /// reads above rely on (see the `Important` note on the type): if this module

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/GitMetadataService.swift
@@ -156,16 +156,21 @@ public struct GitMetadataService: Sendable {
         return Self.githubRepositorySlugs(fromGitRemoteVOutput: output)
     }
 
-    /// Reads the current checked-out branch for the repository enclosing `directory`.
+    /// Reads the checked-out branch state for the repository enclosing
+    /// `directory`.
+    ///
+    /// Distinguishes a detached (or non-branch) checkout from a repository
+    /// whose `HEAD` is missing or malformed, so callers can treat the latter
+    /// as unverified rather than trusting a stale projection.
     ///
     /// - Parameter directory: An absolute path to inspect.
-    /// - Returns: The normalized branch name, or `nil` when `directory` is not
-    ///   inside a repository or `HEAD` is detached.
-    public nonisolated func currentBranchName(forDirectory directory: String) async -> String? {
+    /// - Returns: The ``GitCheckedOutBranch`` for the enclosing repository, or
+    ///   ``GitCheckedOutBranch/notARepository`` when there is none.
+    public nonisolated func checkedOutBranch(forDirectory directory: String) async -> GitCheckedOutBranch {
         guard let repository = Self.resolveGitRepository(containing: directory) else {
-            return nil
+            return .notARepository
         }
-        return Self.normalizedBranchName(Self.gitBranchName(repository: repository))
+        return Self.gitCheckedOutBranch(repository: repository)
     }
 
     /// Whether this module's `nonisolated async` methods execute off the calling

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Model/GitCheckedOutBranch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Model/GitCheckedOutBranch.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// The result of reading a directory's checked-out branch from its
+/// repository's `HEAD`.
+///
+/// Distinguishes a legitimate non-branch checkout (``detached``) from a
+/// repository whose `HEAD` could not be read or parsed (``unreadable``), so
+/// callers can treat the latter as an unverified state instead of trusting a
+/// possibly stale projection.
+public enum GitCheckedOutBranch: Equatable, Sendable {
+    /// The repository is checked out on the associated (normalized) branch.
+    case branch(String)
+    /// `HEAD` is readable but does not name a branch: a detached commit or a
+    /// non-branch symbolic ref.
+    case detached
+    /// The directory is not inside a git repository.
+    case notARepository
+    /// The repository exists but `HEAD` is missing, unreadable, or malformed.
+    case unreadable
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Model/WorkspacePullRequestCandidate.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Model/WorkspacePullRequestCandidate.swift
@@ -12,12 +12,24 @@ public struct WorkspacePullRequestCandidate: Sendable {
     /// GitHub `owner/name` slugs to search, in preference order; empty when the
     /// directory has no GitHub remote (an unsupported repository).
     public let repoSlugs: [String]
+    /// Whether the directory's checked-out branch could not be verified
+    /// (repository present but `HEAD` unreadable/malformed). Such a candidate
+    /// resolves as a transient failure so an existing badge is kept rather
+    /// than re-matched against a possibly stale projected branch.
+    public let branchReadFailed: Bool
 
     /// Creates a resolved candidate.
-    public init(workspaceId: UUID, panelId: UUID, branch: String, repoSlugs: [String]) {
+    public init(
+        workspaceId: UUID,
+        panelId: UUID,
+        branch: String,
+        repoSlugs: [String],
+        branchReadFailed: Bool = false
+    ) {
         self.workspaceId = workspaceId
         self.panelId = panelId
         self.branch = branch
         self.repoSlugs = repoSlugs
+        self.branchReadFailed = branchReadFailed
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Parsing/GitMetadataService+Refs.swift
@@ -25,6 +25,38 @@ extension GitMetadataService {
         return branch.isEmpty ? nil : branch
     }
 
+    /// Classifies the repository's `HEAD` into a ``GitCheckedOutBranch``,
+    /// keeping a legitimate non-branch checkout (detached commit, non-branch
+    /// symbolic ref) distinct from a missing/unreadable/malformed `HEAD`.
+    nonisolated static func gitCheckedOutBranch(repository: ResolvedGitRepository) -> GitCheckedOutBranch {
+        let headURL = URL(fileURLWithPath: repository.gitDirectory).appendingPathComponent("HEAD")
+        guard let contents = try? String(contentsOf: headURL, encoding: .utf8) else {
+            return .unreadable
+        }
+        let trimmed = contents.trimmingCharacters(in: .whitespacesAndNewlines)
+        let branchPrefix = "ref: refs/heads/"
+        if trimmed.hasPrefix(branchPrefix) {
+            guard let branch = normalizedBranchName(String(trimmed.dropFirst(branchPrefix.count))) else {
+                return .unreadable
+            }
+            return .branch(branch)
+        }
+        if trimmed.hasPrefix("ref: ") {
+            return .detached
+        }
+        if isLikelyCommitSHA(trimmed) {
+            return .detached
+        }
+        return .unreadable
+    }
+
+    /// Whether `value` looks like a full git object id (40-hex SHA-1 or
+    /// 64-hex SHA-256).
+    private nonisolated static func isLikelyCommitSHA(_ value: String) -> Bool {
+        guard value.count == 40 || value.count == 64 else { return false }
+        return value.allSatisfy(\.isHexDigit)
+    }
+
     /// A signature of `HEAD` plus the commit it resolves to: the symbolic ref
     /// text and the resolved ref value joined, or the detached SHA directly.
     nonisolated static func gitHeadSignature(repository: ResolvedGitRepository) -> String? {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubAuthHeaderCache.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubAuthHeaderCache.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+/// Caches GitHub CLI auth-header resolution between pull-request refresh passes.
+actor GitHubAuthHeaderCache {
+    private let successLifetime: TimeInterval
+    private let failureLifetime: TimeInterval
+    private let now: @Sendable () -> Date
+    private var cachedHeader: String?
+    private var resolvedAt: Date?
+
+    init(
+        successLifetime: TimeInterval = 5 * 60,
+        failureLifetime: TimeInterval = 60,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        self.successLifetime = successLifetime
+        self.failureLifetime = failureLifetime
+        self.now = now
+    }
+
+    func header(resolve: @Sendable () async -> String?) async -> String? {
+        let currentTime = now()
+        if let resolvedAt {
+            let lifetime = cachedHeader == nil ? failureLifetime : successLifetime
+            if currentTime.timeIntervalSince(resolvedAt) < lifetime {
+                return cachedHeader
+            }
+        }
+
+        let header = await resolve()
+        cachedHeader = header
+        resolvedAt = currentTime
+        return header
+    }
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Auth.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Auth.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+extension PullRequestProbeService {
+    /// Resolves the API auth header: `GH_TOKEN`/`GITHUB_TOKEN` from the
+    /// environment, else `gh auth token` via the injected runner, else `nil`
+    /// (unauthenticated requests).
+    nonisolated func authHeaderValue() async -> String? {
+        let environment = ProcessInfo.processInfo.environment
+        if let envToken = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] {
+            let trimmed = envToken.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                return "Bearer \(trimmed)"
+            }
+        }
+
+        return await authHeaderCache.header {
+            await ghAuthHeaderValue()
+        }
+    }
+
+    private nonisolated func ghAuthHeaderValue() async -> String? {
+        let directory = FileManager.default.currentDirectoryPath
+        let token = await commandRunner.runStandardOutput(
+            directory: directory,
+            executable: "gh",
+            arguments: ["auth", "token"],
+            timeout: Self.probeTimeout
+        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        guard !token.isEmpty else { return nil }
+        return "Bearer \(token)"
+    }
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
@@ -376,27 +376,4 @@ extension PullRequestProbeService {
             return nil
         }
     }
-
-    /// Resolves the API auth header: `GH_TOKEN`/`GITHUB_TOKEN` from the
-    /// environment, else `gh auth token` via the injected runner, else `nil`
-    /// (unauthenticated requests).
-    nonisolated func authHeaderValue() async -> String? {
-        let environment = ProcessInfo.processInfo.environment
-        if let envToken = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] {
-            let trimmed = envToken.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                return "Bearer \(trimmed)"
-            }
-        }
-
-        let directory = FileManager.default.currentDirectoryPath
-        let token = await commandRunner.runStandardOutput(
-            directory: directory,
-            executable: "gh",
-            arguments: ["auth", "token"],
-            timeout: Self.probeTimeout
-        )?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !token.isEmpty else { return nil }
-        return "Bearer \(token)"
-    }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
@@ -91,12 +91,11 @@ public struct PullRequestProbeService: Sendable {
         var candidateBranchesByRepo: [String: Set<String>] = [:]
         var repoDirectoriesBySlug: [String: String] = [:]
         var repoSlugsByDirectory: [String: [String]] = [:]
-        var currentBranchesByDirectory: [String: String] = [:]
-        var currentBranchResolvedDirectories: Set<String> = []
+        var checkedOutBranchesByDirectory: [String: GitCheckedOutBranch] = [:]
 
         for seed in seeds {
             let repoSlugs: [String]
-            let detectedBranch: String?
+            let checkedOutBranch: GitCheckedOutBranch
             if let directory = seed.directory {
                 if let cachedRepoSlugs = repoSlugsByDirectory[directory] {
                     repoSlugs = cachedRepoSlugs
@@ -106,31 +105,46 @@ public struct PullRequestProbeService: Sendable {
                     repoSlugs = resolvedRepoSlugs
                 }
 
-                if currentBranchResolvedDirectories.contains(directory) {
-                    detectedBranch = currentBranchesByDirectory[directory]
+                if let cachedBranch = checkedOutBranchesByDirectory[directory] {
+                    checkedOutBranch = cachedBranch
                 } else {
-                    let resolvedBranch = await gitMetadata.currentBranchName(forDirectory: directory)
-                    currentBranchResolvedDirectories.insert(directory)
-                    if let resolvedBranch {
-                        currentBranchesByDirectory[directory] = resolvedBranch
-                    }
-                    detectedBranch = resolvedBranch
+                    let resolvedBranch = await gitMetadata.checkedOutBranch(forDirectory: directory)
+                    checkedOutBranchesByDirectory[directory] = resolvedBranch
+                    checkedOutBranch = resolvedBranch
                 }
             } else {
                 repoSlugs = []
-                detectedBranch = nil
+                checkedOutBranch = .notARepository
             }
 
-            let candidateBranch = detectedBranch
-                ?? GitMetadataService.normalizedBranchName(seed.branch)
-                ?? seed.branch
-            let shouldLookupBranch = !Self.shouldSkipLookup(branch: candidateBranch)
+            let projectedBranch = GitMetadataService.normalizedBranchName(seed.branch) ?? seed.branch
+            let candidateBranch: String
+            let branchReadFailed: Bool
+            switch checkedOutBranch {
+            case .branch(let detectedBranch):
+                candidateBranch = detectedBranch
+                branchReadFailed = false
+            case .detached, .notARepository:
+                // A legitimate non-branch checkout (or a vanished repository)
+                // keeps the projected association, matching pre-detection
+                // behavior.
+                candidateBranch = projectedBranch
+                branchReadFailed = false
+            case .unreadable:
+                // The repository exists but its branch cannot be verified;
+                // resolve as transient so an existing badge is kept instead
+                // of re-matching a possibly stale projected branch.
+                candidateBranch = projectedBranch
+                branchReadFailed = true
+            }
+            let shouldLookupBranch = !branchReadFailed && !Self.shouldSkipLookup(branch: candidateBranch)
             candidates.append(
                 WorkspacePullRequestCandidate(
                     workspaceId: seed.workspaceId,
                     panelId: seed.panelId,
                     branch: candidateBranch,
-                    repoSlugs: repoSlugs
+                    repoSlugs: repoSlugs,
+                    branchReadFailed: branchReadFailed
                 )
             )
 
@@ -157,9 +171,11 @@ public struct PullRequestProbeService: Sendable {
     /// For each candidate the first repo (in slug preference order) with a PR
     /// for the branch wins; otherwise a transient failure anywhere downgrades
     /// the outcome to ``WorkspacePullRequestRefreshResult/Resolution/transientFailure``
-    /// (so an existing badge is kept), else `notFound`. A candidate on a
-    /// default branch (main/master) resolves `notFound` without matching, so
-    /// returning to the default branch clears any badge.
+    /// (so an existing badge is kept), else `notFound`. A candidate whose
+    /// checked-out branch could not be verified resolves `transientFailure`
+    /// without matching (keeping any badge); a candidate on a default branch
+    /// (main/master) resolves `notFound` without matching, so returning to
+    /// the default branch clears any badge.
     public static func resolveRefreshResults(
         candidates: [WorkspacePullRequestCandidate],
         repoResults: [String: WorkspacePullRequestRepoFetchResult]
@@ -170,6 +186,15 @@ public struct PullRequestProbeService: Sendable {
                     workspaceId: candidate.workspaceId,
                     panelId: candidate.panelId,
                     resolution: .unsupportedRepository,
+                    usedCachedRepoData: false
+                )
+            }
+
+            if candidate.branchReadFailed {
+                return WorkspacePullRequestRefreshResult(
+                    workspaceId: candidate.workspaceId,
+                    panelId: candidate.panelId,
+                    resolution: .transientFailure,
                     usedCachedRepoData: false
                 )
             }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
@@ -16,13 +16,18 @@ public import CmuxFoundation
 /// Like ``GitMetadataService`` it is a stateless `Sendable` value with
 /// `nonisolated async` reads (off the caller's actor, parallel across calls;
 /// see that type's `Important` note on `NonisolatedNonsendingByDefault`). The
-/// repo cache is owned by the caller and passed in, so the service holds no
-/// mutable state. Authentication uses `GH_TOKEN`/`GITHUB_TOKEN` or
+/// repo cache is owned by the caller and passed in. The service only retains a
+/// short-lived auth-header cache so periodic refreshes do not spawn `gh auth
+/// token` on every pass. Authentication uses `GH_TOKEN`/`GITHUB_TOKEN` or
 /// `gh auth token` via the injected ``CmuxProcess/CommandRunning``.
 public struct PullRequestProbeService: Sendable {
     /// Runs `gh auth token` for the API auth header. Injected so tests supply a
     /// fake without spawning a process.
     let commandRunner: any CommandRunning
+
+    /// Caches `gh auth token` results so refresh passes do not repeatedly spawn
+    /// the GitHub CLI when the app has no environment token.
+    let authHeaderCache: GitHubAuthHeaderCache
 
     /// Debug-log sink for probe diagnostics (the app injects its debug logger
     /// in DEBUG builds; defaults to a no-op).
@@ -38,6 +43,7 @@ public struct PullRequestProbeService: Sendable {
         debugLog: @escaping @Sendable (String) -> Void = { _ in }
     ) {
         self.commandRunner = commandRunner
+        self.authHeaderCache = GitHubAuthHeaderCache()
         self.debugLog = debugLog
     }
 
@@ -65,6 +71,13 @@ public struct PullRequestProbeService: Sendable {
     /// across seeds); a seed whose directory has no GitHub remote yields a
     /// candidate with empty ``WorkspacePullRequestCandidate/repoSlugs``.
     ///
+    /// Each directory's checked-out branch is also re-detected on disk (once
+    /// per directory per pass) and overrides the seed's projected branch, so a
+    /// stale sidebar branch projection cannot pin the PR association to an old
+    /// branch. Detached HEAD or a missing repository falls back to the seed's
+    /// branch; a re-detected default branch (main/master) stays on the
+    /// candidate but is excluded from the per-repo lookup index.
+    ///
     /// - Parameters:
     ///   - seeds: One per panel wanting a badge.
     ///   - gitMetadata: The git-metadata reader used for slug resolution.
@@ -78,9 +91,12 @@ public struct PullRequestProbeService: Sendable {
         var candidateBranchesByRepo: [String: Set<String>] = [:]
         var repoDirectoriesBySlug: [String: String] = [:]
         var repoSlugsByDirectory: [String: [String]] = [:]
+        var currentBranchesByDirectory: [String: String] = [:]
+        var currentBranchResolvedDirectories: Set<String> = []
 
         for seed in seeds {
             let repoSlugs: [String]
+            let detectedBranch: String?
             if let directory = seed.directory {
                 if let cachedRepoSlugs = repoSlugsByDirectory[directory] {
                     repoSlugs = cachedRepoSlugs
@@ -89,21 +105,38 @@ public struct PullRequestProbeService: Sendable {
                     repoSlugsByDirectory[directory] = resolvedRepoSlugs
                     repoSlugs = resolvedRepoSlugs
                 }
+
+                if currentBranchResolvedDirectories.contains(directory) {
+                    detectedBranch = currentBranchesByDirectory[directory]
+                } else {
+                    let resolvedBranch = await gitMetadata.currentBranchName(forDirectory: directory)
+                    currentBranchResolvedDirectories.insert(directory)
+                    if let resolvedBranch {
+                        currentBranchesByDirectory[directory] = resolvedBranch
+                    }
+                    detectedBranch = resolvedBranch
+                }
             } else {
                 repoSlugs = []
+                detectedBranch = nil
             }
 
+            let candidateBranch = detectedBranch
+                ?? GitMetadataService.normalizedBranchName(seed.branch)
+                ?? seed.branch
+            let shouldLookupBranch = !Self.shouldSkipLookup(branch: candidateBranch)
             candidates.append(
                 WorkspacePullRequestCandidate(
                     workspaceId: seed.workspaceId,
                     panelId: seed.panelId,
-                    branch: seed.branch,
+                    branch: candidateBranch,
                     repoSlugs: repoSlugs
                 )
             )
 
             for repoSlug in repoSlugs {
-                candidateBranchesByRepo[repoSlug, default: []].insert(seed.branch)
+                guard shouldLookupBranch else { continue }
+                candidateBranchesByRepo[repoSlug, default: []].insert(candidateBranch)
                 if let directory = seed.directory, repoDirectoriesBySlug[repoSlug] == nil {
                     repoDirectoriesBySlug[repoSlug] = directory
                 }
@@ -124,7 +157,9 @@ public struct PullRequestProbeService: Sendable {
     /// For each candidate the first repo (in slug preference order) with a PR
     /// for the branch wins; otherwise a transient failure anywhere downgrades
     /// the outcome to ``WorkspacePullRequestRefreshResult/Resolution/transientFailure``
-    /// (so an existing badge is kept), else `notFound`.
+    /// (so an existing badge is kept), else `notFound`. A candidate on a
+    /// default branch (main/master) resolves `notFound` without matching, so
+    /// returning to the default branch clears any badge.
     public static func resolveRefreshResults(
         candidates: [WorkspacePullRequestCandidate],
         repoResults: [String: WorkspacePullRequestRepoFetchResult]
@@ -135,6 +170,15 @@ public struct PullRequestProbeService: Sendable {
                     workspaceId: candidate.workspaceId,
                     panelId: candidate.panelId,
                     resolution: .unsupportedRepository,
+                    usedCachedRepoData: false
+                )
+            }
+
+            if Self.shouldSkipLookup(branch: candidate.branch) {
+                return WorkspacePullRequestRefreshResult(
+                    workspaceId: candidate.workspaceId,
+                    panelId: candidate.panelId,
+                    resolution: .notFound,
                     usedCachedRepoData: false
                 )
             }

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -95,24 +95,59 @@ import Testing
         #expect(meta.branch == nil)
     }
 
-    @Test func currentBranchNameReadsCheckedOutBranch() async throws {
+    @Test func checkedOutBranchReadsCheckedOutBranch() async throws {
         let fixture = try GitRepositoryFixture()
         try fixture.writeBranch("feature/current")
         let service = GitMetadataService()
 
-        let branch = await service.currentBranchName(forDirectory: fixture.root.path)
+        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
 
-        #expect(branch == "feature/current")
+        #expect(branch == .branch("feature/current"))
     }
 
-    @Test func currentBranchNameIsNilForDetachedHead() async throws {
+    @Test func checkedOutBranchIsDetachedForDetachedHead() async throws {
         let fixture = try GitRepositoryFixture()
         try fixture.writeDetachedHead(commit: String(repeating: "1", count: 40))
         let service = GitMetadataService()
 
-        let branch = await service.currentBranchName(forDirectory: fixture.root.path)
+        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
 
-        #expect(branch == nil)
+        #expect(branch == .detached)
+    }
+
+    @Test func checkedOutBranchIsUnreadableForMissingHead() async throws {
+        let fixture = try GitRepositoryFixture()
+        let service = GitMetadataService()
+
+        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(branch == .unreadable)
+    }
+
+    @Test func checkedOutBranchIsUnreadableForMalformedHead() async throws {
+        let fixture = try GitRepositoryFixture()
+        try "not a ref and not a sha\n".write(
+            to: fixture.gitDirectory.appendingPathComponent("HEAD"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let service = GitMetadataService()
+
+        let branch = await service.checkedOutBranch(forDirectory: fixture.root.path)
+
+        #expect(branch == .unreadable)
+    }
+
+    @Test func checkedOutBranchIsNotARepositoryOutsideRepositories() async throws {
+        let service = GitMetadataService()
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmuxgit-nonrepo-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let branch = await service.checkedOutBranch(forDirectory: directory.path)
+
+        #expect(branch == .notARepository)
     }
 
     // MARK: Dirty detection (index v2)

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitMetadataServiceTests.swift
@@ -95,6 +95,26 @@ import Testing
         #expect(meta.branch == nil)
     }
 
+    @Test func currentBranchNameReadsCheckedOutBranch() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("feature/current")
+        let service = GitMetadataService()
+
+        let branch = await service.currentBranchName(forDirectory: fixture.root.path)
+
+        #expect(branch == "feature/current")
+    }
+
+    @Test func currentBranchNameIsNilForDetachedHead() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeDetachedHead(commit: String(repeating: "1", count: 40))
+        let service = GitMetadataService()
+
+        let branch = await service.currentBranchName(forDirectory: fixture.root.path)
+
+        #expect(branch == nil)
+    }
+
     // MARK: Dirty detection (index v2)
 
     @Test func cleanWorkingTreeIsNotDirty() async throws {

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestAssociationRedetectionTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestAssociationRedetectionTests.swift
@@ -152,6 +152,44 @@ import CmuxFoundation
         }
     }
 
+    @Test func authHeaderValueReusesSuccessfulGitHubCliToken() async {
+        let runner = CountingCommandRunner(outputs: ["token-one\n", "token-two\n"])
+        let service = PullRequestProbeService(commandRunner: runner)
+
+        let first = await service.authHeaderValue()
+        let second = await service.authHeaderValue()
+
+        if Self.hasEnvironmentToken {
+            #expect(first == second)
+            #expect(await runner.runCount == 0)
+        } else {
+            #expect(first == "Bearer token-one")
+            #expect(second == "Bearer token-one")
+            #expect(await runner.runCount == 1)
+        }
+    }
+
+    @Test func authHeaderCacheDoesNotReuseNilForSuccessLifetime() async {
+        let cache = GitHubAuthHeaderCache(successLifetime: 5 * 60, failureLifetime: 0)
+        let counter = ResolutionCounter(outputs: [nil, "Bearer token-two"])
+
+        let first = await cache.header {
+            await counter.next()
+        }
+        let second = await cache.header {
+            await counter.next()
+        }
+
+        #expect(first == nil)
+        #expect(second == "Bearer token-two")
+        #expect(await counter.count == 2)
+    }
+
+    private static var hasEnvironmentToken: Bool {
+        let environment = ProcessInfo.processInfo.environment
+        let token = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] ?? ""
+        return !token.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
 }
 
 private actor CountingCommandRunner: CommandRunning {
@@ -180,3 +218,16 @@ private actor CountingCommandRunner: CommandRunning {
     }
 }
 
+private actor ResolutionCounter {
+    private var outputs: [String?]
+    private(set) var count = 0
+
+    init(outputs: [String?]) {
+        self.outputs = outputs
+    }
+
+    func next() -> String? {
+        count += 1
+        return outputs.isEmpty ? nil : outputs.removeFirst()
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestAssociationRedetectionTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestAssociationRedetectionTests.swift
@@ -1,0 +1,182 @@
+import Foundation
+import Testing
+@testable import CmuxGit
+import CmuxFoundation
+
+@Suite struct PullRequestAssociationRedetectionTests {
+    private func item(
+        number: Int,
+        state: String,
+        branch: String,
+        mergedAt: String? = nil
+    ) -> GitHubPullRequestProbeItem {
+        GitHubPullRequestProbeItem(
+            number: number,
+            state: state,
+            url: "https://github.com/manaflow-ai/cmux/pull/\(number)",
+            updatedAt: "2026-07-01T12:00:00Z",
+            mergedAt: mergedAt,
+            headRefName: branch,
+            baseRefName: "main"
+        )
+    }
+
+    private func writeGitHubRemoteConfig(_ fixture: GitRepositoryFixture) throws {
+        try fixture.writeConfig("""
+        [remote "origin"]
+            url = git@github.com:manaflow-ai/cmux.git
+        """)
+    }
+
+    @Test func staleProjectedBranchReresolvesToOpenPullRequestForCurrentBranch() async throws {
+        let oldBranch = "issue-7728-safari-default-browser-signin"
+        let newBranch = "issue-7728-safari-signin-followup"
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch(newBranch)
+        try writeGitHubRemoteConfig(fixture)
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let seed = WorkspacePullRequestCandidateSeed(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            branch: oldBranch,
+            directory: fixture.root.path
+        )
+        let service = PullRequestProbeService(commandRunner: CountingCommandRunner(outputs: []))
+
+        let resolution = await service.resolveCandidateSeeds(
+            [seed],
+            gitMetadata: GitMetadataService()
+        )
+        let entry = WorkspacePullRequestRepoCacheEntry(
+            fetchedAt: Date(),
+            pullRequestsByBranch: [
+                oldBranch: item(
+                    number: 7739,
+                    state: "MERGED",
+                    branch: oldBranch,
+                    mergedAt: "2026-07-01T12:00:00Z"
+                ),
+                newBranch: item(number: 7776, state: "OPEN", branch: newBranch),
+            ]
+        )
+
+        let results = PullRequestProbeService.resolveRefreshResults(
+            candidates: resolution.candidates,
+            repoResults: ["manaflow-ai/cmux": .success(entry, usedCache: false, transientBranches: [])]
+        )
+        let result = try #require(results.first)
+        guard case .resolved(let resolved) = result.resolution else {
+            Issue.record("expected resolved, got \(result.resolution)")
+            return
+        }
+        #expect(resolved.number == 7776)
+        #expect(resolved.statusRawValue == PullRequestStatus.open.rawValue)
+        #expect(resolved.branch == newBranch)
+    }
+
+    @Test func detachedHeadFallsBackToProjectedBranch() async throws {
+        let projectedBranch = "issue-7728-safari-default-browser-signin"
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeDetachedHead(commit: String(repeating: "1", count: 40))
+        try writeGitHubRemoteConfig(fixture)
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let seed = WorkspacePullRequestCandidateSeed(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            branch: projectedBranch,
+            directory: fixture.root.path
+        )
+        let service = PullRequestProbeService(commandRunner: CountingCommandRunner(outputs: []))
+
+        let resolution = await service.resolveCandidateSeeds(
+            [seed],
+            gitMetadata: GitMetadataService()
+        )
+        let entry = WorkspacePullRequestRepoCacheEntry(
+            fetchedAt: Date(),
+            pullRequestsByBranch: [
+                projectedBranch: item(
+                    number: 7739,
+                    state: "MERGED",
+                    branch: projectedBranch,
+                    mergedAt: "2026-07-01T12:00:00Z"
+                ),
+            ]
+        )
+
+        let results = PullRequestProbeService.resolveRefreshResults(
+            candidates: resolution.candidates,
+            repoResults: ["manaflow-ai/cmux": .success(entry, usedCache: false, transientBranches: [])]
+        )
+        let result = try #require(results.first)
+        guard case .resolved(let resolved) = result.resolution else {
+            Issue.record("expected resolved, got \(result.resolution)")
+            return
+        }
+        #expect(resolved.number == 7739)
+        #expect(resolved.statusRawValue == PullRequestStatus.merged.rawValue)
+        #expect(resolved.branch == projectedBranch)
+    }
+
+    @Test func detectedDefaultBranchResolvesNotFoundWithoutLookup() async throws {
+        let fixture = try GitRepositoryFixture()
+        try fixture.writeBranch("main")
+        try writeGitHubRemoteConfig(fixture)
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let seed = WorkspacePullRequestCandidateSeed(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            branch: "feature/old",
+            directory: fixture.root.path
+        )
+        let service = PullRequestProbeService(commandRunner: CountingCommandRunner(outputs: []))
+
+        let resolution = await service.resolveCandidateSeeds(
+            [seed],
+            gitMetadata: GitMetadataService()
+        )
+
+        #expect(resolution.candidateBranchesByRepo["manaflow-ai/cmux"] == nil)
+        #expect(resolution.repoDirectoriesBySlug["manaflow-ai/cmux"] == nil)
+        let results = PullRequestProbeService.resolveRefreshResults(
+            candidates: resolution.candidates,
+            repoResults: [:]
+        )
+        let result = try #require(results.first)
+        guard case .notFound = result.resolution else {
+            Issue.record("expected notFound, got \(result.resolution)")
+            return
+        }
+    }
+
+}
+
+private actor CountingCommandRunner: CommandRunning {
+    private var outputs: [String?]
+    private(set) var runCount = 0
+
+    init(outputs: [String?]) {
+        self.outputs = outputs
+    }
+
+    func run(
+        directory: String,
+        executable: String,
+        arguments: [String],
+        timeout: TimeInterval?
+    ) async -> CommandResult {
+        runCount += 1
+        let output = outputs.isEmpty ? nil : outputs.removeFirst()
+        return CommandResult(
+            stdout: output ?? "",
+            stderr: nil,
+            exitStatus: output == nil ? 1 : 0,
+            timedOut: false,
+            executionError: nil
+        )
+    }
+}
+

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestAssociationRedetectionTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/PullRequestAssociationRedetectionTests.swift
@@ -120,6 +120,51 @@ import CmuxFoundation
         #expect(resolved.branch == projectedBranch)
     }
 
+    /// A repository whose `HEAD` is missing/unreadable must not re-match the
+    /// stale projected branch: the candidate resolves as a transient failure
+    /// (existing badge kept, no lookup) until the branch can be verified.
+    @Test func unreadableHeadResolvesTransientFailureWithoutLookup() async throws {
+        let projectedBranch = "issue-7728-safari-default-browser-signin"
+        let fixture = try GitRepositoryFixture()
+        try writeGitHubRemoteConfig(fixture)
+        let workspaceId = UUID()
+        let panelId = UUID()
+        let seed = WorkspacePullRequestCandidateSeed(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            branch: projectedBranch,
+            directory: fixture.root.path
+        )
+        let service = PullRequestProbeService(commandRunner: CountingCommandRunner(outputs: []))
+
+        let resolution = await service.resolveCandidateSeeds(
+            [seed],
+            gitMetadata: GitMetadataService()
+        )
+
+        #expect(resolution.candidateBranchesByRepo["manaflow-ai/cmux"] == nil)
+        let entry = WorkspacePullRequestRepoCacheEntry(
+            fetchedAt: Date(),
+            pullRequestsByBranch: [
+                projectedBranch: item(
+                    number: 7739,
+                    state: "MERGED",
+                    branch: projectedBranch,
+                    mergedAt: "2026-07-01T12:00:00Z"
+                ),
+            ]
+        )
+        let results = PullRequestProbeService.resolveRefreshResults(
+            candidates: resolution.candidates,
+            repoResults: ["manaflow-ai/cmux": .success(entry, usedCache: false, transientBranches: [])]
+        )
+        let result = try #require(results.first)
+        guard case .transientFailure = result.resolution else {
+            Issue.record("expected transientFailure, got \(result.resolution)")
+            return
+        }
+    }
+
     @Test func detectedDefaultBranchResolvesNotFoundWithoutLookup() async throws {
         let fixture = try GitRepositoryFixture()
         try fixture.writeBranch("main")

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Hosting/SidebarGitHosting.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Hosting/SidebarGitHosting.swift
@@ -79,6 +79,9 @@ public protocol SidebarGitHosting: AnyObject {
     func updatePanelPullRequest(workspaceId: UUID, panelId: UUID, badge: SidebarPullRequestBadge)
     /// Clears the panel's pull-request badge.
     func clearPanelPullRequest(workspaceId: UUID, panelId: UUID)
+    /// Asks the host to re-probe the panel's local git metadata because the
+    /// pull-request branch disagrees with the current sidebar branch projection.
+    func schedulePanelGitMetadataProbe(workspaceId: UUID, panelId: UUID, reason: String)
     /// Clears every workspace's sidebar git metadata (branches and badges).
     func clearAllSidebarGitMetadata()
     /// Clears every workspace's sidebar pull-request badges.

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
@@ -1,5 +1,5 @@
 public import Foundation
-public import CmuxGit
+import CmuxGit
 
 // MARK: - Applying refresh results, poll-deadline math, and tracking bookkeeping.
 
@@ -110,6 +110,26 @@ extension PullRequestPollService {
                         isStale: false
                     )
                 )
+                let resolvedBranch = GitMetadataService.normalizedBranchName(resolvedPullRequest.branch)
+                let projectedBranch = GitMetadataService.normalizedBranchName(
+                    host.panelGitBranch(workspaceId: result.workspaceId, panelId: result.panelId)?.branch
+                )
+                if resolvedBranch != projectedBranch {
+                    host.schedulePanelGitMetadataProbe(
+                        workspaceId: result.workspaceId,
+                        panelId: result.panelId,
+                        reason: "pullRequestBranchMismatch"
+                    )
+#if DEBUG
+                    debugLog(
+                        "workspace.prRefresh.branchProjectionMismatch " +
+                        "workspace=\(result.workspaceId.uuidString.prefix(5)) " +
+                        "panel=\(result.panelId.uuidString.prefix(5)) " +
+                        "resolved=\(resolvedPullRequest.branch) " +
+                        "projected=\(projectedBranch ?? "nil")"
+                    )
+#endif
+                }
             case .notFound:
                 workspacePullRequestTransientFailureCountByKey[key] = 0
                 workspacePullRequestLastTerminalStateRefreshAtByKey.removeValue(forKey: key)

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
@@ -114,7 +114,11 @@ extension PullRequestPollService {
                 let projectedBranch = GitMetadataService.normalizedBranchName(
                     host.panelGitBranch(workspaceId: result.workspaceId, panelId: result.panelId)?.branch
                 )
-                if resolvedBranch != projectedBranch {
+                // Nudge only while git metadata watching is on: with watching
+                // disabled the probe scheduler clears the panel's branch AND
+                // the badge this pass just applied (there is also no branch
+                // projection to heal).
+                if resolvedBranch != projectedBranch, host.isGitMetadataWatchEnabled {
                     host.schedulePanelGitMetadataProbe(
                         workspaceId: result.workspaceId,
                         panelId: result.panelId,

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+CommandHints.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+CommandHints.swift
@@ -1,5 +1,5 @@
 public import Foundation
-public import CmuxGit
+import CmuxGit
 
 // MARK: - Settings toggles, command-hint reconciliation, and test seams.
 

--- a/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
+++ b/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
@@ -223,6 +223,83 @@ import CmuxGit
         #expect(service.workspacePullRequestTrackedPanelIds(workspaceId: workspaceId).isEmpty)
     }
 
+    @Test func resolvedBadgeWithMismatchedBranchSchedulesGitMetadataProbe() throws {
+        let host = RecordingSidebarGitHost()
+        host.pollingEnabled = true
+        let (workspaceId, panelId) = host.addWorkspace(panelDirectory: "/tmp/repo")
+        host.workspaces[0].state.panels[panelId]?.branch = SidebarPanelGitBranch(
+            branch: "feature/old",
+            isDirty: false
+        )
+        let service = makeService(host: host, clock: ManualGitPollClock())
+        let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+
+        service.applyWorkspacePullRequestRefreshResults(
+            [
+                WorkspacePullRequestRefreshResult(
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    resolution: .resolved(WorkspacePullRequestResolvedItem(
+                        number: 99,
+                        urlString: "https://github.com/o/r/pull/99",
+                        statusRawValue: PullRequestStatus.open.rawValue,
+                        branch: "feature/new"
+                    )),
+                    usedCachedRepoData: false
+                ),
+            ],
+            repoResults: [:],
+            requestedKeys: [key],
+            now: Date(),
+            reason: "test"
+        )
+
+        #expect(host.workspaces[0].state.panels[panelId]?.badge?.number == 99)
+        #expect(host.events.contains(.scheduleGitMetadataProbe(
+            workspaceId,
+            panelId,
+            "pullRequestBranchMismatch"
+        )))
+    }
+
+    @Test func resolvedBadgeWithMatchingBranchDoesNotScheduleProbe() throws {
+        let host = RecordingSidebarGitHost()
+        host.pollingEnabled = true
+        let (workspaceId, panelId) = host.addWorkspace(panelDirectory: "/tmp/repo")
+        host.workspaces[0].state.panels[panelId]?.branch = SidebarPanelGitBranch(
+            branch: "feature/new",
+            isDirty: false
+        )
+        let service = makeService(host: host, clock: ManualGitPollClock())
+        let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+
+        service.applyWorkspacePullRequestRefreshResults(
+            [
+                WorkspacePullRequestRefreshResult(
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    resolution: .resolved(WorkspacePullRequestResolvedItem(
+                        number: 99,
+                        urlString: "https://github.com/o/r/pull/99",
+                        statusRawValue: PullRequestStatus.open.rawValue,
+                        branch: "feature/new"
+                    )),
+                    usedCachedRepoData: false
+                ),
+            ],
+            repoResults: [:],
+            requestedKeys: [key],
+            now: Date(),
+            reason: "test"
+        )
+
+        #expect(host.workspaces[0].state.panels[panelId]?.badge?.number == 99)
+        #expect(!host.events.contains {
+            if case .scheduleGitMetadataProbe = $0 { return true }
+            return false
+        })
+    }
+
     /// Disabling polling resets all tracking and clears every badge.
     @Test func disablingPollingSettingClearsBadgesAndTracking() async throws {
         let host = RecordingSidebarGitHost()

--- a/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
+++ b/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
@@ -300,6 +300,44 @@ import CmuxGit
         })
     }
 
+    /// With git metadata watching disabled, a branch mismatch must not nudge
+    /// the probe scheduler: that path clears the panel's branch and the badge
+    /// the same apply pass just wrote.
+    @Test func resolvedBadgeMismatchDoesNotScheduleProbeWhenWatchDisabled() throws {
+        let host = RecordingSidebarGitHost()
+        host.pollingEnabled = true
+        host.watchEnabled = false
+        let (workspaceId, panelId) = host.addWorkspace(panelDirectory: "/tmp/repo")
+        let service = makeService(host: host, clock: ManualGitPollClock())
+        let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+
+        service.applyWorkspacePullRequestRefreshResults(
+            [
+                WorkspacePullRequestRefreshResult(
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    resolution: .resolved(WorkspacePullRequestResolvedItem(
+                        number: 99,
+                        urlString: "https://github.com/o/r/pull/99",
+                        statusRawValue: PullRequestStatus.open.rawValue,
+                        branch: "feature/new"
+                    )),
+                    usedCachedRepoData: false
+                ),
+            ],
+            repoResults: [:],
+            requestedKeys: [key],
+            now: Date(),
+            reason: "test"
+        )
+
+        #expect(host.workspaces[0].state.panels[panelId]?.badge?.number == 99)
+        #expect(!host.events.contains {
+            if case .scheduleGitMetadataProbe = $0 { return true }
+            return false
+        })
+    }
+
     /// Disabling polling resets all tracking and clears every badge.
     @Test func disablingPollingSettingClearsBadgesAndTracking() async throws {
         let host = RecordingSidebarGitHost()

--- a/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/Support/RecordingSidebarGitHost.swift
+++ b/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/Support/RecordingSidebarGitHost.swift
@@ -12,6 +12,7 @@ final class RecordingSidebarGitHost: SidebarGitHosting {
         case clearGitBranch(UUID, UUID)
         case pullRequestBadge(UUID, UUID, SidebarPullRequestBadge)
         case clearPullRequestBadge(UUID, UUID)
+        case scheduleGitMetadataProbe(UUID, UUID, String)
         case clearAllGitMetadata
         case clearAllPullRequestMetadata
     }
@@ -168,6 +169,10 @@ final class RecordingSidebarGitHost: SidebarGitHosting {
     func clearPanelPullRequest(workspaceId: UUID, panelId: UUID) {
         mutate(workspaceId) { $0.panels[panelId]?.badge = nil }
         record(.clearPullRequestBadge(workspaceId, panelId))
+    }
+
+    func schedulePanelGitMetadataProbe(workspaceId: UUID, panelId: UUID, reason: String) {
+        record(.scheduleGitMetadataProbe(workspaceId, panelId, reason))
     }
 
     func clearAllSidebarGitMetadata() {

--- a/Sources/TabManager+SidebarGitHosting.swift
+++ b/Sources/TabManager+SidebarGitHosting.swift
@@ -150,6 +150,14 @@ extension TabManager: SidebarGitHosting {
         tabs.first(where: { $0.id == workspaceId })?.clearPanelPullRequest(panelId: panelId)
     }
 
+    func schedulePanelGitMetadataProbe(workspaceId: UUID, panelId: UUID, reason: String) {
+        sidebarGitMetadataService.scheduleInitialWorkspaceGitMetadataRefreshIfPossible(
+            workspaceId: workspaceId,
+            panelId: panelId,
+            reason: reason
+        )
+    }
+
     func clearAllSidebarGitMetadata() {
         for workspace in tabs {
             workspace.clearSidebarGitMetadata()


### PR DESCRIPTION
## Summary

Fixes https://github.com/manaflow-ai/cmux/issues/7781 — after a workspace's PR merged and a new PR was opened from the same workspace, the sidebar stayed pinned to the old merged PR (e.g. `PR #7739 merged`) and never showed the new open PR (#7776).

Closes #7781

## Root cause

The PR poller matched pull requests by the panel's **projected** sidebar branch (`panelGitBranch ?? badge.branch`). When that projection lags the real checkout (the known #666 staleness class — verified live: the observed workspace was checked out on `issue-7728-safari-signin-followup` with HEAD equal to PR #7776's head OID while the poller still resolved the old branch), the association latches: every 15-minute terminal-state sweep re-resolves the old branch's merged PR, and the new branch is never queried. The badge-branch fallback makes the latch permanent.

A compounding failure kept badges frozen fleet-wide: `gh auth token` was spawned on **every** refresh pass; when it fails in GUI-app context the fetches run unauthenticated (60 req/hr/IP — observed exhausted at 60/60 on the reporting machine while the authenticated token sat at ~4%), and rate-limited 403s become `.transientFailure`, which by design keeps the existing badge indefinitely.

## Fix

- **Branch re-detection (CmuxGit):** `resolveCandidateSeeds` now re-detects each seed directory's checked-out branch on disk (new `GitMetadataService.currentBranchName(forDirectory:)`, once per directory per pass, pure file reads — **zero extra GitHub API traffic**) and matches PRs for that branch, so the association follows the workspace's real checkout and moves to the new open PR. Detached HEAD / missing repo falls back to the projected branch. A re-detected default branch (main/master) resolves `notFound` (clears the badge) without any per-repo lookup.
- **Branch-projection healing (CmuxSidebarGit):** when a resolved badge's branch disagrees with the sidebar projection, the poll service asks the host (new `SidebarGitHosting.schedulePanelGitMetadataProbe`, forwarded by `TabManager` to the existing git-metadata probe) to re-probe local git metadata, so the branch label heals through the standard probe path and the sidebar's badge/branch display filter passes. Convergence: the probe applies the real branch → the badge re-resolves for it → projection matches → no further nudges.
- **Rate-limit safety:** auth-header resolution moved behind a small actor cache (5 min on success, 60 s on failure; env `GH_TOKEN`/`GITHUB_TOKEN` stays uncached), so refresh passes stop spawning `gh auth token` and poller traffic stays authenticated (5000/hr instead of the unauthenticated 60/hr).

Poll cadences, batch limits, repo-cache lifetimes, and the transient-failure keep-badge semantics are unchanged.

## Commits (red/green regression policy)

1. `5688b58a17` adds the regression tests only — CI red by design: candidate resolution with a stale projected branch must resolve the **open PR for the actual checked-out branch** (pre-fix it resolves the old merged PR), and a re-detected default branch must clear without a lookup.
2. `2a7ad883ae` adds the fix; the tests go green.

## Verification

- `swift test` in `Packages/macOS/CmuxGit` (70 tests) and `Packages/macOS/CmuxSidebarGit` (40 tests): pass with the fix; the two regression tests confirmed failing on the unfixed tree.
- `python3 scripts/swift_file_length_budget.py`: passes; no budget TSV changes; no touched Swift file at/over 500 lines.
- Localization audit: no user-facing strings were added or changed (DEBUG log and test strings only), so no `Localizable.xcstrings` changes are needed.

## Notes

- Related: #2659, #2329, #666, #5748 (the fix rides the existing poller; no new polling paths or API calls).
- The auth-header cache also mitigates the observed frozen-badge amplifier, but persistent 403 handling (explicit rate-limit backoff distinct from `.transientFailure`) is intentionally left out of scope to keep this PR contained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786240976&installation_id=133855650&pr_number=7785&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7785&signature=abdb989bd673fd20a8d05d026349cb3058920472f2f64b08f6bd5d74f8e4d3d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches PR association and sidebar git/PR display paths users rely on, but behavior is localized to probe resolution and healing with extensive regression tests; auth caching only affects GitHub API calls, not credential storage.
> 
> **Overview**
> Fixes stale sidebar PR badges when the panel’s **projected** branch lags the real checkout (e.g. merged PR stuck after opening a new branch).
> 
> **CmuxGit:** `resolveCandidateSeeds` now reads each panel directory’s checked-out branch via new `GitMetadataService.currentBranchName(forDirectory:)` and uses that for PR matching (detached HEAD falls back to the seed branch). Re-detected `main`/`master` skips GitHub lookup and resolves `notFound` to clear badges. `gh auth token` resolution moves to `PullRequestProbeService+Auth` behind a `GitHubAuthHeaderCache` actor (5 min success / 60 s failure) so periodic refreshes don’t spawn the CLI every pass; env tokens stay uncached.
> 
> **CmuxSidebarGit / app:** After applying a resolved badge, if the PR branch ≠ sidebar branch projection and git watch is on, `schedulePanelGitMetadataProbe` nudges the existing git-metadata probe (`TabManager` → `sidebarGitMetadataService`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 645bf58fbb88cf24e802a32319b39d60af668b18. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7781 by making workspace PR badges follow the actual checked-out branch and by healing mismatched sidebar branch labels. Also adds a short-lived `gh` auth-header cache to keep polling authenticated and avoid rate-limit stalls; treats unreadable `HEAD` as unverified to prevent stale re-matches.

- **Bug Fixes**
  - In `CmuxGit`, re-detects each directory’s checked-out branch and matches PRs to it; detached HEAD falls back to the projected branch.
  - If `HEAD` is missing/unreadable, resolves as a transient failure (keeps the existing badge, no lookup) instead of reusing a possibly stale projected branch.
  - Clears the badge when the re-detected branch is the default (`main`/`master`) without a per-repo lookup.
  - In `CmuxSidebarGit`, nudges a local git re-probe when the resolved badge’s branch disagrees with the sidebar projection, gated by `isGitMetadataWatchEnabled`.

- **Performance**
  - Adds an actor-backed cache for the GitHub auth header (5 min on success, 60 s on failure).
  - Stops spawning `gh auth token` on every refresh; prefers `GH_TOKEN`/`GITHUB_TOKEN`.

<sup>Written for commit e540c173da77b62fd2b165189e2f25c84689ff7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added directory-based branch detection for better repository/branch context availability.
* **Bug Fixes**
  * Pull request badges now re-check the panel’s current Git branch, with correct behavior for detached HEAD.
  * Default-branch navigation now clears stale pull request badges when no lookup is performed.
  * GitHub authentication header resolution is cached during refresh cycles to reduce repeated token checks.
  * When the resolved pull request branch differs from the panel projection (and watching is enabled), an extra git metadata probe is scheduled.
* **Tests**
  * Expanded coverage for detached-HEAD handling, badge mismatch probing, and auth/header caching behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->