### PR TITLE
Continue handed-off Safari sign-in in the default browser

### DIFF
--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow+Diagnostics.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow+Diagnostics.swift
@@ -1,18 +1,18 @@
 import Foundation
 
 extension HostBrowserSignInFlow {
-    func authCallbackState(from url: URL) -> String? {
+    nonisolated func authCallbackState(from url: URL) -> String? {
         URLComponents(url: url, resolvingAgainstBaseURL: false)?
             .queryItems?
             .first(where: { $0.name == "cmux_auth_state" })?
             .value
     }
 
-    func redactedAuthState(_ state: String) -> String {
+    nonisolated func redactedAuthState(_ state: String) -> String {
         "\(state.prefix(8))..."
     }
 
-    func authCallbackSummary(_ url: URL) -> String {
+    nonisolated func authCallbackSummary(_ url: URL) -> String {
         let scheme = url.scheme ?? "nil"
         let target = url.host ?? url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
         let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?
@@ -22,7 +22,7 @@ extension HostBrowserSignInFlow {
         return "scheme=\(scheme) target=\(target.isEmpty ? "nil" : target) queryKeys=\(queryItems.isEmpty ? "none" : queryItems)"
     }
 
-    func sessionResultSummary(_ result: HostBrowserAuthSessionResult) -> String {
+    nonisolated func sessionResultSummary(_ result: HostBrowserAuthSessionResult) -> String {
         switch result {
         case let .callback(url):
             return "result=callback \(authCallbackSummary(url))"

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow+Diagnostics.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow+Diagnostics.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+extension HostBrowserSignInFlow {
+    func authCallbackState(from url: URL) -> String? {
+        URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .first(where: { $0.name == "cmux_auth_state" })?
+            .value
+    }
+
+    func redactedAuthState(_ state: String) -> String {
+        "\(state.prefix(8))..."
+    }
+
+    func authCallbackSummary(_ url: URL) -> String {
+        let scheme = url.scheme ?? "nil"
+        let target = url.host ?? url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?
+            .queryItems?
+            .map(\.name)
+            .joined(separator: ",") ?? ""
+        return "scheme=\(scheme) target=\(target.isEmpty ? "nil" : target) queryKeys=\(queryItems.isEmpty ? "none" : queryItems)"
+    }
+
+    func sessionResultSummary(_ result: HostBrowserAuthSessionResult) -> String {
+        switch result {
+        case let .callback(url):
+            return "result=callback \(authCallbackSummary(url))"
+        case let .cancelled(reason):
+            return "result=cancelled reason=\(reason)"
+        case let .failed(reason):
+            return "result=failed reason=\(reason)"
+        }
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -22,6 +22,7 @@ public final class HostBrowserSignInFlow {
     private let callbackRouter: AuthCallbackRouter
     private let makeSignInURL: @MainActor (_ callbackState: String) -> URL
     private let callbackScheme: @MainActor () -> String
+    @ObservationIgnored private let openExternalURL: @MainActor (URL) -> Void
     private let clock: any Clock<Duration>
     private let browserAttemptTimeout: TimeInterval
     private let slowSignInThreshold: TimeInterval
@@ -47,6 +48,7 @@ public final class HostBrowserSignInFlow {
         callbackRouter: AuthCallbackRouter,
         makeSignInURL: @escaping @MainActor (_ callbackState: String) -> URL,
         callbackScheme: @escaping @MainActor () -> String,
+        openExternalURL: @escaping @MainActor (URL) -> Void,
         clock: any Clock<Duration> = ContinuousClock(),
         browserAttemptTimeout: TimeInterval = 10 * 60,
         slowSignInThreshold: TimeInterval = 30
@@ -57,6 +59,7 @@ public final class HostBrowserSignInFlow {
         self.callbackRouter = callbackRouter
         self.makeSignInURL = makeSignInURL
         self.callbackScheme = callbackScheme
+        self.openExternalURL = openExternalURL
         self.clock = clock
         self.browserAttemptTimeout = browserAttemptTimeout
         self.slowSignInThreshold = slowSignInThreshold
@@ -463,37 +466,5 @@ public final class HostBrowserSignInFlow {
 
     private func makeCallbackState() -> String {
         UUID().uuidString.lowercased()
-    }
-
-    private func authCallbackState(from url: URL) -> String? {
-        URLComponents(url: url, resolvingAgainstBaseURL: false)?
-            .queryItems?
-            .first(where: { $0.name == "cmux_auth_state" })?
-            .value
-    }
-
-    private func redactedAuthState(_ state: String) -> String {
-        "\(state.prefix(8))..."
-    }
-
-    private func authCallbackSummary(_ url: URL) -> String {
-        let scheme = url.scheme ?? "nil"
-        let target = url.host ?? url.path.trimmingCharacters(in: CharacterSet(charactersIn: "/"))
-        let queryItems = URLComponents(url: url, resolvingAgainstBaseURL: false)?
-            .queryItems?
-            .map(\.name)
-            .joined(separator: ",") ?? ""
-        return "scheme=\(scheme) target=\(target.isEmpty ? "nil" : target) queryKeys=\(queryItems.isEmpty ? "none" : queryItems)"
-    }
-
-    private func sessionResultSummary(_ result: HostBrowserAuthSessionResult) -> String {
-        switch result {
-        case let .callback(url):
-            return "result=callback \(authCallbackSummary(url))"
-        case let .cancelled(reason):
-            return "result=cancelled reason=\(reason)"
-        case let .failed(reason):
-            return "result=failed reason=\(reason)"
-        }
     }
 }

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -22,7 +22,9 @@ public final class HostBrowserSignInFlow {
     private let callbackRouter: AuthCallbackRouter
     private let makeSignInURL: @MainActor (_ callbackState: String) -> URL
     private let callbackScheme: @MainActor () -> String
-    @ObservationIgnored private let openExternalURL: @MainActor (URL) -> Void
+    /// Opens a URL in the user's default browser. Returns `true` when the
+    /// launch was handed to a browser, `false` when it could not be opened.
+    @ObservationIgnored private let openExternalURL: @MainActor (URL) -> Bool
     private let clock: any Clock<Duration>
     private let browserAttemptTimeout: TimeInterval
     private let slowSignInThreshold: TimeInterval
@@ -49,7 +51,7 @@ public final class HostBrowserSignInFlow {
         callbackRouter: AuthCallbackRouter,
         makeSignInURL: @escaping @MainActor (_ callbackState: String) -> URL,
         callbackScheme: @escaping @MainActor () -> String,
-        openExternalURL: @escaping @MainActor (URL) -> Void,
+        openExternalURL: @escaping @MainActor (URL) -> Bool,
         clock: any Clock<Duration> = ContinuousClock(),
         browserAttemptTimeout: TimeInterval = 10 * 60,
         slowSignInThreshold: TimeInterval = 30
@@ -263,11 +265,16 @@ public final class HostBrowserSignInFlow {
                     self.pendingFallbackCallbackState = self.activeCallbackState
                     self.cancelSlowSignInHint()
                     self.signInIsSlow = true
-                    if self.handedOffAttemptID != attemptID {
-                        self.handedOffAttemptID = attemptID
-                        if let state = self.activeCallbackState {
-                            self.log.log("auth.browser.handoff.continueInDefaultBrowser attempt=\(attemptID)")
-                            self.openExternalURL(self.makeSignInURL(state))
+                    if self.handedOffAttemptID != attemptID, let state = self.activeCallbackState {
+                        self.log.log("auth.browser.handoff.continueInDefaultBrowser attempt=\(attemptID)")
+                        // Commit to the handed-off state only when the browser
+                        // actually launched. If the open fails, leave the attempt
+                        // un-handed-off so a repeat sign-in click starts fresh
+                        // instead of parking on a browser that never appeared.
+                        if self.openExternalURL(self.makeSignInURL(state)) {
+                            self.handedOffAttemptID = attemptID
+                        } else {
+                            self.log.log("auth.browser.handoff.openFailed attempt=\(attemptID)")
                         }
                     }
                     return

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -267,14 +267,22 @@ public final class HostBrowserSignInFlow {
                     self.signInIsSlow = true
                     if self.handedOffAttemptID != attemptID, let state = self.activeCallbackState {
                         self.log.log("auth.browser.handoff.continueInDefaultBrowser attempt=\(attemptID)")
-                        // Commit to the handed-off state only when the browser
-                        // actually launched. If the open fails, leave the attempt
-                        // un-handed-off so a repeat sign-in click starts fresh
-                        // instead of parking on a browser that never appeared.
                         if self.openExternalURL(self.makeSignInURL(state)) {
+                            // Browser launched: keep the attempt parked so the
+                            // eventual cmux://auth-callback resumes it. Open at
+                            // most once per attempt.
                             self.handedOffAttemptID = attemptID
                         } else {
+                            // No browser launched, so nothing will call back.
+                            // End the attempt with a failure instead of parking
+                            // the awaited sign-in until the timeout, so callers
+                            // and the UI stop waiting and the user can retry.
                             self.log.log("auth.browser.handoff.openFailed attempt=\(attemptID)")
+                            self.resumeActiveSessionContinuation(
+                                returning: .failed(reason: "browser_open_failed"),
+                                reason: "handoffOpenFailed",
+                                expectedAttemptID: attemptID
+                            )
                         }
                     }
                     return

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/BrowserSignIn/HostBrowserSignInFlow.swift
@@ -35,6 +35,7 @@ public final class HostBrowserSignInFlow {
     @ObservationIgnored private var slowSignInHintTask: Task<Void, Never>?
     @ObservationIgnored private var nextAttemptID: UInt64 = 0
     @ObservationIgnored private var activeAttemptID: UInt64?
+    @ObservationIgnored private var handedOffAttemptID: UInt64?
     @ObservationIgnored private var activeCallbackState: String?
     @ObservationIgnored private var pendingManualCallbackState: String?
     @ObservationIgnored private var pendingFallbackCallbackState: String?
@@ -69,7 +70,7 @@ public final class HostBrowserSignInFlow {
     /// Reuses a handed-off attempt; otherwise cancels the previous popup.
     public func beginSignIn() {
         log.log("auth.browser.beginSignIn signedIn=\(coordinator.isAuthenticated) signingIn=\(isSigningIn)")
-        if activeAttemptID != nil, !isPresentingSignIn {
+        if let activeAttemptID, handedOffAttemptID == activeAttemptID {
             isPresentingSignIn = true
             signInIsSlow = true
             return
@@ -259,10 +260,16 @@ public final class HostBrowserSignInFlow {
                         self.log.log("auth.browser.session.completion.ignored id=\(attemptID) reason=staleNonAuthCallback active=\(self.activeAttemptID.map(String.init) ?? "nil")")
                         return
                     }
-                    // Stop the UI spinner while the socket waiter remains parked for Safari's AppDelegate callback.
                     self.pendingFallbackCallbackState = self.activeCallbackState
-                    self.isPresentingSignIn = false
                     self.cancelSlowSignInHint()
+                    self.signInIsSlow = true
+                    if self.handedOffAttemptID != attemptID {
+                        self.handedOffAttemptID = attemptID
+                        if let state = self.activeCallbackState {
+                            self.log.log("auth.browser.handoff.continueInDefaultBrowser attempt=\(attemptID)")
+                            self.openExternalURL(self.makeSignInURL(state))
+                        }
+                    }
                     return
                 }
                 self.resumeActiveSessionContinuation(returning: result, reason: "sessionCompletion", expectedAttemptID: attemptID)
@@ -298,6 +305,7 @@ public final class HostBrowserSignInFlow {
         cancelAttemptTimeout()
         cancelSlowSignInHint()
         activeAttemptID = nil
+        handedOffAttemptID = nil
         activeCallbackState = nil
         activeSession = nil
         isSigningIn = false
@@ -315,6 +323,7 @@ public final class HostBrowserSignInFlow {
         cancelAttemptTimeout()
         cancelSlowSignInHint()
         activeAttemptID = nil
+        handedOffAttemptID = nil
         activeCallbackState = nil
         pendingFallbackCallbackState = nil
         activeSession?.cancel()

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowHandoffTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowHandoffTests.swift
@@ -1,0 +1,67 @@
+import AuthenticationServices
+import CMUXAuthCore
+import Foundation
+import Testing
+@testable import CmuxAuthRuntime
+
+/// Behavior tests for default-browser continuation after hosted-browser handoff.
+@MainActor
+@Suite(.serialized) struct HostBrowserSignInFlowHandoffTests {
+    @Test func nonAuthBrowserCompletionContinuesAttemptInDefaultBrowserAndAcceptsLateCallback() async {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let harness = HostBrowserSignInFlowHarness(user: user)
+        let attempt = Task { await harness.flow.signIn(timeout: 60) }
+        await harness.waitForSession()
+        let callbackState = harness.callbackState(harness.factory.sessions[0])
+
+        harness.factory.sessions[0].deliver(URL(string: "https://example.test/handler/sign-in?after_auth_return_to=1")!)
+        // Deadline-bounded graceful wait: on a regression the assertions below
+        // fail instead of aborting the whole test process.
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while harness.openedURLs.isEmpty, clock.now < deadline {
+            await Task.yield()
+        }
+
+        #expect(harness.openedURLs == [
+            URL(string: "https://example.test/handler/sign-in?cmux_auth_state=\(callbackState)")!
+        ])
+        #expect(harness.flow.isSigningIn)
+        #expect(harness.flow.isPresentingSignIn)
+        #expect(harness.flow.signInIsSlow)
+        #expect(harness.factory.sessions.count == 1)
+
+        harness.flow.beginSignIn()
+        await Task.yield()
+
+        #expect(harness.factory.sessions.count == 1)
+        #expect(harness.openedURLs.count == 1)
+
+        let callbackResult = await harness.flow.handleCallbackURL(harness.callbackURL(state: callbackState))
+
+        #expect(callbackResult)
+        #expect(await attempt.value)
+        #expect(harness.coordinator.isAuthenticated)
+        #expect(harness.coordinator.currentUser == user)
+        #expect(await harness.tokenStore.getStoredRefreshToken() == "refresh-1")
+        #expect(await harness.tokenStore.getStoredAccessToken() == "access-1")
+        #expect(!harness.flow.isSigningIn && !harness.flow.isPresentingSignIn)
+    }
+
+    @Test func staleNonAuthCompletionDoesNotOpenBrowser() async {
+        let harness = HostBrowserSignInFlowHarness()
+
+        harness.flow.beginSignIn()
+        await harness.waitForSession()
+        let staleSession = harness.factory.sessions[0]
+        staleSession.deliverCancelCompletion = false
+
+        harness.flow.beginSignIn()
+        await harness.waitForSession(count: 2)
+        staleSession.deliver(URL(string: "https://example.test/handler/sign-in?after_auth_return_to=1")!)
+        await Task.yield()
+
+        #expect(harness.openedURLs.isEmpty)
+        #expect(harness.factory.sessions.count == 2)
+    }
+}

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowHandoffTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowHandoffTests.swift
@@ -48,27 +48,26 @@ import Testing
         #expect(!harness.flow.isSigningIn && !harness.flow.isPresentingSignIn)
     }
 
-    @Test func handoffOpenFailureLeavesAttemptRetryable() async {
+    @Test func handoffOpenFailureEndsAttemptAndAllowsRetry() async {
         // The default browser fails to launch on the handed-off attempt.
         let harness = HostBrowserSignInFlowHarness(openSucceeds: false)
         let attempt = Task { await harness.flow.signIn(timeout: 60) }
         await harness.waitForSession()
 
         harness.factory.sessions[0].deliver(URL(string: "https://example.test/handler/sign-in?after_auth_return_to=1")!)
-        let clock = ContinuousClock()
-        let deadline = clock.now.advanced(by: .seconds(2))
-        while harness.openedURLs.isEmpty, clock.now < deadline {
-            await Task.yield()
-        }
 
-        // The open was attempted but failed, so the attempt must not be locked
-        // into the handed-off state: a repeat sign-in click starts fresh.
+        // The open was attempted once but failed, so the attempt ends promptly
+        // with a failure instead of parking the awaited sign-in until timeout.
+        #expect(await attempt.value == false)
         #expect(harness.openedURLs.count == 1)
+        #expect(!harness.flow.isSigningIn)
+        #expect(!harness.flow.isPresentingSignIn)
+        #expect(harness.flow.lastFailure != nil)
+
+        // A fresh sign-in click starts a brand-new attempt.
         harness.flow.beginSignIn()
         await harness.waitForSession(count: 2)
         #expect(harness.factory.sessions.count == 2)
-
-        _ = await attempt.value
     }
 
     @Test func staleNonAuthCompletionDoesNotOpenBrowser() async {

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowHandoffTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowHandoffTests.swift
@@ -48,6 +48,29 @@ import Testing
         #expect(!harness.flow.isSigningIn && !harness.flow.isPresentingSignIn)
     }
 
+    @Test func handoffOpenFailureLeavesAttemptRetryable() async {
+        // The default browser fails to launch on the handed-off attempt.
+        let harness = HostBrowserSignInFlowHarness(openSucceeds: false)
+        let attempt = Task { await harness.flow.signIn(timeout: 60) }
+        await harness.waitForSession()
+
+        harness.factory.sessions[0].deliver(URL(string: "https://example.test/handler/sign-in?after_auth_return_to=1")!)
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while harness.openedURLs.isEmpty, clock.now < deadline {
+            await Task.yield()
+        }
+
+        // The open was attempted but failed, so the attempt must not be locked
+        // into the handed-off state: a repeat sign-in click starts fresh.
+        #expect(harness.openedURLs.count == 1)
+        harness.flow.beginSignIn()
+        await harness.waitForSession(count: 2)
+        #expect(harness.factory.sessions.count == 2)
+
+        _ = await attempt.value
+    }
+
     @Test func staleNonAuthCompletionDoesNotOpenBrowser() async {
         let harness = HostBrowserSignInFlowHarness()
 

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTestSupport.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTestSupport.swift
@@ -3,12 +3,26 @@ import Foundation
 @testable import CmuxAuthRuntime
 
 @MainActor
+final class OpenedURLRecorder {
+    private(set) var urls: [URL] = []
+
+    func append(_ url: URL) {
+        urls.append(url)
+    }
+}
+
+@MainActor
 struct HostBrowserSignInFlowHarness {
     let flow: HostBrowserSignInFlow
     let coordinator: AuthCoordinator
     let client: FlowFakeAuthClient
     let tokenStore: FlowInMemoryTokenStore
     let factory: FakeBrowserAuthSessionFactory
+    private let openedURLRecorder: OpenedURLRecorder
+
+    var openedURLs: [URL] {
+        openedURLRecorder.urls
+    }
 
     init(
         user: CMUXAuthUser? = nil,
@@ -21,6 +35,7 @@ struct HostBrowserSignInFlowHarness {
         // like production. Split stores hide seed/capture/clear races.
         let tokenStore = FlowInMemoryTokenStore()
         let client = FlowFakeAuthClient(user: user, store: tokenStore)
+        let openedURLRecorder = OpenedURLRecorder()
         let coordinator = AuthCoordinator(
             client: client,
             sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),
@@ -38,6 +53,7 @@ struct HostBrowserSignInFlowHarness {
             callbackRouter: AuthCallbackRouter(),
             makeSignInURL: { URL(string: "https://example.test/handler/sign-in?cmux_auth_state=\($0)")! },
             callbackScheme: { "cmux-dev" },
+            openExternalURL: { openedURLRecorder.append($0) },
             clock: clock ?? ContinuousClock(),
             browserAttemptTimeout: browserAttemptTimeout,
             slowSignInThreshold: slowSignInThreshold
@@ -46,6 +62,7 @@ struct HostBrowserSignInFlowHarness {
         self.client = client
         self.tokenStore = tokenStore
         self.factory = factory
+        self.openedURLRecorder = openedURLRecorder
     }
 
     func callbackURL(state: String) -> URL {

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTestSupport.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTestSupport.swift
@@ -5,9 +5,12 @@ import Foundation
 @MainActor
 final class OpenedURLRecorder {
     private(set) var urls: [URL] = []
+    /// Return value for the opener seam, mimicking `NSWorkspace.open` success.
+    var openSucceeds = true
 
-    func append(_ url: URL) {
+    func append(_ url: URL) -> Bool {
         urls.append(url)
+        return openSucceeds
     }
 }
 
@@ -28,7 +31,8 @@ struct HostBrowserSignInFlowHarness {
         user: CMUXAuthUser? = nil,
         browserAttemptTimeout: TimeInterval = 5 * 60,
         slowSignInThreshold: TimeInterval = 30,
-        clock: (any Clock<Duration>)? = nil
+        clock: (any Clock<Duration>)? = nil,
+        openSucceeds: Bool = true
     ) {
         let store = FakeKeyValueStore()
         // The fake client reads and clears the SAME token store the flow seeds,
@@ -36,6 +40,7 @@ struct HostBrowserSignInFlowHarness {
         let tokenStore = FlowInMemoryTokenStore()
         let client = FlowFakeAuthClient(user: user, store: tokenStore)
         let openedURLRecorder = OpenedURLRecorder()
+        openedURLRecorder.openSucceeds = openSucceeds
         let coordinator = AuthCoordinator(
             client: client,
             sessionCache: CMUXAuthSessionCache(keyValueStore: store, key: "has_tokens"),

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/HostBrowserSignInFlowTests.swift
@@ -24,30 +24,6 @@ import Testing
         #expect(harness.flow.isSigningIn == false)
     }
 
-    @Test func nonAuthBrowserCompletionEndsPresentationAndAcceptsLateExternalCallback() async {
-        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
-        let harness = HostBrowserSignInFlowHarness(user: user)
-        let attempt = Task { await harness.flow.signIn(timeout: 60) }
-        await harness.waitForSession()
-        let callbackState = harness.callbackState(harness.factory.sessions[0])
-        harness.factory.sessions[0].deliver(URL(string: "https://example.test/handler/sign-in?after_auth_return_to=1")!)
-        await Task.yield()
-        #expect(harness.flow.isSigningIn)
-        #expect(!harness.flow.isPresentingSignIn && !harness.coordinator.isAuthenticated)
-        harness.flow.beginSignIn()
-        await Task.yield()
-        #expect(harness.flow.isPresentingSignIn && harness.flow.signInIsSlow)
-        #expect(harness.factory.sessions.count == 1)
-        let callbackResult = await harness.flow.handleCallbackURL(harness.callbackURL(state: callbackState))
-        #expect(callbackResult)
-        #expect(await attempt.value)
-        #expect(harness.coordinator.isAuthenticated)
-        #expect(harness.coordinator.currentUser == user)
-        #expect(await harness.tokenStore.getStoredRefreshToken() == "refresh-1")
-        #expect(await harness.tokenStore.getStoredAccessToken() == "access-1")
-        #expect(!harness.flow.isSigningIn && !harness.flow.isPresentingSignIn)
-    }
-
     @Test func cancelledPopupResolvesFalse() async {
         let harness = HostBrowserSignInFlowHarness()
         let attempt = Task { await harness.flow.signIn(timeout: 60) }

--- a/Sources/Auth/MacAuthComposition.swift
+++ b/Sources/Auth/MacAuthComposition.swift
@@ -125,7 +125,8 @@ struct MacAuthComposition {
             sessionFactory: ASWebBrowserAuthSessionFactory(anchor: anchor),
             callbackRouter: callbackRouter,
             makeSignInURL: { AuthEnvironment.signInURL(callbackState: $0) },
-            callbackScheme: { AuthEnvironment.callbackScheme }
+            callbackScheme: { AuthEnvironment.callbackScheme },
+            openExternalURL: { NSWorkspace.shared.open($0) }
         )
     }
 


### PR DESCRIPTION
## Summary

Follow-up to #7776 (issue #7728). #7776 stopped the Settings spinner from hanging after the macOS 26 Safari sign-in handoff, but it left sign-in **incomplete**: on Safari-as-default, `ASWebAuthenticationSession` immediately hands off to a Safari-hosted web-auth window that dies without rendering the flow, completing the session with the *start* URL (a non-auth "handoff" completion). #7776 cleared the presentation state but never advanced the attempt, so the user was silently left signed-out with no browser open — sign-in only worked with Chrome as default.

This PR makes the handoff actually complete: when the session returns that non-auth handoff completion, the flow keeps the original `signIn` continuation parked, clears only the presentation state, and **opens the same sign-in attempt URL (carrying `cmux_auth_state`) in the user's default browser** via an injected external-URL-opener seam. The real browser renders the hosted flow, the server redirects back to `cmux://auth-callback`, and the late callback resumes the original attempt with success — for **any** default browser, not just Chrome.

## Changes

- `HostBrowserSignInFlow`: on a non-auth handoff completion for the active attempt, open `makeSignInURL(state)` in the default browser (at most once per attempt via `handedOffAttemptID`), keep the continuation parked, and let the external callback complete it. Diagnostics helpers split into `HostBrowserSignInFlow+Diagnostics.swift` to stay under the file-length budget.
- `MacAuthComposition`: wire the opener seam to `NSWorkspace.shared.open`.
- Tests: injected fake opener; new `HostBrowserSignInFlowHandoffTests` asserts the opened URL and that a late callback completes the original attempt.

## Verification

Verified end-to-end on macOS 26 with **Safari as the default browser** against a tagged Debug build: sign-in → dead Safari handoff → `auth.browser.handoff.continueInDefaultBrowser` fires → real Safari tab opens the hosted flow → `auth.callback.external.received` → `signIn.result signedIn=true` → `cmux auth status` reports **Signed in**. This is the exact path that previously dead-ended.

The regression test is added red first (fails without the fix) then green, so CI proves it catches the bug.

Refs #7728, #7776

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7805"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786249534&installation_id=133855650&pr_number=7805&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7805&signature=6a52664e12205803bf8d0185a064c4083871b8d125776b8344c57e0b2b62d838"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches hosted-browser sign-in and callback routing, but existing state checks and new handoff tests limit regression risk.
> 
> **Overview**
> Fixes **macOS 26 Safari default-browser sign-in** when `ASWebAuthenticationSession` completes with a non-auth handoff URL instead of `cmux://auth-callback`. The flow now **opens the same sign-in URL** (with `cmux_auth_state`) in the default browser via an injected **`openExternalURL`** seam, **keeps the original attempt parked**, and completes when the external callback arrives.
> 
> **`beginSignIn()`** reuses an in-flight handed-off attempt (restores presentation without a new popup or second browser open). **`handedOffAttemptID`** limits external opens to once per attempt; if open fails, the attempt **ends with failure** so users can retry instead of waiting on a timeout. Stale non-auth completions are ignored.
> 
> Diagnostics helpers move to **`HostBrowserSignInFlow+Diagnostics.swift`**. **`MacAuthComposition`** wires the opener to **`NSWorkspace.shared.open`**. New **`HostBrowserSignInFlowHandoffTests`** cover continuation, open failure, and stale completion; the prior test that only cleared presentation is removed.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dcf48319a4e802ba2e8cbbdd0912c4a626e5678. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Safari default-browser handoff on macOS 26 by continuing sign-in in the user's default browser and completing the original session via the callback. If the browser fails to launch, the attempt now ends immediately with a clear failure so users can retry, addressing issue #7728.

- **Bug Fixes**
  - On non-auth handoff completion, keep the attempt parked and open the same sign-in URL (with `cmux_auth_state`) in the default browser exactly once; accept the late `cmux://` callback to finish. `beginSignIn()` reuses a handed-off attempt without replacing the popup or reopening the browser; state resets on completion/cancel.
  - Commit the handed-off state only if `openExternalURL` succeeds; on open failure, end the attempt with `browser_open_failed` so the user can retry immediately. Ignore stale non-auth completions. Added tests for default-browser continuation, open-failure immediate end, and stale-completion no-op.

- **Refactors**
  - Injected an external URL opener seam returning `Bool` (production uses `NSWorkspace.shared.open`) and moved diagnostics helpers to `HostBrowserSignInFlow+Diagnostics.swift` marked `nonisolated`.

<sup>Written for commit 6dcf48319a4e802ba2e8cbbdd0912c4a626e5678. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Hosted sign-in can now hand off non-auth completion to the default browser and continue the flow safely.
  * Added richer callback diagnostics for clearer sign-in handoff and result visibility.
* **Bug Fixes**
  * Prevented stale or late callbacks from re-opening browser handoffs or impacting replaced sessions.
  * Improved cleanup and state handling when browser handoff succeeds or fails.
* **Tests**
  * Added coverage for successful handoff, default-browser launch failure, and stale completion scenarios.
  * Removed a now-obsolete non-auth completion test case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->