### PR TITLE
Avoid publishing blank resolved icon renders

### DIFF
--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
@@ -55,8 +55,16 @@ public final class CmuxResolvedIconImageView: NSView {
         }
         let nextKey = RenderKey(request: request, appearance: effectiveAppearance)
         guard force || renderKey != nextKey else { return }
-        renderKey = nextKey
-        imageView.image = renderer.image(for: request, appearance: effectiveAppearance)
+        switch renderer.render(for: request, appearance: effectiveAppearance) {
+        case .success(let image):
+            renderKey = nextKey
+            imageView.image = image
+        case .failure(.sourceUnavailable):
+            renderKey = nextKey
+            imageView.image = nil
+        case .failure(.blankOutput):
+            renderKey = nil
+        }
         imageView.contentTintColor = nil
     }
 

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconImageView.swift
@@ -7,6 +7,8 @@ public final class CmuxResolvedIconImageView: NSView {
     private let renderer = CmuxResolvedIconRenderer()
     private var request: CmuxResolvedIconRequest?
     private var renderKey: RenderKey?
+    private var lastVisibleRenderKey: RenderKey?
+    private var blankRenderKey: RenderKey?
 
     /// Creates the resolved icon view.
     public override init(frame frameRect: NSRect) {
@@ -50,20 +52,33 @@ public final class CmuxResolvedIconImageView: NSView {
     private func renderIfNeeded(force: Bool) {
         guard let request else {
             renderKey = nil
+            lastVisibleRenderKey = nil
+            blankRenderKey = nil
             imageView.image = nil
             return
         }
         let nextKey = RenderKey(request: request, appearance: effectiveAppearance)
         guard force || renderKey != nextKey else { return }
+        guard force || blankRenderKey?.shouldSkipBlankRetry(for: nextKey) != true else { return }
         switch renderer.render(for: request, appearance: effectiveAppearance) {
         case .success(let image):
             renderKey = nextKey
+            lastVisibleRenderKey = nextKey
+            blankRenderKey = nil
             imageView.image = image
         case .failure(.sourceUnavailable):
             renderKey = nextKey
+            lastVisibleRenderKey = nil
+            blankRenderKey = nil
             imageView.image = nil
         case .failure(.blankOutput):
             renderKey = nil
+            blankRenderKey = nextKey
+            guard lastVisibleRenderKey?.matchesRequestAndAppearance(nextKey) == true else {
+                lastVisibleRenderKey = nil
+                imageView.image = nil
+                break
+            }
         }
         imageView.contentTintColor = nil
     }
@@ -101,15 +116,21 @@ public final class CmuxResolvedIconImageView: NSView {
         }
 
         static func == (lhs: RenderKey, rhs: RenderKey) -> Bool {
-            lhs.canReuseRenderedImage &&
-                rhs.canReuseRenderedImage &&
-                lhs.source == rhs.source &&
-                lhs.width == rhs.width &&
-                lhs.height == rhs.height &&
-                lhs.symbolWeight == rhs.symbolWeight &&
-                lhs.appearanceName == rhs.appearanceName &&
-                lhs.appearanceIdentity == rhs.appearanceIdentity &&
-                colorsEqual(lhs.tint, rhs.tint)
+            lhs.canReuseRenderedImage && rhs.canReuseRenderedImage && lhs.matchesRequestAndAppearance(rhs)
+        }
+
+        func matchesRequestAndAppearance(_ other: RenderKey) -> Bool {
+            source == other.source &&
+                width == other.width &&
+                height == other.height &&
+                symbolWeight == other.symbolWeight &&
+                appearanceName == other.appearanceName &&
+                appearanceIdentity == other.appearanceIdentity &&
+                Self.colorsEqual(tint, other.tint)
+        }
+
+        func shouldSkipBlankRetry(for other: RenderKey) -> Bool {
+            canReuseRenderedImage && other.canReuseRenderedImage && matchesRequestAndAppearance(other)
         }
 
         private static func colorsEqual(_ lhs: NSColor?, _ rhs: NSColor?) -> Bool {
@@ -126,7 +147,7 @@ public final class CmuxResolvedIconImageView: NSView {
         private enum SourceKey: Equatable {
             case systemSymbol(name: String, accessibilityDescription: String?)
             case asset(name: String, bundle: ObjectIdentifier)
-            case image
+            case image(ObjectIdentifier)
 
             init(_ source: CmuxResolvedIconSource) {
                 switch source {
@@ -134,8 +155,8 @@ public final class CmuxResolvedIconImageView: NSView {
                     self = .systemSymbol(name: name, accessibilityDescription: accessibilityDescription)
                 case .asset(let name, let bundle):
                     self = .asset(name: name, bundle: ObjectIdentifier(bundle))
-                case .image:
-                    self = .image
+                case .image(let image):
+                    self = .image(ObjectIdentifier(image))
                 }
             }
 

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRenderFailure.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRenderFailure.swift
@@ -1,0 +1,7 @@
+/// Describes why an appearance-resolved icon render did not produce a usable image.
+public enum CmuxResolvedIconRenderFailure: Error, Equatable {
+    /// The requested icon source could not be found or the requested size was invalid.
+    case sourceUnavailable
+    /// The source resolved, but drawing it produced no visible pixels.
+    case blankOutput
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRenderer.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/IconRendering/CmuxResolvedIconRenderer.swift
@@ -13,15 +13,29 @@ public final class CmuxResolvedIconRenderer {
     /// - Parameters:
     ///   - request: Icon render request.
     ///   - appearance: Appearance used to resolve dynamic colors and asset variants.
-    /// - Returns: A copied, sized image, or `nil` when the source cannot be resolved.
+    /// - Returns: A copied, sized image, or `nil` when the source is missing or draws blank.
     public func image(for request: CmuxResolvedIconRequest, appearance: NSAppearance) -> NSImage? {
+        try? render(for: request, appearance: appearance).get()
+    }
+
+    /// Renders a non-template image for the supplied appearance.
+    /// - Parameters:
+    ///   - request: Icon render request.
+    ///   - appearance: Appearance used to resolve dynamic colors and asset variants.
+    /// - Returns: A visible image, or a failure that distinguishes missing sources from blank output.
+    public func render(
+        for request: CmuxResolvedIconRequest,
+        appearance: NSAppearance
+    ) -> Result<NSImage, CmuxResolvedIconRenderFailure> {
         guard let imageSize = normalizedSize(request.size) else {
-            return nil
+            return .failure(.sourceUnavailable)
         }
         var output: NSImage?
+        var failure = CmuxResolvedIconRenderFailure.sourceUnavailable
         appearance.performAsCurrentDrawingAppearance {
             guard let sourceImage = resolvedSourceImage(for: request),
                   let bitmap = bitmapRepresentation(size: imageSize) else {
+                failure = .sourceUnavailable
                 return
             }
             bitmap.size = imageSize
@@ -47,15 +61,20 @@ public final class CmuxResolvedIconRenderer {
                 tintColor.setFill()
                 NSRect(origin: .zero, size: imageSize).fill(using: .sourceAtop)
             }
+            guard containsVisiblePixels(in: bitmap) else {
+                failure = .blankOutput
+                return
+            }
             let rendered = NSImage(size: imageSize)
             rendered.addRepresentation(bitmap)
+            rendered.cacheMode = .never
+            rendered.isTemplate = false
             output = rendered
         }
-        guard let output else {
-            return nil
+        if let output {
+            return .success(output)
         }
-        output.isTemplate = false
-        return output
+        return .failure(failure)
     }
 
     /// Returns PNG data for an icon rendered under the supplied appearance.
@@ -84,7 +103,6 @@ public final class CmuxResolvedIconRenderer {
             )
             let configured = baseImage.withSymbolConfiguration(configuration) ?? baseImage
             let image = copiedImage(configured)
-            image.isTemplate = true
             return image
         case .asset(let name, let bundle):
             guard let image = bundle.image(forResource: name) ?? NSImage(named: name) else {
@@ -100,6 +118,7 @@ public final class CmuxResolvedIconRenderer {
     private func copiedImage(_ image: NSImage) -> NSImage {
         let copy = (image.copy() as? NSImage) ?? image
         copy.cacheMode = .never
+        copy.isTemplate = false
         copy.recache()
         return copy
     }
@@ -117,6 +136,17 @@ public final class CmuxResolvedIconRenderer {
             bytesPerRow: 0,
             bitsPerPixel: 0
         )
+    }
+
+    private func containsVisiblePixels(in bitmap: NSBitmapImageRep) -> Bool {
+        for y in 0..<bitmap.pixelsHigh {
+            for x in 0..<bitmap.pixelsWide {
+                if let color = bitmap.colorAt(x: x, y: y), color.alphaComponent > 0.01 {
+                    return true
+                }
+            }
+        }
+        return false
     }
 
     private func normalizedSize(_ size: NSSize) -> NSSize? {

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconRendererTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconRendererTests.swift
@@ -122,6 +122,47 @@ import Testing
         #expect(visiblePixelCount(in: image) > 0)
     }
 
+    @Test func transparentRasterIsRejectedAsRenderFailure() throws {
+        let renderer = CmuxResolvedIconRenderer()
+        let sourceImage = NSImage(size: NSSize(width: 16, height: 16))
+        sourceImage.addRepresentation(transparentBitmapRepresentation(pixels: 16))
+        let appearance = try #require(NSAppearance(named: .aqua))
+
+        let image = renderer.image(
+            for: CmuxResolvedIconRequest(
+                source: .image(sourceImage),
+                size: NSSize(width: 16, height: 16)
+            ),
+            appearance: appearance
+        )
+
+        #expect(image == nil)
+    }
+
+    @Test func imageViewPreservesLastGoodImageWhenRenderProducesBlankPixels() throws {
+        let view = CmuxResolvedIconImageView(frame: NSRect(x: 0, y: 0, width: 16, height: 16))
+        view.appearance = NSAppearance(named: .aqua)
+        let sourceImage = NSImage(size: NSSize(width: 16, height: 16))
+        let representation = solidBitmapRepresentation(color: .systemRed, pixels: 16)
+        sourceImage.addRepresentation(representation)
+        let request = CmuxResolvedIconRequest(
+            source: .image(sourceImage),
+            size: NSSize(width: 16, height: 16)
+        )
+        view.apply(request)
+        let firstImage = try #require(renderedImage(in: view))
+        let firstPixel = try #require(centerPixelColor(in: firstImage))
+        #expect(firstPixel.redComponent > firstPixel.blueComponent)
+
+        fill(representation, color: .clear, operation: .copy)
+        view.apply(request)
+        let preservedImage = try #require(renderedImage(in: view))
+        let preservedPixel = try #require(centerPixelColor(in: preservedImage))
+
+        #expect(preservedImage === firstImage)
+        #expect(preservedPixel.redComponent > preservedPixel.blueComponent)
+    }
+
     private func solidBitmapRepresentation(color: NSColor, pixels: Int) -> NSBitmapImageRep {
         let representation = NSBitmapImageRep(
             bitmapDataPlanes: nil,
@@ -144,11 +185,21 @@ import Testing
         return representation
     }
 
-    private func fill(_ representation: NSBitmapImageRep, color: NSColor) {
+    private func transparentBitmapRepresentation(pixels: Int) -> NSBitmapImageRep {
+        let representation = solidBitmapRepresentation(color: .clear, pixels: pixels)
+        fill(representation, color: .clear, operation: .copy)
+        return representation
+    }
+
+    private func fill(
+        _ representation: NSBitmapImageRep,
+        color: NSColor,
+        operation: NSCompositingOperation = .sourceOver
+    ) {
         NSGraphicsContext.saveGraphicsState()
         NSGraphicsContext.current = NSGraphicsContext(bitmapImageRep: representation)
         color.setFill()
-        NSRect(origin: .zero, size: representation.size).fill()
+        NSRect(origin: .zero, size: representation.size).fill(using: operation)
         NSGraphicsContext.restoreGraphicsState()
     }
 

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconRendererTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/CmuxResolvedIconRendererTests.swift
@@ -128,7 +128,7 @@ import Testing
         sourceImage.addRepresentation(transparentBitmapRepresentation(pixels: 16))
         let appearance = try #require(NSAppearance(named: .aqua))
 
-        let image = renderer.image(
+        let result = renderer.render(
             for: CmuxResolvedIconRequest(
                 source: .image(sourceImage),
                 size: NSSize(width: 16, height: 16)
@@ -136,7 +136,7 @@ import Testing
             appearance: appearance
         )
 
-        #expect(image == nil)
+        #expect(result == .failure(.blankOutput))
     }
 
     @Test func imageViewPreservesLastGoodImageWhenRenderProducesBlankPixels() throws {
@@ -161,6 +161,27 @@ import Testing
 
         #expect(preservedImage === firstImage)
         #expect(preservedPixel.redComponent > preservedPixel.blueComponent)
+    }
+
+    @Test func imageViewClearsPreviousImageWhenDifferentRequestRendersBlankPixels() throws {
+        let view = CmuxResolvedIconImageView(frame: NSRect(x: 0, y: 0, width: 16, height: 16))
+        view.appearance = NSAppearance(named: .aqua)
+        let visibleImage = NSImage(size: NSSize(width: 16, height: 16))
+        visibleImage.addRepresentation(solidBitmapRepresentation(color: .systemRed, pixels: 16))
+        view.apply(CmuxResolvedIconRequest(
+            source: .image(visibleImage),
+            size: NSSize(width: 16, height: 16)
+        ))
+        #expect(renderedImage(in: view) != nil)
+
+        let blankImage = NSImage(size: NSSize(width: 16, height: 16))
+        blankImage.addRepresentation(transparentBitmapRepresentation(pixels: 16))
+        view.apply(CmuxResolvedIconRequest(
+            source: .image(blankImage),
+            size: NSSize(width: 16, height: 16)
+        ))
+
+        #expect(renderedImage(in: view) == nil)
     }
 
     private func solidBitmapRepresentation(color: NSColor, pixels: Int) -> NSBitmapImageRep {


### PR DESCRIPTION
Refs #7725
Related: #7729, #4476

## Summary
- Adds a shared `CmuxResolvedIconRenderFailure` result path so the AppKit icon renderer rejects zero-alpha output instead of treating blank pixels as a successful render.
- Updates `CmuxResolvedIconImageView` to keep the last visible image when AppKit returns a transient blank render, and to retry on the next real lifecycle/update signal instead of caching the blank state.
- Draws copied source images as non-template images inside the shared renderer so call sites do not rely on AppKit template tint timing.

## Root cause
The post-#7729 pipeline still had one missing invariant: a rendered icon was considered successful even if the bitmap contained no visible pixels. On macOS 15, an intermittent AppKit draw/appearance failure can therefore publish a blank raster and mark the request+appearance as rendered, so the blank icon persists until a force redraw or appearance change.

This PR moves that invariant to the shared renderer/view boundary rather than adding more call-site patches: blank output is now a render failure, and the bridge never records it as a stable rendered state.

## Regression coverage
- Commit 1 adds the failing regression only: a transparent raster is rejected, and the image view preserves its last good render when a later render produces blank pixels.
- Commit 2 implements the renderer/view fix.
- The actual macOS 15 flicker remains a visual/intermittent OS rendering failure, so this does not claim full closure until verified on macOS 15; the deterministic coverage checks the shared contract that allowed that failure to become visible and sticky.

## Verification
- `swift test --package-path Packages/macOS/CmuxAppKitSupportUI --disable-xctest`
- `python3 scripts/swift_file_length_budget.py`
- `git diff --check HEAD~2..HEAD`

Note: plain local `swift test` also ran the Swift Testing suite green, but this host/toolchain exits nonzero before that because the legacy XCTest loader tries to load the arm64 package test bundle as x86_64. The `--disable-xctest` run is the clean local SwiftPM validation.

## Localization
- No user-facing strings were added or changed.
- Changed files were audited for `Text`, `Button`, `Label`, `.help`, alert, tooltip, and accessibility user-facing strings; none were introduced.

## macOS 15 verification caveat
This should be dogfooded on macOS 15 before saying #7725 is fully fixed. I did not run a local tagged build per task instruction; use:

`CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-7725-macos15-icon-flicker-v2 --launch`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7794"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786245785&installation_id=133855650&pr_number=7794&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7794&signature=1fe1dc28a66e79e5c3e6b31feacf84cdd0143ff4b56aa968bbc54eb13ba37e2e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Scoped to AppKit icon rendering in CmuxAppKitSupportUI; behavior change is defensive (reject blank, preserve prior image) with regression tests and no auth or data paths.
> 
> **Overview**
> **Icon rendering** now treats all-transparent bitmaps as failures instead of successful renders, addressing sticky blank icons when AppKit intermittently draws nothing (e.g. macOS 15).
> 
> `CmuxResolvedIconRenderFailure` distinguishes **missing/invalid sources** from **blank output**. `CmuxResolvedIconRenderer` exposes `render(for:appearance:)` returning `Result`, scans the raster for visible pixels before success, and forces copied sources to **non-template** images with `cacheMode = .never`. The legacy `image(for:)` API maps failures to `nil`.
> 
> `CmuxResolvedIconImageView` uses the result API: on **blank output** it clears `renderKey` and **keeps the previous image** so a transient blank draw is not cached; on **source unavailable** it still records the key and clears the image.
> 
> Tests cover transparent raster rejection and last-good-image preservation when pixels go clear in place.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36f1f24a6f4d1c8e13acdbb8dea6cea0a178d8e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents blank icon renders from being published by rejecting zero‑alpha output and preserving the last good image, with per‑request handling to avoid retrying the same blank render. Reduces macOS 15 icon flicker tracked in #7725.

- **Bug Fixes**
  - Added `CmuxResolvedIconRenderFailure` with `.sourceUnavailable` and `.blankOutput`; renderer now returns `Result` and scans for visible pixels.
  - Ensured rendered/copied images are non‑template with `cacheMode = .never`.
  - Image view now tracks `lastVisibleRenderKey` and `blankRenderKey`: keeps the previous image on `.blankOutput` for the same request+appearance, clears if a different request renders blank, and skips redundant retries for the same blank key; clears on `.sourceUnavailable`.
  - Render key matching now includes image identity for `.image` sources and adds helpers to compare request+appearance.
  - Added tests for rejecting transparent rasters, preserving the last good image on blank renders, and clearing the image when a different request renders blank.

<sup>Written for commit b7859959c445e6339555b32a9dbf7f9ea19a0ba7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7794?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a new `render(for:appearance:)` API that returns `Result` with distinct failure reasons for unavailable sources vs blank output.
* **Bug Fixes**
  * Prevented transparent/blank icon renders from replacing the last visible “good” icon in the icon image view.
  * Improved bitmap rendering validation to detect truly blank (transparent) output, with refined template/tint behavior.
* **Tests**
  * Added coverage for blank-output detection and “last good icon” preservation across successive render requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->