### PR TITLE
Fix stale "Connected" badge on dead remote SSH workspaces

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -6484,7 +6484,7 @@ final class Workspace: Identifiable, ObservableObject {
         let proxyOnlyError = trimmedDetail.map(Self.isProxyOnlyRemoteError) ?? false
         let preserveConnectedStateForRetry =
             (state == .connecting || state == .reconnecting) &&
-                preservesProxyFailureForSSHRemoteWorkspace &&
+                (suppressesProxyOnlySidebarErrorForDefaultCloud || preservesProxyFailureWhileSSHTerminalIsAlive) && // #6409 default cloud; otherwise live non-persistent SSH only (#7366/#7823)
                 hasProxyOnlyRemoteSidebarError
         let suppressProxyOnlySidebarError =
             suppressesProxyOnlySidebarErrorForDefaultCloud &&
@@ -6492,7 +6492,7 @@ final class Workspace: Identifiable, ObservableObject {
         let effectiveState: WorkspaceRemoteConnectionState
         if state == .error && proxyOnlyError && suppressesProxyOnlySidebarErrorForDefaultCloud {
             effectiveState = .connected
-        } else if state == .error && proxyOnlyError && preservesProxyFailureForSSHRemoteWorkspace {
+        } else if state == .error && proxyOnlyError && preservesProxyFailureWhileSSHTerminalIsAlive { // live non-persistent SSH terminal only (#6409 vs #7366/#7823)
             effectiveState = .connected
         } else if preserveConnectedStateForRetry {
             effectiveState = .connected

--- a/cmuxTests/WorkspaceRemoteBadgeTruthTests.swift
+++ b/cmuxTests/WorkspaceRemoteBadgeTruthTests.swift
@@ -39,6 +39,40 @@ final class WorkspaceRemoteBadgeTruthTests: XCTestCase {
         XCTAssertEqual(workspace.remoteStatusPayload()["connected"] as? Bool, true)
     }
 
+    @MainActor
+    func testLegacySSHProxyOnlyErrorDowngradesAfterLastTerminalSessionEnds() throws {
+        let workspace = Workspace()
+        let config = remoteConfiguration(preserveAfterTerminalExit: false)
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        XCTAssertEqual(workspace.activeRemoteTerminalSessionCount, 1)
+
+        try endSeededLegacyTerminalSession(in: workspace)
+
+        let proxyError = "Remote proxy to host unavailable: Remote daemon transport failed: daemon transport keepalive timed out"
+        workspace.applyRemoteConnectionStateUpdate(.error, detail: proxyError, target: "host")
+
+        XCTAssertEqual(workspace.remoteConnectionState, .error)
+        XCTAssertEqual(workspace.remoteStatusPayload()["connected"] as? Bool, false)
+    }
+
+    @MainActor
+    func testProxyOnlyRetryDoesNotPinConnectedWithoutLiveTerminalSessions() throws {
+        let workspace = Workspace()
+        let config = remoteConfiguration(preserveAfterTerminalExit: false)
+        workspace.configureRemoteConnection(config, autoConnect: false)
+
+        XCTAssertEqual(workspace.activeRemoteTerminalSessionCount, 1)
+
+        try endSeededLegacyTerminalSession(in: workspace)
+
+        let proxyError = "Remote proxy to host unavailable: Remote daemon transport failed: daemon transport keepalive timed out"
+        workspace.applyRemoteConnectionStateUpdate(.error, detail: proxyError, target: "host")
+        workspace.applyRemoteConnectionStateUpdate(.reconnecting, detail: "Reconnecting to host (retry 1)", target: "host")
+
+        XCTAssertEqual(workspace.remoteConnectionState, .reconnecting)
+    }
+
     private func remoteConfiguration(preserveAfterTerminalExit: Bool) -> WorkspaceRemoteConfiguration {
         WorkspaceRemoteConfiguration(
             destination: "host",
@@ -53,5 +87,26 @@ final class WorkspaceRemoteBadgeTruthTests: XCTestCase {
             terminalStartupCommand: "ssh-pty-attach",
             preserveAfterTerminalExit: preserveAfterTerminalExit
         )
+    }
+
+    @MainActor
+    private func endSeededLegacyTerminalSession(in workspace: Workspace) throws {
+        let surfaceId = try seededTerminalSurfaceID(in: workspace)
+        Workspace.runSSHControlMasterCommandOverrideForTesting = { _ in }
+        defer { Workspace.runSSHControlMasterCommandOverrideForTesting = nil }
+
+        workspace.markRemoteTerminalSessionEnded(surfaceId: surfaceId, relayPort: 64007)
+
+        XCTAssertEqual(workspace.activeRemoteTerminalSessionCount, 0)
+        XCTAssertEqual(workspace.remoteConnectionState, .disconnected)
+    }
+
+    @MainActor
+    private func seededTerminalSurfaceID(in workspace: Workspace) throws -> UUID {
+        let terminalSurfaceIds = workspace.panels.compactMap { panelId, panel in
+            panel is TerminalPanel ? panelId : nil
+        }
+        XCTAssertEqual(terminalSurfaceIds.count, 1)
+        return try XCTUnwrap(terminalSurfaceIds.first)
     }
 }


### PR DESCRIPTION
Closes #7823

## Root cause

`Workspace.applyRemoteConnectionStateUpdate` masks coordinator-published `.error` / `.connecting` / `.reconnecting` states back to `.connected` when the error is classified "proxy-only". Every transport death the daemon RPC client can detect (ssh child exit, stdout EOF, keepalive timeout) is wrapped by `RemoteSessionCoordinator` as `"Remote proxy to … unavailable: …"`, which `isProxyOnlyRemoteError` always classifies as proxy-only. So the gate on that masking is the only thing standing between a dead transport and a lying "Connected" badge.

Commit bd0b24b741 (#6409, "Add persistent Freestyle sshd cloud slot") swapped that gate from `preservesProxyFailureWhileSSHTerminalIsAlive` — which requires `preserveAfterTerminalExit != true` (the #7366 fix: persistent-PTY terminals ride the daemon transport, so a daemon death means the terminals are dead) **and** `activeRemoteTerminalSessionCount > 0` — to the new un-gated `preservesProxyFailureForSSHRemoteWorkspace` (any SSH workspace with a startup command). That silently reverted the #7366 fix and dropped the liveness requirement.

Failure chain from the report: SSH workspace transport dies → terminal pane lands at a local prompt (zero live remote sessions) → coordinator publishes `.error` → masked to `.connected` → sidebar shows **Connected** while dead. The masked error also writes the "Remote proxy unavailable" sidebar entry, which makes `preserveConnectedStateForRetry` pin `.connected` across every subsequent failing reconnect attempt, indefinitely. On reopen, the reconnect failed with OpenSSH `Could not resolve hostname` (environmental DNS/mDNS failure) — but the badge kept saying Connected instead of surfacing the error state.

## Fix

Restore the liveness-gated predicate at both masking sites (the `.error` branch and `preserveConnectedStateForRetry`). Proxy-only failures may only preserve `.connected` while a live SSH terminal session exists and the workspace is not persistent-PTY. The deliberate default-Freestyle-cloud suppression from #6409 (`suppressesProxyOnlySidebarErrorForDefaultCloud`, pinned by `testDefaultCloudProxyOnlyErrorsDoNotPolluteConnectedSidebar`) is untouched.

## Regression tests (red/green, empirically verified from CI logs)

- Commit 1 adds failing tests to `cmuxTests/WorkspaceRemoteBadgeTruthTests.swift`:
  - `testLegacySSHProxyOnlyErrorDowngradesAfterLastTerminalSessionEnds` — after the last remote terminal session ends, a proxy-only error must land as `.error`, not `.connected`.
  - `testProxyOnlyRetryDoesNotPinConnectedWithoutLiveTerminalSessions` — subsequent `.reconnecting` publishes must not be pinned to `.connected` when no terminal is alive.
- Commit 2 applies the fix.
- Commit 3 adds a non-tolerant CI gate for the suite (see below).

Verified from shard-1 logs of two CI runs:
- **Unfixed tree** (test-only commit `e9bd493f51`, [run 29079813532](https://github.com/manaflow-ai/cmux/actions/runs/29079813532)): both new tests **fail**, and the pre-existing #7366 test `testPersistentPTYDaemonTransportErrorPropagatesAsError` **also fails** — empirical confirmation that #6409 regressed it on main.
- **Fixed tree** (this PR, [run 29079814497](https://github.com/manaflow-ai/cmux/actions/runs/29079814497)): all four `WorkspaceRemoteBadgeTruthTests` tests **pass**.

## Why main CI stayed green through the regression (commit 3)

The unfixed run above still reported the shard as green: the full app-host suite step passes whenever the summary says `(0 unexpected)`, but XCTest's "unexpected" count only tracks crashes — plain assertion failures always report `(0 unexpected)`. The unfixed shard-1 summary was literally `Executed 485 tests, with 41 failures (0 unexpected)` → "treating as pass". That hole is exactly how #6409 could revert #7366 with green CI.

Commit 3 follows the repo's established mitigation (#5888, #7380, #7372): a focused, non-tolerant `-only-testing:cmuxTests/WorkspaceRemoteBadgeTruthTests` step on the focused regression shard, so this suite can never crash-skip or fail silently again. A branch pinned at tests+gate without the fix (`issue-7823-red-test-proof` @ `2f48e8018d`) demonstrates the gate goes red on the unfixed tree.

## Bug class 2 from the issue (restore losing the hostname)

Audited the persistence/restore path: `SessionRemoteWorkspaceSnapshot` never persists `remoteConnectionState`; `workspaceConfiguration()` guards empty destinations (returns nil → workspace demotes rather than connect to a garbage host), and every ssh invocation shell-quotes the destination in the final position (or after `--`). No code path was found that corrupts or loses the saved destination. The reported `Could not resolve hostname` is an environmental resolution failure of the saved host (`austins-macbook-pro` style mDNS/LAN name), which — with this fix — now surfaces as a truthful error state with the existing copyable error affordance instead of a stale Connected badge.

## Known adjacent gaps (documented, deliberately not fixed here)

- Reverse-relay (`ssh -R`) death is restarted silently and never publishes a state change (`RemoteSessionCoordinator+ReverseRelay.swift`).
- Restored websocket cloud-VM workspaces set `.connected` unconditionally when no daemon endpoint is present (`Workspace.swift:5366-5372`); managed-cloud UX has its own reconnect overlay.
- App-side heartbeat fields (`remoteLastHeartbeatAt`) are display-only; liveness detection lives in the RPC client keepalive.
- The tolerant full-suite summary parsing (`(0 unexpected)` ⇒ pass) masks **all** plain assertion failures in the app-host shards, not just this suite. The unfixed shard-1 run shows ~38 other failures riding through green on main today. That deserves its own issue; this PR only armors the badge-truth suite.

## Localization audit

No user-facing strings were added or changed; the fix only swaps internal state-machine predicates, adds tests, and adds a CI step. Existing state labels remain localized in `Resources/Localizable.xcstrings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7828"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786263353&installation_id=133855650&pr_number=7828&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7828&signature=7c0dee195fbc24683b17de5136eb512f0161e191bb4b8ef517c98538af31f874"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches remote connection state machine logic that drives sidebar badges and status payloads; behavior change is intentional but affects UX when SSH transport dies without live terminals.
> 
> **Overview**
> Fixes a regression where **proxy-only** remote transport failures were always shown as **Connected** for any SSH workspace with a terminal startup command, even after the last remote terminal session had ended.
> 
> `applyRemoteConnectionStateUpdate` again uses **`preservesProxyFailureWhileSSHTerminalIsAlive`** (non-persistent SSH **and** `activeRemoteTerminalSessionCount > 0`) instead of the broader **`preservesProxyFailureForSSHRemoteWorkspace`** when masking proxy-only `.error` and when pinning `.connecting`/`.reconnecting` during retries. Default Freestyle cloud suppression via **`suppressesProxyOnlySidebarErrorForDefaultCloud`** is unchanged.
> 
> Adds **`WorkspaceRemoteBadgeTruthTests`** coverage: proxy-only errors become **`.error`** after the last legacy terminal session ends, and **`.reconnecting`** is not pinned to connected with no live sessions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f0dc767d1dadcf6dbea0d8fbe0e7937cb82357a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale “Connected” badge on dead SSH workspaces by restoring liveness gating: proxy-only failures only mask to connected while a live, non-persistent SSH terminal session exists. Reconnect attempts now show error/reconnecting instead of being pinned to connected.

- **Bug Fixes**
  - Restored liveness-gated masking in `Workspace.applyRemoteConnectionStateUpdate` for proxy-only `.error` and retry pinning; default cloud suppression remains unchanged.
  - Added tests: `testLegacySSHProxyOnlyErrorDowngradesAfterLastTerminalSessionEnds`, `testProxyOnlyRetryDoesNotPinConnectedWithoutLiveTerminalSessions`.

<sup>Written for commit 6deeb3b8369744a68859d9d5f06154f2ecfbfce1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote connection status handling for proxy-only failures, ensuring the workspace reflects the correct effective state across retry, reconnection, and error transitions.
  * Preserved “connected” behavior only for the intended eligible scenarios during reconnection attempts.
  * Updated connection indicators to align with the final remote/terminal session outcomes.

* **Tests**
  * Added legacy-terminal-session–driven scenarios covering proxy-only errors, reconnection state progression, and final connection status after sessions end.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
