### PR TITLE
Checkout buttons: spinner + direct Stripe redirect (no blank /api page)

### DIFF
--- a/web/app/[locale]/components/pro-cta-link.tsx
+++ b/web/app/[locale]/components/pro-cta-link.tsx
@@ -5,6 +5,7 @@ import {
   pricingActionClassName,
   type PricingActionSize,
 } from "../../components/pricing-shared";
+import { CheckoutSpinner, useCheckoutRedirect } from "../../components/checkout-navigation";
 import {
   isClientConfigFlagEnabled,
   useClientConfigFlag,
@@ -40,19 +41,26 @@ export function ProCtaLink({
         flagEnabled,
         FEATURE_FLAGS.proCheckout.defaultWhenUnavailable,
       ));
+  const href = checkout ? checkoutHref : fallbackHref;
+  const { pending, start } = useCheckoutRedirect();
   return (
     <a
-      href={checkout ? checkoutHref : fallbackHref}
-      onClick={() =>
-        posthog.capture("cmuxterm_pro_cta_clicked", {
-          location,
-          checkout,
-        })
-      }
+      href={href}
+      onClick={(event) => {
+        posthog.capture("cmuxterm_pro_cta_clicked", { location, checkout });
+        // Only the checkout href is intercepted for the spinner; the download
+        // fallback navigates normally.
+        start(href, event);
+      }}
+      aria-busy={pending}
       className={pricingActionClassName("primary", size)}
-      style={{ color: "var(--background)", textDecoration: "none" }}
+      style={{
+        color: "var(--background)",
+        textDecoration: "none",
+        pointerEvents: pending ? "none" : undefined,
+      }}
     >
-      {children}
+      {pending ? <CheckoutSpinner /> : children}
     </a>
   );
 }

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -25,6 +25,7 @@ import {
   type FaqItem,
   type SizeRow,
 } from "../../components/pricing-shared";
+import { CheckoutButton } from "../../components/checkout-navigation";
 
 // The Pro CTA destination is decided at runtime by the proCheckout PostHog
 // flag inside <ProCtaLink> (see app/lib/feature-flags.ts); the download
@@ -136,7 +137,7 @@ export default async function PricingPage({
             price={t("team.price")}
             period={t("perUserMonth")}
           >
-            <PrimaryLink href={TEAM_CHECKOUT_URL}>{t("team.cta")}</PrimaryLink>
+            <CheckoutButton href={TEAM_CHECKOUT_URL}>{t("team.cta")}</CheckoutButton>
             <p className="mt-5 text-sm font-medium">{t("team.featuresLead")}</p>
             <FeatureList items={teamFeatures} />
           </PlanCard>
@@ -195,9 +196,9 @@ export default async function PricingPage({
                 )
               ),
               team: (
-                <PrimaryLink href={TEAM_CHECKOUT_URL} size="compact">
+                <CheckoutButton href={TEAM_CHECKOUT_URL} size="compact">
                   {t("team.cta")}
-                </PrimaryLink>
+                </CheckoutButton>
               ),
               enterprise: (
                 <SecondaryLink href={ENTERPRISE_CTA_URL} size="compact">

--- a/web/app/api/billing/checkout/route.ts
+++ b/web/app/api/billing/checkout/route.ts
@@ -25,7 +25,23 @@ type CheckoutStackServerApp = StackServerApp<true>;
 
 // One-click upgrade entrypoint. Signed-out visitors become anonymous Stack
 // users first, then go straight to Stripe Checkout.
-export async function GET(request: NextRequest) {
+//
+// Default: a browser navigation that 302s to Stripe (works with no JS).
+// With `?format=json`: run the same logic, then hand the client the resolved
+// destination as `{ url }` so a button can show a spinner and redirect itself
+// instead of flashing this route's blank page. The url is whatever we would
+// have redirected to — the Stripe Checkout URL on success, or a /pricing state
+// URL otherwise — so the client just navigates to it either way.
+export async function GET(request: NextRequest): Promise<NextResponse> {
+  const response = await resolveCheckout(request);
+  if (request.nextUrl.searchParams.get("format") !== "json") return response;
+  const location = response.headers.get("location");
+  return NextResponse.json({
+    url: location ?? new URL("/pricing?billing=error", request.url).toString(),
+  });
+}
+
+async function resolveCheckout(request: NextRequest): Promise<NextResponse> {
   if (
     isAppStoreDistributionMode({
       cmux_distribution: request.nextUrl.searchParams.get("cmux_distribution"),

--- a/web/app/app-pricing/page.tsx
+++ b/web/app/app-pricing/page.tsx
@@ -28,6 +28,7 @@ import {
   type FaqItem,
   type SizeRow,
 } from "../components/pricing-shared";
+import { CheckoutButton } from "../components/checkout-navigation";
 
 const ENTERPRISE_CTA_URL = "/enterprise";
 const pricing = enMessages.pricing;
@@ -128,7 +129,7 @@ export default async function AppPricingPage({
               ) : appStorePaymentGated ? (
                 <DisabledButton>{pricing.billingUnavailable}</DisabledButton>
               ) : (
-                <PrimaryLink href={proCheckoutURL}>{pricing.pro.cta}</PrimaryLink>
+                <CheckoutButton href={proCheckoutURL}>{pricing.pro.cta}</CheckoutButton>
               )}
               <p className="mt-5 text-sm font-medium">
                 {pricing.pro.featuresLead}
@@ -144,7 +145,7 @@ export default async function AppPricingPage({
               {appStorePaymentGated ? (
                 <DisabledButton>{pricing.billingUnavailable}</DisabledButton>
               ) : (
-                <PrimaryLink href={teamCheckoutURL}>{pricing.team.cta}</PrimaryLink>
+                <CheckoutButton href={teamCheckoutURL}>{pricing.team.cta}</CheckoutButton>
               )}
               <p className="mt-5 text-sm font-medium">
                 {pricing.team.featuresLead}
@@ -200,16 +201,16 @@ export default async function AppPricingPage({
                 ) : appStorePaymentGated ? (
                   <DisabledButton size="compact">{pricing.billingUnavailable}</DisabledButton>
                 ) : (
-                  <PrimaryLink href={proCheckoutURL} size="compact">
+                  <CheckoutButton href={proCheckoutURL} size="compact">
                     {pricing.pro.cta}
-                  </PrimaryLink>
+                  </CheckoutButton>
                 ),
                 team: appStorePaymentGated ? (
                   <DisabledButton size="compact">{pricing.billingUnavailable}</DisabledButton>
                 ) : (
-                  <PrimaryLink href={teamCheckoutURL} size="compact">
+                  <CheckoutButton href={teamCheckoutURL} size="compact">
                     {pricing.team.cta}
-                  </PrimaryLink>
+                  </CheckoutButton>
                 ),
                 enterprise: appStorePaymentGated ? (
                   <DisabledButton size="compact">{pricing.billingUnavailable}</DisabledButton>

--- a/web/app/components/checkout-navigation.tsx
+++ b/web/app/components/checkout-navigation.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import { useCallback, useState, type CSSProperties, type MouseEvent, type ReactNode } from "react";
+
+import { pricingActionClassName, type PricingActionSize } from "./pricing-shared";
+
+const CHECKOUT_PATH = "/api/billing/checkout";
+
+// Intercepts a checkout link click: instead of navigating to the checkout route
+// (which flashes a blank page while it builds the Stripe session server-side),
+// fetch the resolved destination as JSON and redirect the browser straight
+// there, keeping a spinner on the button until the page leaves.
+export function useCheckoutRedirect() {
+  const [pending, setPending] = useState(false);
+
+  const start = useCallback(
+    (href: string, event?: MouseEvent<HTMLAnchorElement>) => {
+      // Let anything that isn't a plain left-click fall through to the browser's
+      // default navigation (new tab, download, etc.), and only intercept the
+      // checkout route so non-checkout hrefs (e.g. the download fallback) behave
+      // as ordinary links.
+      if (
+        event &&
+        (event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey)
+      ) {
+        return;
+      }
+      if (!href.startsWith(CHECKOUT_PATH)) return;
+      event?.preventDefault();
+      if (pending) return;
+      setPending(true);
+
+      const separator = href.includes("?") ? "&" : "?";
+      void fetch(`${href}${separator}format=json`, {
+        headers: { accept: "application/json" },
+      })
+        .then((response) => response.json())
+        .then((data: unknown) => {
+          const url =
+            data && typeof data === "object" && typeof (data as { url?: unknown }).url === "string"
+              ? (data as { url: string }).url
+              : href;
+          window.location.assign(url);
+        })
+        .catch(() => {
+          // Network/JSON failure: fall back to the plain navigation, which the
+          // route still handles with a server-side 302.
+          window.location.assign(href);
+        });
+    },
+    [pending],
+  );
+
+  return { pending, start };
+}
+
+export function CheckoutSpinner() {
+  return (
+    <svg
+      className="animate-spin"
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+      style={{ display: "inline-block", verticalAlign: "-2px" }}
+    >
+      <circle cx="12" cy="12" r="9" stroke="currentColor" strokeOpacity="0.3" strokeWidth="3" />
+      <path d="M21 12a9 9 0 0 0-9-9" stroke="currentColor" strokeWidth="3" strokeLinecap="round" />
+    </svg>
+  );
+}
+
+const PRIMARY_LINK_STYLE: CSSProperties = {
+  color: "var(--button-foreground, var(--background))",
+  textDecoration: "none",
+};
+
+// A "Get Pro" / "Get Team" checkout button: renders as an anchor (so it works
+// without JS and supports open-in-new-tab), but on a plain click it shows a
+// spinner and redirects straight to Stripe.
+export function CheckoutButton({
+  href,
+  children,
+  size = "default",
+  onClick,
+}: {
+  href: string;
+  children: ReactNode;
+  size?: PricingActionSize;
+  onClick?: (event: MouseEvent<HTMLAnchorElement>) => void;
+}) {
+  const { pending, start } = useCheckoutRedirect();
+  return (
+    <a
+      href={href}
+      onClick={(event) => {
+        onClick?.(event);
+        start(href, event);
+      }}
+      aria-busy={pending}
+      className={pricingActionClassName("primary", size)}
+      style={{ ...PRIMARY_LINK_STYLE, pointerEvents: pending ? "none" : undefined }}
+    >
+      {pending ? <CheckoutSpinner /> : children}
+    </a>
+  );
+}

--- a/web/tests/billing-checkout-route.test.ts
+++ b/web/tests/billing-checkout-route.test.ts
@@ -215,6 +215,35 @@ describe("billing checkout route", () => {
     });
   });
 
+  test("format=json returns the Stripe URL as JSON instead of a 302", async () => {
+    stripeConfigured = true;
+    userResponses = [null, anonymousUser];
+
+    const response = await GET(
+      new NextRequest("https://cmux.test/api/billing/checkout?format=json"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      url: "https://checkout.stripe.com/c/session",
+    });
+    expect(createdStripeSessions).toHaveLength(1);
+  });
+
+  test("format=json returns the redirect destination as JSON when Stripe is unconfigured", async () => {
+    stripeConfigured = false;
+
+    const response = await GET(
+      new NextRequest("https://cmux.test/api/billing/checkout?format=json"),
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({
+      url: "https://cmux.test/pricing?billing=unavailable",
+    });
+    expect(createStripeSession).not.toHaveBeenCalled();
+  });
+
   test("uses yearly Stripe price when interval is year", async () => {
     stripeConfigured = true;
     userResponses = [signedInUser];


### PR DESCRIPTION
Clicking **Get Pro** / **Get Team** navigated to `/api/billing/checkout`, which built the Stripe session server-side and then 302'd to Stripe — so you saw that route's blank page for the 300–800ms round-trip. Now the buttons show a spinner and redirect straight to Stripe.

## How
- **Route:** `GET /api/billing/checkout?format=json` runs the exact same logic, then returns the destination as `{ url }` instead of a 302. The url is whatever it would have redirected to (the Stripe Checkout URL on success, or a `/pricing?...` state URL otherwise), so the client just navigates to it either way. The plain navigation still 302s — a no-JS fallback.
- **Client:** `CheckoutButton` / `useCheckoutRedirect` render as an `<a>` (open-in-new-tab and no-JS still work) but intercept a plain left-click: spinner on, fetch the JSON, `window.location.assign(url)`. Wired into the Get Pro / Get Team CTAs on `app-pricing` and `[locale]/pricing`, and into `ProCtaLink` (the PostHog-flagged pro CTA). Download/fallback links are untouched.

No hover prefetch (it would mint side-effectful Stripe sessions for everyone who hovers) and no new user-facing strings (the spinner is visual + `aria-busy`).

## Verification
- `bun run typecheck` clean; full web suite green.
- New route tests: `format=json` returns the Stripe URL as JSON on success, and the `/pricing?billing=unavailable` destination as JSON when Stripe is unconfigured (no session created).

Web-only (no Swift); Vercel preview below.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7810"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786250799&installation_id=133855650&pr_number=7810&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7810&signature=1c347344da1bb7ce78b7aa2f646cadf6064a2d5a2de9c64cca1b4f39ec0faef7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the billing checkout entry path and client redirect behavior; server checkout logic is unchanged with 302 and fetch fallbacks, but a JSON/client bug could affect paid upgrade flows.
> 
> **Overview**
> **Get Pro** / **Get Team** no longer send users through a blank `/api/billing/checkout` page while Stripe sessions are created. Checkout CTAs stay real `<a>` links (no-JS and open-in-new-tab still work), but a plain left-click shows a spinner and navigates straight to the final destination.
> 
> The checkout API gains `?format=json`, which runs the same logic as before and returns `{ url }` (Stripe Checkout or a `/pricing?billing=…` URL) instead of a 302. **`CheckoutButton`** and **`useCheckoutRedirect`** fetch that JSON and call `window.location.assign`; on failure they fall back to the original href. **`ProCtaLink`** only intercepts the checkout href—the download fallback is unchanged.
> 
> Wired on **`[locale]/pricing`**, **`app-pricing`**, and compare-table team CTAs; tests cover JSON success and unconfigured Stripe.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3f97ec478ada7b8eb85c2afaff3ccae727ba258. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Checkout buttons now show a spinner and redirect straight to Stripe, removing the blank `/api` page flash. No-JS users still get the normal 302 redirect.

- **New Features**
  - `GET /api/billing/checkout?format=json` returns `{ url }` for the same destination the route would 302 to; default navigation still 302s.
  - Added `CheckoutButton` and `useCheckoutRedirect`: anchors that intercept a plain left-click, show a spinner, fetch JSON, and `window.location.assign(url)`; open-in-new-tab and no-JS work.
  - Integrated into `app-pricing`, `[locale]/pricing`, and `ProCtaLink`; download/fallback links unchanged.
  - Added tests for JSON responses when Stripe is configured or unavailable.

<sup>Written for commit c3f97ec478ada7b8eb85c2afaff3ccae727ba258. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added streamlined checkout navigation for Pro and Team pricing actions.
  - Checkout links now show a loading indicator and prevent duplicate interactions while processing.
  - Added JSON support for retrieving checkout destinations.

- **Bug Fixes**
  - Checkout failures now fall back to standard navigation.
  - Billing-unavailable scenarios provide a consistent fallback destination.

- **Tests**
  - Added coverage for successful and unavailable JSON checkout responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->