### PR TITLE
Fix account.me test after Stack billing removal

### DIFF
--- a/web/tests/account-me-orpc.test.ts
+++ b/web/tests/account-me-orpc.test.ts
@@ -5,7 +5,6 @@ import { call } from "@orpc/server";
 
 import { accountMeProcedure } from "../orpc/server/account/me";
 import { generateOpenAPIDocument } from "../orpc/server/openapi";
-import { PRO_PRODUCT_ID } from "../services/billing/pro";
 
 // The two checked-in specs the Swift client and /api/openapi.json ship must
 // stay identical to what the router generates. Resolve relative to this test
@@ -17,8 +16,8 @@ const CHECKED_IN_SPECS = [
 
 // Drives the real resolveProPlanStatus (no module mocks, so it can't leak into
 // other test files). The fake user carries no `id`, so the Stripe-subscription
-// lookup short-circuits to false without touching a database, and the fake
-// user's Stack product list alone decides Pro vs Free.
+// lookup short-circuits to false without touching a database. Its product list
+// represents the removed Stack billing grant and must no longer confer Pro.
 type FakeProduct = {
   id: string;
   subscription: { currentPeriodEnd: Date | null } | null;
@@ -31,13 +30,15 @@ function productsPage(items: FakeProduct[]) {
   return page;
 }
 
-function fakeUser(opts: { email: string | null; pro: boolean }) {
+function fakeUser(opts: { email: string | null; legacyStackPro: boolean }) {
   return {
     primaryEmail: opts.email,
     clientReadOnlyMetadata: {},
     listProducts: async () =>
       productsPage(
-        opts.pro ? [{ id: PRO_PRODUCT_ID, subscription: null, quantity: 1 }] : [],
+        opts.legacyStackPro
+          ? [{ id: "pro", subscription: null, quantity: 1 }]
+          : [],
       ),
     update: async () => undefined,
   };
@@ -48,22 +49,24 @@ function context(user: unknown) {
 }
 
 describe("account.me", () => {
-  test("returns the Pro plan (external billing) for a Stack-Pro user", async () => {
+  test("does not grant Pro from a legacy Stack product", async () => {
     const result = await call(accountMeProcedure, undefined, {
-      context: context(fakeUser({ email: "a@example.com", pro: true })),
+      context: context(
+        fakeUser({ email: "a@example.com", legacyStackPro: true }),
+      ),
     });
     expect(result).toEqual({
       userId: "",
       email: "a@example.com",
-      planId: "pro",
-      isPro: true,
-      billingManagement: "external",
+      planId: "free",
+      isPro: false,
+      billingManagement: "none",
     });
   });
 
   test("returns the Free plan and an empty email for an email-less non-subscriber", async () => {
     const result = await call(accountMeProcedure, undefined, {
-      context: context(fakeUser({ email: null, pro: false })),
+      context: context(fakeUser({ email: null, legacyStackPro: false })),
     });
     expect(result.planId).toBe("free");
     expect(result.isPro).toBe(false);


### PR DESCRIPTION
## Summary
- remove the stale `PRO_PRODUCT_ID` test import deleted by the Stack billing removal
- verify the real `account.me` procedure ignores a legacy Stack Pro product and returns the Stripe-only Free state

## Testing
- `cd web && bun test tests/account-me-orpc.test.ts`
- `cd web && bun run typecheck`

## Context
- Related: https://github.com/manaflow-ai/cmux/commit/f248564423
- Related: https://github.com/manaflow-ai/cmux/commit/571742e3c6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786250188&installation_id=133855650&pr_number=7807&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7807&signature=c08ae59eb9a0e2f02f3f1226cefdd99d1f7da9137f51fd121cf5deba8ec10141"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only changes with no production code touched.
> 
> **Overview**
> Updates **`account-me-orpc.test.ts`** so it matches Stripe-only Pro resolution after Stack billing was removed.
> 
> The test that used to assert Stack Pro users get **`planId: "pro"`** now asserts a user with only a legacy Stack **`pro`** product gets **`free`**, **`isPro: false`**, and **`billingManagement: "none"`**. The **`PRO_PRODUCT_ID`** import is dropped; the fake user helper uses **`legacyStackPro`** and a hardcoded product id instead of **`pro: true`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4203094ace7ae68b5dc09877ce6123519078fd1b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the `account.me` test to remove the stale `PRO_PRODUCT_ID` from Stack billing and verify that a legacy Stack “Pro” product no longer grants Pro status. The test now expects the Stripe-only Free state (`planId: "free"`, `isPro: false`, `billingManagement: "none"`).

<sup>Written for commit 4203094ace7ae68b5dc09877ce6123519078fd1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated account plan handling so legacy Stack billing products correctly remain on the Free plan rather than receiving Pro access.
  * Confirmed expected Free-plan behavior for users without an active Pro subscription, including users without an email address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->