### PR TITLE
Allow App Store profile download overwrite

### DIFF
--- a/.github/scripts/install-app-store-provisioning-profile.sh
+++ b/.github/scripts/install-app-store-provisioning-profile.sh
@@ -247,6 +247,7 @@ download_profile_from_asc() {
     note "reusing App Store profile '$profile_name'"
   fi
 
+  rm -f "$TMP_PROFILE"
   asc profiles download --id "$profile_id" --output "$TMP_PROFILE" >/dev/null
   validate_profile "$TMP_PROFILE" "$TMP_PLIST" "ASC profile '$profile_name'" "true"
   install_profile


### PR DESCRIPTION
## Summary
- remove the stale temp profile before `asc profiles download` writes the generated App Store provisioning profile

## Why
The non-submit App Store workflow got through ASC cert resolution and created/reused `cmuxterm App Store CI F63466C1`, then failed because `asc profiles download` refuses to overwrite the temp file left by earlier rejected secret profile checks.

Failed run: https://github.com/manaflow-ai/cmux/actions/runs/29064935686

## Verification
- `bash -n .github/scripts/install-app-store-provisioning-profile.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786243177&installation_id=133855650&pr_number=7788&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7788&signature=bca4b0452a46f911160df1b167bbb885e856af0e2e7a7a4ae04e9ab61274106b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> One-line change in a CI install script; no app runtime, auth, or data-path impact.
> 
> **Overview**
> Fixes App Store CI when provisioning falls back to **App Store Connect** after secret profile checks fail.
> 
> **`download_profile_from_asc`** now runs **`rm -f "$TMP_PROFILE"`** immediately before **`asc profiles download`**, so a leftover temp file from earlier **`try_secret_profile`** attempts does not block the download (the ASC CLI refuses to overwrite an existing output path).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 384dd756c9bb1adff8047f455c5398eb8be17c49. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the stale temp provisioning profile before running `asc profiles download` so the file can be overwritten. This fixes CI failures in the App Store Connect non-submit workflow when reusing an existing profile.

<sup>Written for commit 384dd756c9bb1adff8047f455c5398eb8be17c49. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7788?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup during App Store provisioning profile downloads by removing temporary files before retrieving a new profile.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->