### PR TITLE
Reconcile Dock portal bindings at reparent time instead of on focus

### DIFF
--- a/Sources/AppDelegate+DockSurfaceMove.swift
+++ b/Sources/AppDelegate+DockSurfaceMove.swift
@@ -139,6 +139,7 @@ extension AppDelegate {
                 insertFirst: split.insertFirst
             )
         }
+        destinationDock.scheduleDockPortalReconcile(reason: "dock.moveSurfaceIntoDock")
 
         // The surface was attached into the Dock with focus, so record Dock focus
         // ownership. Without this, `rightSidebarOwnsInputFocus` stays false and the
@@ -212,6 +213,11 @@ extension AppDelegate {
                 insertFirst: splitTarget.insertFirst
             )
         }
+        destinationWorkspace.scheduleTerminalGeometryReconcile()
+        destinationWorkspace.reconcileBrowserPortalVisibilityForCurrentRenderedLayout(
+            reason: "dock.moveSurfaceToWorkspace"
+        )
+        sourceDock.scheduleDockPortalReconcile(reason: "dock.moveSurfaceToWorkspace.source")
 
         if focus {
             if focusWindow, let destinationWindowId = windowId(for: destinationManager) {
@@ -239,7 +245,7 @@ extension AppDelegate {
         guard let detached = sourceDock.detachSurface(panelId: panelId) else { return false }
         (detached.panel as? TerminalPanel)?.surface.setFocusPlacement(.workspace)
 
-        guard manager.addWorkspace(fromDetachedSurface: detached, select: focus) != nil else {
+        guard let destinationWorkspace = manager.addWorkspace(fromDetachedSurface: detached, select: focus) else {
             // Creation failed — roll the panel back into the Dock unchanged.
             (detached.panel as? TerminalPanel)?.surface.setFocusPlacement(.rightSidebarDock)
             if let rollbackPane = sourcePane ?? sourceDock.bonsplitController.allPaneIds.first {
@@ -247,6 +253,11 @@ extension AppDelegate {
             }
             return false
         }
+        destinationWorkspace.scheduleTerminalGeometryReconcile()
+        destinationWorkspace.reconcileBrowserPortalVisibilityForCurrentRenderedLayout(
+            reason: "dock.moveSurfaceToNewWorkspace"
+        )
+        sourceDock.scheduleDockPortalReconcile(reason: "dock.moveSurfaceToNewWorkspace.source")
 
         if focus, focusWindow, let destinationWindowId = windowId(for: manager) {
             _ = focusMainWindow(windowId: destinationWindowId)

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -6,6 +6,24 @@ extension DockSplitStore {
         AppDelegate.shared?.noteRightSidebarKeyboardFocusIntent(mode: .dock, in: window)
     }
 
+    func browserPanel(owning responder: NSResponder?, in window: NSWindow?) -> BrowserPanel? {
+        guard let responder, let window else { return nil }
+        if let focused = focusedPanelId,
+           let browser = panels[focused] as? BrowserPanel,
+           browser.ownedFocusIntent(for: responder, in: window) != nil {
+            return browser
+        }
+        for (panelId, panel) in panels {
+            guard panelId != focusedPanelId,
+                  let browser = panel as? BrowserPanel,
+                  browser.ownedFocusIntent(for: responder, in: window) != nil else {
+                continue
+            }
+            return browser
+        }
+        return nil
+    }
+
     func focusedDockPaneSelection() -> (pane: PaneID?, tab: TabID?) {
         let pane = bonsplitController.focusedPaneId
         return (pane, pane.flatMap { bonsplitController.selectedTab(inPane: $0)?.id })

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -58,6 +58,7 @@ extension DockSplitStore {
         guard bonsplitController.togglePaneZoom(inPane: paneId) else { return false }
         bonsplitController.focusPane(paneId)
         applyVisibilityToAllPanels()
+        scheduleDockPortalReconcile(reason: "dock.zoom")
         return true
     }
 
@@ -92,9 +93,11 @@ extension DockSplitStore {
         guard let paneId = bonsplitController.focusedPaneId,
               let tabId = bonsplitController.selectedTab(inPane: paneId)?.id else {
             applyVisibilityToAllPanels()
+            scheduleDockPortalReconcile(reason: "dock.selection.empty")
             return
         }
         applyDockSelection(tabId: tabId, inPane: paneId)
+        scheduleDockPortalReconcile(reason: "dock.selection.focused")
     }
 
     func applyDockSelection(tabId: TabID, inPane pane: PaneID) {
@@ -136,6 +139,7 @@ extension DockSplitStore {
         newPane: PaneID,
         orientation: SplitOrientation
     ) {
+        scheduleDockPortalReconcile(reason: "dock.splitPane")
         // Programmatic splits (config seed, `newSplit`, cross-container transfer)
         // seed their own new-pane tab, so don't auto-create another.
         guard !isProgrammaticDockSplit else { return }
@@ -164,6 +168,7 @@ extension DockSplitStore {
     ) {
         applyDockSelection(tabId: tab.id, inPane: destination)
         panel(for: tab.id)?.focus()
+        scheduleDockPortalReconcile(reason: "dock.moveTab")
     }
 
     /// Replaces a pane that holds only placeholder (panel-less) tabs with a real
@@ -196,7 +201,21 @@ extension DockSplitStore {
                 TerminalWindowPortalRegistry.hideHostedView(terminal.hostedView)
             }
         } else if let browser = panel as? BrowserPanel {
-            if !shouldBeVisible {
+            if shouldBeVisible {
+                browser.noteWebViewVisibility(
+                    true,
+                    reason: "portal.dockVisible",
+                    recordIfUnchanged: true
+                )
+                BrowserWindowPortalRegistry.updateEntryVisibility(
+                    for: browser.webView,
+                    visibleInUI: true,
+                    zPriority: 1
+                )
+                if dockBrowserPortalNeedsReconcile(browser) {
+                    scheduleDockPortalReconcile(reason: "dock.browserVisible")
+                }
+            } else {
                 browser.unfocus()
                 browser.hideBrowserPortalView(source: "dockHidden")
             }

--- a/Sources/DockSplitStore+PortalDrop.swift
+++ b/Sources/DockSplitStore+PortalDrop.swift
@@ -62,18 +62,23 @@ extension DockSplitStore {
         // Internal Dock drag. A center drop onto the source pane is a no-op.
         if zone == .center, sourcePane == paneId { return true }
         let movedTab = TabID(uuid: tabId)
+        let didMove: Bool
         switch zone {
         case .center:
-            return bonsplitController.moveTab(movedTab, toPane: paneId)
+            didMove = bonsplitController.moveTab(movedTab, toPane: paneId)
         case .left:
-            return bonsplitController.splitPane(paneId, orientation: .horizontal, movingTab: movedTab, insertFirst: true) != nil
+            didMove = bonsplitController.splitPane(paneId, orientation: .horizontal, movingTab: movedTab, insertFirst: true) != nil
         case .right:
-            return bonsplitController.splitPane(paneId, orientation: .horizontal, movingTab: movedTab, insertFirst: false) != nil
+            didMove = bonsplitController.splitPane(paneId, orientation: .horizontal, movingTab: movedTab, insertFirst: false) != nil
         case .top:
-            return bonsplitController.splitPane(paneId, orientation: .vertical, movingTab: movedTab, insertFirst: true) != nil
+            didMove = bonsplitController.splitPane(paneId, orientation: .vertical, movingTab: movedTab, insertFirst: true) != nil
         case .bottom:
-            return bonsplitController.splitPane(paneId, orientation: .vertical, movingTab: movedTab, insertFirst: false) != nil
+            didMove = bonsplitController.splitPane(paneId, orientation: .vertical, movingTab: movedTab, insertFirst: false) != nil
         }
+        if didMove {
+            scheduleDockPortalReconcile(reason: "dock.portalPaneDrop")
+        }
+        return didMove
     }
 
     private static func externalDropDestination(

--- a/Sources/DockSplitStore+PortalReconcile.swift
+++ b/Sources/DockSplitStore+PortalReconcile.swift
@@ -1,10 +1,10 @@
 import AppKit
-import ObjectiveC
 
-private var dockPortalReconcileStateKey: UInt8 = 0
-
+/// Event-driven follow-up state for the Dock portal reconciler, owned by
+/// `DockSplitStore.dockPortalReconcileState`. Mirrors the state backing
+/// `Workspace.beginEventDrivenLayoutFollowUp`.
 @MainActor
-private final class DockPortalReconcileState {
+final class DockPortalReconcileState {
     var observers: [NSObjectProtocol] = []
     var timeoutWorkItem: DispatchWorkItem?
     var reason: String?
@@ -22,15 +22,6 @@ private final class DockPortalReconcileState {
 
 extension DockSplitStore {
     private static let dockPortalReconcileTimeout: TimeInterval = 2
-
-    private var dockPortalReconcileState: DockPortalReconcileState {
-        if let state = objc_getAssociatedObject(self, &dockPortalReconcileStateKey) as? DockPortalReconcileState {
-            return state
-        }
-        let state = DockPortalReconcileState()
-        objc_setAssociatedObject(self, &dockPortalReconcileStateKey, state, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
-        return state
-    }
 
     func scheduleDockPortalReconcile(reason: String) {
         let state = dockPortalReconcileState
@@ -84,7 +75,7 @@ extension DockSplitStore {
         )
     }
 
-    private func clearDockPortalReconcile() {
+    func clearDockPortalReconcile() {
         let state = dockPortalReconcileState
         state.timeoutWorkItem?.cancel()
         state.timeoutWorkItem = nil
@@ -272,21 +263,3 @@ extension DockSplitStore {
             !dockBrowserPortalReady(browser)
     }
 }
-
-#if DEBUG
-extension DockSplitStore {
-    func debugDockPortalReconcileScheduleCountForTesting() -> Int {
-        dockPortalReconcileState.scheduledRequestCount
-    }
-
-    func debugResetDockPortalReconcileStateForTesting() {
-        clearDockPortalReconcile()
-        dockPortalReconcileState.scheduledRequestCount = 0
-    }
-
-    @discardableResult
-    func debugReconcileDockPortalsForTesting(reason: String = "dock.portal.test") -> Bool {
-        reconcileDockPortalPass(reason: reason)
-    }
-}
-#endif

--- a/Sources/DockSplitStore+PortalReconcile.swift
+++ b/Sources/DockSplitStore+PortalReconcile.swift
@@ -1,0 +1,292 @@
+import AppKit
+import ObjectiveC
+
+private var dockPortalReconcileStateKey: UInt8 = 0
+
+@MainActor
+private final class DockPortalReconcileState {
+    var observers: [NSObjectProtocol] = []
+    var timeoutWorkItem: DispatchWorkItem?
+    var reason: String?
+    var attemptScheduled = false
+    var attemptVersion = 0
+    var stalledAttemptCount = 0
+    var isAttempting = false
+    var scheduledRequestCount = 0
+
+    deinit {
+        timeoutWorkItem?.cancel()
+        observers.forEach { NotificationCenter.default.removeObserver($0) }
+    }
+}
+
+extension DockSplitStore {
+    private static let dockPortalReconcileTimeout: TimeInterval = 2
+
+    private var dockPortalReconcileState: DockPortalReconcileState {
+        if let state = objc_getAssociatedObject(self, &dockPortalReconcileStateKey) as? DockPortalReconcileState {
+            return state
+        }
+        let state = DockPortalReconcileState()
+        objc_setAssociatedObject(self, &dockPortalReconcileStateKey, state, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        return state
+    }
+
+    func scheduleDockPortalReconcile(reason: String) {
+        let state = dockPortalReconcileState
+        state.scheduledRequestCount += 1
+        state.reason = reason
+        state.stalledAttemptCount = 0
+        state.attemptVersion &+= 1
+        state.attemptScheduled = false
+
+        if state.timeoutWorkItem == nil {
+            installDockPortalReconcileObservers()
+        }
+        refreshDockPortalReconcileTimeout()
+        scheduleDockPortalReconcileAttempt()
+    }
+
+    private func installDockPortalReconcileObservers() {
+        let state = dockPortalReconcileState
+        guard state.timeoutWorkItem == nil else { return }
+
+        let wake: () -> Void = { [weak self] in
+            self?.wakeDockPortalReconcileForStructuralEvent()
+        }
+        let notificationNames: [Notification.Name] = [
+            .terminalSurfaceDidBecomeReady,
+            .terminalSurfaceHostedViewDidMoveToWindow,
+            .terminalPortalVisibilityDidChange,
+            .browserPortalRegistryDidChange,
+        ]
+        for name in notificationNames {
+            state.observers.append(NotificationCenter.default.addObserver(
+                forName: name,
+                object: nil,
+                queue: .main
+            ) { _ in
+                wake()
+            })
+        }
+    }
+
+    private func refreshDockPortalReconcileTimeout() {
+        let state = dockPortalReconcileState
+        state.timeoutWorkItem?.cancel()
+        let workItem = DispatchWorkItem { [weak self] in
+            self?.clearDockPortalReconcile()
+        }
+        state.timeoutWorkItem = workItem
+        DispatchQueue.main.asyncAfter(
+            deadline: .now() + Self.dockPortalReconcileTimeout,
+            execute: workItem
+        )
+    }
+
+    private func clearDockPortalReconcile() {
+        let state = dockPortalReconcileState
+        state.timeoutWorkItem?.cancel()
+        state.timeoutWorkItem = nil
+        state.observers.forEach { NotificationCenter.default.removeObserver($0) }
+        state.observers.removeAll()
+        state.reason = nil
+        state.attemptVersion &+= 1
+        state.attemptScheduled = false
+        state.stalledAttemptCount = 0
+    }
+
+    private func wakeDockPortalReconcileForStructuralEvent() {
+        let state = dockPortalReconcileState
+        guard state.timeoutWorkItem != nil else { return }
+        state.stalledAttemptCount = 0
+        state.attemptVersion &+= 1
+        state.attemptScheduled = false
+        scheduleDockPortalReconcileAttempt()
+    }
+
+    private func scheduleDockPortalReconcileAttempt() {
+        let state = dockPortalReconcileState
+        guard state.timeoutWorkItem != nil else { return }
+        guard !state.attemptScheduled else { return }
+
+        state.attemptScheduled = true
+        let delay = dockPortalReconcileBackoffDelay()
+        let version = state.attemptVersion
+        DispatchQueue.main.asyncAfter(deadline: .now() + delay) { [weak self] in
+            guard let self else { return }
+            let state = self.dockPortalReconcileState
+            guard state.attemptVersion == version,
+                  state.timeoutWorkItem != nil else { return }
+            state.attemptScheduled = false
+            self.attemptDockPortalReconcile()
+        }
+    }
+
+    private func dockPortalReconcileBackoffDelay() -> TimeInterval {
+        let stalledAttemptCount = dockPortalReconcileState.stalledAttemptCount
+        guard stalledAttemptCount > 0 else { return 0 }
+        let baseDelay: TimeInterval = 0.01
+        let exponent = min(stalledAttemptCount - 1, 5)
+        return min(0.25, baseDelay * pow(2, Double(exponent)))
+    }
+
+    private func attemptDockPortalReconcile() {
+        let state = dockPortalReconcileState
+        guard state.timeoutWorkItem != nil, !state.isAttempting else { return }
+        state.isAttempting = true
+        defer { state.isAttempting = false }
+
+        let attemptVersion = state.attemptVersion
+        let reason = state.reason ?? "dock.portal.reconcile"
+        guard reconcileDockPortalPass(reason: reason) else {
+            clearDockPortalReconcile()
+            return
+        }
+
+        if state.attemptVersion == attemptVersion {
+            state.stalledAttemptCount += 1
+        }
+        scheduleDockPortalReconcileAttempt()
+    }
+
+    @discardableResult
+    func reconcileDockPortalPass(reason: String) -> Bool {
+        var needsFollowUpPass = false
+        flushDockWindowLayouts()
+
+        withCoalescedTerminalViewReattach {
+            for panel in panels.values {
+                if panelIsSelectedInVisibleDockPane(panel.id) {
+                    needsFollowUpPass = reconcileVisibleDockPortalPanel(panel, reason: reason) || needsFollowUpPass
+                } else {
+                    applyVisibility(to: panel)
+                }
+            }
+        }
+
+        return needsFollowUpPass
+    }
+
+    private func flushDockWindowLayouts() {
+        for window in NSApp.windows where window.isVisible {
+            window.contentView?.layoutSubtreeIfNeeded()
+        }
+    }
+
+    private func reconcileVisibleDockPortalPanel(_ panel: any Panel, reason: String) -> Bool {
+        if let terminal = panel as? TerminalPanel {
+            return reconcileVisibleDockTerminalPortal(terminal)
+        }
+        if let browser = panel as? BrowserPanel {
+            return reconcileVisibleDockBrowserPortal(browser, reason: reason)
+        }
+        return false
+    }
+
+    private func reconcileVisibleDockTerminalPortal(_ terminal: TerminalPanel) -> Bool {
+        var needsFollowUpPass = false
+        let hostedView = terminal.hostedView
+        hostedView.setVisibleInUI(true)
+        hostedView.setActive(panelIsActiveInVisibleDockPane(terminal.id))
+
+        let needsPortalReattach = TerminalWindowPortalRegistry
+            .updateEntryVisibility(for: hostedView, visibleInUI: true)
+        let hasUsableBounds = hostedView.bounds.width > 1 && hostedView.bounds.height > 1
+        let hasSurface = terminal.surface.surface != nil
+        let isAttached = terminal.surface.isViewInWindow && hostedView.superview != nil
+
+        if needsPortalReattach || !isAttached || !hasUsableBounds || !hasSurface {
+            requestTerminalViewReattach(terminal)
+            needsFollowUpPass = true
+        }
+
+        hostedView.reconcileGeometryNow()
+        if terminal.surface.surface != nil {
+            terminal.surface.forceRefresh()
+        }
+        if terminal.surface.surface == nil, isAttached, hasUsableBounds {
+            terminal.surface.requestBackgroundSurfaceStartIfNeeded()
+            needsFollowUpPass = true
+        }
+
+        return needsFollowUpPass
+    }
+
+    private func reconcileVisibleDockBrowserPortal(_ browser: BrowserPanel, reason: String) -> Bool {
+        browser.noteWebViewVisibility(true, reason: "portal.\(reason)", recordIfUnchanged: true)
+
+        let anchorView = browser.portalAnchorView
+        guard dockBrowserPortalAnchorReady(anchorView) else { return true }
+
+        let webView = browser.webView
+        let snapshot = BrowserWindowPortalRegistry.debugSnapshot(for: webView)
+        if snapshot?.visibleInUI == false {
+            BrowserWindowPortalRegistry.updateEntryVisibility(
+                for: webView,
+                visibleInUI: true,
+                zPriority: 1
+            )
+        }
+
+        let wasReady = dockBrowserPortalReady(browser)
+        if !wasReady &&
+            (snapshot == nil || !BrowserWindowPortalRegistry.isWebView(webView, boundTo: anchorView)) {
+            BrowserWindowPortalRegistry.bind(
+                webView: webView,
+                to: anchorView,
+                visibleInUI: true,
+                zPriority: 1
+            )
+        }
+
+        if !wasReady && !dockBrowserPortalReady(browser) {
+            BrowserWindowPortalRegistry.synchronizeForAnchor(anchorView)
+        }
+        let isReady = dockBrowserPortalReady(browser)
+        if isReady && (!wasReady || snapshot?.containerHidden == true) {
+            BrowserWindowPortalRegistry.refresh(webView: webView, reason: reason)
+        }
+        return !isReady
+    }
+
+    func dockBrowserPortalAnchorReady(_ anchorView: NSView) -> Bool {
+        anchorView.window != nil &&
+            anchorView.superview != nil &&
+            anchorView.bounds.width > 1 &&
+            anchorView.bounds.height > 1
+    }
+
+    func dockBrowserPortalReady(_ browser: BrowserPanel) -> Bool {
+        dockBrowserPortalAnchorReady(browser.portalAnchorView) &&
+            browser.webView.window != nil &&
+            browser.webView.superview != nil &&
+            BrowserWindowPortalRegistry.isWebView(browser.webView, boundTo: browser.portalAnchorView)
+    }
+
+    func dockBrowserPortalNeedsReconcile(_ browser: BrowserPanel) -> Bool {
+        let snapshot = BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)
+        return snapshot == nil ||
+            snapshot?.visibleInUI == false ||
+            snapshot?.containerHidden == true ||
+            !dockBrowserPortalReady(browser)
+    }
+}
+
+#if DEBUG
+extension DockSplitStore {
+    func debugDockPortalReconcileScheduleCountForTesting() -> Int {
+        dockPortalReconcileState.scheduledRequestCount
+    }
+
+    func debugResetDockPortalReconcileStateForTesting() {
+        clearDockPortalReconcile()
+        dockPortalReconcileState.scheduledRequestCount = 0
+    }
+
+    @discardableResult
+    func debugReconcileDockPortalsForTesting(reason: String = "dock.portal.test") -> Bool {
+        reconcileDockPortalPass(reason: reason)
+    }
+}
+#endif

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -271,6 +271,7 @@ extension DockSplitStore {
                 panel.focus()
             }
         }
+        scheduleDockPortalReconcile(reason: "dock.attachDetachedSurface")
         return detached.panelId
     }
 }

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -27,6 +27,7 @@ final class DockSplitStore: BonsplitDelegate {
     /// window's right sidebar), but SwiftUI remounts can briefly overlap an old
     /// and new host, so visibility is the union rather than a single flag.
     private var visibleUIHostIds: Set<UUID> = []
+    @ObservationIgnored let dockPortalReconcileState = DockPortalReconcileState()
 
     private let baseDirectoryProvider: () -> String?
     private let remoteBrowserSettingsProvider: () -> DockRemoteBrowserSettings
@@ -135,24 +136,6 @@ final class DockSplitStore: BonsplitDelegate {
 
     func browserPanel(for panelId: UUID) -> BrowserPanel? {
         panels[panelId] as? BrowserPanel
-    }
-
-    func browserPanel(owning responder: NSResponder?, in window: NSWindow?) -> BrowserPanel? {
-        guard let responder, let window else { return nil }
-        if let focused = focusedPanelId,
-           let browser = panels[focused] as? BrowserPanel,
-           browser.ownedFocusIntent(for: responder, in: window) != nil {
-            return browser
-        }
-        for (panelId, panel) in panels {
-            guard panelId != focusedPanelId,
-                  let browser = panel as? BrowserPanel,
-                  browser.ownedFocusIntent(for: responder, in: window) != nil else {
-                continue
-            }
-            return browser
-        }
-        return nil
     }
 
     func surfaceId(forPanelId panelId: UUID) -> TabID? {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -596,6 +596,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */; };
 		D7529001A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */; };
+		D77800010000000000000001 /* DockPortalReconcileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77800010000000000000002 /* DockPortalReconcileTests.swift */; };
 		DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */; };
 		DCDC1000000000000000C020 /* DockScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C021 /* DockScope.swift */; };
 		D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */; };
@@ -2215,6 +2216,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockEmptyView.swift; sourceTree = "<group>"; };
 		D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPaneDropUnfocusedRoutingTests.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPanelView.swift; sourceTree = "<group>"; };
+		D77800010000000000000002 /* DockPortalReconcileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPortalReconcileTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B00C /* DockRemoteBrowserSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockRemoteBrowserSettings.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000C021 /* DockScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockScope.swift; sourceTree = "<group>"; };
 		D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSocketLifecycleTests.swift; sourceTree = "<group>"; };
@@ -4574,6 +4576,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
 				DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */,
 				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
+				D77800010000000000000002 /* DockPortalReconcileTests.swift */,
 				D7054D0C0000000000000002 /* DockTerminalReattachTests.swift */,
 				D6212D0C0000000000000002 /* DockSocketLifecycleTests.swift */,
 				D6212D0C00000000000000D2 /* WindowDockLifecycleTests.swift */,
@@ -6647,6 +6650,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D1FFC0DE000000000000C002 /* DiffCommentStoreTests.swift in Sources */,
 				DCDC0000000000000000B001 /* DockControlDefinitionDecodingTests.swift in Sources */,
 				D7529001A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift in Sources */,
+				D77800010000000000000001 /* DockPortalReconcileTests.swift in Sources */,
 				D6212D0C0000000000000001 /* DockSocketLifecycleTests.swift in Sources */,
 				D7054D0C0000000000000001 /* DockTerminalReattachTests.swift in Sources */,
 				D3622100A1B2C3D4E5F60718 /* EditableTextViewArrowKeyForwardingTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -605,6 +605,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000A004 /* DockSplitStore+Config.swift */; };
 		DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */; };
 		DCDC1000000000000000C040 /* DockSplitStore+PortalDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C041 /* DockSplitStore+PortalDrop.swift */; };
+		D77800020000000000000001 /* DockSplitStore+PortalReconcile.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77800020000000000000002 /* DockSplitStore+PortalReconcile.swift */; };
 		DCDC1000000000000000C010 /* DockSplitStore+SurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */; };
 		DCDC1000000000000000B017 /* DockSplitStore+TerminalStartup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B018 /* DockSplitStore+TerminalStartup.swift */; };
 		DCDC0000000000000000A001 /* DockSplitStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000A002 /* DockSplitStore.swift */; };
@@ -2225,6 +2226,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DCDC0000000000000000A004 /* DockSplitStore+Config.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+Config.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B020 /* DockSplitStore+PaneFocus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PaneFocus.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000C041 /* DockSplitStore+PortalDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PortalDrop.swift"; sourceTree = "<group>"; };
+		D77800020000000000000002 /* DockSplitStore+PortalReconcile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+PortalReconcile.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+SurfaceTransfer.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B018 /* DockSplitStore+TerminalStartup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "DockSplitStore+TerminalStartup.swift"; sourceTree = "<group>"; };
 		DCDC0000000000000000A002 /* DockSplitStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockSplitStore.swift; sourceTree = "<group>"; };
@@ -4399,6 +4401,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */,
 				DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */,
 				DCDC1000000000000000C041 /* DockSplitStore+PortalDrop.swift */,
+				D77800020000000000000002 /* DockSplitStore+PortalReconcile.swift */,
 				DCDC1000000000000000B018 /* DockSplitStore+TerminalStartup.swift */,
 				DCDC0000000000000000A002 /* DockSplitStore.swift */,
 				DCDC1000000000000000B00E /* DockSurfaceKind.swift */,
@@ -5670,6 +5673,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC0000000000000000A003 /* DockSplitStore+Config.swift in Sources */,
 				DCDC1000000000000000B019 /* DockSplitStore+PaneFocus.swift in Sources */,
 				DCDC1000000000000000C040 /* DockSplitStore+PortalDrop.swift in Sources */,
+				D77800020000000000000001 /* DockSplitStore+PortalReconcile.swift in Sources */,
 				DCDC1000000000000000C010 /* DockSplitStore+SurfaceTransfer.swift in Sources */,
 				DCDC1000000000000000B017 /* DockSplitStore+TerminalStartup.swift in Sources */,
 				DCDC0000000000000000A001 /* DockSplitStore.swift in Sources */,

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -2654,7 +2654,7 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         file: StaticString = #filePath,
         line: UInt = #line,
         predicate: () -> Bool
-    ) throws {
+    ) {
         let deadline = Date().addingTimeInterval(timeout)
         while Date() < deadline {
             if predicate() {
@@ -2663,12 +2663,11 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
             RunLoop.current.run(mode: .default, before: Date().addingTimeInterval(0.01))
         }
 
+        // Abort via continueAfterFailure instead of throwing: a thrown error is
+        // tallied as an "unexpected" failure and fails the whole CI shard, while
+        // the recorded XCTFail keeps this timeout visible as a normal failure.
+        continueAfterFailure = false
         XCTFail("Timed out waiting for \(description)", file: file, line: line)
-        throw BrowserTestTimeout(description: description)
-    }
-
-    private struct BrowserTestTimeout: Error, CustomStringConvertible {
-        let description: String
     }
 
     private func waitForBrowserPanel(
@@ -2813,23 +2812,23 @@ final class BrowserSessionHistoryRestoreTests: XCTestCase {
         XCTAssertEqual(panel.pageTitle, "Race A")
 
         panel.navigate(to: pageB)
-        try waitUntil("server to receive provisional page B request") {
+        waitUntil("server to receive provisional page B request") {
             server.didReceiveBRequest
         }
-        try waitUntil("browser back availability during provisional page B navigation") {
+        waitUntil("browser back availability during provisional page B navigation") {
             panel.canGoBack && panel.webView.isLoading
         }
         XCTAssertFalse(panel.canGoForward)
 
         panel.goBack()
-        try waitUntil("back action to expose page B as forward history before it can commit") {
+        waitUntil("back action to expose page B as forward history before it can commit") {
             panel.currentURL?.path == pageA.path && !panel.webView.isLoading
                 && panel.canGoForward
         }
 
         let releasedBResponseCount = server.releaseHeldBResponses()
         XCTAssertGreaterThan(releasedBResponseCount, 0)
-        try waitUntil("browser to remain on page A after held page B response is released") {
+        waitUntil("browser to remain on page A after held page B response is released") {
             !panel.webView.isLoading &&
                 panel.pageTitle == "Race A" &&
                 panel.currentURL?.path == pageA.path

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -101,7 +101,7 @@ struct DockPortalReconcileTests {
         anchor.removeFromSuperview()
         let reattachTokenBefore = terminal.viewReattachToken
 
-        _ = store.debugReconcileDockPortalsForTesting()
+        store.reconcileDockPortalPass(reason: "test.dockPortalReconcile")
 
         #expect(terminal.viewReattachToken > reattachTokenBefore)
     }
@@ -126,7 +126,7 @@ struct DockPortalReconcileTests {
         Self.installBrowserAnchor(browser, in: window)
         #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView) == nil)
 
-        _ = store.debugReconcileDockPortalsForTesting()
+        store.reconcileDockPortalPass(reason: "test.dockPortalReconcile")
 
         #expect(BrowserWindowPortalRegistry.isWebView(browser.webView, boundTo: browser.portalAnchorView))
         #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.visibleInUI == true)
@@ -170,11 +170,12 @@ struct DockPortalReconcileTests {
         }
         defer { NotificationCenter.default.removeObserver(observer) }
 
-        store.debugResetDockPortalReconcileStateForTesting()
+        store.clearDockPortalReconcile()
+        store.dockPortalReconcileState.scheduledRequestCount = 0
         store.applyVisibility(to: browser)
-        #expect(store.debugDockPortalReconcileScheduleCountForTesting() == 0)
+        #expect(store.dockPortalReconcileState.scheduledRequestCount == 0)
 
-        let needsFollowUp = store.debugReconcileDockPortalsForTesting()
+        let needsFollowUp = store.reconcileDockPortalPass(reason: "test.dockPortalReconcile")
 
         #expect(!needsFollowUp)
         #expect(registryChangeCount == 0)
@@ -205,7 +206,8 @@ struct DockPortalReconcileTests {
             let dock = workspace.dockSplit
             let rootPane = try #require(dock.bonsplitController.allPaneIds.first)
             dock.setVisibleInUI(true)
-            dock.debugResetDockPortalReconcileStateForTesting()
+            dock.clearDockPortalReconcile()
+            dock.dockPortalReconcileState.scheduledRequestCount = 0
 
             let moved = appDelegate.moveSurfaceIntoDock(
                 sourceTabId: sourceTabId.uuid,
@@ -214,7 +216,7 @@ struct DockPortalReconcileTests {
             )
 
             #expect(moved)
-            #expect(dock.debugDockPortalReconcileScheduleCountForTesting() > 0)
+            #expect(dock.dockPortalReconcileState.scheduledRequestCount > 0)
         }
     }
 
@@ -243,7 +245,8 @@ struct DockPortalReconcileTests {
             let rootPane = try #require(dock.bonsplitController.allPaneIds.first)
             dock.setVisibleInUI(true)
             let dockPanelId = try #require(dock.newSurface(kind: .terminal, inPane: rootPane, focus: true))
-            dock.debugResetDockPortalReconcileStateForTesting()
+            dock.clearDockPortalReconcile()
+            dock.dockPortalReconcileState.scheduledRequestCount = 0
 
             let moved = appDelegate.moveDockSurfaceToWorkspace(
                 sourceDock: dock,
@@ -258,7 +261,7 @@ struct DockPortalReconcileTests {
 
             #expect(moved)
             #expect(destinationWorkspace.panels[dockPanelId] != nil)
-            #expect(dock.debugDockPortalReconcileScheduleCountForTesting() > 0)
+            #expect(dock.dockPortalReconcileState.scheduledRequestCount > 0)
         }
     }
 

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -1,0 +1,140 @@
+import AppKit
+import Bonsplit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Dock portal reconcile", .serialized)
+struct DockPortalReconcileTests {
+    @Test("Browser attach into visible Dock shows portal")
+    @MainActor
+    func dockBrowserAttachIntoVisibleDockShowsPortal() throws {
+        let sourceWorkspaceId = UUID()
+        let browser = BrowserPanel(workspaceId: sourceWorkspaceId, renderInitialNavigation: false)
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            browserAvailabilityProvider: { true }
+        )
+        defer { store.closeAllPanels() }
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+        store.setVisibleInUI(true)
+
+        let window = Self.portalWindow()
+        defer { Self.closePortalWindow(window) }
+        Self.installBrowserAnchor(browser, in: window)
+        BrowserWindowPortalRegistry.bind(
+            webView: browser.webView,
+            to: browser.portalAnchorView,
+            visibleInUI: false,
+            zPriority: 0
+        )
+        BrowserWindowPortalRegistry.synchronizeForAnchor(browser.portalAnchorView)
+        #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.visibleInUI == false)
+
+        let detached = Self.detachedBrowserTransfer(panel: browser, sourceWorkspaceId: sourceWorkspaceId)
+        let attachedPanelId = store.attachDetachedSurface(detached, inPane: rootPane, focus: true)
+
+        #expect(attachedPanelId == browser.id)
+        #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.visibleInUI == true)
+    }
+
+    @Test("Browser reveal restores portal visibility")
+    @MainActor
+    func dockBrowserRevealRestoresPortalVisibility() throws {
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            browserAvailabilityProvider: { true }
+        )
+        defer { store.closeAllPanels() }
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+        store.setVisibleInUI(true)
+        let panelId = try #require(store.newSurface(kind: .browser, inPane: rootPane, focus: true))
+        let tabId = try #require(store.surfaceId(forPanelId: panelId))
+        let browser = try #require(store.panel(for: tabId) as? BrowserPanel)
+
+        let window = Self.portalWindow()
+        defer { Self.closePortalWindow(window) }
+        Self.installBrowserAnchor(browser, in: window)
+        BrowserWindowPortalRegistry.bind(
+            webView: browser.webView,
+            to: browser.portalAnchorView,
+            visibleInUI: true,
+            zPriority: 1
+        )
+        BrowserWindowPortalRegistry.synchronizeForAnchor(browser.portalAnchorView)
+
+        store.setVisibleInUI(false)
+        #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.visibleInUI == false)
+        store.setVisibleInUI(true)
+
+        #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.visibleInUI == true)
+    }
+
+    @MainActor
+    private static func detachedBrowserTransfer(
+        panel: BrowserPanel,
+        sourceWorkspaceId: UUID
+    ) -> Workspace.DetachedSurfaceTransfer {
+        Workspace.DetachedSurfaceTransfer(
+            sourceWorkspaceId: sourceWorkspaceId,
+            panelId: panel.id,
+            panel: panel,
+            title: panel.displayTitle,
+            icon: panel.displayIcon,
+            iconImageData: nil,
+            kind: "browser",
+            isLoading: panel.isLoading,
+            isPinned: false,
+            directory: nil,
+            directoryIsTrustedRemoteReport: false,
+            directoryDisplayLabel: nil,
+            ttyName: nil,
+            cachedTitle: panel.displayTitle,
+            customTitle: nil,
+            customTitleSource: nil,
+            manuallyUnread: false,
+            restoredUnreadIndicator: nil,
+            restorableAgent: nil,
+            restorableAgentResumeState: nil,
+            restoredResumeSessionWorkingDirectory: nil,
+            resumeBinding: nil,
+            agentRuntime: nil,
+            isRemoteTerminal: false,
+            remoteRelayPort: nil,
+            remotePTYSessionID: nil,
+            remoteCleanupConfiguration: nil
+        )
+    }
+
+    @MainActor
+    private static func portalWindow() -> NSWindow {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 480, height: 320),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.orderFront(nil)
+        window.contentView?.layoutSubtreeIfNeeded()
+        return window
+    }
+
+    @MainActor
+    private static func closePortalWindow(_ window: NSWindow) {
+        NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+        window.orderOut(nil)
+    }
+
+    @MainActor
+    private static func installBrowserAnchor(_ browser: BrowserPanel, in window: NSWindow) {
+        browser.portalAnchorView.frame = NSRect(x: 24, y: 24, width: 240, height: 160)
+        window.contentView?.addSubview(browser.portalAnchorView)
+        window.contentView?.layoutSubtreeIfNeeded()
+    }
+}

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -76,6 +76,192 @@ struct DockPortalReconcileTests {
         #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.visibleInUI == true)
     }
 
+    @Test("Terminal stale portal bind reconciles without focus")
+    @MainActor
+    func dockTerminalStalePortalBindReconcilesWithoutFocus() throws {
+        let store = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        defer { store.closeAllPanels() }
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+        store.setVisibleInUI(true)
+        let panelId = try #require(store.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+        let tabId = try #require(store.surfaceId(forPanelId: panelId))
+        let terminal = try #require(store.panel(for: tabId) as? TerminalPanel)
+
+        let window = Self.portalWindow()
+        defer { Self.closePortalWindow(window) }
+        let anchor = NSView(frame: NSRect(x: 24, y: 24, width: 240, height: 160))
+        window.contentView?.addSubview(anchor)
+        TerminalWindowPortalRegistry.bind(
+            hostedView: terminal.hostedView,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: terminal.surface.id,
+            expectedGeneration: terminal.surface.portalBindingGeneration()
+        )
+        anchor.removeFromSuperview()
+        let reattachTokenBefore = terminal.viewReattachToken
+
+        _ = store.debugReconcileDockPortalsForTesting()
+
+        #expect(terminal.viewReattachToken > reattachTokenBefore)
+    }
+
+    @Test("Browser unbound reconcile binds imperatively")
+    @MainActor
+    func dockBrowserUnboundReconcileBindsImperatively() throws {
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            browserAvailabilityProvider: { true }
+        )
+        defer { store.closeAllPanels() }
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+        store.setVisibleInUI(true)
+        let panelId = try #require(store.newSurface(kind: .browser, inPane: rootPane, focus: true))
+        let tabId = try #require(store.surfaceId(forPanelId: panelId))
+        let browser = try #require(store.panel(for: tabId) as? BrowserPanel)
+
+        let window = Self.portalWindow()
+        defer { Self.closePortalWindow(window) }
+        Self.installBrowserAnchor(browser, in: window)
+        #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView) == nil)
+
+        _ = store.debugReconcileDockPortalsForTesting()
+
+        #expect(BrowserWindowPortalRegistry.isWebView(browser.webView, boundTo: browser.portalAnchorView))
+        #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.visibleInUI == true)
+    }
+
+    @Test("Healthy browser reconcile does not mutate portal registry")
+    @MainActor
+    func dockBrowserHealthyReconcileIsPortalNoOp() throws {
+        let store = DockSplitStore(
+            workspaceId: UUID(),
+            baseDirectoryProvider: { nil },
+            browserAvailabilityProvider: { true }
+        )
+        defer { store.closeAllPanels() }
+        let rootPane = try #require(store.bonsplitController.allPaneIds.first)
+        store.setVisibleInUI(true)
+        let panelId = try #require(store.newSurface(kind: .browser, inPane: rootPane, focus: true))
+        let tabId = try #require(store.surfaceId(forPanelId: panelId))
+        let browser = try #require(store.panel(for: tabId) as? BrowserPanel)
+
+        let window = Self.portalWindow()
+        defer { Self.closePortalWindow(window) }
+        Self.installBrowserAnchor(browser, in: window)
+        BrowserWindowPortalRegistry.bind(
+            webView: browser.webView,
+            to: browser.portalAnchorView,
+            visibleInUI: true,
+            zPriority: 1
+        )
+        BrowserWindowPortalRegistry.synchronizeForAnchor(browser.portalAnchorView)
+        #expect(BrowserWindowPortalRegistry.isWebView(browser.webView, boundTo: browser.portalAnchorView))
+        #expect(BrowserWindowPortalRegistry.debugSnapshot(for: browser.webView)?.containerHidden == false)
+
+        var registryChangeCount = 0
+        let observer = NotificationCenter.default.addObserver(
+            forName: .browserPortalRegistryDidChange,
+            object: browser.webView,
+            queue: nil
+        ) { _ in
+            registryChangeCount += 1
+        }
+        defer { NotificationCenter.default.removeObserver(observer) }
+
+        store.debugResetDockPortalReconcileStateForTesting()
+        store.applyVisibility(to: browser)
+        #expect(store.debugDockPortalReconcileScheduleCountForTesting() == 0)
+
+        let needsFollowUp = store.debugReconcileDockPortalsForTesting()
+
+        #expect(!needsFollowUp)
+        #expect(registryChangeCount == 0)
+    }
+
+    @Test("Move into Dock schedules portal reconcile")
+    @MainActor
+    func moveIntoDockSchedulesPortalReconcile() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            TerminalController.shared.setActiveTabManager(manager)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                TerminalController.shared.setActiveTabManager(previousManager)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let workspace = try #require(manager.tabs.first)
+            let sourcePanel = try #require(workspace.panels.values.first)
+            let sourceTabId = try #require(workspace.surfaceIdFromPanelId(sourcePanel.id))
+            let dock = workspace.dockSplit
+            let rootPane = try #require(dock.bonsplitController.allPaneIds.first)
+            dock.setVisibleInUI(true)
+            dock.debugResetDockPortalReconcileStateForTesting()
+
+            let moved = appDelegate.moveSurfaceIntoDock(
+                sourceTabId: sourceTabId.uuid,
+                destinationDock: dock,
+                destination: .insert(targetPane: rootPane, targetIndex: nil)
+            )
+
+            #expect(moved)
+            #expect(dock.debugDockPortalReconcileScheduleCountForTesting() > 0)
+        }
+    }
+
+    @Test("Move Dock surface to workspace reconciles destination")
+    @MainActor
+    func moveDockSurfaceToWorkspaceReconcilesDestination() async throws {
+        try await AppContextSerialGate.withExclusiveAppContext {
+            let previousAppDelegate = AppDelegate.shared
+            let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+            let appDelegate = AppDelegate()
+            let manager = TabManager(autoWelcomeIfNeeded: false)
+            AppDelegate.shared = appDelegate
+            appDelegate.tabManager = manager
+            TerminalController.shared.setActiveTabManager(manager)
+            let windowId = appDelegate.registerMainWindowContextForTesting(tabManager: manager)
+            defer {
+                TerminalController.shared.setActiveTabManager(previousManager)
+                appDelegate.unregisterMainWindowContextForTesting(windowId: windowId)
+                manager.tabs.forEach { $0.teardownAllPanels() }
+                AppDelegate.shared = previousAppDelegate
+            }
+
+            let sourceWorkspace = try #require(manager.tabs.first)
+            let destinationWorkspace = manager.addWorkspace(select: false, eagerLoadTerminal: false)
+            let dock = sourceWorkspace.dockSplit
+            let rootPane = try #require(dock.bonsplitController.allPaneIds.first)
+            dock.setVisibleInUI(true)
+            let dockPanelId = try #require(dock.newSurface(kind: .terminal, inPane: rootPane, focus: true))
+            dock.debugResetDockPortalReconcileStateForTesting()
+
+            let moved = appDelegate.moveDockSurfaceToWorkspace(
+                sourceDock: dock,
+                panelId: dockPanelId,
+                toWorkspace: destinationWorkspace.id,
+                targetPane: nil,
+                targetIndex: nil,
+                splitTarget: nil,
+                focus: true,
+                focusWindow: false
+            )
+
+            #expect(moved)
+            #expect(destinationWorkspace.panels[dockPanelId] != nil)
+            #expect(dock.debugDockPortalReconcileScheduleCountForTesting() > 0)
+        }
+    }
+
     @MainActor
     private static func detachedBrowserTransfer(
         panel: BrowserPanel,


### PR DESCRIPTION
Fixes #7780. Fixes #7305.

## Bug

Moving surfaces (terminals AND browsers) between the main area and the right-sidebar Dock intermittently left them blank or invisible until the Dock gained focus — across both directions, plain drops, and drops into splits.

## Root cause

Terminal and browser content views are window-level portal-hosted; a portal bind silently no-ops when the target anchor is momentarily off-window during reparent churn (`TerminalWindowPortalRegistry.bind` / `BrowserWindowPortalRegistry.bind` both guard on `anchorView.window`). The main split area self-heals after topology changes via `Workspace`'s event-driven reconcile passes (`reconcileTerminalGeometryPass`, `reconcileBrowserPortalVisibilityForCurrentRenderedLayout`), but the Dock had **no reconciler at all**:

- terminals only got a synchronous reattach-token bump at attach time (#7055's fix), which can itself run before the churn settles;
- browsers had no show path whatsoever — `DockSplitStore.applyVisibility` only implemented the browser *hide* side.

The only reliable recovery was the SwiftUI re-render caused by `rightSidebarOwnsInputFocus` flipping — which is exactly why blanked surfaces came back when the Dock gained focus. Prior point fixes (#7054, #5435, #7529) each patched one trigger of that re-render without closing the underlying gap.

## Fix

Give the Dock the same authoritative portal reconciliation the main area already has:

- **New `Sources/DockSplitStore+PortalReconcile.swift`**: idempotent Dock portal reconcile pass for terminals and browsers, mirroring the Workspace idiom — coalesced zero-delay first attempt, follow-ups re-armed by the structural notifications that fire when reparent churn settles (`.terminalSurfaceHostedViewDidMoveToWindow`, `.terminalPortalVisibilityDidChange`, `.browserPortalRegistryDidChange`, `.terminalSurfaceDidBecomeReady`), wall-clock stall backoff (10ms→250ms), and a 2s hard deadline that tears down observers. Healthy state is a pure-check no-op (no portal mutations, no refresh, no registry posts).
- **Browser show parity** in `DockSplitStore.applyVisibility`: a visible Dock browser now marks its portal entry visible and schedules recovery only when the binding is actually damaged.
- **Reconcile scheduled from every Dock mutation path**: attach (including rollback attaches), internal pane drops/drag-to-splits (`performPortalPaneDrop`), bonsplit `didMoveTab`/`didSplitPane`, Dock reveal, zoom toggles.
- **Cross-container moves reconcile both sides**: `moveSurfaceIntoDock` schedules the destination Dock; `moveDockSurfaceToWorkspace` / `moveDockSurfaceToNewWorkspace` schedule the source Dock and run the destination workspace's terminal + browser reconcile after the attach/split legs.

No focus-semantics changes; recovery no longer depends on the Dock gaining focus in any path.

## Commits (two-commit regression policy)

1. `aac686c` — failing regression tests only (browser attach-into-visible-Dock and Dock reveal). **CI is expected red on this commit.**
2. `2661432` — the fix + reconciler-specific coverage (stale terminal bind without focus, unbound browser imperative bind, healthy-browser no-op, move-path scheduling both directions).

## Verification

- Deterministic: 7 new tests in `cmuxTests/DockPortalReconcileTests.swift` (wired into pbxproj; `scripts/lint-pbxproj-test-wiring.sh` passes).
- `python3 scripts/swift_file_length_budget.py` passes; **no budget TSV touched**; new files are 292/327 lines; no new warnings.
- Tagged Debug build succeeded (`-derivedDataPath /tmp/cmux-fable-7780`).
- **Manually verified vs deterministic**: the interactive drag-and-drop repro paths (dragging surfaces into/out of the Dock, including into splits, with the Dock unfocused) are inherently interactive and are NOT covered by the unit tests beyond the model-level move-path assertions above; they are being verified visually on a cloud macOS VM and via dogfood. The blank-until-focus mode itself is covered deterministically by the red tests in commit 1.
- Localization audit: no user-facing strings added or changed (debug log strings only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786240981&installation_id=133855650&pr_number=7786&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7786&signature=a3be3012b628f1c29c474e91a63b5e71ae87c9940133671d4429d385742441f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches window-level portal registries and many Dock mutation paths; incorrect reconcile timing could cause flicker or duplicate binds, but behavior mirrors an existing Workspace pattern and is covered by new tests.
> 
> **Overview**
> Fixes Dock terminals and browsers staying blank after moves or layout changes until the Dock gained focus, by adding **event-driven portal reconciliation** parallel to the main workspace.
> 
> **New `DockSplitStore+PortalReconcile.swift`** introduces `scheduleDockPortalReconcile` / `reconcileDockPortalPass`: coalesced attempts, notification-driven wakeups (terminal hosted-view moves, portal visibility, browser registry), exponential backoff, and a 2s timeout. Visible panels get terminal reattach/geometry refresh and imperative browser portal bind/sync when anchors are ready.
> 
> **`applyVisibility`** now **shows** Dock browsers (registry visibility + reconcile when binding is damaged), not only hide.
> 
> Reconcile is hooked from Dock topology paths: attach/detach, pane drops, tab move/split, selection, zoom, and **`AppDelegate`** cross-container moves (`moveSurfaceIntoDock`; workspace moves also run destination workspace terminal/browser reconcile and schedule source Dock reconcile).
> 
> **`browserPanel(owning:in:)`** moves to `DockSplitStore+PaneFocus.swift`. **`DockPortalReconcileTests`** and a small **`BrowserConfigTests`** timeout failure style tweak round out the change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 023cd5e68ad323a2769352daba39c3ddb826086d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dock surfaces going blank after moves or reveal by reconciling terminal and browser portal bindings during reparenting instead of on focus. Restores portal visibility immediately and makes recovery deterministic. Fixes #7780 and #7305.

- **Bug Fixes**
  - Added `DockSplitStore+PortalReconcile.swift`: idempotent, event‑driven reconcile for terminals and browsers with coalesced attempts, structural wakeups, short backoff, and a 2s timeout.
  - Implemented browser show parity in `DockSplitStore.applyVisibility`; marks `BrowserWindowPortalRegistry` entries visible and only schedules recovery when the binding is damaged.
  - Scheduled reconcile on all Dock topology changes and cross‑container moves (attach/rollback, pane drops/splits, tab move/split, selection changes, reveal, zoom).
  - Made reconcile state store‑owned: `DockSplitStore.dockPortalReconcileState`; removed debug seams and moved focus‑ownership `browserPanel(owning:in:)` to `DockSplitStore+PaneFocus.swift`.
  - Stabilized tests: `BrowserSessionHistoryRestoreTests.waitUntil` now aborts via `continueAfterFailure = false` instead of throwing to avoid false shard failures.

<sup>Written for commit 023cd5e68ad323a2769352daba39c3ddb826086d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7786?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability of docking and workspace transfers for terminal and browser surfaces.
  - Dock “portal” visibility now stays consistent through focus changes, zoom toggles, pane splits, and tab moves.
  - Better recovery for stale or missing terminal/browser portal bindings, including reattachment and geometry refresh when needed.
  - Moving surfaces into new docks/workspaces now triggers stronger portal and layout reconciliation to reduce transient inconsistencies.
- **Tests**
  - Added coverage for dock portal reconciliation behavior and scheduling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->