### PR TITLE
cmux-tui: drag-resize works with a plugin sidebar

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -2975,6 +2975,48 @@ mod tests {
         mux.close_surface(surface.id);
     }
 
+    #[test]
+    fn plugin_sidebar_registers_resize_drag_hit() {
+        let mux = Mux::new(
+            "plugin-sidebar-drag-test",
+            SurfaceOptions {
+                command: Some(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "sleep 30".to_string(),
+                ]),
+                ..Default::default()
+            },
+        );
+        let surface = mux.new_workspace(Some("work".to_string()), Some((20, 8))).unwrap();
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_width = 12;
+        app.config.sidebar.plugin = Some(cmux_tui_core::SidebarPluginOptions {
+            command: vec!["/bin/sh".to_string(), "-c".to_string(), "sleep 30".to_string()],
+            cwd: None,
+        });
+        app.tree = notify_tree(surface.id, false);
+
+        let mut terminal = Terminal::new(TestBackend::new(40, 12)).unwrap();
+        terminal
+            .draw(|frame| {
+                crate::ui::draw(&mut app, frame);
+            })
+            .unwrap();
+
+        // Regression: with a plugin sidebar the divider column must still be a
+        // drag handle, exactly like the built-in sidebar.
+        let divider_x = app.sidebar_width - 1;
+        assert!(
+            app.hits.iter().any(|(rect, hit)| matches!(hit, super::Hit::SidebarResize)
+                && rect.x == divider_x
+                && rect.width == 1),
+            "plugin sidebar must register the SidebarResize hit on the divider column"
+        );
+
+        mux.close_surface(surface.id);
+    }
+
     fn test_app(session: Session) -> App {
         App {
             session,

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -63,6 +63,10 @@ fn draw_plugin(app: &mut App, frame: &mut Frame) {
             buf[(border_x, y)].set_symbol("│").set_style(border_style);
         }
     }
+    // The divider column is a drag handle exactly like the built-in sidebar's;
+    // without this hit zone, drag-resize is dead whenever a plugin owns the
+    // sidebar (the plugin rect stops one column short of the divider).
+    app.hits.push((Rect { x: border_x, y: 0, width: 1, height }, Hit::SidebarResize));
     if let Some(surface_id) = app.sidebar_plugin_surface {
         let Some(surface) = app.session.surface(surface_id) else { return };
         surface.take_dirty();


### PR DESCRIPTION
Dragging the sidebar divider did nothing when a plugin owned the sidebar: the Hit::SidebarResize zone was only pushed at the end of the built-in draw path, and draw_plugin never registered it. Push the same one-column divider hit in the plugin path — the existing drag handler and the plugin PTY resize (width-driven) work unchanged, so dragging now live-resizes the plugin.

Regression test draws with sidebar.plugin configured and asserts the divider registers the resize hit. Found from user dogfood of the plugin sidebar.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786245631&installation_id=133855650&pr_number=7793&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7793&signature=d59eea569b8d4041203d7645999b747a7b841c06e9747ef6176d8deb4b4bae78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 6c732646dc7f71dd2b6905a2fd668c0843cc3259. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes drag-resize for plugin-owned sidebars by registering the divider resize hit in the plugin draw path. You can now drag the divider to live-resize plugin sidebars.

- **Bug Fixes**
  - Register one-column `SidebarResize` hit at the divider in `draw_plugin`.
  - Keep existing drag handler and plugin PTY resize logic (width-driven) unchanged.
  - Add regression test that configures `sidebar.plugin` and asserts the divider hit is present.

<sup>Written for commit 6c732646dc7f71dd2b6905a2fd668c0843cc3259. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored sidebar resizing when a plugin controls the sidebar.
  * The sidebar divider now correctly responds to drag interactions.
  * Added regression coverage to help prevent future resize interaction issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->