### PR TITLE
Use asc app id for App Store upload

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -935,6 +935,7 @@ upload_app_store_with_asc() {
     "XDG_CACHE_HOME=$asc_xdg_cache"
     "ASC_BYPASS_KEYCHAIN=1"
     "ASC_STRICT_AUTH=true"
+    "ASC_NO_UPDATE=1"
     "ASC_KEY_ID=$ASC_API_KEY_ID"
     "ASC_ISSUER_ID=$ASC_API_ISSUER_ID"
   )
@@ -954,14 +955,26 @@ upload_app_store_with_asc() {
   ) | tee "$OUT_DIR/upload.log"
 }
 
-HAS_ASC_UPLOAD_ENV=0
-if [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ]]; then
-  HAS_ASC_UPLOAD_ENV=1
+HAS_COMPLETE_ASC_UPLOAD_ENV=0
+if [[ -n "${ASC_APP_ID:-}" && -n "${ASC_API_KEY_ID:-}" && -n "${ASC_API_ISSUER_ID:-}" && ( -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
+  HAS_COMPLETE_ASC_UPLOAD_ENV=1
 fi
 
-if [[ "$LANE" == "appstore" && "$HAS_ASC_UPLOAD_ENV" -eq 1 ]]; then
+HAS_ANY_ASC_UPLOAD_ENV=0
+if [[ -n "${ASC_APP_ID:-}" || -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ]]; then
+  HAS_ANY_ASC_UPLOAD_ENV=1
+fi
+
+HAS_APPLE_ID_UPLOAD_ENV=0
+if [[ -n "${APPLE_ID:-}" || -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" || -n "${APPLE_PROVIDER_PUBLIC_ID:-}" ]]; then
+  HAS_APPLE_ID_UPLOAD_ENV=1
+fi
+
+if [[ "$LANE" == "appstore" && "$HAS_COMPLETE_ASC_UPLOAD_ENV" -eq 1 ]]; then
   upload_app_store_with_asc
-elif [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" ]]; then
+elif [[ "$LANE" == "appstore" && "$HAS_ANY_ASC_UPLOAD_ENV" -eq 1 && "$HAS_APPLE_ID_UPLOAD_ENV" -ne 1 ]]; then
+  upload_app_store_with_asc
+elif [[ "$LANE" != "appstore" && ( -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" ) ]]; then
   if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || -z "${ASC_API_KEY_PATH:-}" ]]; then
     echo "error: ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH must be set together" >&2
     exit 2
@@ -981,7 +994,7 @@ elif [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API
     --api-key "$ASC_API_KEY_ID" \
     --api-issuer "$ASC_API_ISSUER_ID" \
     | tee "$OUT_DIR/upload.log"
-elif [[ -n "${APPLE_ID:-}" || -n "${APPLE_APP_SPECIFIC_PASSWORD:-}" || -n "${APPLE_PROVIDER_PUBLIC_ID:-}" ]]; then
+elif [[ "$HAS_APPLE_ID_UPLOAD_ENV" -eq 1 ]]; then
   if [[ -z "${APPLE_ID:-}" || -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" || -z "${APPLE_PROVIDER_PUBLIC_ID:-}" ]]; then
     echo "error: APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_PROVIDER_PUBLIC_ID must be set together" >&2
     exit 2

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -139,6 +139,10 @@ or:
   APPLE_APP_SPECIFIC_PASSWORD
   APPLE_PROVIDER_PUBLIC_ID
 
+With ASC API authentication, the appstore lane also requires ASC_APP_ID and the
+asc CLI so upload can target the numeric App Store Connect app record instead
+of relying on bundle-id lookup. Apple ID credentials keep using altool.
+
 Options:
   --lane <beta|appstore>    Distribution lane. beta is the existing TestFlight
                             path. appstore uploads the production App Store
@@ -899,7 +903,65 @@ if [[ "$EXPORT_ONLY" -eq 1 ]]; then
   exit 0
 fi
 
-if [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" ]]; then
+upload_app_store_with_asc() {
+  if [[ -z "${ASC_APP_ID:-}" ]]; then
+    echo "error: --lane appstore requires ASC_APP_ID so the upload targets the exact App Store Connect app record" >&2
+    exit 2
+  fi
+  if ! command -v asc >/dev/null 2>&1; then
+    echo "error: --lane appstore requires the asc CLI for app-id based upload (install with: brew install asc)" >&2
+    exit 2
+  fi
+
+  local asc_private_key_path="${ASC_API_KEY_PATH:-}"
+  local asc_private_key_b64="${ASC_API_KEY_P8_BASE64:-}"
+  if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "$asc_private_key_path" && -z "$asc_private_key_b64" ) ]]; then
+    echo "error: --lane appstore asc upload requires ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH or ASC_API_KEY_P8_BASE64" >&2
+    exit 2
+  fi
+  if [[ -n "$asc_private_key_path" && ! -f "$asc_private_key_path" ]]; then
+    echo "error: ASC_API_KEY_PATH does not exist: $asc_private_key_path" >&2
+    exit 2
+  fi
+
+  local asc_home="$OUT_DIR/asc-home"
+  local asc_xdg_config="$OUT_DIR/asc-xdg-config"
+  local asc_xdg_cache="$OUT_DIR/asc-xdg-cache"
+  mkdir -p "$asc_home" "$asc_xdg_config" "$asc_xdg_cache"
+
+  local asc_env=(
+    "HOME=$asc_home"
+    "XDG_CONFIG_HOME=$asc_xdg_config"
+    "XDG_CACHE_HOME=$asc_xdg_cache"
+    "ASC_BYPASS_KEYCHAIN=1"
+    "ASC_STRICT_AUTH=true"
+    "ASC_KEY_ID=$ASC_API_KEY_ID"
+    "ASC_ISSUER_ID=$ASC_API_ISSUER_ID"
+  )
+  if [[ -n "$asc_private_key_path" ]]; then
+    asc_env+=( "ASC_PRIVATE_KEY_PATH=$asc_private_key_path" )
+  fi
+  if [[ -n "$asc_private_key_b64" ]]; then
+    asc_env+=( "ASC_PRIVATE_KEY_B64=$asc_private_key_b64" )
+  fi
+
+  (
+    export "${asc_env[@]}"
+    asc builds upload \
+      --app "$ASC_APP_ID" \
+      --ipa "$IPA_PATH" \
+      --output json
+  ) | tee "$OUT_DIR/upload.log"
+}
+
+HAS_ASC_UPLOAD_ENV=0
+if [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" || -n "${ASC_API_KEY_P8_BASE64:-}" ]]; then
+  HAS_ASC_UPLOAD_ENV=1
+fi
+
+if [[ "$LANE" == "appstore" && "$HAS_ASC_UPLOAD_ENV" -eq 1 ]]; then
+  upload_app_store_with_asc
+elif [[ -n "${ASC_API_KEY_ID:-}" || -n "${ASC_API_ISSUER_ID:-}" || -n "${ASC_API_KEY_PATH:-}" ]]; then
   if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || -z "${ASC_API_KEY_PATH:-}" ]]; then
     echo "error: ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH must be set together" >&2
     exit 2


### PR DESCRIPTION
## Summary
- upload the production App Store lane through `asc builds upload --app ""` instead of `altool --upload-app`
- map existing `ASC_API_*` auth env into the `asc` CLI env for local plist and CI compatibility
- document that the appstore lane needs `ASC_APP_ID` and `asc`

## Context
The latest iOS App Store pre-verification run archived, exported, re-signed, and verified the production IPA, then failed during upload with:

`Cannot determine the Apple ID from Bundle ID 'com.cmuxterm.app' and platform 'IOS'. (19)`

Using the numeric App Store Connect app id avoids bundle-id lookup ambiguity.

## Verification
- `bash -n ios/scripts/upload-testflight.sh ios/scripts/upload-app-store.sh .github/scripts/install-app-store-provisioning-profile.sh`
- `ios/scripts/upload-testflight.sh --help`
- `git diff --check`

No tagged reload: release tooling only, no app/runtime behavior change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7795"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786246069&installation_id=133855650&pr_number=7795&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7795&signature=b7ad197ab73157faccf3478a115cb56b9d2c684df892a3568cbf047e43c3c51f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-script-only change with no app runtime impact; main operational risk is CI/local App Store cuts needing `ASC_APP_ID` and `asc` installed.
> 
> **Overview**
> Fixes production **App Store** uploads that failed when `altool` could not resolve Apple ID from bundle id `com.cmuxterm.app`.
> 
> For `--lane appstore`, upload now goes through **`asc builds upload --app "$ASC_APP_ID"`** instead of `xcrun altool --upload-app`. Existing **`ASC_API_*`** credentials are mapped into the `asc` CLI environment (including **`ASC_API_KEY_P8_BASE64`**), with isolated **`HOME` / `XDG_*`** dirs and flags like **`ASC_BYPASS_KEYCHAIN`** and **`ASC_STRICT_AUTH`**. Help text documents that the appstore lane needs **`ASC_APP_ID`** and the **`asc`** binary.
> 
> **TestFlight (`beta`)** and **Apple ID** uploads are unchanged and still use **`altool`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5ccdd93896ef3ee2bbce614f5454c0ae13d626b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch App Store uploads to the App Store Connect `asc` CLI using numeric `ASC_APP_ID` to avoid bundle-id lookup failures. Tightens selection: `asc` runs for `--lane appstore` when ASC API env is complete or when no Apple ID creds are set; otherwise uploads stay on `altool`. Adds strict env checks and isolated config (`HOME`, `XDG_*`) with `ASC_BYPASS_KEYCHAIN=1`, `ASC_STRICT_AUTH=true`, `ASC_NO_UPDATE=1`; maps `ASC_API_*` (incl. `ASC_API_KEY_P8_BASE64`), and writes JSON to `upload.log`. TestFlight and Apple ID uploads remain on `altool`.

- **Migration**
  - Set `ASC_APP_ID` for `--lane appstore`.
  - Install the `asc` CLI (e.g., `brew install asc`).

<sup>Written for commit a5ccdd93896ef3ee2bbce614f5454c0ae13d626b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App Store uploads now use the App Store Connect CLI and can target a specific App Store Connect app via `ASC_APP_ID`.
  * Added private-key authentication support for CLI-based uploads.
  * App Store upload progress is recorded to a dedicated log file for troubleshooting.
* **Bug Fixes**
  * Added stricter validation with clearer failures when required App Store Connect identifiers/credentials or the CLI tool are missing.
* **Chores**
  * The App Store lane now automatically switches to the CLI-based upload flow when ASC upload-related variables are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->