### PR TITLE
iroh transport P4: Mac host lane (accept loop, route minting, QR grammar)

### DIFF
--- a/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
+++ b/Packages/Shared/CMUXMobileCore/Sources/CMUXMobileCore/CmxPairingQRCode.swift
@@ -1,8 +1,12 @@
 import Foundation
 
 /// The minimal pairing-QR grammar: expected Mac account/build metadata plus
-/// plain `host:port` routes in the URL query.
+/// phone-reachable routes in the URL query.
 ///
+/// v3:
+/// `cmux-ios://attach?v=3&ub=<stack-user-id>&pc=<compat>&av=<version>&ab=<build>&i=<iroh-peer-id>&u=<relay-url>&d=<direct-addr>[&d=<direct-addr>...][&r=<host>:<port>...]`
+///
+/// v2 legacy:
 /// `cmux-ios://attach?v=2&ub=<stack-user-id>&pc=<compat>&av=<version>&ab=<build>&r=<host>:<port>[&r=<host>:<port>...]`
 ///
 /// A pairing QR needs to tell the phone where to dial and which non-secret
@@ -17,10 +21,9 @@ import Foundation
 /// - **No display name, no device id.** Both arrive post-handshake from
 ///   `mobile.host.status`; the decoder leaves `macDeviceID` empty and the
 ///   shell adopts the host-reported identity once connected.
-/// - **No loopback, ever.** Routes are Tailscale `host:port` only: the
-///   encoder drops a DEBUG Mac's dev loopback route instead of encoding it,
-///   the Mac refuses to mint a QR without a Tailscale route (it shows the
-///   set-up-Tailscale guidance instead), and the decoder rejects loopback
+/// - **No loopback, ever.** The encoder drops a DEBUG Mac's dev loopback route
+///   instead of encoding it, the Mac refuses to mint a QR without either an
+///   iroh peer route or a Tailscale route, and the decoder rejects loopback
 ///   hosts outright, so a scanned code can never point a phone at itself.
 ///   Loopback pairing for the simulator/dev flows uses the injected attach
 ///   URL path, not a QR. Dropping loopback is also the pairing-latency fix:
@@ -40,8 +43,11 @@ import Foundation
 public struct CmxPairingQRCode: Sendable {
     /// The grammar version carried in the URL's `v` query item. Distinct from
     /// ``CmxAttachTicket/currentVersion`` (the ticket *structure* version):
-    /// `v=1` URLs carry a base64 JSON `payload`, `v=2` URLs carry bare routes.
-    public static let version = 2
+    /// `v=1` URLs carry a base64 JSON `payload`, `v=2` URLs carry bare
+    /// Tailscale routes, and `v=3` URLs can carry an iroh peer route plus
+    /// Tailscale fallback routes.
+    public static let version = 3
+    private static let legacyTailscaleOnlyVersion = 2
 
     /// Defensive cap on routes accepted from a scanned code. The Mac's route
     /// resolver emits at most a couple (MagicDNS name + Tailscale IP); a QR
@@ -53,12 +59,13 @@ public struct CmxPairingQRCode: Sendable {
     /// site; every instance speaks the same grammar version.
     public init() {}
 
-    /// Encode `ticket` as a v2 pairing URL, or `nil` when the ticket does not
+    /// Encode `ticket` as a v3 pairing URL, or `nil` when the ticket does not
     /// qualify (see ``canEncode(_:)``); callers fall back to the compact v1
     /// payload so every ticket still has an attach URL.
     ///
-    /// Only the ticket's Tailscale routes are encoded: a DEBUG Mac's dev
-    /// loopback route is dropped, never written into a scannable code.
+    /// The ticket's iroh peer route and Tailscale fallback routes are encoded:
+    /// a DEBUG Mac's dev loopback route is dropped, never written into a
+    /// scannable code.
     public func encode(_ ticket: CmxAttachTicket) -> String? {
         guard let routes = encodableRoutes(of: ticket) else {
             return nil
@@ -76,7 +83,19 @@ public struct CmxPairingQRCode: Sendable {
         if let build = normalizedNonEmpty(ticket.macAppBuild) {
             items.append("ab=\(percentEncodeQueryValue(build))")
         }
-        let routeItems = routes.map { route -> String in
+        if let irohRoute = routes.iroh {
+            guard case let .peer(peerID, _, directAddrs, relayURL) = irohRoute.endpoint else {
+                return nil
+            }
+            items.append("i=\(percentEncodeQueryValue(peerID))")
+            if let relayURL = normalizedNonEmpty(relayURL) {
+                items.append("u=\(percentEncodeQueryValue(relayURL))")
+            }
+            for directAddr in directAddrs.compactMap({ normalizedNonEmpty($0) }) {
+                items.append("d=\(percentEncodeQueryValue(directAddr))")
+            }
+        }
+        let routeItems = routes.tailscale.map { route -> String in
             guard case let .hostPort(host, port) = route.endpoint else {
                 // Unreachable: `encodableRoutes` admits host/port endpoints only.
                 return ""
@@ -97,33 +116,47 @@ public struct CmxPairingQRCode: Sendable {
         encodableRoutes(of: ticket) != nil
     }
 
-    /// The route subsequence a v2 pairing URL would carry for `ticket`, or
+    /// The route subsequence a v3 pairing URL would carry for `ticket`, or
     /// `nil` when the ticket is not expressible in the minimal grammar.
     ///
-    /// Expressible means: an unscoped pairing ticket whose Tailscale routes
-    /// are exactly the canonical `host:port` sequence the decoder
-    /// resynthesizes (ids `tailscale`, `tailscale_2`, ... and priorities 10,
-    /// 20, ...), with no loopback host and no host that needs escaping.
-    /// The only routes this grammar may silently drop are loopback ones (a
-    /// DEBUG Mac's dev loopback route), which no phone may ever dial anyway.
-    /// Anything else (workspace-scoped tickets, custom route ids, no
-    /// Tailscale route at all, or a non-Tailscale fallback route such as an
-    /// iroh peer that the bare `host:port` grammar cannot express) keeps the
-    /// compact v1 payload so the mapping stays lossless.
-    private func encodableRoutes(of ticket: CmxAttachTicket) -> [CmxAttachRoute]? {
+    /// Expressible means: an unscoped pairing ticket with at most one canonical
+    /// iroh peer route plus canonical Tailscale `host:port` fallbacks (ids
+    /// `tailscale`, `tailscale_2`, ... and priorities 10, 20, ...), with no
+    /// loopback host and no host that needs escaping. The only routes this
+    /// grammar may silently drop are loopback ones (a DEBUG Mac's dev loopback
+    /// route), which no phone may ever dial anyway.
+    private func encodableRoutes(of ticket: CmxAttachTicket) -> EncodableRoutes? {
         guard ticket.version == CmxAttachTicket.currentVersion,
               ticket.workspaceID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
               ticket.terminalID?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty != false else {
             return nil
         }
-        guard ticket.routes.allSatisfy({ $0.kind == .tailscale || CmxLoopbackHost().matches($0) }) else {
+        guard ticket.routes.allSatisfy({
+            $0.kind == .tailscale || $0.kind == .iroh || CmxLoopbackHost().matches($0)
+        }) else {
             return nil
         }
-        let routes = ticket.routes.filter { $0.kind == .tailscale }
-        guard !routes.isEmpty, routes.count <= Self.maximumRouteCount else {
+        let irohRoutes = ticket.routes.filter { $0.kind == .iroh }
+        guard irohRoutes.count <= 1 else {
             return nil
         }
-        for (index, route) in routes.enumerated() {
+        let irohRoute = irohRoutes.first
+        if let irohRoute {
+            guard irohRoute.id == CmxAttachTransportKind.iroh.rawValue,
+                  irohRoute.priority == irohRoutePriority,
+                  case let .peer(peerID, _, directAddrs, relayURL) = irohRoute.endpoint,
+                  normalizedNonEmpty(peerID) != nil,
+                  directAddrs.allSatisfy({ normalizedNonEmpty($0) != nil }),
+                  relayURL == nil || normalizedNonEmpty(relayURL) != nil else {
+                return nil
+            }
+        }
+        let tailscaleRoutes = ticket.routes.filter { $0.kind == .tailscale }
+        guard (irohRoute == nil ? tailscaleRoutes.count : tailscaleRoutes.count + 1) > 0,
+              tailscaleRoutes.count + (irohRoute == nil ? 0 : 1) <= Self.maximumRouteCount else {
+            return nil
+        }
+        for (index, route) in tailscaleRoutes.enumerated() {
             guard route.id == synthesizedRouteID(index: index),
                   route.priority == synthesizedRoutePriority(index: index),
                   case let .hostPort(host, _) = route.endpoint,
@@ -132,13 +165,18 @@ public struct CmxPairingQRCode: Sendable {
                 return nil
             }
         }
-        return routes
+        return EncodableRoutes(iroh: irohRoute, tailscale: tailscaleRoutes)
     }
 
     /// Whether `components` (an already-parsed `cmux-ios://attach` URL) speaks
-    /// this grammar. v1 URLs carry the base64 `payload` item instead.
+    /// a supported pairing-code grammar. v1 URLs carry the base64 `payload`
+    /// item instead.
     public func isPairingCodeURL(_ components: URLComponents) -> Bool {
-        components.queryItems?.first(where: { $0.name == "v" })?.value == "\(Self.version)"
+        guard let rawVersion = components.queryItems?.first(where: { $0.name == "v" })?.value,
+              let version = Int(rawVersion) else {
+            return false
+        }
+        return version == Self.legacyTailscaleOnlyVersion || version == Self.version
     }
 
     /// The integer grammar version declared by an attach URL's `v` query item,
@@ -152,7 +190,7 @@ public struct CmxPairingQRCode: Sendable {
         return Int(raw)
     }
 
-    /// Whether `rawValue` is a v2 pairing URL. String-level convenience for
+    /// Whether `rawValue` is a supported pairing URL. String-level convenience for
     /// callers that hold the encoded URL (the Mac's pairing window asserting
     /// the code it is about to display speaks the minimal grammar).
     public func isPairingCodeURLString(_ rawValue: String) -> Bool {
@@ -165,11 +203,11 @@ public struct CmxPairingQRCode: Sendable {
         return isPairingCodeURL(components)
     }
 
-    /// Decode a v2 pairing URL into a validated ``CmxAttachTicket``.
+    /// Decode a supported pairing URL into a validated ``CmxAttachTicket``.
     ///
     /// The ticket comes back unscoped with an empty `macDeviceID`; the shell
     /// recovers the Mac's identity post-handshake from `mobile.host.status`.
-    /// - Parameter components: The parsed `cmux-ios://attach?v=2&...` URL.
+    /// - Parameter components: The parsed `cmux-ios://attach?v=<version>&...` URL.
     /// - Throws: ``MobileSyncPairingPayloadError/invalidURL`` for malformed
     ///   input and ``MobileSyncPairingPayloadError/loopbackRouteRejected``
     ///   when any route names a loopback host (a scanned code must never
@@ -178,6 +216,26 @@ public struct CmxPairingQRCode: Sendable {
         guard isPairingCodeURL(components) else {
             throw MobileSyncPairingPayloadError.invalidURL
         }
+        let version = Self.attachURLVersion(components)
+        switch version {
+        case .some(Self.legacyTailscaleOnlyVersion):
+            return try decodeLegacyTailscaleOnly(components)
+        case .some(Self.version):
+            return try decodeCurrent(components)
+        default:
+            throw MobileSyncPairingPayloadError.invalidURL
+        }
+    }
+}
+private extension CmxPairingQRCode {
+    struct EncodableRoutes {
+        let iroh: CmxAttachRoute?
+        let tailscale: [CmxAttachRoute]
+    }
+
+    var irohRoutePriority: Int { 5 }
+
+    func decodeLegacyTailscaleOnly(_ components: URLComponents) throws -> CmxAttachTicket {
         let rawRoutes = (components.queryItems ?? [])
             .filter { $0.name == "r" }
             .compactMap(\.value)
@@ -213,8 +271,69 @@ public struct CmxPairingQRCode: Sendable {
         try ticket.validate()
         return ticket
     }
-}
-private extension CmxPairingQRCode {
+
+    func decodeCurrent(_ components: URLComponents) throws -> CmxAttachTicket {
+        let queryItems = components.queryItems ?? []
+        let rawRoutes = queryItems
+            .filter { $0.name == "r" }
+            .compactMap(\.value)
+        let peerID = queryValue(named: "i", in: components)
+        let routeCount = rawRoutes.count + (peerID == nil ? 0 : 1)
+        guard routeCount > 0, routeCount <= Self.maximumRouteCount else {
+            throw MobileSyncPairingPayloadError.invalidURL
+        }
+
+        var routes: [CmxAttachRoute] = []
+        if let peerID {
+            let directAddrs = queryItems
+                .filter { $0.name == "d" }
+                .compactMap { normalizedNonEmpty($0.value) }
+            let relayURL = queryValue(named: "u", in: components)
+            routes.append(try CmxAttachRoute(
+                id: CmxAttachTransportKind.iroh.rawValue,
+                kind: .iroh,
+                endpoint: .peer(
+                    id: peerID,
+                    relayHint: nil,
+                    directAddrs: directAddrs,
+                    relayURL: relayURL
+                ),
+                priority: irohRoutePriority
+            ))
+        }
+
+        let tailscaleRoutes = try rawRoutes.enumerated().map { index, rawRoute -> CmxAttachRoute in
+            let (host, port) = try parseHostPort(rawRoute)
+            guard !CmxLoopbackHost().matches(host) else {
+                throw MobileSyncPairingPayloadError.loopbackRouteRejected
+            }
+            return try CmxAttachRoute(
+                id: synthesizedRouteID(index: index),
+                kind: .tailscale,
+                endpoint: .hostPort(host: host, port: port),
+                priority: synthesizedRoutePriority(index: index)
+            )
+        }
+        routes.append(contentsOf: tailscaleRoutes)
+
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "",
+            macDisplayName: nil,
+            macUserEmail: queryValue(named: "e", in: components),
+            macUserID: queryValue(named: "ub", in: components),
+            macPairingCompatibilityVersion: queryInt(named: "pc", in: components) ?? 0,
+            macAppVersion: queryValue(named: "av", in: components),
+            macAppBuild: queryValue(named: "ab", in: components),
+            routes: routes,
+            expiresAt: nil,
+            authToken: nil
+        )
+        try ticket.validate()
+        return ticket
+    }
+
     /// The route id the Mac's route resolver mints for the route at `index`
     /// (`tailscale` for the first, `tailscale_N` after).
     func synthesizedRouteID(index: Int) -> String {

--- a/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRCodeTests.swift
+++ b/Packages/Shared/CMUXMobileCore/Tests/CMUXMobileCoreTests/CmxPairingQRCodeTests.swift
@@ -2,8 +2,8 @@ import Foundation
 import Testing
 @testable import CMUXMobileCore
 
-/// Coverage for the minimal v2 pairing-QR grammar: bare Tailscale
-/// `host:port` routes in the URL query, nothing else.
+/// Coverage for the minimal pairing-QR grammar: iroh peer routes plus
+/// Tailscale `host:port` fallbacks in the URL query, nothing secret.
 @Suite struct CmxPairingQRCodeTests {
     private func tailscaleRoute(
         index: Int,
@@ -32,6 +32,24 @@ import Testing
         )
     }
 
+    private func irohRoute(
+        peerID: String = "peer-abcdef123456",
+        relayURL: String? = "https://relay.example.com",
+        directAddrs: [String] = ["192.0.2.10:443"]
+    ) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                id: peerID,
+                relayHint: nil,
+                directAddrs: directAddrs,
+                relayURL: relayURL
+            ),
+            priority: 5
+        )
+    }
+
     private func components(_ url: String) throws -> URLComponents {
         let parsed = try #require(URL(string: url))
         return try #require(URLComponents(url: parsed, resolvingAgainstBaseURL: false))
@@ -45,7 +63,7 @@ import Testing
         // The scheme is channel-specific: a release Mac emits cmux-ios, a dev
         // Mac emits cmux-ios-dev, so the system camera routes each channel's QR
         // to its build. The rest of the URL is identical across channels.
-        #expect(url == "\(CmxPairingURLScheme.current)://attach?v=2&r=100.64.0.5:58465")
+        #expect(url == "\(CmxPairingURLScheme.current)://attach?v=3&r=100.64.0.5:58465")
 
         let decoded = try CmxPairingQRCode().decode(try components(url))
         #expect(decoded.routes == ticket.routes)
@@ -73,6 +91,30 @@ import Testing
         // route preference is preserved without encoding either field.
         #expect(decoded.routes.map(\.id) == ["tailscale", "tailscale_2"])
         #expect(decoded.routes.map(\.priority) == [10, 20])
+    }
+
+    @Test func decodesLegacyV2TailscaleOnlyRoutes() throws {
+        let url = "\(CmxPairingURLScheme.current)://attach?v=2&r=100.64.0.5:58465"
+        let decoded = try CmxPairingQRCode().decode(try components(url))
+        #expect(decoded.routes == [
+            try tailscaleRoute(index: 0, host: "100.64.0.5"),
+        ])
+    }
+
+    @Test func roundTripsIrohPreferredWithTailscaleFallback() throws {
+        let iroh = try irohRoute()
+        let tailscale = try tailscaleRoute(index: 0, host: "100.64.0.5")
+        let ticket = try pairingTicket(routes: [iroh, tailscale])
+        let url = try #require(CmxPairingQRCode().encode(ticket))
+        #expect(url.contains("v=3"))
+        #expect(url.contains("i=peer-abcdef123456"))
+        #expect(url.contains("u=https://relay.example.com"))
+        #expect(url.contains("d=192.0.2.10:443"))
+        #expect(url.contains("r=100.64.0.5:58465"))
+
+        let decoded = try CmxPairingQRCode().decode(try components(url))
+        #expect(decoded.routes == [iroh, tailscale])
+        #expect(decoded.preferredRoute(supportedKinds: [.iroh, .tailscale])?.kind == .iroh)
     }
 
     @Test func roundTripsUserIDAndBuildMetadataWithoutExposingEmail() throws {
@@ -134,7 +176,7 @@ import Testing
         let ticket = try pairingTicket(routes: [loopback, tailscale])
 
         let url = try #require(CmxPairingQRCode().encode(ticket))
-        #expect(url == "\(CmxPairingURLScheme.current)://attach?v=2&r=100.64.0.5:58465")
+        #expect(url == "\(CmxPairingURLScheme.current)://attach?v=3&r=100.64.0.5:58465")
         let decoded = try CmxPairingQRCode().decode(try components(url))
         #expect(decoded.routes == [tailscale])
     }
@@ -191,11 +233,9 @@ import Testing
         ])
         #expect(CmxPairingQRCode().encode(loopbackTailscale) == nil)
 
-        // A non-Tailscale fallback route the bare host:port grammar cannot
-        // express (an iroh peer) must NOT be silently dropped: the ticket
-        // keeps the lossless compact payload instead. Only loopback routes,
-        // which no phone may ever dial, are droppable.
-        let withIrohFallback = try pairingTicket(routes: [
+        // A non-canonical iroh priority would not round-trip to the Mac's
+        // preferred route ordering, so it keeps the lossless compact payload.
+        let nonCanonicalIroh = try pairingTicket(routes: [
             tailscale,
             try CmxAttachRoute(
                 id: "iroh",
@@ -204,8 +244,8 @@ import Testing
                 priority: 20
             ),
         ])
-        #expect(CmxPairingQRCode().encode(withIrohFallback) == nil)
-        #expect(!CmxPairingQRCode().canEncode(withIrohFallback))
+        #expect(CmxPairingQRCode().encode(nonCanonicalIroh) == nil)
+        #expect(!CmxPairingQRCode().canEncode(nonCanonicalIroh))
     }
 
     @Test(arguments: [
@@ -230,7 +270,7 @@ import Testing
     ])
     func decodeRejectsLoopbackHosts(host: String) throws {
         let encodedHost = host.contains(":") ? "[\(host)]" : host
-        let url = "cmux-ios://attach?v=2&r=\(encodedHost):58465"
+        let url = "cmux-ios://attach?v=3&r=\(encodedHost):58465"
         #expect(throws: MobileSyncPairingPayloadError.loopbackRouteRejected) {
             try CmxPairingQRCode().decode(try components(url))
         }
@@ -238,7 +278,7 @@ import Testing
 
     @Test func decodeRejectsLoopbackEvenWhenARealRouteIsPresent() throws {
         // Hostile half-and-half codes fail closed, not "dial the good half".
-        let url = "cmux-ios://attach?v=2&r=100.64.0.5:58465&r=127.0.0.1:58465"
+        let url = "cmux-ios://attach?v=3&i=peer-1&r=100.64.0.5:58465&r=127.0.0.1:58465"
         #expect(throws: MobileSyncPairingPayloadError.loopbackRouteRejected) {
             try CmxPairingQRCode().decode(try components(url))
         }
@@ -246,13 +286,13 @@ import Testing
 
     @Test func decodeRejectsMalformedRoutes() throws {
         let malformed = [
-            "cmux-ios://attach?v=2",
-            "cmux-ios://attach?v=2&r=",
-            "cmux-ios://attach?v=2&r=hostonly",
-            "cmux-ios://attach?v=2&r=host:0",
-            "cmux-ios://attach?v=2&r=host:99999",
-            "cmux-ios://attach?v=2&r=host:not-a-port",
-            "cmux-ios://attach?v=2&r=[::1:58465",
+            "cmux-ios://attach?v=3",
+            "cmux-ios://attach?v=3&r=",
+            "cmux-ios://attach?v=3&r=hostonly",
+            "cmux-ios://attach?v=3&r=host:0",
+            "cmux-ios://attach?v=3&r=host:99999",
+            "cmux-ios://attach?v=3&r=host:not-a-port",
+            "cmux-ios://attach?v=3&r=[::1:58465",
         ]
         for url in malformed {
             #expect(throws: (any Error).self, "\(url) should not decode") {
@@ -266,11 +306,19 @@ import Testing
             .map { "r=100.64.0.\($0 + 1):58465" }
             .joined(separator: "&")
         #expect(throws: MobileSyncPairingPayloadError.invalidURL) {
-            try CmxPairingQRCode().decode(try components("cmux-ios://attach?v=2&\(routes)"))
+            try CmxPairingQRCode().decode(try components("cmux-ios://attach?v=3&\(routes)"))
+        }
+
+        let fallbackRoutes = (0..<CmxPairingQRCode.maximumRouteCount)
+            .map { "r=100.64.0.\($0 + 1):58465" }
+            .joined(separator: "&")
+        #expect(throws: MobileSyncPairingPayloadError.invalidURL) {
+            try CmxPairingQRCode().decode(try components("cmux-ios://attach?v=3&i=peer-1&\(fallbackRoutes)"))
         }
     }
 
     @Test func versionedURLDetectionDistinguishesGrammars() throws {
+        #expect(CmxPairingQRCode().isPairingCodeURLString("cmux-ios://attach?v=3&i=peer-1"))
         #expect(CmxPairingQRCode().isPairingCodeURLString("cmux-ios://attach?v=2&r=100.64.0.5:58465"))
         #expect(!CmxPairingQRCode().isPairingCodeURLString("cmux-ios://attach?v=1&payload=abc"))
         #expect(!CmxPairingQRCode().isPairingCodeURLString("cmux-ios://pair?v=1&payload=abc"))
@@ -281,7 +329,7 @@ import Testing
     @Test func decodedTicketStillPairsLongAfterMint() throws {
         // The grammar has no expiry field at all, so a code that sat on the
         // Mac's screen for 10+ minutes still validates and is never expired.
-        let url = "cmux-ios://attach?v=2&r=100.64.0.5:58465"
+        let url = "cmux-ios://attach?v=3&i=peer-1&r=100.64.0.5:58465"
         let decoded = try CmxPairingQRCode().decode(try components(url))
         #expect(decoded.expiresAt == nil)
         #expect(!decoded.isExpired(at: Date.distantFuture))

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingRoute.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingRoute.swift
@@ -24,6 +24,8 @@ public struct MobilePairingRoute: Sendable, Equatable, Identifiable {
     /// The TCP port the phone connects to.
     public let port: Int
 
+    private let displayEndpoint: String?
+
     /// Creates a pairing-route descriptor.
     ///
     /// - Parameters:
@@ -36,6 +38,21 @@ public struct MobilePairingRoute: Sendable, Equatable, Identifiable {
         self.kindLabel = kindLabel
         self.host = host
         self.port = port
+        self.displayEndpoint = nil
+    }
+
+    /// Creates a preformatted pairing-route descriptor for non-host endpoints.
+    ///
+    /// - Parameters:
+    ///   - id: Stable identifier used as the list identity.
+    ///   - kindLabel: Localized transport label.
+    ///   - endpoint: Endpoint display string supplied by the host.
+    public init(id: String, kindLabel: String, endpoint: String) {
+        self.id = id
+        self.kindLabel = kindLabel
+        self.host = endpoint
+        self.port = 0
+        self.displayEndpoint = endpoint
     }
 
     /// The `host:port` pair as a single display string (e.g. `100.64.0.1:58465`).
@@ -43,6 +60,9 @@ public struct MobilePairingRoute: Sendable, Equatable, Identifiable {
     /// IPv6 literals are wrapped in brackets per RFC 3986 (`[fe80::1]:58465`) so
     /// the port colon isn't ambiguous with the address colons.
     public var endpoint: String {
+        if let displayEndpoint {
+            return displayEndpoint
+        }
         let isIPv6Literal = host.contains(":")
         return isIPv6Literal ? "[\(host)]:\(port)" : "\(host):\(port)"
     }

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -293,15 +293,29 @@ final class HostSettingsActions: SettingsHostActions {
     /// Maps the host's ``MobileHostServiceStatus`` into the settings package's
     /// Foundation-only ``MobilePairingStatusSnapshot``. Static so the status
     /// stream's forwarding task does not retain this host bridge.
-    private static func mobilePairingSnapshot(from status: MobileHostServiceStatus) -> MobilePairingStatusSnapshot {
+    static func mobilePairingSnapshot(from status: MobileHostServiceStatus) -> MobilePairingStatusSnapshot {
         let routes = status.routes.compactMap { route -> MobilePairingRoute? in
-            guard case let .hostPort(host, port) = route.endpoint else { return nil }
-            return MobilePairingRoute(
-                id: route.id,
-                kindLabel: routeKindLabel(route.kind),
-                host: host,
-                port: port
-            )
+            switch route.endpoint {
+            case let .hostPort(host, port):
+                return MobilePairingRoute(
+                    id: route.id,
+                    kindLabel: routeKindLabel(route.kind),
+                    host: host,
+                    port: port
+                )
+            case let .peer(endpointID, _, _, relayURL):
+                var endpoint = MobileHostIrohRoute.shortEndpointID(endpointID)
+                if let relayHost = MobileHostIrohRoute.relayHost(relayURL) {
+                    endpoint += " - \(relayHost)"
+                }
+                return MobilePairingRoute(
+                    id: route.id,
+                    kindLabel: routeKindLabel(route.kind),
+                    endpoint: endpoint
+                )
+            case .url:
+                return nil
+            }
         }
         return MobilePairingStatusSnapshot(
             isRunning: status.isRunning,

--- a/Sources/Mobile/MobileHostByteConnection.swift
+++ b/Sources/Mobile/MobileHostByteConnection.swift
@@ -1,0 +1,22 @@
+import Foundation
+
+enum MobileHostByteConnectionState: Sendable, Equatable {
+    case setup
+    case waiting
+    case preparing
+    case ready
+    case failed(String)
+    case cancelled
+}
+
+protocol MobileHostByteConnection: AnyObject, Sendable {
+    func setStateUpdateHandler(_ handler: ((MobileHostByteConnectionState) -> Void)?)
+    func start(queue: DispatchQueue)
+    func receive(
+        minimumIncompleteLength: Int,
+        maximumLength: Int,
+        completion: @escaping (Data?, Bool, String?) -> Void
+    )
+    func send(_ data: Data, completion: @escaping (String?) -> Void)
+    func close()
+}

--- a/Sources/Mobile/MobileHostIrohConnectionAdapter.swift
+++ b/Sources/Mobile/MobileHostIrohConnectionAdapter.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+final class MobileHostIrohConnectionAdapter: MobileHostByteConnection, @unchecked Sendable {
+    private let connection: MobileHostIrohConnectionReference
+    private let ffiClient: any MobileHostIrohFFIClient
+    private let stateHandlerLock = NSLock()
+    private var stateHandler: ((MobileHostByteConnectionState) -> Void)?
+
+    init(
+        connection: MobileHostIrohConnectionReference,
+        ffiClient: any MobileHostIrohFFIClient
+    ) {
+        self.connection = connection
+        self.ffiClient = ffiClient
+    }
+
+    func setStateUpdateHandler(_ handler: ((MobileHostByteConnectionState) -> Void)?) {
+        stateHandlerLock.lock()
+        stateHandler = handler
+        stateHandlerLock.unlock()
+    }
+
+    func start(queue: DispatchQueue) {
+        queue.async { [weak self] in
+            self?.emitState(.ready)
+        }
+    }
+
+    func receive(
+        minimumIncompleteLength _: Int,
+        maximumLength: Int,
+        completion: @escaping (Data?, Bool, String?) -> Void
+    ) {
+        let connection = connection
+        let ffiClient = ffiClient
+        Task.detached(priority: .userInitiated) {
+            do {
+                let data = try ffiClient.receive(
+                    connection: connection,
+                    maximumLength: maximumLength
+                )
+                completion(data, data == nil, nil)
+            } catch {
+                completion(nil, true, String(describing: error))
+            }
+        }
+    }
+
+    func send(_ data: Data, completion: @escaping (String?) -> Void) {
+        let connection = connection
+        let ffiClient = ffiClient
+        Task.detached(priority: .userInitiated) {
+            do {
+                try ffiClient.send(connection: connection, data: data)
+                completion(nil)
+            } catch {
+                completion(String(describing: error))
+            }
+        }
+    }
+
+    func close() {
+        ffiClient.close(connection: connection)
+        emitState(.cancelled)
+    }
+
+    private func emitState(_ state: MobileHostByteConnectionState) {
+        stateHandlerLock.lock()
+        let handler = stateHandler
+        stateHandlerLock.unlock()
+        handler?(state)
+    }
+}

--- a/Sources/Mobile/MobileHostIrohFFI.swift
+++ b/Sources/Mobile/MobileHostIrohFFI.swift
@@ -1,0 +1,222 @@
+import Darwin
+import Foundation
+import CmuxIrohFFI
+
+final class MobileHostIrohEndpointReference: @unchecked Sendable {
+    let raw: OpaquePointer
+
+    init(raw: OpaquePointer) {
+        self.raw = raw
+    }
+}
+
+final class MobileHostIrohConnectionReference: @unchecked Sendable {
+    let raw: OpaquePointer
+
+    init(raw: OpaquePointer) {
+        self.raw = raw
+    }
+}
+
+struct MobileHostIrohFailure: Error, Equatable, Sendable {
+    let kind: MobileHostIrohErrorKind
+    let message: String
+}
+
+enum MobileHostIrohErrorKind: UInt32, Sendable, Equatable {
+    case none = 0
+    case invalidArgument = 1
+    case timedOut = 2
+    case connectionRefused = 3
+    case hostUnreachable = 4
+    case permissionDenied = 5
+    case dnsFailed = 6
+    case secureChannelFailed = 7
+    case endpointClosed = 8
+    case notConnected = 9
+    case io = 10
+    case internalFailure = 11
+    case unknown = 0xffff_ffff
+
+    init(rawFFIValue: UInt32) {
+        self = Self(rawValue: rawFFIValue) ?? .unknown
+    }
+}
+
+protocol MobileHostIrohFFIClient: Sendable {
+    func generateSecretKey() throws -> Data
+    func bindEndpoint(
+        secretKey: Data,
+        enableRelay: Bool,
+        acceptConnections: Bool
+    ) throws -> MobileHostIrohEndpointReference
+    func endpointID(_ endpoint: MobileHostIrohEndpointReference) -> String?
+    func routeJSON(_ endpoint: MobileHostIrohEndpointReference) -> String?
+    func accept(
+        endpoint: MobileHostIrohEndpointReference,
+        timeoutMilliseconds: UInt64
+    ) throws -> MobileHostIrohConnectionReference
+    func receive(connection: MobileHostIrohConnectionReference, maximumLength: Int) throws -> Data?
+    func send(connection: MobileHostIrohConnectionReference, data: Data) throws
+    func close(connection: MobileHostIrohConnectionReference)
+    func close(endpoint: MobileHostIrohEndpointReference)
+}
+
+struct MobileHostIrohSystemFFIClient: MobileHostIrohFFIClient {
+    private static let errorMessageCapacity = 2_048
+
+    func generateSecretKey() throws -> Data {
+        var key = [UInt8](repeating: 0, count: Int(CMUX_IROH_SECRET_KEY_LEN))
+        try key.withUnsafeMutableBufferPointer { keyBuffer in
+            try withIrohError { rawError in
+                let error = rawError.assumingMemoryBound(to: CmuxIrohError.self)
+                let rc = cmux_iroh_secret_key_generate(
+                    keyBuffer.baseAddress,
+                    keyBuffer.count,
+                    error
+                )
+                guard rc == 0 else {
+                    throw failure(from: rawError)
+                }
+            }
+        }
+        return Data(key)
+    }
+
+    func bindEndpoint(
+        secretKey: Data,
+        enableRelay: Bool,
+        acceptConnections: Bool
+    ) throws -> MobileHostIrohEndpointReference {
+        try secretKey.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                throw MobileHostIrohFailure(kind: .invalidArgument, message: "empty iroh secret key")
+            }
+            return try withIrohError { rawError in
+                let error = rawError.assumingMemoryBound(to: CmuxIrohError.self)
+                guard let endpoint = cmux_iroh_endpoint_bind(
+                    baseAddress,
+                    secretKey.count,
+                    enableRelay,
+                    acceptConnections,
+                    error
+                ) else {
+                    throw failure(from: rawError)
+                }
+                return MobileHostIrohEndpointReference(raw: endpoint)
+            }
+        }
+    }
+
+    func endpointID(_ endpoint: MobileHostIrohEndpointReference) -> String? {
+        guard let cString = cmux_iroh_endpoint_id(endpoint.raw) else {
+            return nil
+        }
+        defer { cmux_iroh_string_free(cString) }
+        return String(cString: cString)
+    }
+
+    func routeJSON(_ endpoint: MobileHostIrohEndpointReference) -> String? {
+        guard let cString = cmux_iroh_endpoint_route_json(endpoint.raw) else {
+            return nil
+        }
+        defer { cmux_iroh_string_free(cString) }
+        return String(cString: cString)
+    }
+
+    func accept(
+        endpoint: MobileHostIrohEndpointReference,
+        timeoutMilliseconds: UInt64
+    ) throws -> MobileHostIrohConnectionReference {
+        try withIrohError { rawError in
+            let error = rawError.assumingMemoryBound(to: CmuxIrohError.self)
+            guard let connection = cmux_iroh_endpoint_accept(
+                endpoint.raw,
+                timeoutMilliseconds,
+                error
+            ) else {
+                throw failure(from: rawError)
+            }
+            return MobileHostIrohConnectionReference(raw: connection)
+        }
+    }
+
+    func receive(connection: MobileHostIrohConnectionReference, maximumLength: Int) throws -> Data? {
+        var buffer = [UInt8](repeating: 0, count: maximumLength)
+        return try buffer.withUnsafeMutableBufferPointer { bytes in
+            try withIrohError { rawError in
+                let error = rawError.assumingMemoryBound(to: CmuxIrohError.self)
+                let count = cmux_iroh_connection_recv(
+                    connection.raw,
+                    bytes.baseAddress,
+                    bytes.count,
+                    error
+                )
+                if count == 0 {
+                    return nil
+                }
+                guard count > 0 else {
+                    throw failure(from: rawError)
+                }
+                return Data(bytes.prefix(Int(count)))
+            }
+        }
+    }
+
+    func send(connection: MobileHostIrohConnectionReference, data: Data) throws {
+        guard !data.isEmpty else { return }
+        try data.withUnsafeBytes { rawBuffer in
+            guard let baseAddress = rawBuffer.bindMemory(to: UInt8.self).baseAddress else {
+                return
+            }
+            try withIrohError { rawError in
+                let error = rawError.assumingMemoryBound(to: CmuxIrohError.self)
+                let rc = cmux_iroh_connection_send(
+                    connection.raw,
+                    baseAddress,
+                    data.count,
+                    error
+                )
+                guard rc == 0 else {
+                    throw failure(from: rawError)
+                }
+            }
+        }
+    }
+
+    func close(connection: MobileHostIrohConnectionReference) {
+        cmux_iroh_connection_close(connection.raw)
+    }
+
+    func close(endpoint: MobileHostIrohEndpointReference) {
+        cmux_iroh_endpoint_close(endpoint.raw)
+    }
+
+    private func withIrohError<T>(_ body: (UnsafeMutableRawPointer) throws -> T) throws -> T {
+        var message = [CChar](repeating: 0, count: Self.errorMessageCapacity)
+        return try message.withUnsafeMutableBufferPointer { buffer in
+            var error = CmuxIrohError(
+                kind: MobileHostIrohErrorKind.none.rawValue,
+                message: buffer.baseAddress,
+                message_cap: buffer.count
+            )
+            return try withUnsafeMutablePointer(to: &error) { errorPointer in
+                try body(UnsafeMutableRawPointer(errorPointer))
+            }
+        }
+    }
+
+    private func failure(from rawError: UnsafeMutableRawPointer) -> MobileHostIrohFailure {
+        let error = rawError.assumingMemoryBound(to: CmuxIrohError.self)
+        let message: String
+        if let cString = error.pointee.message, cString.pointee != 0 {
+            message = String(cString: cString)
+        } else {
+            message = "iroh operation failed"
+        }
+        return MobileHostIrohFailure(
+            kind: MobileHostIrohErrorKind(rawFFIValue: error.pointee.kind),
+            message: message
+        )
+    }
+}

--- a/Sources/Mobile/MobileHostIrohFlag.swift
+++ b/Sources/Mobile/MobileHostIrohFlag.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+struct MobileHostIrohFlag: Sendable, Equatable {
+    static let envKey = "CMUX_MOBILE_IROH_TRANSPORT"
+    static let defaultsKey = "mobileIrohTransport"
+
+    let isEnabled: Bool
+
+    static func resolved(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard,
+        isDebugBuild: Bool = Self.isDebugBuild
+    ) -> MobileHostIrohFlag {
+        func parseBool(_ raw: String) -> Bool {
+            switch raw.lowercased() {
+            case "1", "true", "yes", "on": return true
+            default: return false
+            }
+        }
+
+        if let raw = environment[envKey]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !raw.isEmpty {
+            return MobileHostIrohFlag(isEnabled: parseBool(raw))
+        }
+        if defaults.object(forKey: defaultsKey) != nil {
+            return MobileHostIrohFlag(isEnabled: defaults.bool(forKey: defaultsKey))
+        }
+        return MobileHostIrohFlag(isEnabled: isDebugBuild)
+    }
+
+    static var isDebugBuild: Bool {
+        #if DEBUG
+        return true
+        #else
+        return false
+        #endif
+    }
+}

--- a/Sources/Mobile/MobileHostIrohRoute.swift
+++ b/Sources/Mobile/MobileHostIrohRoute.swift
@@ -1,0 +1,41 @@
+import CMUXMobileCore
+import Foundation
+
+struct MobileHostIrohRoute {
+    static let priority = 5
+
+    static func route(from json: String) -> CmxAttachRoute? {
+        guard let data = json.data(using: .utf8),
+              let decoded = try? JSONDecoder().decode(CmxAttachRoute.self, from: data) else {
+            return nil
+        }
+        return normalized(decoded)
+    }
+
+    static func normalized(_ route: CmxAttachRoute) -> CmxAttachRoute? {
+        guard route.kind == .iroh,
+              case .peer = route.endpoint else {
+            return nil
+        }
+        return try? CmxAttachRoute(
+            id: CmxAttachTransportKind.iroh.rawValue,
+            kind: .iroh,
+            endpoint: route.endpoint,
+            priority: priority
+        )
+    }
+
+    static func shortEndpointID(_ endpointID: String) -> String {
+        let trimmed = endpointID.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 12 else { return trimmed }
+        return String(trimmed.prefix(12))
+    }
+
+    static func relayHost(_ relayURL: String?) -> String? {
+        guard let relayURL = relayURL?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !relayURL.isEmpty else {
+            return nil
+        }
+        return URL(string: relayURL)?.host ?? relayURL
+    }
+}

--- a/Sources/Mobile/MobileHostIrohSecretKeyStore.swift
+++ b/Sources/Mobile/MobileHostIrohSecretKeyStore.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Security
+
+protocol MobileHostIrohSecretKeyStoring: Sendable {
+    func loadSecretKey() throws -> Data?
+    func saveSecretKey(_ key: Data) throws
+}
+
+enum MobileHostIrohSecretKeyStoreError: Error, Equatable, Sendable {
+    case invalidLength(Int)
+    case keychainReadFailed(OSStatus)
+    case keychainWriteFailed(OSStatus)
+}
+
+struct MobileHostIrohSecretKeyProvider: Sendable {
+    static let secretKeyLength = 32
+
+    let store: any MobileHostIrohSecretKeyStoring
+    let generate: @Sendable () throws -> Data
+
+    func secretKey() throws -> Data {
+        if let existing = try store.loadSecretKey() {
+            try validate(existing)
+            return existing
+        }
+        let generated = try generate()
+        try validate(generated)
+        try store.saveSecretKey(generated)
+        return generated
+    }
+
+    private func validate(_ key: Data) throws {
+        guard key.count == Self.secretKeyLength else {
+            throw MobileHostIrohSecretKeyStoreError.invalidLength(key.count)
+        }
+    }
+}
+
+struct MobileHostIrohKeychainSecretStore: MobileHostIrohSecretKeyStoring {
+    private let service: String
+    private let account: String
+
+    init(
+        service: String = "dev.cmux.mobile.iroh.endpoint",
+        account: String = "mac-host-endpoint-secret-key"
+    ) {
+        self.service = service
+        self.account = account
+    }
+
+    func loadSecretKey() throws -> Data? {
+        var query = baseQuery()
+        query[kSecReturnData as String] = kCFBooleanTrue
+        query[kSecMatchLimit as String] = kSecMatchLimitOne
+
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+        if status == errSecItemNotFound {
+            return nil
+        }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw MobileHostIrohSecretKeyStoreError.keychainReadFailed(status)
+        }
+        return data
+    }
+
+    func saveSecretKey(_ key: Data) throws {
+        var attributes = baseQuery()
+        attributes[kSecValueData as String] = key
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+
+        let addStatus = SecItemAdd(attributes as CFDictionary, nil)
+        if addStatus == errSecSuccess {
+            return
+        }
+        if addStatus != errSecDuplicateItem {
+            throw MobileHostIrohSecretKeyStoreError.keychainWriteFailed(addStatus)
+        }
+
+        let update: [String: Any] = [
+            kSecValueData as String: key,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly,
+        ]
+        let updateStatus = SecItemUpdate(baseQuery() as CFDictionary, update as CFDictionary)
+        guard updateStatus == errSecSuccess else {
+            throw MobileHostIrohSecretKeyStoreError.keychainWriteFailed(updateStatus)
+        }
+    }
+
+    private func baseQuery() -> [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: kCFBooleanFalse as Any,
+        ]
+    }
+}

--- a/Sources/Mobile/MobileHostNWConnectionAdapter.swift
+++ b/Sources/Mobile/MobileHostNWConnectionAdapter.swift
@@ -1,0 +1,69 @@
+import Foundation
+@preconcurrency import Network
+
+// Wraps NWConnection, whose callbacks are delivered on the Network framework's
+// queue; the adapter owns no mutable state beyond the underlying connection.
+final class MobileHostNWConnectionAdapter: MobileHostByteConnection, @unchecked Sendable {
+    private let connection: NWConnection
+
+    init(connection: NWConnection) {
+        self.connection = connection
+    }
+
+    func setStateUpdateHandler(_ handler: ((MobileHostByteConnectionState) -> Void)?) {
+        connection.stateUpdateHandler = { state in
+            handler?(Self.mapState(state))
+        }
+    }
+
+    func start(queue: DispatchQueue) {
+        connection.start(queue: queue)
+    }
+
+    func receive(
+        minimumIncompleteLength: Int,
+        maximumLength: Int,
+        completion: @escaping (Data?, Bool, String?) -> Void
+    ) {
+        connection.receive(
+            minimumIncompleteLength: minimumIncompleteLength,
+            maximumLength: maximumLength
+        ) { data, _, isComplete, error in
+            completion(data, isComplete, error.map { String(describing: $0) })
+        }
+    }
+
+    func send(_ data: Data, completion: @escaping (String?) -> Void) {
+        connection.send(
+            content: data,
+            contentContext: .defaultMessage,
+            isComplete: false,
+            completion: .contentProcessed { error in
+                completion(error.map { String(describing: $0) })
+            }
+        )
+    }
+
+    func close() {
+        connection.cancel()
+    }
+
+    private static func mapState(_ state: NWConnection.State) -> MobileHostByteConnectionState {
+        switch state {
+        case .setup:
+            return .setup
+        case .waiting:
+            return .waiting
+        case .preparing:
+            return .preparing
+        case .ready:
+            return .ready
+        case let .failed(error):
+            return .failed(String(describing: error))
+        case .cancelled:
+            return .cancelled
+        @unknown default:
+            return .waiting
+        }
+    }
+}

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1016,7 +1016,7 @@ final class MobileHostService {
             let id = UUID()
             let session = MobileHostConnection(
                 id: id,
-                connection: connection,
+                connection: MobileHostNWConnectionAdapter(connection: connection),
                 authorizeRequest: { request in
                     if !Self.requiresAuthorization(method: request.method) {
                         return nil
@@ -1139,7 +1139,7 @@ final class MobileHostService {
         let id = UUID()
         let session = MobileHostConnection(
             id: id,
-            connection: connection,
+            connection: MobileHostNWConnectionAdapter(connection: connection),
             authorizeRequest: { request in
                 await MobileHostService.shared.authorizationError(for: request)
             },
@@ -1949,7 +1949,7 @@ actor MobileHostConnection {
     private static let defaultIdleTimeoutNanoseconds: UInt64 = 30 * 1_000_000_000
 
     private let id: UUID
-    private let connection: NWConnection
+    private let connection: any MobileHostByteConnection
     private let callbackQueue: DispatchQueue
     private let firstFrameTimeoutNanoseconds: UInt64
     private let idleTimeoutNanoseconds: UInt64
@@ -1969,7 +1969,7 @@ actor MobileHostConnection {
 
     init(
         id: UUID,
-        connection: NWConnection,
+        connection: any MobileHostByteConnection,
         firstFrameTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultFirstFrameTimeoutNanoseconds,
         idleTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultIdleTimeoutNanoseconds,
         authorizeRequest: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult?,
@@ -1989,7 +1989,7 @@ actor MobileHostConnection {
     }
 
     func start() {
-        connection.stateUpdateHandler = { [weak self, id] state in
+        connection.setStateUpdateHandler { [weak self, id] state in
             guard let self else { return }
             Task { await self.handleState(state, connectionID: id) }
         }
@@ -2021,8 +2021,8 @@ actor MobileHostConnection {
             )
         }
         mobileHostLog.info("mobile host connection closed \(self.id.uuidString, privacy: .public): \(reason, privacy: .public)")
-        connection.stateUpdateHandler = nil
-        connection.cancel()
+        connection.setStateUpdateHandler(nil)
+        connection.close()
         Task { await onClose(id) }
     }
 
@@ -2033,9 +2033,8 @@ actor MobileHostConnection {
         connection.receive(
             minimumIncompleteLength: 1,
             maximumLength: 64 * 1024
-        ) { [weak self] data, _, isComplete, error in
+        ) { [weak self] data, isComplete, errorDescription in
             guard let self else { return }
-            let errorDescription = error.map { String(describing: $0) }
             Task {
                 await self.handleReceive(
                     data: data,
@@ -2345,37 +2344,30 @@ actor MobileHostConnection {
         }
 
         return await withCheckedContinuation { continuation in
-            connection.send(
-                content: frame,
-                contentContext: .defaultMessage,
-                isComplete: false,
-                completion: .contentProcessed { [weak self] error in
-                    guard let self else {
-                        continuation.resume(returning: false)
-                        return
-                    }
-                    if let error {
-                        Task { await self.close(reason: String(describing: error)) }
-                        continuation.resume(returning: false)
-                    } else {
-                        continuation.resume(returning: true)
-                    }
+            connection.send(frame) { [weak self] errorDescription in
+                guard let self else {
+                    continuation.resume(returning: false)
+                    return
                 }
-            )
+                if let errorDescription {
+                    Task { await self.close(reason: errorDescription) }
+                    continuation.resume(returning: false)
+                } else {
+                    continuation.resume(returning: true)
+                }
+            }
         }
     }
 
-    private func handleState(_ state: NWConnection.State, connectionID: UUID) {
+    private func handleState(_ state: MobileHostByteConnectionState, connectionID: UUID) {
         switch state {
         case .failed(let error):
-            close(reason: String(describing: error))
+            close(reason: error)
         case .cancelled:
             close(reason: "cancelled")
         case .ready:
             mobileHostLog.debug("mobile host connection ready \(connectionID.uuidString, privacy: .public)")
         case .setup, .waiting, .preparing:
-            break
-        @unknown default:
             break
         }
     }

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -380,10 +380,16 @@ final class MobileHostService {
     private let callbackQueue = DispatchQueue(label: "dev.cmux.mobile.host-listener")
     private let routeResolver = MobileRouteResolver()
     private let ticketStore = MobileAttachTicketStore()
+    private let irohFFIClient: any MobileHostIrohFFIClient
+    private let irohSecretKeyProvider: MobileHostIrohSecretKeyProvider
     private var listener: NWListener?
     private var listenerGeneration = UUID()
     private var listenerUsesEphemeralFallback = false
     private var listenerPort: Int?
+    private var irohEndpoint: MobileHostIrohEndpointReference?
+    private var irohEndpointGeneration = UUID()
+    private var irohAcceptTask: Task<Void, Never>?
+    private var irohRoute: CmxAttachRoute?
     /// The preferred port the active start-sequence targeted (regardless of an
     /// ephemeral fallback). Used to decide whether a settings change needs a
     /// restart. `nil` while stopped.
@@ -406,7 +412,17 @@ final class MobileHostService {
     private var debugAcceptedStackAuthToken: String?
     #endif
 
-    private init() {}
+    private init(
+        irohFFIClient: any MobileHostIrohFFIClient = MobileHostIrohSystemFFIClient(),
+        irohSecretKeyProvider: MobileHostIrohSecretKeyProvider? = nil
+    ) {
+        let resolvedIrohFFIClient = irohFFIClient
+        self.irohFFIClient = resolvedIrohFFIClient
+        self.irohSecretKeyProvider = irohSecretKeyProvider ?? MobileHostIrohSecretKeyProvider(
+            store: MobileHostIrohKeychainSecretStore(),
+            generate: { try resolvedIrohFFIClient.generateSecretKey() }
+        )
+    }
 
     /// Inject the auth dependency. Call once at the composition root.
     func configure(auth: AuthCoordinator) {
@@ -722,7 +738,7 @@ final class MobileHostService {
                 self?.updatePublicStatusRoutes(port: port, generation: generation, tailscaleHosts: hosts)
             }
         })
-        MobileHostPublicStatusCache.update(routes: routeResolver.routes(port: port).routes)
+        MobileHostPublicStatusCache.update(routes: resolvedRoutes(port: port))
         startNetworkPathMonitorIfNeeded()
         drainReadinessWaiters()
     }
@@ -739,9 +755,11 @@ final class MobileHostService {
             return
         }
         guard listener == nil else {
+            startIrohEndpointIfNeeded()
             return
         }
 
+        startIrohEndpointIfNeeded()
         startListener(usePreferredPort: true)
     }
 
@@ -759,7 +777,7 @@ final class MobileHostService {
         listenerPort = port
         appliedPreferredPort = port
         lastErrorDescription = nil
-        MobileHostPublicStatusCache.update(routes: routeResolver.routes(port: port).routes)
+        MobileHostPublicStatusCache.update(routes: resolvedRoutes(port: port))
         mobileHostLog.info("mobile host listener disabled; publishing XCTest routes without binding")
     }
     #endif
@@ -819,8 +837,144 @@ final class MobileHostService {
         return try NWListener(using: parameters, on: .any)
     }
 
+    private func startIrohEndpointIfNeeded() {
+        guard MobileHostIrohFlag.resolved().isEnabled else {
+            return
+        }
+        guard irohEndpoint == nil else {
+            return
+        }
+        do {
+            let secretKey = try irohSecretKeyProvider.secretKey()
+            let endpoint = try irohFFIClient.bindEndpoint(
+                secretKey: secretKey,
+                enableRelay: true,
+                acceptConnections: true
+            )
+            let generation = UUID()
+            irohEndpoint = endpoint
+            irohEndpointGeneration = generation
+            irohRoute = route(forIrohEndpoint: endpoint) ?? irohRoute
+            startIrohAcceptLoop(endpoint: endpoint, generation: generation)
+            if listenerPort == nil {
+                MobileHostPublicStatusCache.update(routes: resolvedRoutesForCurrentHost())
+            }
+            if let endpointID = irohFFIClient.endpointID(endpoint) {
+                mobileHostLog.info("mobile host iroh endpoint ready \(endpointID, privacy: .public)")
+            } else {
+                mobileHostLog.info("mobile host iroh endpoint ready")
+            }
+        } catch {
+            irohEndpoint = nil
+            irohRoute = nil
+            mobileHostLog.error("mobile host iroh endpoint failed to bind: \(String(describing: error), privacy: .public)")
+        }
+    }
+
+    private func stopIrohEndpoint() {
+        irohAcceptTask?.cancel()
+        irohAcceptTask = nil
+        irohEndpointGeneration = UUID()
+        let endpoint = irohEndpoint
+        irohEndpoint = nil
+        irohRoute = nil
+        if let endpoint {
+            irohFFIClient.close(endpoint: endpoint)
+        }
+    }
+
+    private func startIrohAcceptLoop(
+        endpoint: MobileHostIrohEndpointReference,
+        generation: UUID
+    ) {
+        let ffiClient = irohFFIClient
+        irohAcceptTask?.cancel()
+        irohAcceptTask = Task.detached(priority: .userInitiated) {
+            while !Task.isCancelled {
+                do {
+                    let connection = try ffiClient.accept(
+                        endpoint: endpoint,
+                        timeoutMilliseconds: 500
+                    )
+                    MobileHostRequestActivity.beginConnection()
+                    let byteConnection = MobileHostIrohConnectionAdapter(
+                        connection: connection,
+                        ffiClient: ffiClient
+                    )
+                    Self.acceptByteConnectionOffMain(
+                        byteConnection,
+                        canAccept: {
+                            await MobileHostService.shared.canAcceptIrohConnection(generation: generation)
+                        }
+                    )
+                } catch let failure as MobileHostIrohFailure {
+                    switch failure.kind {
+                    case .timedOut:
+                        continue
+                    case .endpointClosed:
+                        return
+                    default:
+                        mobileHostLog.error("mobile host iroh accept failed: \(failure.message, privacy: .public)")
+                    }
+                } catch {
+                    mobileHostLog.error("mobile host iroh accept failed: \(String(describing: error), privacy: .public)")
+                }
+            }
+        }
+    }
+
+    private func route(forIrohEndpoint endpoint: MobileHostIrohEndpointReference) -> CmxAttachRoute? {
+        guard let json = irohFFIClient.routeJSON(endpoint),
+              let route = MobileHostIrohRoute.route(from: json) else {
+            return nil
+        }
+        return route
+    }
+
+    private func currentIrohRoute() -> CmxAttachRoute? {
+        guard let endpoint = irohEndpoint else {
+            irohRoute = nil
+            return nil
+        }
+        if let route = route(forIrohEndpoint: endpoint) {
+            irohRoute = route
+            return route
+        }
+        return irohRoute
+    }
+
+    private func resolvedRoutes(port: Int) -> [CmxAttachRoute] {
+        routeResolver.routes(
+            port: port,
+            irohRoute: currentIrohRoute()
+        ).routes
+    }
+
+    private func resolvedRoutes(port: Int, tailscaleHosts: [String]) -> [CmxAttachRoute] {
+        routeResolver.routes(
+            port: port,
+            irohRoute: currentIrohRoute(),
+            tailscaleHosts: tailscaleHosts
+        ).routes
+    }
+
+    private func resolvedRoutesForCurrentHost() -> [CmxAttachRoute] {
+        if let listenerPort {
+            return resolvedRoutes(port: listenerPort)
+        }
+        return irohOnlyRoutes()
+    }
+
+    private func irohOnlyRoutes() -> [CmxAttachRoute] {
+        guard let route = currentIrohRoute().flatMap(MobileHostIrohRoute.normalized) else {
+            return []
+        }
+        return [route]
+    }
+
     func stop() {
         stopNetworkPathMonitor()
+        stopIrohEndpoint()
         listenerGeneration = UUID()
         listenerUsesEphemeralFallback = false
         listener?.stateUpdateHandler = nil
@@ -844,8 +998,7 @@ final class MobileHostService {
     }
 
     func statusSnapshot() -> MobileHostServiceStatus {
-        let routes = listenerPort.map { routeResolver.routes(port: $0).routes } ?? []
-        return makeStatus(routes: routes)
+        makeStatus(routes: resolvedRoutesForCurrentHost())
     }
 
     /// Emits the current ``MobileHostServiceStatus`` immediately, then a fresh
@@ -931,7 +1084,9 @@ final class MobileHostService {
     }
 
     private func makeStatus(routes: [CmxAttachRoute]) -> MobileHostServiceStatus {
-        let isRunning = listener != nil && listenerPort != nil
+        let listenerReady = listener != nil && listenerPort != nil
+        let hasIrohRoute = routes.contains { $0.kind == .iroh }
+        let isRunning = listenerReady || hasIrohRoute
         return MobileHostServiceStatus(
             isRunning: isRunning,
             port: listenerPort,
@@ -964,7 +1119,7 @@ final class MobileHostService {
             ?? Self.configuredPort(defaults: defaults)
         switch Self.syncDecision(
             enabled: Self.isListeningEnabled(defaults: defaults),
-            listenerRunning: listener != nil,
+            listenerRunning: listener != nil || irohEndpoint != nil,
             desiredPort: desiredPort,
             appliedPort: appliedPreferredPort
         ) {
@@ -1013,10 +1168,32 @@ final class MobileHostService {
             }
             #endif
 
+            Self.acceptByteConnectionOffMain(
+                MobileHostNWConnectionAdapter(connection: connection),
+                canAccept: {
+                    await MobileHostService.shared.canAcceptConnection(generation: generation)
+                }
+            )
+        }
+    }
+
+    nonisolated private static func acceptByteConnectionOffMain(
+        _ byteConnection: any MobileHostByteConnection,
+        canAccept: @escaping @Sendable () async -> Bool
+    ) {
+        Task.detached(priority: .userInitiated) {
+            let canAccept = await canAccept()
+            guard canAccept else {
+                mobileHostLog.info("mobile host rejected stale listener connection")
+                byteConnection.close()
+                MobileHostRequestActivity.endConnection()
+                return
+            }
+
             let id = UUID()
             let session = MobileHostConnection(
                 id: id,
-                connection: MobileHostNWConnectionAdapter(connection: connection),
+                connection: byteConnection,
                 authorizeRequest: { request in
                     if !Self.requiresAuthorization(method: request.method) {
                         return nil
@@ -1051,7 +1228,7 @@ final class MobileHostService {
                 limit: Self.maximumActiveConnectionCount
             ) else {
                 mobileHostLog.error("mobile host rejected connection because active connection limit was reached")
-                connection.cancel()
+                byteConnection.close()
                 MobileHostRequestActivity.endConnection()
                 return
             }
@@ -1063,19 +1240,18 @@ final class MobileHostService {
         listener != nil && generation == listenerGeneration
     }
 
+    private func canAcceptIrohConnection(generation: UUID) -> Bool {
+        irohEndpoint != nil && generation == irohEndpointGeneration
+    }
+
     func createAttachTicket(
         workspaceID: String,
         terminalID: String?,
         ttl: TimeInterval,
         routeID: String? = nil,
         routeKind: String? = nil
-    ) async throws -> [String: Any] {
-        let routes: [CmxAttachRoute]
-        if let listenerPort {
-            routes = routeResolver.routes(port: listenerPort).routes
-        } else {
-            routes = []
-        }
+        ) async throws -> [String: Any] {
+        let routes = resolvedRoutesForCurrentHost()
         let selectedRoutes = try Self.filteredRoutes(
             routes,
             routeID: routeID,
@@ -1121,50 +1297,6 @@ final class MobileHostService {
             throw MobileAttachTicketStoreError.routeUnavailable
         }
         return filtered
-    }
-
-    private func accept(_ connection: NWConnection, generation: UUID) {
-        guard listener != nil, generation == listenerGeneration else {
-            connection.cancel()
-            MobileHostRequestActivity.endConnection()
-            return
-        }
-        guard activeConnections.count < Self.maximumActiveConnectionCount else {
-            mobileHostLog.error("mobile host rejected connection because active connection limit was reached")
-            connection.cancel()
-            MobileHostRequestActivity.endConnection()
-            return
-        }
-
-        let id = UUID()
-        let session = MobileHostConnection(
-            id: id,
-            connection: MobileHostNWConnectionAdapter(connection: connection),
-            authorizeRequest: { request in
-                await MobileHostService.shared.authorizationError(for: request)
-            },
-            onAuthorizedRequest: { request in
-                if let clientID = Self.clientID(from: request.params) {
-                    await MobileHostService.shared.recordClientID(clientID, for: id)
-                }
-            },
-            handleRequest: { request in
-                if request.method == "mobile.host.status" {
-                    return await MobileHostService.networkStatusResult(for: request)
-                }
-                let result = await TerminalController.shared.mobileHostHandleRPC(request)
-                await MobileHostService.shared.recordCreatedResourcesIfNeeded(
-                    request: request,
-                    result: result
-                )
-                return result
-            },
-            onClose: { id in
-                await MobileHostService.shared.removeConnection(id: id)
-            }
-        )
-        activeConnections[id] = session
-        Task { await session.start() }
     }
 
     /// Whether an incoming connection's remote peer is on the loopback interface.
@@ -1543,9 +1675,9 @@ final class MobileHostService {
                         )
                     }
                 })
-                MobileHostPublicStatusCache.update(routes: routeResolver.routes(port: listenerPort).routes)
+                MobileHostPublicStatusCache.update(routes: resolvedRoutes(port: listenerPort))
             } else {
-                MobileHostPublicStatusCache.update(routes: [])
+                MobileHostPublicStatusCache.update(routes: irohOnlyRoutes())
             }
             mobileHostLog.info("mobile host listener ready on port \(self.listenerPort ?? 0)")
             drainReadinessWaiters()
@@ -1556,7 +1688,7 @@ final class MobileHostService {
             listener = nil
             listenerUsesEphemeralFallback = false
             listenerPort = nil
-            MobileHostPublicStatusCache.update(routes: [])
+            MobileHostPublicStatusCache.update(routes: irohOnlyRoutes())
             drainReadinessWaiters()
         case let .waiting(error):
             // A preferred-port bind blocked by another listener surfaces as
@@ -1567,11 +1699,11 @@ final class MobileHostService {
                 handleListenerBindFailure(error: error, context: "in use (waiting)")
             } else {
                 listenerPort = nil
-                MobileHostPublicStatusCache.update(routes: [])
+                MobileHostPublicStatusCache.update(routes: irohOnlyRoutes())
             }
         case .setup:
             listenerPort = nil
-            MobileHostPublicStatusCache.update(routes: [])
+            MobileHostPublicStatusCache.update(routes: irohOnlyRoutes())
         @unknown default:
             break
         }
@@ -1582,7 +1714,7 @@ final class MobileHostService {
     /// Shared by the `.failed` and `.waiting(addressUnavailable)` paths.
     private func handleListenerBindFailure(error: NWError, context: String) {
         lastErrorDescription = String(describing: error)
-        MobileHostPublicStatusCache.update(routes: [])
+        MobileHostPublicStatusCache.update(routes: irohOnlyRoutes())
         let shouldRetryWithEphemeralPort = !listenerUsesEphemeralFallback
         listener?.stateUpdateHandler = nil
         listener?.newConnectionHandler = nil
@@ -1611,7 +1743,7 @@ final class MobileHostService {
             return
         }
         MobileHostPublicStatusCache.update(
-            routes: routeResolver.routes(port: port, tailscaleHosts: tailscaleHosts).routes
+            routes: resolvedRoutes(port: port, tailscaleHosts: tailscaleHosts)
         )
     }
 
@@ -1647,7 +1779,10 @@ final class MobileHostService {
         guard let port = listenerPort else {
             // Mid-bind (no port yet): the `.ready` handler publishes against the
             // current path when the bind completes, and the invalidation above
-            // guarantees it resolves freshly.
+            // guarantees it resolves freshly. A live iroh endpoint can still
+            // publish refreshed relay/direct-address hints without a host:port
+            // route.
+            MobileHostPublicStatusCache.update(routes: irohOnlyRoutes())
             return
         }
         let generation = listenerGeneration
@@ -1658,7 +1793,7 @@ final class MobileHostService {
                 self?.updatePublicStatusRoutes(port: port, generation: generation, tailscaleHosts: hosts)
             }
         })
-        MobileHostPublicStatusCache.update(routes: routeResolver.routes(port: port).routes)
+        MobileHostPublicStatusCache.update(routes: resolvedRoutes(port: port))
     }
 }
 
@@ -1666,6 +1801,7 @@ final class MobileHostService {
 #if DEBUG
 extension MobileHostService {
     func debugResetMobileLifecycleStateForTesting() {
+        stopIrohEndpoint()
         listenerGeneration = UUID()
         listenerUsesEphemeralFallback = false
         listenerPort = nil
@@ -1986,6 +2122,28 @@ actor MobileHostConnection {
         self.onAuthorizedRequest = onAuthorizedRequest
         self.handleRequest = handleRequest
         self.onClose = onClose
+    }
+
+    init(
+        id: UUID,
+        connection: NWConnection,
+        firstFrameTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultFirstFrameTimeoutNanoseconds,
+        idleTimeoutNanoseconds: UInt64 = MobileHostConnection.defaultIdleTimeoutNanoseconds,
+        authorizeRequest: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult?,
+        onAuthorizedRequest: @escaping @Sendable (MobileHostRPCRequest) async -> Void,
+        handleRequest: @escaping @Sendable (MobileHostRPCRequest) async -> MobileHostRPCResult,
+        onClose: @escaping @Sendable (UUID) async -> Void
+    ) {
+        self.init(
+            id: id,
+            connection: MobileHostNWConnectionAdapter(connection: connection),
+            firstFrameTimeoutNanoseconds: firstFrameTimeoutNanoseconds,
+            idleTimeoutNanoseconds: idleTimeoutNanoseconds,
+            authorizeRequest: authorizeRequest,
+            onAuthorizedRequest: onAuthorizedRequest,
+            handleRequest: handleRequest,
+            onClose: onClose
+        )
     }
 
     func start() {

--- a/Sources/Mobile/MobileRouteResolver.swift
+++ b/Sources/Mobile/MobileRouteResolver.swift
@@ -27,23 +27,26 @@ final class MobileRouteResolver: @unchecked Sendable {
     func routes(
         port: Int,
         now: Date = Date(),
+        irohRoute: CmxAttachRoute? = nil,
         immediateHosts: () -> [String] = { MobileRouteResolver.tailscaleRouteHosts(resolveDNS: false) }
     ) -> MobileHostRouteSnapshot {
         refreshTailscaleRoutes()
         let cachedHosts = resolvedTailscaleRouteHostsFromCache(now: now) ?? []
         return routes(
             port: port,
+            irohRoute: irohRoute,
             tailscaleHosts: Self.deduplicatedHosts(cachedHosts + immediateHosts())
         )
     }
 
     func routesResolvingTailscaleDNS(
         port: Int,
+        irohRoute: CmxAttachRoute? = nil,
         resolveHosts: @escaping @Sendable () -> [String] = { MobileRouteResolver.tailscaleRouteHosts(resolveDNS: true) },
         now: Date = Date()
     ) async -> MobileHostRouteSnapshot {
         let hosts = await resolvedTailscaleRouteHosts(resolveHosts: resolveHosts, now: now)
-        return routes(port: port, tailscaleHosts: hosts)
+        return routes(port: port, irohRoute: irohRoute, tailscaleHosts: hosts)
     }
 
     /// Drop the resolved-host cache and orphan any in-flight resolution.
@@ -64,7 +67,11 @@ final class MobileRouteResolver: @unchecked Sendable {
         cacheLock.unlock()
     }
 
-    func routes(port: Int, tailscaleHosts: [String]) -> MobileHostRouteSnapshot {
+    func routes(
+        port: Int,
+        irohRoute: CmxAttachRoute? = nil,
+        tailscaleHosts: [String]
+    ) -> MobileHostRouteSnapshot {
         var resolved: [CmxAttachRoute] = []
 
         if Self.includesDebugLoopbackRoute {
@@ -76,6 +83,10 @@ final class MobileRouteResolver: @unchecked Sendable {
             ) {
                 resolved.append(debugRoute)
             }
+        }
+
+        if let irohRoute = irohRoute.flatMap(MobileHostIrohRoute.normalized) {
+            resolved.append(irohRoute)
         }
 
         for (index, tailscaleHost) in tailscaleHosts.enumerated() {

--- a/Sources/Mobile/Pairing/MobilePairingModel.swift
+++ b/Sources/Mobile/Pairing/MobilePairingModel.swift
@@ -29,9 +29,9 @@ final class MobilePairingModel {
         /// A phone has attached to the listener; show a paired/success state
         /// instead of the QR + spinner.
         case connected(Ready)
-        /// The listener is up but there is no route a phone can reach (no
-        /// Tailscale address on this Mac), so no ticket can be minted yet.
-        case needsTailscale
+        /// The listener is up but there is no route a phone can reach, so no
+        /// ticket can be minted yet.
+        case noReachableRoute
         /// The listener could not be started or no ticket could be minted.
         case failed(String)
     }
@@ -43,8 +43,10 @@ final class MobilePairingModel {
         /// The Mac's display name, shown above the code.
         let macName: String
         /// Reachable Tailscale `host:port` routes. Empty when Tailscale is not
-        /// detected, in which case a real iPhone cannot reach this Mac.
+        /// detected. Iroh-only pairing can still be reachable with this empty.
         let tailscaleLines: [String]
+        /// Whether the QR includes an iroh peer route.
+        let hasIrohRoute: Bool
         /// The best route for manual phone entry, behind the "Copy IP" and
         /// "Copy Port" buttons. `nil` when no phone-dialable route exists.
         let manualEntry: CmxManualPairingEntry?
@@ -124,13 +126,12 @@ final class MobilePairingModel {
             )
             return
         }
-        // No route a phone can reach: a real iPhone needs a Tailscale address
-        // on this Mac. A DEBUG build's dev loopback route does not count — a
-        // QR pointing at 127.0.0.1 would make the phone dial itself, so the
-        // window shows the set-up-Tailscale guidance instead of a weak code.
+        // No route a phone can reach. A DEBUG build's dev loopback route does
+        // not count — a QR pointing at 127.0.0.1 would make the phone dial
+        // itself, so the window shows route guidance instead of a weak code.
         // (Simulator/dev pairing uses the injected attach URL path, not the QR.)
         guard status.routes.contains(where: Self.isPhoneReachableRoute) else {
-            state = .needsTailscale
+            state = .noReachableRoute
             return
         }
         do {
@@ -149,12 +150,12 @@ final class MobilePairingModel {
                 )
                 return
             }
-            // Only the minimal v2 grammar (Tailscale routes only, no loopback,
-            // no token) may ever be displayed as a scannable code. If the mint
-            // raced a Tailscale route loss and fell back to the v1 payload,
-            // show the Tailscale guidance rather than a weak QR.
+            // Only the minimal pairing grammar (phone-reachable routes, no
+            // loopback, no token) may ever be displayed as a scannable code.
+            // If the mint raced a route loss and fell back to the v1 payload,
+            // show route guidance rather than a weak QR.
             guard CmxPairingQRCode().isPairingCodeURLString(attachURL) else {
-                state = .needsTailscale
+                state = .noReachableRoute
                 return
             }
             state = .ready(
@@ -162,12 +163,13 @@ final class MobilePairingModel {
                     attachURL: attachURL,
                     macName: Self.macDisplayName,
                     tailscaleLines: Self.tailscaleLines(status.routes),
+                    hasIrohRoute: Self.hasIrohRoute(status.routes),
                     manualEntry: CmxManualPairingEntry.best(in: status.routes)
                 )
             )
             observeConnections()
         } catch MobileAttachTicketStoreError.noRoutes, MobileAttachTicketStoreError.routeUnavailable {
-            state = .needsTailscale
+            state = .noReachableRoute
         } catch {
             state = .failed(
                 String(
@@ -257,11 +259,18 @@ final class MobilePairingModel {
     }
 
     /// Whether `route` is one a physical iPhone can actually dial: a
-    /// Tailscale route that does not point back at this Mac. The dev loopback
-    /// route a DEBUG build always carries must not count as reachability, or
-    /// the pairing window would happily display a QR no phone can use.
-    private static func isPhoneReachableRoute(_ route: CmxAttachRoute) -> Bool {
-        route.kind == .tailscale && !CmxLoopbackHost().matches(route)
+    /// non-loopback Tailscale host/port or an iroh peer route. The dev
+    /// loopback route a DEBUG build always carries must not count as
+    /// reachability, or the pairing window would display a QR no phone can use.
+    static func isPhoneReachableRoute(_ route: CmxAttachRoute) -> Bool {
+        if route.kind == .tailscale {
+            return !CmxLoopbackHost().matches(route)
+        }
+        if route.kind == .iroh,
+           case let .peer(peerID, _, _, _) = route.endpoint {
+            return !peerID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+        return false
     }
 
     private static func tailscaleLines(_ routes: [CmxAttachRoute]) -> [String] {
@@ -271,6 +280,12 @@ final class MobilePairingModel {
                 return nil
             }
             return "\(host):\(port)"
+        }
+    }
+
+    private static func hasIrohRoute(_ routes: [CmxAttachRoute]) -> Bool {
+        routes.contains { route in
+            route.kind == .iroh && Self.isPhoneReachableRoute(route)
         }
     }
 }

--- a/Sources/Mobile/Pairing/MobilePairingView.swift
+++ b/Sources/Mobile/Pairing/MobilePairingView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 /// Walks the user through the two requirements (signed in to cmux, Tailscale
 /// reachable) and then shows a scannable QR code with step-by-step
 /// instructions. Pairing is gated on sign-in because authorization is a Stack
-/// same-account check; Tailscale is what gives the iPhone a route to this Mac.
+/// same-account check; iroh or Tailscale gives the iPhone a route to this Mac.
 struct MobilePairingView: View {
     @State private var model = MobilePairingModel()
     /// The manual-entry value that was just copied (the host or the port
@@ -27,6 +27,13 @@ struct MobilePairingView: View {
     private static let tailscaleDownloadURL = URL(string: "https://tailscale.com/download")!
     /// Where a Mac user goes to get cmux for iPhone while the beta is invite-only.
     private static let iphoneAppURL = URL(string: "https://github.com/manaflow-ai/cmux#founders-edition")!
+
+    private enum RouteAvailability: Equatable {
+        case iroh
+        case tailscale
+        case missing
+        case unknown
+    }
 
     var body: some View {
         ScrollView {
@@ -67,7 +74,7 @@ struct MobilePairingView: View {
     private var requirements: some View {
         VStack(alignment: .leading, spacing: 12) {
             signInRow
-            tailscaleRow
+            routeRow
         }
     }
 
@@ -81,13 +88,13 @@ struct MobilePairingView: View {
         }
     }
 
-    private var tailscaleRow: some View {
-        let reachable = tailscaleReachable
+    private var routeRow: some View {
+        let availability = routeAvailability
         return requirementRow(
-            title: String(localized: "mobile.pairing.req.tailscale.title", defaultValue: "Tailscale"),
-            subtitle: tailscaleSubtitle(reachable: reachable)
+            title: String(localized: "mobile.pairing.req.route.title", defaultValue: "Connection route"),
+            subtitle: routeSubtitle(availability: availability)
         ) {
-            if reachable != true {
+            if availability == .missing {
                 Link(
                     String(localized: "mobile.pairing.req.tailscale.get", defaultValue: "Get Tailscale"),
                     destination: Self.tailscaleDownloadURL
@@ -97,24 +104,29 @@ struct MobilePairingView: View {
         }
     }
 
-    /// `true` reachable, `false` not detected, `nil` not yet known.
-    private var tailscaleReachable: Bool? {
+    private var routeAvailability: RouteAvailability {
         switch model.state {
-        case let .ready(ready): return ready.reachableViaTailscale
-        case let .connected(ready): return ready.reachableViaTailscale
-        case .needsTailscale: return false
-        default: return nil
+        case let .ready(ready), let .connected(ready):
+            if ready.hasIrohRoute { return .iroh }
+            if ready.reachableViaTailscale { return .tailscale }
+            return .missing
+        case .noReachableRoute:
+            return .missing
+        default:
+            return .unknown
         }
     }
 
-    private func tailscaleSubtitle(reachable: Bool?) -> String {
-        switch reachable {
-        case .some(true):
+    private func routeSubtitle(availability: RouteAvailability) -> String {
+        switch availability {
+        case .iroh:
+            return String(localized: "mobile.pairing.req.route.iroh", defaultValue: "Reachable over Iroh. Tailscale is optional.")
+        case .tailscale:
             return String(localized: "mobile.pairing.req.tailscale.reachable", defaultValue: "Reachable over Tailscale.")
-        case .some(false):
-            return String(localized: "mobile.pairing.req.tailscale.missing", defaultValue: "Not detected. Install Tailscale on this Mac and your iPhone, signed in to the same account.")
-        case .none:
-            return String(localized: "mobile.pairing.req.tailscale.hint", defaultValue: "Your Mac and iPhone both need Tailscale to connect over the internet.")
+        case .missing:
+            return String(localized: "mobile.pairing.req.route.missing", defaultValue: "No Iroh endpoint or Tailscale route is available.")
+        case .unknown:
+            return String(localized: "mobile.pairing.req.route.hint", defaultValue: "cmux will use Iroh when available, with Tailscale as a fallback.")
         }
     }
 
@@ -151,8 +163,8 @@ struct MobilePairingView: View {
                 Text(String(localized: "mobile.pairing.preparing", defaultValue: "Preparing a pairing code…"))
                     .foregroundStyle(.secondary)
             }
-        case .needsTailscale:
-            needsTailscaleContent
+        case .noReachableRoute:
+            noReachableRouteContent
         case let .failed(message):
             failure(message: message)
         case let .ready(ready):
@@ -162,12 +174,12 @@ struct MobilePairingView: View {
         }
     }
 
-    private var needsTailscaleContent: some View {
+    private var noReachableRouteContent: some View {
         VStack(spacing: 12) {
             Image(systemName: "network.slash")
                 .cmuxFont(size: 28)
                 .foregroundStyle(.orange)
-            Text(String(localized: "mobile.pairing.needsTailscale.body", defaultValue: "This Mac has no Tailscale address, so your iPhone can't reach it. Install Tailscale on this Mac and your iPhone (same account), then refresh."))
+            Text(String(localized: "mobile.pairing.noReachableRoute.body", defaultValue: "This Mac has no Iroh endpoint or Tailscale route available, so your iPhone can't reach it. Refresh or set up Tailscale on both devices."))
                 .multilineTextAlignment(.center)
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -867,6 +867,12 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */; };
 		C1F00410C1F00410C1F00410 /* MobileHostByteConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00411C1F00411C1F00411 /* MobileHostByteConnection.swift */; };
 		B8B056D80000000000000001 /* MobileHostIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B056D80000000000000002 /* MobileHostIdentityTests.swift */; };
+		C1F00426C1F00426C1F00426 /* MobileHostIrohConnectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00427C1F00427C1F00427 /* MobileHostIrohConnectionAdapter.swift */; };
+		C1F00420C1F00420C1F00420 /* MobileHostIrohFFI.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00421C1F00421C1F00421 /* MobileHostIrohFFI.swift */; };
+		C1F00428C1F00428C1F00428 /* MobileHostIrohFlag.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00429C1F00429C1F00429 /* MobileHostIrohFlag.swift */; };
+		C1F00424C1F00424C1F00424 /* MobileHostIrohRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00425C1F00425C1F00425 /* MobileHostIrohRoute.swift */; };
+		C1F00422C1F00422C1F00422 /* MobileHostIrohSecretKeyStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00423C1F00423C1F00423 /* MobileHostIrohSecretKeyStore.swift */; };
+		C1F0042AC1F0042AC1F0042A /* MobileHostIrohSecretKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F0042BC1F0042BC1F0042B /* MobileHostIrohSecretKeyTests.swift */; };
 		DE71CE000000000000000008 /* MobileHostNetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE71CE000000000000000007 /* MobileHostNetworkPathMonitor.swift */; };
 		DE71CE000000000000000006 /* MobileHostNetworkPathRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE71CE000000000000000005 /* MobileHostNetworkPathRefreshTests.swift */; };
 		C1F00412C1F00412C1F00412 /* MobileHostNWConnectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00413C1F00413C1F00413 /* MobileHostNWConnectionAdapter.swift */; };
@@ -2512,6 +2518,12 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostBuildIdentity.swift; sourceTree = "<group>"; };
 		C1F00411C1F00411C1F00411 /* MobileHostByteConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostByteConnection.swift; sourceTree = "<group>"; };
 		B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityTests.swift; sourceTree = "<group>"; };
+		C1F00427C1F00427C1F00427 /* MobileHostIrohConnectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostIrohConnectionAdapter.swift; sourceTree = "<group>"; };
+		C1F00421C1F00421C1F00421 /* MobileHostIrohFFI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostIrohFFI.swift; sourceTree = "<group>"; };
+		C1F00429C1F00429C1F00429 /* MobileHostIrohFlag.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostIrohFlag.swift; sourceTree = "<group>"; };
+		C1F00425C1F00425C1F00425 /* MobileHostIrohRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostIrohRoute.swift; sourceTree = "<group>"; };
+		C1F00423C1F00423C1F00423 /* MobileHostIrohSecretKeyStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostIrohSecretKeyStore.swift; sourceTree = "<group>"; };
+		C1F0042BC1F0042BC1F0042B /* MobileHostIrohSecretKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostIrohSecretKeyTests.swift; sourceTree = "<group>"; };
 		DE71CE000000000000000007 /* MobileHostNetworkPathMonitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostNetworkPathMonitor.swift; sourceTree = "<group>"; };
 		DE71CE000000000000000005 /* MobileHostNetworkPathRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostNetworkPathRefreshTests.swift; sourceTree = "<group>"; };
 		C1F00413C1F00413C1F00413 /* MobileHostNWConnectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostNWConnectionAdapter.swift; sourceTree = "<group>"; };
@@ -3489,6 +3501,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */,
 				47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */,
 				C1F00411C1F00411C1F00411 /* MobileHostByteConnection.swift */,
+				C1F00427C1F00427C1F00427 /* MobileHostIrohConnectionAdapter.swift */,
+				C1F00421C1F00421C1F00421 /* MobileHostIrohFFI.swift */,
+				C1F00429C1F00429C1F00429 /* MobileHostIrohFlag.swift */,
+				C1F00425C1F00425C1F00425 /* MobileHostIrohRoute.swift */,
+				C1F00423C1F00423C1F00423 /* MobileHostIrohSecretKeyStore.swift */,
 				C1F00413C1F00413C1F00413 /* MobileHostNWConnectionAdapter.swift */,
 				7ACA497A6831165EA879C642 /* MobileHostService.swift */,
 				C0DE00000000000000000C8C /* MobileHostService+TicketAuthorization.swift */,
@@ -5020,6 +5037,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE002010 /* FileExplorerDoubleClickActionTests.swift */,
 				FE002003 /* FileSearchRipgrepParserTests.swift */,
 				9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */,
+				C1F0042BC1F0042BC1F0042B /* MobileHostIrohSecretKeyTests.swift */,
 				C0DE73840000000000000002 /* MobileHostWorkspaceTicketAuthorizationTests.swift */,
 				B8B056D80000000000000002 /* MobileHostIdentityTests.swift */,
 				5E2701030000000000000002 /* SentryEventScrubberTests.swift */,
@@ -5940,6 +5958,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEA7710000000000000009 /* MobileConnectTitlebarAccessory.swift in Sources */,
 				C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */,
 				C1F00410C1F00410C1F00410 /* MobileHostByteConnection.swift in Sources */,
+				C1F00426C1F00426C1F00426 /* MobileHostIrohConnectionAdapter.swift in Sources */,
+				C1F00420C1F00420C1F00420 /* MobileHostIrohFFI.swift in Sources */,
+				C1F00428C1F00428C1F00428 /* MobileHostIrohFlag.swift in Sources */,
+				C1F00424C1F00424C1F00424 /* MobileHostIrohRoute.swift in Sources */,
+				C1F00422C1F00422C1F00422 /* MobileHostIrohSecretKeyStore.swift in Sources */,
 				DE71CE000000000000000008 /* MobileHostNetworkPathMonitor.swift in Sources */,
 				C1F00412C1F00412C1F00412 /* MobileHostNWConnectionAdapter.swift in Sources */,
 				4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */,
@@ -6833,6 +6856,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */,
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
 				B8B056D80000000000000001 /* MobileHostIdentityTests.swift in Sources */,
+				C1F0042AC1F0042AC1F0042A /* MobileHostIrohSecretKeyTests.swift in Sources */,
 				DE71CE000000000000000006 /* MobileHostNetworkPathRefreshTests.swift in Sources */,
 				C0DE10510000000000000001 /* MobileHostServiceSettingsTests.swift in Sources */,
 				4C1A7E10B2D34F56A8C90013 /* MobileHostStatusVerificationLimiterTests.swift in Sources */,
@@ -7153,6 +7177,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7187,6 +7215,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				SPARKLE_PUBLIC_KEY = "avjcgKibf1FTvhIjLBxhd+0HSpsXU4D0IGlVk8cgqRc=";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_ENABLE_BATCH_MODE = NO;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				SWIFT_OBJC_BRIDGING_HEADER = "cmux-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
@@ -7205,6 +7237,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DEVELOPMENT_TEAM = "";
 				ENABLE_HARDENED_RUNTIME = NO;
 				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				INFOPLIST_FILE = Resources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -7235,6 +7271,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				PRODUCT_NAME = cmux;
 				SPARKLE_PUBLIC_KEY = "avjcgKibf1FTvhIjLBxhd+0HSpsXU4D0IGlVk8cgqRc=";
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				SWIFT_OBJC_BRIDGING_HEADER = "cmux-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
 			};
@@ -7352,12 +7392,20 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 97;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.64.17;
 				ONLY_ACTIVE_ARCH = YES;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/cmux DEV.app/Contents/MacOS/cmux DEV";
 				TEST_TARGET_NAME = cmux;
@@ -7371,11 +7419,19 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 97;
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
 				MARKETING_VERSION = 0.64.17;
 				ONLY_ACTIVE_ARCH = NO;
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.apptests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/native/cmux-iroh/include",
+				);
 				SWIFT_VERSION = 5.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/cmux.app/Contents/MacOS/cmux";
 				TEST_TARGET_NAME = cmux;

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -865,9 +865,11 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DEA7710000000000000009 /* MobileConnectTitlebarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEA771000000000000000A /* MobileConnectTitlebarAccessory.swift */; };
 		6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */; };
 		C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */; };
+		C1F00410C1F00410C1F00410 /* MobileHostByteConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00411C1F00411C1F00411 /* MobileHostByteConnection.swift */; };
 		B8B056D80000000000000001 /* MobileHostIdentityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8B056D80000000000000002 /* MobileHostIdentityTests.swift */; };
 		DE71CE000000000000000008 /* MobileHostNetworkPathMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE71CE000000000000000007 /* MobileHostNetworkPathMonitor.swift */; };
 		DE71CE000000000000000006 /* MobileHostNetworkPathRefreshTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE71CE000000000000000005 /* MobileHostNetworkPathRefreshTests.swift */; };
+		C1F00412C1F00412C1F00412 /* MobileHostNWConnectionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1F00413C1F00413C1F00413 /* MobileHostNWConnectionAdapter.swift */; };
 		4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */; };
 		C7A50B000000000000000014 /* MobileHostService+Capabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000013 /* MobileHostService+Capabilities.swift */; };
 		C0DE00000000000000000C8D /* MobileHostService+TicketAuthorization.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C8C /* MobileHostService+TicketAuthorization.swift */; };
@@ -2508,9 +2510,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DEA771000000000000000A /* MobileConnectTitlebarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileConnectTitlebarAccessory.swift; sourceTree = "<group>"; };
 		9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostAuthorizationTests.swift; sourceTree = "<group>"; };
 		C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostBuildIdentity.swift; sourceTree = "<group>"; };
+		C1F00411C1F00411C1F00411 /* MobileHostByteConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostByteConnection.swift; sourceTree = "<group>"; };
 		B8B056D80000000000000002 /* MobileHostIdentityTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIdentityTests.swift; sourceTree = "<group>"; };
 		DE71CE000000000000000007 /* MobileHostNetworkPathMonitor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostNetworkPathMonitor.swift; sourceTree = "<group>"; };
 		DE71CE000000000000000005 /* MobileHostNetworkPathRefreshTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostNetworkPathRefreshTests.swift; sourceTree = "<group>"; };
+		C1F00413C1F00413C1F00413 /* MobileHostNWConnectionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostNWConnectionAdapter.swift; sourceTree = "<group>"; };
 		47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostRPC.swift; sourceTree = "<group>"; };
 		C7A50B000000000000000013 /* MobileHostService+Capabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileHostService+Capabilities.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C8C /* MobileHostService+TicketAuthorization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "MobileHostService+TicketAuthorization.swift"; sourceTree = "<group>"; };
@@ -3484,6 +3488,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			children = (
 				8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */,
 				47BDC06F004C02A52B05E4A0 /* MobileHostRPC.swift */,
+				C1F00411C1F00411C1F00411 /* MobileHostByteConnection.swift */,
+				C1F00413C1F00413C1F00413 /* MobileHostNWConnectionAdapter.swift */,
 				7ACA497A6831165EA879C642 /* MobileHostService.swift */,
 				C0DE00000000000000000C8C /* MobileHostService+TicketAuthorization.swift */,
 				C7A50B000000000000000021 /* MobileHostTerminalTheme.swift */,
@@ -5933,7 +5939,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				284FD21ACF8BD1ED6AEBD7A0 /* MobileAttachTicketStore.swift in Sources */,
 				C0DEA7710000000000000009 /* MobileConnectTitlebarAccessory.swift in Sources */,
 				C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */,
+				C1F00410C1F00410C1F00410 /* MobileHostByteConnection.swift in Sources */,
 				DE71CE000000000000000008 /* MobileHostNetworkPathMonitor.swift in Sources */,
+				C1F00412C1F00412C1F00412 /* MobileHostNWConnectionAdapter.swift in Sources */,
 				4E673EDE464BF3AB80E94C1D /* MobileHostRPC.swift in Sources */,
 				C7A50B000000000000000014 /* MobileHostService+Capabilities.swift in Sources */,
 				C0DE00000000000000000C8D /* MobileHostService+TicketAuthorization.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -463,7 +463,6 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
-		C1F00100C1F00100C1F00100 /* CmuxIrohFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1F00101C1F00101C1F00101 /* CmuxIrohFFI.xcframework */; };
 		E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */; };
 		2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C07000000000000000001 /* CmuxMainWindow.swift */; };
 		D36090010000000000000005 /* CmuxMainWindowConstrainFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */; };
@@ -3303,7 +3302,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A2C00000000000000000C3 /* CmuxFeedback in Frameworks */,
 				CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */,
 				C617000000000000000000A3 /* CmuxGit in Frameworks */,
-				C1F00100C1F00100C1F00100 /* CmuxIrohFFI.xcframework in Frameworks */,
 				799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */,
 				E3B7A30000000000000000D3 /* CmuxNotifications in Frameworks */,
 				E3B7A30000000000000000F3 /* CmuxPanes in Frameworks */,
@@ -7186,6 +7184,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/CmuxIrohFFI.xcframework/macos-arm64_x86_64",
+				);
 				MARKETING_VERSION = 0.64.17;
 				OTHER_LDFLAGS = (
 					"-lc++",
@@ -7205,6 +7207,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					CoreWLAN,
 					"-framework",
 					Security,
+					"-lcmux_iroh_ffi",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.app.debug;
 				PRODUCT_NAME = "cmux DEV";
@@ -7246,6 +7249,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/CmuxIrohFFI.xcframework/macos-arm64_x86_64",
+				);
 				MARKETING_VERSION = 0.64.17;
 				ONLY_ACTIVE_ARCH = NO;
 				OTHER_LDFLAGS = (
@@ -7266,6 +7273,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					CoreWLAN,
 					"-framework",
 					Security,
+					"-lcmux_iroh_ffi",
 				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.cmuxterm.app;
 				PRODUCT_NAME = cmux;

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -215,6 +215,77 @@ struct MobileHostAuthorizationTests {
         }
         #expect(snapshot.routes.filter { $0.kind == .debugLoopback }.count == 1)
     }
+
+    @Test func testMobileRouteResolverMintsIrohAheadOfTailscale() throws {
+        let resolver = MobileRouteResolver()
+        let irohRoute = try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                id: "peer-abcdef",
+                relayHint: nil,
+                directAddrs: ["192.0.2.10:443"],
+                relayURL: "https://relay.example.com"
+            ),
+            priority: 5
+        )
+        let snapshot = resolver.routes(
+            port: 61234,
+            irohRoute: irohRoute,
+            tailscaleHosts: ["100.71.210.41"]
+        )
+
+        let iroh = try #require(snapshot.routes.first { $0.kind == .iroh })
+        #expect(iroh.priority == 5)
+        #expect(snapshot.routes.first { $0.kind == .tailscale }?.priority == 10)
+        #expect(snapshot.routes.filter { $0.kind == .iroh }.count == 1)
+        let preferred = snapshot.routes
+            .filter { $0.kind == .iroh || $0.kind == .tailscale }
+            .sorted { $0.priority < $1.priority }
+            .first
+        #expect(preferred?.kind == .iroh)
+    }
+
+    @Test func testMobileRouteResolverOmitsIrohWhenNoEndpointRouteIsAvailable() throws {
+        let resolver = MobileRouteResolver()
+        let snapshot = resolver.routes(
+            port: 61234,
+            irohRoute: nil,
+            tailscaleHosts: ["100.71.210.41"]
+        )
+        #expect(snapshot.routes.contains { $0.kind == .tailscale })
+        #expect(!snapshot.routes.contains { $0.kind == .iroh })
+    }
+
+    @Test func testMobilePairingSnapshotShowsPeerRoutes() throws {
+        let status = MobileHostServiceStatus(
+            isRunning: true,
+            port: 61234,
+            configuredPort: 61234,
+            usesEphemeralFallback: false,
+            routes: [
+                try CmxAttachRoute(
+                    id: "iroh",
+                    kind: .iroh,
+                    endpoint: .peer(
+                        id: "peer-abcdef1234567890",
+                        relayHint: nil,
+                        directAddrs: [],
+                        relayURL: "https://relay.example.com/path"
+                    ),
+                    priority: 5
+                ),
+            ],
+            activeConnectionCount: 0,
+            lastErrorDescription: nil
+        )
+
+        let snapshot = HostSettingsActions.mobilePairingSnapshot(from: status)
+        let route = try #require(snapshot.routes.first)
+        #expect(route.kindLabel == String(localized: "settings.mobile.route.iroh", defaultValue: "Iroh"))
+        #expect(route.endpoint == "peer-abcdef1 - relay.example.com")
+    }
+
     @Test func testMobileRouteResolverAwaitsMagicDNSForPublicStatusRoutes() async throws {
         let resolver = MobileRouteResolver()
         let snapshot = await resolver.routesResolvingTailscaleDNS(

--- a/cmuxTests/MobileHostIrohSecretKeyTests.swift
+++ b/cmuxTests/MobileHostIrohSecretKeyTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Mobile host iroh secret key")
+struct MobileHostIrohSecretKeyTests {
+    private let keyLength = 32
+
+    @Test func providerPersistsGeneratedKeyAndReusesIt() throws {
+        let store = InMemorySecretKeyStore()
+        let counter = LockedCounter()
+        let generated = Data((0..<keyLength).map { UInt8($0) })
+        let provider = MobileHostIrohSecretKeyProvider(
+            store: store,
+            generate: {
+                counter.increment()
+                return generated
+            }
+        )
+
+        let first = try provider.secretKey()
+        let second = try provider.secretKey()
+
+        #expect(first == generated)
+        #expect(second == generated)
+        #expect(counter.value == 1)
+        #expect(store.savedKey == generated)
+    }
+
+    @Test func providerRejectsInvalidStoredLength() throws {
+        let store = InMemorySecretKeyStore(initialKey: Data([1, 2, 3]))
+        let provider = MobileHostIrohSecretKeyProvider(
+            store: store,
+            generate: {
+                Issue.record("generate should not run when an invalid stored key exists")
+                return Data(repeating: 0, count: keyLength)
+            }
+        )
+
+        #expect(throws: MobileHostIrohSecretKeyStoreError.invalidLength(3)) {
+            try provider.secretKey()
+        }
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+}
+
+private final class InMemorySecretKeyStore: MobileHostIrohSecretKeyStoring, @unchecked Sendable {
+    private let lock = NSLock()
+    private var key: Data?
+
+    init(initialKey: Data? = nil) {
+        key = initialKey
+    }
+
+    var savedKey: Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return key
+    }
+
+    func loadSecretKey() throws -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return key
+    }
+
+    func saveSecretKey(_ key: Data) throws {
+        lock.lock()
+        self.key = key
+        lock.unlock()
+    }
+}

--- a/cmuxTests/MobilePairingConnectionTransitionTests.swift
+++ b/cmuxTests/MobilePairingConnectionTransitionTests.swift
@@ -16,6 +16,7 @@ struct MobilePairingConnectionTransitionTests {
             attachURL: "cmux-ios://attach?ticket=abc",
             macName: "Test Mac",
             tailscaleLines: ["100.64.0.1:7777"],
+            hasIrohRoute: false,
             manualEntry: CmxManualPairingEntry(host: "100.64.0.1", port: 7777)
         )
     }
@@ -102,5 +103,49 @@ struct MobilePairingConnectionTransitionTests {
             baselineConnectionCount: 0
         )
         #expect(next == .signedOut)
+    }
+
+    @Test("Iroh-only routes are reachable for QR pairing")
+    func irohOnlyRouteIsReachableForPairing() throws {
+        let route = try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                id: "peer-abcdef",
+                relayHint: nil,
+                directAddrs: [],
+                relayURL: "https://relay.example.com"
+            ),
+            priority: 5
+        )
+        #expect(MobilePairingModel.isPhoneReachableRoute(route))
+
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "mac",
+            macDisplayName: nil,
+            routes: [route]
+        )
+        let url = try #require(CmxPairingQRCode().encode(ticket))
+        #expect(CmxPairingQRCode().isPairingCodeURLString(url))
+    }
+
+    @Test("Loopback-only routes leave pairing in the no-route guidance path")
+    func loopbackOnlyRouteIsNotReachableForPairing() throws {
+        let route = try CmxAttachRoute(
+            id: "debug_loopback",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: 58465)
+        )
+        #expect(!MobilePairingModel.isPhoneReachableRoute(route))
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "mac",
+            macDisplayName: nil,
+            routes: [route]
+        )
+        #expect(CmxPairingQRCode().encode(ticket) == nil)
     }
 }

--- a/native/cmux-iroh/include/module.modulemap
+++ b/native/cmux-iroh/include/module.modulemap
@@ -1,0 +1,4 @@
+module CmuxIrohFFI {
+  header "cmux_iroh_ffi.h"
+  export *
+}


### PR DESCRIPTION
Implements delivery-plan step 4 of https://github.com/manaflow-ai/cmux/blob/main/plans/feat-ios-iroh/DESIGN.md, stacked on https://github.com/manaflow-ai/cmux/pull/7819.

Commit 1 is a pure refactor: extracts a `MobileHostByteConnection` protocol from `MobileHostService`'s three direct NWConnection touch points, with an NWConnection adapter and zero behavior change. Commit 2 adds the iroh lane: a long-lived endpoint on ALPN `dev.cmux.mobile.terminal/0` behind the same mobile.iOSPairingHost opt-in gates (no endpoint before opt-in), Keychain secret-key custody for a stable EndpointId, iroh route minting in `MobileRouteResolver` at priority 5 (beats tailscale's 10+, loses to DEBUG loopback's 0), QR grammar extension so pairing codes carry the iroh peer route with tailscale fallback (legacy tailscale-only QRs still decode; loopback still rejected; route-count cap extended), the pairing window mints a QR on a Mac with no Tailscale (needsTailscale refusal replaced; guidance retained only when both lanes are unavailable), and `.peer` routes visible in Settings mobile diagnostics.

Verified: CMUXMobileCore 148 tests, CmuxSettingsUI 96 tests, pbxproj test-wiring lint (418 files), cmux-unit build-for-testing + cmux app tagged compile, cargo FFI bind/connect/echo test, localization audit (new Mac strings en+ja). Registry/web guard rails inspected: manual-route enforcement is scoped to manual tailscale routes; registry-published routes are opaque JSON, so iroh routes pass through with no web change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786263768&installation_id=133855650&pr_number=7830&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7830&signature=4a3e063a7e9f3dd7f09c773213259a17a08bf089de3919811cd0797236e6e1e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core mobile pairing connectivity (new FFI accept loop, Keychain secret key, QR grammar v3) and shared connection handling; regressions could block pairing or mis-route phones, though legacy v2 QRs and the NW path are preserved.
> 
> **Overview**
> Adds an **iroh transport lane** on the Mac mobile host so iPhones can pair without Tailscale when iroh is available. Behind `CMUX_MOBILE_IROH_TRANSPORT` / `mobileIrohTransport` (on by default in DEBUG), the host binds a long-lived iroh endpoint via `CmuxIrohFFI`, keeps a stable peer id in Keychain, accepts connections through the same RPC path as TCP, and publishes an iroh route at **priority 5** ahead of Tailscale fallbacks.
> 
> **Pairing QR grammar moves to v3** (`v=3`): optional `i` / `u` / `d` for the iroh peer plus existing `r=` Tailscale routes; **v2 tailscale-only QRs still decode**. Reachability and minting now treat iroh peers as phone-dialable; the pairing UI replaces **needsTailscale** with **no reachable route** when neither iroh nor Tailscale is available, with new en/ja copy and a “connection route” checklist.
> 
> Refactors **`MobileHostConnection`** onto a **`MobileHostByteConnection`** protocol with NW and iroh adapters (no intended NW behavior change). Settings diagnostics show **peer** routes via a preformatted endpoint on `MobilePairingRoute`. Xcode links **`libcmux_iroh_ffi`** directly with a local module map instead of the xcframework in Frameworks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 733ebb7cd3bb8bbaa951c91226462e3aa9a35dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a new Mac iroh transport lane for mobile pairing. It mints and prefers iroh peer routes, upgrades the QR grammar to v3, enables pairing without Tailscale, and includes the P3 replay ownership fix.

- **New Features**
  - Added a long‑lived iroh endpoint with ALPN `dev.cmux.mobile.terminal/0`, accept loop via `CmuxIrohFFI`, gated by `CMUX_MOBILE_IROH_TRANSPORT` or `mobileIrohTransport`.
  - Introduced Keychain‑backed 32‑byte secret key custody for a stable iroh endpoint/peer ID.
  - Minted iroh route at priority 5 (above Tailscale), surfaced in Settings diagnostics (peer endpoints) and used by the pairing flow.
  - Upgraded pairing QR to v3: includes iroh peer route (`i`, `u`, `d`) with Tailscale fallback (`r`); legacy v2 QRs still decode; loopback still rejected; higher route cap.
  - Pairing UI shows a QR on Macs without Tailscale when iroh is available, with a new “no reachable route” state when neither lane exists. Added localized strings (en/ja).

- **Refactors**
  - Extracted `MobileHostByteConnection` with `NWConnection` and iroh adapters; no behavior change to the NW path.
  - Updated `MobileRouteResolver` to accept an optional iroh route and sort by priority; `MobilePairingRoute` supports preformatted non‑host endpoints.
  - Fixed `CmuxIrohFFI` modulemap build collision by linking the macOS static slice directly and removing the xcframework from the app Frameworks phase; added a local `module.modulemap` under `native/cmux-iroh/include`.

<sup>Written for commit 733ebb7cd3bb8bbaa951c91226462e3aa9a35dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7830?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

