### PR TITLE
feat(shortcuts): add bindable Pin/Unpin Workspace action

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -64,6 +64,10 @@ extension ShortcutAction {
         case .closeTab: return ShortcutStroke(key: "w", command: true)
         case .closeOtherTabsInPane: return ShortcutStroke(key: "t", command: true, option: true)
         case .closeWorkspace: return ShortcutStroke(key: "w", command: true, shift: true)
+        // Unbound by default: "Pin Workspace" is reachable through the context
+        // menu and command palette. Shipping it unbound avoids colliding with an
+        // existing default; users can bind it (e.g. ⌘⇧F) in Settings.
+        case .togglePinnedWorkspace: return nil
         case .newWorkspaceGroup: return ShortcutStroke(key: "g", command: true, control: true)
         case .groupSelectedWorkspaces: return ShortcutStroke(key: "g", command: true, shift: true)
         case .toggleFocusedWorkspaceGroupCollapsed: return ShortcutStroke(key: ".", command: true, control: true)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -60,6 +60,8 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     case closeTab
     case closeOtherTabsInPane
     case closeWorkspace
+    /// Toggles the pinned state of the focused workspace.
+    case togglePinnedWorkspace
     /// Creates a new empty workspace group.
     case newWorkspaceGroup
     /// Groups the selected workspaces in the workspace list.
@@ -187,6 +189,7 @@ extension ShortcutAction {
              .prevSidebarTab, .focusHistoryBack, .focusHistoryForward,
              .selectWorkspaceByNumber, .renameTab, .renameWorkspace,
              .editWorkspaceDescription, .closeTab, .closeOtherTabsInPane, .closeWorkspace,
+             .togglePinnedWorkspace,
              .newWorkspaceGroup, .groupSelectedWorkspaces, .toggleFocusedWorkspaceGroupCollapsed,
              .reopenClosedBrowserPanel, .newSurface, .toggleTerminalCopyMode,
              .focusTextBoxInput, .cycleTextBoxSubmitAction, .attachTextBoxFile, .sendCtrlFToTerminal,
@@ -375,6 +378,8 @@ extension ShortcutAction {
         case .closeTab: return "Close Tab"
         case .closeOtherTabsInPane: return "Close Other Tabs in Pane"
         case .closeWorkspace: return "Close Workspace"
+        case .togglePinnedWorkspace:
+            return String(localized: "shortcut.togglePinnedWorkspace.label", defaultValue: "Pin or Unpin Focused Workspace")
         case .newWorkspaceGroup:
             return String(localized: "shortcut.newWorkspaceGroup.label", defaultValue: "New Workspace Group")
         case .groupSelectedWorkspaces:

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -14946,7 +14946,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         // Don't consume the event when there is no focused workspace — let the
         // matched chord propagate, consistent with the group shortcuts'
         // fall-through policy.
-        guard let focusedId = tabManager.selectedTabId else { return false }
+        guard let focusedId = tabManager.selectedTabId,
+              tabManager.tabs.contains(where: { $0.id == focusedId }) else {
+            // The selected id can be stale mid-transition; togglePin silently
+            // no-ops on an absent id, so don't consume the chord when there's
+            // no live workspace to pin.
+            return false
+        }
         tabManager.togglePin(tabId: focusedId)
         return true
     }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -13728,6 +13728,17 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
         }
 
+        if matchConfiguredShortcut(event: event, action: .togglePinnedWorkspace) {
+            // Only consume the event when a focused workspace was resolved and
+            // toggled. Otherwise fall through so a rebinding that shares this
+            // chord with another action still works.
+            if handleTogglePinnedWorkspaceShortcut(
+                preferredWindow: commandPaletteTargetWindow ?? event.window ?? shortcutRoutingActiveWindow
+            ) {
+                return true
+            }
+        }
+
         if matchConfiguredShortcut(event: event, action: .editWorkspaceDescription) {
 #if DEBUG
             cmuxDebugLog(
@@ -14925,6 +14936,18 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
         tabManager.toggleWorkspaceGroupCollapsed(groupId: groupId)
+        return true
+    }
+
+    func handleTogglePinnedWorkspaceShortcut(preferredWindow: NSWindow? = nil) -> Bool {
+        let targetWindow = preferredWindow ?? shortcutRoutingActiveWindow
+        let resolvedTabManager: TabManager? = contextForMainWindow(targetWindow)?.tabManager ?? self.tabManager
+        guard let tabManager = resolvedTabManager else { return false }
+        // Don't consume the event when there is no focused workspace — let the
+        // matched chord propagate, consistent with the group shortcuts'
+        // fall-through policy.
+        guard let focusedId = tabManager.selectedTabId else { return false }
+        tabManager.togglePin(tabId: focusedId)
         return true
     }
 

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -111,6 +111,7 @@ enum KeyboardShortcutSettings {
         case closeTab
         case closeOtherTabsInPane
         case closeWorkspace
+        case togglePinnedWorkspace
         case newWorkspaceGroup
         case groupSelectedWorkspaces
         case toggleFocusedWorkspaceGroupCollapsed
@@ -234,6 +235,7 @@ enum KeyboardShortcutSettings {
             case .closeTab: return String(localized: "menu.file.closeTab", defaultValue: "Close Tab")
             case .closeOtherTabsInPane: return String(localized: "menu.file.closeOtherTabs", defaultValue: "Close Other Tabs in Pane")
             case .closeWorkspace: return String(localized: "shortcut.closeWorkspace.label", defaultValue: "Close Workspace")
+            case .togglePinnedWorkspace: return String(localized: "shortcut.togglePinnedWorkspace.label", defaultValue: "Pin or Unpin Focused Workspace")
             case .newWorkspaceGroup: return String(localized: "shortcut.newWorkspaceGroup.label", defaultValue: "New Workspace Group")
             case .groupSelectedWorkspaces: return String(localized: "shortcut.groupSelectedWorkspaces.label", defaultValue: "Group Selected Workspaces")
             case .toggleFocusedWorkspaceGroupCollapsed: return String(localized: "shortcut.toggleFocusedWorkspaceGroupCollapsed.label", defaultValue: "Toggle Focused Workspace's Group Collapse")
@@ -409,6 +411,11 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "t", command: true, shift: false, option: true, control: false)
             case .closeWorkspace:
                 return StoredShortcut(key: "w", command: true, shift: true, option: false, control: false)
+            case .togglePinnedWorkspace:
+                // Unbound by default: reachable through the context menu and
+                // command palette. Ships unbound to avoid colliding with an
+                // existing default; users can bind it (e.g. Cmd+Shift+F).
+                return .unbound
             case .newWorkspaceGroup:
                 return StoredShortcut(key: "g", command: true, shift: false, option: false, control: true)
             case .groupSelectedWorkspaces:

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -122,6 +122,7 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "selectWorkspaceByNumber", combos: [["⌘", "1…9"]], description: { en: "Select workspace 1…9", ja: "ワークスペース1…9を選択" } },
       { id: "renameWorkspace", combos: [["⌘", "⇧", "R"]], description: { en: "Rename workspace", ja: "ワークスペース名を変更" } },
       { id: "editWorkspaceDescription", combos: [["⌥", "⌘", "E"]], description: { en: "Edit workspace description", ja: "ワークスペースの説明を編集" } },
+      { id: "togglePinnedWorkspace", combos: [], description: { en: "Pin or unpin the focused workspace", ja: "フォーカス中のワークスペースをピン留め/解除" } },
       { id: "newWorkspaceGroup", combos: [["⌃", "⌘", "G"]], description: { en: "New empty workspace group", ja: "空のワークスペースグループを作成" } },
       { id: "groupSelectedWorkspaces", combos: [["⌘", "⇧", "G"]], description: { en: "Group selected workspaces", ja: "選択したワークスペースをグループ化" } },
       {

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1555,6 +1555,7 @@
               "closeTab",
               "closeOtherTabsInPane",
               "closeWorkspace",
+              "togglePinnedWorkspace",
               "newWorkspaceGroup",
               "groupSelectedWorkspaces",
               "toggleFocusedWorkspaceGroupCollapsed",


### PR DESCRIPTION
▎ 🤖 Authored with AI assistance. This change was implemented with Claude (Anthropic) via Claude Code. A human author reviewed it and is responsible for the submission. Commits carry a Co-Authored-By: Claude trailer.

Summary

What changed? Adds a bindable keyboard-shortcut action, Pin or Unpin Focused Workspace, that toggles the pinned state of the currently focused workspace.

Why? The behavior already exists via the workspace context menu and the command palette (TabManager.togglePin), but there was no way to pin/unpin from the keyboard. This exposes it as a first-class, user-customizable shortcut action.

Design notes:
- Ships unbound by default. The natural mnemonic (⌘⇧F) collides with an existing default binding, so instead of forcing a conflicting default, the action ships unbound and users can assign any chord in Settings → Keyboard Shortcuts. This mirrors the precedent set by sendFeedback and the canvas-align actions.
- Implementation mirrors the existing toggleFocusedWorkspaceGroupCollapsed action end-to-end (enum case, group, label, default, routing) to stay consistent with how focused-workspace actions are wired.
- The routing handler returns false (lets the chord propagate) when no workspace is focused, consistent with the group shortcuts' fall-through policy.

Files changed:
- CmuxSettings/ShortcutAction: new togglePinnedWorkspace case + navigation group membership + display label
- CmuxSettings/ShortcutAction+Defaults: unbound default stroke
- KeyboardShortcutSettings.Action: mirrored case, label, and unbound default
- AppDelegate: shortcut routing + handleTogglePinnedWorkspaceShortcut (calls TabManager.togglePin on the focused workspace)
- web/data/cmux.schema.json + web/data/cmux-shortcuts.ts: binding enum entry + shortcuts metadata

Testing

- CmuxSettings package builds cleanly (swift build) and all 251 package tests pass (swift test).
- Full macOS app (Debug) builds cleanly with the change.
- Verified manually: bound the action to ⌘⇧F in Settings → Keyboard Shortcuts, then confirmed it pins and unpins the focused workspace, matching the existing context-menu "Pin Workspace" behavior.

Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment:

Review Trigger (Copy/Paste as PR comment)

@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review

Checklist

- [x] I tested the change locally
- [ ] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

---
🤖 Generated with Claude Code

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786241700&installation_id=133855650&pr_number=7787&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7787&signature=888b8da449bba55e60d7ee60435f943aebea45a95ba2cce67d4ee5029d667361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Shortcut plumbing only; no new pin logic beyond calling existing `togglePin`, ships unbound so default behavior is unchanged.
> 
> **Overview**
> Adds a new customizable shortcut action **Pin or Unpin Focused Workspace** so users can toggle pin state from the keyboard; it reuses existing `TabManager.togglePin` behavior already available from the context menu and command palette.
> 
> The action is wired end-to-end like other focused-workspace shortcuts: new `togglePinnedWorkspace` cases in CmuxSettings and `KeyboardShortcutSettings`, **unbound by default** (to avoid default-key collisions such as ⌘⇧F), and `AppDelegate` routing via `handleTogglePinnedWorkspaceShortcut` that only consumes the key when a focused workspace exists—otherwise the chord falls through to other bindings.
> 
> Web shortcut metadata and `cmux.schema.json` are updated so the action appears in docs and config validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a0498f0d22fe663d112dcdd0db344260cb9880ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bindable keyboard shortcut to pin or unpin the focused workspace. The handler only fires when a live focused workspace exists; otherwise the chord falls through.

- **New Features**
  - Added `togglePinnedWorkspace` action; routed in `AppDelegate` to call `TabManager.togglePin` on the focused workspace.
  - Ships unbound by default; assign a chord in Settings → Keyboard Shortcuts (e.g., ⌘⇧F).
  - Updated web shortcuts metadata, `cmux.schema.json`, and localized labels so the action appears across locales.

<sup>Written for commit dde656ff9cbbb6944b85f7f9beffe5db70d4509a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7787?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Pin or Unpin Focused Workspace” shortcut action, available in the context menu and command palette.
  * The action is intentionally shipped unbound by default to avoid shortcut collisions.
  * Added localized label/description (English and Japanese) and enabled configurable bindings in shortcut settings (including chords).

* **Bug Fixes**
  * Shortcut handling no longer consumes keyboard events when no valid focused workspace/tab is available, allowing other matching shortcuts to trigger.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->