### PR TITLE
iroh: authenticate the client to a private JWT-gated relay (bind-path token)

### DIFF
--- a/Native/cmux-iroh/Cargo.lock
+++ b/Native/cmux-iroh/Cargo.lock
@@ -224,6 +224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -289,7 +295,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -446,12 +452,12 @@ dependencies = [
 
 [[package]]
 name = "curve25519-dalek"
-version = "5.0.0-pre.6"
+version = "5.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "335f1947f241137a14106b6f5acc5918a5ede29c9d71d3f2cb1678d5075d9fc3"
+checksum = "4f359e08ca85e7bd759e1fd933ff2bccd81864c60a8fba0e259c7f822b0924bf"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures 0.3.0",
  "curve25519-dalek-derive",
  "digest",
  "fiat-crypto",
@@ -621,7 +627,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
 dependencies = [
  "block-buffer",
- "const-oid",
  "crypto-common 0.2.2",
 ]
 
@@ -672,9 +677,9 @@ dependencies = [
 
 [[package]]
 name = "ed25519-dalek"
-version = "3.0.0-pre.7"
+version = "3.0.0-rc.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20449acd54b660981ae5caa2bcb56d1fe7f25f2e37a38ec507400fab034d4bb6"
+checksum = "b011170fe4f04665565b4110afef66774fe9ffff278f3eb5b81cc73d26e27d60"
 dependencies = [
  "curve25519-dalek",
  "ed25519",
@@ -1029,10 +1034,10 @@ dependencies = [
  "http",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "rand",
  "rustls",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tokio",
  "tokio-rustls",
@@ -1049,12 +1054,12 @@ dependencies = [
  "data-encoding",
  "idna",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "once_cell",
  "prefix-trie",
  "rand",
  "ring",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "url",
@@ -1072,7 +1077,7 @@ dependencies = [
  "hickory-proto",
  "ipconfig",
  "ipnet",
- "jni",
+ "jni 0.22.4",
  "moka",
  "ndk-context",
  "once_cell",
@@ -1082,7 +1087,7 @@ dependencies = [
  "rustls",
  "smallvec",
  "system-configuration",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-rustls",
  "tracing",
@@ -1412,9 +1417,9 @@ dependencies = [
 
 [[package]]
 name = "iroh"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef865dc2d11a19fe670ff217b68ffc3b511bddf473dc3a3e120090b9f691803"
+checksum = "5fca9b4b462c343ff88fc0af4096c186f939b602a0bc08723536ef2c31c93971"
 dependencies = [
  "backon",
  "blake3",
@@ -1449,7 +1454,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "rustls-pki-types",
- "rustls-webpki",
  "serde",
  "smallvec",
  "strum",
@@ -1460,36 +1464,32 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen-futures",
- "webpki-roots",
 ]
 
 [[package]]
 name = "iroh-base"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af93d67701c00c504982154569192ad384738c0450ba1196930314b955100552"
+checksum = "830a582cd54410dc1aa71d4786a82c3297d7b0165accd8b6dbbb3b240b48140d"
 dependencies = [
  "curve25519-dalek",
  "data-encoding",
  "data-encoding-macro",
  "derive_more",
- "digest",
  "ed25519-dalek",
  "getrandom 0.4.2",
  "n0-error",
  "rand",
  "serde",
- "sha2",
  "url",
  "zeroize",
- "zeroize_derive",
 ]
 
 [[package]]
 name = "iroh-dns"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de4112c91eb64094d77df9d3112606dcf7ff216421afccd2dc762fda5a7b2879"
+checksum = "516e4eedc38e33ab69a6bd325520332dc3d67b25454e2d590ebb84a25240dd9a"
 dependencies = [
  "arc-swap",
  "cfg_aliases",
@@ -1499,8 +1499,8 @@ dependencies = [
  "n0-error",
  "n0-future",
  "ndk-context",
+ "portable-atomic",
  "rand",
- "reqwest",
  "rustls",
  "simple-dns",
  "strum",
@@ -1511,9 +1511,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d102597d0ee523f17fdb672c532395e634dbe945429284c811430d63bacc0d8a"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
 dependencies = [
  "iroh-metrics-derive",
  "itoa",
@@ -1526,9 +1526,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-metrics-derive"
-version = "1.0.0-rc.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c8e0c97f1dc787107f388433c349397c565572fe6406d600ff7bb7b7fe3b30"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -1538,9 +1538,9 @@ dependencies = [
 
 [[package]]
 name = "iroh-relay"
-version = "1.0.0-rc.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a70030b9e71c1183bd4f88fbdbebfa1af2a5be549dd6f20a1e8ac3cd0202ee9d"
+checksum = "8149bb6a57126225a07d6928846d82dcedfd24ea0f863ef7b2eb475e1d726354"
 dependencies = [
  "blake3",
  "bytes",
@@ -1590,6 +1590,22 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -1597,10 +1613,10 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
- "thiserror",
+ "thiserror 2.0.18",
  "walkdir",
  "windows-link",
 ]
@@ -1616,6 +1632,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -1766,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "223e946a84aa91644507a6b7865cfebbb9a231ace499041c747ab0fd30408212"
+checksum = "c37e81176a83a77d2514528b91bdafc70ef88aab428f0e1b91aebb8d99888895"
 dependencies = [
  "n0-error-macros",
  "spez",
@@ -1776,9 +1801,9 @@ dependencies = [
 
 [[package]]
 name = "n0-error-macros"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "565305a21e6b3bf26640ad98f05a0fda12d3ab4315394566b52a7bddb8b34828"
+checksum = "e2acd8b070213b0299282f884b4beba4e7b52d624fdcd504a3ad3665390c11e1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1808,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "n0-watcher"
-version = "1.0.0-rc.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "928d8039a66cce5efcfd35e88b32d3defc8eba630b3ac451522997f563956a52"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
 dependencies = [
  "derive_more",
  "n0-error",
@@ -1825,19 +1850,22 @@ checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
 name = "netdev"
-version = "0.43.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57bacaf873ee4eab5646f99b381b271ec75e716902a67cf962c0f328c5eb5bfb"
+checksum = "569dfbdd2efd771b24ec9bb57f956e04d4fbfc72f62b2f11961723f9b3f4b020"
 dependencies = [
  "block2",
  "dispatch2",
  "dlopen2",
  "ipnet",
+ "jni 0.21.1",
  "libc",
  "mac-addr",
+ "ndk-context",
  "netlink-packet-core",
- "netlink-packet-route 0.29.0",
+ "netlink-packet-route",
  "netlink-sys",
+ "objc2",
  "objc2-core-foundation",
  "objc2-core-wlan",
  "objc2-foundation",
@@ -1858,21 +1886,9 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.29.0"
+version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9854ea6ad14e3f4698a7f03b65bce0833dd2d81d594a0e4a984170537146b6"
-dependencies = [
- "bitflags",
- "libc",
- "log",
- "netlink-packet-core",
-]
-
-[[package]]
-name = "netlink-packet-route"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be8919612f6028ab4eacbbfe1234a9a43e3722c6e0915e7ff519066991905092"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
 dependencies = [
  "bitflags",
  "libc",
@@ -1891,7 +1907,7 @@ dependencies = [
  "log",
  "netlink-packet-core",
  "netlink-sys",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1909,14 +1925,15 @@ dependencies = [
 
 [[package]]
 name = "netwatch"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071e0c2b5b229622c459096b84f1ad51afa150cdeeefdad491ef3704e581d91"
+checksum = "4d9cbe01741347ef750d743d6690603f5eed8341e679fb51c8e629337aa11976"
 dependencies = [
  "atomic-waker",
  "bytes",
  "cfg_aliases",
  "derive_more",
+ "ipnet",
  "js-sys",
  "libc",
  "n0-error",
@@ -1924,7 +1941,7 @@ dependencies = [
  "n0-watcher",
  "netdev",
  "netlink-packet-core",
- "netlink-packet-route 0.30.0",
+ "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
  "noq-udp",
@@ -1945,9 +1962,9 @@ dependencies = [
 
 [[package]]
 name = "noq"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "198b99fc085a5db1f7d259edb5ede8311e59f28cdd2687920b4313613d21a73f"
+checksum = "4bf95190af1bd4a00a10e8255ca0c8ddd9e9a9f5e79151d7a7eb6d56aff5dc89"
 dependencies = [
  "bytes",
  "cfg_aliases",
@@ -1958,7 +1975,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2",
- "thiserror",
+ "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
  "tracing",
@@ -1967,9 +1984,9 @@ dependencies = [
 
 [[package]]
 name = "noq-proto"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ab0ac774795ce1e42a7e61266e71f3be8110210630441169ac8dda403dd23f1"
+checksum = "aa6c890013591e709a3e45dd53501351b7e27e7ff3c7e9fc3dce43e300e7e9d3"
 dependencies = [
  "aes-gcm",
  "bytes",
@@ -1986,7 +2003,7 @@ dependencies = [
  "rustls-pki-types",
  "slab",
  "sorted-index-buffer",
- "thiserror",
+ "thiserror 2.0.18",
  "tinyvec",
  "tracing",
  "web-time",
@@ -1994,9 +2011,9 @@ dependencies = [
 
 [[package]]
 name = "noq-udp"
-version = "1.0.0-rc.1"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3c1520eacd33fd6b009e2e70116b05508ade51db5e0d315ff8bf6b702148c2b"
+checksum = "3137a52df66c20090a889828d1c655f21f52294cba64e5c4fbb04fc83eee7c8e"
 dependencies = [
  "cfg_aliases",
  "libc",
@@ -2314,9 +2331,9 @@ dependencies = [
 
 [[package]]
 name = "portmapper"
-version = "0.18.0"
+version = "0.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64959cbabf952c8ffcbaea13745308508f1f825922f4068353f3de08d42cf214"
+checksum = "eb3713e4977408279158444a18c1a01ac9bf2e7eaf1fbfd1a19ac9cd18d90721"
 dependencies = [
  "base64",
  "bytes",
@@ -2612,7 +2629,7 @@ checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
  "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls",
@@ -3019,11 +3036,31 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3787,11 +3824,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3805,18 +3851,33 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
 
 [[package]]
@@ -3830,15 +3891,33 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3854,9 +3933,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3866,9 +3957,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3989,7 +4092,7 @@ dependencies = [
  "futures",
  "log",
  "serde",
- "thiserror",
+ "thiserror 2.0.18",
  "windows",
  "windows-core",
 ]
@@ -4013,7 +4116,7 @@ dependencies = [
  "pharos",
  "rustc_version",
  "send_wrapper",
- "thiserror",
+ "thiserror 2.0.18",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4080,18 +4183,18 @@ dependencies = [
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
 dependencies = [
  "zeroize_derive",
 ]
 
 [[package]]
 name = "zeroize_derive"
-version = "1.4.3"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+checksum = "3c50655cbb0fe3fc43170059e702f1ce5e19b84cec58dc87b037a09935c2f328"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Native/cmux-iroh/Cargo.toml
+++ b/Native/cmux-iroh/Cargo.toml
@@ -18,7 +18,7 @@ crate-type = ["staticlib"]
 # Pinned exactly: 1.0.0-rc.1 is the newest published iroh as of 2026-06-11 and
 # the version the FFI spike proved (experiments/iroh-swift-ffi-spike). Bump
 # deliberately and re-run the spike proof, see README.md.
-iroh = "=1.0.0-rc.1"
+iroh = "=1.0.2"
 serde_json = "1.0"
 tokio = { version = "1.48", features = ["rt-multi-thread", "time"] }
 

--- a/Native/cmux-iroh/src/lib.rs
+++ b/Native/cmux-iroh/src/lib.rs
@@ -382,15 +382,20 @@ pub unsafe extern "C" fn cmux_iroh_secret_key_endpoint_id(
 /// - `enable_relay == true` and `relay_url` set: a custom single-relay map
 ///   (`RelayMode::Custom`), i.e. the user's own `iroh-relay`. This is the *only*
 ///   relay (no n0 fallback), so the dialer must be told the same relay URL (it
-///   travels in the published route / pairing code).
+///   travels in the published route / pairing code). When `relay_auth_token`
+///   is non-null and non-empty, it authenticates this endpoint to that custom
+///   relay. A token is ignored when relays are disabled or no custom relay URL
+///   is supplied.
 ///
 /// Returns null on failure with the cause in the error out-params. A malformed
-/// `relay_url` fails with `InvalidArgument`.
+/// `relay_url` fails with `InvalidArgument`. The relay auth token is never
+/// logged or included in route JSON.
 ///
 /// # Safety
 ///
 /// - `secret_key` must point at `secret_key_len` readable bytes.
 /// - `relay_url`, when non-null, must be a NUL-terminated C string.
+/// - `relay_auth_token`, when non-null, must be a NUL-terminated C string.
 /// - `err_kind`, when non-null, must point at a writable `int32_t`.
 /// - `err_buf`, when non-null, must point at `err_cap` writable bytes.
 #[unsafe(no_mangle)]
@@ -400,6 +405,7 @@ pub unsafe extern "C" fn cmux_iroh_endpoint_bind(
     secret_key_len: usize,
     enable_relay: bool,
     relay_url: *const c_char,
+    relay_auth_token: *const c_char,
     accept_connections: bool,
     err_kind: *mut i32,
     err_buf: *mut c_char,
@@ -411,6 +417,7 @@ pub unsafe extern "C" fn cmux_iroh_endpoint_bind(
         secret_key_len,
         enable_relay,
         relay_url,
+        relay_auth_token,
         accept_connections,
         false,
     );
@@ -442,6 +449,7 @@ pub unsafe extern "C" fn cmux_iroh_endpoint_bind_relay_only(
     secret_key_len: usize,
     enable_relay: bool,
     relay_url: *const c_char,
+    relay_auth_token: *const c_char,
     accept_connections: bool,
     err_kind: *mut i32,
     err_buf: *mut c_char,
@@ -453,6 +461,7 @@ pub unsafe extern "C" fn cmux_iroh_endpoint_bind_relay_only(
         secret_key_len,
         enable_relay,
         relay_url,
+        relay_auth_token,
         accept_connections,
         true,
     );
@@ -470,28 +479,12 @@ fn bind_impl(
     secret_key_len: usize,
     enable_relay: bool,
     relay_url: *const c_char,
+    relay_auth_token: *const c_char,
     accept_connections: bool,
     relay_only: bool,
 ) -> Result<Endpoint, FfiError> {
     let key = parse_secret_key(secret_key, secret_key_len)?;
-    // Parse an optional custom relay URL up front so a malformed value fails
-    // fast with `InvalidArgument` (mirrors the dial path's relay handling).
-    let custom_relay = match c_to_str(relay_url) {
-        Some(raw) if !raw.is_empty() => Some(RelayUrl::from_str(raw).map_err(|error| {
-            FfiError::new(
-                CmuxIrohErrorKind::InvalidArgument,
-                format!("invalid relay url: {error:#}"),
-            )
-        })?),
-        _ => None,
-    };
-    let relay_mode = if !enable_relay {
-        RelayMode::Disabled
-    } else if let Some(url) = custom_relay {
-        RelayMode::Custom(RelayMap::from(url))
-    } else {
-        RelayMode::Default
-    };
+    let relay_mode = relay_mode(enable_relay, relay_url, relay_auth_token)?;
     runtime()?
         .block_on(async move {
             let mut builder = Endpoint::builder(presets::N0)
@@ -511,6 +504,42 @@ fn bind_impl(
                 format!("bind failed: {error:#}"),
             )
         })
+}
+
+/// Builds the relay mode used by both endpoint bind entrypoints.
+fn relay_mode(
+    enable_relay: bool,
+    relay_url: *const c_char,
+    relay_auth_token: *const c_char,
+) -> Result<RelayMode, FfiError> {
+    // Parse an optional custom relay URL up front so a malformed value fails
+    // fast with `InvalidArgument` (mirrors the dial path's relay handling).
+    let custom_relay = match c_to_str(relay_url) {
+        Some(raw) if !raw.is_empty() => Some(RelayUrl::from_str(raw).map_err(|error| {
+            FfiError::new(
+                CmuxIrohErrorKind::InvalidArgument,
+                format!("invalid relay url: {error:#}"),
+            )
+        })?),
+        _ => None,
+    };
+    let relay_auth_token = c_to_str(relay_auth_token).filter(|token| !token.is_empty());
+    let relay_mode = if !enable_relay {
+        RelayMode::Disabled
+    } else if let Some(url) = custom_relay {
+        let relay_map = RelayMap::from(url);
+        let relay_map = if let Some(token) = relay_auth_token {
+            relay_map.with_auth_token(token)
+        } else {
+            relay_map
+        };
+        RelayMode::Custom(relay_map)
+    } else {
+        // A token without a custom relay URL is intentionally ignored: relay
+        // auth applies only to the caller-selected private relay map.
+        RelayMode::Default
+    };
+    Ok(relay_mode)
 }
 
 /// Returns the endpoint's `EndpointId` (z-base-32) as a heap string.
@@ -1416,6 +1445,7 @@ mod ffi_seam_tests {
                 key.len(),
                 false, // relay disabled: hermetic, local UDP only
                 ptr::null(),
+                ptr::null(),
                 accept,
                 &raw mut err.kind,
                 err.buf.as_mut_ptr(),
@@ -1473,6 +1503,7 @@ mod ffi_seam_tests {
                 CMUX_IROH_SECRET_KEY_LEN,
                 false,
                 ptr::null(),
+                ptr::null(),
                 false,
                 &raw mut err.kind,
                 err.buf.as_mut_ptr(),
@@ -1490,6 +1521,7 @@ mod ffi_seam_tests {
                 key.as_ptr(),
                 16,
                 false,
+                ptr::null(),
                 ptr::null(),
                 false,
                 &raw mut err.kind,
@@ -1514,6 +1546,7 @@ mod ffi_seam_tests {
                 key.len(),
                 true,
                 bogus.as_ptr(),
+                ptr::null(),
                 false,
                 &raw mut err.kind,
                 err.buf.as_mut_ptr(),
@@ -1523,6 +1556,54 @@ mod ffi_seam_tests {
         assert!(endpoint.is_null(), "malformed relay url must be rejected");
         assert_eq!(err.kind(), CmuxIrohErrorKind::InvalidArgument as i32);
         assert!(err.message().contains("relay url"), "{}", err.message());
+    }
+
+    #[test]
+    fn bind_relay_mode_applies_auth_token_only_to_custom_map() {
+        let relay_url = RelayUrl::from_str("https://127.0.0.1:9/").expect("valid relay url");
+        let relay_cstr = CString::new(relay_url.to_string()).expect("cstring");
+        let token = "cmux.test.jwt";
+        let token_cstr = CString::new(token).expect("cstring");
+        let empty_token = CString::new("").expect("cstring");
+
+        let mode = relay_mode(true, relay_cstr.as_ptr(), token_cstr.as_ptr())
+            .ok()
+            .expect("custom relay mode should parse");
+        let RelayMode::Custom(map) = mode else {
+            panic!("bind path should build a custom relay map");
+        };
+        let config = map
+            .get(&relay_url)
+            .expect("custom relay config must be installed");
+        assert!(
+            config.auth_token.as_deref() == Some(token),
+            "custom relay config should carry the auth token"
+        );
+
+        for absent_token in [ptr::null(), empty_token.as_ptr()] {
+            let mode = relay_mode(true, relay_cstr.as_ptr(), absent_token)
+                .ok()
+                .expect("custom relay mode should parse without a token");
+            let RelayMode::Custom(map) = mode else {
+                panic!("bind path should preserve the custom relay map");
+            };
+            let config = map
+                .get(&relay_url)
+                .expect("custom relay config must be installed");
+            assert!(
+                config.auth_token.is_none(),
+                "null and empty tokens must preserve unauthenticated relay config"
+            );
+        }
+
+        assert!(matches!(
+            relay_mode(true, ptr::null(), token_cstr.as_ptr()),
+            Ok(RelayMode::Default)
+        ));
+        assert!(matches!(
+            relay_mode(false, relay_cstr.as_ptr(), token_cstr.as_ptr()),
+            Ok(RelayMode::Disabled)
+        ));
     }
 
     #[test]
@@ -1606,6 +1687,7 @@ mod ffi_seam_tests {
             usize,
             bool,
             *const c_char,
+            *const c_char,
             bool,
             *mut i32,
             *mut c_char,
@@ -1675,6 +1757,7 @@ mod ffi_seam_tests {
                 listener_key.len(),
                 true,
                 ptr::null(),
+                ptr::null(),
                 true,
                 &raw mut err.kind,
                 err.buf.as_mut_ptr(),
@@ -1711,6 +1794,7 @@ mod ffi_seam_tests {
                 dialer_key.as_ptr(),
                 dialer_key.len(),
                 true,
+                ptr::null(),
                 ptr::null(),
                 false,
                 &raw mut err.kind,

--- a/Packages/Shared/CmuxIrohFFI/Sources/CmuxIrohFFI/include/cmux_iroh_ffi.h
+++ b/Packages/Shared/CmuxIrohFFI/Sources/CmuxIrohFFI/include/cmux_iroh_ffi.h
@@ -59,13 +59,17 @@ char *cmux_iroh_secret_key_endpoint_id(
 //     (cmux-hosted iroh).
 //   - enable_relay == true, relay_url set: a custom single-relay map (the
 //     user's own iroh-relay). A malformed relay_url fails with InvalidArgument.
-// relay_url, when non-null, must be a NUL-terminated C string. Returns null on
-// failure with the cause in the error out-params.
+// relay_auth_token authenticates this endpoint to that custom relay when
+// non-null/non-empty; it is ignored when relays are disabled or without a
+// custom relay_url, and is never logged or included in route JSON. relay_url
+// and relay_auth_token, when non-null, must be NUL-terminated C strings.
+// Returns null on failure with the cause in the error out-params.
 CmuxIrohEndpoint *cmux_iroh_endpoint_bind(
     const uint8_t *secret_key,
     size_t secret_key_len,
     bool enable_relay,
     const char *relay_url,
+    const char *relay_auth_token,
     bool accept_connections,
     int32_t *err_kind,
     char *err_buf,
@@ -74,12 +78,14 @@ CmuxIrohEndpoint *cmux_iroh_endpoint_bind(
 // Binds an endpoint with relays enabled as requested but with all local IP
 // transports removed. Pair with cmux_iroh_endpoint_connect_relay_only for
 // DEBUG/simulator relay-path verification; the default bind/connect APIs keep
-// direct+relay behavior.
+// direct+relay behavior. relay_url and relay_auth_token have the same contract
+// as cmux_iroh_endpoint_bind.
 CmuxIrohEndpoint *cmux_iroh_endpoint_bind_relay_only(
     const uint8_t *secret_key,
     size_t secret_key_len,
     bool enable_relay,
     const char *relay_url,
+    const char *relay_auth_token,
     bool accept_connections,
     int32_t *err_kind,
     char *err_buf,

--- a/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteListener.swift
+++ b/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteListener.swift
@@ -19,6 +19,7 @@ public actor CmxIrohByteListener {
     private let secretKey: [UInt8]?
     private let enableRelay: Bool
     private let relayURL: String?
+    private let relayAuthToken: String?
     private let relayOnly: Bool
     private let maximumReceiveLength: Int
 
@@ -30,6 +31,7 @@ public actor CmxIrohByteListener {
         attributes: .concurrent
     )
 
+    /// Creates a listener that binds an iroh endpoint when ``start()`` runs.
     /// - Parameters:
     ///   - secretKey: The Mac's 32-byte iroh secret key. When nil a fresh
     ///     ephemeral key is generated on ``start()``; the host supplies a stable
@@ -39,18 +41,23 @@ public actor CmxIrohByteListener {
     ///   - relayURL: When set (and `enableRelay` is true), the endpoint homes on
     ///     this custom relay (the user's own `iroh-relay`) instead of the default
     ///     n0 fleet. nil/empty keeps the default fleet (cmux-hosted iroh).
+    ///   - relayAuthToken: An optional token that authenticates this endpoint to
+    ///     the custom relay at bind time. It is never logged or published.
     ///   - relayOnly: Whether the listener disables local IP transports.
     ///     Defaults to false.
+    ///   - maximumReceiveLength: The maximum bytes returned by one receive.
     public init(
         secretKey: [UInt8]? = nil,
         enableRelay: Bool = true,
         relayURL: String? = nil,
+        relayAuthToken: String? = nil,
         relayOnly: Bool = false,
         maximumReceiveLength: Int = CmxIrohByteTransport.defaultMaximumReceiveLength
     ) {
         self.secretKey = secretKey
         self.enableRelay = enableRelay
         self.relayURL = relayURL
+        self.relayAuthToken = relayAuthToken
         self.relayOnly = relayOnly
         self.maximumReceiveLength = maximumReceiveLength
     }
@@ -74,37 +81,22 @@ public actor CmxIrohByteListener {
         }
         let relayEnabled = enableRelay
         let relay = relayURL
+        let relayAuth = relayAuthToken
         let relayOnlyBind = relayOnly
 
         let result = await runBlocking { () -> Result<CmxIrohUnsafeBox<OpaquePointer>, CmxIrohByteTransportError> in
             let bind = CmxIrohByteTransport.withErrorBuffer { kindPtr, errBuf, cap in
-                CmxIrohByteTransport.withOptionalCString(relay) { relayC in
-                    key.withUnsafeBufferPointer { keyBuffer in
-                        if relayOnlyBind {
-                            cmux_iroh_endpoint_bind_relay_only(
-                                keyBuffer.baseAddress,
-                                keyBuffer.count,
-                                relayEnabled,
-                                relayC,
-                                true,
-                                kindPtr,
-                                errBuf,
-                                cap
-                            )
-                        } else {
-                            cmux_iroh_endpoint_bind(
-                                keyBuffer.baseAddress,
-                                keyBuffer.count,
-                                relayEnabled,
-                                relayC,
-                                true,
-                                kindPtr,
-                                errBuf,
-                                cap
-                            )
-                        }
-                    }
-                }
+                CmxIrohByteTransport.bindEndpoint(
+                    key: key,
+                    enableRelay: relayEnabled,
+                    relayURL: relay,
+                    relayAuthToken: relayAuth,
+                    relayOnly: relayOnlyBind,
+                    acceptConnections: true,
+                    kindPtr,
+                    errBuf,
+                    cap
+                )
             }
             guard let endpoint = bind.result else {
                 return .failure(.bindFailed(bind.message))

--- a/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteTransport+FFI.swift
+++ b/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteTransport+FFI.swift
@@ -45,6 +45,52 @@ extension CmxIrohByteTransport {
         return CmxIrohCallOutcome(result: result, errorKind: kind, message: String(cString: buffer))
     }
 
+    /// Binds a local endpoint, applying `relayAuthToken` only through the FFI's
+    /// bind-time custom relay map. The token is never passed to dial hints.
+    static func bindEndpoint(
+        key: [UInt8],
+        enableRelay: Bool,
+        relayURL: String?,
+        relayAuthToken: String?,
+        relayOnly: Bool,
+        acceptConnections: Bool,
+        _ errKind: UnsafeMutablePointer<Int32>,
+        _ errBuffer: UnsafeMutablePointer<CChar>,
+        _ errCapacity: Int
+    ) -> OpaquePointer? {
+        withOptionalCString(relayURL) { relayC in
+            withOptionalCString(relayAuthToken) { relayAuthTokenC in
+                key.withUnsafeBufferPointer { keyBuffer in
+                    if relayOnly {
+                        cmux_iroh_endpoint_bind_relay_only(
+                            keyBuffer.baseAddress,
+                            keyBuffer.count,
+                            enableRelay,
+                            relayC,
+                            relayAuthTokenC,
+                            acceptConnections,
+                            errKind,
+                            errBuffer,
+                            errCapacity
+                        )
+                    } else {
+                        cmux_iroh_endpoint_bind(
+                            keyBuffer.baseAddress,
+                            keyBuffer.count,
+                            enableRelay,
+                            relayC,
+                            relayAuthTokenC,
+                            acceptConnections,
+                            errKind,
+                            errBuffer,
+                            errCapacity
+                        )
+                    }
+                }
+            }
+        }
+    }
+
     /// Dials `endpointID` over `endpoint`, returning the connection or nil.
     static func dialConnection(
         _ endpoint: OpaquePointer,

--- a/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteTransport.swift
+++ b/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteTransport.swift
@@ -19,6 +19,7 @@ public actor CmxIrohByteTransport: CmxByteTransport {
 
     private let endpointID: String
     private let relayURL: String?
+    private let relayAuthToken: String?
     private let directAddrs: [String]
     private let secretKey: [UInt8]?
     private let enableRelay: Bool
@@ -40,7 +41,12 @@ public actor CmxIrohByteTransport: CmxByteTransport {
     /// Creates a transport that will dial the given peer when ``connect()`` runs.
     /// - Parameters:
     ///   - endpointID: The peer Mac's z-base-32 EndpointId.
-    ///   - relayURL: The peer's home relay URL hint, if known.
+    ///   - relayURL: The peer's home relay URL hint, if known. When a non-empty
+    ///     `relayAuthToken` is also supplied, the local endpoint authenticates
+    ///     to this relay through its bind-time custom relay map.
+    ///   - relayAuthToken: An optional token that authenticates the local
+    ///     endpoint to the custom relay at bind time. It is never used as a
+    ///     per-dial hint or logged.
     ///   - directAddrs: Direct socket-address hints for holepunch-free dials.
     ///   - secretKey: The phone's 32-byte iroh secret key. When nil, a fresh
     ///     ephemeral key is generated on connect (full PR 3 supplies a stable
@@ -49,9 +55,12 @@ public actor CmxIrohByteTransport: CmxByteTransport {
     ///     Defaults to true; tests pass false for hermetic loopback dials.
     ///   - relayOnly: Whether the dialer disables local IP transports and dials
     ///     with relay hints only. Defaults to false.
+    ///   - connectTimeoutMilliseconds: The deadline for dialing the peer.
+    ///   - maximumReceiveLength: The maximum bytes returned by one receive.
     public init(
         endpointID: String,
         relayURL: String?,
+        relayAuthToken: String? = nil,
         directAddrs: [String],
         secretKey: [UInt8]? = nil,
         enableRelay: Bool = true,
@@ -61,6 +70,7 @@ public actor CmxIrohByteTransport: CmxByteTransport {
     ) {
         self.endpointID = endpointID
         self.relayURL = relayURL
+        self.relayAuthToken = relayAuthToken
         self.directAddrs = directAddrs
         self.secretKey = secretKey
         self.enableRelay = enableRelay
@@ -70,10 +80,21 @@ public actor CmxIrohByteTransport: CmxByteTransport {
     }
 
     /// Creates a transport for an `.iroh` `.peer` route.
+    /// - Parameters:
+    ///   - route: The peer route to dial.
+    ///   - relayAuthToken: An optional token for authenticating the local
+    ///     endpoint to the route's custom relay at bind time.
+    ///   - secretKey: The phone's stable iroh secret key, or nil for an
+    ///     ephemeral key.
+    ///   - enableRelay: Whether the local endpoint enables relays and discovery.
+    ///   - relayOnly: Whether the dialer disables local IP transports.
+    ///   - connectTimeoutMilliseconds: The deadline for dialing the peer.
+    ///   - maximumReceiveLength: The maximum bytes returned by one receive.
     /// - Throws: ``CmxIrohByteTransportError`` when the route kind or endpoint is
     ///   not a dial-able iroh peer, or the route fails validation.
     public init(
         route: CmxAttachRoute,
+        relayAuthToken: String? = nil,
         secretKey: [UInt8]? = nil,
         enableRelay: Bool = true,
         relayOnly: Bool = false,
@@ -90,6 +111,7 @@ public actor CmxIrohByteTransport: CmxByteTransport {
         self.init(
             endpointID: id,
             relayURL: relayURL,
+            relayAuthToken: relayAuthToken,
             directAddrs: directAddrs,
             secretKey: secretKey,
             enableRelay: enableRelay,
@@ -124,6 +146,10 @@ public actor CmxIrohByteTransport: CmxByteTransport {
 
         let id = endpointID
         let relay = relayURL
+        let relayAuth = relayAuthToken
+        // Preserve the existing default-map bind when no token is available;
+        // a non-empty token makes the peer relay the local authenticated map.
+        let bindRelay = relayAuth?.isEmpty == false ? relay : nil
         let addrs = directAddrs
         let relayEnabled = enableRelay
         let relayOnlyDial = relayOnly
@@ -131,39 +157,17 @@ public actor CmxIrohByteTransport: CmxByteTransport {
 
         let result = await runBlocking { () -> Result<CmxIrohHandles, CmxIrohByteTransportError> in
             let bind = Self.withErrorBuffer { kindPtr, errBuf, cap in
-                key.withUnsafeBufferPointer { keyBuffer in
-                    if relayOnlyDial {
-                        cmux_iroh_endpoint_bind_relay_only(
-                            keyBuffer.baseAddress,
-                            keyBuffer.count,
-                            relayEnabled,
-                            // The dialer homes on the default relay fleet; the
-                            // peer's relay (custom or default) is supplied as a dial
-                            // hint in `dialConnection` below, so cross-relay dials
-                            // still work.
-                            nil,
-                            false,
-                            kindPtr,
-                            errBuf,
-                            cap
-                        )
-                    } else {
-                        cmux_iroh_endpoint_bind(
-                            keyBuffer.baseAddress,
-                            keyBuffer.count,
-                            relayEnabled,
-                            // The dialer homes on the default relay fleet; the
-                            // peer's relay (custom or default) is supplied as a dial
-                            // hint in `dialConnection` below, so cross-relay dials
-                            // still work.
-                            nil,
-                            false,
-                            kindPtr,
-                            errBuf,
-                            cap
-                        )
-                    }
-                }
+                Self.bindEndpoint(
+                    key: key,
+                    enableRelay: relayEnabled,
+                    relayURL: bindRelay,
+                    relayAuthToken: relayAuth,
+                    relayOnly: relayOnlyDial,
+                    acceptConnections: false,
+                    kindPtr,
+                    errBuf,
+                    cap
+                )
             }
             guard let endpoint = bind.result else {
                 return .failure(.bindFailed(bind.message))

--- a/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteTransportFactory.swift
+++ b/Packages/Shared/CmuxMobileIrohTransport/Sources/CmuxMobileIrohTransport/CmxIrohByteTransportFactory.swift
@@ -9,15 +9,24 @@ public struct CmxIrohByteTransportFactory: CmxRouteAwareByteTransportFactory {
     /// ephemeral key; full PR 3 supplies the stable Keychain key so the phone
     /// keeps one EndpointId.
     private let secretKey: [UInt8]?
+    private let relayAuthToken: String?
     private let relayOnly: Bool
     private let maximumReceiveLength: Int
 
+    /// Creates a factory for iroh route transports.
+    /// - Parameters:
+    ///   - secretKey: The phone's stable iroh secret key, or nil for ephemeral keys.
+    ///   - relayAuthToken: An optional bind-time custom relay auth token.
+    ///   - relayOnly: Whether transports disable local IP paths.
+    ///   - maximumReceiveLength: The maximum bytes returned by one receive.
     public init(
         secretKey: [UInt8]? = nil,
+        relayAuthToken: String? = nil,
         relayOnly: Bool = false,
         maximumReceiveLength: Int = CmxIrohByteTransport.defaultMaximumReceiveLength
     ) {
         self.secretKey = secretKey
+        self.relayAuthToken = relayAuthToken
         self.relayOnly = relayOnly
         self.maximumReceiveLength = maximumReceiveLength
     }
@@ -28,6 +37,7 @@ public struct CmxIrohByteTransportFactory: CmxRouteAwareByteTransportFactory {
         }
         return try CmxIrohByteTransport(
             route: route,
+            relayAuthToken: relayAuthToken,
             secretKey: secretKey,
             relayOnly: relayOnly,
             maximumReceiveLength: maximumReceiveLength

--- a/Sources/Mobile/MobileIrohHostLane.swift
+++ b/Sources/Mobile/MobileIrohHostLane.swift
@@ -80,7 +80,9 @@ final class MobileIrohHostLane {
         let listener = CmxIrohByteListener(
             secretKey: Self.loadOrCreateIrohSecretKey(),
             enableRelay: true,
-            relayURL: relayURL
+            relayURL: relayURL,
+            // TODO: mint via web API.
+            relayAuthToken: nil
         )
         let generation = UUID()
         acceptGeneration = generation

--- a/ios/cmux/cmuxApp.swift
+++ b/ios/cmux/cmuxApp.swift
@@ -36,7 +36,11 @@ struct cmuxApp: App {
         registrations.append(
             CmxRouteTransportFactoryRegistration(
                 kind: .iroh,
-                factory: CmxIrohByteTransportFactory(relayOnly: irohRelayOnly)
+                factory: CmxIrohByteTransportFactory(
+                    // TODO: mint via web API.
+                    relayAuthToken: nil,
+                    relayOnly: irohRelayOnly
+                )
             )
         )
         let transportFactory: CmxRouteTransportFactory


### PR DESCRIPTION
Threads an optional relay auth token (a cmux-signed EdDSA JWT) through the cmux-iroh **bind** path so the client can use a private, JWT-gated iroh relay instead of being denied.

## What
- New `relay_auth_token: *const c_char` param on `cmux_iroh_endpoint_bind` and `cmux_iroh_endpoint_bind_relay_only` (and `bind_impl`). When a custom `relay_url` **and** a non-empty token are supplied, the relay map is built as `RelayMap::from(url).with_auth_token(token)`; otherwise behavior is unchanged (token ignored on the default n0 map, on disabled relays, or when absent).
- Relay-mode construction refactored into a `relay_mode()` helper shared by both bind entrypoints.
- C header + Swift wrappers (`CmxIrohByteTransport(+FFI)`, `CmxIrohByteListener`, factory) thread an optional `relayAuthToken: String? = nil`.

## Security
Bind-path only. The token is **never** placed in route JSON, pairing codes, or logs, so it cannot leak through the dial/route-serialization paths (which is why `MobileRouteResolver`/`CmxTransport` are deliberately untouched). All call sites pass `nil` today; minting the JWT via the web API is a follow-up (TODOs at the composition roots), so this PR is behavior-neutral.

## Why now
A private relay fleet (separate repo) is live and **requires** a valid cmux JWT; anonymous is denied. Proven end-to-end against the deployed relay: a valid token relays real traffic, missing/bad tokens are denied (relay logs: allow for the valid endpoints, deny for the rest). This PR is the client half so cmux can present that token.

## Tests
- Rust: new `bind_relay_mode_applies_auth_token_only_to_custom_map` asserts the token lands only on a custom map (present with URL+token; absent for null/empty; token-without-URL falls back to `RelayMode::Default`). `cargo build`/`test`/`clippy -D warnings` pass.
- `swift build` passes for `CMUXMobileCore`, `CmuxIrohFFI`, `CmuxMobileIrohTransport`.
- App-target Swift files (`MobileIrohHostLane`, `cmuxApp`) pass `nil` with matching labels; CI compiles them here (not locally checkable without Xcode).

Based on `feat-ios-device-list-v2` (#7327), which already added `RelayMode::Custom`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786261896&installation_id=133855650&pr_number=7826&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7826&signature=897eea0b43ec07d1843a92e412b691de9a954b05a3e9cbccfe1772b9acb8c44d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches relay authentication and a breaking FFI bind signature, but tokens are bind-only, excluded from routes, and all entry points still pass nil until JWT minting ships; the iroh 1.0.2 bump adds dependency regression surface.
> 
> **Overview**
> Adds **optional relay authentication at endpoint bind** so clients can home on a **custom, JWT-gated private relay**, and bumps the pinned **`iroh` crate from `1.0.0-rc.1` to `1.0.2`** (with matching `Cargo.lock` churn).
> 
> The **C FFI** gains a `relay_auth_token` argument on `cmux_iroh_endpoint_bind` and `cmux_iroh_endpoint_bind_relay_only`. Relay selection is centralized in a **`relay_mode()`** helper: with a custom `relay_url` and a non-empty token, the map is built as **`RelayMap::from(url).with_auth_token(token)`**; otherwise behavior is unchanged (token ignored on default n0 map, disabled relays, or missing URL). The token is documented as **never logged or included in route JSON**; dial/connect APIs are unchanged.
> 
> **Swift** threads `relayAuthToken` through the listener, dial transport, factory, and a shared **`bindEndpoint`** helper. On dial, a non-empty token switches the local bind from the default fleet to the **peer’s relay URL** for authenticated homing, while relay URL hints on connect stay as before. **Mac host and iOS app** still pass **`nil`** (TODO: mint via web API), so production behavior stays neutral until token wiring lands.
> 
> A Rust unit test **`bind_relay_mode_applies_auth_token_only_to_custom_map`** locks in token placement rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266adb14278f908b067739281d12c2304444ea1a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional bind-time JWT auth for custom `iroh-relay` so clients can use a private, token-gated relay. Also bumps `iroh` to `1.0.2`. Behavior is unchanged unless both a custom `relay_url` and a non-empty token are provided.

- **New Features**
  - Added `relay_auth_token` to `cmux_iroh_endpoint_bind` and `cmux_iroh_endpoint_bind_relay_only`; applied only with a custom `relay_url` and relays enabled, otherwise ignored.
  - Introduced `relay_mode()` to build the relay map and attach the token only to a custom `RelayMap`.
  - Swift: `CmxIrohByteTransport(+FFI)`, `CmxIrohByteListener`, and `CmxIrohByteTransportFactory` accept `relayAuthToken` and pass it at bind; token is never in dial hints, route JSON, pairing codes, or logs.
  - Tests: new Rust test asserts the token is set only for custom maps; Rust and Swift builds pass.

- **Dependencies**
  - Bumped `iroh` from `1.0.0-rc.1` to `1.0.2`; updated lockfile to match the relay fleet.

<sup>Written for commit 266adb14278f908b067739281d12c2304444ea1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

