### PR TITLE
Fix flaky acked-input bridge test: don't block a 5 MiB send against an intentionally paused read window

### DIFF
--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/BridgeTestClient.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/BridgeTestClient.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Network
+@testable import CmuxRemoteWorkspace
+
+/// Loopback TCP client helper for talking to a bridge endpoint.
+final class BridgeTestClient: @unchecked Sendable {
+    private let connection: NWConnection
+    private let queue = DispatchQueue(label: "bridge-test-client")
+    private let lock = NSLock()
+    private var received = Data()
+    private var closed = false
+
+    init(endpoint: RemotePTYBridgeServer.Endpoint) {
+        connection = NWConnection(
+            host: NWEndpoint.Host(endpoint.host),
+            port: NWEndpoint.Port(rawValue: UInt16(endpoint.port))!,
+            using: .tcp
+        )
+        connection.start(queue: queue)
+        receiveLoop()
+    }
+
+    private func receiveLoop() {
+        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
+            guard let self else { return }
+            self.lock.lock()
+            if let data { self.received.append(data) }
+            if isComplete || error != nil { self.closed = true }
+            let done = self.closed
+            self.lock.unlock()
+            if !done { self.receiveLoop() }
+        }
+    }
+
+    func send(_ data: Data) {
+        connection.send(content: data, completion: .contentProcessed { _ in })
+    }
+
+    /// Sends data and returns a thread-safe pollable flag that flips once the
+    /// network stack has accepted the entire payload. When the server pauses
+    /// reads, assert this only after acks drain the input window.
+    func sendTracked(_ data: Data) -> @Sendable () -> Bool {
+        let lock = NSLock()
+        // Guarded by `lock`; read and written only by the completion and returned closure.
+        nonisolated(unsafe) var completed = false
+        connection.send(content: data, completion: .contentProcessed { _ in
+            lock.lock()
+            completed = true
+            lock.unlock()
+        })
+        return {
+            lock.lock()
+            defer { lock.unlock() }
+            return completed
+        }
+    }
+
+    /// Polls until `predicate` over the received bytes holds or the deadline
+    /// passes (generous upper bound only; the happy path returns quickly).
+    func waitForReceived(timeout: TimeInterval = 5.0, _ predicate: (Data, Bool) -> Bool) -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            lock.lock()
+            let snapshot = received
+            let isClosed = closed
+            lock.unlock()
+            if predicate(snapshot, isClosed) { return true }
+            usleep(20_000)
+        }
+        return false
+    }
+
+    var isClosed: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return closed
+    }
+
+    func cancel() {
+        connection.cancel()
+    }
+}

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/BridgeTestClient.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/BridgeTestClient.swift
@@ -37,15 +37,15 @@ final class BridgeTestClient: @unchecked Sendable {
     }
 
     /// Sends data and returns a thread-safe pollable flag that flips once the
-    /// network stack has accepted the entire payload. When the server pauses
-    /// reads, assert this only after acks drain the input window.
+    /// network stack has accepted the entire payload without error. When the
+    /// server pauses reads, assert this only after acks drain the input window.
     func sendTracked(_ data: Data) -> @Sendable () -> Bool {
         let lock = NSLock()
         // Guarded by `lock`; read and written only by the completion and returned closure.
         nonisolated(unsafe) var completed = false
-        connection.send(content: data, completion: .contentProcessed { _ in
+        connection.send(content: data, completion: .contentProcessed { error in
             lock.lock()
-            completed = true
+            completed = (error == nil)
             lock.unlock()
         })
         return {

--- a/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeServerTests.swift
+++ b/Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeServerTests.swift
@@ -178,74 +178,6 @@ struct TestPTYBridgeStrings: RemotePTYBridgeStrings {
     var attachFailed: String { "test-attach-failed" }
 }
 
-/// Loopback TCP client helper for talking to a bridge endpoint.
-private final class BridgeTestClient: @unchecked Sendable {
-    private let connection: NWConnection
-    private let queue = DispatchQueue(label: "bridge-test-client")
-    private let lock = NSLock()
-    private var received = Data()
-    private var closed = false
-
-    init(endpoint: RemotePTYBridgeServer.Endpoint) {
-        connection = NWConnection(
-            host: NWEndpoint.Host(endpoint.host),
-            port: NWEndpoint.Port(rawValue: UInt16(endpoint.port))!,
-            using: .tcp
-        )
-        connection.start(queue: queue)
-        receiveLoop()
-    }
-
-    private func receiveLoop() {
-        connection.receive(minimumIncompleteLength: 1, maximumLength: 65536) { [weak self] data, _, isComplete, error in
-            guard let self else { return }
-            self.lock.lock()
-            if let data { self.received.append(data) }
-            if isComplete || error != nil { self.closed = true }
-            let done = self.closed
-            self.lock.unlock()
-            if !done { self.receiveLoop() }
-        }
-    }
-
-    func send(_ data: Data) {
-        connection.send(content: data, completion: .contentProcessed { _ in })
-    }
-
-    func sendBlocking(_ data: Data, timeout: TimeInterval = 5.0) -> Bool {
-        let semaphore = DispatchSemaphore(value: 0)
-        connection.send(content: data, completion: .contentProcessed { _ in
-            semaphore.signal()
-        })
-        return semaphore.wait(timeout: .now() + timeout) == .success
-    }
-
-    /// Polls until `predicate` over the received bytes holds or the deadline
-    /// passes (generous upper bound only; the happy path returns quickly).
-    func waitForReceived(timeout: TimeInterval = 5.0, _ predicate: (Data, Bool) -> Bool) -> Bool {
-        let deadline = Date().addingTimeInterval(timeout)
-        while Date() < deadline {
-            lock.lock()
-            let snapshot = received
-            let isClosed = closed
-            lock.unlock()
-            if predicate(snapshot, isClosed) { return true }
-            usleep(20_000)
-        }
-        return false
-    }
-
-    var isClosed: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return closed
-    }
-
-    func cancel() {
-        connection.cancel()
-    }
-}
-
 @Suite("RemotePTYBridgeServer")
 struct RemotePTYBridgeServerTests {
     private func makeServer(
@@ -378,7 +310,9 @@ struct RemotePTYBridgeServerTests {
         })
 
         let input = patternedInput(byteCount: 5 * 1024 * 1024)
-        #expect(client.sendBlocking(input))
+        // Acked input intentionally pauses reads at the 4 MiB window; awaiting
+        // the full send before acks would race kernel socket buffer capacity.
+        let inputSendCompleted = client.sendTracked(input)
 
         // No acks: the window must fill and pause, bounding delivery.
         let windowFillTarget = 3 * 1024 * 1024
@@ -406,6 +340,8 @@ struct RemotePTYBridgeServerTests {
         let deliveredMatchesInput = delivered == input
         #expect(deliveredMatchesInput)
         #expect(!client.isClosed)
+        // Only after acks drain the window can the client-side send complete.
+        #expect(waitUntil { inputSendCompleted() })
     }
 
     @Test("a pty.error mid-stream closes the session")


### PR DESCRIPTION
Fixes the flaky `swift-package-tests` failure that turned main red in https://github.com/manaflow-ai/cmux/actions/runs/29075799069 (commit 8443096d): the Swift Testing case "acked input mode drains only on cumulative ack and preserves seq order" (`ackedInputModeDrainsOnAck`) failed `#expect(client.sendBlocking(input))` at `Packages/macOS/CmuxRemoteWorkspace/Tests/CmuxRemoteWorkspaceTests/RemotePTYBridgeServerTests.swift:381` after 6.049s with a 5 MiB payload. Since `ci-status` gates on `swift-package-tests`, this single flake breaks main CI.

## Root cause: a test-design race — the product code is correct

In acked-input mode, `RemotePTYBridgeServer.Session` caps the pending input window at 4 MiB (`maxPendingInputBytes`) and intentionally stops calling `receiveNext()` while `inputFlow.isPaused` (`Sources/CmuxRemoteWorkspace/PTYBridge/RemotePTYBridgeSession.swift`, receive loop). Pausing socket reads under an unacked window is the behavior under test, not a bug.

The test, however, blocked on `sendBlocking(5 MiB)` — a `DispatchSemaphore` wait on NWConnection's `.contentProcessed` completion with a 5s timeout — **before emitting any acks**. With the server deliberately paused at ~4 MiB, whether the ~1 MiB tail gets accepted by the network stack in time depends entirely on kernel/socket buffer capacity (macOS defaults: `net.inet.tcp.sendspace`/`recvspace` = 128 KiB, autotuned under load), i.e. on the machine and its load, not on the code under test.

Empirical proof, from an instrumentation probe replicating the exact test scenario with **no acks ever emitted**:

- 5 MiB payload: the server consumed 4,176,776 bytes then paused at the window, yet the client's `.contentProcessed` completion fired in **6 ms** — the ~1 MiB tail was absorbed entirely by stack/kernel buffers.
- 16 MiB payload: the server consumed exactly 4,194,304 bytes (the 4 MiB cap, precisely as designed), and the completion **never fired within 8 s**.

So the old assertion was broken in both directions: it could **pass** on a machine with generous buffers even if the server never resumed reads (masking a real product regression), and it could **fail** on a loaded CI runner even though the product behaves exactly per design (the observed flake). The window/pause/resume logic itself behaved correctly in every observation, including the failing CI run — only the line-381 expectation failed there; the drain-phase assertions all passed.

## The fix (test-only; no product changes)

- Replace the blocking send with a non-blocking tracked send: `sendTracked(_:)` returns a thread-safe pollable flag that flips when the stack accepts the full payload. The test now sends the 5 MiB asynchronously — matching the neighboring legacy-mode test — and asserts completion **only after** the ack-drain phase, the one point where it is deterministic (the server has resumed reads and consumed all 5 MiB; if the drain itself stalled, the pre-existing `delivered.count == input.count` expectation already fails first, so no new failure mode is introduced).
- All pre-existing assertions are preserved verbatim and in order: window fill ≥ 3 MiB, delivery capped ≤ 4 MiB while unacked, contiguous seq numbering, byte-exact delivery of all 5 MiB after acks, connection never closed. The original assertion's intent (the full send is eventually accepted, proving reads resume) is retained, just sequenced after the acks that make it meaningful.
- `sendBlocking` is deleted outright (this was its only caller) so the pattern can't be reused.
- `BridgeTestClient` moved to a new `BridgeTestClient.swift`: the test file sat at 499 lines, one under the `.github/swift-file-length-budget.tsv` tracking threshold; extraction keeps both files well clear (435 and 82 lines) with no TSV changes. SPM test targets auto-discover sources, so no other wiring is needed.

No timeout was bumped and no retry added; the race is removed structurally. A two-commit red/green structure is not applicable here since there is no product fix — this PR changes only the test's own synchronization.

## Verification

- Focused flake loop after the fix: **40/40 green** iterations of `swift test --package-path Packages/macOS/CmuxRemoteWorkspace --filter RemotePTYBridgeServer` (plus 50/50 green on the pre-fix test on the same machine — the flake is machine/load-dependent and never reproduced locally, which is exactly the buffer-capacity dependence described above).
- Full `swift test --package-path Packages/macOS/CmuxRemoteWorkspace` (what the `swift-package-tests` CI job runs for this package): green.
- `python3 scripts/swift_file_length_budget.py`: clean; neither budget TSV is touched.
- Warning-clean build of the package tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786262168&installation_id=133855650&pr_number=7827&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7827&signature=7d7fa56fc79f563b79a62884efbfe39f65a4b9c431c91760aa9f841874df9e8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only test helpers and one test’s synchronization change; no production bridge or PTY code is modified.
> 
> **Overview**
> **Test-only change** to stop `ackedInputModeDrainsOnAck` from flaking in `swift-package-tests`. The case was blocking on a 5 MiB `sendBlocking` while the bridge intentionally pauses socket reads at the 4 MiB ack window with no acks yet—whether NWConnection finishes in time depended on kernel buffer capacity, not product behavior.
> 
> `BridgeTestClient` moves to **`BridgeTestClient.swift`**. **`sendBlocking`** is removed; **`sendTracked`** sends asynchronously and exposes a pollable completion flag. The acked-input test starts the 5 MiB send with `sendTracked`, keeps the existing window/seq/delivery assertions, and only checks send completion **after** acks drain the window.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ad9d05c12e2cd238e40cb1cb9d4c399d80a8d3ee. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a flaky acked-input bridge test by replacing a buffer-dependent blocking send with a tracked async send and asserting completion after acks; the tracked flag now flips only on error-free acceptance. Stabilizes `swift-package-tests` without product code changes.

- **Bug Fixes**
  - Replaced `sendBlocking` with `sendTracked` (pollable, flips only on success); send 5 MiB asynchronously and assert completion after the ack-drain to avoid kernel socket buffer races.
  - Preserves the intended behavior under test (4 MiB pause window) while making delivery/order checks deterministic.
  - Removes a CI flake in `swift-package-tests`.

- **Refactors**
  - Moved `BridgeTestClient` to `BridgeTestClient.swift` and deleted `sendBlocking`.
  - No timeouts bumped, no retries added, and no product code changes.

<sup>Written for commit ad9d05c12e2cd238e40cb1cb9d4c399d80a8d3ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Improved remote workspace bridge tests by introducing a dedicated loopback test client to send and monitor data processing.
  * Updated acknowledgment-related coverage to use tracked “send complete” behavior, ensuring completion only occurs after input acknowledgments drain the paused write window.
  * Added stronger assertions around connection state handling and reliable timing for receive/send verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->