### PR TITLE
Render local HTML in the embedded browser on cmd-click

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/FileRouteSettingsStore.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Stores/FileRouteSettingsStore.swift
@@ -100,6 +100,15 @@ public struct FileRouteSettingsStore: FileRouteSettingsReading {
         return ext == "md" || ext == "markdown" || ext == "mkd" || ext == "mdx"
     }
 
+    /// Cheap extension check for files that render as a real page in the
+    /// embedded browser (matching `cmux open`'s handling, #6717) rather than a
+    /// source preview. Parallels `isMarkdownPath`; safe to call off the main
+    /// thread before any filesystem probe.
+    public static func isHTMLPath(_ path: String) -> Bool {
+        let ext = (path as NSString).pathExtension.lowercased()
+        return ext == "html" || ext == "htm"
+    }
+
     /// Whether `path` (after resolving symlinks) is a readable regular file.
     public func isReadableRegularFile(path: String) -> Bool {
         let resolved = (path as NSString).resolvingSymlinksInPath

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Bonsplit
 import CmuxSettings
 import Foundation
 
@@ -9,6 +10,22 @@ enum CommandClickFileOpenRouter {
             || store.shouldRouteSupportedFile(path: path)
     }
 
+    /// The most recent cmd-click HTML→browser open, keyed by workspace + path,
+    /// used to collapse the two cmd-click routing paths — the mouse handler and
+    /// Ghostty's OPEN_URL action, both of which reach `openInCmux` for one
+    /// physical click — into a single browser tab.
+    ///
+    /// Interim: unlike `openOrFocus*Split`, `newBrowserSplit` doesn't dedupe,
+    /// and `BrowserPanel` carries no stable local-file identity to match on (its
+    /// `currentURL` drifts to WebKit-normalized values after navigation), so a
+    /// panel-scan open-or-focus isn't reliable here today. Remove this once a
+    /// browser surface has a stable local-file key (cf. #7413) and route through
+    /// an idempotent open-or-focus primitive. Keyed by workspace so the same
+    /// path opened in another workspace within the window isn't swallowed; the
+    /// 1s window only needs to absorb the two dispatches of one click.
+    @MainActor private static var recentBrowserOpen: (workspaceId: UUID, path: String, at: Date)?
+    private static let browserOpenDedupeWindow: TimeInterval = 1.0
+
     @MainActor
     static func openInCmux(
         workspace: Workspace,
@@ -16,6 +33,39 @@ enum CommandClickFileOpenRouter {
         filePath: String
     ) -> Bool {
         let store = FileRouteSettingsStore(defaults: .standard)
+
+        // Local HTML renders in the embedded browser (a rendered page), not the
+        // raw-source preview. Gated by the same toggle + readable-regular-file
+        // discipline as the other routed files (via `shouldRouteSupportedFile`)
+        // so an opt-out — or a missing / non-regular path — falls through to the
+        // external opener instead of a broken embedded tab.
+        if FileRouteSettingsStore.isHTMLPath(filePath),
+           store.shouldRouteSupportedFile(path: filePath),
+           BrowserAvailabilitySettings.isEnabled() {
+            // The same path can arrive from both cmd-click routes for one click;
+            // see `recentBrowserOpen` for why this window collapses the second
+            // into a no-op instead of opening a duplicate tab.
+            let now = Date()
+            if let recent = recentBrowserOpen,
+               recent.workspaceId == workspace.id,
+               recent.path == filePath,
+               now.timeIntervalSince(recent.at) < browserOpenDedupeWindow {
+                return true
+            }
+            if workspace.newBrowserSplit(
+                from: sourcePanelId,
+                orientation: .horizontal,
+                url: URL(fileURLWithPath: filePath)
+            ) != nil {
+                recentBrowserOpen = (workspaceId: workspace.id, path: filePath, at: now)
+                return true
+            }
+            // Browser is on but the split couldn't be created (e.g. a remote
+            // tmux mirror has no local browser surface): open externally rather
+            // than dumping raw HTML source into a preview pane.
+            return false
+        }
+
         if store.shouldRouteMarkdown(path: filePath),
            workspace.openOrFocusMarkdownSplit(from: sourcePanelId, filePath: filePath) != nil {
             return true

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -1,5 +1,4 @@
 import AppKit
-import Bonsplit
 import CmuxSettings
 import Foundation
 
@@ -9,22 +8,6 @@ enum CommandClickFileOpenRouter {
         return store.shouldRouteMarkdown(path: path)
             || store.shouldRouteSupportedFile(path: path)
     }
-
-    /// The most recent cmd-click HTML→browser open, keyed by workspace + path,
-    /// used to collapse the two cmd-click routing paths — the mouse handler and
-    /// Ghostty's OPEN_URL action, both of which reach `openInCmux` for one
-    /// physical click — into a single browser tab.
-    ///
-    /// Interim: unlike `openOrFocus*Split`, `newBrowserSplit` doesn't dedupe,
-    /// and `BrowserPanel` carries no stable local-file identity to match on (its
-    /// `currentURL` drifts to WebKit-normalized values after navigation), so a
-    /// panel-scan open-or-focus isn't reliable here today. Remove this once a
-    /// browser surface has a stable local-file key (cf. #7413) and route through
-    /// an idempotent open-or-focus primitive. Keyed by workspace so the same
-    /// path opened in another workspace within the window isn't swallowed; the
-    /// 1s window only needs to absorb the two dispatches of one click.
-    @MainActor private static var recentBrowserOpen: (workspaceId: UUID, path: String, at: Date)?
-    private static let browserOpenDedupeWindow: TimeInterval = 1.0
 
     @MainActor
     static func openInCmux(
@@ -36,34 +19,20 @@ enum CommandClickFileOpenRouter {
 
         // Local HTML renders in the embedded browser (a rendered page), not the
         // raw-source preview. Gated by the same toggle + readable-regular-file
-        // discipline as the other routed files (via `shouldRouteSupportedFile`)
+        // discipline as the other routed files (via `shouldRouteSupportedFile`),
         // so an opt-out — or a missing / non-regular path — falls through to the
-        // external opener instead of a broken embedded tab.
+        // external opener instead of a broken embedded tab. `openOrFocusBrowserSplit`
+        // focuses an existing tab for this file (matched on a stable local-file
+        // identity), so the two dispatches of one cmd-click (mouse handler +
+        // Ghostty OPEN_URL) collapse into a single tab, and a re-click focuses
+        // the open tab instead of duplicating it.
         if FileRouteSettingsStore.isHTMLPath(filePath),
            store.shouldRouteSupportedFile(path: filePath),
            BrowserAvailabilitySettings.isEnabled() {
-            // The same path can arrive from both cmd-click routes for one click;
-            // see `recentBrowserOpen` for why this window collapses the second
-            // into a no-op instead of opening a duplicate tab.
-            let now = Date()
-            if let recent = recentBrowserOpen,
-               recent.workspaceId == workspace.id,
-               recent.path == filePath,
-               now.timeIntervalSince(recent.at) < browserOpenDedupeWindow {
-                return true
-            }
-            if workspace.newBrowserSplit(
+            return workspace.openOrFocusBrowserSplit(
                 from: sourcePanelId,
-                orientation: .horizontal,
-                url: URL(fileURLWithPath: filePath)
-            ) != nil {
-                recentBrowserOpen = (workspaceId: workspace.id, path: filePath, at: now)
-                return true
-            }
-            // Browser is on but the split couldn't be created (e.g. a remote
-            // tmux mirror has no local browser surface): open externally rather
-            // than dumping raw HTML source into a preview pane.
-            return false
+                localFileURL: URL(fileURLWithPath: filePath)
+            ) != nil
         }
 
         if store.shouldRouteMarkdown(path: filePath),

--- a/Sources/CommandClickFileOpenRouter.swift
+++ b/Sources/CommandClickFileOpenRouter.swift
@@ -18,21 +18,24 @@ enum CommandClickFileOpenRouter {
         let store = FileRouteSettingsStore(defaults: .standard)
 
         // Local HTML renders in the embedded browser (a rendered page), not the
-        // raw-source preview. Gated by the same toggle + readable-regular-file
-        // discipline as the other routed files (via `shouldRouteSupportedFile`),
-        // so an opt-out — or a missing / non-regular path — falls through to the
-        // external opener instead of a broken embedded tab. `openOrFocusBrowserSplit`
-        // focuses an existing tab for this file (matched on a stable local-file
-        // identity), so the two dispatches of one cmd-click (mouse handler +
-        // Ghostty OPEN_URL) collapse into a single tab, and a re-click focuses
-        // the open tab instead of duplicating it.
+        // raw-source preview — gated by the same toggle + readable-regular-file
+        // discipline as the other routed files (via `shouldRouteSupportedFile`).
+        // `openOrFocusBrowserSplit` focuses an existing tab for this file
+        // (matched on a stable local-file identity), so the two dispatches of one
+        // cmd-click (mouse handler + Ghostty OPEN_URL) collapse into a single tab
+        // and a re-click focuses the open tab. Success-only early return, like
+        // the markdown route below: if the browser is off or the open fails, this
+        // falls through to the in-app preview; an opt-out / missing / non-regular
+        // path isn't supported-file-eligible, so it falls through to the external
+        // opener.
         if FileRouteSettingsStore.isHTMLPath(filePath),
            store.shouldRouteSupportedFile(path: filePath),
-           BrowserAvailabilitySettings.isEnabled() {
-            return workspace.openOrFocusBrowserSplit(
-                from: sourcePanelId,
-                localFileURL: URL(fileURLWithPath: filePath)
-            ) != nil
+           BrowserAvailabilitySettings.isEnabled(),
+           workspace.openOrFocusBrowserSplit(
+               from: sourcePanelId,
+               localFileURL: URL(fileURLWithPath: filePath)
+           ) != nil {
+            return true
         }
 
         if store.shouldRouteMarkdown(path: filePath),

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2736,6 +2736,12 @@ final class BrowserPanel: Panel, ObservableObject {
     let stableSurfaceIdentity = PanelStableSurfaceIdentity()
     let panelType: PanelType = .browser
 
+    /// The local file this browser tab was opened to render, set at
+    /// construction and never changed by navigation. Lets an existing tab for a
+    /// file be focused instead of opening a duplicate (unlike `currentURL`,
+    /// which drifts to WebKit-normalized values). `nil` for web tabs.
+    let sourceLocalFileURL: URL?
+
     /// The workspace ID this panel belongs to
     private(set) var workspaceId: UUID
 
@@ -3936,6 +3942,7 @@ final class BrowserPanel: Panel, ObservableObject {
         workspaceId: UUID,
         profileID: UUID? = nil,
         initialURL: URL? = nil,
+        sourceLocalFileURL: URL? = nil,
         initialRequest: URLRequest? = nil,
         renderInitialNavigation: Bool = true,
         preloadInitialNavigationInBackground: Bool = false,
@@ -3952,6 +3959,7 @@ final class BrowserPanel: Panel, ObservableObject {
         Self.bootstrapBrowserDefaultsIfNeeded()
         self.id = UUID()
         self.workspaceId = workspaceId
+        self.sourceLocalFileURL = sourceLocalFileURL
         let resolvedProfileID = Self.resolvedProfileID(requested: profileID)
         self.profileID = resolvedProfileID
         self.historyStore = BrowserProfileStore.shared.historyStore(for: resolvedProfileID)

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -6185,6 +6185,17 @@ func resolveBrowserNavigableURL(_ input: String) -> URL? {
         return URL(string: "http://\(trimmed)")
     }
 
+    // A bare absolute filesystem path ("/Users/.../page.html", "~/page.html")
+    // is a local file, not a web host. Without this it falls through to the
+    // "contains /" branch below and becomes a broken "https:///Users/..." URL.
+    // "//host" is left alone as a protocol-relative web reference.
+    if trimmed.hasPrefix("/"), !trimmed.hasPrefix("//") {
+        return URL(fileURLWithPath: trimmed)
+    }
+    if trimmed == "~" || trimmed.hasPrefix("~/") {
+        return URL(fileURLWithPath: (trimmed as NSString).expandingTildeInPath)
+    }
+
     if let url = URL(string: trimmed), let scheme = url.scheme?.lowercased() {
         if scheme == "http" || scheme == "https" {
             return url

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -7916,6 +7916,7 @@ final class Workspace: Identifiable, ObservableObject {
         orientation: SplitOrientation,
         insertFirst: Bool = false,
         url: URL? = nil,
+        sourceLocalFileURL: URL? = nil,
         preferredProfileID: UUID? = nil,
         focus: Bool = true,
         creationPolicy: BrowserPanelCreationPolicy = .userInitiated,
@@ -7956,6 +7957,7 @@ final class Workspace: Identifiable, ObservableObject {
                 sourcePanelId: panelId
             ),
             initialURL: url,
+            sourceLocalFileURL: sourceLocalFileURL,
             renderInitialNavigation: browserEnabled || creationPolicy != .restoration,
             preloadInitialNavigationInBackground: creationPolicy.preloadsInitialNavigationInBackground,
             omnibarVisible: omnibarVisible,
@@ -8027,6 +8029,7 @@ final class Workspace: Identifiable, ObservableObject {
     func newBrowserSurface(
         inPane paneId: PaneID,
         url: URL? = nil,
+        sourceLocalFileURL: URL? = nil,
         initialRequest: URLRequest? = nil,
         focus: Bool? = nil,
         selectWhenNotFocused: Bool = false,
@@ -8063,6 +8066,7 @@ final class Workspace: Identifiable, ObservableObject {
                 sourcePanelId: sourcePanelId
             ),
             initialURL: url,
+            sourceLocalFileURL: sourceLocalFileURL,
             initialRequest: initialRequest,
             renderInitialNavigation: browserEnabled || creationPolicy != .restoration,
             preloadInitialNavigationInBackground: creationPolicy.preloadsInitialNavigationInBackground,
@@ -8185,6 +8189,42 @@ final class Workspace: Identifiable, ObservableObject {
     /// Returns `nil` when no existing viewer matches and split creation
     /// fails, so callers can fall back to the preferred editor / system opener.
     @discardableResult
+    /// Focus an existing browser tab already opened for `localFileURL`, or open
+    /// one in a right-side split (mirroring `openOrFocusMarkdownSplit`). Matches
+    /// on the stable `sourceLocalFileURL` set at construction, so the two
+    /// dispatches of one cmd-click collapse into a single tab and a re-click
+    /// focuses the existing tab instead of duplicating it.
+    func openOrFocusBrowserSplit(
+        from panelId: UUID,
+        localFileURL: URL
+    ) -> BrowserPanel? {
+        let canonical = (localFileURL.path as NSString).resolvingSymlinksInPath
+        for (existingId, panel) in panels {
+            guard let browser = panel as? BrowserPanel,
+                  let source = browser.sourceLocalFileURL,
+                  (source.path as NSString).resolvingSymlinksInPath == canonical else { continue }
+            focusPanel(existingId)
+            return browser
+        }
+
+        if let targetPane = preferredRightSideTargetPane(fromPanelId: panelId) {
+            return newBrowserSurface(
+                inPane: targetPane,
+                url: localFileURL,
+                sourceLocalFileURL: localFileURL,
+                focus: true
+            )
+        }
+
+        return newBrowserSplit(
+            from: panelId,
+            orientation: .horizontal,
+            url: localFileURL,
+            sourceLocalFileURL: localFileURL,
+            focus: true
+        )
+    }
+
     func openOrFocusMarkdownSplit(
         from panelId: UUID,
         filePath: String

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -8182,18 +8182,13 @@ final class Workspace: Identifiable, ObservableObject {
         return extensionBrowserPanel
     }
 
-    /// Open the markdown viewer for `filePath`, reusing an existing
-    /// `MarkdownPanel` in this workspace that already shows the same file.
-    /// Paths are compared after symlink resolution so `./README.md` and a
-    /// symlink pointing at the same file focus the same viewer.
-    /// Returns `nil` when no existing viewer matches and split creation
-    /// fails, so callers can fall back to the preferred editor / system opener.
-    @discardableResult
     /// Focus an existing browser tab already opened for `localFileURL`, or open
     /// one in a right-side split (mirroring `openOrFocusMarkdownSplit`). Matches
     /// on the stable `sourceLocalFileURL` set at construction, so the two
     /// dispatches of one cmd-click collapse into a single tab and a re-click
-    /// focuses the existing tab instead of duplicating it.
+    /// focuses the existing tab instead of duplicating it. Returns `nil` when no
+    /// existing viewer matches and split creation fails.
+    @discardableResult
     func openOrFocusBrowserSplit(
         from panelId: UUID,
         localFileURL: URL
@@ -8225,6 +8220,13 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
+    /// Open the markdown viewer for `filePath`, reusing an existing
+    /// `MarkdownPanel` in this workspace that already shows the same file.
+    /// Paths are compared after symlink resolution so `./README.md` and a
+    /// symlink pointing at the same file focus the same viewer.
+    /// Returns `nil` when no existing viewer matches and split creation
+    /// fails, so callers can fall back to the preferred editor / system opener.
+    @discardableResult
     func openOrFocusMarkdownSplit(
         from panelId: UUID,
         filePath: String

--- a/cmuxTests/BrowserConfigTests.swift
+++ b/cmuxTests/BrowserConfigTests.swift
@@ -5304,6 +5304,23 @@ final class BrowserLinkOpenSettingsTests: XCTestCase {
         #expect(resolved.path == "/tmp/cmux-local-test.html")
     }
 
+    @Test func resolvesBareAbsolutePathAsFileURL() throws {
+        // A bare "/Users/.../page.html" typed/pasted in the omnibar must open as
+        // a local file, not be rewritten to a broken "https:///Users/..." URL.
+        let resolved = try #require(resolveBrowserNavigableURL("/tmp/cmux-local-test.html"))
+        #expect(resolved.isFileURL)
+        #expect(resolved.path == "/tmp/cmux-local-test.html")
+
+        // "//host" stays a protocol-relative web reference, not a file path.
+        #expect(resolveBrowserNavigableURL("//example.com/path")?.isFileURL != true)
+
+        // "~/..." expands to an absolute home-directory file URL.
+        let tilde = try #require(resolveBrowserNavigableURL("~/cmux-local-test.html"))
+        #expect(tilde.isFileURL)
+        #expect(tilde.path.hasPrefix(NSHomeDirectory()))
+        #expect(tilde.path.hasSuffix("/cmux-local-test.html"))
+    }
+
     @Test func resolvesBareLocalhostSubdomainAsHTTPURL() throws {
         let resolved = try #require(resolveBrowserNavigableURL("api.localhost:3000"))
         #expect(resolved.scheme == "http")

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -1975,6 +1975,29 @@ final class DraggableFolderHitTests: XCTestCase {
 }
 
 
+@Suite("Command-click HTML routing")
+struct CommandClickFileOpenRouterHTMLTests {
+    @Test func htmlAndHtmPathsAreBrowserRenderable() {
+        #expect(FileRouteSettingsStore.isHTMLPath("/tmp/report.html"))
+        #expect(FileRouteSettingsStore.isHTMLPath("/tmp/report.htm"))
+        #expect(FileRouteSettingsStore.isHTMLPath("/tmp/REPORT.HTML"))
+    }
+
+    @Test func nonHtmlPathsAreNotBrowserRenderable() {
+        #expect(!FileRouteSettingsStore.isHTMLPath("/tmp/notes.txt"))
+        #expect(!FileRouteSettingsStore.isHTMLPath("/tmp/page.htmlx"))
+        #expect(!FileRouteSettingsStore.isHTMLPath("/tmp/noext"))
+    }
+
+    @Test func nonexistentHTMLPathDoesNotRouteIntoCmux() {
+        // Regression: `.html` must not bypass the readable-regular-file gate its
+        // sibling routes enforce. A not-yet-generated path must fall through to
+        // the external opener, never open a broken embedded browser tab.
+        let missing = "/tmp/cmux-does-not-exist-\(UUID().uuidString).html"
+        #expect(!CommandClickFileOpenRouter.shouldRouteInCmux(path: missing))
+    }
+}
+
 @MainActor
 @Suite struct MainWindowHostingViewTests {
     @Test func testReportsPolicyMinimumInsteadOfChildMinimum() {


### PR DESCRIPTION
## Summary

Cmd-clicking a local `.html`/`.htm` file (a terminal path, the file explorer, or a drop) previously opened its **raw source** in the file-preview pane. This routes it to the **embedded browser** so it renders — matching how [`cmux open`](https://github.com/manaflow-ai/cmux/pull/6717) already handles local HTML, and the direction of [#7413](https://github.com/manaflow-ai/cmux/pull/7413).

## What changed

- **`.html`/`.htm` → embedded browser** via `newBrowserSplit`, gated by the same **"Open Supported Files in cmux"** toggle + `isReadableRegularFile` check as the other routed file types (through `shouldRouteSupportedFile`). So a missing / not-yet-generated, non-regular (e.g. a directory named `build.html`), or opted-out path falls through to the external opener instead of a broken embedded tab. When the browser is disabled, HTML still falls back to the source preview.
- **Single tab per click.** One cmd-click reaches the router through two paths — the mouse handler and Ghostty's `OPEN_URL` action — so a short per-workspace guard collapses them into one browser tab. Documented as an interim until a browser surface carries a stable local-file identity (cf. [#7413](https://github.com/manaflow-ai/cmux/pull/7413)).
- **Omnibar bare-path fix.** A bare absolute `/…` or `~/…` path typed/pasted in the browser omnibar now resolves to a `file://` URL instead of a broken `https:///…`.
- **`FileRouteSettingsStore.isHTMLPath`** added next to `isMarkdownPath`, so all viewer-category extension mappings sit at one seam (where [#7337](https://github.com/manaflow-ai/cmux/issues/7337) will fold them in).

## Not in scope

The deeper dedupe (an `openOrFocusBrowserSplit` that matches an existing browser surface by a stable local-file key) is left to [#7413](https://github.com/manaflow-ai/cmux/pull/7413): `BrowserPanel` has no stable local-file identity today (`currentURL` drifts to WebKit-normalized values after navigation), so a panel-scan open-or-focus isn't reliable yet. File-explorer double-click and browser file-drop already route through the same `openInCmux` path, so they inherit this behavior.

## Testing

- `xcodebuild test -scheme cmux-unit -only-testing:cmuxTests/CommandClickFileOpenRouterHTMLTests -only-testing:cmuxTests/BrowserNavigableURLResolutionTests` — 10 tests pass, including a regression test that a nonexistent `.html` does **not** route into cmux (guards against opening a broken embedded tab).
- Tagged dogfood build (`./scripts/reload.sh --tag html-preview`): cmd-clicking a local HTML file opens a single rendered browser tab.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7842"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786275801&installation_id=133855650&pr_number=7842&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7842&signature=645572e8ceb6b2b838f611e5e92e772d88ca3081f5765e91e3ea47aeb656000d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> User-facing routing and URL parsing changes with clear gates and regression tests; no auth, security, or data-layer impact.
> 
> **Overview**
> Cmd-clicking a local **`.html`/`.htm`** file now opens a **rendered page in the embedded browser** instead of the raw file-preview pane, when the supported-files route toggle applies, the path is a readable regular file, and the browser is enabled.
> 
> **`openOrFocusBrowserSplit`** (mirroring markdown) scans workspace browser panels by a new immutable **`sourceLocalFileURL`** on `BrowserPanel`, so duplicate dispatches from one cmd-click and repeat clicks **focus one tab** rather than opening duplicates. **`FileRouteSettingsStore.isHTMLPath`** identifies HTML extensions alongside `isMarkdownPath`.
> 
> **`resolveBrowserNavigableURL`** now treats bare **`/…`** and **`~/…`** as `file://` URLs (while leaving `//host` as web), fixing broken `https:///…` omnibar navigation for local paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04e8d5a36b35f2568459857f8e7a445d1eb0c495. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cmd-clicking a local `.html`/`.htm` now opens a rendered page in the embedded browser instead of raw source. Tabs dedupe via open-or-focus, and the omnibar treats bare file paths as `file://` URLs.

- **New Features**
  - Route local `.html`/`.htm` to the embedded browser via `openOrFocusBrowserSplit`, gated by “Open Supported Files in cmux”, `isReadableRegularFile`, and browser availability. Success-only: if the browser is off or the open fails, fall through to the in-app file preview; opted-out/missing/non-regular paths fall back to the external opener.
  - Idempotent dedupe: `BrowserPanel.sourceLocalFileURL` gives each tab a stable local-file identity so duplicate dispatches and re-clicks focus the existing tab; separate workspaces open their own tabs.
  - Added `FileRouteSettingsStore.isHTMLPath` alongside `isMarkdownPath`.

- **Bug Fixes**
  - The browser omnibar now resolves `/...` and `~/...` to `file://` URLs; `//host` remains a protocol-relative web URL.
  - Restored `@discardableResult` and docs on `openOrFocusBrowserSplit` and the markdown variant to fix an attribute misbinding.

<sup>Written for commit 0b28ca0971bbe57a3ef966fc6d8391c79157afec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command-clicking local **.html/.htm** files can now open in cmux’s embedded browser.
  * Browser panels now remember the originating local file, enabling reuse of an existing tab/split.
* **Bug Fixes**
  * Bare absolute paths and **~ / ~/…** are now correctly handled as file URLs, avoiding malformed web URLs.
  * Unsupported or nonexistent **.html** paths no longer route into cmux and instead fall back externally.
* **Tests**
  * Added coverage for file URL resolution and HTML command-click routing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->