### PR TITLE
iroh transport P3: iOS phone dial lane (CmxIrohByteTransport + EndpointId pinning)

### DIFF
--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -137,6 +137,12 @@ jobs:
           export DEVELOPER_DIR="$XCODE_DIR"
           xcodebuild -version
 
+      - name: Provision cmux-iroh FFI
+        run: |
+          ./scripts/install-rust-ci.sh
+          export PATH="$HOME/.cargo/bin:$PATH"
+          ./scripts/ensure-cmux-iroh.sh
+
       - name: Run CMUXMobileCore package tests
         run: |
           swift test --package-path Packages/Shared/CMUXMobileCore

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
@@ -36,6 +36,10 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
     /// User's custom icon override, synced per user. `nil` = the automatic icon.
     /// An SF Symbol name (ASCII, e.g. `"desktopcomputer"`) or an emoji.
     public var customIcon: String?
+    /// The trusted iroh EndpointId for this Mac. Once set, iroh routes with a
+    /// different EndpointId require explicit re-trust before Stack credentials
+    /// may be sent over that route.
+    public var irohEndpointID: String?
 
     /// The Mac device identifier doubles as the stable `Identifiable` id.
     public var id: String { macDeviceID }
@@ -68,7 +72,8 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
         teamID: String? = nil,
         customName: String? = nil,
         customColor: String? = nil,
-        customIcon: String? = nil
+        customIcon: String? = nil,
+        irohEndpointID: String? = nil
     ) {
         self.macDeviceID = macDeviceID
         self.displayName = displayName
@@ -81,5 +86,6 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
         self.customName = customName
         self.customColor = customColor
         self.customIcon = customIcon
+        self.irohEndpointID = irohEndpointID
     }
 }

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+IrohPinning.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+IrohPinning.swift
@@ -1,0 +1,21 @@
+import CMUXMobileCore
+import Foundation
+
+extension MobilePairedMacStore {
+    static func firstIrohEndpointID(in routes: [CmxAttachRoute]) -> String? {
+        for route in routes.sorted(by: { lhs, rhs in
+            if lhs.priority != rhs.priority {
+                return lhs.priority < rhs.priority
+            }
+            return lhs.id < rhs.id
+        }) where route.kind == .iroh {
+            if case let .peer(id, _, _, _) = route.endpoint {
+                let trimmed = id.trimmingCharacters(in: .whitespacesAndNewlines)
+                if !trimmed.isEmpty {
+                    return trimmed
+                }
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Support.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Support.swift
@@ -1,0 +1,40 @@
+import CMUXMobileCore
+import Foundation
+import SQLite3
+
+extension MobilePairedMacStore {
+    struct MacRow {
+        let macDeviceID: String
+        let ownerKey: String
+        let displayName: String?
+        let stackUserID: String?
+        let teamID: String?
+        let createdAt: Date
+        let lastSeenAt: Date
+        let isActive: Bool
+        var customName: String? = nil
+        var customColor: String? = nil
+        var customIcon: String? = nil
+        var irohEndpointID: String? = nil
+    }
+
+    enum BindValue {
+        case text(String)
+        case int(Int64)
+        case real(Double)
+        case null
+    }
+
+    static func encodeRoute(_ route: CmxAttachRoute) throws -> String {
+        let data = try JSONEncoder().encode(route)
+        guard let string = String(data: data, encoding: .utf8) else {
+            throw MobilePairedMacStoreError.decodeFailed
+        }
+        return string
+    }
+
+    static func readNullableText(_ statement: OpaquePointer?, column: Int32) -> String? {
+        guard let cString = sqlite3_column_text(statement, column) else { return nil }
+        return String(cString: cString)
+    }
+}

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
@@ -14,7 +14,7 @@ private let pairedMacStoreLog = Logger(subsystem: "com.cmuxterm.app", category: 
 /// inject it as `any MobilePairedMacStoring`.
 public actor MobilePairedMacStore: MobilePairedMacStoring {
     /// The schema version this build creates and migrates to.
-    public static let currentSchemaVersion: Int32 = 4
+    public static let currentSchemaVersion: Int32 = 5
 
     private let dbPath: String
     // `nonisolated(unsafe)` only so the (Swift 6 nonisolated) `deinit` can close
@@ -109,27 +109,36 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV2()
                 try migrateToV3()
                 try migrateToV4()
-                try setUserVersion(4)
+                try migrateToV5()
+                try setUserVersion(5)
             }
         case 1:
             try transaction {
                 try migrateToV2()
                 try migrateToV3()
                 try migrateToV4()
-                try setUserVersion(4)
+                try migrateToV5()
+                try setUserVersion(5)
             }
         case 2:
             try transaction {
                 try migrateToV3()
                 try migrateToV4()
-                try setUserVersion(4)
+                try migrateToV5()
+                try setUserVersion(5)
             }
         case 3:
             try transaction {
                 try migrateToV4()
-                try setUserVersion(4)
+                try migrateToV5()
+                try setUserVersion(5)
             }
         case 4:
+            try transaction {
+                try migrateToV5()
+                try setUserVersion(5)
+            }
+        case 5:
             break
         default:
             // A newer build wrote a higher schema version. Schema migrations are
@@ -289,6 +298,13 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         try exec("CREATE INDEX IF NOT EXISTS idx_routes_device ON mac_routes(mac_device_id, owner_key);")
     }
 
+    /// v5: pin the trusted Mac iroh EndpointId in the paired-Mac row.
+    private func migrateToV5() throws {
+        let existing = try tableColumns("paired_macs")
+        if !existing.contains("iroh_endpoint_id") {
+            try exec("ALTER TABLE paired_macs ADD COLUMN iroh_endpoint_id TEXT;")
+        }
+    }
     /// Column names defined on `table` (via `PRAGMA table_info`), used to make
     /// additive column migrations idempotent.
     private func tableColumns(_ table: String) throws -> Set<String> {
@@ -344,6 +360,9 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 claimedLegacy = legacy
             }
             let createdAt = existing?.createdAt ?? claimedLegacy?.createdAt ?? now
+            let irohEndpointID = existing?.irohEndpointID
+                ?? claimedLegacy?.irohEndpointID
+                ?? Self.firstIrohEndpointID(in: routes)
             try upsertMacRow(
                 macDeviceID: macDeviceID,
                 ownerKey: ownerKey,
@@ -352,7 +371,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 teamID: teamID,
                 createdAt: createdAt,
                 lastSeenAt: now,
-                isActive: markActive
+                isActive: markActive,
+                irohEndpointID: irohEndpointID
             )
             try exec(
                 "DELETE FROM mac_routes WHERE mac_device_id = ? AND owner_key = ?;",
@@ -472,25 +492,12 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         try exec("PRAGMA user_version = \(version);")
     }
 
-    private struct MacRow {
-        let macDeviceID: String
-        let ownerKey: String
-        let displayName: String?
-        let stackUserID: String?
-        var teamID: String? = nil
-        let createdAt: Date
-        let lastSeenAt: Date
-        let isActive: Bool
-        var customName: String? = nil
-        var customColor: String? = nil
-        var customIcon: String? = nil
-    }
-
     private func fetchMacRow(macDeviceID: String, ownerKey: String) throws -> MacRow? {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         let sql = """
-            SELECT display_name, stack_user_id, created_at, last_seen_at, is_active, team_id
+            SELECT display_name, stack_user_id, created_at, last_seen_at, is_active, team_id,
+                   iroh_endpoint_id
             FROM paired_macs WHERE mac_device_id = ? AND owner_key = ?;
         """
         let rc = sqlite3_prepare_v2(db, sql, -1, &statement, nil)
@@ -517,7 +524,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             teamID: teamID,
             createdAt: createdAt,
             lastSeenAt: lastSeenAt,
-            isActive: isActive
+            isActive: isActive,
+            irohEndpointID: Self.readNullableText(statement, column: 6)
         )
     }
 
@@ -529,17 +537,25 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         teamID: String?,
         createdAt: Date,
         lastSeenAt: Date,
-        isActive: Bool
+        isActive: Bool,
+        irohEndpointID: String?
     ) throws {
         try exec("""
-            INSERT INTO paired_macs (mac_device_id, owner_key, display_name, stack_user_id, team_id, created_at, last_seen_at, is_active)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO paired_macs (
+                mac_device_id, owner_key, display_name, stack_user_id, team_id,
+                created_at, last_seen_at, is_active, iroh_endpoint_id
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
             ON CONFLICT(mac_device_id, owner_key) DO UPDATE SET
                 display_name = excluded.display_name,
                 stack_user_id = excluded.stack_user_id,
                 team_id = excluded.team_id,
                 last_seen_at = excluded.last_seen_at,
-                is_active = excluded.is_active;
+                is_active = excluded.is_active,
+                iroh_endpoint_id = CASE
+                    WHEN paired_macs.iroh_endpoint_id IS NULL THEN excluded.iroh_endpoint_id
+                    ELSE paired_macs.iroh_endpoint_id
+                END;
         """, binding: [
             .text(macDeviceID),
             .text(ownerKey),
@@ -549,6 +565,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             .real(createdAt.timeIntervalSince1970),
             .real(lastSeenAt.timeIntervalSince1970),
             .int(isActive ? 1 : 0),
+            irohEndpointID.map(BindValue.text) ?? .null,
         ])
     }
 
@@ -579,11 +596,13 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         try exec("""
             INSERT INTO paired_macs (
                 mac_device_id, owner_key, display_name, stack_user_id, team_id,
-                created_at, last_seen_at, is_active, custom_name, custom_color, custom_icon
+                created_at, last_seen_at, is_active, custom_name, custom_color, custom_icon,
+                iroh_endpoint_id
             )
             SELECT
                 mac_device_id, ?, display_name, stack_user_id, ?, created_at,
-                last_seen_at, is_active, custom_name, custom_color, custom_icon
+                last_seen_at, is_active, custom_name, custom_color, custom_icon,
+                iroh_endpoint_id
             FROM paired_macs
             WHERE mac_device_id = ? AND owner_key = ?;
         """, binding: [
@@ -634,7 +653,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         let whereClause = clauses.isEmpty ? "" : "WHERE " + clauses.joined(separator: " AND ")
         let sql = """
             SELECT mac_device_id, owner_key, display_name, stack_user_id, created_at, last_seen_at, is_active,
-                   custom_name, custom_color, custom_icon, team_id
+                   custom_name, custom_color, custom_icon, team_id, iroh_endpoint_id
             FROM paired_macs
             \(whereClause)
             ORDER BY last_seen_at DESC;
@@ -666,7 +685,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 isActive: isActive,
                 customName: Self.readNullableText(statement, column: 7),
                 customColor: Self.readNullableText(statement, column: 8),
-                customIcon: Self.readNullableText(statement, column: 9)
+                customIcon: Self.readNullableText(statement, column: 9),
+                irohEndpointID: Self.readNullableText(statement, column: 11)
             ))
         }
 
@@ -683,7 +703,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 teamID: row.teamID,
                 customName: row.customName,
                 customColor: row.customColor,
-                customIcon: row.customIcon
+                customIcon: row.customIcon,
+                irohEndpointID: row.irohEndpointID
             )
         }
     }
@@ -718,28 +739,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         return routes
     }
 
-    private static func encodeRoute(_ route: CmxAttachRoute) throws -> String {
-        let encoder = JSONEncoder()
-        let data = try encoder.encode(route)
-        guard let string = String(data: data, encoding: .utf8) else {
-            throw MobilePairedMacStoreError.decodeFailed
-        }
-        return string
-    }
-
-    private static func readNullableText(_ statement: OpaquePointer?, column: Int32) -> String? {
-        guard let cString = sqlite3_column_text(statement, column) else { return nil }
-        return String(cString: cString)
-    }
-
     // MARK: - Statement helpers
-
-    private enum BindValue {
-        case text(String)
-        case int(Int64)
-        case real(Double)
-        case null
-    }
 
     private func exec(_ sql: String, binding parameters: [BindValue] = []) throws {
         if parameters.isEmpty {

--- a/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacStoreIrohPinTests.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacStoreIrohPinTests.swift
@@ -1,0 +1,37 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobilePairedMac
+
+@Suite struct MobilePairedMacStoreIrohPinTests {
+    @Test func irohEndpointPinPersistsAndSurvivesRouteRefresh() async throws {
+        let (store, directory) = try makeStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let first = try CmxAttachRoute(
+            id: "iroh-a",
+            kind: .iroh,
+            endpoint: .peer(id: "endpoint-a", relayHint: nil, directAddrs: [], relayURL: nil)
+        )
+        let changed = try CmxAttachRoute(
+            id: "iroh-b",
+            kind: .iroh,
+            endpoint: .peer(id: "endpoint-b", relayHint: nil, directAddrs: [], relayURL: nil)
+        )
+
+        try await store.upsert(macDeviceID: "mac-iroh", displayName: "Iroh Mac", routes: [first], markActive: true, stackUserID: "user-1", now: Date())
+        try await store.upsert(macDeviceID: "mac-iroh", displayName: "Iroh Mac", routes: [changed], markActive: true, stackUserID: "user-1", now: Date())
+
+        let mac = try #require(await store.activeMac(stackUserID: "user-1"))
+        #expect(mac.irohEndpointID == "endpoint-a")
+        #expect(mac.routes.map(\.id) == ["iroh-b"])
+    }
+
+    private func makeStore() throws -> (MobilePairedMacStore, URL) {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let store = try MobilePairedMacStore(databaseURL: directory.appendingPathComponent("paired-macs.sqlite3"))
+        return (store, directory)
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -235,6 +235,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
                   MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) else {
                 throw MobileShellConnectionError.insecureManualRoute
             }
+            try await validateIrohEndpointTrust()
             do {
                 auth["stack_access_token"] = try await stackAccessToken(deadline: deadline)
             } catch let error as MobileShellConnectionError {
@@ -272,6 +273,11 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     }
 
     private func stackAccessTokenForStatus(deadline: RPCRequestDeadline) async throws -> String? {
+        do {
+            try await validateIrohEndpointTrust()
+        } catch {
+            return nil
+        }
         let task = Task<String?, any Error> { [runtime] in
             await runtime.stackAccessTokenForStatusProvider()
         }
@@ -290,6 +296,13 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         try await stackTokenGate.token(timeoutNanoseconds: try deadline.remainingNanoseconds()) { [runtime] in
             try await runtime.stackAccessTokenProvider()
         }
+    }
+
+    private func validateIrohEndpointTrust() async throws {
+        guard route.kind == .iroh else {
+            return
+        }
+        try await runtime.irohEndpointTrustValidator(route, ticket)
     }
 
     private static func requestNeedsStackAuthFallback(_ request: [String: Any], ticket: CmxAttachTicket) -> Bool {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
@@ -19,6 +19,10 @@ public enum MobileShellConnectionError: LocalizedError {
     /// associated value is a user-facing message; the caller should drive a
     /// re-authentication flow into the owner's account rather than retry.
     case accountMismatch(String)
+    /// The pinned iroh EndpointId for this Mac does not match the route being
+    /// dialed. The associated value is a user-facing message that should drive
+    /// an explicit re-trust flow rather than silently accepting the new key.
+    case irohEndpointChanged(String)
     /// A server-reported RPC error: optional code plus a message.
     case rpcError(String?, String)
 
@@ -37,6 +41,8 @@ public enum MobileShellConnectionError: LocalizedError {
         case let .authorizationFailed(message):
             return message
         case let .accountMismatch(message):
+            return message
+        case let .irohEndpointChanged(message):
             return message
         case let .rpcError(_, message):
             return message

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileSyncRuntime.swift
@@ -26,6 +26,10 @@ public protocol MobileSyncRuntime: Sendable {
     /// Transport kinds the app can dial, used to filter attach routes before
     /// connecting. Empty means "no filter" (accept every advertised route).
     var supportedRouteKinds: [CmxAttachTransportKind] { get }
+    /// Validates that an iroh route's peer EndpointId is trusted before the RPC
+    /// layer sends Stack account credentials over it. Non-iroh routes should be
+    /// accepted by the validator.
+    var irohEndpointTrustValidator: @Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void { get }
     /// Shorter deadline for pairing-time requests (ticket mint, initial
     /// workspace list), in nanoseconds.
     var pairingRequestTimeoutNanoseconds: UInt64 { get }
@@ -54,6 +58,11 @@ public extension MobileSyncRuntime {
     /// Default user-facing pairing deadline. Individual RPCs can have their own
     /// request timeout, but the sheet must not spin through stacked route waits.
     var pairingAttemptTimeoutNanoseconds: UInt64 { 8_000_000_000 }
+
+    /// Default trust policy for runtimes that do not use iroh.
+    var irohEndpointTrustValidator: @Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void {
+        { _, _ in }
+    }
 
     /// Default probe deadline: generous against a momentarily loaded Mac,
     /// while keeping dead-stream recovery within a few seconds of the silence

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientIrohTrustTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCClientIrohTrustTests.swift
@@ -1,0 +1,94 @@
+import CMUXMobileCore
+import CmuxMobileRPC
+import Testing
+
+@Suite struct MobileCoreRPCClientIrohTrustTests {
+    @Test func irohEndpointMismatchWithholdsStackTokenForAuthorizedRequest() async throws {
+        let route = try peerRoute(endpointID: "changed-endpoint")
+        let transport = QueuedCancellationProbeTransport()
+        let tokenProviderCalled = AsyncFlag()
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: QueuedCancellationProbeTransportFactory(transport: transport),
+            stackAccessTokenProvider: {
+                await tokenProviderCalled.set()
+                return "must-not-send"
+            },
+            irohEndpointTrustValidator: { _, _ in
+                throw MobileShellConnectionError.irohEndpointChanged("endpoint changed")
+            }
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "mac-1",
+            macDisplayName: "Mac",
+            routes: [route]
+        )
+        let client = MobileCoreRPCClient(runtime: runtime, route: route, ticket: ticket, allowsStackAuthFallback: true)
+
+        await #expect(throws: MobileShellConnectionError.self) {
+            _ = try await client.sendRequest(try MobileCoreRPCClient.requestData(method: "workspace.create"))
+        }
+
+        #expect(await tokenProviderCalled.isSet() == false)
+        #expect(try await transport.sentRequests().isEmpty)
+    }
+
+    @Test func irohEndpointMismatchKeepsHostStatusProbeTokenless() async throws {
+        let route = try peerRoute(endpointID: "changed-endpoint")
+        let statusProviderCalled = AsyncFlag()
+        let probe = try await sentHostStatusProbe(
+            route: route,
+            stackAccessTokenForStatusProvider: {
+                await statusProviderCalled.set()
+                return "must-not-send"
+            },
+            irohEndpointTrustValidator: { _, _ in
+                throw MobileShellConnectionError.irohEndpointChanged("endpoint changed")
+            }
+        )
+
+        #expect(probe?.hasAuth == false)
+        #expect(await statusProviderCalled.isSet() == false)
+    }
+
+    private func sentHostStatusProbe(
+        route: CmxAttachRoute,
+        stackAccessTokenForStatusProvider: @escaping @Sendable () async -> String?,
+        irohEndpointTrustValidator: @escaping @Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void
+    ) async throws -> RecordedRPCRequest? {
+        let transport = QueuedCancellationProbeTransport()
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: QueuedCancellationProbeTransportFactory(transport: transport),
+            stackAccessToken: "test-stack-token",
+            stackAccessTokenForStatusProvider: stackAccessTokenForStatusProvider,
+            irohEndpointTrustValidator: irohEndpointTrustValidator
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "mac-1",
+            macDisplayName: "Mac",
+            routes: [route]
+        )
+        let client = MobileCoreRPCClient(runtime: runtime, route: route, ticket: ticket, allowsStackAuthFallback: true)
+        let task = Task {
+            try await client.sendRequest(
+                try MobileCoreRPCClient.requestData(method: "mobile.host.status")
+            )
+        }
+        let sent = try await transport.waitForSentRequestCount(1)
+        task.cancel()
+        _ = try? await task.value
+        return sent.first
+    }
+
+    private func peerRoute(endpointID: String) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(id: endpointID, relayHint: nil, directAddrs: [], relayURL: nil),
+            priority: 0
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/TransportTestDoubles.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/TransportTestDoubles.swift
@@ -14,6 +14,7 @@ struct TestMobileSyncRuntime: MobileSyncRuntime {
     var rpcRequestTimeoutNanoseconds: UInt64
     var pairingRequestTimeoutNanoseconds: UInt64
     var now: @Sendable () -> Date
+    var irohEndpointTrustValidator: @Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void
     var supportsServerPushEvents: Bool
 
     init(
@@ -23,6 +24,7 @@ struct TestMobileSyncRuntime: MobileSyncRuntime {
         stackAccessTokenForStatus: String? = nil,
         stackAccessTokenProvider: (@Sendable () async throws -> String)? = nil,
         stackAccessTokenForStatusProvider: (@Sendable () async -> String?)? = nil,
+        irohEndpointTrustValidator: (@Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void)? = nil,
         rpcRequestTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000,
         pairingRequestTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000,
         now: @escaping @Sendable () -> Date = Date.init,
@@ -41,6 +43,7 @@ struct TestMobileSyncRuntime: MobileSyncRuntime {
             guard let stackAccessToken else { throw MissingTestStackAccessToken() }
             return stackAccessToken
         }
+        self.irohEndpointTrustValidator = irohEndpointTrustValidator ?? { _, _ in }
         self.rpcRequestTimeoutNanoseconds = rpcRequestTimeoutNanoseconds
         self.pairingRequestTimeoutNanoseconds = pairingRequestTimeoutNanoseconds
         self.now = now

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore.swift
@@ -415,10 +415,10 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
             isActive: mac.isActive,
             customName: mac.customName,
             customColor: mac.customColor,
-            customIcon: mac.customIcon
+            customIcon: mac.customIcon,
+            irohEndpointID: mac.irohEndpointID
         )
     }
-
     /// Upload the current record for one Mac. `includesCustomizations` is true
     /// only for explicit rename/color/icon writes; other mirrors preserve the
     /// server's current customizations. Best-effort.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure+Iroh.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure+Iroh.swift
@@ -1,0 +1,74 @@
+internal import CmuxMobileSupport
+internal import CmuxMobileTransport
+
+extension MobilePairingFailureCategory {
+    var irohMessage: String? {
+        switch self {
+        case .irohMacUnreachable:
+            return L10n.string(
+                "mobile.pairing.irohMacUnavailable",
+                defaultValue: "Could not reach this Mac over Iroh. Make sure cmux is open on the Mac and it is awake, then try again."
+            )
+        case .irohTimedOut:
+            return L10n.string(
+                "mobile.pairing.irohTimedOut",
+                defaultValue: "Iroh did not get a response from this Mac in time. Make sure the Mac is awake and online, then try again."
+            )
+        case .irohSecureChannelFailed:
+            return L10n.string(
+                "mobile.pairing.irohSecureChannelFailed",
+                defaultValue: "Iroh could not verify the secure connection to this Mac. Trust the Mac again before connecting."
+            )
+        case .irohEndpointChanged:
+            return L10n.string(
+                "mobile.pairing.irohEndpointChanged",
+                defaultValue: "This Mac's Iroh identity changed. Trust it again from the Mac before sending account credentials."
+            )
+        case .irohConnectionDropped:
+            return L10n.string(
+                "mobile.pairing.irohConnectionDropped",
+                defaultValue: "Connected to this Mac over Iroh, but the connection closed before pairing finished."
+            )
+        default:
+            return nil
+        }
+    }
+
+    var irohGuidance: String? {
+        switch self {
+        case .irohMacUnreachable, .irohTimedOut, .irohConnectionDropped:
+            return L10n.string(
+                "mobile.pairing.guidance.irohReachability",
+                defaultValue: "No Tailscale setup is needed for Iroh. Keep cmux open on the Mac and make sure both devices are online."
+            )
+        case .irohSecureChannelFailed, .irohEndpointChanged:
+            return L10n.string(
+                "mobile.pairing.guidance.irohRetrust",
+                defaultValue: "Open cmux on the Mac and trust this phone again before retrying."
+            )
+        default:
+            return nil
+        }
+    }
+
+    static func classifyIroh(error: any Error, host: String?, port: Int?) -> MobilePairingFailureCategory? {
+        guard let irohError = error as? CmxIrohByteTransportError else { return nil }
+        switch irohError {
+        case let .connectionFailed(_, kind),
+             let .endpointBindFailed(_, kind):
+            switch kind {
+            case .timedOut:
+                return .irohTimedOut
+            case .secureChannelFailed:
+                return .irohSecureChannelFailed
+            case .connectionRefused, .hostUnreachable, .dnsFailed, .permissionDenied, .generic:
+                return .irohMacUnreachable
+            }
+        case .receiveFailed, .sendFailed, .alreadyClosed, .notConnected:
+            return .irohConnectionDropped
+        case .emptyPeerID, .invalidMaximumReceiveLength,
+             .unsupportedRouteKind, .unsupportedEndpoint:
+            return .unknown(host: host, port: port)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -84,6 +84,16 @@ public enum MobilePairingFailureCategory: Equatable, Sendable {
     /// The pairing code carried no route kind this device build can dial (for
     /// example an iroh-only ticket on a build without the iroh transport).
     case noSupportedRoute
+    /// Could not reach the Mac over iroh.
+    case irohMacUnreachable
+    /// The iroh dial timed out.
+    case irohTimedOut
+    /// Iroh could not establish a secure channel to the pinned peer.
+    case irohSecureChannelFailed
+    /// The pinned iroh EndpointId changed and must be explicitly trusted again.
+    case irohEndpointChanged
+    /// The iroh stream closed before pairing completed.
+    case irohConnectionDropped
     /// The attempt was cancelled (the user tapped Cancel, or a newer attempt
     /// superseded it). Not surfaced as an error.
     case cancelled
@@ -113,6 +123,11 @@ extension MobilePairingFailureCategory {
         case .loopbackRejected: return "loopback_rejected"
         case .unsupportedRoute: return "unsupported_route"
         case .noSupportedRoute: return "no_supported_route"
+        case .irohMacUnreachable: return "iroh_unreachable"
+        case .irohTimedOut: return "iroh_timeout"
+        case .irohSecureChannelFailed: return "iroh_secure_channel_failed"
+        case .irohEndpointChanged: return "iroh_endpoint_changed"
+        case .irohConnectionDropped: return "iroh_connection_dropped"
         case .cancelled: return "cancelled"
         case .unknown: return "other"
         }
@@ -259,6 +274,8 @@ extension MobilePairingFailureCategory {
                 "mobile.pairing.unsupportedRoute",
                 defaultValue: "This pairing code is not supported."
             )
+        case .irohMacUnreachable, .irohTimedOut, .irohSecureChannelFailed, .irohEndpointChanged, .irohConnectionDropped:
+            return irohMessage ?? ""
         case .cancelled:
             return ""
         case let .unknown(host, port):
@@ -318,6 +335,9 @@ extension MobilePairingFailureCategory {
                 "mobile.pairing.guidance.rescanFresh",
                 defaultValue: "Open the pairing window on your Mac and scan a fresh QR or link."
             )
+        case .irohMacUnreachable, .irohTimedOut, .irohConnectionDropped,
+             .irohSecureChannelFailed, .irohEndpointChanged:
+            return irohGuidance
         case .unrecognizedVersion:
             return L10n.string(
                 "mobile.pairing.guidance.updateApp",
@@ -367,6 +387,10 @@ extension MobilePairingFailureCategory {
             }
         }
 
+        if let category = Self.classifyIroh(error: error, host: host, port: port) {
+            return category
+        }
+
         if let connectionError = error as? MobileShellConnectionError {
             switch connectionError {
             case .requestTimedOut:
@@ -379,6 +403,8 @@ extension MobilePairingFailureCategory {
                 return .authFailed
             case .accountMismatch:
                 return .accountMismatch
+            case .irohEndpointChanged:
+                return .irohEndpointChanged
             case .connectionClosed:
                 return .connectionDropped(host: host, port: port)
             case .invalidResponse:

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+AuthorizationFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+AuthorizationFailure.swift
@@ -1,0 +1,29 @@
+import CmuxMobileRPC
+import Foundation
+
+@MainActor
+extension MobileShellComposite {
+    static func shouldDisconnectForAuthorizationFailure(_ error: any Error) -> Bool {
+        guard let connectionError = error as? MobileShellConnectionError else {
+            return false
+        }
+        switch connectionError {
+        case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
+            return true
+        case let .rpcError(code, message):
+            let normalizedCode = code?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            if let normalizedCode,
+               ["unauthorized", "forbidden", "invalid_token", "token_expired", "expired_token", "auth_required"].contains(normalizedCode) {
+                return true
+            }
+            let normalizedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return normalizedMessage.contains("unauthorized")
+                || normalizedMessage.contains("forbidden")
+                || normalizedMessage.contains("invalid token")
+                || normalizedMessage.contains("expired token")
+                || normalizedMessage.contains("token expired")
+        case .invalidResponse, .connectionClosed, .requestTimedOut, .irohEndpointChanged:
+            return false
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -1,5 +1,6 @@
 import CMUXMobileCore
 import CmuxMobilePairedMac
+import CmuxMobileShellModel
 import Foundation
 
 @MainActor
@@ -54,8 +55,8 @@ extension MobileShellComposite {
     func freshReconnectRoutesAfterLocalFailure(
         for mac: MobilePairedMac,
         scope: MobileShellScopeSnapshot,
-        triedRoutes: [(host: String, port: Int, routeID: String)]
-    ) async -> [(host: String, port: Int, routeID: String)]? {
+        triedRoutes: [CmxAttachRoute]
+    ) async -> [CmxAttachRoute]? {
         guard let deviceRegistry,
               await isScopeCurrent(scope),
               await !isForgottenMacDeviceID(mac.macDeviceID, scope: scope),
@@ -67,14 +68,14 @@ extension MobileShellComposite {
             return nil
         }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
-        let refreshed = Self.reconnectHostPortRoutes(
+        let refreshed = Self.reconnectRoutes(
             updatedRoutes,
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
         guard !refreshed.isEmpty else { return nil }
-        let tried = Set(triedRoutes.map { "\($0.host)\u{1F}\($0.port)" })
-        let fresh = Set(refreshed.map { "\($0.host)\u{1F}\($0.port)" })
+        let tried = Set(triedRoutes.map(Self.reconnectRouteKey))
+        let fresh = Set(refreshed.map(Self.reconnectRouteKey))
         guard fresh != tried else { return nil }
         return refreshed
     }
@@ -123,42 +124,102 @@ extension MobileShellComposite {
         supportedKinds: [CmxAttachTransportKind],
         preferNonLoopback: Bool = false
     ) -> [(host: String, port: Int, routeID: String)] {
+        reconnectRoutes(
+            routes,
+            supportedKinds: supportedKinds,
+            preferNonLoopback: preferNonLoopback
+        ).compactMap { route in
+            guard case let .hostPort(host, port) = route.endpoint else {
+                return nil
+            }
+            return (host: host, port: port, routeID: route.id)
+        }
+    }
+
+    /// Ordered reconnect candidates for a Mac, preserving route priority while
+    /// treating iroh peer routes as first-class candidates.
+    static func reconnectRoutes(
+        _ routes: [CmxAttachRoute],
+        supportedKinds: [CmxAttachTransportKind],
+        preferNonLoopback: Bool = false
+    ) -> [CmxAttachRoute] {
         let supportedKinds = Set(supportedKinds)
         let ordered = routes.sorted(by: Self.routeSortsBefore)
         var seenEndpoints = Set<String>()
 
         func appendCandidates(
             where predicate: (CmxAttachRoute) -> Bool,
-            to candidates: inout [(host: String, port: Int, routeID: String)]
+            to candidates: inout [CmxAttachRoute]
         ) {
             for route in ordered {
                 if !supportedKinds.isEmpty, !supportedKinds.contains(route.kind) {
                     continue
                 }
-                guard predicate(route),
-                      case let .hostPort(host, port) = route.endpoint else {
+                guard predicate(route) else {
                     continue
                 }
-                let endpointKey = "\(host)\u{1F}\(port)"
+                let endpointKey = reconnectRouteKey(route)
                 guard seenEndpoints.insert(endpointKey).inserted else { continue }
-                candidates.append((host: host, port: port, routeID: route.id))
+                candidates.append(route)
             }
         }
 
-        var candidates: [(host: String, port: Int, routeID: String)] = []
+        var candidates: [CmxAttachRoute] = []
         if preferNonLoopback {
             appendCandidates(where: { route in
-                guard route.kind != .debugLoopback,
-                      case let .hostPort(host, _) = route.endpoint else { return false }
-                return Self.isIPLiteralHost(host)
+                switch route.endpoint {
+                case let .hostPort(host, _):
+                    return route.kind != .debugLoopback && Self.isIPLiteralHost(host)
+                case .peer:
+                    return route.kind == .iroh
+                case .url:
+                    return false
+                }
             }, to: &candidates)
-            appendCandidates(where: { $0.kind != .debugLoopback }, to: &candidates)
+            appendCandidates(where: { route in
+                guard route.kind != .debugLoopback else { return false }
+                if case .hostPort = route.endpoint { return true }
+                return false
+            }, to: &candidates)
             // Any real candidate found: stop here so loopback is unreachable
             // even as a dial-everything fallback (see the doc comment).
             guard candidates.isEmpty else { return candidates }
         }
         appendCandidates(where: { _ in true }, to: &candidates)
         return candidates
+    }
+
+    private static func reconnectRouteKey(_ route: CmxAttachRoute) -> String {
+        switch route.endpoint {
+        case let .hostPort(host, port):
+            return "host:\(host)\u{1F}\(port)"
+        case let .peer(id, _, directAddrs, relayURL):
+            return "peer:\(id)\u{1F}\(directAddrs.joined(separator: ","))\u{1F}\(relayURL ?? "")"
+        case let .url(url):
+            return "url:\(url)"
+        }
+    }
+
+    static func reconnectDisplayName(for route: CmxAttachRoute) -> String {
+        switch route.endpoint {
+        case let .hostPort(host, _):
+            return host
+        case let .peer(id, _, _, _):
+            return id
+        case let .url(url):
+            return url
+        }
+    }
+
+    static func isStoredMacReconnectableRoute(_ route: CmxAttachRoute) -> Bool {
+        switch route.endpoint {
+        case let .hostPort(host, _):
+            return MobileShellRouteAuthPolicy.normalizedManualHost(host) != nil
+        case .peer:
+            return route.kind == .iroh
+        case .url:
+            return false
+        }
     }
 
     /// Merges a constrained reconnect ticket with the previously persisted route set.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -382,6 +382,8 @@ extension MobileShellComposite {
             return .requestTimedOut(hostDisplayName: hostDisplayName)
         case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
             return .authorizationFailed(hostDisplayName: hostDisplayName)
+        case .irohEndpointChanged:
+            return .rejected(hostDisplayName: hostDisplayName)
         case let .rpcError(code, _):
             let normalizedCode = code?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
             if let normalizedCode,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceCreateRequest.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceCreateRequest.swift
@@ -94,6 +94,8 @@ extension MobileShellComposite {
                     return .failure(.requestTimedOut(hostDisplayName: connectedHostName))
                 case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
                     return .failure(.authorizationFailed(hostDisplayName: connectedHostName))
+                case .irohEndpointChanged:
+                    return .failure(.rejected(hostDisplayName: connectedHostName))
                 case let .rpcError(code, _):
                     let normalizedCode = code?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
                     if let normalizedCode,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1549,21 +1549,53 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         )
     }
 
-    private func connectStoredMacHost(
+    private func connectStoredMacRoute(
         name: String,
-        host: String,
-        port: Int,
+        route: CmxAttachRoute,
         pairedMacDeviceID: String,
         ifStillCurrent: (() -> Bool)? = nil
     ) async {
-        await connectManualHost(
-            name: name,
-            host: host,
-            port: port,
-            pairedMacDeviceID: pairedMacDeviceID,
-            recordsPairingAttempt: false,
-            ifStillCurrent: ifStillCurrent
-        )
+        if case let .hostPort(host, port) = route.endpoint {
+            await connectManualHost(
+                name: name,
+                host: host,
+                port: port,
+                pairedMacDeviceID: pairedMacDeviceID,
+                recordsPairingAttempt: false,
+                ifStillCurrent: ifStillCurrent
+            )
+            return
+        }
+        guard route.kind == .iroh, case .peer = route.endpoint else { return }
+        activeRoute = route
+        let attemptID = beginPairingValidationAttempt()
+        guard await failPairingIfOffline(attemptID: attemptID, phase: "preflight", routes: [route]) == .proceed else {
+            return
+        }
+        do {
+            let ticket = try CmxAttachTicket(workspaceID: "", terminalID: nil, macDeviceID: pairedMacDeviceID, macDisplayName: name, routes: [route])
+            guard isCurrentPairingAttempt(attemptID), ifStillCurrent?() ?? true else { return }
+            let noThrowFailure = try await connect(ticket: ticket, pairedMacDeviceID: pairedMacDeviceID, ifStillCurrent: ifStillCurrent)
+            guard isCurrentPairingAttempt(attemptID), ifStillCurrent?() ?? true else { return }
+            if connectionState == .connected {
+                recordPairingSucceeded()
+            } else {
+                recordFailureForCurrentConnectionError(phase: "connect", category: noThrowFailure)
+            }
+        } catch is CancellationError {
+            guard isCurrentPairingAttempt(attemptID) else { return }
+            connectionState = .disconnected
+            macConnectionStatus = .unavailable
+            clearRemoteConnectionContext()
+        } catch {
+            guard isCurrentPairingAttempt(attemptID) else { return }
+            mobileShellLog.error("stored iroh reconnect failed: \(String(describing: error), privacy: .private)")
+            if disconnectForAuthorizationFailureIfNeeded(error) { return }
+            applyPairingFailure(MobilePairingFailureCategory.classify(error: error, route: route), phase: "connect")
+            connectionState = .disconnected
+            macConnectionStatus = .unavailable
+            clearRemoteConnectionContext()
+        }
     }
 
     /// - Parameter pairedMacDeviceID: the REAL paired-Mac device id when the caller
@@ -1695,8 +1727,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         }
         guard await isScopeCurrent(scope) else { finishStoredMacReconnectAttempt(generation: generation); return false }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
-        func reachableRoutes(_ mac: MobilePairedMac) -> [(host: String, port: Int, routeID: String)] {
-            Self.reconnectHostPortRoutes(
+        func reachableRoutes(_ mac: MobilePairedMac) -> [CmxAttachRoute] {
+            Self.reconnectRoutes(
                 mac.routes,
                 supportedKinds: supportedKinds,
                 preferNonLoopback: Self.prefersNonLoopbackRoutes
@@ -1785,10 +1817,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             for route in localRoutes {
                 guard generation == storedMacReconnectGeneration,
                       await isScopeCurrent(scope) else { break }
-                await connectStoredMacHost(
-                    name: mac.displayName ?? route.host,
-                    host: route.host,
-                    port: route.port,
+                await connectStoredMacRoute(
+                    name: mac.displayName ?? Self.reconnectDisplayName(for: route),
+                    route: route,
                     pairedMacDeviceID: mac.macDeviceID)
                 if connectionState == .connected { break }
             }
@@ -1802,10 +1833,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 for route in refreshedRoutes {
                     guard generation == storedMacReconnectGeneration,
                           await isScopeCurrent(scope) else { break }
-                    await connectStoredMacHost(
-                        name: mac.displayName ?? route.host,
-                        host: route.host,
-                        port: route.port,
+                    await connectStoredMacRoute(
+                        name: mac.displayName ?? Self.reconnectDisplayName(for: route),
+                        route: route,
                         pairedMacDeviceID: mac.macDeviceID)
                     if connectionState == .connected { break }
                 }
@@ -2299,11 +2329,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         instance: RegistryAppInstance
     ) async {
         let supportedKinds = runtime?.supportedRouteKinds ?? []
-        let candidateRoutes = Self.reconnectHostPortRoutes(
+        let candidateRoutes = Self.reconnectRoutes(
             instance.routes,
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
-        ).filter { MobileShellRouteAuthPolicy.normalizedManualHost($0.host) != nil }
+        ).filter(Self.isStoredMacReconnectableRoute)
         guard !candidateRoutes.isEmpty else {
             mobileShellLog.error(
                 "connectToRegistryInstance: no reconnectable route device=\(device.deviceId, privacy: .public) tag=\(instance.tag, privacy: .public)"
@@ -2315,8 +2345,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
            connectedMacDeviceID == device.deviceId,
            case let .hostPort(liveHost, livePort)? = activeRoute?.endpoint {
             for route in candidateRoutes {
-                if MobileShellRouteAuthPolicy.normalizedManualHost(route.host) == liveHost,
-                   livePort == route.port {
+                if case let .hostPort(host, port) = route.endpoint,
+                   MobileShellRouteAuthPolicy.normalizedManualHost(host) == liveHost,
+                   livePort == port {
                     return
                 }
             }
@@ -2330,17 +2361,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // switch failure.
         let previousActive = pairedMacs.first { $0.isActive }
         let scope = await currentScopeSnapshot()
-        var connectedRoute: (host: String, port: Int, routeID: String)?
+        var connectedRoute: CmxAttachRoute?
         for route in candidateRoutes {
-            await connectManualHost(
-                name: device.displayName ?? route.host,
-                host: route.host,
-                port: route.port,
+            await connectStoredMacRoute(
+                name: device.displayName ?? Self.reconnectDisplayName(for: route),
+                route: route,
                 pairedMacDeviceID: device.deviceId)
-            guard connectionState == .connected,
-                  case let .hostPort(liveHost, livePort)? = activeRoute?.endpoint,
-                  liveHost == MobileShellRouteAuthPolicy.normalizedManualHost(route.host),
-                  livePort == route.port else {
+            guard connectionState == .connected else {
                 continue
             }
             connectedRoute = route
@@ -2598,11 +2625,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             macSwitchRestoreBaseline = nil
         }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
-        let candidateRoutes = Self.reconnectHostPortRoutes(
+        let candidateRoutes = Self.reconnectRoutes(
             refreshedTarget.routes,
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
-        ).filter { MobileShellRouteAuthPolicy.normalizedManualHost($0.host) != nil }
+        ).filter(Self.isStoredMacReconnectableRoute)
         guard !candidateRoutes.isEmpty else {
             mobileShellLog.error("switchToMac: no reconnectable route mac=\(macDeviceID, privacy: .private)")
             if !hasActiveMacConnection,
@@ -2615,12 +2642,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return false
         }
         for route in candidateRoutes {
-            await connectManualHost(
-                name: refreshedTarget.displayName ?? route.host,
-                host: route.host,
-                port: route.port,
+            await connectStoredMacRoute(
+                name: refreshedTarget.displayName ?? Self.reconnectDisplayName(for: route),
+                route: route,
                 pairedMacDeviceID: macDeviceID,
-                recordsPairingAttempt: true,
                 ifStillCurrent: { [weak self] in
                     self?.isCurrentMacSwitchAttempt(switchAttemptID) == true
                 }
@@ -2731,21 +2756,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
         guard !previousStillForeground else { return true }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
-        let candidateRoutes = Self.reconnectHostPortRoutes(
+        let candidateRoutes = Self.reconnectRoutes(
             previousActive.routes,
             supportedKinds: supportedKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
-        ).filter { MobileShellRouteAuthPolicy.normalizedManualHost($0.host) != nil }
+        ).filter(Self.isStoredMacReconnectableRoute)
         guard !candidateRoutes.isEmpty else {
             mobileShellLog.error("restorePreviousMacIfNeeded: no reconnectable route mac=\(previousActive.macDeviceID, privacy: .private)")
             return false
         }
         for route in candidateRoutes {
             guard await isScopeCurrent(restoreScope), isRestoreCurrent() else { return false }
-            await connectStoredMacHost(
-                name: previousActive.displayName ?? route.host,
-                host: route.host,
-                port: route.port,
+            await connectStoredMacRoute(
+                name: previousActive.displayName ?? Self.reconnectDisplayName(for: route),
+                route: route,
                 pairedMacDeviceID: previousActive.macDeviceID,
                 ifStillCurrent: isRestoreCurrent
             )
@@ -7625,30 +7649,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // also route through here never emit `ios_pairing_failed`.
         recordPairingFailed(reason: category.analyticsReason, phase: "auth")
         return true
-    }
-
-    private static func shouldDisconnectForAuthorizationFailure(_ error: any Error) -> Bool {
-        guard let connectionError = error as? MobileShellConnectionError else {
-            return false
-        }
-        switch connectionError {
-        case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
-            return true
-        case let .rpcError(code, message):
-            let normalizedCode = code?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            if let normalizedCode,
-               ["unauthorized", "forbidden", "invalid_token", "token_expired", "expired_token", "auth_required"].contains(normalizedCode) {
-                return true
-            }
-            let normalizedMessage = message.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-            return normalizedMessage.contains("unauthorized")
-                || normalizedMessage.contains("forbidden")
-                || normalizedMessage.contains("invalid token")
-                || normalizedMessage.contains("expired token")
-                || normalizedMessage.contains("token expired")
-        case .invalidResponse, .connectionClosed, .requestTimedOut:
-            return false
-        }
     }
 
     private func applyPreviewTicket(_ ticket: CmxAttachTicket, route: CmxAttachRoute) {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
@@ -12,7 +12,8 @@ struct MobileShellMacAvailabilityFailureClassifier {
         switch shellError {
         case .connectionClosed, .requestTimedOut:
             return true
-        case .invalidResponse, .insecureManualRoute, .attachTicketExpired, .authorizationFailed, .accountMismatch, .rpcError:
+        case .invalidResponse, .insecureManualRoute, .attachTicketExpired, .authorizationFailed,
+             .accountMismatch, .irohEndpointChanged, .rpcError:
             // .accountMismatch means the Mac is reachable but signed in to a
             // different account; that is an auth problem, not a Mac-availability one.
             return false

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecord.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecord.swift
@@ -21,6 +21,8 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
     public var customColor: String?
     /// User-selected icon override, or `nil` for the platform default.
     public var customIcon: String?
+    /// Trusted iroh EndpointId pinned for this Mac, if any.
+    public var irohEndpointID: String?
 
     /// Create one wire backup record.
     public init(
@@ -32,7 +34,8 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
         isActive: Bool,
         customName: String? = nil,
         customColor: String? = nil,
-        customIcon: String? = nil
+        customIcon: String? = nil,
+        irohEndpointID: String? = nil
     ) {
         self.macDeviceID = macDeviceID
         self.displayName = displayName
@@ -43,11 +46,13 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
         self.customName = customName
         self.customColor = customColor
         self.customIcon = customIcon
+        self.irohEndpointID = irohEndpointID
     }
 
     enum CodingKeys: String, CodingKey {
         case macDeviceID, displayName, routes, createdAt, lastSeenAt, isActive
         case customName, customColor, customIcon
+        case irohEndpointID
     }
 
     /// Decode one saved-host backup record, dropping unsupported route entries
@@ -64,6 +69,7 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
         customName = try c.decodeIfPresent(String.self, forKey: .customName)
         customColor = try c.decodeIfPresent(String.self, forKey: .customColor)
         customIcon = try c.decodeIfPresent(String.self, forKey: .customIcon)
+        irohEndpointID = try c.decodeIfPresent(String.self, forKey: .irohEndpointID)
     }
 
     /// Encode custom override keys even when they are `nil`, so clears sync.
@@ -78,5 +84,6 @@ public struct PairedMacBackupRecord: Codable, Sendable, Equatable {
         try c.encode(customName, forKey: .customName)
         try c.encode(customColor, forKey: .customColor)
         try c.encode(customIcon, forKey: .customIcon)
+        try c.encodeIfPresent(irohEndpointID, forKey: .irohEndpointID)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecordWire.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupRecordWire.swift
@@ -13,6 +13,7 @@ struct PairedMacBackupRecordWire: Encodable {
         try c.encode(record.createdAt, forKey: .createdAt)
         try c.encode(record.lastSeenAt, forKey: .lastSeenAt)
         try c.encode(record.isActive, forKey: .isActive)
+        try c.encodeIfPresent(record.irohEndpointID, forKey: .irohEndpointID)
         guard includesCustomizations else { return }
         try c.encode(record.customName, forKey: .customName)
         try c.encode(record.customColor, forKey: .customColor)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePairingFailureTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePairingFailureTests.swift
@@ -82,6 +82,20 @@ import Testing
         #expect(category.guidance != nil)
     }
 
+    @Test func irohTimeoutClassifiesWithIrohGuidance() throws {
+        let category = MobilePairingFailureCategory.classify(
+            error: CmxIrohByteTransportError.connectionFailed("timeout", .timedOut),
+            route: try CmxAttachRoute(
+                id: "iroh",
+                kind: .iroh,
+                endpoint: .peer(id: "endpoint-a", relayHint: nil, directAddrs: [], relayURL: nil)
+            )
+        )
+        #expect(category == .irohTimedOut)
+        #expect(category.analyticsReason == "iroh_timeout")
+        #expect(category.guidance?.contains("Tailscale setup") == true)
+    }
+
     @Test func receiveFailureMeansConnectionDropped() throws {
         let category = MobilePairingFailureCategory.classify(
             error: CmxNetworkByteTransportError.receiveFailed("eof"),

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -30,6 +30,15 @@ import Testing
         )
     }
 
+    private func iroh(id: String = "endpoint-a", priority: Int = 1) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "iroh-\(id)",
+            kind: .iroh,
+            endpoint: .peer(id: id, relayHint: nil, directAddrs: [], relayURL: nil),
+            priority: priority
+        )
+    }
+
     @Test func physicalDevicePrefersRealRouteOverLowerPriorityLoopback() throws {
         let pick = MobileShellComposite.firstReconnectHostPortRoute(
             [try loopback(), try tailscale()],
@@ -67,6 +76,26 @@ import Testing
         )
 
         #expect(candidates.map { $0.host } == ["127.0.0.1", "100.82.214.112"])
+    }
+
+    @Test func reconnectCandidatesIncludeIrohPeerRoutesByPriority() throws {
+        let candidates = MobileShellComposite.reconnectRoutes(
+            [try tailscale(), try iroh(priority: 1)],
+            supportedKinds: [.iroh, .tailscale],
+            preferNonLoopback: false
+        )
+
+        #expect(candidates.map(\.kind) == [.iroh, .tailscale])
+    }
+
+    @Test func physicalDeviceCandidatesKeepIrohPeerBeforeLoopback() throws {
+        let candidates = MobileShellComposite.reconnectRoutes(
+            [try loopback(), try iroh(priority: 1)],
+            supportedKinds: [.debugLoopback, .iroh],
+            preferNonLoopback: true
+        )
+
+        #expect(candidates.map(\.kind) == [.iroh])
     }
 
     @Test func physicalDeviceCandidatesNeverIncludeLoopbackWhenRealRoutesExist() throws {

--- a/Packages/iOS/CmuxMobileTransport/Package.swift
+++ b/Packages/iOS/CmuxMobileTransport/Package.swift
@@ -18,13 +18,28 @@ let package = Package(
         .package(path: "../../Shared/CMUXMobileCore"),
     ],
     targets: [
+        .binaryTarget(
+            name: "CmuxIrohFFI",
+            path: "../../../CmuxIrohFFI.xcframework"
+        ),
+        .target(
+            name: "CmuxIrohC",
+            dependencies: ["CmuxIrohFFI"],
+            publicHeadersPath: "include"
+        ),
         .target(
             name: "CmuxMobileTransport",
-            dependencies: ["CMUXMobileCore"],
+            dependencies: ["CMUXMobileCore", "CmuxIrohC"],
             swiftSettings: [
                 .swiftLanguageMode(.v6),
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
+            ],
+            linkerSettings: [
+                .linkedFramework("CoreWLAN", .when(platforms: [.macOS])),
+                .linkedFramework("Network"),
+                .linkedFramework("Security"),
+                .linkedFramework("SystemConfiguration"),
             ]
         ),
         .testTarget(

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxIrohC/CmuxIrohC.c
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxIrohC/CmuxIrohC.c
@@ -1,0 +1,2 @@
+#include "CmuxIrohC.h"
+

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxIrohC/include/CmuxIrohC.h
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxIrohC/include/CmuxIrohC.h
@@ -1,0 +1,85 @@
+#ifndef CMUX_IROH_C_H
+#define CMUX_IROH_C_H
+
+#include <stdbool.h>
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CMUX_IROH_SECRET_KEY_LEN 32
+
+typedef struct CmuxIrohEndpoint CmuxIrohEndpoint;
+typedef struct CmuxIrohConnection CmuxIrohConnection;
+
+typedef enum CmuxIrohErrorKind {
+    CMUX_IROH_ERROR_NONE = 0,
+    CMUX_IROH_ERROR_INVALID_ARGUMENT = 1,
+    CMUX_IROH_ERROR_TIMED_OUT = 2,
+    CMUX_IROH_ERROR_CONNECTION_REFUSED = 3,
+    CMUX_IROH_ERROR_HOST_UNREACHABLE = 4,
+    CMUX_IROH_ERROR_PERMISSION_DENIED = 5,
+    CMUX_IROH_ERROR_DNS_FAILED = 6,
+    CMUX_IROH_ERROR_SECURE_CHANNEL_FAILED = 7,
+    CMUX_IROH_ERROR_ENDPOINT_CLOSED = 8,
+    CMUX_IROH_ERROR_NOT_CONNECTED = 9,
+    CMUX_IROH_ERROR_IO = 10,
+    CMUX_IROH_ERROR_INTERNAL = 11,
+} CmuxIrohErrorKind;
+
+typedef struct CmuxIrohError {
+    uint32_t kind;
+    char *message;
+    size_t message_cap;
+} CmuxIrohError;
+
+int cmux_iroh_secret_key_generate(uint8_t *out_secret_key, size_t len, CmuxIrohError *error);
+
+CmuxIrohEndpoint *cmux_iroh_endpoint_bind(
+    const uint8_t *secret_key,
+    size_t secret_key_len,
+    bool enable_relay,
+    bool accept_connections,
+    CmuxIrohError *error
+);
+
+char *cmux_iroh_endpoint_id(const CmuxIrohEndpoint *endpoint);
+char *cmux_iroh_endpoint_route_json(const CmuxIrohEndpoint *endpoint);
+int cmux_iroh_endpoint_online(CmuxIrohEndpoint *endpoint, uint64_t timeout_ms, CmuxIrohError *error);
+CmuxIrohConnection *cmux_iroh_endpoint_accept(CmuxIrohEndpoint *endpoint, uint64_t timeout_ms, CmuxIrohError *error);
+
+CmuxIrohConnection *cmux_iroh_endpoint_connect(
+    CmuxIrohEndpoint *endpoint,
+    const char *endpoint_id,
+    const char *relay_url,
+    const char *const *direct_addrs,
+    size_t direct_addr_count,
+    uint64_t timeout_ms,
+    CmuxIrohError *error
+);
+
+intptr_t cmux_iroh_connection_recv(
+    CmuxIrohConnection *connection,
+    uint8_t *buffer,
+    size_t buffer_len,
+    CmuxIrohError *error
+);
+
+int cmux_iroh_connection_send(
+    CmuxIrohConnection *connection,
+    const uint8_t *bytes,
+    size_t len,
+    CmuxIrohError *error
+);
+
+void cmux_iroh_connection_close(CmuxIrohConnection *connection);
+void cmux_iroh_endpoint_close(CmuxIrohEndpoint *endpoint);
+void cmux_iroh_string_free(char *value);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohByteTransport.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohByteTransport.swift
@@ -1,0 +1,200 @@
+public import CMUXMobileCore
+public import Foundation
+
+/// A ``CmxRouteAwareByteTransportFactory`` that builds iroh byte transports for
+/// peer routes.
+public struct CmxIrohByteTransportFactory: CmxRouteAwareByteTransportFactory {
+    /// The route kinds this factory can build a transport for.
+    public var supportedKinds: [CmxAttachTransportKind] { [.iroh] }
+
+    let endpointManager: CmxIrohEndpointManager
+    let ffiClient: any CmxIrohFFIClient
+    private let maximumReceiveLength: Int
+    private let connectTimeoutNanoseconds: UInt64
+
+    /// Creates a factory using a shared endpoint manager.
+    public init(
+        endpointManager: CmxIrohEndpointManager = CmxIrohEndpointManager(),
+        maximumReceiveLength: Int = CmxIrohByteTransport.defaultMaximumReceiveLength,
+        connectTimeoutNanoseconds: UInt64 = CmxIrohByteTransport.defaultConnectTimeoutNanoseconds
+    ) {
+        self.init(
+            endpointManager: endpointManager,
+            ffiClient: CmxIrohSystemFFIClient(),
+            maximumReceiveLength: maximumReceiveLength,
+            connectTimeoutNanoseconds: connectTimeoutNanoseconds
+        )
+    }
+
+    init(
+        endpointManager: CmxIrohEndpointManager,
+        ffiClient: any CmxIrohFFIClient,
+        maximumReceiveLength: Int = CmxIrohByteTransport.defaultMaximumReceiveLength,
+        connectTimeoutNanoseconds: UInt64 = CmxIrohByteTransport.defaultConnectTimeoutNanoseconds
+    ) {
+        self.endpointManager = endpointManager
+        self.ffiClient = ffiClient
+        self.maximumReceiveLength = maximumReceiveLength
+        self.connectTimeoutNanoseconds = connectTimeoutNanoseconds
+    }
+
+    /// Builds a connected-on-demand iroh transport for a supported peer route.
+    public func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        try CmxIrohByteTransport(
+            route: route,
+            endpointManager: endpointManager,
+            ffiClient: ffiClient,
+            maximumReceiveLength: maximumReceiveLength,
+            connectTimeoutNanoseconds: connectTimeoutNanoseconds
+        )
+    }
+}
+
+/// A ``CmxByteTransport`` over one iroh bidirectional stream.
+public actor CmxIrohByteTransport: CmxByteTransport {
+    /// Default per-receive byte cap.
+    public static let defaultMaximumReceiveLength = 64 * 1024
+    /// Default iroh connect deadline.
+    public static let defaultConnectTimeoutNanoseconds: UInt64 = 15 * 1_000_000_000
+
+    private enum State {
+        case idle
+        case ready(CmxIrohConnectionReference)
+        case closed
+    }
+
+    private let peerID: String
+    private let relayURL: String?
+    private let directAddrs: [String]
+    private let endpointManager: CmxIrohEndpointManager
+    private let ffiClient: any CmxIrohFFIClient
+    private let maximumReceiveLength: Int
+    private let connectTimeoutMilliseconds: UInt64
+    private var state: State = .idle
+
+    /// Creates an iroh transport from an attach route.
+    public init(
+        route: CmxAttachRoute,
+        endpointManager: CmxIrohEndpointManager = CmxIrohEndpointManager(),
+        maximumReceiveLength: Int = CmxIrohByteTransport.defaultMaximumReceiveLength,
+        connectTimeoutNanoseconds: UInt64 = CmxIrohByteTransport.defaultConnectTimeoutNanoseconds
+    ) throws {
+        try self.init(
+            route: route,
+            endpointManager: endpointManager,
+            ffiClient: CmxIrohSystemFFIClient(),
+            maximumReceiveLength: maximumReceiveLength,
+            connectTimeoutNanoseconds: connectTimeoutNanoseconds
+        )
+    }
+
+    init(
+        route: CmxAttachRoute,
+        endpointManager: CmxIrohEndpointManager,
+        ffiClient: any CmxIrohFFIClient,
+        maximumReceiveLength: Int = CmxIrohByteTransport.defaultMaximumReceiveLength,
+        connectTimeoutNanoseconds: UInt64 = CmxIrohByteTransport.defaultConnectTimeoutNanoseconds
+    ) throws {
+        try route.validate()
+        guard route.kind == .iroh else {
+            throw CmxIrohByteTransportError.unsupportedRouteKind(route.kind)
+        }
+        guard case let .peer(id, _, directAddrs, relayURL) = route.endpoint else {
+            throw CmxIrohByteTransportError.unsupportedEndpoint(route.endpoint)
+        }
+        let normalizedPeerID = id.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedPeerID.isEmpty else {
+            throw CmxIrohByteTransportError.emptyPeerID
+        }
+        guard maximumReceiveLength > 0 else {
+            throw CmxIrohByteTransportError.invalidMaximumReceiveLength(maximumReceiveLength)
+        }
+        self.peerID = normalizedPeerID
+        self.relayURL = relayURL?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+        self.directAddrs = directAddrs.map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        self.endpointManager = endpointManager
+        self.ffiClient = ffiClient
+        self.maximumReceiveLength = maximumReceiveLength
+        self.connectTimeoutMilliseconds = max(1, connectTimeoutNanoseconds / 1_000_000)
+    }
+
+    /// Opens the iroh stream.
+    public func connect() async throws {
+        try Task.checkCancellation()
+        switch state {
+        case .idle:
+            break
+        case .ready:
+            return
+        case .closed:
+            throw CmxIrohByteTransportError.alreadyClosed
+        }
+
+        let endpoint = try await endpointManager.boundEndpoint()
+        do {
+            let connection = try ffiClient.connect(
+                endpoint: endpoint,
+                peerID: peerID,
+                relayURL: relayURL,
+                directAddrs: directAddrs,
+                timeoutMilliseconds: connectTimeoutMilliseconds
+            )
+            state = .ready(connection)
+        } catch let failure as CmxIrohFailure {
+            throw CmxIrohByteTransportError.connectFailed(failure)
+        }
+    }
+
+    /// Receives the next chunk of bytes, or `nil` at end of stream.
+    public func receive() async throws -> Data? {
+        try Task.checkCancellation()
+        guard case let .ready(connection) = state else {
+            if case .closed = state { return nil }
+            throw CmxIrohByteTransportError.notConnected
+        }
+        do {
+            return try ffiClient.receive(
+                connection: connection,
+                maximumLength: maximumReceiveLength
+            )
+        } catch let failure as CmxIrohFailure {
+            throw CmxIrohByteTransportError.receiveFailed(failure)
+        }
+    }
+
+    /// Sends bytes over the stream. Empty data is a no-op.
+    public func send(_ data: Data) async throws {
+        guard !data.isEmpty else {
+            return
+        }
+        try Task.checkCancellation()
+        guard case let .ready(connection) = state else {
+            if case .closed = state {
+                throw CmxIrohByteTransportError.alreadyClosed
+            }
+            throw CmxIrohByteTransportError.notConnected
+        }
+        do {
+            try ffiClient.send(connection: connection, data: data)
+        } catch let failure as CmxIrohFailure {
+            throw CmxIrohByteTransportError.sendFailed(failure)
+        }
+    }
+
+    /// Closes the stream and releases the FFI connection handle.
+    public func close() async {
+        guard case let .ready(connection) = state else {
+            state = .closed
+            return
+        }
+        state = .closed
+        ffiClient.close(connection: connection)
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohByteTransportError.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohByteTransportError.swift
@@ -1,0 +1,42 @@
+public import CMUXMobileCore
+public import Foundation
+
+/// Errors raised while establishing or operating a ``CmxIrohByteTransport``.
+public enum CmxIrohByteTransportError: Error, Equatable, Sendable {
+    /// The iroh peer endpoint id was empty.
+    case emptyPeerID
+    /// The configured maximum receive length was not positive.
+    case invalidMaximumReceiveLength(Int)
+    /// The route kind cannot be served by the iroh transport.
+    case unsupportedRouteKind(CmxAttachTransportKind)
+    /// The endpoint is not a peer endpoint this transport can dial.
+    case unsupportedEndpoint(CmxAttachEndpoint)
+    /// An operation was attempted before the connection became ready.
+    case notConnected
+    /// The transport was already closed.
+    case alreadyClosed
+    /// The endpoint could not be bound.
+    case endpointBindFailed(String, CmxConnectFailureKind)
+    /// The peer connection failed.
+    case connectionFailed(String, CmxConnectFailureKind)
+    /// A receive failed; the associated value describes the cause.
+    case receiveFailed(String)
+    /// A send failed; the associated value describes the cause.
+    case sendFailed(String)
+
+    static func bindFailed(_ failure: CmxIrohFailure) -> CmxIrohByteTransportError {
+        .endpointBindFailed(failure.message, failure.kind.connectFailureKind)
+    }
+
+    static func connectFailed(_ failure: CmxIrohFailure) -> CmxIrohByteTransportError {
+        .connectionFailed(failure.message, failure.kind.connectFailureKind)
+    }
+
+    static func receiveFailed(_ failure: CmxIrohFailure) -> CmxIrohByteTransportError {
+        .receiveFailed(failure.message)
+    }
+
+    static func sendFailed(_ failure: CmxIrohFailure) -> CmxIrohByteTransportError {
+        .sendFailed(failure.message)
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohEndpointManager.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohEndpointManager.swift
@@ -1,0 +1,70 @@
+public import Foundation
+
+/// Owns the phone-side iroh endpoint for the current foreground lifecycle.
+///
+/// The endpoint is bound lazily on first use and can be closed when the app
+/// enters the background. Swift owns the persisted secret key; the FFI only
+/// receives it while binding the endpoint.
+public actor CmxIrohEndpointManager {
+    private let keyProvider: CmxIrohSecretKeyProvider
+    private let ffiClient: any CmxIrohFFIClient
+    private let enableRelay: Bool
+    private let acceptConnections: Bool
+    private var endpoint: CmxIrohEndpointReference?
+
+    /// Creates a production endpoint manager using the iOS Keychain.
+    public init(
+        enableRelay: Bool = true,
+        acceptConnections: Bool = false
+    ) {
+        let ffiClient = CmxIrohSystemFFIClient()
+        self.init(
+            keyProvider: CmxIrohSecretKeyProvider(
+                store: CmxIrohKeychainSecretStore(),
+                generate: { try ffiClient.generateSecretKey() }
+            ),
+            ffiClient: ffiClient,
+            enableRelay: enableRelay,
+            acceptConnections: acceptConnections
+        )
+    }
+
+    init(
+        keyProvider: CmxIrohSecretKeyProvider,
+        ffiClient: any CmxIrohFFIClient,
+        enableRelay: Bool = true,
+        acceptConnections: Bool = false
+    ) {
+        self.keyProvider = keyProvider
+        self.ffiClient = ffiClient
+        self.enableRelay = enableRelay
+        self.acceptConnections = acceptConnections
+    }
+
+    func boundEndpoint() throws -> CmxIrohEndpointReference {
+        if let endpoint {
+            return endpoint
+        }
+        let secretKey = try keyProvider.secretKey()
+        do {
+            let endpoint = try ffiClient.bindEndpoint(
+                secretKey: secretKey,
+                enableRelay: enableRelay,
+                acceptConnections: acceptConnections
+            )
+            self.endpoint = endpoint
+            return endpoint
+        } catch let failure as CmxIrohFailure {
+            throw CmxIrohByteTransportError.bindFailed(failure)
+        }
+    }
+
+    /// Closes and forgets the current bound endpoint, if any.
+    public func closeEndpoint() {
+        guard let endpoint else {
+            return
+        }
+        self.endpoint = nil
+        ffiClient.close(endpoint: endpoint)
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohFFIClient.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohFFIClient.swift
@@ -1,0 +1,263 @@
+import Darwin
+public import Foundation
+@preconcurrency import CmuxIrohC
+
+final class CmxIrohEndpointReference: @unchecked Sendable {
+    let raw: OpaquePointer
+
+    init(raw: OpaquePointer) {
+        self.raw = raw
+    }
+}
+
+final class CmxIrohConnectionReference: @unchecked Sendable {
+    let raw: OpaquePointer
+
+    init(raw: OpaquePointer) {
+        self.raw = raw
+    }
+}
+
+protocol CmxIrohFFIClient: Sendable {
+    func generateSecretKey() throws -> Data
+    func bindEndpoint(
+        secretKey: Data,
+        enableRelay: Bool,
+        acceptConnections: Bool
+    ) throws -> CmxIrohEndpointReference
+    func endpointID(_ endpoint: CmxIrohEndpointReference) -> String?
+    func routeJSON(_ endpoint: CmxIrohEndpointReference) -> String?
+    func online(endpoint: CmxIrohEndpointReference, timeoutMilliseconds: UInt64) throws
+    func accept(
+        endpoint: CmxIrohEndpointReference,
+        timeoutMilliseconds: UInt64
+    ) throws -> CmxIrohConnectionReference
+    func connect(
+        endpoint: CmxIrohEndpointReference,
+        peerID: String,
+        relayURL: String?,
+        directAddrs: [String],
+        timeoutMilliseconds: UInt64
+    ) throws -> CmxIrohConnectionReference
+    func receive(connection: CmxIrohConnectionReference, maximumLength: Int) throws -> Data?
+    func send(connection: CmxIrohConnectionReference, data: Data) throws
+    func close(connection: CmxIrohConnectionReference)
+    func close(endpoint: CmxIrohEndpointReference)
+}
+
+struct CmxIrohSystemFFIClient: CmxIrohFFIClient {
+    private static let errorMessageCapacity = 2_048
+
+    func generateSecretKey() throws -> Data {
+        var key = [UInt8](repeating: 0, count: Int(CMUX_IROH_SECRET_KEY_LEN))
+        try key.withUnsafeMutableBufferPointer { keyBuffer in
+            try withIrohError { error in
+                let rc = cmux_iroh_secret_key_generate(
+                    keyBuffer.baseAddress,
+                    keyBuffer.count,
+                    error
+                )
+                guard rc == 0 else {
+                    throw failure(from: error)
+                }
+            }
+        }
+        return Data(key)
+    }
+
+    func bindEndpoint(
+        secretKey: Data,
+        enableRelay: Bool,
+        acceptConnections: Bool
+    ) throws -> CmxIrohEndpointReference {
+        try secretKey.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                throw CmxIrohFailure(
+                    kind: .invalidArgument,
+                    message: "empty iroh secret key"
+                )
+            }
+            return try withIrohError { error in
+                guard let endpoint = cmux_iroh_endpoint_bind(
+                    baseAddress,
+                    secretKey.count,
+                    enableRelay,
+                    acceptConnections,
+                    error
+                ) else {
+                    throw failure(from: error)
+                }
+                return CmxIrohEndpointReference(raw: endpoint)
+            }
+        }
+    }
+
+    func endpointID(_ endpoint: CmxIrohEndpointReference) -> String? {
+        guard let cString = cmux_iroh_endpoint_id(endpoint.raw) else {
+            return nil
+        }
+        defer { cmux_iroh_string_free(cString) }
+        return String(cString: cString)
+    }
+
+    func routeJSON(_ endpoint: CmxIrohEndpointReference) -> String? {
+        guard let cString = cmux_iroh_endpoint_route_json(endpoint.raw) else {
+            return nil
+        }
+        defer { cmux_iroh_string_free(cString) }
+        return String(cString: cString)
+    }
+
+    func online(endpoint: CmxIrohEndpointReference, timeoutMilliseconds: UInt64) throws {
+        try withIrohError { error in
+            let rc = cmux_iroh_endpoint_online(endpoint.raw, timeoutMilliseconds, error)
+            guard rc == 0 else {
+                throw failure(from: error)
+            }
+        }
+    }
+
+    func accept(
+        endpoint: CmxIrohEndpointReference,
+        timeoutMilliseconds: UInt64
+    ) throws -> CmxIrohConnectionReference {
+        try withIrohError { error in
+            guard let connection = cmux_iroh_endpoint_accept(
+                endpoint.raw,
+                timeoutMilliseconds,
+                error
+            ) else {
+                throw failure(from: error)
+            }
+            return CmxIrohConnectionReference(raw: connection)
+        }
+    }
+
+    func connect(
+        endpoint: CmxIrohEndpointReference,
+        peerID: String,
+        relayURL: String?,
+        directAddrs: [String],
+        timeoutMilliseconds: UInt64
+    ) throws -> CmxIrohConnectionReference {
+        let duplicatedAddrs = try directAddrs.map { address in
+            guard let copy = strdup(address) else {
+                throw CmxIrohFailure(kind: .internalFailure, message: "failed to allocate direct address")
+            }
+            return copy
+        }
+        defer {
+            duplicatedAddrs.forEach { free($0) }
+        }
+        var addrPointers = duplicatedAddrs.map { Optional(UnsafePointer<CChar>($0)) }
+
+        return try peerID.withCString { peerPtr in
+            try withOptionalCString(relayURL) { relayPtr in
+                try addrPointers.withUnsafeBufferPointer { addrBuffer in
+                    try withIrohError { error in
+                        guard let connection = cmux_iroh_endpoint_connect(
+                            endpoint.raw,
+                            peerPtr,
+                            relayPtr,
+                            addrBuffer.baseAddress,
+                            addrBuffer.count,
+                            timeoutMilliseconds,
+                            error
+                        ) else {
+                            throw failure(from: error)
+                        }
+                        return CmxIrohConnectionReference(raw: connection)
+                    }
+                }
+            }
+        }
+    }
+
+    func receive(connection: CmxIrohConnectionReference, maximumLength: Int) throws -> Data? {
+        var buffer = [UInt8](repeating: 0, count: maximumLength)
+        return try buffer.withUnsafeMutableBufferPointer { bytes in
+            try withIrohError { error in
+                let count = cmux_iroh_connection_recv(
+                    connection.raw,
+                    bytes.baseAddress,
+                    bytes.count,
+                    error
+                )
+                if count == 0 {
+                    return nil
+                }
+                guard count > 0 else {
+                    throw failure(from: error)
+                }
+                return Data(bytes.prefix(Int(count)))
+            }
+        }
+    }
+
+    func send(connection: CmxIrohConnectionReference, data: Data) throws {
+        guard !data.isEmpty else {
+            return
+        }
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                return
+            }
+            try withIrohError { error in
+                let rc = cmux_iroh_connection_send(
+                    connection.raw,
+                    baseAddress,
+                    data.count,
+                    error
+                )
+                guard rc == 0 else {
+                    throw failure(from: error)
+                }
+            }
+        }
+    }
+
+    func close(connection: CmxIrohConnectionReference) {
+        cmux_iroh_connection_close(connection.raw)
+    }
+
+    func close(endpoint: CmxIrohEndpointReference) {
+        cmux_iroh_endpoint_close(endpoint.raw)
+    }
+
+    private func withOptionalCString<T>(
+        _ string: String?,
+        _ body: (UnsafePointer<CChar>?) throws -> T
+    ) throws -> T {
+        guard let string else {
+            return try body(nil)
+        }
+        return try string.withCString { pointer in
+            try body(pointer)
+        }
+    }
+
+    private func withIrohError<T>(_ body: (UnsafeMutablePointer<CmuxIrohError>) throws -> T) throws -> T {
+        var message = [CChar](repeating: 0, count: Self.errorMessageCapacity)
+        return try message.withUnsafeMutableBufferPointer { buffer in
+            var error = CmuxIrohError(
+                kind: CmxIrohErrorKind.none.rawValue,
+                message: buffer.baseAddress,
+                message_cap: buffer.count
+            )
+            return try body(&error)
+        }
+    }
+
+    private func failure(from error: UnsafeMutablePointer<CmuxIrohError>) -> CmxIrohFailure {
+        let message: String
+        if let cString = error.pointee.message, cString.pointee != 0 {
+            message = String(cString: cString)
+        } else {
+            message = "iroh operation failed"
+        }
+        return CmxIrohFailure(
+            kind: CmxIrohErrorKind(rawFFIValue: error.pointee.kind),
+            message: message
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohFailure.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohFailure.swift
@@ -1,0 +1,57 @@
+public import Foundation
+
+/// A classified error returned by the cmux iroh C FFI.
+public struct CmxIrohFailure: Error, Equatable, Sendable {
+    /// The raw FFI error kind.
+    public var kind: CmxIrohErrorKind
+    /// Human-readable detail supplied by the FFI.
+    public var message: String
+
+    /// Creates an iroh FFI failure.
+    public init(kind: CmxIrohErrorKind, message: String) {
+        self.kind = kind
+        self.message = message
+    }
+}
+
+/// Stable iroh C FFI error-kind codes.
+public enum CmxIrohErrorKind: UInt32, Sendable, Equatable {
+    case none = 0
+    case invalidArgument = 1
+    case timedOut = 2
+    case connectionRefused = 3
+    case hostUnreachable = 4
+    case permissionDenied = 5
+    case dnsFailed = 6
+    case secureChannelFailed = 7
+    case endpointClosed = 8
+    case notConnected = 9
+    case io = 10
+    case internalFailure = 11
+    case unknown = 0xffff_ffff
+
+    /// The matching generic connect-failure classification used by the shell UI.
+    public var connectFailureKind: CmxConnectFailureKind {
+        switch self {
+        case .timedOut:
+            return .timedOut
+        case .connectionRefused:
+            return .connectionRefused
+        case .hostUnreachable, .endpointClosed, .notConnected:
+            return .hostUnreachable
+        case .permissionDenied:
+            return .permissionDenied
+        case .dnsFailed:
+            return .dnsFailed
+        case .secureChannelFailed:
+            return .secureChannelFailed
+        case .none, .invalidArgument, .io, .internalFailure, .unknown:
+            return .generic
+        }
+    }
+
+    /// Creates a known kind, or ``unknown`` for future FFI codes.
+    public init(rawFFIValue: UInt32) {
+        self = Self(rawValue: rawFFIValue) ?? .unknown
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohKeychainSecretStore.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohKeychainSecretStore.swift
@@ -1,0 +1,63 @@
+import Foundation
+import Security
+
+struct CmxIrohKeychainSecretStore: CmxIrohSecretKeyStoring {
+    private let service: String
+    private let account: String
+
+    init(
+        service: String = "dev.cmux.mobile.iroh.endpoint",
+        account: String = "phone-endpoint-secret-key"
+    ) {
+        self.service = service
+        self.account = account
+    }
+
+    func loadSecretKey() throws -> Data? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = kCFBooleanTrue
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw CmxIrohSecretKeyStoreError.keychainReadFailed(status)
+        }
+        return data
+    }
+
+    func saveSecretKey(_ key: Data) throws {
+        var attributes = baseQuery()
+        attributes[kSecValueData as String] = key
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let addStatus = SecItemAdd(attributes as CFDictionary, nil)
+        if addStatus == errSecSuccess {
+            return
+        }
+        if addStatus != errSecDuplicateItem {
+            throw CmxIrohSecretKeyStoreError.keychainWriteFailed(addStatus)
+        }
+
+        let update: [String: Any] = [
+            kSecValueData as String: key,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(baseQuery() as CFDictionary, update as CFDictionary)
+        guard updateStatus == errSecSuccess else {
+            throw CmxIrohSecretKeyStoreError.keychainWriteFailed(updateStatus)
+        }
+    }
+
+    private func baseQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+        ]
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohSecretKeyStore.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohSecretKeyStore.swift
@@ -1,0 +1,35 @@
+import Foundation
+@preconcurrency import CmuxIrohC
+
+protocol CmxIrohSecretKeyStoring: Sendable {
+    func loadSecretKey() throws -> Data?
+    func saveSecretKey(_ key: Data) throws
+}
+
+enum CmxIrohSecretKeyStoreError: Error, Equatable, Sendable {
+    case invalidLength(Int)
+    case keychainReadFailed(OSStatus)
+    case keychainWriteFailed(OSStatus)
+}
+
+struct CmxIrohSecretKeyProvider: Sendable {
+    let store: any CmxIrohSecretKeyStoring
+    let generate: @Sendable () throws -> Data
+
+    func secretKey() throws -> Data {
+        if let existing = try store.loadSecretKey() {
+            try validate(existing)
+            return existing
+        }
+        let generated = try generate()
+        try validate(generated)
+        try store.saveSecretKey(generated)
+        return generated
+    }
+
+    private func validate(_ data: Data) throws {
+        guard data.count == Int(CMUX_IROH_SECRET_KEY_LEN) else {
+            throw CmxIrohSecretKeyStoreError.invalidLength(data.count)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkRoutePinger.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxNetworkRoutePinger.swift
@@ -2,16 +2,21 @@ public import CMUXMobileCore
 import Foundation
 
 /// The production ``CmxRoutePinging``: opens (and immediately closes) a real TCP
-/// connection over ``CmxNetworkByteTransport`` and times the connect. Lives in
-/// the transport package (the only place that knows the concrete socket layer);
-/// the protocol and result type it satisfies live in CMUXMobileCore.
+/// or iroh connection and times the connect. Lives in the transport package
+/// (the only place that knows the concrete socket layers); the protocol and
+/// result type it satisfies live in CMUXMobileCore.
 public struct CmxNetworkRoutePinger: CmxRoutePinging {
-    /// Creates a pinger that dials real TCP connections via ``CmxNetworkByteTransport``.
-    public init() {}
+    private let irohFactory: CmxIrohByteTransportFactory?
 
-    /// Open a TCP connection to the route's host/port, measure the connect
-    /// latency, then close. Returns the latency or a classified failure; never
-    /// throws.
+    /// Creates a pinger that dials real TCP and iroh connections.
+    public init(
+        irohFactory: CmxIrohByteTransportFactory? = CmxIrohByteTransportFactory()
+    ) {
+        self.irohFactory = irohFactory
+    }
+
+    /// Open a connection to the route, measure connect latency, then close.
+    /// Returns the latency or a classified failure; never throws.
     /// - Parameters:
     ///   - route: The route to probe. Non-host/port routes return
     ///     ``CmxRoutePingResult/unsupportedRoute``.
@@ -21,6 +26,10 @@ public struct CmxNetworkRoutePinger: CmxRoutePinging {
         _ route: CmxAttachRoute,
         timeoutNanoseconds: UInt64 = 5 * 1_000_000_000
     ) async -> CmxRoutePingResult {
+        if route.kind == .iroh {
+            return await pingIroh(route, timeoutNanoseconds: timeoutNanoseconds)
+        }
+
         let transport: CmxNetworkByteTransport
         do {
             transport = try CmxNetworkByteTransport(
@@ -40,6 +49,42 @@ public struct CmxNetworkRoutePinger: CmxRoutePinging {
             await transport.close()
             return .reachable(latencyMilliseconds: elapsed.cmxWholeMilliseconds)
         } catch let error as CmxNetworkByteTransportError {
+            await transport.close()
+            return pingResult(for: error)
+        } catch {
+            await transport.close()
+            return .failed(description: String(describing: error))
+        }
+    }
+
+    private func pingIroh(
+        _ route: CmxAttachRoute,
+        timeoutNanoseconds: UInt64
+    ) async -> CmxRoutePingResult {
+        guard let irohFactory else {
+            return .unsupportedRoute
+        }
+        let transport: any CmxByteTransport
+        do {
+            transport = try CmxIrohByteTransport(
+                route: route,
+                endpointManager: irohFactory.endpointManagerForPinger,
+                ffiClient: irohFactory.ffiClientForPinger,
+                maximumReceiveLength: CmxIrohByteTransport.defaultMaximumReceiveLength,
+                connectTimeoutNanoseconds: timeoutNanoseconds
+            )
+        } catch {
+            return .unsupportedRoute
+        }
+
+        let clock = ContinuousClock()
+        let start = clock.now
+        do {
+            try await transport.connect()
+            let elapsed = clock.now - start
+            await transport.close()
+            return .reachable(latencyMilliseconds: elapsed.cmxWholeMilliseconds)
+        } catch let error as CmxIrohByteTransportError {
             await transport.close()
             return pingResult(for: error)
         } catch {
@@ -78,6 +123,45 @@ public struct CmxNetworkRoutePinger: CmxRoutePinging {
              .sendAlreadyInProgress, .receiveFailed, .sendFailed:
             return .failed(description: String(describing: error))
         }
+    }
+
+    private func pingResult(for error: CmxIrohByteTransportError) -> CmxRoutePingResult {
+        switch error {
+        case let .connectionFailed(description, kind),
+             let .endpointBindFailed(description, kind):
+            return pingResult(description: description, kind: kind)
+        case .emptyPeerID, .invalidMaximumReceiveLength, .unsupportedRouteKind, .unsupportedEndpoint:
+            return .unsupportedRoute
+        case .notConnected, .alreadyClosed, .receiveFailed, .sendFailed:
+            return .failed(description: String(describing: error))
+        }
+    }
+
+    private func pingResult(description: String, kind: CmxConnectFailureKind) -> CmxRoutePingResult {
+        switch kind {
+        case .connectionRefused:
+            return .refused
+        case .hostUnreachable:
+            return .unreachable
+        case .timedOut:
+            return .timedOut
+        case .dnsFailed:
+            return .dnsFailed
+        case .permissionDenied:
+            return .permissionDenied
+        case .secureChannelFailed, .generic:
+            return .failed(description: description)
+        }
+    }
+}
+
+extension CmxIrohByteTransportFactory {
+    var endpointManagerForPinger: CmxIrohEndpointManager {
+        endpointManager
+    }
+
+    var ffiClientForPinger: any CmxIrohFFIClient {
+        ffiClient
     }
 }
 

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/MobileIrohTransportFlag.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/MobileIrohTransportFlag.swift
@@ -1,0 +1,52 @@
+public import Foundation
+
+/// Feature flag for the iOS iroh transport lane.
+///
+/// Resolution order is environment override, UserDefaults override, then build
+/// flavor. DEBUG defaults on for dogfood and package tests; Release defaults
+/// off until the rollout slice flips it.
+public struct MobileIrohTransportFlag: Sendable, Equatable {
+    /// Environment variable override for dogfood and tagged builds.
+    public static let envKey = "CMUX_MOBILE_IROH_TRANSPORT"
+    /// UserDefaults key for local dogfood toggles.
+    public static let defaultsKey = "mobileIrohTransport"
+
+    /// Whether iroh transport registration is enabled.
+    public let isEnabled: Bool
+
+    /// Creates a resolved flag.
+    public init(isEnabled: Bool) {
+        self.isEnabled = isEnabled
+    }
+
+    /// Resolves the flag from environment, defaults, and build flavor.
+    public static func resolved(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard,
+        isDebugBuild: Bool = MobileIrohTransportFlag.isDebugBuild
+    ) -> MobileIrohTransportFlag {
+        func parseBool(_ raw: String) -> Bool {
+            switch raw.lowercased() {
+            case "1", "true", "yes", "on": return true
+            default: return false
+            }
+        }
+
+        if let raw = environment[envKey]?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
+            return MobileIrohTransportFlag(isEnabled: parseBool(raw))
+        }
+        if defaults.object(forKey: defaultsKey) != nil {
+            return MobileIrohTransportFlag(isEnabled: defaults.bool(forKey: defaultsKey))
+        }
+        return MobileIrohTransportFlag(isEnabled: isDebugBuild)
+    }
+
+    /// Compile-time build flavor, parameterized above for tests.
+    public static var isDebugBuild: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxIrohByteTransportTests.swift
+++ b/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxIrohByteTransportTests.swift
@@ -1,0 +1,245 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobileTransport
+
+@Suite struct CmxIrohByteTransportTests {
+    @Test func routeFactoryRegistersIrohPeerRoutes() throws {
+        let ffi = FakeIrohFFIClient()
+        let manager = CmxIrohEndpointManager(
+            keyProvider: CmxIrohSecretKeyProvider(
+                store: InMemoryIrohSecretStore(),
+                generate: { Data(repeating: 7, count: 32) }
+            ),
+            ffiClient: ffi
+        )
+        let irohFactory = CmxIrohByteTransportFactory(endpointManager: manager, ffiClient: ffi)
+        let factory = try CmxRouteTransportFactory([
+            CmxRouteTransportFactoryRegistration(kind: .iroh, factory: irohFactory),
+        ])
+        let route = try peerRoute(endpointID: "peer-a")
+
+        let transport = try factory.makeTransport(for: route)
+
+        #expect(factory.supportedKinds == [.iroh])
+        #expect(transport is CmxIrohByteTransport)
+    }
+
+    @Test func secretKeyProviderPersistsGeneratedKey() throws {
+        let store = InMemoryIrohSecretStore()
+        let generateCount = LockedCounter()
+        let provider = CmxIrohSecretKeyProvider(store: store) {
+            generateCount.increment()
+            return Data(repeating: 3, count: 32)
+        }
+
+        let first = try provider.secretKey()
+        let second = try provider.secretKey()
+
+        #expect(first == Data(repeating: 3, count: 32))
+        #expect(second == first)
+        #expect(generateCount.value() == 1)
+        #expect(try store.loadSecretKey() == first)
+    }
+
+    @Test func connectFailureKindMapsFromFfiCodes() {
+        #expect(CmxIrohErrorKind.timedOut.connectFailureKind == .timedOut)
+        #expect(CmxIrohErrorKind.connectionRefused.connectFailureKind == .connectionRefused)
+        #expect(CmxIrohErrorKind.hostUnreachable.connectFailureKind == .hostUnreachable)
+        #expect(CmxIrohErrorKind.permissionDenied.connectFailureKind == .permissionDenied)
+        #expect(CmxIrohErrorKind.dnsFailed.connectFailureKind == .dnsFailed)
+        #expect(CmxIrohErrorKind.secureChannelFailed.connectFailureKind == .secureChannelFailed)
+        #expect(CmxIrohErrorKind.internalFailure.connectFailureKind == .generic)
+    }
+
+    @Test func irohPingerDialsPeerRouteAndCloses() async throws {
+        let ffi = FakeIrohFFIClient()
+        let manager = CmxIrohEndpointManager(
+            keyProvider: CmxIrohSecretKeyProvider(
+                store: InMemoryIrohSecretStore(),
+                generate: { Data(repeating: 9, count: 32) }
+            ),
+            ffiClient: ffi
+        )
+        let factory = CmxIrohByteTransportFactory(endpointManager: manager, ffiClient: ffi)
+        let pinger = CmxNetworkRoutePinger(irohFactory: factory)
+
+        let result = await pinger.ping(try peerRoute(endpointID: "peer-ping"), timeoutNanoseconds: 1_000_000_000)
+
+        guard case .reachable = result else {
+            Issue.record("expected reachable, got \(result)")
+            return
+        }
+        #expect(ffi.connectedPeerIDs() == ["peer-ping"])
+        #expect(ffi.closedConnectionCount() == 1)
+    }
+
+    @Test func localIrohLoopbackEchoesBytes() async throws {
+        let packageURL = URL(filePath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let xcframeworkURL = packageURL.appending(path: "../../../CmuxIrohFFI.xcframework").standardizedFileURL
+        guard FileManager.default.fileExists(atPath: xcframeworkURL.path) else {
+            return
+        }
+
+        let ffi = CmxIrohSystemFFIClient()
+        let serverKey = try ffi.generateSecretKey()
+        let clientKey = try ffi.generateSecretKey()
+        let server = try ffi.bindEndpoint(
+            secretKey: serverKey,
+            enableRelay: false,
+            acceptConnections: true
+        )
+        defer { ffi.close(endpoint: server) }
+        let routeJSON = try #require(ffi.routeJSON(server)?.data(using: .utf8))
+        let route = try JSONDecoder().decode(CmxAttachRoute.self, from: routeJSON)
+        let manager = CmxIrohEndpointManager(
+            keyProvider: CmxIrohSecretKeyProvider(
+                store: InMemoryIrohSecretStore(initialKey: clientKey),
+                generate: { clientKey }
+            ),
+            ffiClient: ffi,
+            enableRelay: false,
+            acceptConnections: false
+        )
+        let transport = try CmxIrohByteTransport(
+            route: route,
+            endpointManager: manager,
+            ffiClient: ffi,
+            connectTimeoutNanoseconds: 5_000_000_000
+        )
+        let serverTask = Task.detached {
+            let connection = try ffi.accept(endpoint: server, timeoutMilliseconds: 5_000)
+            defer { ffi.close(connection: connection) }
+            let received = try #require(try ffi.receive(connection: connection, maximumLength: 64))
+            #expect(received == Data("ping".utf8))
+            try ffi.send(connection: connection, data: Data("pong".utf8))
+        }
+
+        try await transport.connect()
+        try await transport.send(Data("ping".utf8))
+        let reply = try await transport.receive()
+        await transport.close()
+        try await serverTask.value
+
+        #expect(reply == Data("pong".utf8))
+    }
+
+    private func peerRoute(endpointID: String) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(id: endpointID, relayHint: nil, directAddrs: [], relayURL: nil),
+            priority: 0
+        )
+    }
+}
+
+private final class InMemoryIrohSecretStore: CmxIrohSecretKeyStoring, @unchecked Sendable {
+    private var key: Data?
+
+    init(initialKey: Data? = nil) {
+        key = initialKey
+    }
+
+    func loadSecretKey() throws -> Data? {
+        key
+    }
+
+    func saveSecretKey(_ key: Data) throws {
+        self.key = key
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+    }
+
+    func value() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+}
+
+private final class FakeIrohFFIClient: CmxIrohFFIClient, @unchecked Sendable {
+    private let lock = NSLock()
+    private var peers: [String] = []
+    private var closedConnections = 0
+
+    func generateSecretKey() throws -> Data {
+        Data(repeating: 1, count: 32)
+    }
+
+    func bindEndpoint(
+        secretKey: Data,
+        enableRelay: Bool,
+        acceptConnections: Bool
+    ) throws -> CmxIrohEndpointReference {
+        CmxIrohEndpointReference(raw: OpaquePointer(bitPattern: 0x1)!)
+    }
+
+    func endpointID(_ endpoint: CmxIrohEndpointReference) -> String? {
+        "fake-phone"
+    }
+
+    func routeJSON(_ endpoint: CmxIrohEndpointReference) -> String? {
+        nil
+    }
+
+    func online(endpoint: CmxIrohEndpointReference, timeoutMilliseconds: UInt64) throws {}
+
+    func accept(
+        endpoint: CmxIrohEndpointReference,
+        timeoutMilliseconds: UInt64
+    ) throws -> CmxIrohConnectionReference {
+        CmxIrohConnectionReference(raw: OpaquePointer(bitPattern: 0x2)!)
+    }
+
+    func connect(
+        endpoint: CmxIrohEndpointReference,
+        peerID: String,
+        relayURL: String?,
+        directAddrs: [String],
+        timeoutMilliseconds: UInt64
+    ) throws -> CmxIrohConnectionReference {
+        lock.lock()
+        defer { lock.unlock() }
+        peers.append(peerID)
+        return CmxIrohConnectionReference(raw: OpaquePointer(bitPattern: 0x3)!)
+    }
+
+    func receive(connection: CmxIrohConnectionReference, maximumLength: Int) throws -> Data? {
+        nil
+    }
+
+    func send(connection: CmxIrohConnectionReference, data: Data) throws {}
+
+    func close(connection: CmxIrohConnectionReference) {
+        lock.lock()
+        defer { lock.unlock() }
+        closedConnections += 1
+    }
+
+    func close(endpoint: CmxIrohEndpointReference) {}
+
+    func connectedPeerIDs() -> [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return peers
+    }
+
+    func closedConnectionCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return closedConnections
+    }
+}

--- a/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxRoutePingTests.swift
+++ b/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxRoutePingTests.swift
@@ -44,9 +44,9 @@ import Testing
 
 @Test func pingReportsUnsupportedRouteForNonHostPortEndpoint() async throws {
     let route = try CmxAttachRoute(
-        id: "iroh",
-        kind: .iroh,
-        endpoint: .peer(id: "node-1", relayHint: nil, directAddrs: [], relayURL: nil)
+        id: "websocket",
+        kind: .websocket,
+        endpoint: .url("wss://example.invalid/cmux")
     )
 
     let result = await CmxNetworkRoutePinger().ping(route)

--- a/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "6104d2cb8b5660da4a5b51b4e654037e3bc623e8e169544d7f9c329f6afe6789",
+  "pins" : [
+    {
+      "identity" : "sentry-cocoa",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/getsentry/sentry-cocoa.git",
+      "state" : {
+        "revision" : "53eb9bd5da18e208cfd80e86863d3f4c7ba21b1d",
+        "version" : "9.21.0"
+      }
+    },
+    {
+      "identity" : "swift-asn1",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-asn1.git",
+      "state" : {
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
+      }
+    },
+    {
+      "identity" : "swift-crypto",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-crypto.git",
+      "state" : {
+        "revision" : "95ba0316a9b733e92bb6b071255ff46263bbe7dc",
+        "version" : "3.15.1"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/ios/cmux/AppCompositionRoot.swift
+++ b/ios/cmux/AppCompositionRoot.swift
@@ -23,6 +23,7 @@ final class AppCompositionRoot {
     let runtime: CMUXMobileRuntime
     let auth: MobileAuthComposition
     let reachability: any ReachabilityProviding
+    let irohEndpointManager: CmxIrohEndpointManager?
     let pushCoordinator: MobilePushCoordinator
     let analytics: MobileAnalyticsComposition
     let displaySettings: MobileDisplaySettings
@@ -52,7 +53,8 @@ final class AppCompositionRoot {
     init(
         runtime: CMUXMobileRuntime,
         auth: MobileAuthComposition,
-        reachability: any ReachabilityProviding
+        reachability: any ReachabilityProviding,
+        irohEndpointManager: CmxIrohEndpointManager? = nil
     ) {
         #if DEBUG
         // Arm the durable debug log at launch: `.shared` is lazy, and without
@@ -63,6 +65,7 @@ final class AppCompositionRoot {
         self.runtime = runtime
         self.auth = auth
         self.reachability = reachability
+        self.irohEndpointManager = irohEndpointManager
         let telemetryConsent = UserDefaultsAnalyticsConsentProvider(defaults: .standard)
         MobileCrashReporter.startIfEnabled(
             consent: telemetryConsent,
@@ -156,6 +159,9 @@ final class AppCompositionRoot {
             }
             // Force a flush before the OS may suspend us, so queued events survive.
             Task { await emitter.flush() }
+            if let irohEndpointManager {
+                Task { await irohEndpointManager.closeEndpoint() }
+            }
         case .inactive:
             break
         @unknown default:

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -3384,6 +3384,40 @@
         }
       }
     },
+    "mobile.pairing.guidance.irohReachability": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Tailscale setup is needed for Iroh. Keep cmux open on the Mac and make sure both devices are online."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh に Tailscale の設定は不要です。Mac で cmux を開いたままにし、両方の端末がオンラインであることを確認してください。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.guidance.irohRetrust": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Open cmux on the Mac and trust this phone again before retrying."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac で cmux を開き、この iPhone をもう一度信頼してから再試行してください。"
+          }
+        }
+      }
+    },
     "mobile.pairing.guidance.reachability": {
       "extractionState": "manual",
       "localizations": {
@@ -3465,6 +3499,91 @@
           "stringUnit": {
             "state": "translated",
             "value": "%@:%d に接続できません。Macがスリープしておらず、この端末と同じTailscaleネットワーク上にあることを確認してください。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.irohConnectionDropped": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected to this Mac over Iroh, but the connection closed before pairing finished."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh でこの Mac に接続しましたが、ペアリングが完了する前に接続が閉じられました。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.irohEndpointChanged": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This Mac's Iroh identity changed. Trust it again from the Mac before sending account credentials."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この Mac の Iroh ID が変更されました。アカウント認証情報を送信する前に、Mac からもう一度信頼してください。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.irohMacUnavailable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Could not reach this Mac over Iroh. Make sure cmux is open on the Mac and it is awake, then try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh でこの Mac に到達できませんでした。Mac がスリープしておらず、cmux が開いていることを確認してから再試行してください。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.irohSecureChannelFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh could not verify the secure connection to this Mac. Trust the Mac again before connecting."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh がこの Mac への安全な接続を確認できませんでした。接続する前に Mac をもう一度信頼してください。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.irohTimedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh did not get a response from this Mac in time. Make sure the Mac is awake and online, then try again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh が時間内にこの Mac から応答を受け取れませんでした。Mac がスリープしておらずオンラインであることを確認してから、もう一度お試しください。"
           }
         }
       }

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -16,13 +16,25 @@ struct cmuxApp: App {
         // attach to an in-runner mock host; release device builds keep only
         // real transports.
         #if targetEnvironment(simulator) || DEBUG
-        let supportedKinds: [CmxAttachTransportKind] = [.debugLoopback, .tailscale]
+        let baseSupportedKinds: [CmxAttachTransportKind] = [.debugLoopback, .tailscale]
         #else
-        let supportedKinds: [CmxAttachTransportKind] = [.tailscale]
+        let baseSupportedKinds: [CmxAttachTransportKind] = [.tailscale]
         #endif
-        let networkFactory = CmxNetworkByteTransportFactory(supportedKinds: supportedKinds)
-        let registrations = supportedKinds.map { kind in
+        let irohEndpointManager: CmxIrohEndpointManager?
+        let irohEnabled = MobileIrohTransportFlag.resolved().isEnabled
+        if irohEnabled {
+            irohEndpointManager = CmxIrohEndpointManager()
+        } else {
+            irohEndpointManager = nil
+        }
+        let supportedKinds = irohEnabled ? baseSupportedKinds + [.iroh] : baseSupportedKinds
+        let networkFactory = CmxNetworkByteTransportFactory(supportedKinds: baseSupportedKinds)
+        var registrations = baseSupportedKinds.map { kind in
             CmxRouteTransportFactoryRegistration(kind: kind, factory: networkFactory)
+        }
+        if let irohEndpointManager {
+            let irohFactory = CmxIrohByteTransportFactory(endpointManager: irohEndpointManager)
+            registrations.append(CmxRouteTransportFactoryRegistration(kind: .iroh, factory: irohFactory))
         }
         let transportFactory: CmxRouteTransportFactory
         do {
@@ -42,7 +54,12 @@ struct cmuxApp: App {
             stackAccessTokenForceRefresher: CMUXMobileRuntime.stackAccessTokenForceRefresher(from: auth.coordinator)
         )
 
-        return AppCompositionRoot(runtime: runtime, auth: auth, reachability: reachability)
+        return AppCompositionRoot(
+            runtime: runtime,
+            auth: auth,
+            reachability: reachability,
+            irohEndpointManager: irohEndpointManager
+        )
     }()
 
     init() {
@@ -77,6 +94,7 @@ struct cmuxApp: App {
             displaySettings: Self.root.displaySettings,
             onboardingStore: Self.root.onboardingStore,
             tailscaleStatusMonitor: Self.root.tailscaleStatusMonitor,
+            irohEndpointManager: Self.root.irohEndpointManager,
             diagnosticLog: Self.root.diagnosticLog
         )
         #else
@@ -88,7 +106,8 @@ struct cmuxApp: App {
             pushCoordinator: Self.root.pushCoordinator,
             displaySettings: Self.root.displaySettings,
             onboardingStore: Self.root.onboardingStore,
-            tailscaleStatusMonitor: Self.root.tailscaleStatusMonitor
+            tailscaleStatusMonitor: Self.root.tailscaleStatusMonitor,
+            irohEndpointManager: Self.root.irohEndpointManager
         )
         #endif
     }

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -3,6 +3,7 @@ import CMUXMobileCore
 import CmuxAuthRuntime
 import CmuxMobileAnalytics
 import CmuxMobilePairedMac
+import CmuxMobileRPC
 import CmuxMobileShell
 import CmuxMobileShellModel
 import CmuxMobileSupport
@@ -54,6 +55,9 @@ public struct CMUXMobileRootScene: View {
     /// separately and replaces this at the composition root without touching the
     /// shell.
     private let draftStore: any TerminalDraftStoring
+    /// Shared phone-side iroh endpoint manager, injected from the app root so
+    /// transport connects and route pings obey the same scene lifecycle.
+    private let irohEndpointManager: CmxIrohEndpointManager?
     #if DEBUG
     /// The structured diagnostic log injected into the shell store so the DEV
     /// dogfood feedback round-trip can export it. DEBUG-only; `nil` when the app
@@ -88,6 +92,7 @@ public struct CMUXMobileRootScene: View {
         displaySettings: MobileDisplaySettings,
         onboardingStore: MobileOnboardingStore,
         tailscaleStatusMonitor: any TailscaleStatusObserving,
+        irohEndpointManager: CmxIrohEndpointManager? = nil,
         diagnosticLog: DiagnosticLog? = nil
     ) {
         self.runtime = runtime
@@ -100,6 +105,7 @@ public struct CMUXMobileRootScene: View {
         self.tailscaleStatusMonitor = tailscaleStatusMonitor
         self.pairedMacStore = Self.openPairedMacStore()
         self.draftStore = InMemoryTerminalDraftStore()
+        self.irohEndpointManager = irohEndpointManager
         #if DEBUG
         self.diagnosticLog = diagnosticLog
         #endif
@@ -110,7 +116,8 @@ public struct CMUXMobileRootScene: View {
         runtime: CMUXMobileRuntime,
         auth: MobileAuthComposition,
         reachability: any ReachabilityProviding,
-        analytics: any AnalyticsEmitting
+        analytics: any AnalyticsEmitting,
+        irohEndpointManager: CmxIrohEndpointManager? = nil
     ) {
         self.runtime = runtime
         self.auth = auth
@@ -119,6 +126,7 @@ public struct CMUXMobileRootScene: View {
         self.tailscaleStatusMonitor = nil
         self.pairedMacStore = Self.openPairedMacStore()
         self.draftStore = InMemoryTerminalDraftStore()
+        self.irohEndpointManager = irohEndpointManager
         #if DEBUG
         self.diagnosticLog = nil
         #endif
@@ -270,6 +278,16 @@ public struct CMUXMobileRootScene: View {
         let deviceRegistry = makeDeviceRegistry()
         let restoreBoundary = PairedMacRestoreBoundary()
         let backedUpPairedMacStore = makeBackedUpPairedMacStore(restoreBoundary: restoreBoundary)
+        var scopedRuntime = runtime
+        scopedRuntime.irohEndpointTrustValidator = Self.makeIrohEndpointTrustValidator(
+            pairedMacStore: backedUpPairedMacStore,
+            currentUserID: { await coordinator.currentUser?.id },
+            teamID: { await coordinator.resolvedTeamID },
+            now: runtime.now
+        )
+        let routePinger = CmxNetworkRoutePinger(
+            irohFactory: irohEndpointManager.map { CmxIrohByteTransportFactory(endpointManager: $0) }
+        )
         let forgottenMacStore = UserDefaultsPairedMacForgottenStore()
         let feedbackEmailSubmitter = MobileFeedbackEmailClient(apiBaseURL: auth.config.apiBaseURL)
         let feedbackStampProvider: @MainActor () -> MobileFeedbackStamp = {
@@ -277,7 +295,7 @@ public struct CMUXMobileRootScene: View {
         }
         #if DEBUG
         return CMUXMobileShellStore(
-            runtime: runtime,
+            runtime: scopedRuntime,
             pairedMacStore: backedUpPairedMacStore,
             pairedMacRestoreBoundary: restoreBoundary,
             deviceRegistry: deviceRegistry,
@@ -285,6 +303,7 @@ public struct CMUXMobileRootScene: View {
             identityProvider: identityProvider,
             teamIDProvider: { await coordinator.resolvedTeamID },
             reachability: reachability,
+            routePinger: routePinger,
             forgottenMacStore: forgottenMacStore,
             analytics: analytics,
             diagnosticLog: diagnosticLog,
@@ -294,7 +313,7 @@ public struct CMUXMobileRootScene: View {
         )
         #else
         return CMUXMobileShellStore(
-            runtime: runtime,
+            runtime: scopedRuntime,
             pairedMacStore: backedUpPairedMacStore,
             pairedMacRestoreBoundary: restoreBoundary,
             deviceRegistry: deviceRegistry,
@@ -302,6 +321,7 @@ public struct CMUXMobileRootScene: View {
             identityProvider: identityProvider,
             teamIDProvider: { await coordinator.resolvedTeamID },
             reachability: reachability,
+            routePinger: routePinger,
             forgottenMacStore: forgottenMacStore,
             analytics: analytics,
             feedbackEmailSubmitter: feedbackEmailSubmitter,
@@ -309,5 +329,65 @@ public struct CMUXMobileRootScene: View {
             draftStore: draftStore
         )
         #endif
+    }
+
+    private static func makeIrohEndpointTrustValidator(
+        pairedMacStore: (any MobilePairedMacStoring)?,
+        currentUserID: @escaping @Sendable () async -> String?,
+        teamID: @escaping @Sendable () async -> String?,
+        now: @escaping @Sendable () -> Date
+    ) -> @Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void {
+        { route, ticket in
+            guard route.kind == .iroh,
+                  case let .peer(rawEndpointID, _, _, _) = route.endpoint else {
+                return
+            }
+            let endpointID = rawEndpointID.trimmingCharacters(in: .whitespacesAndNewlines)
+            let macDeviceID = ticket.macDeviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !endpointID.isEmpty, !macDeviceID.isEmpty else {
+                return
+            }
+            guard let pairedMacStore else {
+                throw MobileShellConnectionError.irohEndpointChanged(Self.irohEndpointChangedMessage())
+            }
+            let userID = await currentUserID() ?? ticket.macUserID
+            let teamID = await teamID()
+            let macs = try await pairedMacStore.loadAll(stackUserID: userID, teamID: teamID)
+            if let existing = macs.first(where: { $0.macDeviceID == macDeviceID }) {
+                if let pinned = existing.irohEndpointID?.trimmingCharacters(in: .whitespacesAndNewlines),
+                   !pinned.isEmpty {
+                    guard pinned == endpointID else {
+                        throw MobileShellConnectionError.irohEndpointChanged(Self.irohEndpointChangedMessage())
+                    }
+                    return
+                }
+                try await pairedMacStore.upsert(
+                    macDeviceID: macDeviceID,
+                    displayName: ticket.macDisplayName ?? existing.displayName,
+                    routes: ticket.routes,
+                    markActive: existing.isActive,
+                    stackUserID: userID,
+                    teamID: teamID,
+                    now: now()
+                )
+                return
+            }
+            try await pairedMacStore.upsert(
+                macDeviceID: macDeviceID,
+                displayName: ticket.macDisplayName,
+                routes: ticket.routes,
+                markActive: false,
+                stackUserID: userID,
+                teamID: teamID,
+                now: now()
+            )
+        }
+    }
+
+    nonisolated private static func irohEndpointChangedMessage() -> String {
+        L10n.string(
+            "mobile.pairing.irohEndpointChanged",
+            defaultValue: "This Mac's Iroh identity changed. Trust it again from the Mac before sending account credentials."
+        )
     }
 }

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRuntime.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRuntime.swift
@@ -24,6 +24,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
     public var pairingRequestTimeoutNanoseconds: UInt64
     public var pairingAttemptTimeoutNanoseconds: UInt64
     public var now: @Sendable () -> Date
+    public var irohEndpointTrustValidator: @Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void
     /// When false, `MobileShellStore` skips background terminal refresh.
     /// Scripted transport tests set this off so background subscribe/poll
     /// requests don't consume responses intended for foreground methods.
@@ -136,6 +137,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         pairingRequestTimeoutNanoseconds: UInt64 = CMUXMobileRuntime.defaultPairingRequestTimeoutNanoseconds,
         pairingAttemptTimeoutNanoseconds: UInt64 = CMUXMobileRuntime.defaultPairingAttemptTimeoutNanoseconds,
         now: @escaping @Sendable () -> Date = Date.init,
+        irohEndpointTrustValidator: (@Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void)? = nil,
         supportsServerPushEvents: Bool = true
     ) {
         self.supportedRouteKinds = supportedRouteKinds
@@ -147,6 +149,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         self.pairingRequestTimeoutNanoseconds = pairingRequestTimeoutNanoseconds
         self.pairingAttemptTimeoutNanoseconds = pairingAttemptTimeoutNanoseconds
         self.now = now
+        self.irohEndpointTrustValidator = irohEndpointTrustValidator ?? { _, _ in }
         self.supportsServerPushEvents = supportsServerPushEvents
     }
 
@@ -159,6 +162,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         pairingRequestTimeoutNanoseconds: UInt64 = CMUXMobileRuntime.defaultPairingRequestTimeoutNanoseconds,
         pairingAttemptTimeoutNanoseconds: UInt64 = CMUXMobileRuntime.defaultPairingAttemptTimeoutNanoseconds,
         now: @escaping @Sendable () -> Date = Date.init,
+        irohEndpointTrustValidator: (@Sendable (CmxAttachRoute, CmxAttachTicket) async throws -> Void)? = nil,
         supportsServerPushEvents: Bool = true
     ) {
         self.supportedRouteKinds = transportFactory.supportedKinds
@@ -171,6 +175,7 @@ public struct CMUXMobileRuntime: Sendable, MobileSyncRuntime {
         self.pairingAttemptTimeoutNanoseconds = pairingAttemptTimeoutNanoseconds
         self.supportsServerPushEvents = supportsServerPushEvents
         self.now = now
+        self.irohEndpointTrustValidator = irohEndpointTrustValidator ?? { _, _ in }
     }
 }
 

--- a/scripts/check-package-resolved-policy.py
+++ b/scripts/check-package-resolved-policy.py
@@ -19,7 +19,19 @@ ALLOWED_IGNORED_PREFIXES = (
 XCODE_PACKAGE_RESOLVED = (
     "cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 )
+IOS_XCODE_PACKAGE_RESOLVED = (
+    "ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved"
+)
+XCODE_PACKAGE_RESOLVED_FILES = (
+    XCODE_PACKAGE_RESOLVED,
+    IOS_XCODE_PACKAGE_RESOLVED,
+)
 XCODE_PROJECT_FILE = "cmux.xcodeproj/project.pbxproj"
+IOS_XCODE_PROJECT_FILE = "ios/cmux-ios.xcodeproj/project.pbxproj"
+XCODE_PACKAGE_RESOLVED_BY_PROJECT_FILE = {
+    XCODE_PROJECT_FILE: XCODE_PACKAGE_RESOLVED,
+    IOS_XCODE_PROJECT_FILE: IOS_XCODE_PACKAGE_RESOLVED,
+}
 XCODE_PACKAGE_REFERENCE_TOKENS = (
     "XCRemoteSwiftPackageReference",
     "repositoryURL",
@@ -230,29 +242,35 @@ def file_text_at(ref: str, path: str) -> str:
         return ""
 
 
-def xcode_package_reference_changed(
+def xcode_package_reference_changes(
     merge_base: str | None,
     changed_files: set[str],
-) -> bool:
-    if merge_base is None or XCODE_PROJECT_FILE not in changed_files:
-        return False
-    diff = git_stdout(
-        "diff",
-        "--unified=0",
-        f"{merge_base}..HEAD",
-        "--",
-        XCODE_PROJECT_FILE,
-    )
-    for line in diff.splitlines():
-        if not line.startswith(("+", "-")) or line.startswith(("+++", "---")):
+) -> list[tuple[str, str]]:
+    if merge_base is None:
+        return []
+    changed_projects: list[tuple[str, str]] = []
+    project_lockfiles = XCODE_PACKAGE_RESOLVED_BY_PROJECT_FILE.items()
+    for project_file, package_resolved in project_lockfiles:
+        if project_file not in changed_files:
             continue
-        if any(token in line for token in XCODE_PACKAGE_REFERENCE_TOKENS):
-            return True
-    return False
+        diff = git_stdout(
+            "diff",
+            "--unified=0",
+            f"{merge_base}..HEAD",
+            "--",
+            project_file,
+        )
+        for line in diff.splitlines():
+            if not line.startswith(("+", "-")) or line.startswith(("+++", "---")):
+                continue
+            if any(token in line for token in XCODE_PACKAGE_REFERENCE_TOKENS):
+                changed_projects.append((project_file, package_resolved))
+                break
+    return changed_projects
 
 
 def is_expected_lockfile_path(lockfile: str, roots: set[str]) -> bool:
-    if lockfile == XCODE_PACKAGE_RESOLVED:
+    if lockfile in XCODE_PACKAGE_RESOLVED_FILES:
         return True
     if has_skipped_part(lockfile):
         return False
@@ -328,13 +346,15 @@ def main() -> int:
             ):
                 changed_dependency_roots.add(root)
 
-    if (
-        xcode_package_reference_changed(merge_base, changed_files)
-        and XCODE_PACKAGE_RESOLVED not in changed_files
+    for project_file, package_resolved in xcode_package_reference_changes(
+        merge_base,
+        changed_files,
     ):
+        if package_resolved in changed_files:
+            continue
         errors.append(
-            f"{XCODE_PROJECT_FILE} changed SwiftPM package references without "
-            f"matching Xcode Package.resolved diff: {XCODE_PACKAGE_RESOLVED}"
+            f"{project_file} changed SwiftPM package references without "
+            f"matching Xcode Package.resolved diff: {package_resolved}"
         )
 
     for gitignore in sorted(Path(".").rglob(".gitignore")):


### PR DESCRIPTION
Implements delivery-plan step 3 of https://github.com/manaflow-ai/cmux/blob/main/plans/feat-ios-iroh/DESIGN.md, stacked on https://github.com/manaflow-ai/cmux/pull/7813.

Adds `CmxIrohByteTransport` (actor over the cmux-iroh C FFI, blocking calls off the main actor), phone endpoint Keychain key custody (kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly, no iCloud sync), `.iroh` registration in the transport factory behind `MobileIrohTransportFlag` (DEBUG on, release off until P5), EndpointId pinning in `MobilePairedMacStore` with Stack-token withholding on pin mismatch and explicit re-trust on change, iroh error-kind → `CmxConnectFailureKind`/`MobilePairingFailure` mapping with localized en+ja copy, and first-class `.peer` route support in reconnect iteration and the Settings route pinger (both were host:port-only).

Verified: swift test green in CmuxMobileTransport (32, incl. live local iroh loopback echo), CmuxMobilePairedMac (12), CmuxMobileRPC (77), CmuxMobileShell (415), CmuxMobileShellModel (94), CMUXMobileCore (146); iOS simulator tagged compile; file-length budget, Package.resolved policy, localization audit (new iroh keys en+ja). Note: the CmuxMobileShell replay/barrier test family is scheduling-flaky under parallel swift test on unmodified main too (reproduced 1/2 runs on main); passes single-worker and in 2/2 full parallel reruns on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7819"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786257989&installation_id=133855650&pr_number=7819&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7819&signature=6df9dc70b30c476f0d25bf731c7a1a32488052d2ba57047ddc3e77c8d979809a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes mobile auth/RPC credential gating and paired-Mac persistence for a new transport; mistakes could leak Stack tokens or block legitimate reconnects.
> 
> **Overview**
> Adds an **iOS iroh dial lane** behind `MobileIrohTransportFlag` (DEBUG on by default, Release off): `CmuxIrohFFI`/`CmuxIrohC`, `CmxIrohByteTransport`, Keychain-backed phone endpoint manager, and `.iroh` registration in the app transport factory with endpoint teardown on background.
> 
> **Pins each paired Mac’s trusted iroh EndpointId** in SQLite v5 and backup sync; upserts seed the pin from the first iroh peer route but **do not overwrite** an existing pin when routes refresh. RPC runs `irohEndpointTrustValidator` before attaching Stack tokens on iroh routes—mismatch surfaces `irohEndpointChanged` and blocks credentials until re-trust.
> 
> **Reconnect, mac switch, and route ping** treat `.peer` routes as first-class (not host:port only), with iroh-specific pairing failures, analytics reasons, and en/ja copy. CI provisions `cmux-iroh` for package tests and tracks `ios/cmux.xcworkspace/Package.resolved`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3c679309c9cece8626507d6a579dd69660a4f3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds iOS iroh transport with endpoint key pinning and trust checks to enable secure `.peer` routes from phone to Mac. Also merges the P2 replay-ownership and App Store lane guard fixes; the lane is feature-flagged (`DEBUG` on, Release off).

- **New Features**
  - Introduced iroh byte transport and C FFI bridge in `CmuxMobileTransport` (`CmuxIrohC` + `CmuxIrohFFI`) with a Keychain-backed phone endpoint manager.
  - Registered `.iroh` in the route factory behind `MobileIrohTransportFlag`; `CmxNetworkRoutePinger` now times iroh connects.
  - Added EndpointId pinning and trust validation: `MobilePairedMac` stores a trusted `irohEndpointID`; RPC withholds Stack tokens on mismatch until explicit re-trust via `MobileSyncRuntime.irohEndpointTrustValidator`.
  - Reconnect considers `.peer` routes by priority; mapped iroh failures to pairing/connection categories with localized en/ja copy.
  - Migrated paired-Mac store to schema v5 (`iroh_endpoint_id`) and synced the pin in backup records.

- **Dependencies**
  - Added `CmuxIrohFFI` (binary) and `CmuxIrohC` (C) targets to `CmuxMobileTransport`; linked `Network`, `Security`, and `CoreWLAN` (macOS).
  - CI provisions `CmuxIrohFFI` for iOS package tests; accept `ios/cmux.xcworkspace/Package.resolved` as a managed lockfile.

<sup>Written for commit b3c679309c9cece8626507d6a579dd69660a4f3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

