### PR TITLE
Return tab to plain terminal icon when a live agent session exits

### DIFF
--- a/Sources/TerminalTabAgentIcon.swift
+++ b/Sources/TerminalTabAgentIcon.swift
@@ -351,7 +351,11 @@ extension Workspace {
         // is recorded shows the generic terminal icon; fixing that means
         // carrying the registration into live agent state at the lifecycle
         // recording boundary (TerminalController), not loading config here.
-        let snapshot = restoredAgentSnapshotsByPanelId[panelId]
+        // A `.recordedSessionOnly` snapshot stays resumable but is known not
+        // to be running here, so it must not brand the tab (#7822).
+        let snapshot = restoredAgentResumeStatesByPanelId[panelId] == .recordedSessionOnly
+            ? nil
+            : restoredAgentSnapshotsByPanelId[panelId]
         let registration = snapshot?.registration
         return TerminalTabAgentIconResolver().assetName(
             liveAgents: liveAgents,
@@ -421,14 +425,17 @@ extension DockSplitStore {
     func terminalTabAgentIconAsset(forPanelId panelId: UUID) -> String? {
         let transfer = detachedSurfaceTransfersByPanelId[panelId]
         let registration = transfer?.restorableAgent?.registration
+        let restorableAgentBrandsTab = transfer?.restorableAgentResumeState != .recordedSessionOnly
         return TerminalTabAgentIconResolver().assetName(
             agentPIDKeys: transfer?.agentRuntime?.agentPIDKeys ?? [],
             processIdentities: transfer?.agentRuntime?.agentPIDProcessIdentities ?? [:],
             knownStatusKeys: transfer?.agentRuntime.map { Set($0.statusEntries.keys) } ?? [],
             titleDerivedStatusKey: titleDerivedAgentStatusKeysByPanelId[panelId],
-            restoredAgent: transfer?.restorableAgent.map(
-                TerminalTabAgentIconResolver.RestoredAgent.init(snapshot:)
-            ),
+            restoredAgent: restorableAgentBrandsTab
+                ? transfer?.restorableAgent.map(
+                    TerminalTabAgentIconResolver.RestoredAgent.init(snapshot:)
+                )
+                : nil,
             registrationIconAssetName: { statusKey in
                 registration?.id == statusKey ? registration?.iconAssetName : nil
             }

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -148,14 +148,20 @@ extension Workspace {
     @discardableResult
     func clearStaleAgentPIDs(refreshPorts: Bool = true) -> Bool {
         var didChange = false
+        var prunedPanelIds: Set<UUID> = []
         for (key, pid) in agentPIDs where !isRecordedAgentPIDLive(key: key, pid: pid) {
+            let ownedPanelId = agentPIDPanelIdsByKey[key]
             if clearAgentPID(key: key, clearStatus: true, refreshPorts: false) {
                 didChange = true
+                if let ownedPanelId { prunedPanelIds.insert(ownedPanelId) }
             }
         }
         if didChange {
             if refreshPorts { refreshTrackedAgentPorts() }
             AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id)
+            for panelId in prunedPanelIds {
+                invalidateRestoredAgentSnapshotForProvenAgentExit(panelId: panelId)
+            }
         }
         return didChange
     }
@@ -179,6 +185,7 @@ extension Workspace {
         if didChange {
             if refreshPorts { refreshTrackedAgentPorts() }
             AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
+            invalidateRestoredAgentSnapshotForProvenAgentExit(panelId: panelId)
         }
         return didChange
     }

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -160,7 +160,7 @@ extension Workspace {
             if refreshPorts { refreshTrackedAgentPorts() }
             AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id)
             for panelId in prunedPanelIds {
-                invalidateRestoredAgentSnapshotForProvenAgentExit(panelId: panelId)
+                downgradeRestoredAgentSnapshotForProvenAgentExit(panelId: panelId)
             }
         }
         return didChange
@@ -185,7 +185,7 @@ extension Workspace {
         if didChange {
             if refreshPorts { refreshTrackedAgentPorts() }
             AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: id, surfaceId: panelId)
-            invalidateRestoredAgentSnapshotForProvenAgentExit(panelId: panelId)
+            downgradeRestoredAgentSnapshotForProvenAgentExit(panelId: panelId)
         }
         return didChange
     }

--- a/Sources/Workspace+RestoredAgentLifecycle.swift
+++ b/Sources/Workspace+RestoredAgentLifecycle.swift
@@ -2,26 +2,23 @@ import Foundation
 
 /// Lifecycle rules for a panel's restored (resumable) agent snapshot.
 ///
-/// The snapshot drives the tab's agent brand icon, fork availability, and the
-/// restorable agent persisted for app relaunch, so its lifetime must track the
-/// invariant behind https://github.com/manaflow-ai/cmux/issues/7822: a
-/// plain-shell tab with no live agent and no pending restore shows the plain
-/// terminal icon. Two rules enforce that here, for every agent kind:
-///
-/// - A snapshot may only be adopted from the persist-time hook index while
-///   there is evidence the session is current (recorded agent runtime or a
-///   running foreground command). Restore, hibernation, and Dock-detach
-///   seeding are the only other ways in.
-/// - Proof that a panel's recorded agent process died is an agent exit
-///   signal, equivalent to the shell-activity machine observing the exit, and
-///   invalidates the snapshot.
+/// The snapshot serves two roles with different lifetimes. As the *recorded
+/// session* it must survive an agent exit: session persistence, manual resume
+/// after relaunch, and conversation forking all rely on it (auto-resume is
+/// separately suppressed via `wasAgentRunning`). As the *icon signal* it must
+/// not survive an agent exit: a plain-shell tab with no live agent and no
+/// pending restore shows the plain terminal icon (#7822), for every agent
+/// kind. `RestoredAgentResumeState.recordedSessionOnly` carries that
+/// distinction: it keeps the snapshot while telling the icon resolver the
+/// agent is known not to be running here.
 extension Workspace {
     /// Reconciles a persist-time indexed restorable-agent snapshot into the
     /// panel's in-memory restored-agent state. An invalidated fingerprint (an
-    /// observed agent exit) clears instead of re-adopting, and a panel with no
-    /// restored snapshot only adopts one while the agent is plausibly running
-    /// there. Without that gate, a persist running after the user quit the
-    /// agent would repaint the agent brand icon on a plain shell tab.
+    /// observed agent exit followed by a new foreground command) clears
+    /// instead of re-adopting. A fresh adoption's resume state records
+    /// whether the agent is plausibly the running foreground command; without
+    /// that provenance, a persist running after the user quit the agent would
+    /// repaint the agent brand icon on a plain shell tab.
     func adoptIndexedRestorableAgentSnapshot(
         _ snapshot: SessionRestorableAgentSnapshot,
         panelId: UUID
@@ -30,12 +27,6 @@ extension Workspace {
         guard invalidatedRestoredAgentFingerprintsByPanelId[panelId] != fingerprint else {
             clearRestoredAgentSnapshot(panelId: panelId)
             return
-        }
-        if restoredAgentSnapshotsByPanelId[panelId] == nil {
-            guard !(agentPIDKeysByPanelId[panelId] ?? []).isEmpty
-                || panelShellActivityStates[panelId] == .commandRunning else {
-                return
-            }
         }
         restoredAgentSnapshotsByPanelId[panelId] = snapshot
         if restoredAgentResumeStatesByPanelId[panelId] == nil {
@@ -47,27 +38,41 @@ extension Workspace {
         syncTerminalTabAgentIconAsset(forPanelId: panelId)
     }
 
+    /// Adoption provenance: only a running foreground command makes the
+    /// adopted session an "observed running agent". Anything else — an idle
+    /// prompt after the user quit the agent, or an unknown shell state — is a
+    /// recorded session whose icon relevance is owned by live agent runtime,
+    /// not by this snapshot. Seeded restore paths assign
+    /// `.manualResumeAvailable` themselves and never come through here.
     func restoredAgentResumeStateForAcceptedSnapshot(panelId: UUID) -> RestoredAgentResumeState {
         panelShellActivityStates[panelId] == .commandRunning
             ? .observedAgentCommandRunning
-            : .manualResumeAvailable
+            : .recordedSessionOnly
     }
 
     /// A stale-agent prune proved that an agent process recorded for this
     /// panel died, so the panel's restorable snapshot no longer describes a
-    /// running session: invalidate it and return the tab to the plain terminal
-    /// icon, exactly as the shell-activity machine does when it observes the
-    /// exit. A queued auto-resume and a hibernated panel keep their snapshot
-    /// (their recorded runtime describes a previous run, not the pending
-    /// resume), and remote workspaces are skipped because local process
-    /// liveness proves nothing about a remote agent.
-    func invalidateRestoredAgentSnapshotForProvenAgentExit(panelId: UUID) {
+    /// running session: downgrade it to `.recordedSessionOnly` so the tab
+    /// returns to the plain terminal icon while the session stays recorded
+    /// for manual resume, relaunch persistence, and forking. Pending
+    /// auto-resume states keep their snapshot untouched (their recorded
+    /// runtime describes a previous run, not the pending resume), hibernated
+    /// panels keep their deliberate brand mark, and remote workspaces are
+    /// skipped because local process liveness proves nothing about a remote
+    /// agent.
+    func downgradeRestoredAgentSnapshotForProvenAgentExit(panelId: UUID) {
         guard !isRemoteWorkspace,
-              let snapshot = restoredAgentSnapshotsByPanelId[panelId],
-              restoredAgentResumeStatesByPanelId[panelId] != .awaitingAutoResumeCommand,
+              restoredAgentSnapshotsByPanelId[panelId] != nil,
               (panels[panelId] as? TerminalPanel)?.isAgentHibernated != true else {
             return
         }
-        invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: snapshot)
+        switch restoredAgentResumeStatesByPanelId[panelId] {
+        case .some(.awaitingAutoResumeCommand), .some(.autoResumeCommandRunning),
+             .some(.recordedSessionOnly):
+            return
+        case .some(.manualResumeAvailable), .some(.observedAgentCommandRunning), nil:
+            restoredAgentResumeStatesByPanelId[panelId] = .recordedSessionOnly
+            syncTerminalTabAgentIconAsset(forPanelId: panelId)
+        }
     }
 }

--- a/Sources/Workspace+RestoredAgentLifecycle.swift
+++ b/Sources/Workspace+RestoredAgentLifecycle.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// Lifecycle rules for a panel's restored (resumable) agent snapshot.
+///
+/// The snapshot drives the tab's agent brand icon, fork availability, and the
+/// restorable agent persisted for app relaunch, so its lifetime must track the
+/// invariant behind https://github.com/manaflow-ai/cmux/issues/7822: a
+/// plain-shell tab with no live agent and no pending restore shows the plain
+/// terminal icon. Two rules enforce that here, for every agent kind:
+///
+/// - A snapshot may only be adopted from the persist-time hook index while
+///   there is evidence the session is current (recorded agent runtime or a
+///   running foreground command). Restore, hibernation, and Dock-detach
+///   seeding are the only other ways in.
+/// - Proof that a panel's recorded agent process died is an agent exit
+///   signal, equivalent to the shell-activity machine observing the exit, and
+///   invalidates the snapshot.
+extension Workspace {
+    /// Reconciles a persist-time indexed restorable-agent snapshot into the
+    /// panel's in-memory restored-agent state. An invalidated fingerprint (an
+    /// observed agent exit) clears instead of re-adopting, and a panel with no
+    /// restored snapshot only adopts one while the agent is plausibly running
+    /// there. Without that gate, a persist running after the user quit the
+    /// agent would repaint the agent brand icon on a plain shell tab.
+    func adoptIndexedRestorableAgentSnapshot(
+        _ snapshot: SessionRestorableAgentSnapshot,
+        panelId: UUID
+    ) {
+        let fingerprint = TabManager.restorableAgentSnapshotFingerprint(snapshot)
+        guard invalidatedRestoredAgentFingerprintsByPanelId[panelId] != fingerprint else {
+            clearRestoredAgentSnapshot(panelId: panelId)
+            return
+        }
+        if restoredAgentSnapshotsByPanelId[panelId] == nil {
+            guard !(agentPIDKeysByPanelId[panelId] ?? []).isEmpty
+                || panelShellActivityStates[panelId] == .commandRunning else {
+                return
+            }
+        }
+        restoredAgentSnapshotsByPanelId[panelId] = snapshot
+        if restoredAgentResumeStatesByPanelId[panelId] == nil {
+            restoredAgentResumeStatesByPanelId[panelId] = restoredAgentResumeStateForAcceptedSnapshot(
+                panelId: panelId
+            )
+        }
+        invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
+        syncTerminalTabAgentIconAsset(forPanelId: panelId)
+    }
+
+    func restoredAgentResumeStateForAcceptedSnapshot(panelId: UUID) -> RestoredAgentResumeState {
+        panelShellActivityStates[panelId] == .commandRunning
+            ? .observedAgentCommandRunning
+            : .manualResumeAvailable
+    }
+
+    /// A stale-agent prune proved that an agent process recorded for this
+    /// panel died, so the panel's restorable snapshot no longer describes a
+    /// running session: invalidate it and return the tab to the plain terminal
+    /// icon, exactly as the shell-activity machine does when it observes the
+    /// exit. A queued auto-resume and a hibernated panel keep their snapshot
+    /// (their recorded runtime describes a previous run, not the pending
+    /// resume), and remote workspaces are skipped because local process
+    /// liveness proves nothing about a remote agent.
+    func invalidateRestoredAgentSnapshotForProvenAgentExit(panelId: UUID) {
+        guard !isRemoteWorkspace,
+              let snapshot = restoredAgentSnapshotsByPanelId[panelId],
+              restoredAgentResumeStatesByPanelId[panelId] != .awaitingAutoResumeCommand,
+              (panels[panelId] as? TerminalPanel)?.isAgentHibernated != true else {
+            return
+        }
+        invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: snapshot)
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2350,6 +2350,14 @@ final class Workspace: Identifiable, ObservableObject {
         case awaitingAutoResumeCommand
         case autoResumeCommandRunning
         case observedAgentCommandRunning
+        /// The session is recorded and resumable (persisted for relaunch,
+        /// forkable, manually resumable) but the agent is known not to be
+        /// running in this panel right now — either the persist-time adoption
+        /// happened while no command was running, or a recorded agent process
+        /// was proven dead. Unlike the seeded `.manualResumeAvailable`, this
+        /// state must not drive the tab's agent brand icon: the panel is a
+        /// plain shell (#7822).
+        case recordedSessionOnly
     }
     var restoredAgentResumeStatesByPanelId: [UUID: RestoredAgentResumeState] = [:]
     var invalidatedRestoredAgentFingerprintsByPanelId: [UUID: Int] = [:]
@@ -4588,14 +4596,15 @@ final class Workspace: Identifiable, ObservableObject {
                 restoredAgentResumeStatesByPanelId[panelId] = .autoResumeCommandRunning
             case .some(.autoResumeCommandRunning), .some(.observedAgentCommandRunning):
                 break
-            case .some(.manualResumeAvailable), nil:
+            case .some(.manualResumeAvailable), .some(.recordedSessionOnly), nil:
                 invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: restoredAgent)
             }
         case .promptIdle:
             switch restoredAgentResumeStatesByPanelId[panelId] {
             case .some(.autoResumeCommandRunning), .some(.observedAgentCommandRunning):
                 invalidateRestoredAgentSnapshot(panelId: panelId, restoredAgent: restoredAgent)
-            case .some(.awaitingAutoResumeCommand), .some(.manualResumeAvailable), nil:
+            case .some(.awaitingAutoResumeCommand), .some(.manualResumeAvailable),
+                 .some(.recordedSessionOnly), nil:
                 break
             }
         case .unknown:
@@ -4622,7 +4631,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
-    func invalidateRestoredAgentSnapshot(
+    private func invalidateRestoredAgentSnapshot(
         panelId: UUID,
         restoredAgent: SessionRestorableAgentSnapshot
     ) {

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -409,19 +409,7 @@ extension Workspace {
             clearRestoredAgentSnapshot(panelId: panelId)
         }
         if let compatibleRestorableAgent = compatibleIndexedRestorableAgent {
-            let fingerprint = TabManager.restorableAgentSnapshotFingerprint(compatibleRestorableAgent)
-            if invalidatedRestoredAgentFingerprintsByPanelId[panelId] == fingerprint {
-                clearRestoredAgentSnapshot(panelId: panelId)
-            } else {
-                restoredAgentSnapshotsByPanelId[panelId] = compatibleRestorableAgent
-                if restoredAgentResumeStatesByPanelId[panelId] == nil {
-                    restoredAgentResumeStatesByPanelId[panelId] = restoredAgentResumeStateForAcceptedSnapshot(
-                        panelId: panelId
-                    )
-                }
-                invalidatedRestoredAgentFingerprintsByPanelId.removeValue(forKey: panelId)
-                syncTerminalTabAgentIconAsset(forPanelId: panelId)
-            }
+            adoptIndexedRestorableAgentSnapshot(compatibleRestorableAgent, panelId: panelId)
         }
         let hibernationState = (panel as? TerminalPanel)?.agentHibernationState
         let effectiveHibernationState = hibernationState.flatMap { state in
@@ -4588,12 +4576,6 @@ final class Workspace: Identifiable, ObservableObject {
         return didResume
     }
 
-    private func restoredAgentResumeStateForAcceptedSnapshot(panelId: UUID) -> RestoredAgentResumeState {
-        panelShellActivityStates[panelId] == .commandRunning
-            ? .observedAgentCommandRunning
-            : .manualResumeAvailable
-    }
-
     private func updateRestoredAgentResumeState(
         panelId: UUID,
         restoredAgent: SessionRestorableAgentSnapshot,
@@ -4640,7 +4622,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
     }
 
-    private func invalidateRestoredAgentSnapshot(
+    func invalidateRestoredAgentSnapshot(
         panelId: UUID,
         restoredAgent: SessionRestorableAgentSnapshot
     ) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1602,6 +1602,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000006 /* Workspace+FullWidthTab.swift */; };
 		C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
+		C3744E060000000000000001 /* Workspace+RestoredAgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E050000000000000001 /* Workspace+RestoredAgentLifecycle.swift */; };
 		7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */; };
 		D77340010000000000000002 /* Workspace+RemoteTmuxTabOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77340010000000000000001 /* Workspace+RemoteTmuxTabOrder.swift */; };
 		C548600A000000000000001 /* Workspace+SessionRestoreIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C548600A000000000000002 /* Workspace+SessionRestoreIdentity.swift */; };
@@ -3278,6 +3279,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F17F00000000000000000006 /* Workspace+FullWidthTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FullWidthTab.swift"; sourceTree = "<group>"; };
 		C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+LayoutCapture.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
+		C3744E050000000000000001 /* Workspace+RestoredAgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RestoredAgentLifecycle.swift"; sourceTree = "<group>"; };
 		7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTmuxControlTopology.swift"; sourceTree = "<group>"; };
 		D77340010000000000000001 /* Workspace+RemoteTmuxTabOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTmuxTabOrder.swift"; sourceTree = "<group>"; };
 		C548600A000000000000002 /* Workspace+SessionRestoreIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SessionRestoreIdentity.swift"; sourceTree = "<group>"; };
@@ -3961,6 +3963,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F0ACC0DE000000000000000C /* WorkspaceForkAgentConversationAvailability.swift */,
 				F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */,
 				C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */,
+				C3744E050000000000000001 /* Workspace+RestoredAgentLifecycle.swift */,
 				C3744E100000000000000002 /* Workspace+SidebarStatusVisibility.swift */,
 				A6AC73020000000000000002 /* Workspace+AgentLifecycle.swift */,
 				42C2726A34F27E7A43B77368 /* Workspace+CustomSidebarPullRequests.swift */,
@@ -6580,6 +6583,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */,
 				C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
+				C3744E060000000000000001 /* Workspace+RestoredAgentLifecycle.swift in Sources */,
 				7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */,
 				D77340010000000000000002 /* Workspace+RemoteTmuxTabOrder.swift in Sources */,
 				C548600A000000000000001 /* Workspace+SessionRestoreIdentity.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1491,8 +1491,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D3052001000000000000001 /* TerminalSurfaceResizePolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */; };
 		C750500000000000000000B1 /* TerminalSurfaceRuntimeWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */; };
 		A91C0D0E0000000000000002 /* TerminalTabAgentIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0D0E0000000000000001 /* TerminalTabAgentIcon.swift */; };
-		A91C0D0E0000000000000004 /* TerminalTabAgentIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0D0E0000000000000003 /* TerminalTabAgentIconTests.swift */; };
 		A91C0D0E0000000000000006 /* TerminalTabAgentIconRestoredSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0D0E0000000000000005 /* TerminalTabAgentIconRestoredSnapshotTests.swift */; };
+		A91C0D0E0000000000000004 /* TerminalTabAgentIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0D0E0000000000000003 /* TerminalTabAgentIconTests.swift */; };
 		EC010A01 /* TerminalUploadCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010A02 /* TerminalUploadCommand.swift */; };
 		EC010C01 /* TerminalUploadCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010C02 /* TerminalUploadCommandTests.swift */; };
 		5154BEAB50364B86A9E36E4B /* TerminalViewportUITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */; };
@@ -1602,9 +1602,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000006 /* Workspace+FullWidthTab.swift */; };
 		C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */; };
 		C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */; };
-		C3744E060000000000000001 /* Workspace+RestoredAgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E050000000000000001 /* Workspace+RestoredAgentLifecycle.swift */; };
 		7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */; };
 		D77340010000000000000002 /* Workspace+RemoteTmuxTabOrder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77340010000000000000001 /* Workspace+RemoteTmuxTabOrder.swift */; };
+		C3744E060000000000000001 /* Workspace+RestoredAgentLifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E050000000000000001 /* Workspace+RestoredAgentLifecycle.swift */; };
 		C548600A000000000000001 /* Workspace+SessionRestoreIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C548600A000000000000002 /* Workspace+SessionRestoreIdentity.swift */; };
 		C7268002000000000000001 /* Workspace+SidebarDirectories.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7268002000000000000002 /* Workspace+SidebarDirectories.swift */; };
 		C3744E100000000000000001 /* Workspace+SidebarStatusVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E100000000000000002 /* Workspace+SidebarStatusVisibility.swift */; };
@@ -3167,8 +3167,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D3052001000000000000002 /* TerminalSurfaceResizePolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceResizePolicyTests.swift; sourceTree = "<group>"; };
 		C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceRuntimeWiring.swift; sourceTree = "<group>"; };
 		A91C0D0E0000000000000001 /* TerminalTabAgentIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabAgentIcon.swift; sourceTree = "<group>"; };
-		A91C0D0E0000000000000003 /* TerminalTabAgentIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabAgentIconTests.swift; sourceTree = "<group>"; };
 		A91C0D0E0000000000000005 /* TerminalTabAgentIconRestoredSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabAgentIconRestoredSnapshotTests.swift; sourceTree = "<group>"; };
+		A91C0D0E0000000000000003 /* TerminalTabAgentIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabAgentIconTests.swift; sourceTree = "<group>"; };
 		EC010A02 /* TerminalUploadCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalUploadCommand.swift; sourceTree = "<group>"; };
 		EC010C02 /* TerminalUploadCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalUploadCommandTests.swift; sourceTree = "<group>"; };
 		31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalViewportUITestRecorder.swift; sourceTree = "<group>"; };
@@ -3279,9 +3279,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F17F00000000000000000006 /* Workspace+FullWidthTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FullWidthTab.swift"; sourceTree = "<group>"; };
 		C0DE1A050000000000000002 /* Workspace+LayoutCapture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+LayoutCapture.swift"; sourceTree = "<group>"; };
 		C3744E020000000000000001 /* Workspace+PanelLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+PanelLifecycle.swift"; sourceTree = "<group>"; };
-		C3744E050000000000000001 /* Workspace+RestoredAgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RestoredAgentLifecycle.swift"; sourceTree = "<group>"; };
 		7738D0037738D0037738D003 /* Workspace+RemoteTmuxControlTopology.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTmuxControlTopology.swift"; sourceTree = "<group>"; };
 		D77340010000000000000001 /* Workspace+RemoteTmuxTabOrder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RemoteTmuxTabOrder.swift"; sourceTree = "<group>"; };
+		C3744E050000000000000001 /* Workspace+RestoredAgentLifecycle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+RestoredAgentLifecycle.swift"; sourceTree = "<group>"; };
 		C548600A000000000000002 /* Workspace+SessionRestoreIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SessionRestoreIdentity.swift"; sourceTree = "<group>"; };
 		C7268002000000000000002 /* Workspace+SidebarDirectories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SidebarDirectories.swift"; sourceTree = "<group>"; };
 		C3744E100000000000000002 /* Workspace+SidebarStatusVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SidebarStatusVisibility.swift"; sourceTree = "<group>"; };
@@ -6583,9 +6583,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */,
 				C0DE1A050000000000000001 /* Workspace+LayoutCapture.swift in Sources */,
 				C3744E010000000000000001 /* Workspace+PanelLifecycle.swift in Sources */,
-				C3744E060000000000000001 /* Workspace+RestoredAgentLifecycle.swift in Sources */,
 				7738C0037738C0037738C003 /* Workspace+RemoteTmuxControlTopology.swift in Sources */,
 				D77340010000000000000002 /* Workspace+RemoteTmuxTabOrder.swift in Sources */,
+				C3744E060000000000000001 /* Workspace+RestoredAgentLifecycle.swift in Sources */,
 				C548600A000000000000001 /* Workspace+SessionRestoreIdentity.swift in Sources */,
 				C7268002000000000000001 /* Workspace+SidebarDirectories.swift in Sources */,
 				C3744E100000000000000001 /* Workspace+SidebarStatusVisibility.swift in Sources */,
@@ -7167,8 +7167,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D5671101D5671101D5671101 /* TerminalScrollSpeedSettingsFileStoreTests.swift in Sources */,
 				C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */,
 				D3052001000000000000001 /* TerminalSurfaceResizePolicyTests.swift in Sources */,
-				A91C0D0E0000000000000004 /* TerminalTabAgentIconTests.swift in Sources */,
 				A91C0D0E0000000000000006 /* TerminalTabAgentIconRestoredSnapshotTests.swift in Sources */,
+				A91C0D0E0000000000000004 /* TerminalTabAgentIconTests.swift in Sources */,
 				EC010C01 /* TerminalUploadCommandTests.swift in Sources */,
 				C95BAC3D37A6111B487582DC /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift in Sources */,
 				B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1492,6 +1492,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C750500000000000000000B1 /* TerminalSurfaceRuntimeWiring.swift in Sources */ = {isa = PBXBuildFile; fileRef = C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */; };
 		A91C0D0E0000000000000002 /* TerminalTabAgentIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0D0E0000000000000001 /* TerminalTabAgentIcon.swift */; };
 		A91C0D0E0000000000000004 /* TerminalTabAgentIconTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0D0E0000000000000003 /* TerminalTabAgentIconTests.swift */; };
+		A91C0D0E0000000000000006 /* TerminalTabAgentIconRestoredSnapshotTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A91C0D0E0000000000000005 /* TerminalTabAgentIconRestoredSnapshotTests.swift */; };
 		EC010A01 /* TerminalUploadCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010A02 /* TerminalUploadCommand.swift */; };
 		EC010C01 /* TerminalUploadCommandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC010C02 /* TerminalUploadCommandTests.swift */; };
 		5154BEAB50364B86A9E36E4B /* TerminalViewportUITestRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */; };
@@ -3166,6 +3167,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C750500000000000000000B2 /* TerminalSurfaceRuntimeWiring.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSurfaceRuntimeWiring.swift; sourceTree = "<group>"; };
 		A91C0D0E0000000000000001 /* TerminalTabAgentIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabAgentIcon.swift; sourceTree = "<group>"; };
 		A91C0D0E0000000000000003 /* TerminalTabAgentIconTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabAgentIconTests.swift; sourceTree = "<group>"; };
+		A91C0D0E0000000000000005 /* TerminalTabAgentIconRestoredSnapshotTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalTabAgentIconRestoredSnapshotTests.swift; sourceTree = "<group>"; };
 		EC010A02 /* TerminalUploadCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalUploadCommand.swift; sourceTree = "<group>"; };
 		EC010C02 /* TerminalUploadCommandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalUploadCommandTests.swift; sourceTree = "<group>"; };
 		31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = TerminalViewportUITestRecorder.swift; sourceTree = "<group>"; };
@@ -4918,6 +4920,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6342F0C20000000000000001 /* WorkspaceTerminalFocusRecoveryTests.swift */,
 				6047C0DE6047C0DE60470002 /* WorkspaceTerminalTabWorkingDirectoryTests.swift */,
 				A91C0D0E0000000000000003 /* TerminalTabAgentIconTests.swift */,
+				A91C0D0E0000000000000005 /* TerminalTabAgentIconRestoredSnapshotTests.swift */,
 				EF7347934AB1BD387686EE43 /* WorkspaceActionDispatcherTests.swift */,
 				E241BE1D74A7459C8D9C16BC /* WorkspaceTitleProvenanceTests.swift */,
 				F92AB6D1CB714189A8F167E5 /* SetAutoTitleSocketTests.swift */,
@@ -7161,6 +7164,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE53360000000000000001 /* TerminalSearchOverlayMouseReleaseTests.swift in Sources */,
 				D3052001000000000000001 /* TerminalSurfaceResizePolicyTests.swift in Sources */,
 				A91C0D0E0000000000000004 /* TerminalTabAgentIconTests.swift in Sources */,
+				A91C0D0E0000000000000006 /* TerminalTabAgentIconRestoredSnapshotTests.swift in Sources */,
 				EC010C01 /* TerminalUploadCommandTests.swift in Sources */,
 				C95BAC3D37A6111B487582DC /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift in Sources */,
 				B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */,

--- a/cmuxTests/TerminalTabAgentIconRestoredSnapshotTests.swift
+++ b/cmuxTests/TerminalTabAgentIconRestoredSnapshotTests.swift
@@ -53,9 +53,12 @@ struct TerminalTabAgentIconRestoredSnapshotTests {
         #expect(workspace.updatePanelTitle(panelId: panel.id, title: "~/manaflow/cmuxterm-hq"))
 
         #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == nil)
-        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) == nil)
         #expect(workspace.bonsplitController.tab(tabId)?.iconImageData == nil)
         #expect(workspace.bonsplitController.tab(tabId)?.iconAsset == nil)
+        // The exited session stays recorded: manual resume, forking, and
+        // relaunch persistence must survive the icon reverting.
+        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) != nil)
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panel.id] == .recordedSessionOnly)
     }
 
     /// Ordering variant of the same exit: the shell already reported an idle
@@ -73,10 +76,14 @@ struct TerminalTabAgentIconRestoredSnapshotTests {
             panelId: panel.id,
             sessionId: "7b7b7b7b-8c8c-9d9d-0e0e-1f1f1f1f1f1f"
         )
-        _ = workspace.sessionSnapshot(includeScrollback: false, restorableAgentIndex: index)
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false, restorableAgentIndex: index)
 
         #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == nil)
-        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) == nil)
+        // Adoption still records the exited session — persisted for manual
+        // resume after relaunch — it just may not brand the tab.
+        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) != nil)
+        #expect(workspace.restoredAgentResumeStatesByPanelId[panel.id] == .recordedSessionOnly)
+        #expect(snapshot.panels.first { $0.id == panel.id }?.terminal?.agent != nil)
     }
 
     /// A session persist while the agent is the foreground command must keep

--- a/cmuxTests/TerminalTabAgentIconRestoredSnapshotTests.swift
+++ b/cmuxTests/TerminalTabAgentIconRestoredSnapshotTests.swift
@@ -1,0 +1,207 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Regression coverage for https://github.com/manaflow-ai/cmux/issues/7822:
+/// quitting a live agent session back to a plain shell must return the tab to
+/// the plain terminal icon — for every agent brand — while app-relaunch
+/// restored panels and pending auto-resume panels keep their brand mark.
+@MainActor
+struct TerminalTabAgentIconRestoredSnapshotTests {
+    private func agentSnapshot(
+        kind: RestorableAgentKind,
+        sessionId: String = "1a1a1a1a-2b2b-3c3c-4d4d-5e5e5e5e5e5e"
+    ) -> SessionRestorableAgentSnapshot {
+        SessionRestorableAgentSnapshot(
+            kind: kind,
+            sessionId: sessionId,
+            workingDirectory: "/tmp/cmux-agent-icon-tests",
+            launchCommand: nil
+        )
+    }
+
+    /// The user repro: an agent runs live in the panel (recorded runtime plus
+    /// the restorable snapshot a mid-run session persist adopts), then the
+    /// user quits it. The agent process dies and the terminal title reverts to
+    /// the shell cwd. No shell-activity prompt event is delivered — shell
+    /// integration may be absent or its report may arrive late — so the title
+    /// update path must return the tab to the plain terminal icon on its own.
+    @Test(arguments: [
+        (RestorableAgentKind.claude, "claude_code.session-a", "AgentIcons/Claude"),
+        (RestorableAgentKind.codex, "codex.session-b", "AgentIcons/Codex"),
+        (RestorableAgentKind.opencode, "opencode.session-c", "AgentIcons/OpenCode"),
+    ])
+    func quittingLiveAgentReturnsTabToPlainTerminalIcon(
+        kind: RestorableAgentKind,
+        agentPIDKey: String,
+        brandAsset: String
+    ) throws {
+        let workspace = Workspace()
+        let panel = try #require(workspace.focusedTerminalPanel)
+        let tabId = try #require(workspace.surfaceIdFromPanelId(panel.id))
+
+        workspace.updatePanelShellActivityState(panelId: panel.id, state: .commandRunning)
+        workspace.recordAgentPID(key: agentPIDKey, pid: 0, panelId: panel.id, refreshPorts: false)
+        workspace.setRestoredAgentSnapshotForTesting(agentSnapshot(kind: kind), panelId: panel.id)
+        #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == brandAsset)
+
+        #expect(workspace.updatePanelTitle(panelId: panel.id, title: "~/manaflow/cmuxterm-hq"))
+
+        #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == nil)
+        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) == nil)
+        #expect(workspace.bonsplitController.tab(tabId)?.iconImageData == nil)
+        #expect(workspace.bonsplitController.tab(tabId)?.iconAsset == nil)
+    }
+
+    /// Ordering variant of the same exit: the shell already reported an idle
+    /// prompt (the agent is gone, its runtime already pruned) before any
+    /// session persist ran. The persist still finds the exited session in the
+    /// hook index; adopting it must not paint an agent brand icon onto a
+    /// plain shell tab.
+    @Test func sessionPersistAfterAgentExitDoesNotPaintAgentIconOnPlainShell() throws {
+        let workspace = Workspace()
+        let panel = try #require(workspace.focusedTerminalPanel)
+
+        workspace.updatePanelShellActivityState(panelId: panel.id, state: .promptIdle)
+        let index = try claudeHookIndex(
+            workspaceId: workspace.id,
+            panelId: panel.id,
+            sessionId: "7b7b7b7b-8c8c-9d9d-0e0e-1f1f1f1f1f1f"
+        )
+        _ = workspace.sessionSnapshot(includeScrollback: false, restorableAgentIndex: index)
+
+        #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == nil)
+        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) == nil)
+    }
+
+    /// A session persist while the agent is the foreground command must keep
+    /// adopting the indexed snapshot: that adoption is what lets the session
+    /// resume after an app relaunch.
+    @Test func sessionPersistWhileAgentCommandRunsStillAdoptsSnapshot() throws {
+        let workspace = Workspace()
+        let panel = try #require(workspace.focusedTerminalPanel)
+
+        workspace.updatePanelShellActivityState(panelId: panel.id, state: .commandRunning)
+        let index = try claudeHookIndex(
+            workspaceId: workspace.id,
+            panelId: panel.id,
+            sessionId: "3d3d3d3d-4e4e-5f5f-6a6a-7b7b7b7b7b7b"
+        )
+        let snapshot = workspace.sessionSnapshot(includeScrollback: false, restorableAgentIndex: index)
+
+        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) != nil)
+        #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == "AgentIcons/Claude")
+        #expect(snapshot.panels.first { $0.id == panel.id }?.terminal?.agent != nil)
+    }
+
+    /// App-relaunch restore with auto-resume off: the panel sits at a plain
+    /// shell prompt with a manually resumable agent session, and the brand
+    /// icon is intentional. No agent runtime was ever recorded in this app
+    /// run, so shell title churn must not clear it.
+    @Test func relaunchRestoredManualResumePanelKeepsBrandIcon() throws {
+        let workspace = Workspace()
+        let panel = try #require(workspace.focusedTerminalPanel)
+
+        workspace.seedSessionRestoredAgentIconState(
+            panelId: panel.id,
+            restorableAgent: agentSnapshot(kind: .claude),
+            willRunStartupCommand: false,
+            willRunStartupInput: false
+        )
+        #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == "AgentIcons/Claude")
+
+        #expect(workspace.updatePanelTitle(panelId: panel.id, title: "~/manaflow/cmuxterm-hq"))
+        #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == "AgentIcons/Claude")
+    }
+
+    /// A pending auto-resume must survive a stale-runtime prune: leftover dead
+    /// agent runtime describes the previous run, not the queued resume, so
+    /// pruning it must not tear down the pending restore or its icon.
+    @Test func pendingAutoResumePanelKeepsBrandIconThroughStaleRuntimePrune() throws {
+        let workspace = Workspace()
+        let panel = try #require(workspace.focusedTerminalPanel)
+
+        workspace.seedSessionRestoredAgentIconState(
+            panelId: panel.id,
+            restorableAgent: agentSnapshot(kind: .codex),
+            willRunStartupCommand: false,
+            willRunStartupInput: true
+        )
+        workspace.recordAgentPID(key: "codex.previous-run", pid: 0, panelId: panel.id, refreshPorts: false)
+
+        #expect(workspace.updatePanelTitle(panelId: panel.id, title: "~/manaflow/cmuxterm-hq"))
+
+        #expect(workspace.terminalTabAgentIconAsset(forPanelId: panel.id) == "AgentIcons/Codex")
+        #expect(workspace.restoredAgentSnapshotForTesting(panelId: panel.id) != nil)
+    }
+
+    // MARK: - Claude hook index fixture
+
+    /// Builds a real `RestorableAgentSessionIndex` from an on-disk claude hook
+    /// store fixture so tests exercise the same persist-time adoption path the
+    /// app runs, then removes the fixture (the index loads eagerly).
+    private func claudeHookIndex(
+        workspaceId: UUID,
+        panelId: UUID,
+        sessionId: String
+    ) throws -> RestorableAgentSessionIndex {
+        let fm = FileManager.default
+        let root = fm.temporaryDirectory
+            .appendingPathComponent("cmux-agent-icon-restore-\(UUID().uuidString)", isDirectory: true)
+        defer { try? fm.removeItem(at: root) }
+
+        let configDir = root.appendingPathComponent("claude-config", isDirectory: true)
+        let projectsDir = configDir.appendingPathComponent("projects", isDirectory: true)
+        let cwd = root.appendingPathComponent("repo", isDirectory: true)
+        try fm.createDirectory(at: cwd, withIntermediateDirectories: true)
+        let transcriptDir = projectsDir.appendingPathComponent(
+            RestorableAgentSessionIndex.encodeClaudeProjectDir(cwd.path),
+            isDirectory: true
+        )
+        try fm.createDirectory(at: transcriptDir, withIntermediateDirectories: true)
+        try """
+        {"type":"last-prompt","sessionId":"\(sessionId)"}
+        {"type":"user","sessionId":"\(sessionId)","cwd":"\(cwd.path)","message":{"role":"user","content":"hello"}}
+
+        """.write(
+            to: transcriptDir.appendingPathComponent("\(sessionId).jsonl", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let record: [String: Any] = [
+            "sessionId": sessionId,
+            "workspaceId": workspaceId.uuidString,
+            "surfaceId": panelId.uuidString,
+            "cwd": cwd.path,
+            "pid": NSNull(),
+            "updatedAt": 20,
+            "launchCommand": [
+                "launcher": "claude",
+                "executablePath": "/usr/local/bin/claude",
+                "arguments": ["/usr/local/bin/claude", "--dangerously-skip-permissions"],
+                "workingDirectory": cwd.path,
+                "environment": ["CLAUDE_CONFIG_DIR": configDir.path],
+                "capturedAt": 20,
+                "source": "test",
+            ],
+        ]
+        let stateDir = root.appendingPathComponent(".cmuxterm", isDirectory: true)
+        try fm.createDirectory(at: stateDir, withIntermediateDirectories: true)
+        let storeData = try JSONSerialization.data(
+            withJSONObject: ["version": 1, "sessions": [sessionId: record]],
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        try storeData.write(
+            to: stateDir.appendingPathComponent("claude-hook-sessions.json", isDirectory: false),
+            options: .atomic
+        )
+
+        return RestorableAgentSessionIndex.load(homeDirectory: root.path, fileManager: fm)
+    }
+}


### PR DESCRIPTION
Closes #7822

## Bug

Quitting a live agent session (Claude, Codex, OpenCode — any recognized agent) so the terminal returns to a plain shell left the tab still showing the agent brand icon. The title reverted to the shell cwd, the icon never did. Reproduced on nightly 0.64.17, which already includes #7740, so this was a remaining gap in that fix.

## Root cause

A panel's restored (resumable) agent snapshot — `restoredAgentSnapshotsByPanelId`, the icon resolver's final fallback — had two unguarded lifecycle gaps:

1. **Unconditional adoption.** Every session persist adopts the hook-index session into the panel's in-memory restored state (`sessionPanelSnapshot`) with no evidence the agent is still running. A persist running *after* the user quit the agent re-adopted the (still resumable) session at an idle prompt as `.manualResumeAvailable` and repainted the brand icon on a plain shell tab.
2. **Single exit signal.** The only thing that invalidated the snapshot on a live exit was the shell-activity state machine, which needs a `report_shell_state` event to arrive after adoption. The proven-dead-PID prune (#7740's title path) cleared live agent runtime but left the snapshot driving the icon.

## Fix

New `Sources/Workspace+RestoredAgentLifecycle.swift` centralizes the snapshot's lifecycle rules:

- `adoptIndexedRestorableAgentSnapshot` gates fresh persist-time adoption on evidence the session is current: recorded agent runtime or a running foreground command. Invalidated fingerprints keep clearing instead of re-adopting.
- `invalidateRestoredAgentSnapshotForProvenAgentExit` treats a stale-agent prune (title update, submit-action refresh, or the 30s PID sweep — all proofs the agent process died) as an observed agent exit, invalidating the snapshot exactly like the shell-activity machine does. Pending auto-resume (`.awaitingAutoResumeCommand`), hibernated panels, and remote workspaces are exempt.

App-relaunch restores never record agent PIDs, so seeded manual-resume/hibernation brand icons are untouched by construction. The invariant now holds for every agent kind: **a plain-shell tab with no live agent and no pending restore shows the plain terminal icon.** This also un-sticks the text box's agent-bound submit context after an exit (same underlying map).

## Tests

Two-commit structure so CI proves the tests catch the bug — commit 1 adds `cmuxTests/TerminalTabAgentIconRestoredSnapshotTests.swift` (wired into pbxproj) and should be red, commit 2 adds the fix:

- `quittingLiveAgentReturnsTabToPlainTerminalIcon` (parameterized: Claude/Codex/OpenCode) — dead recorded runtime + populated restored snapshot + `updatePanelTitle` title revert must clear the icon with no shell-activity event. **Fails without the fix.**
- `sessionPersistAfterAgentExitDoesNotPaintAgentIconOnPlainShell` — real `sessionSnapshot` persist over an on-disk claude hook-store fixture at an idle prompt must not adopt/repaint. **Fails without the fix.**
- Guards: persist while the agent command runs still adopts (relaunch resume keeps working); app-relaunch manual-resume and pending auto-resume panels keep their brand icon through title churn and stale-runtime prunes.

Localization audit: no user-facing strings added or changed (state/icon plumbing only). Swift file budget respected (`Workspace.swift` shrank by 20 lines; new files are 73/211 lines); no budget TSV touched; no new warnings in touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7834"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786267491&installation_id=133855650&pr_number=7834&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7834&signature=a5b768fd0ffc9c2586e7d133f477e3d06d7b2df91d45f39fdf67cee25f8b124f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal tab icon resolution and restored-agent resume state across persist, title updates, and PID pruning; behavior is guarded by targeted tests but spans several lifecycle edge cases (auto-resume, relaunch, Dock).
> 
> **Overview**
> Fixes **#7822**: after a live agent quits to a plain shell, the tab icon returns to the generic terminal mark instead of keeping the agent brand, while the resumable session snapshot stays for manual resume, relaunch, and forking.
> 
> Introduces **`RestoredAgentResumeState.recordedSessionOnly`** so “session recorded” and “tab should show agent branding” are separate. Persist-time adoption in **`Workspace+RestoredAgentLifecycle`** now sets **`.observedAgentCommandRunning`** only when the shell reports a running foreground command; otherwise adoption uses **`.recordedSessionOnly`** so a post-exit persist does not repaint the brand on an idle prompt. **`downgradeRestoredAgentSnapshotForProvenAgentExit`** runs when stale agent PIDs are pruned (including via **`updatePanelTitle`**) and moves eligible panels to **`.recordedSessionOnly`** without dropping the snapshot; pending auto-resume, hibernated panels, and remote workspaces are exempt.
> 
> **`TerminalTabAgentIcon`** (workspace and Dock) ignores the restored snapshot for icon resolution when resume state is **`.recordedSessionOnly`**. Regression coverage lives in **`TerminalTabAgentIconRestoredSnapshotTests`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42c29a2cee5c77f5e9f3355b5d97fb477d3e4f6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7822. When a live agent exits, the tab icon now reverts to the plain terminal icon even without a shell-activity event, while keeping the exited session resumable. Applies to Claude, Codex, and OpenCode.

- **Bug Fixes**
  - Introduced `RestoredAgentResumeState.recordedSessionOnly` and updated icon resolvers to ignore restored snapshots in this state, so plain-shell tabs don’t show agent branding.
  - Persist-time adoption now always records the snapshot but only brands the tab when a foreground command is running; otherwise it marks `.recordedSessionOnly` so manual resume/relaunch/fork stay intact without repainting the icon.
  - Proven agent exit (title/submit refresh prune or periodic PID sweep) downgrades the state to `.recordedSessionOnly` and syncs the icon; pending auto-resume, hibernated panels, and remote workspaces are exempt. Centralized in `Workspace+RestoredAgentLifecycle.swift` via `adoptIndexedRestorableAgentSnapshot` and `downgradeRestoredAgentSnapshotForProvenAgentExit`. Added regression tests for exit, persist-after-exit, live persist, manual resume, and pending auto-resume.

- **Refactors**
  - Normalized `project.pbxproj` entry ordering.

<sup>Written for commit 42c29a2cee5c77f5e9f3355b5d97fb477d3e4f6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved restoration of agent sessions and terminal tab icons after app relaunches.
  * Prevented stale or exited agent sessions from incorrectly restoring agent branding on plain shell tabs.
  * Preserved correct agent icons for pending, manually resumable, and actively running sessions.
  * Enhanced cleanup of stale agent processes to also invalidate related restore metadata.
* **Tests**
  * Added new regression tests covering terminal tab agent icon restoration across multiple agent lifecycle and relaunch scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->