### PR TITLE
Fix account.me test broken by Stack billing removal merge race

### DIFF
--- a/web/tests/account-me-orpc.test.ts
+++ b/web/tests/account-me-orpc.test.ts
@@ -5,7 +5,7 @@ import { call } from "@orpc/server";
 
 import { accountMeProcedure } from "../orpc/server/account/me";
 import { generateOpenAPIDocument } from "../orpc/server/openapi";
-import { PRO_PRODUCT_ID } from "../services/billing/pro";
+import { resolveProPlanStatus } from "../services/billing/pro";
 
 // The two checked-in specs the Swift client and /api/openapi.json ship must
 // stay identical to what the router generates. Resolve relative to this test
@@ -16,29 +16,13 @@ const CHECKED_IN_SPECS = [
 ] as const;
 
 // Drives the real resolveProPlanStatus (no module mocks, so it can't leak into
-// other test files). The fake user carries no `id`, so the Stripe-subscription
-// lookup short-circuits to false without touching a database, and the fake
-// user's Stack product list alone decides Pro vs Free.
-type FakeProduct = {
-  id: string;
-  subscription: { currentPeriodEnd: Date | null } | null;
-  quantity: number;
-};
-
-function productsPage(items: FakeProduct[]) {
-  const page = [...items] as FakeProduct[] & { nextCursor: string | null };
-  page.nextCursor = null;
-  return page;
-}
-
-function fakeUser(opts: { email: string | null; pro: boolean }) {
+// other test files). Plan resolution is Stripe-backed: an id-less fake user
+// short-circuits the Stripe-subscription lookup to Free without touching a
+// database, and the Pro path injects the subscription query directly.
+function fakeUser(opts: { email: string | null }) {
   return {
     primaryEmail: opts.email,
     clientReadOnlyMetadata: {},
-    listProducts: async () =>
-      productsPage(
-        opts.pro ? [{ id: PRO_PRODUCT_ID, subscription: null, quantity: 1 }] : [],
-      ),
     update: async () => undefined,
   };
 }
@@ -48,27 +32,46 @@ function context(user: unknown) {
 }
 
 describe("account.me", () => {
-  test("returns the Pro plan (external billing) for a Stack-Pro user", async () => {
+  test("returns the Free plan for a user with no Stripe subscription", async () => {
     const result = await call(accountMeProcedure, undefined, {
-      context: context(fakeUser({ email: "a@example.com", pro: true })),
+      context: context(fakeUser({ email: "a@example.com" })),
     });
     expect(result).toEqual({
       userId: "",
       email: "a@example.com",
-      planId: "pro",
-      isPro: true,
-      billingManagement: "external",
+      planId: "free",
+      isPro: false,
+      billingManagement: "none",
     });
   });
 
   test("returns the Free plan and an empty email for an email-less non-subscriber", async () => {
     const result = await call(accountMeProcedure, undefined, {
-      context: context(fakeUser({ email: null, pro: false })),
+      context: context(fakeUser({ email: null })),
     });
     expect(result.planId).toBe("free");
     expect(result.isPro).toBe(false);
     expect(result.email).toBe("");
     expect(result.billingManagement).toBe("none");
+  });
+
+  test("resolves Stripe-managed Pro and syncs plan metadata for an active subscription", async () => {
+    const updates: unknown[] = [];
+    const user = {
+      id: "user-1",
+      clientReadOnlyMetadata: {},
+      update: async (options: unknown) => {
+        updates.push(options);
+      },
+    };
+    const status = await resolveProPlanStatus(user, {
+      hasActiveStripeSubscription: async (stackUserId) => stackUserId === "user-1",
+    });
+    expect(status.planId).toBe("pro");
+    expect(status.isPro).toBe(true);
+    expect(status.billingManagement).toBe("stripe");
+    // The read-time reconciliation must write cmuxPlan: "pro" back to Stack.
+    expect(updates).toEqual([{ clientReadOnlyMetadata: { cmuxPlan: "pro" } }]);
   });
 
   test("rejects unauthenticated callers before resolving a plan", async () => {


### PR DESCRIPTION
Main CI is red: `web-typecheck` fails on every completed run since 25b5fd8 with:

```
tests/account-me-orpc.test.ts(8,10): error TS2305: Module '../services/billing/pro' has no exported member 'PRO_PRODUCT_ID'.
```

## Root cause: merge race
- https://github.com/manaflow-ai/cmux/pull/7662 (571742e, 03:29 UTC) removed legacy Stack product billing, including the `PRO_PRODUCT_ID` export and the Stack-product path in `resolveProPlanStatus`.
- https://github.com/manaflow-ai/cmux/pull/7757 (f248564, 03:31 UTC) added `web/tests/account-me-orpc.test.ts` written against pre-#7662 main, faking a Stack product list and expecting `billingManagement: "external"`.

Both PRs were green pre-merge against bases that lacked the other; the post-merge CI runs on main were cancelled by newer pushes (concurrency), so the first completed run to surface the break was 25b5fd8. Every CI run on main since then fails `web-typecheck`, which cascades into the `tests`, `linux-preflight`, and `ci-status` gates.

## Fix
Rework the test to the post-#7662 Stripe-backed billing model, keeping the DB-free property:
- Procedure-level Free coverage: id-less fake users short-circuit the Stripe subscription lookup, asserting the full `{userId, email, planId, isPro, billingManagement: "none"}` shape.
- Pro coverage moves to `resolveProPlanStatus` directly with an injected `hasActiveStripeSubscription` (the procedure no longer exposes an injection point), asserting `billingManagement: "stripe"` and the read-time `cmuxPlan: "pro"` metadata sync.
- Unauthenticated, OpenAPI advertisement, and spec byte-parity tests unchanged.

## Verification
- `bun run typecheck` in `web/`: clean.
- Full CI-order suite: 565 pass, 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7803"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786248719&installation_id=133855650&pr_number=7803&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7803&signature=2f3292b550d6c3e53f96cfc4d4b1228388c00bfdc4d03e63a9ee8b0a85c71184"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes; no production billing or API behavior modified.
> 
> **Overview**
> Repairs **`web/tests/account-me-orpc.test.ts`** after main dropped Stack product billing (`PRO_PRODUCT_ID` and `billingManagement: "external"`).
> 
> The test no longer fakes Stack product lists. **Free** plan behavior is asserted via **`accountMeProcedure`** with id-less users that skip Stripe lookups and return **`billingManagement: "none"`**. **Pro** is covered by calling **`resolveProPlanStatus`** with an injected **`hasActiveStripeSubscription`**, expecting **`billingManagement: "stripe"`** and a Stack metadata sync **`cmuxPlan: "pro"`**. Auth rejection, OpenAPI, and checked-in spec parity tests are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f51fa1bae6e80e4d241a85c6134498d9e93529a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by updating the `account.me` test to the Stripe-backed billing model after Stack product billing was removed. Restores green web typecheck and keeps tests DB-free.

- **Bug Fixes**
  - Replaced Stack product check with Stripe plan resolution; Free path uses id-less fake users and asserts `billingManagement: "none"`.
  - Added direct `resolveProPlanStatus` test with injected `hasActiveStripeSubscription`, asserting `billingManagement: "stripe"` and `cmuxPlan: "pro"` metadata sync.
  - Left unauthenticated, OpenAPI advertisement, and spec parity tests unchanged.

<sup>Written for commit 3f51fa1bae6e80e4d241a85c6134498d9e93529a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for determining Pro-plan status from an active Stripe subscription.
  * Verified plan metadata and account updates are reconciled correctly.
  * Updated account scenarios to confirm users without Stripe subscriptions or email addresses remain on the Free plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->