### PR TITLE
Make pane-divider resize cursors easier to hit and stop cursor bleed-through from occluded windows

### DIFF
--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -240,6 +240,7 @@ final class WindowBrowserHostView: NSView {
     private var splitDividerResizeObserver: NSObjectProtocol?
     private var trackingArea: NSTrackingArea?
     private var activeDividerCursorKind: DividerCursorKind?
+    private let dividerCursorOcclusion = PortalDividerCursorOcclusion()
     private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
     private var lastHostedInspectorLayoutBoundsSize: NSSize?
 
@@ -347,7 +348,7 @@ final class WindowBrowserHostView: NSView {
         super.resetCursorRects()
         invalidateSplitDividerRegionCache()
         let regions = splitDividerRegions()
-        let expansion: CGFloat = 4
+        let expansion = PortalSplitDividerRegion.dividerHitExpansion
         for region in regions {
             var rectInHost = convert(region.rectInWindow, from: nil)
             rectInHost = rectInHost.insetBy(
@@ -766,6 +767,10 @@ final class WindowBrowserHostView: NSView {
         let nextKind = resolvedDividerHit?.kind ?? (resolvedHostedInspectorHit == nil ? nil : .vertical)
         guard let nextKind else {
             clearActiveDividerCursor(restoreArrow: true)
+            return
+        }
+        guard dividerCursorOcclusion.mayAssertDividerCursor(in: window) else {
+            clearActiveDividerCursor(restoreArrow: false)
             return
         }
         activeDividerCursorKind = nextKind

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -215,17 +215,7 @@ final class WindowBrowserHostView: NSView {
         let initialInspectorFrame: NSRect
     }
 
-    private enum DividerCursorKind: Equatable {
-        case vertical
-        case horizontal
-
-        var cursor: NSCursor {
-            switch self {
-            case .vertical: return .resizeLeftRight
-            case .horizontal: return .resizeUpDown
-            }
-        }
-    }
+    private typealias DividerCursorKind = PortalDividerCursorKind
 
     override var isOpaque: Bool { false }
     private static let sidebarLeadingEdgeEpsilon: CGFloat = 1

--- a/Sources/DockSplitStore+Appearance.swift
+++ b/Sources/DockSplitStore+Appearance.swift
@@ -45,6 +45,7 @@ extension DockSplitStore {
             // orientations while still keeping a usable floor.
             minimumPaneWidth: Self.minimumDockPaneSize,
             minimumPaneHeight: Self.minimumDockPaneSize,
+            dividerHitExpansion: PortalSplitDividerRegion.dividerHitExpansion,
             splitButtonBackdropEffect: Workspace.bonsplitSplitButtonBackdropEffect(),
             splitButtonTooltips: Workspace.currentSplitButtonTooltips(),
             enableAnimations: false,

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5503,6 +5503,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         private static let adaptiveBottomDockRequestCooldown: TimeInterval = 0.25
         private var trackingArea: NSTrackingArea?
         private var activeDividerCursorKind: DividerCursorKind?
+        private let dividerCursorOcclusion = PortalDividerCursorOcclusion()
         private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
         private var preferredHostedInspectorWidth: CGFloat?
         private var preferredHostedInspectorWidthFraction: CGFloat?
@@ -6664,6 +6665,10 @@ struct WebViewRepresentable: NSViewRepresentable {
             }
             guard resolvedHostedInspectorHit != nil else {
                 clearActiveDividerCursor(restoreArrow: true)
+                return
+            }
+            guard dividerCursorOcclusion.mayAssertDividerCursor(in: window) else {
+                clearActiveDividerCursor(restoreArrow: false)
                 return
             }
             activeDividerCursorKind = .vertical

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5491,18 +5491,13 @@ struct WebViewRepresentable: NSViewRepresentable {
             let initialInspectorFrame: NSRect
         }
 
-        private enum DividerCursorKind: Equatable {
-            case vertical
-
-            var cursor: NSCursor { .resizeLeftRight }
-        }
 
         private static let hostedInspectorDividerHitExpansion: CGFloat = 10
         private static let minimumHostedInspectorWidth: CGFloat = 120
         private static let minimumHostedInspectorPageWidthForSideDock: CGFloat = 240
         private static let adaptiveBottomDockRequestCooldown: TimeInterval = 0.25
         private var trackingArea: NSTrackingArea?
-        private var activeDividerCursorKind: DividerCursorKind?
+        private var activeDividerCursorKind: PortalDividerCursorKind?
         private let dividerCursorOcclusion = PortalDividerCursorOcclusion()
         private var hostedInspectorDividerDrag: HostedInspectorDividerDragState?
         private var preferredHostedInspectorWidth: CGFloat?

--- a/Sources/PortalSplitDividerRegion.swift
+++ b/Sources/PortalSplitDividerRegion.swift
@@ -13,8 +13,20 @@ struct PortalDividerCursorOcclusion {
         return windowNumber > 0 ? windowNumber : nil
     }
 
+    var isLeftMouseButtonPressed: () -> Bool = {
+        (NSEvent.pressedMouseButtons & 1) != 0
+    }
+
     func mayAssertDividerCursor(screenPoint: NSPoint, windowNumber: Int) -> Bool {
         topmostMouseEventWindowNumber(screenPoint) == windowNumber
+    }
+
+    /// Hit-test callers see pointer-drag events too. An in-flight left-button
+    /// drag keeps the resize cursor: drag events only arrive after a
+    /// legitimate mouse-down on this window, and the divider being dragged may
+    /// momentarily sit under an overlapping window without the drag ending.
+    func mayAssertDividerCursorDuringHitTest(in window: NSWindow?) -> Bool {
+        isLeftMouseButtonPressed() || mayAssertDividerCursor(in: window)
     }
 
     func mayAssertDividerCursor(in window: NSWindow?) -> Bool {

--- a/Sources/PortalSplitDividerRegion.swift
+++ b/Sources/PortalSplitDividerRegion.swift
@@ -26,6 +26,20 @@ struct PortalDividerCursorOcclusion {
     }
 }
 
+/// Orientation of a hovered split divider and the resize cursor it shows.
+/// Shared by the portal host views and the hosted web-inspector divider.
+enum PortalDividerCursorKind: Equatable {
+    case vertical
+    case horizontal
+
+    var cursor: NSCursor {
+        switch self {
+        case .vertical: return .resizeLeftRight
+        case .horizontal: return .resizeUpDown
+        }
+    }
+}
+
 @MainActor
 final class PortalSplitDividerRegion {
     weak var splitView: NSSplitView?

--- a/Sources/PortalSplitDividerRegion.swift
+++ b/Sources/PortalSplitDividerRegion.swift
@@ -1,5 +1,31 @@
 import AppKit
 
+/// Divider hover cursors are asserted manually from `.activeAlways` tracking
+/// areas, which AppKit delivers even when another window covers this one at
+/// the pointer. Gate `NSCursor.set()` on the host window actually being the
+/// topmost mouse target so a backgrounded window cannot flip the cursor
+/// through an overlapping window (same bug class as the sidebar resizer
+/// occlusion fix).
+@MainActor
+struct PortalDividerCursorOcclusion {
+    var topmostMouseEventWindowNumber: (NSPoint) -> Int? = { screenPoint in
+        let windowNumber = NSWindow.windowNumber(at: screenPoint, belowWindowWithWindowNumber: 0)
+        return windowNumber > 0 ? windowNumber : nil
+    }
+
+    func mayAssertDividerCursor(screenPoint: NSPoint, windowNumber: Int) -> Bool {
+        topmostMouseEventWindowNumber(screenPoint) == windowNumber
+    }
+
+    func mayAssertDividerCursor(in window: NSWindow?) -> Bool {
+        guard let window else { return false }
+        return mayAssertDividerCursor(
+            screenPoint: NSEvent.mouseLocation,
+            windowNumber: window.windowNumber
+        )
+    }
+}
+
 @MainActor
 final class PortalSplitDividerRegion {
     weak var splitView: NSSplitView?
@@ -10,7 +36,11 @@ final class PortalSplitDividerRegion {
     let isVertical: Bool
     let isInHostedContent: Bool
 
-    static let dividerHitExpansion: CGFloat = 5
+    /// Extra points on each side of the hairline divider that show the resize
+    /// cursor and accept a divider drag. Bonsplit's drag effective rect is fed
+    /// the same value (see `Workspace.bonsplitAppearance`), so every point
+    /// that shows the cursor can start a drag.
+    static let dividerHitExpansion: CGFloat = 8
 
     init(
         splitView: NSSplitView,

--- a/Sources/PortalSplitDividerRegion.swift
+++ b/Sources/PortalSplitDividerRegion.swift
@@ -13,20 +13,8 @@ struct PortalDividerCursorOcclusion {
         return windowNumber > 0 ? windowNumber : nil
     }
 
-    var isLeftMouseButtonPressed: () -> Bool = {
-        (NSEvent.pressedMouseButtons & 1) != 0
-    }
-
     func mayAssertDividerCursor(screenPoint: NSPoint, windowNumber: Int) -> Bool {
         topmostMouseEventWindowNumber(screenPoint) == windowNumber
-    }
-
-    /// Hit-test callers see pointer-drag events too. An in-flight left-button
-    /// drag keeps the resize cursor: drag events only arrive after a
-    /// legitimate mouse-down on this window, and the divider being dragged may
-    /// momentarily sit under an overlapping window without the drag ending.
-    func mayAssertDividerCursorDuringHitTest(in window: NSWindow?) -> Bool {
-        isLeftMouseButtonPressed() || mayAssertDividerCursor(in: window)
     }
 
     func mayAssertDividerCursor(in window: NSWindow?) -> Bool {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -109,13 +109,11 @@ final class WindowTerminalHostView: NSView {
     }
 
     override func cursorUpdate(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        updateDividerCursor(at: point)
+        updateDividerCursor(at: convert(event.locationInWindow, from: nil))
     }
 
     override func mouseMoved(with event: NSEvent) {
-        let point = convert(event.locationInWindow, from: nil)
-        updateDividerCursor(at: point)
+        updateDividerCursor(at: convert(event.locationInWindow, from: nil))
     }
 
     override func mouseExited(with event: NSEvent) {
@@ -153,17 +151,8 @@ final class WindowTerminalHostView: NSView {
             }
 
             if let kind = splitDividerCursorKind(at: point) {
-                // Hover events reach hit testing even when this window is occluded.
-                if dividerCursorOcclusion.mayAssertDividerCursorDuringHitTest(in: window) {
-                    activeDividerCursorKind = kind
-                    kind.cursor.set()
-                } else {
-                    clearActiveDividerCursor(restoreArrow: false)
-                }
-                TerminalWindowPortalRegistry.noteSplitDividerInteraction(
-                    in: window,
-                    event: currentEvent
-                )
+                assertDividerCursor(kind)
+                TerminalWindowPortalRegistry.noteSplitDividerInteraction(in: window, event: currentEvent)
                 return nil
             }
 
@@ -346,12 +335,18 @@ final class WindowTerminalHostView: NSView {
             clearActiveDividerCursor(restoreArrow: true)
             return
         }
-        guard dividerCursorOcclusion.mayAssertDividerCursor(in: window) else {
+        assertDividerCursor(nextKind)
+    }
+
+    // A registry-latched divider drag owned by this window bypasses occlusion; a pressed button alone is not ownership.
+    private func assertDividerCursor(_ kind: DividerCursorKind) {
+        guard TerminalWindowPortalRegistry.isSplitDividerDragActive(in: window)
+            || dividerCursorOcclusion.mayAssertDividerCursor(in: window) else {
             clearActiveDividerCursor(restoreArrow: false)
             return
         }
-        activeDividerCursorKind = nextKind
-        nextKind.cursor.set()
+        activeDividerCursorKind = kind
+        kind.cursor.set()
     }
 
     private func clearActiveDividerCursor(restoreArrow: Bool) {
@@ -1863,6 +1858,11 @@ enum TerminalWindowPortalRegistry {
         }
 
         return false
+    }
+
+    fileprivate static func isSplitDividerDragActive(in window: NSWindow?) -> Bool {
+        guard let window, isCurrentEventSplitDividerDrag() else { return false }
+        return activeSplitDividerDragWindowId == ObjectIdentifier(window)
     }
 
     private static func clearActiveSplitDividerDrag() {

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -360,8 +360,7 @@ final class WindowTerminalHostView: NSView {
 
     private func splitDividerCursorKind(at point: NSPoint) -> DividerCursorKind? {
         guard window != nil else { return nil }
-        let windowPoint = convert(point, to: nil)
-        return Self.dividerCursorKind(at: windowPoint, in: splitDividerRegions(), checkLiveness: false)
+        return Self.dividerCursorKind(at: convert(point, to: nil), in: splitDividerRegions(), checkLiveness: false)
     }
 
     static func hasSplitDivider(atScreenPoint screenPoint: NSPoint, in window: NSWindow) -> Bool {
@@ -1870,9 +1869,10 @@ enum TerminalWindowPortalRegistry {
         activeSplitDividerDragEventNumber = nil
     }
 
+    // Only the event's own window may latch drag ownership: a foreign drag routed through an occluded host must not self-authorize its cursor.
     fileprivate static func noteSplitDividerInteraction(in window: NSWindow?, event: NSEvent?) {
-        guard let window, let event else { return }
-        guard (NSEvent.pressedMouseButtons & 1) != 0 else { return }
+        guard let window, let event, event.window === window,
+              (NSEvent.pressedMouseButtons & 1) != 0 else { return }
 
         switch event.type {
         case .leftMouseDown, .leftMouseDragged:

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -34,6 +34,7 @@ final class WindowTerminalHostView: NSView {
     private var splitDividerResizeObserver: NSObjectProtocol?
     private var trackingArea: NSTrackingArea?
     private var activeDividerCursorKind: DividerCursorKind?
+    private let dividerCursorOcclusion = PortalDividerCursorOcclusion()
     let paneDropRoutingSession = PaneDropRoutingSession()
 #if DEBUG
     private var lastDragRouteSignature: String?
@@ -85,7 +86,7 @@ final class WindowTerminalHostView: NSView {
         super.resetCursorRects()
         invalidateSplitDividerRegionCache()
         let regions = splitDividerRegions()
-        let expansion: CGFloat = 4
+        let expansion = PortalSplitDividerRegion.dividerHitExpansion
         for region in regions {
             var rectInHost = convert(region.rectInWindow, from: nil)
             rectInHost = rectInHost.insetBy(
@@ -348,6 +349,10 @@ final class WindowTerminalHostView: NSView {
 
         guard let nextKind = splitDividerCursorKind(at: point) else {
             clearActiveDividerCursor(restoreArrow: true)
+            return
+        }
+        guard dividerCursorOcclusion.mayAssertDividerCursor(in: window) else {
+            clearActiveDividerCursor(restoreArrow: false)
             return
         }
         activeDividerCursorKind = nextKind

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -153,8 +153,13 @@ final class WindowTerminalHostView: NSView {
             }
 
             if let kind = splitDividerCursorKind(at: point) {
-                activeDividerCursorKind = kind
-                kind.cursor.set()
+                // Hover events reach hit testing even when this window is occluded.
+                if dividerCursorOcclusion.mayAssertDividerCursorDuringHitTest(in: window) {
+                    activeDividerCursorKind = kind
+                    kind.cursor.set()
+                } else {
+                    clearActiveDividerCursor(restoreArrow: false)
+                }
                 TerminalWindowPortalRegistry.noteSplitDividerInteraction(
                     in: window,
                     event: currentEvent

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -11,17 +11,7 @@ private var cmuxWindowTerminalPortalCloseObserverKey: UInt8 = 0
 
 final class WindowTerminalHostView: NSView {
     private typealias DividerRegion = PortalSplitDividerRegion
-    private enum DividerCursorKind: Equatable {
-        case vertical
-        case horizontal
-
-        var cursor: NSCursor {
-            switch self {
-            case .vertical: return .resizeLeftRight
-            case .horizontal: return .resizeUpDown
-            }
-        }
-    }
+    private typealias DividerCursorKind = PortalDividerCursorKind
 
     override var isOpaque: Bool { false }
     private static let sidebarLeadingEdgeEpsilon: CGFloat = 1

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2736,6 +2736,9 @@ final class Workspace: Identifiable, ObservableObject {
         return BonsplitConfiguration.Appearance(
             tabBarHeight: WindowChromeMetrics.bonsplitTabBarHeight,
             tabTitleFontSize: tabTitleFontSize,
+            // Keep the drag effective rect in lockstep with the resize-cursor
+            // band the portals advertise over split dividers.
+            dividerHitExpansion: PortalSplitDividerRegion.dividerHitExpansion,
             splitButtonBackdropEffect: Self.bonsplitSplitButtonBackdropEffect(),
             splitButtonTooltips: Self.currentSplitButtonTooltips(),
             enableAnimations: false,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2570,14 +2570,6 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
-    private static func bonsplitAppearance(from config: GhosttyConfig) -> BonsplitConfiguration.Appearance {
-        bonsplitAppearance(
-            from: config.backgroundColor,
-            backgroundOpacity: config.backgroundOpacity,
-            tabTitleFontSize: config.surfaceTabBarFontSize
-        )
-    }
-
     nonisolated static func usesSharedSurfaceBackdrop(defaults: UserDefaults = .standard) -> Bool {
         defaults.bool(forKey: "sidebarMatchTerminalBackground")
     }
@@ -2736,8 +2728,6 @@ final class Workspace: Identifiable, ObservableObject {
         return BonsplitConfiguration.Appearance(
             tabBarHeight: WindowChromeMetrics.bonsplitTabBarHeight,
             tabTitleFontSize: tabTitleFontSize,
-            // Keep the drag effective rect in lockstep with the resize-cursor
-            // band the portals advertise over split dividers.
             dividerHitExpansion: PortalSplitDividerRegion.dividerHitExpansion,
             splitButtonBackdropEffect: Self.bonsplitSplitButtonBackdropEffect(),
             splitButtonTooltips: Self.currentSplitButtonTooltips(),

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -954,6 +954,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D1F0A00100000000000000A5 /* PhonePushPayloadKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A6 /* PhonePushPayloadKind.swift */; };
 		D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00300000000000000C2 /* PhonePushPresenceGateTests.swift */; };
 		B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */; };
+		5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */; };
 		B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */; };
 		D0C658660000000000000004 /* PortalSplitDividerCacheInvalidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */; };
 		D0C658660000000000000002 /* PortalSplitDividerRegion.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C658660000000000000001 /* PortalSplitDividerRegion.swift */; };
@@ -2609,6 +2610,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D1F0A00100000000000000A6 /* PhonePushPayloadKind.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushPayloadKind.swift; sourceTree = "<group>"; };
 		D1F0A00300000000000000C2 /* PhonePushPresenceGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhonePushPresenceGateTests.swift; sourceTree = "<group>"; };
 		B35750000000000000000009 /* PiVaultAgentPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PiVaultAgentPersistenceTests.swift; sourceTree = "<group>"; };
+		5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalDividerCursorOcclusionTests.swift; sourceTree = "<group>"; };
 		4335E241A33344C48361AD51 /* PortalHitTestingPerformanceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalHitTestingPerformanceTests.swift; sourceTree = "<group>"; };
 		D0C658660000000000000003 /* PortalSplitDividerCacheInvalidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerCacheInvalidator.swift; sourceTree = "<group>"; };
 		D0C658660000000000000001 /* PortalSplitDividerRegion.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortalSplitDividerRegion.swift; sourceTree = "<group>"; };
@@ -4919,6 +4921,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
 				5B0C00010000000000000004 /* SidebarResizerOcclusionResolverTests.swift */,
+				5B0C00010000000000000006 /* PortalDividerCursorOcclusionTests.swift */,
 				C0DE1A080000000000000002 /* SavedLayoutDefinitionTests.swift */,
 				C0DE1A070000000000000002 /* SavedLayoutStoreTests.swift */,
 				5830CA11BAC0000000000001 /* SocketCallbackAwaiterMainThreadTests.swift */,
@@ -6892,6 +6895,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
 					D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */,
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
+				5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */,
 					B1D5CEE0407545B6B57E3B0E /* PortalHitTestingPerformanceTests.swift in Sources */,
 					D0B10008A1B2C3D4E5F60001 /* PortalTabDragRoutingTests.swift in Sources */,
 					F4100000A1B2C3D4E5F60718 /* PortScannerTests.swift in Sources */,

--- a/cmuxTests/PortalDividerCursorOcclusionTests.swift
+++ b/cmuxTests/PortalDividerCursorOcclusionTests.swift
@@ -1,0 +1,34 @@
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite struct PortalDividerCursorOcclusionTests {
+    @Test func sameTopmostWindowMayAssertCursor() {
+        let occlusion = PortalDividerCursorOcclusion { _ in 10 }
+
+        #expect(occlusion.mayAssertDividerCursor(screenPoint: .zero, windowNumber: 10))
+    }
+
+    @Test func overlappingWindowSuppressesCursor() {
+        let occlusion = PortalDividerCursorOcclusion { _ in 11 }
+
+        #expect(!occlusion.mayAssertDividerCursor(screenPoint: .zero, windowNumber: 10))
+    }
+
+    @Test func nilPointerWindowSuppressesCursor() {
+        let occlusion = PortalDividerCursorOcclusion { _ in nil }
+
+        #expect(!occlusion.mayAssertDividerCursor(screenPoint: .zero, windowNumber: 10))
+    }
+
+    @Test func nilHostWindowSuppressesCursor() {
+        let occlusion = PortalDividerCursorOcclusion { _ in 10 }
+
+        #expect(!occlusion.mayAssertDividerCursor(in: nil))
+    }
+}

--- a/cmuxTests/PortalDividerCursorOcclusionTests.swift
+++ b/cmuxTests/PortalDividerCursorOcclusionTests.swift
@@ -31,4 +31,22 @@ import Testing
 
         #expect(!occlusion.mayAssertDividerCursor(in: nil))
     }
+
+    @Test func hitTestKeepsCursorDuringLeftButtonDrag() {
+        let occlusion = PortalDividerCursorOcclusion(
+            topmostMouseEventWindowNumber: { _ in 11 },
+            isLeftMouseButtonPressed: { true }
+        )
+
+        #expect(occlusion.mayAssertDividerCursorDuringHitTest(in: nil))
+    }
+
+    @Test func hitTestSuppressesHoverCursorWhenNotDragging() {
+        let occlusion = PortalDividerCursorOcclusion(
+            topmostMouseEventWindowNumber: { _ in 11 },
+            isLeftMouseButtonPressed: { false }
+        )
+
+        #expect(!occlusion.mayAssertDividerCursorDuringHitTest(in: nil))
+    }
 }

--- a/cmuxTests/PortalDividerCursorOcclusionTests.swift
+++ b/cmuxTests/PortalDividerCursorOcclusionTests.swift
@@ -31,22 +31,4 @@ import Testing
 
         #expect(!occlusion.mayAssertDividerCursor(in: nil))
     }
-
-    @Test func hitTestKeepsCursorDuringLeftButtonDrag() {
-        let occlusion = PortalDividerCursorOcclusion(
-            topmostMouseEventWindowNumber: { _ in 11 },
-            isLeftMouseButtonPressed: { true }
-        )
-
-        #expect(occlusion.mayAssertDividerCursorDuringHitTest(in: nil))
-    }
-
-    @Test func hitTestSuppressesHoverCursorWhenNotDragging() {
-        let occlusion = PortalDividerCursorOcclusion(
-            topmostMouseEventWindowNumber: { _ in 11 },
-            isLeftMouseButtonPressed: { false }
-        )
-
-        #expect(!occlusion.mayAssertDividerCursorDuringHitTest(in: nil))
-    }
 }


### PR DESCRIPTION
Two resize-cursor problems:

**Divider hard to grab.** The split divider is a 1pt hairline whose resize cursor and drag engaged only within ±5pt, and the AppKit cursor rects used a mismatched ±4pt. The interactive band is now ±8pt (~17pt total) driven by one constant: `PortalSplitDividerRegion.dividerHitExpansion` feeds the portal cursor rects, the manual hover-cursor hit test, and (via the new `Appearance.dividerHitExpansion` from https://github.com/manaflow-ai/bonsplit/pull/171, submodule bumped here) Bonsplit's drag effective rect and drag-start detection, so every point that shows the resize cursor can start a drag.

**Cursor bleed-through.** Divider hover cursors are asserted from `.activeAlways` tracking areas, which AppKit delivers even when another window covers the host window at the pointer, so a backgrounded window could flip the cursor through an overlapping Settings/sibling window. This is the same class of bug as the sidebar resizer fix in https://github.com/manaflow-ai/cmux/pull/7765; `PortalDividerCursorOcclusion` now checks the topmost mouse-event window before `NSCursor.set()` in `TerminalWindowPortal`, `BrowserWindowPortal`, and the hosted web-inspector divider in `BrowserPanelView`. The window-server lookup is injectable and unit-tested (`PortalDividerCursorOcclusionTests`); the query only runs on the cursor-set path, so hit-test hot paths pay nothing.

No user-facing strings changed, so no localization impact.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786255704&installation_id=133855650&pr_number=7816&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7816&signature=1943b502dd32371331e60df9d7371714edef10d1850f747574aaf72b5bb0a7ea"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized AppKit pointer/cursor behavior with unit tests; no auth, data, or API surface changes beyond slightly wider divider interaction.
> 
> **Overview**
> Makes pane split dividers easier to grab and stops resize cursors from leaking through windows stacked on top.
> 
> **Divider targeting** — `PortalSplitDividerRegion.dividerHitExpansion` goes from 5pt to **8pt** and becomes the single source for portal cursor rects, manual hover hit tests, and Bonsplit appearance (`Workspace` / Dock), so hover and drag use the same band (~17pt on a 1pt divider).
> 
> **Cursor bleed-through** — New `PortalDividerCursorOcclusion` only calls `NSCursor.set()` when this window is the topmost mouse target (`NSWindow.windowNumber(at:belowWindowWithWindowNumber:)`), applied in browser/terminal portal hosts and hosted web-inspector divider code. Terminal portal centralizes cursor assertion and still shows the resize cursor during an active divider drag owned by that window (`isSplitDividerDragActive`); drag ownership latching now requires `event.window === window`.
> 
> **Cleanup** — Shared `PortalDividerCursorKind` replaces duplicate local enums; adds `PortalDividerCursorOcclusionTests`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a3b9dae6c65776f0b64af093ff536750271b9b27. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the pane divider easier to grab and stop resize cursors from appearing through covered windows. Expands the hit band to ~17pt and only shows the cursor when this window is topmost.

- **Bug Fixes**
  - Expanded divider resize/drag band to ±8pt around the 1pt divider; portal cursor rects and `bonsplit` drag effective rect now share the same constant so any cursor point can start a drag.
  - Prevented cursor bleed-through by checking the topmost mouse-target window before setting the cursor; applied to terminal/browser portals and the hosted web inspector. Terminal hover and hit-test now assert the cursor through one gate, with an exemption only when this window owns the active divider drag; drag ownership now latches only if the event was dispatched to that window, so foreign drags can’t self-authorize the cursor. Added `PortalDividerCursorOcclusionTests`.

- **Refactors**
  - Replaced per-file `DividerCursorKind` enums with shared `PortalDividerCursorKind`; removed unused `bonsplitAppearance(from:)`.

<sup>Written for commit a3b9dae6c65776f0b64af093ff536750271b9b27. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded split-divider hit areas (effective drag/resize region increased) to make pane resizing easier.
  * Improved divider cursor behavior across browser, terminal, and docking layouts to better reflect what can be resized.
* **Bug Fixes**
  * Prevented covered/overlapping windows from incorrectly triggering divider resize cursors.
  * Avoided applying new divider cursors when occluded, reducing cursor flicker and incorrect hover states.
* **Tests**
  * Added automated tests to verify divider cursor assertion is correctly suppressed when windows overlap or are unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->