### PR TITLE
agent-chat catalog: direct cmux.com default, fast initial-fetch retry

### DIFF
--- a/agent-chat/catalog.ts
+++ b/agent-chat/catalog.ts
@@ -56,7 +56,7 @@ interface CatalogStoreOptions {
 }
 
 const PROVIDERS = ["claude", "codex", "gemini"] as const;
-const DEFAULT_URL = "https://cmux.dev/api/agent-models";
+const DEFAULT_URL = "https://cmux.com/api/agent-models";
 const DEFAULT_CACHE = `${homedir()}/.cache/cmux-agent-chat/models.json`;
 export const AGENT_MODEL_CATALOG_TTL_MS = 60 * 60_000;
 
@@ -180,7 +180,9 @@ export class AgentModelCatalogStore {
   }
   isStale(): boolean {
     if (this.state) return this.now() - this.state.fetchedAt >= this.ttlMs;
-    return this.lastAttemptAt === 0 || this.now() - this.lastAttemptAt >= this.ttlMs;
+    // No payload yet: retry failed initial fetches quickly instead of
+    // waiting out the full TTL with only built-in fallbacks.
+    return this.lastAttemptAt === 0 || this.now() - this.lastAttemptAt >= Math.min(this.ttlMs, 60_000);
   }
   refreshIfStale(): Promise<boolean> { return this.isStale() ? this.refresh() : Promise.resolve(false); }
   async refresh(): Promise<boolean> {


### PR DESCRIPTION
Follow-ups to https://github.com/manaflow-ai/cmux/pull/7751: the sidecar default now targets https://cmux.com/api/agent-models directly (cmux.dev 301s there — verified live in prod), and when no payload was ever cached a failed initial fetch retries within a minute instead of waiting the full TTL with only built-in fallbacks (codex-connector P2).

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786285222&installation_id=133855650&pr_number=7846&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7846&signature=85bb76f5f0c0bb6a2bb9df5b590b0ba6d43d4b1a2e1e0b0b1e531e2ea9a2dfb8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavior change in catalog URL and cold-start refresh timing; no auth or data-model changes.
> 
> **Overview**
> Updates the agent-chat model catalog so the default fetch URL is **`https://cmux.com/api/agent-models`** instead of `cmux.dev`, avoiding an extra redirect on the sidecar’s catalog pull.
> 
> When there is **no cached payload yet**, `AgentModelCatalogStore.isStale()` now treats a failed initial fetch as stale again after **at most one minute** (`Math.min(ttlMs, 60_000)`), rather than waiting the full one-hour TTL before retrying—so a bad first request does not leave the UI on built-in fallbacks for an hour.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f98098e0ecd657f47ae8086564f2420bd4ef8af4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the agent catalog default to https://cmux.com/api/agent-models to remove the cmux.dev redirect and speed refreshes. When no cache exists, failed first fetches now retry within 60s instead of waiting the full TTL.

- **Dependencies**
  - Restored `vendor/bonsplit` submodule pointer.

<sup>Written for commit 56eb45d16c3e81739778101408946f27a18647b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the default agent model catalog address to ensure catalog requests reach the correct service.
  * Improved catalog retry behavior during startup and offline fallback, allowing failed requests to be retried sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->