### PR TITLE
fix(web): unbreak main — account.me test dropped removed PRO_PRODUCT_ID

### DIFF
--- a/web/tests/account-me-orpc.test.ts
+++ b/web/tests/account-me-orpc.test.ts
@@ -5,7 +5,6 @@ import { call } from "@orpc/server";
 
 import { accountMeProcedure } from "../orpc/server/account/me";
 import { generateOpenAPIDocument } from "../orpc/server/openapi";
-import { PRO_PRODUCT_ID } from "../services/billing/pro";
 
 // The two checked-in specs the Swift client and /api/openapi.json ship must
 // stay identical to what the router generates. Resolve relative to this test
@@ -15,60 +14,42 @@ const CHECKED_IN_SPECS = [
   "../../Packages/Shared/CmuxAPIClient/Sources/CmuxAPIClient/openapi.json",
 ] as const;
 
-// Drives the real resolveProPlanStatus (no module mocks, so it can't leak into
-// other test files). The fake user carries no `id`, so the Stripe-subscription
-// lookup short-circuits to false without touching a database, and the fake
-// user's Stack product list alone decides Pro vs Free.
-type FakeProduct = {
-  id: string;
-  subscription: { currentPeriodEnd: Date | null } | null;
-  quantity: number;
-};
-
-function productsPage(items: FakeProduct[]) {
-  const page = [...items] as FakeProduct[] & { nextCursor: string | null };
-  page.nextCursor = null;
-  return page;
-}
-
-function fakeUser(opts: { email: string | null; pro: boolean }) {
-  return {
-    primaryEmail: opts.email,
-    clientReadOnlyMetadata: {},
-    listProducts: async () =>
-      productsPage(
-        opts.pro ? [{ id: PRO_PRODUCT_ID, subscription: null, quantity: 1 }] : [],
-      ),
-    update: async () => undefined,
-  };
-}
-
+// Drives the real resolveProPlanStatus with no module mocks, so nothing leaks
+// into other test files. Pro is resolved from Stripe subscriptions; the fake
+// user carries no `id`, so that lookup short-circuits to false without touching
+// a database, and account.me maps the resulting Free plan onto its response.
 function context(user: unknown) {
   return { request: new Request("http://localhost/api/rpc"), user } as never;
 }
 
+function fakeUser(email: string | null) {
+  return {
+    primaryEmail: email,
+    clientReadOnlyMetadata: {},
+    update: async () => undefined,
+  };
+}
+
 describe("account.me", () => {
-  test("returns the Pro plan (external billing) for a Stack-Pro user", async () => {
+  test("maps the resolved plan and email onto the response for a non-subscriber", async () => {
     const result = await call(accountMeProcedure, undefined, {
-      context: context(fakeUser({ email: "a@example.com", pro: true })),
+      context: context(fakeUser("a@example.com")),
     });
     expect(result).toEqual({
       userId: "",
       email: "a@example.com",
-      planId: "pro",
-      isPro: true,
-      billingManagement: "external",
+      planId: "free",
+      isPro: false,
+      billingManagement: "none",
     });
   });
 
-  test("returns the Free plan and an empty email for an email-less non-subscriber", async () => {
+  test("defaults an absent email to an empty string", async () => {
     const result = await call(accountMeProcedure, undefined, {
-      context: context(fakeUser({ email: null, pro: false })),
+      context: context(fakeUser(null)),
     });
-    expect(result.planId).toBe("free");
-    expect(result.isPro).toBe(false);
     expect(result.email).toBe("");
-    expect(result.billingManagement).toBe("none");
+    expect(result.planId).toBe("free");
   });
 
   test("rejects unauthenticated callers before resolving a plan", async () => {


### PR DESCRIPTION
**Main is red.** #7757 (account.me) and #7662 (legacy Stack billing removal) were each green, but conflict once both landed: #7662 deleted `PRO_PRODUCT_ID` and made `resolveProPlanStatus` Stripe-only (no more `listProducts`), while #7757's `account-me-orpc.test.ts` imported `PRO_PRODUCT_ID` and drove Pro through a fake Stack product list. The squash-merges didn't re-run CI against the combined tree, so `web-typecheck`/`tests` broke on main.

This rewrites the test for the post-#7662 world:
- no `PRO_PRODUCT_ID` import, no Stack-product fake;
- drives the real (now Stripe-only) `resolveProPlanStatus` with an id-less user so the Stripe lookup short-circuits to `false` without a database;
- asserts `account.me` maps the Free plan + email onto its response, plus the auth gate and the OpenAPI operation/byte-identity checks.

`bun run typecheck` clean; full web suite green (566 pass / 0 fail). Test-only change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7808"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786250409&installation_id=133855650&pr_number=7808&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7808&signature=d22fbc7bc083d6d14702190525ea17840ff96234b7ebc3874913d684113a6ed8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change with no production code or billing logic modified.
> 
> **Overview**
> **Fixes a broken main** after legacy Stack billing removal left `account-me-orpc.test.ts` importing deleted `PRO_PRODUCT_ID` and faking Pro via `listProducts`.
> 
> The suite is rewritten for **Stripe-only** `resolveProPlanStatus`: no billing constant import, no Stack product fakes, and a slimmer `fakeUser` that only supplies email. Comments now describe short-circuiting the Stripe lookup with an **id-less** user so the real resolver returns Free without a database.
> 
> Assertions shift from a Stack-Pro scenario to **non-subscriber** mapping (`free`, `isPro: false`, `billingManagement: "none"`) plus email defaults; auth rejection and OpenAPI checks are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a694a3a943dc16142195f84e5993b6949728e47. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broken main by rewriting the `account.me` test for the Stripe-only billing flow after legacy Stack removal. Removes the `PRO_PRODUCT_ID` import and updates assertions to reflect a Free plan for non-subscribers.

- **Bug Fixes**
  - Updated `account-me-orpc.test.ts` to stop using `PRO_PRODUCT_ID` and Stack `listProducts`.
  - Drives real `resolveProPlanStatus` with an id-less user; asserts Free plan, email mapping, and default empty email.
  - Keeps auth gate and OpenAPI/byte-identity checks. Test-only change.

<sup>Written for commit 2a694a3a943dc16142195f84e5993b6949728e47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated account status test coverage to use the standard account flow.
  * Added verification that non-subscribers receive the free plan with no billing management options.
  * Added coverage for accounts with a missing email address, which now default to the free plan.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->