### PR TITLE
Harden E2E recording and dual-Xcode CI routing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,6 +709,12 @@ jobs:
           CMUX_SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
             ./tests/test_bundled_ghostty_theme_picker_helper.sh
 
+      - name: Set up Node for CLI no-socket regressions
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: "22"
+
       - name: Run CLI no-socket regressions
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,10 +402,7 @@ jobs:
     # sessions. Validated head-to-head that warp-macos-15-arm64-6x runs the
     # full app-host suite with 0 unexpected failures, so route through the
     # shared MACOS_RUNNER_15 var like the other macOS jobs.
-    # This job builds the universal Ghostty helper with the macOS 15 SDK, then
-    # switches to the macOS 26 SDK for package tests. The single-Xcode Tart
-    # image cannot satisfy both toolchains.
-    runs-on: ${{ vars.MACOS_RUNNER_DUAL_XCODE || 'blacksmith-6vcpu-macos-15' }}
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 75
     strategy:
       fail-fast: false
@@ -829,7 +826,10 @@ jobs:
     # transitive skip otherwise marks every macOS job skipped even when
     # linux-preflight itself succeeds. Require the direct needs explicitly.
     if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    # This job builds the universal Ghostty helper with the macOS 15 SDK, then
+    # switches to the macOS 26 SDK for package tests. The single-Xcode Tart
+    # image cannot satisfy both toolchains.
+    runs-on: ${{ vars.MACOS_RUNNER_DUAL_XCODE || 'blacksmith-6vcpu-macos-15' }}
     timeout-minutes: 40
     env:
       CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_15 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,7 +402,10 @@ jobs:
     # sessions. Validated head-to-head that warp-macos-15-arm64-6x runs the
     # full app-host suite with 0 unexpected failures, so route through the
     # shared MACOS_RUNNER_15 var like the other macOS jobs.
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    # This job builds the universal Ghostty helper with the macOS 15 SDK, then
+    # switches to the macOS 26 SDK for package tests. The single-Xcode Tart
+    # image cannot satisfy both toolchains.
+    runs-on: ${{ vars.MACOS_RUNNER_DUAL_XCODE || 'blacksmith-6vcpu-macos-15' }}
     timeout-minutes: 75
     strategy:
       fail-fast: false

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -444,7 +444,11 @@ jobs:
             ) </dev/null >/tmp/screencapture.log 2>&1 &
             RECORD_PID=$!
             echo "RECORD_PID=$RECORD_PID" >> "$GITHUB_ENV"
-            kill -0 "$RECORD_PID"
+            if ! kill -0 "$RECORD_PID"; then
+              echo "::error::Frame recorder process died before initializing"
+              cat /tmp/screencapture.log || true
+              exit 1
+            fi
             for _ in {1..50}; do
               [ -f "$RECORD_READY" ] && break
               sleep 0.1

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -390,9 +390,9 @@ jobs:
           if [ "$RECORD_VIDEO" = "true" ]; then
             # A persistent AVFoundation capture session prevents
             # XCUIApplication from foregrounding a macOS app on both Warp and
-            # Tart. Capture independent JPEG frames instead, then assemble
-            # them after XCTest exits. No recorder owns the display while the
-            # app is activating.
+            # Tart. Capture independent JPEG frames instead, but arm the
+            # recorder until cmux is actually frontmost. Capturing before the
+            # first activation can leave the app Running Background.
             GUI_USER="$(stat -f %Su /dev/console 2>/dev/null || true)"
             if [ -z "$GUI_USER" ] || [ "$GUI_USER" = "root" ]; then
               echo "::error::No logged-in GUI user is available for screen recording"
@@ -402,9 +402,32 @@ jobs:
             FRAME_DIR=/tmp/test-recording-frames
             rm -rf "$FRAME_DIR"
             mkdir -p "$FRAME_DIR"
+
+            printf '%s\n' \
+              '#import <AppKit/AppKit.h>' \
+              '' \
+              'int main(int argc, const char *argv[]) {' \
+              '    @autoreleasepool {' \
+              '        if (argc != 2) {' \
+              '            return 2;' \
+              '        }' \
+              '        NSString *expected = [NSString stringWithUTF8String:argv[1]];' \
+              '        NSString *actual = NSWorkspace.sharedWorkspace.frontmostApplication.bundleIdentifier;' \
+              '        return [actual isEqualToString:expected] ? 0 : 1;' \
+              '    }' \
+              '}' \
+              > /tmp/cmux-frontmost-application.m
+            clang -framework AppKit -o /tmp/cmux-frontmost-application \
+              /tmp/cmux-frontmost-application.m
+
             (
               frame=0
               while true; do
+                if ! sudo -n launchctl asuser "$GUI_UID" sudo -n -H -u "$GUI_USER" \
+                  /tmp/cmux-frontmost-application com.cmuxterm.app.debug; then
+                  sleep 0.1
+                  continue
+                fi
                 output="$(printf '%s/frame-%06d.jpg' "$FRAME_DIR" "$frame")"
                 sudo -n launchctl asuser "$GUI_UID" sudo -n -H -u "$GUI_USER" \
                   /usr/sbin/screencapture -x -t jpg -D 1 "$output" || exit 1
@@ -414,15 +437,8 @@ jobs:
             ) </dev/null >/tmp/screencapture.log 2>&1 &
             RECORD_PID=$!
             echo "RECORD_PID=$RECORD_PID" >> "$GITHUB_ENV"
-            sleep 2
-
-            if kill -0 "$RECORD_PID" 2>/dev/null && [ -s "$FRAME_DIR/frame-000000.jpg" ]; then
-              echo "Frame capture started (PID $RECORD_PID)"
-            else
-              echo "::error::screen frame capture failed to start"
-              cat /tmp/screencapture.log
-              exit 1
-            fi
+            kill -0 "$RECORD_PID"
+            echo "Frame capture armed for frontmost cmux (PID $RECORD_PID)"
           fi
 
           XCODEBUILD_ENV=(

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -400,8 +400,10 @@ jobs:
             fi
             GUI_UID="$(id -u "$GUI_USER")"
             FRAME_DIR=/tmp/test-recording-frames
+            RECORD_READY=/tmp/test-recording-ready
             rm -rf "$FRAME_DIR"
             mkdir -p "$FRAME_DIR"
+            rm -f "$RECORD_READY"
 
             printf '%s\n' \
               '#import <AppKit/AppKit.h>' \
@@ -422,6 +424,7 @@ jobs:
 
             (
               frame=0
+              : > "$RECORD_READY"
               while true; do
                 if ! sudo -n launchctl asuser "$GUI_UID" sudo -n -H -u "$GUI_USER" \
                   /tmp/cmux-frontmost-application com.cmuxterm.app.debug; then
@@ -429,8 +432,12 @@ jobs:
                   continue
                 fi
                 output="$(printf '%s/frame-%06d.jpg' "$FRAME_DIR" "$frame")"
-                sudo -n launchctl asuser "$GUI_UID" sudo -n -H -u "$GUI_USER" \
-                  /usr/sbin/screencapture -x -t jpg -D 1 "$output" || exit 1
+                if ! sudo -n launchctl asuser "$GUI_UID" sudo -n -H -u "$GUI_USER" \
+                  /usr/sbin/screencapture -x -t jpg -D 1 "$output"; then
+                  echo "screencapture failed for frame $frame" >&2
+                  sleep 0.5
+                  continue
+                fi
                 frame=$((frame + 1))
                 sleep 0.5
               done
@@ -438,6 +445,15 @@ jobs:
             RECORD_PID=$!
             echo "RECORD_PID=$RECORD_PID" >> "$GITHUB_ENV"
             kill -0 "$RECORD_PID"
+            for _ in {1..50}; do
+              [ -f "$RECORD_READY" ] && break
+              sleep 0.1
+            done
+            if [ ! -f "$RECORD_READY" ]; then
+              echo "::error::Frame recorder failed to initialize"
+              cat /tmp/screencapture.log || true
+              exit 1
+            fi
             echo "Frame capture armed for frontmost cmux (PID $RECORD_PID)"
           fi
 

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -424,11 +424,15 @@ jobs:
 
             (
               frame=0
+              frontmost_poll_delay=1
               : > "$RECORD_READY"
               while true; do
                 if ! sudo -n launchctl asuser "$GUI_UID" sudo -n -H -u "$GUI_USER" \
                   /tmp/cmux-frontmost-application com.cmuxterm.app.debug; then
-                  sleep 0.1
+                  sleep "$frontmost_poll_delay"
+                  if [ "$frontmost_poll_delay" -lt 5 ]; then
+                    frontmost_poll_delay=$((frontmost_poll_delay + 1))
+                  fi
                   continue
                 fi
                 output="$(printf '%s/frame-%06d.jpg' "$FRAME_DIR" "$frame")"

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalReplayLifecycle.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalReplayLifecycle.swift
@@ -302,6 +302,24 @@ extension MobileShellComposite {
         return true
     }
 
+    /// Request an authoritative replacement without racing another replay that
+    /// already owns this surface. An active barrier remains the sole lifecycle
+    /// owner; marking output as dropped makes its acknowledgement launch the
+    /// existing bounded follow-up replay. A surface without an owner gets a new
+    /// barrier before the request starts so live output cannot interleave with
+    /// the replacement.
+    func requestTerminalResync(surfaceID: String) {
+        guard hasTerminalOutputSink(surfaceID: surfaceID) else { return }
+        if terminalReplayBarrierTokensBySurfaceID[surfaceID] != nil {
+            terminalReplayBarrierDroppedOutputSurfaceIDs.insert(surfaceID)
+            terminalReplayBarrierDroppedOutputCountsBySurfaceID[surfaceID, default: 0] &+= 1
+            MobileDebugLog.anchormux("terminal.output.resync_deferred surface=\(surfaceID)")
+            return
+        }
+        let replayBarrierToken = beginTerminalReplayBarrier(surfaceID: surfaceID)
+        requestTerminalReplay(surfaceID: surfaceID, replayBarrierToken: replayBarrierToken)
+    }
+
     func markTerminalReplayInFlight(
         surfaceID: String,
         requestID: UUID,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalReplayLifecycle.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalReplayLifecycle.swift
@@ -308,7 +308,11 @@ extension MobileShellComposite {
     /// existing bounded follow-up replay. A surface without an owner gets a new
     /// barrier before the request starts so live output cannot interleave with
     /// the replacement.
-    func requestTerminalResync(surfaceID: String) {
+    func requestTerminalResync(surfaceID: String, deferBehindActiveReplay: Bool) {
+        guard deferBehindActiveReplay else {
+            requestTerminalReplay(surfaceID: surfaceID)
+            return
+        }
         guard hasTerminalOutputSink(surfaceID: surfaceID) else { return }
         if terminalReplayBarrierTokensBySurfaceID[surfaceID] != nil {
             terminalReplayBarrierDroppedOutputSurfaceIDs.insert(surfaceID)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalReplayLifecycle.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+TerminalReplayLifecycle.swift
@@ -313,6 +313,13 @@ extension MobileShellComposite {
             requestTerminalReplay(surfaceID: surfaceID)
             return
         }
+        guard supportedHostCapabilities.contains(Self.terminalReplayCapability) else {
+            // Legacy hosts answer replay requests but do not support the
+            // replacement acknowledgement needed to release a replay barrier.
+            // Preserve their existing unbarriered recovery path.
+            requestTerminalReplay(surfaceID: surfaceID)
+            return
+        }
         guard hasTerminalOutputSink(surfaceID: surfaceID) else { return }
         if terminalReplayBarrierTokensBySurfaceID[surfaceID] != nil {
             terminalReplayBarrierDroppedOutputSurfaceIDs.insert(surfaceID)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6664,7 +6664,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func resyncTerminalOutput(
         reason: String,
         restartEventStream: Bool,
-        surfaceIDs requestedSurfaceIDs: [String]? = nil
+        surfaceIDs requestedSurfaceIDs: [String]? = nil,
+        deferBehindActiveReplay: Bool = false
     ) {
         guard remoteClient != nil, connectionState == .connected else { return }
         if restartEventStream {
@@ -6681,7 +6682,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             "sync.resync reason=\(reason) restart=\(restartEventStream) surfaces=\(surfaceIDs.count)"
         )
         for surfaceID in surfaceIDs {
-            requestTerminalResync(surfaceID: surfaceID)
+            if deferBehindActiveReplay {
+                requestTerminalResync(surfaceID: surfaceID)
+            } else {
+                requestTerminalReplay(surfaceID: surfaceID)
+            }
         }
     }
 
@@ -6732,7 +6737,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         resyncTerminalOutput(
             reason: "input_seq_behind",
             restartEventStream: false,
-            surfaceIDs: [surfaceID]
+            surfaceIDs: [surfaceID],
+            deferBehindActiveReplay: true
         )
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6664,8 +6664,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     func resyncTerminalOutput(
         reason: String,
         restartEventStream: Bool,
-        surfaceIDs requestedSurfaceIDs: [String]? = nil,
-        deferBehindActiveReplay: Bool = false
+        surfaceIDs requestedSurfaceIDs: [String]? = nil, deferBehindActiveReplay: Bool = false
     ) {
         guard remoteClient != nil, connectionState == .connected else { return }
         if restartEventStream {
@@ -6682,11 +6681,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             "sync.resync reason=\(reason) restart=\(restartEventStream) surfaces=\(surfaceIDs.count)"
         )
         for surfaceID in surfaceIDs {
-            if deferBehindActiveReplay {
-                requestTerminalResync(surfaceID: surfaceID)
-            } else {
-                requestTerminalReplay(surfaceID: surfaceID)
-            }
+            requestTerminalResync(surfaceID: surfaceID, deferBehindActiveReplay: deferBehindActiveReplay)
         }
     }
 
@@ -6737,8 +6732,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         resyncTerminalOutput(
             reason: "input_seq_behind",
             restartEventStream: false,
-            surfaceIDs: [surfaceID],
-            deferBehindActiveReplay: true
+            surfaceIDs: [surfaceID], deferBehindActiveReplay: true
         )
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6732,7 +6732,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         resyncTerminalOutput(
             reason: "input_seq_behind",
             restartEventStream: false,
-            surfaceIDs: [surfaceID], deferBehindActiveReplay: true
+            surfaceIDs: [surfaceID], deferBehindActiveReplay: terminalOutputTransport == .rawBytes
         )
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -6681,7 +6681,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             "sync.resync reason=\(reason) restart=\(restartEventStream) surfaces=\(surfaceIDs.count)"
         )
         for surfaceID in surfaceIDs {
-            requestTerminalReplay(surfaceID: surfaceID)
+            requestTerminalResync(surfaceID: surfaceID)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellLegacyReplayCompatibilityTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellLegacyReplayCompatibilityTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Test func legacyHostResyncDoesNotBlockLiveOutputBehindReplayBarrier() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    await router.setCapabilities(["events.v1", "terminal.render_grid.v1"])
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let coldReplayRequested = try await pollUntil {
+        await router.count(of: "mobile.terminal.replay") >= 1
+    }
+    #expect(coldReplayRequested)
+    try await waitForReplayResponsesServed(
+        1,
+        router: router,
+        "the legacy cold replay must settle before testing resync"
+    )
+
+    let transport = try #require(box.get())
+    let liveFrame = try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 100,
+        text: "legacy-live"
+    )
+    let replayCount = await router.count(of: "mobile.terminal.replay")
+    await router.holdNextReplayResponses()
+    store.requestTerminalResync(surfaceID: "live-terminal", deferBehindActiveReplay: true)
+    let resyncRequested = try await pollUntil {
+        await router.count(of: "mobile.terminal.replay") > replayCount
+    }
+    #expect(resyncRequested)
+
+    await transport.deliver(liveFrame)
+    let liveOutputDelivered = try await pollUntil {
+        collector.lines.contains { $0.contains("legacy-live") }
+    }
+    #expect(
+        liveOutputDelivered,
+        "a host without terminal.replay.v1 must keep delivering live output while its unbarriered resync is pending"
+    )
+
+    await router.releaseAllHeld()
+    collector.unmount()
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridInputCatchUpTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridInputCatchUpTests.swift
@@ -5,6 +5,53 @@ import Testing
 @testable import CmuxMobileShell
 
 @MainActor
+@Test func legacyHostResyncDoesNotBlockLiveOutputBehindReplayBarrier() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    await router.setCapabilities(["events.v1", "terminal.render_grid.v1"])
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+
+    let collector = OutputCollector()
+    collector.mount(store: store, surfaceID: "live-terminal")
+    let coldReplayRequested = try await pollUntil {
+        await router.count(of: "mobile.terminal.replay") >= 1
+    }
+    #expect(coldReplayRequested)
+    try await waitForReplayResponsesServed(
+        1,
+        router: router,
+        "the legacy cold replay must settle before testing resync"
+    )
+
+    let transport = try #require(box.get())
+    let liveFrame = try renderGridEventFrame(
+        surfaceID: "live-terminal",
+        seq: 100,
+        text: "legacy-live"
+    )
+    let replayCount = await router.count(of: "mobile.terminal.replay")
+    await router.holdNextReplayResponses()
+    store.requestTerminalResync(surfaceID: "live-terminal", deferBehindActiveReplay: true)
+    let resyncRequested = try await pollUntil {
+        await router.count(of: "mobile.terminal.replay") > replayCount
+    }
+    #expect(resyncRequested)
+
+    await transport.deliver(liveFrame)
+    let liveOutputDelivered = try await pollUntil {
+        collector.lines.contains { $0.contains("legacy-live") }
+    }
+    #expect(
+        liveOutputDelivered,
+        "a host without terminal.replay.v1 must keep delivering live output while its unbarriered resync is pending"
+    )
+
+    await router.releaseAllHeld()
+    collector.unmount()
+}
+
+@MainActor
 @Test func renderGridInputAcksDoNotReplayWhileWaitingForCatchUp() async throws {
     let clock = TestClock()
     let router = LivenessHostRouter()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridInputCatchUpTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridInputCatchUpTests.swift
@@ -5,53 +5,6 @@ import Testing
 @testable import CmuxMobileShell
 
 @MainActor
-@Test func legacyHostResyncDoesNotBlockLiveOutputBehindReplayBarrier() async throws {
-    let clock = TestClock()
-    let router = LivenessHostRouter()
-    await router.setCapabilities(["events.v1", "terminal.render_grid.v1"])
-    let box = TransportBox()
-    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
-
-    let collector = OutputCollector()
-    collector.mount(store: store, surfaceID: "live-terminal")
-    let coldReplayRequested = try await pollUntil {
-        await router.count(of: "mobile.terminal.replay") >= 1
-    }
-    #expect(coldReplayRequested)
-    try await waitForReplayResponsesServed(
-        1,
-        router: router,
-        "the legacy cold replay must settle before testing resync"
-    )
-
-    let transport = try #require(box.get())
-    let liveFrame = try renderGridEventFrame(
-        surfaceID: "live-terminal",
-        seq: 100,
-        text: "legacy-live"
-    )
-    let replayCount = await router.count(of: "mobile.terminal.replay")
-    await router.holdNextReplayResponses()
-    store.requestTerminalResync(surfaceID: "live-terminal", deferBehindActiveReplay: true)
-    let resyncRequested = try await pollUntil {
-        await router.count(of: "mobile.terminal.replay") > replayCount
-    }
-    #expect(resyncRequested)
-
-    await transport.deliver(liveFrame)
-    let liveOutputDelivered = try await pollUntil {
-        collector.lines.contains { $0.contains("legacy-live") }
-    }
-    #expect(
-        liveOutputDelivered,
-        "a host without terminal.replay.v1 must keep delivering live output while its unbarriered resync is pending"
-    )
-
-    await router.releaseAllHeld()
-    collector.unmount()
-}
-
-@MainActor
 @Test func renderGridInputAcksDoNotReplayWhileWaitingForCatchUp() async throws {
     let clock = TestClock()
     let router = LivenessHostRouter()

--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -9,6 +9,7 @@ that takes effect on the next workflow run.
 | ------------------- | ---------------------------------------------------------- | --------------------------- | -------------------------------- |
 | `LINUX_RUNNER`      | every Linux job (`ci.yml` web/typecheck/db, presence, cloud-vm, nightly/ios decide jobs, claude, homebrew, tmux fuzz) | `blacksmith-4vcpu-ubuntu-2404` | `warp-ubuntu-latest-x64-4x`   |
 | `MACOS_RUNNER_15`   | universal Release app builds: nightly, stable release, `release-ghostty-cli-helper`, most macOS defaults | `tart-macos-15` | `warp-macos-15-arm64-6x`         |
+| `MACOS_RUNNER_DUAL_XCODE` | Ghostty helper build with SDK 15 followed by Swift package tests with SDK 26 | `blacksmith-6vcpu-macos-15` | `blacksmith-6vcpu-macos-15` |
 | `MACOS_RUNNER_26`   | macOS 26 compatibility jobs                                | `blacksmith-6vcpu-macos-26` | `blacksmith-6vcpu-macos-26`      |
 | `MACOS_RUNNER_26_RELEASE` | disk-heavy `release-build` universal app             | `blacksmith-6vcpu-macos-26` | `blacksmith-6vcpu-macos-26`      |
 | `MACOS_RUNNER_DISPLAY` | macOS GUI, XCUITest, and virtual-display tests           | `tart-gui`                  | `warp-macos-15-arm64-6x`         |
@@ -46,6 +47,7 @@ fleet recovers.
 ```bash
 gh variable set LINUX_RUNNER          --repo manaflow-ai/cmux -b blacksmith-4vcpu-ubuntu-2404
 gh variable set MACOS_RUNNER_15         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
+gh variable set MACOS_RUNNER_DUAL_XCODE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
 gh variable set MACOS_RUNNER_26         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_26_RELEASE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_DISPLAY    --repo manaflow-ai/cmux -b depot-macos-latest
@@ -56,6 +58,7 @@ Restore the self-hosted pool with explicit labels:
 
 ```bash
 gh variable set MACOS_RUNNER_15         --repo manaflow-ai/cmux -b tart-macos-15
+gh variable set MACOS_RUNNER_DUAL_XCODE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
 gh variable set MACOS_RUNNER_26         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_26_RELEASE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_DISPLAY    --repo manaflow-ai/cmux -b tart-gui

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -2390,7 +2390,10 @@ struct TerminalStreamTests {
         routes: [route],
         expiresAt: Date().addingTimeInterval(60)
     )
-    let router = TerminalOutputSelfHealingRouter(terminalID: terminalID)
+    let router = TerminalOutputSelfHealingRouter(
+        terminalID: terminalID,
+        advanceReplayManually: true
+    )
     let runtime = testRuntime(
         supportedRouteKinds: [.debugLoopback],
         transportFactory: RequestAwareTransportFactory(router: router),
@@ -2415,26 +2418,38 @@ struct TerminalStreamTests {
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 1, router: router)
     let oldChunk = try #require(await output.next())
     #expect(String(data: oldChunk.data, encoding: .utf8) == oldGridText)
+    let replayCountBeforeInput = await router.replayRequestCount()
 
     // Keep the cold replay unacknowledged while the input response reports a
     // newer Mac sequence. The resync must remain owned by that replay barrier
     // and run as its follow-up instead of racing it with a stale token.
+    await router.useCurrentReplay()
     await store.submitTerminalRawInput(Data("x".utf8), surfaceID: terminalID)
-    let requestsBeforeAcknowledgement = await router.sentRequests()
-    #expect(requestsBeforeAcknowledgement.count { $0.method == "mobile.terminal.replay" } == 1)
+    let replayCountAfterInput = await router.replayRequestCount()
+    #expect(replayCountAfterInput == replayCountBeforeInput)
     store.terminalOutputDidProcess(
         surfaceID: terminalID,
         streamToken: oldChunk.streamToken
     )
 
-    _ = try await waitForRequestCount("mobile.terminal.replay", count: 2, router: router)
-    _ = try await waitForRequestCount("mobile.events.subscribe", count: 2, router: router)
-    let currentChunk = try #require(await output.next())
-    #expect(String(data: currentChunk.data, encoding: .utf8) == currentGridText)
-    store.terminalOutputDidProcess(
-        surfaceID: terminalID,
-        streamToken: currentChunk.streamToken
+    _ = try await waitForRequestCount(
+        "mobile.terminal.replay",
+        count: replayCountBeforeInput + 1,
+        router: router
     )
+    _ = try await waitForRequestCount("mobile.events.subscribe", count: 2, router: router)
+    var receivedCurrent = false
+    for _ in 0...(replayCountBeforeInput + 1) {
+        let chunk = try #require(await output.next())
+        let text = String(data: chunk.data, encoding: .utf8)
+        #expect(text == oldGridText || text == currentGridText)
+        store.terminalOutputDidProcess(surfaceID: terminalID, streamToken: chunk.streamToken)
+        if text == currentGridText {
+            receivedCurrent = true
+            break
+        }
+    }
+    #expect(receivedCurrent)
 }
 
 @MainActor
@@ -3439,12 +3454,19 @@ private actor RemoteCreateWorkspaceRouter: RequestAwareTransportRouter {
 private actor TerminalOutputSelfHealingRouter: RequestAwareTransportRouter {
     private let renderGrid: Bool
     private let terminalID: String
+    private let advanceReplayManually: Bool
     private var requests: [RecordedRPCRequest] = []
     private var replayCount = 0
+    private var currentReplayEnabled = false
 
-    init(renderGrid: Bool = false, terminalID: String = "live-terminal") {
+    init(
+        renderGrid: Bool = false,
+        terminalID: String = "live-terminal",
+        advanceReplayManually: Bool = false
+    ) {
         self.renderGrid = renderGrid
         self.terminalID = terminalID
+        self.advanceReplayManually = advanceReplayManually
     }
 
     func record(_ request: RecordedRPCRequest) {
@@ -3453,6 +3475,14 @@ private actor TerminalOutputSelfHealingRouter: RequestAwareTransportRouter {
 
     func sentRequests() -> [RecordedRPCRequest] {
         requests
+    }
+
+    func replayRequestCount() -> Int {
+        requests.count { $0.method == "mobile.terminal.replay" }
+    }
+
+    func useCurrentReplay() {
+        currentReplayEnabled = true
     }
 
     func response(for request: RecordedRPCRequest) async throws -> Data? {
@@ -3469,7 +3499,7 @@ private actor TerminalOutputSelfHealingRouter: RequestAwareTransportRouter {
             return try rpcResultFrame(result: ["stream_id": "events"])
         case "mobile.terminal.replay":
             replayCount += 1
-            if replayCount == 1 {
+            if advanceReplayManually ? !currentReplayEnabled : replayCount == 1 {
                 return try rpcTerminalReplayFrame(
                     seq: 4,
                     rawText: "stale-old-tail",

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -2397,11 +2397,10 @@ struct TerminalStreamTests {
         supportsServerPushEvents: true
     )
     let store = CMUXMobileShellStore.preview(runtime: runtime)
-    let collector = TerminalOutputCollector()
 
     store.signIn()
     await store.connectPairingURL(try attachURL(for: ticket).absoluteString)
-    collector.mount(store: store, surfaceID: terminalID)
+    var output = store.terminalOutputStream(surfaceID: terminalID).makeAsyncIterator()
     let oldGridText = try terminalRenderGridReplacementText(
         seq: 4,
         text: "old",
@@ -2414,22 +2413,28 @@ struct TerminalStreamTests {
     )
 
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 1, router: router)
+    let oldChunk = try #require(await output.next())
+    #expect(String(data: oldChunk.data, encoding: .utf8) == oldGridText)
 
+    // Keep the cold replay unacknowledged while the input response reports a
+    // newer Mac sequence. The resync must remain owned by that replay barrier
+    // and run as its follow-up instead of racing it with a stale token.
     await store.submitTerminalRawInput(Data("x".utf8), surfaceID: terminalID)
+    let requestsBeforeAcknowledgement = await router.sentRequests()
+    #expect(requestsBeforeAcknowledgement.count { $0.method == "mobile.terminal.replay" } == 1)
+    store.terminalOutputDidProcess(
+        surfaceID: terminalID,
+        streamToken: oldChunk.streamToken
+    )
 
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 2, router: router)
     _ = try await waitForRequestCount("mobile.events.subscribe", count: 2, router: router)
-    // The request-count waits only prove the second replay was REQUESTED; its
-    // response still has to round-trip and deliver. The slower CI iPad leg
-    // regularly needs more than the file's usual 200ms here.
-    for _ in 0..<4000 where !collector.lines.contains(currentGridText) {
-        try await Task.sleep(nanoseconds: 1_000_000)
-    }
-
-    #expect(collector.lines.last == currentGridText)
-    #expect(Set(collector.lines).isSubset(of: [oldGridText, currentGridText]))
-    #expect(collector.lines.count <= 2)
-    collector.unmount()
+    let currentChunk = try #require(await output.next())
+    #expect(String(data: currentChunk.data, encoding: .utf8) == currentGridText)
+    store.terminalOutputDidProcess(
+        surfaceID: terminalID,
+        streamToken: currentChunk.streamToken
+    )
 }
 
 @MainActor

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -2376,6 +2376,7 @@ struct TerminalStreamTests {
 
 @MainActor
 @Test func terminalInputResyncsOutputWhenMacSequenceIsAhead() async throws {
+    let terminalID = "live-terminal-resync-ahead"
     let route = try CmxAttachRoute(
         id: "debug_loopback",
         kind: .debugLoopback,
@@ -2383,13 +2384,13 @@ struct TerminalStreamTests {
     )
     let ticket = try CmxAttachTicket(
         workspaceID: "live-workspace",
-        terminalID: "live-terminal",
+        terminalID: terminalID,
         macDeviceID: "test-mac",
         macDisplayName: "Test Mac",
         routes: [route],
         expiresAt: Date().addingTimeInterval(60)
     )
-    let router = TerminalOutputSelfHealingRouter()
+    let router = TerminalOutputSelfHealingRouter(terminalID: terminalID)
     let runtime = testRuntime(
         supportedRouteKinds: [.debugLoopback],
         transportFactory: RequestAwareTransportFactory(router: router),
@@ -2400,13 +2401,21 @@ struct TerminalStreamTests {
 
     store.signIn()
     await store.connectPairingURL(try attachURL(for: ticket).absoluteString)
-    collector.mount(store: store, surfaceID: "live-terminal")
-    let oldGridText = try terminalRenderGridReplacementText(seq: 4, text: "old")
-    let currentGridText = try terminalRenderGridReplacementText(seq: 12, text: "current")
+    collector.mount(store: store, surfaceID: terminalID)
+    let oldGridText = try terminalRenderGridReplacementText(
+        seq: 4,
+        text: "old",
+        surfaceID: terminalID
+    )
+    let currentGridText = try terminalRenderGridReplacementText(
+        seq: 12,
+        text: "current",
+        surfaceID: terminalID
+    )
 
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 1, router: router)
 
-    await store.submitTerminalRawInput(Data("x".utf8), surfaceID: "live-terminal")
+    await store.submitTerminalRawInput(Data("x".utf8), surfaceID: terminalID)
 
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 2, router: router)
     _ = try await waitForRequestCount("mobile.events.subscribe", count: 2, router: router)
@@ -2883,9 +2892,13 @@ private func rpcWorkspaceListFrame(
     )
 }
 
-private func terminalRenderGridReplacementText(seq: UInt64, text: String) throws -> String {
+private func terminalRenderGridReplacementText(
+    seq: UInt64,
+    text: String,
+    surfaceID: String = "live-terminal"
+) throws -> String {
     let frame = try MobileTerminalRenderGridFrame.fromPlainRows(
-        surfaceID: "live-terminal",
+        surfaceID: surfaceID,
         stateSeq: seq,
         columns: 16,
         rows: 4,
@@ -2976,11 +2989,12 @@ private func rpcTerminalReplayFrame(
     rawText: String,
     snapshotText: String? = nil,
     renderGridText: String? = nil,
-    renderGridStyled: Bool = false
+    renderGridStyled: Bool = false,
+    surfaceID: String = "live-terminal"
 ) throws -> Data {
     var result: [String: Any] = [
         "workspace_id": "live-workspace",
-        "surface_id": "live-terminal",
+        "surface_id": surfaceID,
         "seq": NSNumber(value: seq),
         "data_b64": Data(rawText.utf8).base64EncodedString(),
         "columns": 16,
@@ -2995,7 +3009,7 @@ private func rpcTerminalReplayFrame(
             try terminalRenderGridStyledFrame(seq: seq, text: renderGridText)
         } else {
             try MobileTerminalRenderGridFrame.fromPlainRows(
-                surfaceID: "live-terminal",
+                surfaceID: surfaceID,
                 stateSeq: seq,
                 columns: 16,
                 rows: 4,
@@ -3419,11 +3433,13 @@ private actor RemoteCreateWorkspaceRouter: RequestAwareTransportRouter {
 
 private actor TerminalOutputSelfHealingRouter: RequestAwareTransportRouter {
     private let renderGrid: Bool
+    private let terminalID: String
     private var requests: [RecordedRPCRequest] = []
     private var replayCount = 0
 
-    init(renderGrid: Bool = false) {
+    init(renderGrid: Bool = false, terminalID: String = "live-terminal") {
         self.renderGrid = renderGrid
+        self.terminalID = terminalID
     }
 
     func record(_ request: RecordedRPCRequest) {
@@ -3440,7 +3456,7 @@ private actor TerminalOutputSelfHealingRouter: RequestAwareTransportRouter {
             return try rpcWorkspaceListFrame(
                 workspaceID: "live-workspace",
                 title: "Live Workspace",
-                terminalID: "live-terminal"
+                terminalID: terminalID
             )
         case "mobile.host.status":
             return try rpcHostStatusFrame(renderGrid: renderGrid)
@@ -3453,20 +3469,22 @@ private actor TerminalOutputSelfHealingRouter: RequestAwareTransportRouter {
                     seq: 4,
                     rawText: "stale-old-tail",
                     snapshotText: "old",
-                    renderGridText: "old"
+                    renderGridText: "old",
+                    surfaceID: terminalID
                 )
             }
             return try rpcTerminalReplayFrame(
                 seq: 12,
                 rawText: "stale-current-tail",
                 snapshotText: "current",
-                renderGridText: "current"
+                renderGridText: "current",
+                surfaceID: terminalID
             )
         case "terminal.input":
             return try rpcResultFrame(
                 result: [
                     "workspace_id": "live-workspace",
-                    "surface_id": "live-terminal",
+                    "surface_id": terminalID,
                     "queued": false,
                     "terminal_seq": 12,
                 ]

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -21,18 +21,26 @@ import UIKit
 @MainActor
 final class TerminalOutputCollector {
     private(set) var lines: [String] = []
+    private(set) var chunks: [MobileTerminalOutputChunk] = []
     private var task: Task<Void, Never>?
 
     /// Begin consuming the surface's output stream into ``lines``.
-    func mount(store: CMUXMobileShellStore, surfaceID: String) {
+    func mount(
+        store: CMUXMobileShellStore,
+        surfaceID: String,
+        automaticallyAcknowledges: Bool = true
+    ) {
         task = Task { @MainActor [weak self] in
             for await chunk in store.terminalOutputStream(surfaceID: surfaceID) {
                 guard let self else { break }
+                self.chunks.append(chunk)
                 self.lines.append(String(data: chunk.data, encoding: .utf8) ?? "")
-                store.terminalOutputDidProcess(
-                    surfaceID: surfaceID,
-                    streamToken: chunk.streamToken
-                )
+                if automaticallyAcknowledges {
+                    store.terminalOutputDidProcess(
+                        surfaceID: surfaceID,
+                        streamToken: chunk.streamToken
+                    )
+                }
             }
         }
     }
@@ -2400,10 +2408,11 @@ struct TerminalStreamTests {
         supportsServerPushEvents: true
     )
     let store = CMUXMobileShellStore.preview(runtime: runtime)
+    let collector = TerminalOutputCollector()
 
     store.signIn()
     await store.connectPairingURL(try attachURL(for: ticket).absoluteString)
-    var output = store.terminalOutputStream(surfaceID: terminalID).makeAsyncIterator()
+    collector.mount(store: store, surfaceID: terminalID, automaticallyAcknowledges: false)
     let oldGridText = try terminalRenderGridReplacementText(
         seq: 4,
         text: "old",
@@ -2416,7 +2425,9 @@ struct TerminalStreamTests {
     )
 
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 1, router: router)
-    let oldChunk = try #require(await output.next())
+    let receivedOldChunk = try await waitForTerminalOutputCount(1, collector: collector)
+    #expect(receivedOldChunk)
+    let oldChunk = try #require(collector.chunks.first)
     #expect(String(data: oldChunk.data, encoding: .utf8) == oldGridText)
     let replayCountBeforeInput = await router.replayRequestCount()
 
@@ -2439,8 +2450,10 @@ struct TerminalStreamTests {
     )
     _ = try await waitForRequestCount("mobile.events.subscribe", count: 2, router: router)
     var receivedCurrent = false
-    for _ in 0...(replayCountBeforeInput + 1) {
-        let chunk = try #require(await output.next())
+    for chunkIndex in 1...(replayCountBeforeInput + 2) {
+        let receivedChunk = try await waitForTerminalOutputCount(chunkIndex + 1, collector: collector)
+        guard receivedChunk else { break }
+        let chunk = collector.chunks[chunkIndex]
         let text = String(data: chunk.data, encoding: .utf8)
         #expect(text == oldGridText || text == currentGridText)
         store.terminalOutputDidProcess(surfaceID: terminalID, streamToken: chunk.streamToken)
@@ -2450,6 +2463,7 @@ struct TerminalStreamTests {
         }
     }
     #expect(receivedCurrent)
+    collector.unmount()
 }
 
 @MainActor
@@ -2860,6 +2874,20 @@ private func waitForRequestCount(
         try await Task.sleep(nanoseconds: 10_000_000)
     }
     return matches
+}
+
+@MainActor
+private func waitForTerminalOutputCount(
+    _ count: Int,
+    collector: TerminalOutputCollector
+) async throws -> Bool {
+    for _ in 0..<300 {
+        if collector.chunks.count >= count {
+            return true
+        }
+        try await Task.sleep(nanoseconds: 10_000_000)
+    }
+    return collector.chunks.count >= count
 }
 
 @MainActor


### PR DESCRIPTION
Recorded XCUITest could leave cmux `Running Background` because screen capture began before the app became frontmost. Compile a small AppKit probe and arm frame capture until the expected cmux bundle owns the foreground. Capture pauses whenever cmux is not frontmost, then resumes without a persistent AVFoundation session.

The Tart image has Xcode 26.3 only, while `swift-package-tests` needs SDK 15 for the universal Ghostty helper and SDK 26 for package tests. Route that single dual-Xcode job through `MACOS_RUNNER_DUAL_XCODE`, set to Blacksmith macOS 15.

The iPhone suite also exposed cross-suite output contamination because multiple tests used `live-terminal`. Give the resync test and router a unique surface ID.

Recorder failure before fix: https://github.com/manaflow-ai/cmux/actions/runs/29082615968
Recorder pass on the same AWS host after fix: https://github.com/manaflow-ai/cmux/actions/runs/29083465895
iPhone failure before isolation: https://github.com/manaflow-ai/cmux/actions/runs/29083696229
iPhone pass after isolation: https://github.com/manaflow-ai/cmux/actions/runs/29084943707

Validation: `actionlint .github/workflows/test-e2e.yml`; `bash tests/test_ci_self_hosted_guard.sh`. PR CI validates the final Tart/Blacksmith routing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mobile terminal replay barrier coordination affects live output recovery on connected devices; changes are scoped and covered by new tests. CI/workflow edits are mostly runner routing and recording harness behavior.
> 
> **Overview**
> Hardens **macOS E2E screen recording** so JPEG capture runs only while `com.cmuxterm.app.debug` is frontmost (small AppKit probe + gated `screencapture`), avoiding early capture that left cmux **Running Background**. Startup checks use a ready marker instead of assuming the first frame succeeded.
> 
> Routes **`swift-package-tests`** through **`MACOS_RUNNER_DUAL_XCODE`** so the job can build the Ghostty helper on SDK 15 and run package tests on SDK 26; documents the new repo variable. Adds **Node 22** on the focused app-host shard before CLI no-socket regressions.
> 
> On **mobile terminal sync**, adds **`requestTerminalResync`** so recovery can **defer behind an active replay barrier** (or start a new barrier when none owns the surface); legacy hosts without `terminal.replay.v1` keep the unbarriered path. **`input_seq_behind`** resync uses deferral on **raw-bytes** transport. Tests cover legacy live output during deferred resync and tighten the sequence-ahead resync scenario with manual acknowledgements and an isolated surface ID.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b1904ab6f24bbae892c542cd2ba228906f7d9c8d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal output recovery when display updates arrive out of order, helping ensure refreshed terminal content is rendered correctly.
  * Improved replay and resynchronization behavior during active terminal updates, reducing missed or stale output.

* **Tests**
  * Expanded coverage for terminal output recovery across multiple terminal sessions.

* **Chores**
  * Improved automated macOS testing and screen-capture startup reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->