### PR TITLE
Fix remote tmux mirror pane titles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -709,6 +709,32 @@ jobs:
           CMUX_SOURCE_PACKAGES_DIR="$PWD/.ci-source-packages" \
             ./tests/test_bundled_ghostty_theme_picker_helper.sh
 
+      - name: Ensure node for wrapper regressions
+        id: detect-node
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        run: |
+          set -euo pipefail
+          # The claude wrapper regressions below exec `node` from fake claude
+          # binaries. The tart-macos-15 runner image shipped without node on
+          # the runner PATH (2026-07-10), which failed every branch. Reuse an
+          # image-provided node when present; otherwise install one below.
+          for candidate in "$(command -v node || true)" /opt/homebrew/bin/node /usr/local/bin/node; do
+            if [ -n "$candidate" ] && [ -x "$candidate" ]; then
+              dirname "$candidate" >> "$GITHUB_PATH"
+              "$candidate" --version
+              echo "found=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          done
+          echo "no node runtime in the runner image; installing via setup-node"
+          echo "found=false" >> "$GITHUB_OUTPUT"
+
+      - name: Install node (runner image has none)
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) && steps.detect-node.outputs.found == 'false' }}
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: "22"
+
       - name: Run CLI no-socket regressions
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,8 +853,7 @@ jobs:
       - name: Select helper Xcode
         run: |
           set -euo pipefail
-          CMUX_CI_XCODE_APP="$CMUX_CI_HELPER_XCODE_APP" \
-            CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15 \
+          CMUX_CI_XCODE_APP="${CMUX_CI_HELPER_XCODE_APP:-$CMUX_CI_XCODE_APP}" \
             ./scripts/select-ci-xcode.sh
 
       - name: Install zig
@@ -870,6 +869,7 @@ jobs:
       - name: Build universal Ghostty CLI helper
         run: |
           set -euo pipefail
+          required_sdk_major="${CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:?}"
           mkdir -p ghostty-cli-helper
           ./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty
           lipo ghostty-cli-helper/ghostty -verify_arch arm64 x86_64
@@ -878,7 +878,7 @@ jobs:
             lipo ghostty-cli-helper/ghostty -thin "$arch" -output "$thin"
             HELPER_SDK_VERSION="$(otool -l "$thin" | awk '/LC_BUILD_VERSION/ { in_version=1; next } in_version && /sdk / { print $2; exit }')"
             echo "Ghostty helper $arch SDK version: $HELPER_SDK_VERSION"
-            [[ "$HELPER_SDK_VERSION" == 15.* ]]
+            [[ "${HELPER_SDK_VERSION%%.*}" == "$required_sdk_major" ]]
           done
 
       - name: Upload universal Ghostty CLI helper

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -731,9 +731,9 @@ jobs:
 
       - name: Install node (runner image has none)
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) && steps.detect-node.outputs.found == 'false' }}
-        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: "22"
+          node-version: "20"
 
       - name: Run CLI no-socket regressions
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -826,7 +826,8 @@ jobs:
     # transitive skip otherwise marks every macOS job skipped even when
     # linux-preflight itself succeeds. Require the direct needs explicitly.
     if: ${{ !cancelled() && needs.changes.result == 'success' && needs.linux-preflight.result == 'success' && needs.changes.outputs.macos == 'true' }}
-    runs-on: ${{ vars.MACOS_RUNNER_15 || 'warp-macos-15-arm64-6x' }}
+    # Build the release helper with SDK 15, then run package tests with SDK 26.
+    runs-on: ${{ vars.MACOS_RUNNER_DUAL_XCODE || 'blacksmith-6vcpu-macos-15' }}
     timeout-minutes: 40
     env:
       CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_15 }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -853,7 +853,8 @@ jobs:
       - name: Select helper Xcode
         run: |
           set -euo pipefail
-          CMUX_CI_XCODE_APP="${CMUX_CI_HELPER_XCODE_APP:-$CMUX_CI_XCODE_APP}" \
+          CMUX_CI_XCODE_APP="$CMUX_CI_HELPER_XCODE_APP" \
+            CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15 \
             ./scripts/select-ci-xcode.sh
 
       - name: Install zig
@@ -869,7 +870,6 @@ jobs:
       - name: Build universal Ghostty CLI helper
         run: |
           set -euo pipefail
-          required_sdk_major="${CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:?}"
           mkdir -p ghostty-cli-helper
           ./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty
           lipo ghostty-cli-helper/ghostty -verify_arch arm64 x86_64
@@ -878,7 +878,7 @@ jobs:
             lipo ghostty-cli-helper/ghostty -thin "$arch" -output "$thin"
             HELPER_SDK_VERSION="$(otool -l "$thin" | awk '/LC_BUILD_VERSION/ { in_version=1; next } in_version && /sdk / { print $2; exit }')"
             echo "Ghostty helper $arch SDK version: $HELPER_SDK_VERSION"
-            [[ "${HELPER_SDK_VERSION%%.*}" == "$required_sdk_major" ]]
+            [[ "$HELPER_SDK_VERSION" == 15.* ]]
           done
 
       - name: Upload universal Ghostty CLI helper

--- a/Sources/RemoteTmuxRawLayoutParser.swift
+++ b/Sources/RemoteTmuxRawLayoutParser.swift
@@ -28,6 +28,8 @@ enum RemoteTmuxRawLayoutParser {
         }
         var cursor = 0
         guard let node = parseNode(chars, &cursor), cursor == chars.count else { return nil }
+        let paneIDs = node.paneIDsInOrder
+        guard Set(paneIDs).count == paneIDs.count else { return nil }
         return node
     }
 

--- a/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
+++ b/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
@@ -365,7 +365,7 @@ extension RemoteTmuxWindowMirror {
     }
 
     func title(forPane paneId: Int) -> String {
-        let index = paneIDsInOrder.firstIndex(of: paneId) ?? 0
+        let index = paneIndexByPaneId[paneId] ?? 0
         return Self.windowPaneTitle(windowTitle, paneIndex: index)
     }
 

--- a/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
+++ b/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
@@ -365,10 +365,8 @@ extension RemoteTmuxWindowMirror {
     }
 
     func title(forPane paneId: Int) -> String {
-        Self.paneTitle(
-            command: connection?.paneForegroundStates[paneId]?.command,
-            cwd: cwdByPaneId[paneId]
-        ) ?? String(localized: "remoteTmux.tab.pane", defaultValue: "tmux pane")
+        let index = paneIDsInOrder.firstIndex(of: paneId) ?? 0
+        return Self.windowPaneTitle(windowTitle, paneIndex: index)
     }
 
     func combined(children: [RemoteTmuxLayoutNode], orientation: SplitOrientation) -> RemoteTmuxLayoutNode {

--- a/Sources/RemoteTmuxWindowMirror+BonsplitLayout.swift
+++ b/Sources/RemoteTmuxWindowMirror+BonsplitLayout.swift
@@ -46,7 +46,12 @@ extension RemoteTmuxWindowMirror {
         let base = trimmed.isEmpty
             ? String(localized: "remoteTmux.tab.window", defaultValue: "tmux window")
             : trimmed
-        return paneIndex == 0 ? base : "\(base) [\(paneIndex)]"
+        guard paneIndex > 0 else { return base }
+        let formattedIndex = paneIndex.formatted()
+        return String(
+            localized: "remoteTmux.tab.windowPaneIndexed",
+            defaultValue: "\(base) [\(formattedIndex)]"
+        )
     }
 
     nonisolated static func dividerFraction(

--- a/Sources/RemoteTmuxWindowMirror+BonsplitLayout.swift
+++ b/Sources/RemoteTmuxWindowMirror+BonsplitLayout.swift
@@ -41,18 +41,12 @@ extension RemoteTmuxWindowMirror {
         ).clientGrid(layout: layout, contentSize: contentSize)
     }
 
-    nonisolated static func paneTitle(command: String?, cwd: String?) -> String? {
-        let trimmedCommand = command?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmedCommand.isEmpty,
-           !RemoteTmuxPaneForegroundState.plainShellCommands.contains(trimmedCommand) {
-            return trimmedCommand
-        }
-        let trimmedCwd = cwd?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        if !trimmedCwd.isEmpty {
-            let component = URL(fileURLWithPath: trimmedCwd).lastPathComponent
-            if !component.isEmpty { return component }
-        }
-        return nil
+    nonisolated static func windowPaneTitle(_ windowTitle: String, paneIndex: Int) -> String {
+        let trimmed = windowTitle.trimmingCharacters(in: .whitespacesAndNewlines)
+        let base = trimmed.isEmpty
+            ? String(localized: "remoteTmux.tab.window", defaultValue: "tmux window")
+            : trimmed
+        return paneIndex == 0 ? base : "\(base) [\(paneIndex)]"
     }
 
     nonisolated static func dividerFraction(

--- a/Sources/RemoteTmuxWindowMirror+ControlTopology.swift
+++ b/Sources/RemoteTmuxWindowMirror+ControlTopology.swift
@@ -10,13 +10,11 @@ extension RemoteTmuxWindowMirror {
                   let panel = panel(forPane: tmuxPaneID) else {
                 return nil
             }
-            let header = paneHeaderLabels[tmuxPaneID]?
-                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
             return RemoteTmuxControlPane(
                 tmuxPaneID: tmuxPaneID,
                 paneID: paneID,
                 panel: panel,
-                title: header.isEmpty ? panel.displayTitle : header,
+                title: title(forPane: tmuxPaneID),
                 isFocused: tmuxPaneID == activePaneId
             )
         }

--- a/Sources/RemoteTmuxWindowMirror.swift
+++ b/Sources/RemoteTmuxWindowMirror.swift
@@ -63,6 +63,9 @@ final class RemoteTmuxWindowMirror {
     private(set) var layoutStructureVersion = 0
     /// The tmux pane the user last focused (drives the focus overlay + splits).
     private(set) var activePaneId: Int?
+    /// Display title for this mirrored tmux window; every inner surface/tab title
+    /// derives from this tmux window name, never from pane-border labels.
+    private(set) var windowTitle = String(localized: "remoteTmux.tab.window", defaultValue: "tmux window")
 
     /// Only the visible tab's mirror writes after its initial claim. Hidden
     /// tabs stay mounted and still receive geometry callbacks, so default-hidden
@@ -168,6 +171,8 @@ final class RemoteTmuxWindowMirror {
     /// never creates or closes panels, and f's output is zoom-invariant.
     func apply(window: RemoteTmuxWindow) {
         let previousRenderedLayout = renderedLayout
+        let nextTitle = RemoteTmuxSessionMirror.tabTitle(for: window)
+        if windowTitle != nextTitle { windowTitle = nextTitle }
         let newVisible = window.zoomed ? window.visibleLayout : nil
         if visibleLayout != newVisible { visibleLayout = newVisible }
         if zoomed != window.zoomed { zoomed = window.zoomed }

--- a/Sources/RemoteTmuxWindowMirror.swift
+++ b/Sources/RemoteTmuxWindowMirror.swift
@@ -194,7 +194,8 @@ final class RemoteTmuxWindowMirror {
         let livePaneIDsInOrder = newLayout.paneIDsInOrder
         let livePaneIds = Set(livePaneIDsInOrder)
         paneIndexByPaneId = Dictionary(
-            uniqueKeysWithValues: livePaneIDsInOrder.enumerated().map { ($0.element, $0.offset) }
+            livePaneIDsInOrder.enumerated().map { ($0.element, $0.offset) },
+            uniquingKeysWith: { firstIndex, _ in firstIndex }
         )
         for paneId in livePaneIDsInOrder where panelsByPaneId[paneId] == nil {
             guard let panel = makePanel(paneId) else { continue }

--- a/Sources/RemoteTmuxWindowMirror.swift
+++ b/Sources/RemoteTmuxWindowMirror.swift
@@ -80,6 +80,7 @@ final class RemoteTmuxWindowMirror {
     @ObservationIgnored var paneIdByPaneId: [Int: PaneID] = [:]
     @ObservationIgnored var paneIdByBonsplitPane: [PaneID: Int] = [:]
     @ObservationIgnored var paneIdByTabId: [TabID: Int] = [:]
+    @ObservationIgnored var paneIndexByPaneId: [Int: Int] = [:]
     @ObservationIgnored var cwdByPaneId: [Int: String] = [:]
     @ObservationIgnored var isApplyingRemoteLayout = false
     @ObservationIgnored var isApplyingTmuxFocus = false
@@ -190,8 +191,12 @@ final class RemoteTmuxWindowMirror {
         layout newLayout: RemoteTmuxLayoutNode,
         previousRenderedLayout: RemoteTmuxLayoutNode
     ) {
-        let livePaneIds = Set(newLayout.paneIDsInOrder)
-        for paneId in newLayout.paneIDsInOrder where panelsByPaneId[paneId] == nil {
+        let livePaneIDsInOrder = newLayout.paneIDsInOrder
+        let livePaneIds = Set(livePaneIDsInOrder)
+        paneIndexByPaneId = Dictionary(
+            uniqueKeysWithValues: livePaneIDsInOrder.enumerated().map { ($0.element, $0.offset) }
+        )
+        for paneId in livePaneIDsInOrder where panelsByPaneId[paneId] == nil {
             guard let panel = makePanel(paneId) else { continue }
             panelsByPaneId[paneId] = panel
             let surface = panel.surface

--- a/cmuxTests/RemoteTmuxControlParserTests.swift
+++ b/cmuxTests/RemoteTmuxControlParserTests.swift
@@ -413,6 +413,10 @@ import Testing
         #expect(RemoteTmuxRawLayoutParser.parse("abcd,60x40,0,0{60x40,0,0,4}") == nil)
     }
 
+    @Test func rejectsDuplicatePaneIDs() {
+        #expect(RemoteTmuxRawLayoutParser.parse("abcd,120x40,0,0{60x40,0,0,4,59x40,61,0,4}") == nil)
+    }
+
     @Test func rejectsGarbageLayout() {
         #expect(RemoteTmuxRawLayoutParser.parse("not-a-layout") == nil)
         #expect(RemoteTmuxRawLayoutParser.parse("") == nil)

--- a/cmuxTests/RemoteTmuxMirrorLayoutMathTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorLayoutMathTests.swift
@@ -212,9 +212,4 @@ import Testing
         #expect(grid?.rows == 5)
     }
 
-    @Test func paneTitleUsesCommandThenShellCwdThenNil() {
-        #expect(RemoteTmuxWindowMirror.paneTitle(command: "vim", cwd: "/tmp/project") == "vim")
-        #expect(RemoteTmuxWindowMirror.paneTitle(command: "zsh", cwd: "/tmp/project") == "project")
-        #expect(RemoteTmuxWindowMirror.paneTitle(command: "", cwd: nil) == nil)
-    }
 }

--- a/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
@@ -389,4 +389,111 @@ struct RemoteTmuxMirrorTargetingTests {
             "swap-window -d -s @0 -t @2",
         ])
     }
+
+    @Test func multiPaneMirrorSurfaceTitlesUseWindowName() throws {
+        let harness = try MirrorTitleHarness()
+        defer { harness.tearDown() }
+        harness.publishListWindows([
+            "@1 f92f,80x24,0,0,0 f92f,80x24,0,0,0 [] editor",
+            "@2 abcd,120x40,0,0{60x40,0,0,4,59x40,61,0[59x20,61,0,5,59x19,61,21,8]} abcd,120x40,0,0{60x40,0,0,4,59x40,61,0[59x20,61,0,5,59x19,61,21,8]} [] logs",
+        ])
+        harness.publishPaneRects(["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""])
+        harness.publishPaneRects([
+            "%4 0 0 60 40 1 off :0 \"cmuxs-Mac-mini.local\"",
+            "%5 61 0 59 20 0 off :1 \"cmuxs-Mac-mini.local\"",
+            "%8 61 21 59 19 0 off :2 \"cmuxs-Mac-mini.local\"",
+        ])
+
+        #expect(try harness.surfaceTitles() == ["editor", "logs", "logs [1]", "logs [2]"])
+    }
+
+    @Test func singlePaneMirrorSurfaceTitleStillUsesWindowName() throws {
+        let harness = try MirrorTitleHarness()
+        defer { harness.tearDown() }
+        harness.publishListWindows(["@1 f92f,80x24,0,0,0 f92f,80x24,0,0,0 [] editor"])
+        harness.publishPaneRects(["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""])
+
+        #expect(try harness.surfaceTitles() == ["editor"])
+    }
+
+    @Test func singlePaneToMultiPaneTransitionKeepsWindowNameInSurfaceTitles() throws {
+        let harness = try MirrorTitleHarness()
+        defer { harness.tearDown() }
+        harness.publishListWindows(["@2 f92f,80x24,0,0,4 f92f,80x24,0,0,4 [] logs"])
+        harness.publishPaneRects(["%4 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""])
+        #expect(try harness.surfaceTitles() == ["logs"])
+
+        harness.connection.handleMessageForTesting(.layoutChange(
+            windowId: 2, layout: "abcd,120x40,0,0{60x40,0,0,4,59x40,61,0,5}", visibleLayout: nil, zoomed: false
+        ))
+        harness.publishPaneRects([
+            "%4 0 0 60 40 1 off :0 \"cmuxs-Mac-mini.local\"",
+            "%5 61 0 59 40 0 off :1 \"cmuxs-Mac-mini.local\"",
+        ])
+
+        #expect(try harness.surfaceTitles() == ["logs", "logs [1]"])
+    }
+
+    private struct MirrorTitleHarness {
+        let windowId: UUID
+        let controller: RemoteTmuxController
+        let host: RemoteTmuxHost
+        let connection: RemoteTmuxControlConnection
+        let writer: RemoteTmuxControlPipeWriter
+        let pipe: Pipe
+        let workspace: Workspace
+
+        init() throws {
+            let appDelegate = try #require(AppDelegate.shared)
+            let windowId = appDelegate.createMainWindow()
+            let manager = try #require(appDelegate.tabManagerFor(windowId: windowId))
+            let controller = RemoteTmuxController()
+            let host = RemoteTmuxHost(destination: "user@host")
+            let connection = RemoteTmuxControlConnection(host: host, sessionName: "dogfood-a")
+            let pipe = Pipe()
+            let writer = RemoteTmuxControlPipeWriter(
+                handle: pipe.fileHandleForWriting, label: "remote-tmux-title-test", maxPendingBytes: 1 << 16, onFailure: {}
+            )
+            connection.installStdinWriterForTesting(writer)
+            connection.handleMessageForTesting(.enter)
+            connection.handleMessageForTesting(.commandResult(commandNumber: 0, lines: [], isError: false))
+            controller.cacheConnection(connection)
+            try controller.mirrorSession(host: host, sessionName: "dogfood-a", into: manager)
+            workspace = try #require(manager.tabs.first(where: \.isRemoteTmuxMirror))
+            self.windowId = windowId
+            self.controller = controller
+            self.host = host
+            self.connection = connection
+            self.writer = writer
+            self.pipe = pipe
+        }
+
+        func publishListWindows(_ lines: [String]) {
+            connection.handleMessageForTesting(.commandResult(commandNumber: 1, lines: lines, isError: false))
+        }
+
+        func publishPaneRects(_ lines: [String]) {
+            connection.handleMessageForTesting(.commandResult(commandNumber: 2, lines: lines, isError: false))
+        }
+
+        func surfaceTitles() throws -> [String] {
+            let snapshot = try #require(TerminalController.shared.controlSurfaceList(routing: routing()))
+            return snapshot.surfaces.map(\.title)
+        }
+
+        private func routing() -> ControlRoutingSelectors {
+            ControlRoutingSelectors(
+                hasWindowIDParam: false, windowID: nil, groupID: nil, workspaceID: workspace.id, surfaceID: nil, paneID: nil
+            )
+        }
+
+        func tearDown() {
+            controller.detach(host: host, sessionName: "dogfood-a")
+            writer.close()
+            try? pipe.fileHandleForReading.close()
+            let identifier = "cmux.main.\(windowId.uuidString)"
+            NSApp.windows.first { $0.identifier?.rawValue == identifier }?.performClose(nil)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        }
+    }
 }

--- a/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
@@ -9,8 +9,7 @@ import CmuxSettings
 @testable import cmux
 #endif
 
-/// Behavior tests for remote-tmux mirror targeting and lifecycle decisions using
-/// pure seams and cached unstarted control connections; no ssh/tmux is launched.
+/// Remote-tmux behavior tests using pure seams and cached, unstarted connections.
 @MainActor
 @Suite(.serialized)
 struct RemoteTmuxMirrorTargetingTests {
@@ -397,13 +396,14 @@ struct RemoteTmuxMirrorTargetingTests {
             "@1 f92f,80x24,0,0,0 f92f,80x24,0,0,0 [] editor",
             "@2 abcd,120x40,0,0{60x40,0,0,4,59x40,61,0[59x20,61,0,5,59x19,61,21,8]} abcd,120x40,0,0{60x40,0,0,4,59x40,61,0[59x20,61,0,5,59x19,61,21,8]} [] logs",
         ])
-        harness.publishPaneRects(["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""])
-        harness.publishPaneRects([
-            "%4 0 0 60 40 1 off :0 \"cmuxs-Mac-mini.local\"",
-            "%5 61 0 59 20 0 off :1 \"cmuxs-Mac-mini.local\"",
-            "%8 61 21 59 19 0 off :2 \"cmuxs-Mac-mini.local\"",
+        try harness.publishPaneRects([
+            1: ["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""],
+            2: [
+                "%4 0 0 60 40 1 off :0 \"cmuxs-Mac-mini.local\"",
+                "%5 61 0 59 20 0 off :1 \"cmuxs-Mac-mini.local\"",
+                "%8 61 21 59 19 0 off :2 \"cmuxs-Mac-mini.local\"",
+            ],
         ])
-
         #expect(try harness.surfaceTitles() == ["editor", "logs", "logs [1]", "logs [2]"])
     }
 
@@ -411,8 +411,7 @@ struct RemoteTmuxMirrorTargetingTests {
         let harness = try MirrorTitleHarness()
         defer { harness.tearDown() }
         harness.publishListWindows(["@1 f92f,80x24,0,0,0 f92f,80x24,0,0,0 [] editor"])
-        harness.publishPaneRects(["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""])
-
+        try harness.publishPaneRects([1: ["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""]])
         #expect(try harness.surfaceTitles() == ["editor"])
     }
 
@@ -420,16 +419,16 @@ struct RemoteTmuxMirrorTargetingTests {
         let harness = try MirrorTitleHarness()
         defer { harness.tearDown() }
         harness.publishListWindows(["@2 f92f,80x24,0,0,4 f92f,80x24,0,0,4 [] logs"])
-        harness.publishPaneRects(["%4 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""])
+        try harness.publishPaneRects([2: ["%4 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""]])
         #expect(try harness.surfaceTitles() == ["logs"])
 
         harness.connection.handleMessageForTesting(.layoutChange(
             windowId: 2, layout: "abcd,120x40,0,0{60x40,0,0,4,59x40,61,0,5}", visibleLayout: nil, zoomed: false
         ))
-        harness.publishPaneRects([
+        try harness.publishPaneRects([2: [
             "%4 0 0 60 40 1 off :0 \"cmuxs-Mac-mini.local\"",
             "%5 61 0 59 40 0 off :1 \"cmuxs-Mac-mini.local\"",
-        ])
+        ]])
 
         #expect(try harness.surfaceTitles() == ["logs", "logs [1]"])
     }
@@ -472,19 +471,20 @@ struct RemoteTmuxMirrorTargetingTests {
             connection.handleMessageForTesting(.commandResult(commandNumber: 1, lines: lines, isError: false))
         }
 
-        func publishPaneRects(_ lines: [String]) {
-            connection.handleMessageForTesting(.commandResult(commandNumber: 2, lines: lines, isError: false))
+        func publishPaneRects(_ linesByWindow: [Int: [String]]) throws {
+            while let kind = connection.pendingCommandKindsForTesting.first {
+                guard case let .paneRects(windowId, _) = kind else { return }
+                let lines = try #require(linesByWindow[windowId])
+                connection.handleMessageForTesting(.commandResult(commandNumber: 2, lines: lines, isError: false))
+            }
         }
 
         func surfaceTitles() throws -> [String] {
-            let snapshot = try #require(TerminalController.shared.controlSurfaceList(routing: routing()))
-            return snapshot.surfaces.map(\.title)
-        }
-
-        private func routing() -> ControlRoutingSelectors {
-            ControlRoutingSelectors(
+            let routing = ControlRoutingSelectors(
                 hasWindowIDParam: false, windowID: nil, groupID: nil, workspaceID: workspace.id, surfaceID: nil, paneID: nil
             )
+            let snapshot = try #require(TerminalController.shared.controlSurfaceList(routing: routing))
+            return snapshot.surfaces.map(\.title)
         }
 
         func tearDown() {

--- a/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
@@ -434,7 +434,7 @@ struct RemoteTmuxMirrorTargetingTests {
         #expect(try harness.surfaceTitles() == ["logs", "logs [1]"])
     }
 
-    private struct MirrorTitleHarness {
+    @MainActor private struct MirrorTitleHarness {
         let windowId: UUID
         let controller: RemoteTmuxController
         let host: RemoteTmuxHost
@@ -459,7 +459,7 @@ struct RemoteTmuxMirrorTargetingTests {
             connection.handleMessageForTesting(.commandResult(commandNumber: 0, lines: [], isError: false))
             controller.cacheConnection(connection)
             try controller.mirrorSession(host: host, sessionName: "dogfood-a", into: manager)
-            workspace = try #require(manager.tabs.first(where: \.isRemoteTmuxMirror))
+            workspace = try #require(manager.tabs.first { $0.isRemoteTmuxMirror })
             self.windowId = windowId
             self.controller = controller
             self.host = host

--- a/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
@@ -1,16 +1,16 @@
+import AppKit
+import CmuxControlSocket
 import Foundation
 import Testing
 import CmuxSettings
-
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
 @testable import cmux
 #endif
 
-/// Behavior tests for remote-tmux mirror targeting and lifecycle decisions. These
-/// exercise pure seams and cached unstarted control connections; no ssh/tmux
-/// process is launched.
+/// Behavior tests for remote-tmux mirror targeting and lifecycle decisions using
+/// pure seams and cached unstarted control connections; no ssh/tmux is launched.
 @MainActor
 @Suite(.serialized)
 struct RemoteTmuxMirrorTargetingTests {

--- a/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTargetingTests.swift
@@ -396,7 +396,7 @@ struct RemoteTmuxMirrorTargetingTests {
             "@1 f92f,80x24,0,0,0 f92f,80x24,0,0,0 [] editor",
             "@2 abcd,120x40,0,0{60x40,0,0,4,59x40,61,0[59x20,61,0,5,59x19,61,21,8]} abcd,120x40,0,0{60x40,0,0,4,59x40,61,0[59x20,61,0,5,59x19,61,21,8]} [] logs",
         ])
-        try harness.publishPaneRects([
+        try harness.drainThroughPaneRects([
             1: ["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""],
             2: [
                 "%4 0 0 60 40 1 off :0 \"cmuxs-Mac-mini.local\"",
@@ -411,7 +411,7 @@ struct RemoteTmuxMirrorTargetingTests {
         let harness = try MirrorTitleHarness()
         defer { harness.tearDown() }
         harness.publishListWindows(["@1 f92f,80x24,0,0,0 f92f,80x24,0,0,0 [] editor"])
-        try harness.publishPaneRects([1: ["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""]])
+        try harness.drainThroughPaneRects([1: ["%0 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""]])
         #expect(try harness.surfaceTitles() == ["editor"])
     }
 
@@ -419,13 +419,13 @@ struct RemoteTmuxMirrorTargetingTests {
         let harness = try MirrorTitleHarness()
         defer { harness.tearDown() }
         harness.publishListWindows(["@2 f92f,80x24,0,0,4 f92f,80x24,0,0,4 [] logs"])
-        try harness.publishPaneRects([2: ["%4 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""]])
+        try harness.drainThroughPaneRects([2: ["%4 0 0 80 24 1 off :0 \"cmuxs-Mac-mini.local\""]])
         #expect(try harness.surfaceTitles() == ["logs"])
 
         harness.connection.handleMessageForTesting(.layoutChange(
             windowId: 2, layout: "abcd,120x40,0,0{60x40,0,0,4,59x40,61,0,5}", visibleLayout: nil, zoomed: false
         ))
-        try harness.publishPaneRects([2: [
+        try harness.drainThroughPaneRects([2: [
             "%4 0 0 60 40 1 off :0 \"cmuxs-Mac-mini.local\"",
             "%5 61 0 59 40 0 off :1 \"cmuxs-Mac-mini.local\"",
         ]])
@@ -471,10 +471,10 @@ struct RemoteTmuxMirrorTargetingTests {
             connection.handleMessageForTesting(.commandResult(commandNumber: 1, lines: lines, isError: false))
         }
 
-        func publishPaneRects(_ linesByWindow: [Int: [String]]) throws {
+        func drainThroughPaneRects(_ linesByWindow: [Int: [String]]) throws {
             while let kind = connection.pendingCommandKindsForTesting.first {
-                guard case let .paneRects(windowId, _) = kind else { return }
-                let lines = try #require(linesByWindow[windowId])
+                let lines: [String]
+                if case let .paneRects(windowId, _) = kind { lines = try #require(linesByWindow[windowId]) } else { lines = [] }
                 connection.handleMessageForTesting(.commandResult(commandNumber: 2, lines: lines, isError: false))
             }
         }

--- a/docs/ci-runners.md
+++ b/docs/ci-runners.md
@@ -9,6 +9,7 @@ that takes effect on the next workflow run.
 | ------------------- | ---------------------------------------------------------- | --------------------------- | -------------------------------- |
 | `LINUX_RUNNER`      | every Linux job (`ci.yml` web/typecheck/db, presence, cloud-vm, nightly/ios decide jobs, claude, homebrew, tmux fuzz) | `blacksmith-4vcpu-ubuntu-2404` | `warp-ubuntu-latest-x64-4x`   |
 | `MACOS_RUNNER_15`   | universal Release app builds: nightly, stable release, `release-ghostty-cli-helper`, most macOS defaults | `tart-macos-15` | `warp-macos-15-arm64-6x`         |
+| `MACOS_RUNNER_DUAL_XCODE` | `swift-package-tests` (SDK 15 release helper, then SDK 26 package tests) | `blacksmith-6vcpu-macos-15` | `blacksmith-6vcpu-macos-15` |
 | `MACOS_RUNNER_26`   | macOS 26 compatibility jobs                                | `blacksmith-6vcpu-macos-26` | `blacksmith-6vcpu-macos-26`      |
 | `MACOS_RUNNER_26_RELEASE` | disk-heavy `release-build` universal app             | `blacksmith-6vcpu-macos-26` | `blacksmith-6vcpu-macos-26`      |
 | `MACOS_RUNNER_DISPLAY` | macOS GUI, XCUITest, and virtual-display tests           | `tart-gui`                  | `warp-macos-15-arm64-6x`         |
@@ -46,6 +47,7 @@ fleet recovers.
 ```bash
 gh variable set LINUX_RUNNER          --repo manaflow-ai/cmux -b blacksmith-4vcpu-ubuntu-2404
 gh variable set MACOS_RUNNER_15         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
+gh variable set MACOS_RUNNER_DUAL_XCODE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
 gh variable set MACOS_RUNNER_26         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_26_RELEASE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_DISPLAY    --repo manaflow-ai/cmux -b depot-macos-latest
@@ -56,11 +58,15 @@ Restore the self-hosted pool with explicit labels:
 
 ```bash
 gh variable set MACOS_RUNNER_15         --repo manaflow-ai/cmux -b tart-macos-15
+gh variable set MACOS_RUNNER_DUAL_XCODE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-15
 gh variable set MACOS_RUNNER_26         --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_26_RELEASE --repo manaflow-ai/cmux -b blacksmith-6vcpu-macos-26
 gh variable set MACOS_RUNNER_DISPLAY    --repo manaflow-ai/cmux -b tart-gui
 gh variable set MACOS_RUNNER_IOS        --repo manaflow-ai/cmux -b tart-ios
 ```
+
+`MACOS_RUNNER_DUAL_XCODE` remains on Blacksmith because the Tart macOS 15
+image currently carries Xcode 26 only and cannot build the SDK 15 helper.
 
 Check current values:
 

--- a/tests/node_runtime.py
+++ b/tests/node_runtime.py
@@ -1,0 +1,49 @@
+"""Locate a usable Node.js runtime for tests whose fake binaries `exec node`.
+
+CI macOS runner images have dropped `node` from the default PATH before
+(2026-07-10 warp-macos-15 image), which made every wrapper test fail with
+`exec: node: not found` on all branches. Tests that need node call
+`ensure_node_on_path()` first: it repairs PATH when node exists but is not
+reachable, and lets the caller SKIP (like the existing `bun` skip in
+test_pi_extension_install.py) when node is genuinely absent.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+
+def _candidate_nodes() -> list[Path]:
+    candidates = [
+        Path("/opt/homebrew/bin/node"),
+        Path("/usr/local/bin/node"),
+        Path("/usr/bin/node"),
+        Path.home() / ".volta" / "bin" / "node",
+    ]
+    nvm_versions = Path.home() / ".nvm" / "versions" / "node"
+    if nvm_versions.is_dir():
+        for version_dir in sorted(nvm_versions.iterdir(), reverse=True):
+            candidates.append(version_dir / "bin" / "node")
+    return candidates
+
+
+def ensure_node_on_path() -> str | None:
+    """Return a node executable path, prepending its directory to PATH.
+
+    Returns None when no node runtime can be found on this machine.
+    """
+    node = shutil.which("node")
+    if node is None:
+        for candidate in _candidate_nodes():
+            if candidate.is_file() and os.access(candidate, os.X_OK):
+                node = str(candidate)
+                break
+    if node is None:
+        return None
+    node_dir = str(Path(node).parent)
+    path = os.environ.get("PATH", "")
+    if node_dir not in path.split(os.pathsep):
+        os.environ["PATH"] = f"{node_dir}{os.pathsep}{path}" if path else node_dir
+    return node

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -601,11 +601,10 @@ def test_required_macos_topology_collapses_display_and_release_helper_jobs() -> 
     assert "CMUX_CI_HELPER_XCODE_APP" in package_block
     assert "/Applications/Xcode_16.4.app" not in package_block
     assert "Select helper Xcode" in package_block
-    assert 'CMUX_CI_XCODE_APP="${CMUX_CI_HELPER_XCODE_APP:-$CMUX_CI_XCODE_APP}"' in package_block
-    assert 'required_sdk_major="${CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:?}"' in package_block
+    assert "CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15" in package_block
     assert "Build universal Ghostty CLI helper" in package_block
     assert "./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty" in package_block
-    assert '[[ "${HELPER_SDK_VERSION%%.*}" == "$required_sdk_major" ]]' in package_block
+    assert '[[ "$HELPER_SDK_VERSION" == 15.* ]]' in package_block
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in package_block
     assert package_block.index("Select helper Xcode") < package_block.index("Build universal Ghostty CLI helper")
     assert package_block.index("Build universal Ghostty CLI helper") < package_block.index("Select Xcode")

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -601,10 +601,11 @@ def test_required_macos_topology_collapses_display_and_release_helper_jobs() -> 
     assert "CMUX_CI_HELPER_XCODE_APP" in package_block
     assert "/Applications/Xcode_16.4.app" not in package_block
     assert "Select helper Xcode" in package_block
-    assert "CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15" in package_block
+    assert 'CMUX_CI_XCODE_APP="${CMUX_CI_HELPER_XCODE_APP:-$CMUX_CI_XCODE_APP}"' in package_block
+    assert 'required_sdk_major="${CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:?}"' in package_block
     assert "Build universal Ghostty CLI helper" in package_block
     assert "./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty" in package_block
-    assert '[[ "$HELPER_SDK_VERSION" == 15.* ]]' in package_block
+    assert '[[ "${HELPER_SDK_VERSION%%.*}" == "$required_sdk_major" ]]' in package_block
     assert "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a" in package_block
     assert package_block.index("Select helper Xcode") < package_block.index("Build universal Ghostty CLI helper")
     assert package_block.index("Build universal Ghostty CLI helper") < package_block.index("Select Xcode")

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -588,6 +588,7 @@ def test_required_macos_topology_collapses_display_and_release_helper_jobs() -> 
     package_block = workflow_job_block("swift-package-tests")
     release_block = workflow_job_block("release-build")
 
+    assert "vars.MACOS_RUNNER_DUAL_XCODE" in package_block
     assert "\n  ui-regressions:" not in workflow
     assert "\n  release-ghostty-cli-helper:" not in workflow
     assert "build-for-testing" in runtime_block

--- a/tests/test_ci_release_sdk_lane.sh
+++ b/tests/test_ci_release_sdk_lane.sh
@@ -76,28 +76,28 @@ if [[ "$swift_package_section" != *"timeout-minutes: 40"* ]]; then
 fi
 
 if [[ "$swift_package_section" != *"CMUX_CI_HELPER_XCODE_APP"* ]]; then
-  echo "FAIL: CI swift-package-tests must use a helper-specific Xcode pin" >&2
+  echo "FAIL: CI swift-package-tests must expose a helper-specific Xcode override" >&2
   exit 1
 fi
 
-if [[ "$swift_package_section" == *"/Applications/Xcode_16.4.app"* ]]; then
-  echo "FAIL: CI swift-package-tests must scan for a macOS 15 SDK when the helper Xcode override is unset" >&2
+if [[ "$swift_package_section" != *'CMUX_CI_XCODE_APP="${CMUX_CI_HELPER_XCODE_APP:-$CMUX_CI_XCODE_APP}"'* ]]; then
+  echo "FAIL: CI swift-package-tests must fall back to the package-test Xcode when the helper override is unset" >&2
   exit 1
 fi
 
 if [[ "$swift_package_section" != *"./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty"* ]]; then
-  echo "FAIL: CI swift-package-tests must build the universal Ghostty CLI helper on the macOS 15 lane" >&2
+  echo "FAIL: CI swift-package-tests must build the universal Ghostty CLI helper on the package-test lane" >&2
   exit 1
 fi
 
 if [[ "$swift_package_section" != *"actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"* ]]; then
-  echo "FAIL: CI swift-package-tests must upload the macOS 15-built Ghostty helper artifact" >&2
+  echo "FAIL: CI swift-package-tests must upload the Ghostty helper artifact" >&2
   exit 1
 fi
 
 swift_package_before_xcode="${swift_package_section%%- name: Select Xcode*}"
-if [[ "$swift_package_before_xcode" != *"CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15"* ]]; then
-  echo "FAIL: CI swift-package-tests must require a macOS 15 SDK for the helper build" >&2
+if [[ "$swift_package_before_xcode" != *'required_sdk_major="${CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:?}"'* ]]; then
+  echo "FAIL: CI swift-package-tests must bind helper validation to the required SDK major" >&2
   exit 1
 fi
 
@@ -111,14 +111,14 @@ if [[ "$swift_package_before_xcode" != *"actions/upload-artifact@043fb46d1a93c77
   exit 1
 fi
 
-if [[ "$swift_package_section" != *'[[ "$HELPER_SDK_VERSION" == 15.* ]]'* ]]; then
-  echo "FAIL: CI swift-package-tests must validate the uploaded Ghostty helper was built with a macOS 15 SDK" >&2
+if [[ "$swift_package_section" != *'[[ "${HELPER_SDK_VERSION%%.*}" == "$required_sdk_major" ]]'* ]]; then
+  echo "FAIL: CI swift-package-tests must validate the uploaded Ghostty helper SDK major" >&2
   exit 1
 fi
 
 release_build_section="$(job_section "$CI_FILE" "release-build")"
 if [[ "$release_build_section" != *"actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0"* ]]; then
-  echo "FAIL: CI release-build must download the macOS 15-built Ghostty helper artifact" >&2
+  echo "FAIL: CI release-build must download the Ghostty helper artifact" >&2
   exit 1
 fi
 
@@ -137,4 +137,4 @@ if grep -Fq "release-ghostty-cli-helper:" "$CI_FILE"; then
   exit 1
 fi
 
-echo "PASS: release uses artifact helper handoff; CI release-build downloads the helper from the existing macOS 15 package lane"
+echo "PASS: release uses artifact helper handoff; CI release-build downloads the helper from the package-test lane"

--- a/tests/test_ci_release_sdk_lane.sh
+++ b/tests/test_ci_release_sdk_lane.sh
@@ -76,28 +76,28 @@ if [[ "$swift_package_section" != *"timeout-minutes: 40"* ]]; then
 fi
 
 if [[ "$swift_package_section" != *"CMUX_CI_HELPER_XCODE_APP"* ]]; then
-  echo "FAIL: CI swift-package-tests must expose a helper-specific Xcode override" >&2
+  echo "FAIL: CI swift-package-tests must use a helper-specific Xcode pin" >&2
   exit 1
 fi
 
-if [[ "$swift_package_section" != *'CMUX_CI_XCODE_APP="${CMUX_CI_HELPER_XCODE_APP:-$CMUX_CI_XCODE_APP}"'* ]]; then
-  echo "FAIL: CI swift-package-tests must fall back to the package-test Xcode when the helper override is unset" >&2
+if [[ "$swift_package_section" == *"/Applications/Xcode_16.4.app"* ]]; then
+  echo "FAIL: CI swift-package-tests must scan for a macOS 15 SDK when the helper Xcode override is unset" >&2
   exit 1
 fi
 
 if [[ "$swift_package_section" != *"./scripts/build-ghostty-cli-helper.sh --universal --output ghostty-cli-helper/ghostty"* ]]; then
-  echo "FAIL: CI swift-package-tests must build the universal Ghostty CLI helper on the package-test lane" >&2
+  echo "FAIL: CI swift-package-tests must build the universal Ghostty CLI helper on the macOS 15 lane" >&2
   exit 1
 fi
 
 if [[ "$swift_package_section" != *"actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1"* ]]; then
-  echo "FAIL: CI swift-package-tests must upload the Ghostty helper artifact" >&2
+  echo "FAIL: CI swift-package-tests must upload the macOS 15-built Ghostty helper artifact" >&2
   exit 1
 fi
 
 swift_package_before_xcode="${swift_package_section%%- name: Select Xcode*}"
-if [[ "$swift_package_before_xcode" != *'required_sdk_major="${CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:?}"'* ]]; then
-  echo "FAIL: CI swift-package-tests must bind helper validation to the required SDK major" >&2
+if [[ "$swift_package_before_xcode" != *"CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15"* ]]; then
+  echo "FAIL: CI swift-package-tests must require a macOS 15 SDK for the helper build" >&2
   exit 1
 fi
 
@@ -111,14 +111,14 @@ if [[ "$swift_package_before_xcode" != *"actions/upload-artifact@043fb46d1a93c77
   exit 1
 fi
 
-if [[ "$swift_package_section" != *'[[ "${HELPER_SDK_VERSION%%.*}" == "$required_sdk_major" ]]'* ]]; then
-  echo "FAIL: CI swift-package-tests must validate the uploaded Ghostty helper SDK major" >&2
+if [[ "$swift_package_section" != *'[[ "$HELPER_SDK_VERSION" == 15.* ]]'* ]]; then
+  echo "FAIL: CI swift-package-tests must validate the uploaded Ghostty helper was built with a macOS 15 SDK" >&2
   exit 1
 fi
 
 release_build_section="$(job_section "$CI_FILE" "release-build")"
 if [[ "$release_build_section" != *"actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7.0.0"* ]]; then
-  echo "FAIL: CI release-build must download the Ghostty helper artifact" >&2
+  echo "FAIL: CI release-build must download the macOS 15-built Ghostty helper artifact" >&2
   exit 1
 fi
 
@@ -137,4 +137,4 @@ if grep -Fq "release-ghostty-cli-helper:" "$CI_FILE"; then
   exit 1
 fi
 
-echo "PASS: release uses artifact helper handoff; CI release-build downloads the helper from the package-test lane"
+echo "PASS: release uses artifact helper handoff; CI release-build downloads the helper from the existing macOS 15 package lane"

--- a/tests/test_ci_release_sdk_lane.sh
+++ b/tests/test_ci_release_sdk_lane.sh
@@ -70,6 +70,11 @@ if ! grep -Fq "actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef35013
 fi
 
 swift_package_section="$(job_section "$CI_FILE" "swift-package-tests")"
+if [[ "$swift_package_section" != *'runs-on: ${{ vars.MACOS_RUNNER_DUAL_XCODE || '\''blacksmith-6vcpu-macos-15'\'' }}'* ]]; then
+  echo "FAIL: CI swift-package-tests must use the dual-Xcode runner lane" >&2
+  exit 1
+fi
+
 if [[ "$swift_package_section" != *"timeout-minutes: 40"* ]]; then
   echo "FAIL: CI swift-package-tests must have enough timeout budget for helper build plus package tests" >&2
   exit 1

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -280,6 +280,7 @@ check_release_helper_artifact_from_package_lane() {
     /^  swift-package-tests:/ { in_job=1; next }
     in_job && /^  [^[:space:]#][^:]*:[[:space:]]*(#.*)?$/ { in_job=0 }
 
+    in_job && /runs-on:[[:space:]]*\$\{\{ vars\.MACOS_RUNNER_DUAL_XCODE \|\| '\''blacksmith-6vcpu-macos-15'\'' \}\}/ { saw_dual_runner=1 }
     in_job && /timeout-minutes:[[:space:]]*40/ { saw_timeout=1 }
     in_job && /CMUX_CI_HELPER_XCODE_APP:/ { saw_helper_xcode_env=1 }
     in_job && /- name: Select helper Xcode/ { saw_helper_select=1; next }
@@ -306,10 +307,10 @@ check_release_helper_artifact_from_package_lane() {
     in_job && /\[\[ "\$HELPER_SDK_VERSION" == 15\.\* \]\]/ { saw_helper_sdk_validation=1 }
 
     END {
-      exit !(saw_timeout && saw_helper_xcode_env && saw_helper_select && saw_helper_sdk_pin && saw_build_step && saw_build && saw_lipo && saw_helper_sdk_validation && saw_upload_step && saw_upload && saw_artifact_name && saw_select && !saw_build_after_select && !saw_upload_after_select)
+      exit !(saw_dual_runner && saw_timeout && saw_helper_xcode_env && saw_helper_select && saw_helper_sdk_pin && saw_build_step && saw_build && saw_lipo && saw_helper_sdk_validation && saw_upload_step && saw_upload && saw_artifact_name && saw_select && !saw_build_after_select && !saw_upload_after_select)
     }
   ' "$CI_FILE"; then
-    echo "FAIL: swift-package-tests must pin and validate the macOS 15 Ghostty helper before selecting Xcode 26"
+    echo "FAIL: swift-package-tests must use the dual-Xcode runner, then pin and validate the macOS 15 Ghostty helper before selecting Xcode 26"
     exit 1
   fi
 

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -283,7 +283,7 @@ check_release_helper_artifact_from_package_lane() {
     in_job && /timeout-minutes:[[:space:]]*40/ { saw_timeout=1 }
     in_job && /CMUX_CI_HELPER_XCODE_APP:/ { saw_helper_xcode_env=1 }
     in_job && /- name: Select helper Xcode/ { saw_helper_select=1; next }
-    in_job && /CMUX_CI_XCODE_APP="\$\{CMUX_CI_HELPER_XCODE_APP:-\$CMUX_CI_XCODE_APP\}"/ { saw_helper_xcode_fallback=1 }
+    in_job && /CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15/ { saw_helper_sdk_pin=1 }
     in_job && /- name: Select Xcode/ { saw_select=1; after_select=1; next }
     in_job && /- name: Build universal Ghostty CLI helper/ {
       saw_build_step=1
@@ -303,14 +303,13 @@ check_release_helper_artifact_from_package_lane() {
     }
     in_job && /uses: actions\/upload-artifact@/ { saw_upload=1 }
     in_job && /name:[[:space:]]*cmux-ghostty-cli-helper/ { saw_artifact_name=1 }
-    in_job && /required_sdk_major="\$\{CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:\?\}"/ { saw_required_sdk_major=1 }
-    in_job && /\[\[ "\$\{HELPER_SDK_VERSION%%\.\*\}" == "\$required_sdk_major" \]\]/ { saw_helper_sdk_validation=1 }
+    in_job && /\[\[ "\$HELPER_SDK_VERSION" == 15\.\* \]\]/ { saw_helper_sdk_validation=1 }
 
     END {
-      exit !(saw_timeout && saw_helper_xcode_env && saw_helper_select && saw_helper_xcode_fallback && saw_build_step && saw_build && saw_lipo && saw_required_sdk_major && saw_helper_sdk_validation && saw_upload_step && saw_upload && saw_artifact_name && saw_select && !saw_build_after_select && !saw_upload_after_select)
+      exit !(saw_timeout && saw_helper_xcode_env && saw_helper_select && saw_helper_sdk_pin && saw_build_step && saw_build && saw_lipo && saw_helper_sdk_validation && saw_upload_step && saw_upload && saw_artifact_name && saw_select && !saw_build_after_select && !saw_upload_after_select)
     }
   ' "$CI_FILE"; then
-    echo "FAIL: swift-package-tests must build and validate the Ghostty helper before selecting the final Xcode"
+    echo "FAIL: swift-package-tests must pin and validate the macOS 15 Ghostty helper before selecting Xcode 26"
     exit 1
   fi
 

--- a/tests/test_ci_self_hosted_guard.sh
+++ b/tests/test_ci_self_hosted_guard.sh
@@ -283,7 +283,7 @@ check_release_helper_artifact_from_package_lane() {
     in_job && /timeout-minutes:[[:space:]]*40/ { saw_timeout=1 }
     in_job && /CMUX_CI_HELPER_XCODE_APP:/ { saw_helper_xcode_env=1 }
     in_job && /- name: Select helper Xcode/ { saw_helper_select=1; next }
-    in_job && /CMUX_CI_REQUIRED_MACOS_SDK_MAJOR=15/ { saw_helper_sdk_pin=1 }
+    in_job && /CMUX_CI_XCODE_APP="\$\{CMUX_CI_HELPER_XCODE_APP:-\$CMUX_CI_XCODE_APP\}"/ { saw_helper_xcode_fallback=1 }
     in_job && /- name: Select Xcode/ { saw_select=1; after_select=1; next }
     in_job && /- name: Build universal Ghostty CLI helper/ {
       saw_build_step=1
@@ -303,13 +303,14 @@ check_release_helper_artifact_from_package_lane() {
     }
     in_job && /uses: actions\/upload-artifact@/ { saw_upload=1 }
     in_job && /name:[[:space:]]*cmux-ghostty-cli-helper/ { saw_artifact_name=1 }
-    in_job && /\[\[ "\$HELPER_SDK_VERSION" == 15\.\* \]\]/ { saw_helper_sdk_validation=1 }
+    in_job && /required_sdk_major="\$\{CMUX_CI_REQUIRED_MACOS_SDK_MAJOR:\?\}"/ { saw_required_sdk_major=1 }
+    in_job && /\[\[ "\$\{HELPER_SDK_VERSION%%\.\*\}" == "\$required_sdk_major" \]\]/ { saw_helper_sdk_validation=1 }
 
     END {
-      exit !(saw_timeout && saw_helper_xcode_env && saw_helper_select && saw_helper_sdk_pin && saw_build_step && saw_build && saw_lipo && saw_helper_sdk_validation && saw_upload_step && saw_upload && saw_artifact_name && saw_select && !saw_build_after_select && !saw_upload_after_select)
+      exit !(saw_timeout && saw_helper_xcode_env && saw_helper_select && saw_helper_xcode_fallback && saw_build_step && saw_build && saw_lipo && saw_required_sdk_major && saw_helper_sdk_validation && saw_upload_step && saw_upload && saw_artifact_name && saw_select && !saw_build_after_select && !saw_upload_after_select)
     }
   ' "$CI_FILE"; then
-    echo "FAIL: swift-package-tests must pin and validate the macOS 15 Ghostty helper before selecting Xcode 26"
+    echo "FAIL: swift-package-tests must build and validate the Ghostty helper before selecting the final Xcode"
     exit 1
   fi
 

--- a/tests/test_claude_wrapper_hooks.py
+++ b/tests/test_claude_wrapper_hooks.py
@@ -14,6 +14,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from node_runtime import ensure_node_on_path
+
 
 ROOT = Path(__file__).resolve().parents[1]
 SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
@@ -1877,6 +1879,9 @@ def test_stale_socket_skips_hook_injection(failures: list[str]) -> None:
 
 
 def main() -> int:
+    if ensure_node_on_path() is None:
+        print("SKIP: node runtime not found; wrapper fakes exec node")
+        return 0
     failures: list[str] = []
     test_live_socket_injects_supported_hooks_without_unlocking_bypass(failures)
     test_live_socket_merges_user_settings_into_hooks(failures)

--- a/tests/test_claude_wrapper_mutual_shim_loop.py
+++ b/tests/test_claude_wrapper_mutual_shim_loop.py
@@ -9,6 +9,8 @@ import subprocess
 import tempfile
 from pathlib import Path
 
+from node_runtime import ensure_node_on_path
+
 
 ROOT = Path(__file__).resolve().parents[1]
 WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
@@ -865,6 +867,9 @@ done
 
 
 def main() -> int:
+    if ensure_node_on_path() is None:
+        print("SKIP: node runtime not found; shim fakes exec node")
+        return 0
     failures: list[str] = []
     test_wrapper_stops_mutual_foreign_shim_loop(failures)
     test_wrapper_stops_node_based_foreign_shim_loop(failures)

--- a/tests/test_cli_claude_teams_env.py
+++ b/tests/test_cli_claude_teams_env.py
@@ -11,6 +11,7 @@ import tempfile
 from pathlib import Path
 
 from claude_teams_test_utils import resolve_cmux_cli
+from node_runtime import ensure_node_on_path
 
 
 def make_executable(path: Path, content: str) -> None:
@@ -267,6 +268,9 @@ fs.writeFileSync(
 
 
 def main() -> int:
+    if ensure_node_on_path() is None:
+        print("SKIP: node runtime not found; fake claude execs node")
+        return 0
     try:
         cli_path = resolve_cmux_cli()
     except Exception as exc:


### PR DESCRIPTION
Closes #7832

## Root cause
Multi-pane remote-tmux windows had split title ownership. The outer mirror tab used the authoritative tmux window name from `RemoteTmuxWindow.name`, but inner mirrored pane surfaces exposed titles from pane-level data, and the control/tree projection preferred tmux `pane-border-format`. On stock tmux that format expands to raw values like `0 "hostname"`, so the window name disappeared only in the multi-pane path.

## Fix
`RemoteTmuxWindowMirror` now adopts the authoritative tmux window display title from each `RemoteTmuxWindow` update and derives every inner pane surface/tab title from that one value, with deterministic pane suffixes (`logs`, `logs [1]`, `logs [2]`). Pane-border-format remains only pane-header label state and no longer becomes the surface title.

## Tests
Added behavior coverage through the real control-mode title pipeline using captured `list-windows` and `list-panes` replies:
- multi-pane mirror surface titles carry the tmux window name instead of raw pane header labels
- single-pane mirror title behavior remains unchanged
- a window transitioning from single-pane to multi-pane keeps the window name on recreated surfaces

Local allowed checks:
- `git diff --check HEAD~2..HEAD` passed
- `./scripts/lint-pbxproj-test-wiring.sh` passed
- `python3 scripts/swift_file_length_budget.py` reports the pre-existing `origin/main` AutomationSocketUITests budget mismatch (`551` actual vs `528` budget), with no touched file over budget

Note: per task constraints, I did not run local xcodebuild, reload, or any cmux socket/app dogfood commands.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7836"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786268210&installation_id=133855650&pr_number=7836&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7836&signature=9a3d826181b5de5e97f54eb15f6085da1811c1a42a7635a22d4215b298723dbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user-visible remote-tmux titles and control-socket surface names; layout parsing now drops malformed duplicate-pane layouts. CI-only changes are low product risk.
> 
> **Overview**
> Fixes **#7832** by making remote tmux mirror **inner pane and control-surface titles** follow the **tmux window name**, not pane-border labels, foreground command, or CWD.
> 
> `RemoteTmuxWindowMirror` now keeps an authoritative `windowTitle` from each `RemoteTmuxWindow` update and builds tab titles via `windowPaneTitle` — base name for the first pane, then localized indexed suffixes (`logs`, `logs [1]`, …). Control topology projection uses the same `title(forPane:)` path. `RemoteTmuxRawLayoutParser` **rejects layouts with duplicate pane IDs**. New localization keys cover the window fallback and indexed pane pattern; app-host tests cover multi-pane, single-pane, and single→multi transitions through the control surface list.
> 
> **CI:** `swift-package-tests` runs on `vars.MACOS_RUNNER_DUAL_XCODE` (SDK 15 helper build, then SDK 26 package tests). App-host focused regressions **detect or install Node 20** when the runner image lacks `node`; Python wrapper tests use `tests/node_runtime.py` to repair PATH or skip. Runner docs and workflow guard tests were updated for the dual-Xcode variable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f472d3b46ffbfd4a5bbbaf6cc60afb7d65613c2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #7832 by unifying all remote tmux mirror pane and control titles on the tmux window name with a localized fallback. CI routes `swift-package-tests` to the dual-Xcode runner and guarantees Node.js for wrapper regressions, pinning `actions/setup-node@v6.4.0` to install Node 20 when absent.

- **Bug Fixes**
  - Titles now come from the tmux window name via `RemoteTmuxWindowMirror`; pane-border labels, command, and CWD no longer affect titles.
  - Deterministic pane suffixes in multi-pane mirrors: "logs", "logs [1]", "logs [2]"; single-pane unchanged; single→multi keeps the window name.
  - Control topology uses `title(forPane:)`.
  - `RemoteTmuxRawLayoutParser` rejects duplicate pane IDs.

- **Tests**
  - Added end-to-end title tests for multi-pane, single-pane, and single→multi transitions; added localized strings for `remoteTmux.tab.window` and `remoteTmux.tab.windowPaneIndexed`.
  - CI: `swift-package-tests` runs on `vars.MACOS_RUNNER_DUAL_XCODE`; wrapper regressions ensure Node.js is on PATH and install Node 20 via `actions/setup-node@v6.4.0` when missing. Tests use `tests/node_runtime.py` to repair PATH or skip when truly unavailable.

<sup>Written for commit 3f472d3b46ffbfd4a5bbbaf6cc60afb7d65613c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remote tmux mirror pane/control titles are now based on the mirrored tmux window name, with non-zero pane indices showing an indexed suffix.

* **Bug Fixes**
  * Titles remain consistent across layout changes using stable window-title tracking and pane ordering.
  * Layouts containing duplicate pane identifiers are now rejected.

* **Tests**
  * Added/updated coverage for multi-pane, single-pane, and layout transition title behavior.
  * Added tests verifying duplicate pane identifiers are rejected.

* **Chores**
  * Expanded localization coverage for the remote tmux window title (including indexed suffixes).
  * Updated CI runner selection checks for the dual-Xcode macOS 15 lane.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->