### PR TITLE
fix(port-scan): stop lsof pinning fileproviderd/fseventsd on macOS

### DIFF
--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -57,6 +57,10 @@ extension SidebarWorkspaceDetailDefaults {
     static func pullRequestPollingEnabled(defaults: UserDefaults) -> Bool {
         watchGitStatusValue(defaults: defaults) && showPullRequestsValue(defaults: defaults)
     }
+
+    static func showPortsValue(defaults: UserDefaults) -> Bool {
+        boolValue(defaults: defaults, key: showPortsKey, defaultValue: showPorts)
+    }
 }
 
 enum AutomationSettings {

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -13,6 +13,7 @@ enum SidebarWorkspaceDetailDefaults {
     static let showProgressKey = "sidebarShowProgress"
     static let showAgentActivityKey = "sidebarShowAgentActivity"
     static let showCustomMetadataKey = "sidebarShowStatusPills"
+    static let hideAllDetailsKey = "sidebarHideAllDetails"
 
     static let showBranchDirectory = true
     static let showPullRequests = true
@@ -23,6 +24,7 @@ enum SidebarWorkspaceDetailDefaults {
     static let showProgress = true
     static let showAgentActivity = true
     static let showCustomMetadata = true
+    static let hideAllDetails = false
 }
 
 enum SidebarWorkspaceTitleWrapSettings {
@@ -60,6 +62,18 @@ extension SidebarWorkspaceDetailDefaults {
 
     static func showPortsValue(defaults: UserDefaults) -> Bool {
         boolValue(defaults: defaults, key: showPortsKey, defaultValue: showPorts)
+    }
+
+    /// Ports are surfaced only when `showPorts` is on AND details aren't globally
+    /// hidden — mirrors the remote-session gate
+    /// (`Workspace.remotePortScanningEnabledFromSettings`). When this is false the
+    /// sidebar shows no ports, so scanning for them is pure waste.
+    static func portScanningEnabled(defaults: UserDefaults) -> Bool {
+        showPortsValue(defaults: defaults) && !hideAllDetailsValue(defaults: defaults)
+    }
+
+    private static func hideAllDetailsValue(defaults: UserDefaults) -> Bool {
+        boolValue(defaults: defaults, key: hideAllDetailsKey, defaultValue: hideAllDetails)
     }
 }
 

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -91,10 +91,16 @@ extension SidebarWorkspaceDetailDefaults {
         UserDefaultsSettingsClient(defaults: defaults).value(for: SidebarCatalogSection().showPorts)
     }
 
-    /// Ports are only surfaced when `showPorts` is on. When it is off the sidebar
-    /// shows no ports, so scanning for them is pure waste.
+    /// Ports are surfaced only when `showPorts` is on AND details aren't globally
+    /// hidden — mirrors the remote-session gate
+    /// (`Workspace.remotePortScanningEnabledFromSettings`). When this is false the
+    /// sidebar shows no ports, so scanning for them is pure waste.
     static func portScanningEnabled(defaults: UserDefaults) -> Bool {
-        showPortsValue(defaults: defaults)
+        showPortsValue(defaults: defaults) && !hideAllDetailsValue(defaults: defaults)
+    }
+
+    private static func hideAllDetailsValue(defaults: UserDefaults) -> Bool {
+        UserDefaultsSettingsClient(defaults: defaults).value(for: SidebarCatalogSection().hideAllDetails)
     }
 
     static func pullRequestActivity(defaults: UserDefaults) -> SidebarGitMetadataActivity {

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -87,6 +87,16 @@ extension SidebarWorkspaceDetailDefaults {
             : .passiveReportsOnly
     }
 
+    static func showPortsValue(defaults: UserDefaults) -> Bool {
+        UserDefaultsSettingsClient(defaults: defaults).value(for: SidebarCatalogSection().showPorts)
+    }
+
+    /// Ports are only surfaced when `showPorts` is on. When it is off the sidebar
+    /// shows no ports, so scanning for them is pure waste.
+    static func portScanningEnabled(defaults: UserDefaults) -> Bool {
+        showPortsValue(defaults: defaults)
+    }
+
     static func pullRequestActivity(defaults: UserDefaults) -> SidebarGitMetadataActivity {
         guard watchGitStatusValue(defaults: defaults) else {
             return .disabled

--- a/Sources/PortScanner+Process.swift
+++ b/Sources/PortScanner+Process.swift
@@ -584,10 +584,17 @@ extension PortScanner {
             directory: "/",
             executable: "/usr/sbin/lsof",
             // A PID-scoped TCP query does not depend on filesystem mount
-            // metadata. Suppress warning-class diagnostics such as lsof's
-            // Time Machine `can't stat()` warning so unrelated mounts cannot
-            // make every port miss permanently incomplete.
-            arguments: ["-nP", "-w", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"],
+            // metadata. `-b` avoids the blocking kernel stat/lstat/readlink
+            // calls on the target processes' fds: they are unnecessary for
+            // identifying listening TCP sockets (the socket address arrives in
+            // the `n` field regardless), but on macOS they fault in fds pointing
+            // at File Provider domains (iCloud/Google Drive/OneDrive), which
+            // pegs `fileproviderd` and `fseventsd` and stalls Finder. `-w`
+            // suppresses warning-class diagnostics such as lsof's Time Machine
+            // `can't stat()` warning, both the ones `-b` produces and the ones
+            // unrelated mounts produce, so neither can make every port miss
+            // permanently incomplete.
+            arguments: ["-b", "-w", "-nP", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"],
             timeout: Self.processScanTimeout
         )
 

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -16,6 +16,14 @@ import Foundation
 final class PortScanner: @unchecked Sendable {
     static let shared = PortScanner()
 
+    /// Port scanning is only useful when the sidebar surfaces detected ports.
+    /// When `sidebar.showPorts` is off, skip scanning entirely — otherwise the
+    /// periodic `lsof` sweep over agent process trees runs (and can pin
+    /// `fileproviderd`/`fseventsd`) for data nothing consumes.
+    private var portScanningEnabled: Bool {
+        SidebarWorkspaceDetailDefaults.showPortsValue(defaults: .standard)
+    }
+
     /// Callback delivers `(workspaceId, panelId, ports)` on the main actor.
     var onPortsUpdated: (@MainActor (_ workspaceId: UUID, _ panelId: UUID, _ ports: [Int]) -> Void)?
     /// Callback delivers workspace-scoped ports owned by tracked agents.
@@ -82,6 +90,7 @@ final class PortScanner: @unchecked Sendable {
 
     func kick(workspaceId: UUID, panelId: UUID) {
         queue.async { [self] in
+            guard portScanningEnabled else { return }
             let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
             guard ttyNames[key] != nil else { return }
             pendingKicks.insert(key)
@@ -157,6 +166,11 @@ final class PortScanner: @unchecked Sendable {
         // Already on `queue`. Snapshot which panels to scan and their TTYs.
         // We scan all registered panels, not just pending ones, since ports can
         // appear/disappear on any panel.
+        guard portScanningEnabled else {
+            pendingKicks.removeAll()
+            return
+        }
+
         let panelSnapshot = ttyNames
 
         guard !panelSnapshot.isEmpty else {
@@ -294,6 +308,7 @@ final class PortScanner: @unchecked Sendable {
     }
 
     private func runTrackedAgentScan() {
+        guard portScanningEnabled else { return }
         let workspaceIds = trackedAgentWorkspaces
         guard !workspaceIds.isEmpty else {
             updateAgentScanTimerLocked()
@@ -622,10 +637,16 @@ final class PortScanner: @unchecked Sendable {
     }
 
     private func runLsof(pidsCsv: String) -> [Int: Set<Int>] {
-        // `lsof -nP -a -p <pids> -iTCP -sTCP:LISTEN -F pn`
+        // `lsof -b -w -nP -a -p <pids> -iTCP -sTCP:LISTEN -F pn`
+        // `-b` avoids blocking kernel stat/lstat/readlink calls on the target
+        // processes' fds. Those calls are unnecessary for identifying listening
+        // TCP sockets (the socket address arrives in the `n` field regardless),
+        // but on macOS they fault in fds pointing at File Provider domains
+        // (iCloud/Google Drive/OneDrive/etc.), which pegs `fileproviderd` and
+        // `fseventsd` and stalls Finder. `-w` suppresses the resulting warnings.
         guard let output = Self.captureStandardOutput(
             executablePath: "/usr/sbin/lsof",
-            arguments: ["-nP", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"]
+            arguments: ["-b", "-w", "-nP", "-a", "-p", pidsCsv, "-iTCP", "-sTCP:LISTEN", "-Fpn"]
         ) else {
             return [:]
         }

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -16,12 +16,12 @@ import Foundation
 final class PortScanner: @unchecked Sendable {
     static let shared = PortScanner()
 
-    /// Port scanning is only useful when the sidebar surfaces detected ports.
-    /// When `sidebar.showPorts` is off, skip scanning entirely — otherwise the
+    /// Port scanning is only useful when the sidebar surfaces detected ports
+    /// (`sidebar.showPorts` on and details not globally hidden). Otherwise the
     /// periodic `lsof` sweep over agent process trees runs (and can pin
     /// `fileproviderd`/`fseventsd`) for data nothing consumes.
     private var portScanningEnabled: Bool {
-        SidebarWorkspaceDetailDefaults.showPortsValue(defaults: .standard)
+        SidebarWorkspaceDetailDefaults.portScanningEnabled(defaults: .standard)
     }
 
     /// Callback delivers `(workspaceId, panelId, ports)` on the main actor.
@@ -212,7 +212,10 @@ final class PortScanner: @unchecked Sendable {
         agentPIDsByWorkspace: [UUID: Set<Int>],
         agentRevisions: [UUID: UInt64]
     ) {
-        // Already on `queue`.
+        // Already on `queue`. Fail-closed re-check: this is the authoritative
+        // gate right before `runLsof`, catching a setting change during the
+        // async `agentPIDsProvider` hop that ran after the earlier check.
+        guard portScanningEnabled else { return }
         let workspaceIds = Set(panelSnapshot.keys.map(\.workspaceId))
 
         // Build TTY set (deduplicated).
@@ -371,6 +374,11 @@ final class PortScanner: @unchecked Sendable {
         agentPIDsByWorkspace: [UUID: Set<Int>],
         agentRevisions: [UUID: UInt64]
     ) {
+        // Fail-closed re-check: `refreshAgentPorts()` reaches here directly
+        // (bypassing the `runTrackedAgentScan` gate), and the setting can flip
+        // during the async `agentPIDsProvider` hop. This is the authoritative
+        // gate before `runLsof`.
+        guard portScanningEnabled else { return }
         guard !workspaceIds.isEmpty else { return }
 
         let agentPidToWorkspaces = expandAgentProcessTree(agentPIDsByWorkspace: agentPIDsByWorkspace)

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -176,6 +176,29 @@ final class PortScanner: @unchecked Sendable {
         return publicationState.currentPanelTTYName(for: key, sessionIdentity: sessionIdentity)
     }
 
+    /// Reacts to the sidebar ports-visibility settings changing.
+    ///
+    /// Turning it off only needs the queued work dropped, since the sidebar
+    /// hides the ports either way. Turning it back on has to rescan: everything
+    /// published before the setting went off is stale, and the next kick or
+    /// agent tick can be seconds away.
+    func portScanningEnablementDidChange() {
+        queue.async { [self] in
+            guard portScanningEnabled else {
+                pendingKicks.removeAll()
+                scansRemainingForPendingKicks = 0
+                return
+            }
+            guard !ttyNames.isEmpty || !trackedAgentWorkspaces.isEmpty else { return }
+            pendingKicks.formUnion(ttyNames.keys)
+            scansRemainingForPendingKicks = Self.minimumScansPerKick
+            if !burstActive {
+                startCoalesce()
+            }
+            runTrackedAgentScan()
+        }
+    }
+
     func kick(workspaceId: UUID, panelId: UUID) {
         queue.async { [self] in
             guard portScanningEnabled else { return }

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -21,9 +21,10 @@ final class PortScanner: @unchecked Sendable {
 
     let commandRunner: any CommandRunning
 
-    /// Port scanning is only useful when the sidebar surfaces detected ports.
-    /// Otherwise the periodic `lsof` sweep over agent process trees runs (and
-    /// can pin `fileproviderd`/`fseventsd`) for data nothing consumes.
+    /// Port scanning is only useful when the sidebar surfaces detected ports
+    /// (`sidebar.showPorts` on and details not globally hidden). Otherwise the
+    /// periodic `lsof` sweep over agent process trees runs (and can pin
+    /// `fileproviderd`/`fseventsd`) for data nothing consumes.
     private var portScanningEnabled: Bool {
         SidebarWorkspaceDetailDefaults.portScanningEnabled(defaults: .standard)
     }
@@ -343,6 +344,10 @@ final class PortScanner: @unchecked Sendable {
         agentRevisions: [UUID: UInt64],
         requestID: UInt64
     ) async {
+        // Fail-closed re-check: this is the authoritative gate right before
+        // `runLsof`, catching a setting change during the async hops that ran
+        // after the earlier check.
+        guard portScanningEnabled else { return }
         let workspaceIds = Set(panelSnapshot.keys.map(\.workspaceId))
 
         // Build TTY set (deduplicated).
@@ -703,6 +708,10 @@ final class PortScanner: @unchecked Sendable {
         agentRootsByWorkspace: [UUID: Set<AgentPortRootIdentity>],
         agentRevisions: [UUID: UInt64]
     ) {
+        // Fail-closed re-check: `refreshAgentPorts()` reaches here directly,
+        // bypassing the `runTrackedAgentScan` gate, and the setting can flip
+        // between the two.
+        guard portScanningEnabled else { return }
         guard !workspaceIds.isEmpty else { return }
         let request = AgentPortScanRequest(
             workspaceIds: workspaceIds,

--- a/Sources/PortScanner.swift
+++ b/Sources/PortScanner.swift
@@ -21,6 +21,13 @@ final class PortScanner: @unchecked Sendable {
 
     let commandRunner: any CommandRunning
 
+    /// Port scanning is only useful when the sidebar surfaces detected ports.
+    /// Otherwise the periodic `lsof` sweep over agent process trees runs (and
+    /// can pin `fileproviderd`/`fseventsd`) for data nothing consumes.
+    private var portScanningEnabled: Bool {
+        SidebarWorkspaceDetailDefaults.portScanningEnabled(defaults: .standard)
+    }
+
     /// Callback delivers `(workspaceId, panelId, ports)` on the main actor.
     @MainActor var onPortsUpdated: (@MainActor (_ workspaceId: UUID, _ panelId: UUID, _ ports: [Int]) -> Void)?
     /// Callback delivers workspace-scoped ports owned by tracked agents.
@@ -170,6 +177,7 @@ final class PortScanner: @unchecked Sendable {
 
     func kick(workspaceId: UUID, panelId: UUID) {
         queue.async { [self] in
+            guard portScanningEnabled else { return }
             let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
             guard ttyNames[key] != nil else { return }
             pendingKicks.insert(key)
@@ -283,6 +291,12 @@ final class PortScanner: @unchecked Sendable {
         let generation = requestedGeneration ?? burstGeneration
         // We scan all registered panels, not just pending ones, since ports can
         // appear/disappear on any panel.
+        guard portScanningEnabled else {
+            pendingKicks.removeAll()
+            scansRemainingForPendingKicks = 0
+            return
+        }
+
         let panelSnapshot = ttyNames
 
         guard !panelSnapshot.isEmpty else {
@@ -663,6 +677,7 @@ final class PortScanner: @unchecked Sendable {
     }
 
     private func runTrackedAgentScan() {
+        guard portScanningEnabled else { return }
         let workspaceIds = trackedAgentWorkspaces
         guard !workspaceIds.isEmpty else {
             updateAgentScanTimerLocked()

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -787,6 +787,10 @@ class TabManager: ObservableObject {
         for tab in tabs where tab.isRemoteWorkspace {
             tab.applyRemotePortScanningEnabled(enabled)
         }
+        // The local scanner reads the same two settings and needs the same
+        // teardown and re-arm, or re-enabling shows the ports as they were when
+        // it was switched off.
+        PortScanner.shared.portScanningEnablementDidChange()
     }
 
     func refreshTrackedWorkspaceGitMetadataForTesting() {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6621,11 +6621,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
     /// detail is not displayed there is nothing for the remote scans to
     /// populate, so the backend ssh port-scan loop is suspended (issue #6123).
     static func remotePortScanningEnabledFromSettings(defaults: UserDefaults = .standard) -> Bool {
-        let settings = UserDefaultsSettingsClient(defaults: defaults)
-        let catalog = SettingCatalog()
-        let showsPorts = settings.value(for: catalog.sidebar.showPorts)
-        let hidesAllDetails = settings.value(for: catalog.sidebar.hideAllDetails)
-        return showsPorts && !hidesAllDetails
+        SidebarWorkspaceDetailDefaults.portScanningEnabled(defaults: defaults)
     }
 
     /// Pushes the current remote port-scanning enablement to this workspace's


### PR DESCRIPTION
Fixes #7791.

## What

On macOS, `PortScanner`'s `lsof` sweep pins `fileproviderd`/`fseventsd` near 100% CPU and makes every Finder file operation beachball for seconds whenever an agent-heavy pane is active. Two changes:

1. **Add `-b -w` to the `lsof` invocation.** `-b` skips the blocking kernel `stat`/`lstat`/`readlink` calls lsof makes on every fd of the scanned processes. Those calls are unnecessary for identifying listening TCP sockets (the address arrives in the `-Fpn` `n` field regardless), but on macOS they fault in descriptors pointing at File Provider domains (iCloud/Google Drive/OneDrive/Dropbox/Synology), routing through `fileproviderd` and flooding `fseventsd`. `-w` suppresses the warnings `-b` would otherwise print.

2. **Gate all scan paths on `sidebar.showPorts`.** `kick`, `runScan`, and `runTrackedAgentScan` now no-op when the setting is off, via a new `SidebarWorkspaceDetailDefaults.showPortsValue(defaults:)` accessor (mirrors the existing `pullRequestPollingEnabled` pattern). Previously the sweep ran even with ports hidden.

## Verification

`-b` does not change detection — the `-Fpn` output is byte-identical with and without it on macOS:

```
# without -b
p1319 f10 n*:57803 p6306 f35 n[::1]:42050 p22197 f26 n127.0.0.1:50107 ...
# with -b -w  (identical)
p1319 f10 n*:57803 p6306 f35 n[::1]:42050 p22197 f26 n127.0.0.1:50107 ...
```

Scoped to the two files; no submodule or unrelated changes. I did not run a full Xcode build in this environment — the change is mechanical (one arg array, one gate helper reusing existing patterns in the same target). A maintainer build/CI pass is warranted before merge.

## Notes for reviewers

- The `showPortsValue` accessor and gate live in the app target alongside `PortScanner`, using `UserDefaults.standard` consistent with sibling sidebar settings.
- The agent rescan timer still fires when disabled but `runTrackedAgentScan` returns immediately (no `lsof`); happy to fully cancel/reschedule the timer on setting change if you'd prefer.
- Related latent issue noted in #7791: `RemoteSessionCoordinator+PortScan.swift`'s `remoteAllPortsScanScript` has an unscoped `lsof -nP -iTCP -sTCP:LISTEN` fallback (shadowed by `netstat` on macOS today). Left untouched to keep this PR focused.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7792"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786244641&installation_id=133855650&pr_number=7792&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7792&signature=827b385b55ff207533ea68ce96dd8a69c0abc775f3421177bb3447a9f4bea4f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped performance fix in port detection and sidebar preference gating; no auth, data, or API surface changes, with detection output claimed unchanged for `-b`.
> 
> **Overview**
> Fixes macOS stalls where periodic **`PortScanner`** `lsof` sweeps over agent process trees pegged **`fileproviderd`** / **`fseventsd`** and beachballed Finder.
> 
> **`lsof`** now runs with **`-b -w`** so it skips blocking `stat`/`lstat`/`readlink` on scanned fds (unnecessary for TCP listen detection via **`-Fpn`**) while suppressing warnings from **`-b`**.
> 
> Local port scanning is gated on **`SidebarWorkspaceDetailDefaults.portScanningEnabled`**: **`showPorts`** must be on and **`hideAllDetails`** off, matching remote-session behavior. **`kick`**, panel bursts, tracked-agent rescans, and paths into **`runLsof`** no-op or fail-closed when disabled, including re-checks after async PID lookup so settings flips mid-scan do not spawn **`lsof`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3517c241a93c0b6f7ae2c745abde561eeafbe9c6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops `lsof`-based port scans from pinning `fileproviderd`/`fseventsd` and stalling Finder on macOS, and no longer runs scans when ports aren't surfaced. Also re-arms the scanner when ports become visible again so they're fresh instead of stale.

- **Bug Fixes**
  - Added `-b -w` to the `lsof` invocation so it skips blocking `stat`/`lstat`/`readlink` calls, with `-Fpn` detection output unchanged.
  - Gated all scan entry points on `sidebar.showPorts` and `sidebar.hideAllDetails` (ports only shown when `showPorts` is on and `hideAllDetails` is off), with fail-closed re-checks right before `runLsof` so settings flips mid-scan don't spawn `lsof`.
  - When the setting turns off, queued scans are dropped; when it turns back on, all registered panels and tracked-agent scans are re-kicked immediately.
  - `Workspace.remotePortScanningEnabledFromSettings` now delegates to the same predicate, collapsing the duplicated logic.

<sup>Written for commit 902cc07166aa0e28f60799eab64b2a8ce60819ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace detail settings now consistently control whether port scanning is enabled.
  * Saved “show ports” preferences are applied across local and remote workspaces.

* **Bug Fixes**
  * Disabled port scanning no longer queues or runs scans, including refresh-triggered scans.
  * Port collection stops safely when settings change during scanning.
  * Improved port detection reliability by preventing blocking file-system lookups and reducing related warnings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->