### PR TITLE
Separate iOS beta and App Store versions

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -165,7 +165,7 @@ jobs:
           FINAL_BUILD_NUMBER: ${{ steps.upload.outputs.final_build_number }}
         run: |
           set -euo pipefail
-          VERSION="$(sed -nE 's/^[[:space:]]*MARKETING_VERSION[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\1/p' ios/Config/Shared.xcconfig | head -n 1)"
+          VERSION="$(sed -nE 's/^[[:space:]]*CMUX_IOS_APPSTORE_MARKETING_VERSION[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\1/p' ios/Config/Shared.xcconfig | tail -n 1)"
           ./ios/scripts/validate-app-store-release.sh \
             --app "$ASC_APP_ID" \
             --version "$VERSION" \

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -40,8 +40,8 @@ on:
     # TestFlight beta lane within ~2h of landing on main, and a failed or missed
     # run retries the not-yet-uploaded commit instead of permanently stranding
     # it. These uploads are external-eligible too, and reuse
-    # the checked-in iOS MARKETING_VERSION so external testers receive new builds
-    # under the already-approved version until that version is intentionally bumped.
+    # CMUX_IOS_BETA_MARKETING_VERSION so external testers receive new builds under
+    # the already-approved beta version until that version is intentionally bumped.
     #
     # Why ~2h and not a push trigger / per-commit: a per-push lane needs either a
     # shared concurrency group (which cancels superseded pending runs into red
@@ -102,7 +102,7 @@ jobs:
             //
             // Manual marketing-version-override uploads are deliberately excluded
             // from this canonical lane. They ship the current main SHA under an
-            // operator-selected MARKETING_VERSION as a one-off escape hatch, but
+            // operator-selected beta marketing version as a one-off escape hatch, but
             // they must NOT suppress the next scheduled canonical beta for the
             // same commit. Override runs upload a dedicated
             // ios-testflight-build-metadata-override artifact instead of the
@@ -475,14 +475,14 @@ jobs:
           # of the per-build "What to Test" commit range. Empty on the very first
           # run / a missing history, where the generator falls back gracefully.
           LAST_UPLOADED_SHA: ${{ needs.decide.outputs.last_uploaded_sha }}
-          # Optional manual one-off override that reuses an older approved
-          # MARKETING_VERSION so external testers can install it immediately.
+          # Optional manual one-off override that reuses an older approved beta
+          # marketing version so external testers can install it immediately.
           INPUT_MARKETING_VERSION_OVERRIDE: ${{ github.event.inputs.marketing_version_override }}
         run: |
           set -euo pipefail
           if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
             # One-time operator escape hatch: upload latest main as another build
-            # of an already-approved MARKETING_VERSION, which avoids starting a
+            # of an already-approved beta marketing version, which avoids starting a
             # fresh Beta App Review for that version. This path intentionally
             # skips changelog-driven notes because ios/CHANGELOG.md tracks the
             # current release line, not the reused older version.
@@ -495,7 +495,7 @@ jobs:
               --marketing-version "$INPUT_MARKETING_VERSION_OVERRIDE" \
               --skip-notes
           else
-            # Reuse the checked-in iOS MARKETING_VERSION for scheduled betas.
+            # Reuse the checked-in CMUX_IOS_BETA_MARKETING_VERSION for scheduled betas.
             # External TestFlight only requires Beta App Review once per marketing
             # version, so staying on the approved version lets CI keep publishing
             # main-tracking builds automatically while the next version remains
@@ -543,10 +543,10 @@ jobs:
             if [ -n "${INPUT_MARKETING_VERSION_OVERRIDE:-}" ]; then
               echo "- marketing version override: \`${INPUT_MARKETING_VERSION_OVERRIDE}\`"
             else
-              echo "- marketing version: checked-in iOS MARKETING_VERSION"
+              echo "- marketing version: checked-in beta marketing version"
             fi
             echo "- build number (CFBundleVersion): \`${BUILD_NUMBER}\`"
-            echo "- audience: internal testers immediately, external testers automatically after external-group assignment; new MARKETING_VERSIONs are auto-submitted for Apple Beta App Review"
+            echo "- audience: internal testers immediately, external testers automatically after external-group assignment; new beta marketing versions are auto-submitted for Apple Beta App Review"
           } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Persist uploaded build metadata

--- a/ios/AppStoreReview/README.md
+++ b/ios/AppStoreReview/README.md
@@ -20,6 +20,7 @@ ios/scripts/upload-app-store.sh --export-only
 Defaults:
 
 - Bundle ID: `com.cmux.app`
+- Marketing version: `CMUX_IOS_APPSTORE_MARKETING_VERSION` in `ios/Config/Shared.xcconfig`
 - Display name: `cmux`
 - Provisioning profile: `cmux App Store Distribution`
 - Entitlements: `Config/cmux-release.entitlements`
@@ -38,7 +39,6 @@ Run the App Store readiness package after upload:
 ```bash
 ios/scripts/validate-app-store-release.sh \
   --app "$ASC_APP_ID" \
-  --version "$(sed -nE 's/^[[:space:]]*MARKETING_VERSION[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\1/p' ios/Config/Shared.xcconfig | head -1)" \
   --build-number "$CF_BUNDLE_VERSION" \
   --wait-build \
   --strict

--- a/ios/AppStoreReview/metadata-screenshots-checklist.md
+++ b/ios/AppStoreReview/metadata-screenshots-checklist.md
@@ -7,7 +7,7 @@ complete in App Store Connect or in the submitted binary.
 
 - [ ] Bundle ID is `com.cmux.app`.
 - [ ] Display name is `cmux`, not `cmux BETA` or any dev tag.
-- [ ] `MARKETING_VERSION` in `ios/Config/Shared.xcconfig` matches the App Store version.
+- [ ] `CMUX_IOS_APPSTORE_MARKETING_VERSION` in `ios/Config/Shared.xcconfig` matches the App Store version.
 - [ ] `CURRENT_PROJECT_VERSION` is higher than every prior ASC build for the app.
 - [ ] `ITSAppUsesNonExemptEncryption` remains `false` only if the build uses no non-exempt encryption beyond standard TLS.
 

--- a/ios/CHANGELOG.md
+++ b/ios/CHANGELOG.md
@@ -9,10 +9,11 @@ build is no longer an opaque timestamp on install or auto-update.
 
 TestFlight shows each build as `MARKETING_VERSION (CURRENT_PROJECT_VERSION)`, for
 example `1.0.3 (20260613120501)`. `MARKETING_VERSION` is the human version
-(`ios/Config/Shared.xcconfig`, semver `X.Y.Z`); the number in parens is the build
-id, a 14-digit UTC timestamp stamped at upload time (unique and monotonic, but not
-meant to be read). Testers should track the marketing version; the timestamp only
-distinguishes rapid internal iterations of the same version.
+(`CMUX_IOS_BETA_MARKETING_VERSION` in `ios/Config/Shared.xcconfig`, semver
+`X.Y.Z`); the number in parens is the build id, a 14-digit UTC timestamp stamped
+at upload time (unique and monotonic, but not meant to be read). Testers should
+track the marketing version; the timestamp only distinguishes rapid internal
+iterations of the same version.
 
 Two audiences, two notes per entry:
 
@@ -35,9 +36,10 @@ sheet on first launch after an update, sourced from the External block. Spec in
 Keep entries short. No fluff, no AI rhetorical patterns, no em dashes (repo rule).
 Newest version on top.
 
-The top entry's version MUST equal the checked-in `MARKETING_VERSION` in
-`ios/Config/Shared.xcconfig`. `upload-testflight.sh` enforces this before upload
-(it refuses to attach notes for a different version), so bump the version with
+The top entry's version MUST equal the checked-in
+`CMUX_IOS_BETA_MARKETING_VERSION` in `ios/Config/Shared.xcconfig`.
+`upload-testflight.sh` enforces this before upload (it refuses to attach notes
+for a different version), so bump the beta version with
 `ios/scripts/bump-ios-version.sh` in the SAME change that adds the top entry.
 
 ---
@@ -46,7 +48,7 @@ The top entry's version MUST equal the checked-in `MARKETING_VERSION` in
 
 ### Internal
 
-- Version-sync bump: checked-in `MARKETING_VERSION` catches up to `1.0.4`, the version already live to external founders (an earlier upload under that version shipped stale, pre-#7636 code; the CI reship on 2026-07-09 replaced it with current `main`).
+- Version-sync bump: checked-in beta marketing version catches up to `1.0.4`, the version already live to external founders (an earlier upload under that version shipped stale, pre-#7636 code; the CI reship on 2026-07-09 replaced it with current `main`).
 - Fix iOS surface-teardown deadlock behind external-beta watchdog kills (#7666).
 - Add iOS account deletion and legal links (#7645).
 - iOS: terminal connection/render resilience, fail-open delivery gates, route iteration, persistent terminal surface (#7675).

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -9,11 +9,14 @@
 PRODUCT_NAME = cmux
 PRODUCT_DISPLAY_NAME = cmux
 PRODUCT_BUNDLE_IDENTIFIER = dev.cmux.ios
-// User-visible version (CFBundleShortVersionString). Semver X.Y.Z, bumped on
-// release with ios/scripts/bump-ios-version.sh. Keep this human-meaningful and
-// tellable; CFBundleVersion (CURRENT_PROJECT_VERSION) is the monotonic build id
-// (a UTC timestamp stamped by ios/scripts/upload-testflight.sh on TestFlight).
-MARKETING_VERSION = 1.0.4
+// User-visible versions (CFBundleShortVersionString). Keep beta and production
+// independent: TestFlight can stay on the already-approved beta version while
+// the first production App Store upload starts from its own release version.
+// Semver X.Y.Z; CFBundleVersion (CURRENT_PROJECT_VERSION) is the monotonic build
+// id stamped by ios/scripts/upload-testflight.sh on upload.
+CMUX_IOS_BETA_MARKETING_VERSION = 1.0.4
+CMUX_IOS_APPSTORE_MARKETING_VERSION = 1.0.0
+MARKETING_VERSION = $(CMUX_IOS_BETA_MARKETING_VERSION)
 CURRENT_PROJECT_VERSION = 1
 
 // Dev-build identity, surfaced in-app (Settings > About) so a DEBUG dogfood

--- a/ios/README.md
+++ b/ios/README.md
@@ -98,11 +98,12 @@ no review. An `--external` build is different: the FIRST external build of a new
 `MARKETING_VERSION` must pass a one-time Apple Beta App Review (~24h) before any
 external tester can install it. Subsequent external builds of the same version
 ship without re-review. The scheduled `main` sync lane now uploads
-external-eligible builds too, so founders track `main` once the current version
-has cleared that review gate. That lane reuses the checked-in
-`ios/Config/Shared.xcconfig` `MARKETING_VERSION`; bump it only when you want a
-fresh Beta App Review cycle. The upload path assigns the processed build to the
-app's external beta group automatically, auto-selecting the single external
+external-eligible builds too, so founders track `main` once the current beta
+version has cleared that review gate. That lane reuses
+`CMUX_IOS_BETA_MARKETING_VERSION` from `ios/Config/Shared.xcconfig`; bump it
+only when you want a fresh Beta App Review cycle. The upload path assigns the
+processed build to the app's external beta group automatically, auto-selecting
+the single external
 group or using `IOS_TESTFLIGHT_EXTERNAL_GROUP_ID` / `IOS_TESTFLIGHT_EXTERNAL_GROUP_NAME`
 repo variables when the app has multiple external groups. When Apple reports the
 build as `READY_FOR_BETA_SUBMISSION`, the same lane also creates the beta app
@@ -124,7 +125,7 @@ TestFlight push would silently fail. The workflow tracks `main` on a schedule an
 uploads beta builds as external-eligible. Internal testers get the build
 immediately, and the post-upload external distribution step both assigns the
 build to the founders group and keeps using the checked-in approved
-`MARKETING_VERSION`. When that version is intentionally bumped, the same
+`CMUX_IOS_BETA_MARKETING_VERSION`. When that version is intentionally bumped, the same
 distribution step auto-submits the first build of the new version for Beta App
 Review.
 
@@ -152,12 +153,13 @@ ios/scripts/upload-app-store.sh
 ios/scripts/upload-app-store.sh --export-only
 
 # Run the read-only ASC readiness package after upload
-ios/scripts/validate-app-store-release.sh --app "$ASC_APP_ID" --version "$VERSION" --build-number "$CF_BUNDLE_VERSION" --wait-build --strict
+ios/scripts/validate-app-store-release.sh --app "$ASC_APP_ID" --build-number "$CF_BUNDLE_VERSION" --wait-build --strict
 ```
 
 Defaults:
 
 - Bundle ID: `com.cmux.app`
+- Marketing version: `CMUX_IOS_APPSTORE_MARKETING_VERSION` in `ios/Config/Shared.xcconfig`
 - Display name: `cmux`
 - Provisioning profile: `cmux App Store Distribution`
 - Entitlements: `Config/cmux-release.entitlements`

--- a/ios/scripts/bump-ios-version.sh
+++ b/ios/scripts/bump-ios-version.sh
@@ -1,37 +1,111 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Bump the iOS app's MARKETING_VERSION (CFBundleShortVersionString) in
-# ios/Config/Shared.xcconfig. This is the user-visible, tellable version testers
-# report. It is bumped MANUALLY on release (semver, human-meaningful) — unlike
-# CFBundleVersion (the monotonic build id), which ios/scripts/upload-testflight.sh
-# stamps per upload as a UTC timestamp. Keeping the marketing bump manual avoids
-# a CI commit-back loop on every merge; the patch number moves only when you cut
-# a build worth reporting.
+# Bump the iOS app's lane-specific marketing version
+# (CFBundleShortVersionString) in ios/Config/Shared.xcconfig. Beta and App Store
+# versions are intentionally independent: beta can stay on an already-approved
+# TestFlight version while production starts at its own App Store version.
+# CFBundleVersion remains the monotonic build id stamped by
+# ios/scripts/upload-testflight.sh on upload.
 #
 # Usage:
-#   ios/scripts/bump-ios-version.sh           # Bump patch (1.0.0 -> 1.0.1, default)
-#   ios/scripts/bump-ios-version.sh patch     # Bump patch (1.0.0 -> 1.0.1)
-#   ios/scripts/bump-ios-version.sh minor     # Bump minor (1.0.0 -> 1.1.0)
-#   ios/scripts/bump-ios-version.sh major     # Bump major (1.0.0 -> 2.0.0)
-#   ios/scripts/bump-ios-version.sh 1.2.3     # Set a specific version
+#   ios/scripts/bump-ios-version.sh                    # Bump beta patch
+#   ios/scripts/bump-ios-version.sh --lane appstore    # Bump App Store patch
+#   ios/scripts/bump-ios-version.sh 1.0.1 --lane appstore
+#   ios/scripts/bump-ios-version.sh minor              # Bump beta minor
+#   ios/scripts/bump-ios-version.sh --lane beta 1.2.3  # Set beta version
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 XCCONFIG="$IOS_DIR/Config/Shared.xcconfig"
+TMP_XCCONFIG=""
+
+cleanup_tmp() {
+  if [[ -n "$TMP_XCCONFIG" && -f "$TMP_XCCONFIG" ]]; then
+    rm -f "$TMP_XCCONFIG"
+  fi
+}
+trap cleanup_tmp EXIT
 
 if [[ ! -f "$XCCONFIG" ]]; then
   echo "Error: $XCCONFIG not found." >&2
   exit 1
 fi
 
-CURRENT_MARKETING="$(grep -m1 '^MARKETING_VERSION = ' "$XCCONFIG" | sed 's/^MARKETING_VERSION = //')"
+usage() {
+  echo "Usage: $0 [--lane beta|appstore] [version|patch|minor|major]" >&2
+  echo "       $0 [version|patch|minor|major] [--lane beta|appstore]" >&2
+}
+
+read_xcconfig_setting() {
+  local key="$1"
+  sed -nE "s/^[[:space:]]*$key[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\\1/p" "$XCCONFIG" | tail -n 1
+}
+
+LANE="beta"
+LANE_SET=0
+VERSION_ARG=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --lane)
+      if [[ "$LANE_SET" -eq 1 || -z "${2:-}" || "${2:-}" == --* ]]; then
+        usage
+        exit 1
+      fi
+      LANE="$2"
+      LANE_SET=1
+      shift 2
+      ;;
+    --lane=*)
+      if [[ "$LANE_SET" -eq 1 || -z "${1#--lane=}" ]]; then
+        usage
+        exit 1
+      fi
+      LANE="${1#--lane=}"
+      LANE_SET=1
+      shift
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    --*)
+      usage
+      exit 1
+      ;;
+    *)
+      if [[ -n "$VERSION_ARG" ]]; then
+        usage
+        exit 1
+      fi
+      VERSION_ARG="$1"
+      shift
+      ;;
+  esac
+done
+
+case "$LANE" in
+  beta)
+    KEY="CMUX_IOS_BETA_MARKETING_VERSION"
+    DISPLAY_LANE="beta"
+    ;;
+  appstore)
+    KEY="CMUX_IOS_APPSTORE_MARKETING_VERSION"
+    DISPLAY_LANE="App Store"
+    ;;
+  *)
+    usage
+    exit 1
+    ;;
+esac
+
+CURRENT_MARKETING="$(read_xcconfig_setting "$KEY")"
 if [[ -z "$CURRENT_MARKETING" ]]; then
-  echo "Error: could not read MARKETING_VERSION from $XCCONFIG" >&2
+  echo "Error: could not read the configured $DISPLAY_LANE marketing version from $XCCONFIG" >&2
   exit 1
 fi
 
-echo "Current: MARKETING_VERSION=$CURRENT_MARKETING"
+echo "Current $DISPLAY_LANE marketing version: $CURRENT_MARKETING"
 
 # Normalize to X.Y.Z (tolerate a bare "1.0" by treating the missing patch as 0).
 IFS='.' read -r MAJOR MINOR PATCH <<< "$CURRENT_MARKETING"
@@ -39,16 +113,16 @@ MAJOR="${MAJOR:-0}"
 MINOR="${MINOR:-0}"
 PATCH="${PATCH:-0}"
 
-if [[ $# -eq 0 ]] || [[ "$1" == "patch" ]]; then
+if [[ -z "$VERSION_ARG" ]] || [[ "$VERSION_ARG" == "patch" ]]; then
   NEW_MARKETING="$MAJOR.$MINOR.$((PATCH + 1))"
-elif [[ "$1" == "minor" ]]; then
+elif [[ "$VERSION_ARG" == "minor" ]]; then
   NEW_MARKETING="$MAJOR.$((MINOR + 1)).0"
-elif [[ "$1" == "major" ]]; then
+elif [[ "$VERSION_ARG" == "major" ]]; then
   NEW_MARKETING="$((MAJOR + 1)).0.0"
-elif [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
-  NEW_MARKETING="$1"
+elif [[ "$VERSION_ARG" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  NEW_MARKETING="$VERSION_ARG"
 else
-  echo "Usage: $0 [version|patch|minor|major]" >&2
+  usage
   echo "  version: specific version like 1.2.3" >&2
   echo "  patch: bump patch version (default)" >&2
   echo "  minor: bump minor version" >&2
@@ -56,11 +130,13 @@ else
   exit 1
 fi
 
-echo "New:     MARKETING_VERSION=$NEW_MARKETING"
+echo "New $DISPLAY_LANE marketing version: $NEW_MARKETING"
 
-sed -i '' "s/^MARKETING_VERSION = $CURRENT_MARKETING\$/MARKETING_VERSION = $NEW_MARKETING/" "$XCCONFIG"
+TMP_XCCONFIG="$(mktemp "${XCCONFIG}.XXXXXX")"
+sed -E "s/^([[:space:]]*$KEY[[:space:]]*=[[:space:]]*).*/\\1$NEW_MARKETING/" "$XCCONFIG" > "$TMP_XCCONFIG"
+mv "$TMP_XCCONFIG" "$XCCONFIG"
 
-UPDATED_MARKETING="$(grep -m1 '^MARKETING_VERSION = ' "$XCCONFIG" | sed 's/^MARKETING_VERSION = //')"
+UPDATED_MARKETING="$(read_xcconfig_setting "$KEY")"
 if [[ "$UPDATED_MARKETING" != "$NEW_MARKETING" ]]; then
   echo "Error: version update failed!" >&2
   exit 1

--- a/ios/scripts/cloud-testflight.sh
+++ b/ios/scripts/cloud-testflight.sh
@@ -132,6 +132,15 @@ done
   || die "invalid --marketing-version (want X.Y or X.Y.Z): $MARKETING_VERSION_OVERRIDE"
 [[ -d "$IOS_DIR/cmux.xcworkspace" ]] || die "run from a cmux checkout containing ios/cmux.xcworkspace"
 
+# Pin the expected beta version before any archive path runs. The local fallback
+# and the fleet build both stamp this version into the archive; upload-testflight.sh
+# reads the same env var when it verifies a reused --archive-path.
+if [[ -n "$MARKETING_VERSION_OVERRIDE" ]]; then
+  export BETA_MARKETING_VERSION="$MARKETING_VERSION_OVERRIDE"
+else
+  unset BETA_MARKETING_VERSION
+fi
+
 # --- locate the hq cloud build script (mirrors ios/scripts/reload-cloud.sh) ---
 # scripts/reload-cloud-ios.sh lives in the cmuxterm-hq checkout, two levels up
 # from the worktree's git common dir (.../cmuxterm-hq/repo/.git -> cmuxterm-hq).
@@ -163,14 +172,6 @@ build_archive_cloud() {
   log="$(mktemp "${TMPDIR:-/tmp}/cloud-testflight-cloud.XXXXXX")"
   err "building UNSIGNED Release beta archive on the fleet via $hq_cloud"
   local args=( --mode beta-archive --tag "$TAG" --keep-artifacts --beta-bundle-id "$BETA_BUNDLE_ID" )
-  # Pin BETA_MARKETING_VERSION to exactly the requested override; explicitly
-  # unset otherwise so a stray value already in the caller's environment can
-  # not leak into the cloud build and desync it from a local cut.
-  if [[ -n "$MARKETING_VERSION_OVERRIDE" ]]; then
-    export BETA_MARKETING_VERSION="$MARKETING_VERSION_OVERRIDE"
-  else
-    unset BETA_MARKETING_VERSION
-  fi
   [[ -n "$HOST_FILTER" ]] && args+=( --host "$HOST_FILTER" )
   [[ "$WAIT_SECONDS" =~ ^[0-9]+$ && "$WAIT_SECONDS" -gt 0 ]] && args+=( --wait "$WAIT_SECONDS" )
   # Run from the repo root so the hq script's "run from a cmux checkout" check and

--- a/ios/scripts/set-testflight-notes.sh
+++ b/ios/scripts/set-testflight-notes.sh
@@ -115,7 +115,7 @@ else
   TOP_VERSION="$(sed -n 's/^## \[\([^]]*\)\].*/\1/p' "$CHANGELOG" | head -n1)"
   [[ -n "$TOP_VERSION" ]] || { echo "error: no '## [version]' entry found in $CHANGELOG" >&2; exit 1; }
   if [[ -n "$EXPECT_MARKETING_VERSION" && "$TOP_VERSION" != "$EXPECT_MARKETING_VERSION" ]]; then
-    echo "error: changelog top entry is [$TOP_VERSION] but the build's marketing version is $EXPECT_MARKETING_VERSION; refusing to attach mismatched What to Test notes. Add a [$EXPECT_MARKETING_VERSION] entry to the top of $CHANGELOG (or bump MARKETING_VERSION to $TOP_VERSION before cutting)." >&2
+    echo "error: changelog top entry is [$TOP_VERSION] but the build's marketing version is $EXPECT_MARKETING_VERSION; refusing to attach mismatched What to Test notes. Add a [$EXPECT_MARKETING_VERSION] entry to the top of $CHANGELOG (or bump the beta marketing version with ios/scripts/bump-ios-version.sh before cutting)." >&2
     exit 1
   fi
 

--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -246,11 +246,11 @@ Options:
                             lane so each build's notes reflect what changed since
                             the previous beta for the selected audience). Skips
                             the changelog preflight and version-match guard.
-  --auto-version            Stamp the build's MARKETING_VERSION at archive time
+  --auto-version            Stamp the beta build's MARKETING_VERSION at archive time
                             (no repo commit) to the next patch above the last
                             iOS release (newest ios-v<X.Y.Z> tag, else the
-                            checked-in MARKETING_VERSION), so betas show e.g.
-                            1.0.4 while 1.0.3 is the last release. Implies
+                            checked-in beta marketing version), so betas show
+                            e.g. 1.0.4 while 1.0.3 is the last release. Implies
                             range-notes mode (skips the changelog preflight and
                             version-match guard, since the stamped version
                             deliberately will not match the changelog top); when
@@ -268,6 +268,42 @@ require_option_value() {
     usage >&2
     exit 2
   fi
+}
+
+read_xcconfig_setting() {
+  local key="$1"
+  local file="$2"
+  sed -nE "s/^[[:space:]]*$key[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\\1/p" "$file" 2>/dev/null | tail -n 1
+}
+
+require_marketing_version() {
+  local label="$1"
+  local value="$2"
+  if [[ ! "$value" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+    echo "error: $label marketing version must be X.Y or X.Y.Z (got '${value:-}')" >&2
+    exit 2
+  fi
+}
+
+version_gt() {
+  local left="$1"
+  local right="$2"
+  local left_major left_minor left_patch right_major right_minor right_patch
+  [[ "$left" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]] || return 1
+  [[ "$right" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]] || return 0
+  IFS='.' read -r left_major left_minor left_patch <<< "$left"
+  IFS='.' read -r right_major right_minor right_patch <<< "$right"
+  left_patch="${left_patch:-0}"
+  right_patch="${right_patch:-0}"
+  if (( 10#$left_major != 10#$right_major )); then
+    (( 10#$left_major > 10#$right_major ))
+    return
+  fi
+  if (( 10#$left_minor != 10#$right_minor )); then
+    (( 10#$left_minor > 10#$right_minor ))
+    return
+  fi
+  (( 10#$left_patch > 10#$right_patch ))
 }
 
 LANE="beta"
@@ -293,8 +329,8 @@ SIGNING="manual"
 # Default 0 keeps the historical internal-only behavior (fast dogfood, no Apple
 # review). Set to 1 by --external or CMUX_TESTFLIGHT_EXTERNAL=1 to drop the
 # testFlightInternalTestingOnly flag so the build can be added to an external
-# group; such builds then require a one-time Apple Beta App Review per
-# MARKETING_VERSION.
+# group; such builds then require a one-time Apple Beta App Review per beta
+# marketing version.
 EXTERNAL_TESTING=0
 if [[ "${CMUX_TESTFLIGHT_EXTERNAL:-}" == "1" ]]; then
   EXTERNAL_TESTING=1
@@ -322,9 +358,9 @@ fi
 # preflight + version-match guard are skipped (the notes no longer come from the
 # changelog, and --auto-version stamps a version the changelog would not match).
 NOTES_RANGE_BASE=""
-# --auto-version: stamp the build's MARKETING_VERSION at archive time (no repo
-# commit-back, mirroring the timestamp build number) to the next patch above the
-# last iOS release, so betas show e.g. 1.0.4 while 1.0.3 is the last release.
+# --auto-version: stamp the beta build's MARKETING_VERSION at archive time (no
+# repo commit-back, mirroring the timestamp build number) to the next patch above
+# the last iOS release, so betas show e.g. 1.0.4 while 1.0.3 is the last release.
 AUTO_VERSION=0
 
 while [[ $# -gt 0 ]]; do
@@ -407,7 +443,7 @@ if [[ "$LANE" == "appstore" && "$EXTERNAL_TESTING" -eq 1 ]]; then
 fi
 
 if [[ "$LANE" == "appstore" && "$AUTO_VERSION" -eq 1 ]]; then
-  echo "error: --auto-version is beta-only. Set ios/Config/Shared.xcconfig MARKETING_VERSION intentionally before an App Store upload." >&2
+  echo "error: --auto-version is beta-only. Set the configured App Store marketing version intentionally before an App Store upload." >&2
   exit 2
 fi
 
@@ -425,21 +461,39 @@ IOS_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORKSPACE="$IOS_DIR/cmux.xcworkspace"
 SCHEME="cmux-ios"
 DEVELOPMENT_TEAM="${IOS_DEVELOPMENT_TEAM:-7WLXT3NR37}"
+SHARED_XCCONFIG="$IOS_DIR/Config/Shared.xcconfig"
+CHECKED_IN_BETA_MARKETING_VERSION="$(read_xcconfig_setting CMUX_IOS_BETA_MARKETING_VERSION "$SHARED_XCCONFIG")"
+CHECKED_IN_APPSTORE_MARKETING_VERSION="$(read_xcconfig_setting CMUX_IOS_APPSTORE_MARKETING_VERSION "$SHARED_XCCONFIG")"
+
+case "$LANE" in
+  beta)
+    LANE_MARKETING_VERSION="${BETA_MARKETING_VERSION:-${IOS_BETA_MARKETING_VERSION:-$CHECKED_IN_BETA_MARKETING_VERSION}}"
+    ;;
+  appstore)
+    LANE_MARKETING_VERSION="${IOS_APPSTORE_MARKETING_VERSION:-$CHECKED_IN_APPSTORE_MARKETING_VERSION}"
+    ;;
+esac
+require_marketing_version "$LANE" "$LANE_MARKETING_VERSION"
 
 # Notes audience is driven by the testing lane (External block for --external).
 NOTES_AUDIENCE="internal"
 [[ "$EXTERNAL_TESTING" == "1" ]] && NOTES_AUDIENCE="external"
 
+# Stamp the lane's marketing version at archive time. Release.xcconfig defaults
+# to the beta value for normal TestFlight builds, but the App Store lane shares
+# the same Xcode configuration and must override MARKETING_VERSION explicitly so
+# production can start from its own version.
+MARKETING_VERSION_ARGS=( "MARKETING_VERSION=$LANE_MARKETING_VERSION" )
+EXPECTED_MARKETING_VERSION="$LANE_MARKETING_VERSION"
+
 # --auto-version: compute the beta marketing version (next patch above the last
 # iOS release) and prepare it as an archive build-setting override. No repo write:
 # this mirrors the timestamp BUILD_NUMBER, which is also stamped at archive time
 # and never committed. Source of "last release" is the newest `ios-v<X.Y.Z>` git
-# tag (the `v1.x` tags are the macOS app); fallback to the checked-in
-# MARKETING_VERSION if no iOS tag exists. So while 1.0.3 is the last release, every
-# beta archives as 1.0.4; a real release sets + tags the version and the stamp
-# tracks it.
-MARKETING_VERSION_ARGS=()
-BETA_MARKETING_VERSION=""
+# tag (the `v1.x` tags are the macOS app); fallback to the checked-in beta
+# marketing version if no iOS tag exists. So while 1.0.3 is the last release,
+# every beta archives as 1.0.4; a real release sets + tags the version and the
+# stamp tracks it.
 if [[ "$AUTO_VERSION" -eq 1 ]]; then
   # --auto-version stamps the marketing version at archive time and disables the
   # changelog version guard (RANGE_NOTES_MODE). Both only make sense when THIS
@@ -455,23 +509,31 @@ if [[ "$AUTO_VERSION" -eq 1 ]]; then
   if [[ "$last_ios_tag" =~ ^ios-v([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
     base_version="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.${BASH_REMATCH[3]}"
   else
-    base_version="$(sed -nE 's/^[[:space:]]*MARKETING_VERSION[[:space:]]*=[[:space:]]*([0-9]+(\.[0-9]+){1,2}).*/\1/p' "$IOS_DIR/Config/Shared.xcconfig" 2>/dev/null | head -1)"
+    base_version="$CHECKED_IN_BETA_MARKETING_VERSION"
+  fi
+  if version_gt "$CHECKED_IN_BETA_MARKETING_VERSION" "$base_version"; then
+    base_version="$CHECKED_IN_BETA_MARKETING_VERSION"
   fi
   if [[ "$base_version" =~ ^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
-    BETA_MARKETING_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( BASH_REMATCH[3] + 1 ))"
+    COMPUTED_BETA_MARKETING_VERSION="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}.$(( BASH_REMATCH[3] + 1 ))"
   elif [[ "$base_version" =~ ^([0-9]+)\.([0-9]+)$ ]]; then
-    BETA_MARKETING_VERSION="${BASH_REMATCH[1]}.$(( BASH_REMATCH[2] + 1 )).0"
+    COMPUTED_BETA_MARKETING_VERSION="${BASH_REMATCH[1]}.$(( BASH_REMATCH[2] + 1 )).0"
   fi
-  if [[ -n "$BETA_MARKETING_VERSION" ]]; then
-    MARKETING_VERSION_ARGS=( "MARKETING_VERSION=$BETA_MARKETING_VERSION" )
-    echo "auto-version: stamping beta MARKETING_VERSION=$BETA_MARKETING_VERSION (last release base ${base_version:-unknown})" >&2
+  if [[ -n "${COMPUTED_BETA_MARKETING_VERSION:-}" ]]; then
+    MARKETING_VERSION_ARGS=( "MARKETING_VERSION=$COMPUTED_BETA_MARKETING_VERSION" )
+    EXPECTED_MARKETING_VERSION="$COMPUTED_BETA_MARKETING_VERSION"
+    echo "auto-version: stamping beta MARKETING_VERSION=$COMPUTED_BETA_MARKETING_VERSION (last release base ${base_version:-unknown})" >&2
   else
     # Fail closed: --auto-version disables the changelog version guard, so if we
     # cannot compute a stamp we must not silently upload the un-bumped checked-in
     # version with the guard off.
-    echo "error: --auto-version could not compute a beta version (base '${base_version:-}'); refusing to upload with the version guard disabled and no stamp. Ensure an ios-v<X.Y.Z> tag or a valid MARKETING_VERSION in ios/Config/Shared.xcconfig." >&2
+    echo "error: --auto-version could not compute a beta version (base '${base_version:-}'); refusing to upload with the version guard disabled and no stamp. Ensure an ios-v<X.Y.Z> tag or a valid configured beta marketing version in ios/Config/Shared.xcconfig." >&2
     exit 1
   fi
+elif [[ -z "$ARCHIVE_PATH" ]]; then
+  echo "lane-version: stamping $LANE MARKETING_VERSION=$LANE_MARKETING_VERSION" >&2
+else
+  echo "lane-version: expecting $LANE MARKETING_VERSION=$LANE_MARKETING_VERSION in reused archive" >&2
 fi
 
 # Are the notes auto-generated from a commit range instead of the changelog?
@@ -710,25 +772,33 @@ if [[ -n "$ARCHIVE_APP" && -d "$ARCHIVE_APP" ]]; then
   fi
 fi
 
+ARCHIVE_MARKETING_VERSION="$("$PLISTBUDDY" -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
+if [[ ! "$ARCHIVE_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
+  echo "error: archive marketing version is unreadable or invalid ('$ARCHIVE_MARKETING_VERSION'); refusing to export an unverifiable $LANE build." >&2
+  exit 1
+fi
+if [[ "$ARCHIVE_MARKETING_VERSION" != "$EXPECTED_MARKETING_VERSION" ]]; then
+  echo "error: archive marketing version is '$ARCHIVE_MARKETING_VERSION' but lane '$LANE' requires '$EXPECTED_MARKETING_VERSION'. Re-archive for the selected lane." >&2
+  exit 1
+fi
+
 # Now that the archive exists, its marketing version (CFBundleShortVersionString)
 # is the version testers will see. Re-run the notes preflight WITH that version so
 # a deterministic mismatch (changelog top is 1.0.3 but the archived build is 1.0.0)
 # fails BEFORE the export/upload, not after (when the notes step is non-fatal and
 # would just ship an opaque build). Skipped for --export-only / --skip-notes. If the
-# archive's version is unreadable, the version-match guard simply does not run.
+# archive's version is unreadable, the lane version guard above fails closed
+# before this notes-specific check.
 # Skipped in range-notes mode: the notes come from the commit range, not the
 # changelog, and --auto-version intentionally stamps a version the changelog would
 # not match.
 if [[ "$LANE" == "beta" && "$EXPORT_ONLY" -ne 1 && "$SKIP_NOTES" -ne 1 && "$RANGE_NOTES_MODE" -ne 1 ]]; then
-  ARCHIVE_MARKETING_VERSION="$("$PLISTBUDDY" -c 'Print :ApplicationProperties:CFBundleShortVersionString' "$ARCHIVE_PATH/Info.plist" 2>/dev/null || true)"
   if [[ "$ARCHIVE_MARKETING_VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]]; then
     if ! "$SCRIPT_DIR/set-testflight-notes.sh" --validate-only \
         --audience "$NOTES_AUDIENCE" --expect-marketing-version "$ARCHIVE_MARKETING_VERSION"; then
       echo "error: ios/CHANGELOG.md top entry does not match the archived marketing version $ARCHIVE_MARKETING_VERSION (see above); refusing to upload a build whose What to Test notes would be for the wrong version. Update ios/CHANGELOG.md, or pass --skip-notes." >&2
       exit 1
     fi
-  else
-    echo "note: could not read the archive's marketing version; deferring the notes version-match guard to the post-upload step" >&2
   fi
 fi
 
@@ -1220,8 +1290,9 @@ fi
 # eligible in principle". After upload, assign the processed build to the app's
 # external beta group so external testers actually receive it, and create the
 # Beta App Review submission when Apple requires one for a new
-# MARKETING_VERSION. This is fatal: a red CI/upload is preferable to claiming
-# the external lane tracked main when the build never reached the founders lane.
+# beta marketing version. This is fatal: a red CI/upload is preferable to
+# claiming the external lane tracked main when the build never reached the
+# founders lane.
 if [[ "$LANE" == "beta" && "$EXPORT_ONLY" -ne 1 && "$EXTERNAL_TESTING" -eq 1 && "$ASSIGN_EXTERNAL_GROUP" -eq 1 ]]; then
   if [[ -z "${ASC_API_KEY_ID:-}" || -z "${ASC_API_ISSUER_ID:-}" || ( -z "${ASC_API_KEY_PATH:-}" && -z "${ASC_API_KEY_P8_BASE64:-}" ) ]]; then
     echo "warning: no ASC API key (JWT) available; uploaded the external-eligible build but skipped automatic external-group assignment and Beta App Review submission. Supply ASC_API_KEY_ID, ASC_API_ISSUER_ID, and ASC_API_KEY_PATH (or ASC_API_KEY_P8_BASE64) to distribute the build automatically." >&2

--- a/ios/scripts/validate-app-store-release.sh
+++ b/ios/scripts/validate-app-store-release.sh
@@ -46,6 +46,12 @@ EOF
 die() { printf 'validate-app-store-release: %s\n' "$*" >&2; exit 1; }
 note() { printf 'validate-app-store-release: %s\n' "$*" >&2; }
 
+read_xcconfig_setting() {
+  local key="$1"
+  local file="$2"
+  sed -nE "s/^[[:space:]]*$key[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\\1/p" "$file" 2>/dev/null | tail -n 1
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --app) APP="${2:-}"; shift 2 ;;
@@ -78,10 +84,7 @@ done
 [[ -n "$APP" ]] || die "configured app id is required; pass --app or configure the release app id"
 [[ "$APP" =~ ^[0-9]+$ ]] || die "configured app id must be numeric; do not pass a bundle id"
 if [[ -z "$VERSION" ]]; then
-  VERSION="$(
-    sed -nE 's/^[[:space:]]*MARKETING_VERSION[[:space:]]*=[[:space:]]*([0-9]+(\.[0-9]+){1,2}).*/\1/p' \
-      "$IOS_DIR/Config/Shared.xcconfig" 2>/dev/null | head -n 1
-  )"
+  VERSION="$(read_xcconfig_setting CMUX_IOS_APPSTORE_MARKETING_VERSION "$IOS_DIR/Config/Shared.xcconfig")"
 fi
 [[ "$VERSION" =~ ^[0-9]+(\.[0-9]+){1,2}$ ]] || die "--version must be X.Y or X.Y.Z (got '${VERSION:-}')"
 if [[ -n "$BUILD_NUMBER" && -n "$BUILD_ID" ]]; then

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -7,6 +7,7 @@ import base64
 import json
 import os
 import plistlib
+import shutil
 import stat
 import subprocess
 import sys
@@ -19,8 +20,12 @@ ROOT = Path(__file__).resolve().parents[1]
 TEAM_ID = "7WLXT3NR37"
 APPSTORE_BUNDLE_ID = "com.cmux.app"
 APPSTORE_APP_ID = f"{TEAM_ID}.{APPSTORE_BUNDLE_ID}"
+BETA_BUNDLE_ID = "dev.cmux.app.beta"
+BETA_APP_ID = f"{TEAM_ID}.{BETA_BUNDLE_ID}"
 ASC_APP_ID = "6783338052"
 IDENTITY = f"Apple Distribution: Manaflow, Inc. ({TEAM_ID})"
+APPSTORE_MARKETING_VERSION = "1.0.0"
+BETA_MARKETING_VERSION = "1.0.4"
 
 FAILURES: list[str] = []
 
@@ -37,17 +42,21 @@ def _plist_bytes(value: object) -> bytes:
     return plistlib.dumps(value, fmt=plistlib.FMT_XML)
 
 
-def _profile_plist() -> dict[str, object]:
+def _profile_plist(
+    bundle_id: str = APPSTORE_BUNDLE_ID,
+    name: str = "cmux App Store Distribution Test",
+) -> dict[str, object]:
+    app_id = f"{TEAM_ID}.{bundle_id}"
     return {
-        "Name": "cmux App Store Distribution Test",
+        "Name": name,
         "UUID": "00000000-0000-0000-0000-000000000001",
         "Entitlements": {
-            "application-identifier": APPSTORE_APP_ID,
+            "application-identifier": app_id,
             "com.apple.developer.team-identifier": TEAM_ID,
             "get-task-allow": False,
             "aps-environment": "production",
             "com.apple.developer.applesignin": ["Default"],
-            "keychain-access-groups": [APPSTORE_APP_ID],
+            "keychain-access-groups": [app_id],
         },
     }
 
@@ -60,9 +69,14 @@ def _write_executable(path: Path, body: str) -> None:
 def _install_fake_tools(fakebin: Path) -> None:
     fakebin.mkdir(parents=True, exist_ok=True)
     common = f"""
+import plistlib
+from pathlib import Path
+
 TEAM_ID = {TEAM_ID!r}
-BUNDLE_ID = {APPSTORE_BUNDLE_ID!r}
-APP_ID = {APPSTORE_APP_ID!r}
+APPSTORE_BUNDLE_ID = {APPSTORE_BUNDLE_ID!r}
+APPSTORE_APP_ID = {APPSTORE_APP_ID!r}
+BETA_BUNDLE_ID = {BETA_BUNDLE_ID!r}
+BETA_APP_ID = {BETA_APP_ID!r}
 IDENTITY = {IDENTITY!r}
 
 def plist_bytes(value):
@@ -72,8 +86,25 @@ def write_plist(path, value):
     path.parent.mkdir(parents=True, exist_ok=True)
     path.write_bytes(plist_bytes(value))
 
-PROFILE = {_profile_plist()!r}
-ENTITLEMENTS = PROFILE["Entitlements"]
+APPSTORE_PROFILE = {_profile_plist()!r}
+BETA_PROFILE = {_profile_plist(BETA_BUNDLE_ID, "cmux Beta Distribution Test")!r}
+
+def profile_for_bundle(bundle_id):
+    if bundle_id == BETA_BUNDLE_ID:
+        return BETA_PROFILE
+    return APPSTORE_PROFILE
+
+def bundle_id_for_target(path):
+    target = Path(path)
+    info = target / "Info.plist" if target.is_dir() else target
+    try:
+        value = plistlib.loads(info.read_bytes()).get("CFBundleIdentifier", "")
+    except Exception:
+        value = ""
+    return value or APPSTORE_BUNDLE_ID
+
+def entitlements_for_bundle(bundle_id):
+    return profile_for_bundle(bundle_id)["Entitlements"]
 """
 
     _write_executable(
@@ -260,7 +291,7 @@ if "archive" in args:
     archive = Path(after("-archivePath"))
     bundle_id = setting("PRODUCT_BUNDLE_IDENTIFIER=")
     build_number = setting("CURRENT_PROJECT_VERSION=") or "1"
-    marketing_version = setting("MARKETING_VERSION=") or "1.0.4"
+    marketing_version = setting("MARKETING_VERSION=") or {BETA_MARKETING_VERSION!r}
     app = archive / "Products" / "Applications" / "cmux.app"
     write_plist(
         archive / "Info.plist",
@@ -288,11 +319,13 @@ if "-exportArchive" in args:
     export_options = Path(after("-exportOptionsPlist"))
     shutil.copyfile(export_options, os.environ["CMUX_FAKE_EXPORT_OPTIONS_COPY"])
     app_info = next((archive / "Products" / "Applications").glob("*.app/Info.plist"))
-    bundle_id = plistlib.loads(app_info.read_bytes())["CFBundleIdentifier"]
+    archived_info = plistlib.loads(app_info.read_bytes())
+    bundle_id = archived_info["CFBundleIdentifier"]
     payload_root = export_path / "Payload"
     app = payload_root / "cmux.app"
-    write_plist(app / "Info.plist", {{"CFBundleIdentifier": bundle_id}})
-    (app / "embedded.mobileprovision").write_text("fake profile", encoding="utf-8")
+    write_plist(app / "Info.plist", archived_info)
+    profile_marker = "beta profile" if bundle_id == BETA_BUNDLE_ID else "fake profile"
+    (app / "embedded.mobileprovision").write_text(profile_marker, encoding="utf-8")
     ipa = export_path / "cmux.ipa"
     ipa.parent.mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(ipa, "w") as zf:
@@ -315,7 +348,8 @@ args = sys.argv[1:]
 if "--verify" in args:
     sys.exit(0)
 if "-d" in args and "--entitlements" in args:
-    sys.stdout.buffer.write(plist_bytes(ENTITLEMENTS))
+    bundle_id = bundle_id_for_target(args[-1])
+    sys.stdout.buffer.write(plist_bytes(entitlements_for_bundle(bundle_id)))
     sys.exit(0)
 if "--force" in args:
     sys.exit(0)
@@ -331,8 +365,8 @@ import plistlib
 import sys
 from pathlib import Path
 {common}
-LEGACY_PROFILE = copy.deepcopy(PROFILE)
-LEGACY_PROFILE["Entitlements"] = dict(PROFILE["Entitlements"])
+LEGACY_PROFILE = copy.deepcopy(APPSTORE_PROFILE)
+LEGACY_PROFILE["Entitlements"] = dict(APPSTORE_PROFILE["Entitlements"])
 LEGACY_PROFILE["Entitlements"]["application-identifier"] = f"{{TEAM_ID}}.com.cmuxterm.app"
 LEGACY_PROFILE["Entitlements"]["keychain-access-groups"] = [f"{{TEAM_ID}}.com.cmuxterm.app"]
 
@@ -341,11 +375,15 @@ if args[:3] == ["find-identity", "-v", "-p"]:
     print(f'  1) ABCDEF "{{IDENTITY}}"')
     sys.exit(0)
 if len(args) >= 2 and args[0] == "cms" and args[1] == "-D":
-    profile = PROFILE
+    profile = APPSTORE_PROFILE
     if "-i" in args:
         source = Path(args[args.index("-i") + 1])
-        if source.exists() and b"legacy profile" in source.read_bytes():
-            profile = LEGACY_PROFILE
+        if source.exists():
+            body = source.read_bytes()
+            if b"legacy profile" in body:
+                profile = LEGACY_PROFILE
+            elif b"beta profile" in body:
+                profile = BETA_PROFILE
     sys.stdout.buffer.write(plist_bytes(profile))
     sys.exit(0)
 if args and args[0] == "find-certificate":
@@ -419,11 +457,12 @@ def _run(
     *,
     env: dict[str, str],
     tmp: Path,
+    cwd: Path = ROOT,
     log_failure: bool = True,
 ) -> subprocess.CompletedProcess[str]:
     result = subprocess.run(
         args,
-        cwd=ROOT,
+        cwd=cwd,
         env=env,
         text=True,
         stdout=subprocess.PIPE,
@@ -433,6 +472,260 @@ def _run(
         print(result.stdout)
         print(result.stderr, file=sys.stderr)
     return result
+
+
+def _version_tuple(version: str) -> tuple[int, int, int]:
+    parts = [int(part) for part in version.split(".")]
+    while len(parts) < 3:
+        parts.append(0)
+    return parts[0], parts[1], parts[2]
+
+
+def _bump_patch(version: str) -> str:
+    major, minor, patch = _version_tuple(version)
+    return f"{major}.{minor}.{patch + 1}"
+
+
+def _write_fake_archive(path: Path, *, bundle_id: str, build_number: str, marketing_version: str) -> None:
+    app = path / "Products" / "Applications" / "cmux.app"
+    info = {
+        "CFBundleIdentifier": bundle_id,
+        "CFBundleVersion": build_number,
+        "CFBundleShortVersionString": marketing_version,
+    }
+    (path).mkdir(parents=True, exist_ok=True)
+    app.mkdir(parents=True, exist_ok=True)
+    (path / "Info.plist").write_bytes(
+        _plist_bytes(
+            {
+                "ApplicationProperties": {
+                    "CFBundleIdentifier": bundle_id,
+                    "CFBundleVersion": build_number,
+                    "CFBundleShortVersionString": marketing_version,
+                }
+            }
+        )
+    )
+    (app / "Info.plist").write_bytes(_plist_bytes(info))
+
+
+def _copy_isolated_ios_upload_repo(target: Path) -> Path:
+    repo = target / "repo"
+    for relative in (
+        "ios/scripts/upload-testflight.sh",
+        "ios/Config/Shared.xcconfig",
+        "ios/Config/cmux-release.entitlements",
+    ):
+        source = ROOT / relative
+        destination = repo / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+
+    subprocess.run(["git", "init"], cwd=repo, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.invalid"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test Runner"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "--allow-empty", "-m", "init"], cwd=repo, stdout=subprocess.PIPE, stderr=subprocess.PIPE, check=True)
+    subprocess.run(["git", "tag", "ios-v1.0.0"], cwd=repo, check=True)
+    return repo
+
+
+def _copy_isolated_ios_version_repo(target: Path) -> Path:
+    repo = target / "repo"
+    for relative in (
+        "ios/scripts/bump-ios-version.sh",
+        "ios/Config/Shared.xcconfig",
+    ):
+        source = ROOT / relative
+        destination = repo / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+    return repo
+
+
+def _read_xcconfig_setting(path: Path, key: str) -> str:
+    values = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        before_comment = line.split("//", 1)[0].strip()
+        if not before_comment.startswith(f"{key} "):
+            continue
+        name, _, value = before_comment.partition("=")
+        if name.strip() == key:
+            values.append(value.strip())
+    return values[-1] if values else ""
+
+
+def test_upload_beta_lane_uses_beta_marketing_version(tmp: Path, fakebin: Path) -> None:
+    env = _base_env(tmp, fakebin)
+    env["CMUX_IOS_UPLOAD_DIR"] = str(tmp / "upload")
+    env["CMUX_BUILD_NUMBER_OUT_FILE"] = str(tmp / "build-number.txt")
+    result = _run(
+        [
+            "bash",
+            str(ROOT / "ios" / "scripts" / "upload-testflight.sh"),
+            "--lane",
+            "beta",
+            "--signing",
+            "manual",
+            "--export-only",
+            "--build-number",
+            "20260710041749",
+        ],
+        env=env,
+        tmp=tmp,
+    )
+    _check(result.returncode == 0, "beta export-only lane succeeds with fake Apple tools")
+
+    xcodebuild_calls = [
+        json.loads(line)
+        for line in (tmp / "xcodebuild.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    archive_call = next(call for call in xcodebuild_calls if "archive" in call)
+    _check(
+        f"PRODUCT_BUNDLE_IDENTIFIER={BETA_BUNDLE_ID}" in archive_call,
+        "beta archive command stamps the beta bundle id",
+    )
+    _check(
+        f"MARKETING_VERSION={BETA_MARKETING_VERSION}" in archive_call,
+        "beta archive command stamps the beta marketing version",
+    )
+    _check(
+        f"MARKETING_VERSION={APPSTORE_MARKETING_VERSION}" not in archive_call,
+        "beta archive command does not stamp the App Store marketing version",
+    )
+
+    export_options = plistlib.loads((tmp / "ExportOptions.plist").read_bytes())
+    profiles = export_options.get("provisioningProfiles", {})
+    _check(
+        profiles.get(BETA_BUNDLE_ID) == "cmux Beta Distribution",
+        "export options map the beta profile to dev.cmux.app.beta",
+    )
+
+    ipa_line = next(line for line in result.stdout.splitlines() if line.startswith("IPA_PATH="))
+    ipa_path = Path(ipa_line.removeprefix("IPA_PATH="))
+    with zipfile.ZipFile(ipa_path) as zf:
+        info = plistlib.loads(zf.read("Payload/cmux.app/Info.plist"))
+    _check(
+        info.get("CFBundleIdentifier") == BETA_BUNDLE_ID,
+        "final signed beta IPA Info.plist is dev.cmux.app.beta",
+    )
+    _check(
+        info.get("CFBundleShortVersionString") == BETA_MARKETING_VERSION,
+        "final signed beta IPA keeps the beta marketing version",
+    )
+
+
+def test_upload_beta_archive_path_accepts_marketing_version_override(tmp: Path, fakebin: Path) -> None:
+    override_version = "1.0.3"
+    archive = tmp / "cmux-beta.xcarchive"
+    _write_fake_archive(
+        archive,
+        bundle_id=BETA_BUNDLE_ID,
+        build_number="20260710041748",
+        marketing_version=override_version,
+    )
+    env = _base_env(tmp, fakebin)
+    env["BETA_MARKETING_VERSION"] = override_version
+    env["CMUX_IOS_UPLOAD_DIR"] = str(tmp / "upload")
+    result = _run(
+        [
+            "bash",
+            str(ROOT / "ios" / "scripts" / "upload-testflight.sh"),
+            "--lane",
+            "beta",
+            "--archive-path",
+            str(archive),
+            "--signing",
+            "manual",
+            "--export-only",
+        ],
+        env=env,
+        tmp=tmp,
+    )
+    _check(result.returncode == 0, "beta archive override export succeeds")
+
+    ipa_line = next(line for line in result.stdout.splitlines() if line.startswith("IPA_PATH="))
+    ipa_path = Path(ipa_line.removeprefix("IPA_PATH="))
+    with zipfile.ZipFile(ipa_path) as zf:
+        info = plistlib.loads(zf.read("Payload/cmux.app/Info.plist"))
+    _check(
+        info.get("CFBundleShortVersionString") == override_version,
+        "reused beta archive keeps the override marketing version",
+    )
+
+
+def test_upload_beta_auto_version_uses_checked_in_beta_floor(tmp: Path, fakebin: Path) -> None:
+    isolated_repo = _copy_isolated_ios_upload_repo(tmp / "isolated")
+    expected_version = _bump_patch(BETA_MARKETING_VERSION)
+    env = _base_env(tmp, fakebin)
+    env["CMUX_IOS_UPLOAD_DIR"] = str(tmp / "upload")
+    result = _run(
+        [
+            "bash",
+            str(isolated_repo / "ios" / "scripts" / "upload-testflight.sh"),
+            "--lane",
+            "beta",
+            "--auto-version",
+            "--signing",
+            "manual",
+            "--export-only",
+            "--build-number",
+            "20260710041752",
+        ],
+        env=env,
+        tmp=tmp,
+        cwd=isolated_repo,
+    )
+
+    _check(result.returncode == 0, "beta auto-version export succeeds with a lower release tag")
+    xcodebuild_calls = [
+        json.loads(line)
+        for line in (tmp / "xcodebuild.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    archive_call = next(call for call in xcodebuild_calls if "archive" in call)
+    stamped_version = next(
+        arg.removeprefix("MARKETING_VERSION=")
+        for arg in archive_call
+        if arg.startswith("MARKETING_VERSION=")
+    )
+    _check(
+        stamped_version == expected_version,
+        "beta auto-version uses the greater of release tags and checked-in beta version",
+    )
+    _check(
+        _version_tuple(stamped_version) > _version_tuple(BETA_MARKETING_VERSION),
+        "beta auto-version does not decrease below the checked-in beta version",
+    )
+
+
+def test_bump_ios_version_accepts_trailing_appstore_lane(tmp: Path, fakebin: Path) -> None:
+    isolated_repo = _copy_isolated_ios_version_repo(tmp / "isolated-version")
+    config = isolated_repo / "ios" / "Config" / "Shared.xcconfig"
+    result = _run(
+        [
+            "bash",
+            str(isolated_repo / "ios" / "scripts" / "bump-ios-version.sh"),
+            "1.0.1",
+            "--lane",
+            "appstore",
+        ],
+        env=os.environ.copy(),
+        tmp=tmp,
+        cwd=isolated_repo,
+    )
+
+    _check(result.returncode == 0, "bump helper accepts trailing --lane appstore")
+    _check(
+        _read_xcconfig_setting(config, "CMUX_IOS_APPSTORE_MARKETING_VERSION") == "1.0.1",
+        "trailing appstore lane updates the App Store marketing version",
+    )
+    _check(
+        _read_xcconfig_setting(config, "CMUX_IOS_BETA_MARKETING_VERSION") == BETA_MARKETING_VERSION,
+        "trailing appstore lane leaves the beta marketing version unchanged",
+    )
+    _check(
+        "CMUX_IOS_APPSTORE_MARKETING_VERSION" not in result.stdout + result.stderr,
+        "bump helper output describes the lane without exposing the internal xcconfig key",
+    )
 
 
 def test_upload_appstore_lane_uses_production_bundle_id(tmp: Path, fakebin: Path) -> None:
@@ -465,6 +758,14 @@ def test_upload_appstore_lane_uses_production_bundle_id(tmp: Path, fakebin: Path
         "archive command stamps com.cmux.app",
     )
     _check(
+        f"MARKETING_VERSION={APPSTORE_MARKETING_VERSION}" in archive_call,
+        "archive command stamps the App Store marketing version",
+    )
+    _check(
+        f"MARKETING_VERSION={BETA_MARKETING_VERSION}" not in archive_call,
+        "archive command does not stamp the beta marketing version",
+    )
+    _check(
         all("PRODUCT_BUNDLE_IDENTIFIER=com.cmuxterm.app" not in call for call in archive_call),
         "archive command does not stamp the retired com.cmuxterm.app id",
     )
@@ -482,6 +783,10 @@ def test_upload_appstore_lane_uses_production_bundle_id(tmp: Path, fakebin: Path
     with zipfile.ZipFile(ipa_path) as zf:
         info = plistlib.loads(zf.read("Payload/cmux.app/Info.plist"))
     _check(info.get("CFBundleIdentifier") == APPSTORE_BUNDLE_ID, "final signed IPA Info.plist is com.cmux.app")
+    _check(
+        info.get("CFBundleShortVersionString") == APPSTORE_MARKETING_VERSION,
+        "final signed IPA keeps the App Store marketing version",
+    )
 
 
 def test_upload_appstore_checks_asc_app_bundle_id_before_upload(tmp: Path, fakebin: Path) -> None:
@@ -561,7 +866,7 @@ def test_validate_appstore_release_requires_numeric_app_id(tmp: Path, fakebin: P
     env = _base_env(tmp, fakebin)
     env["ASC_APP_ID"] = ASC_APP_ID
     result = _run(
-        ["bash", str(ROOT / "ios" / "scripts" / "validate-app-store-release.sh"), "--version", "1.0.4"],
+        ["bash", str(ROOT / "ios" / "scripts" / "validate-app-store-release.sh")],
         env=env,
         tmp=tmp,
     )
@@ -573,6 +878,11 @@ def test_validate_appstore_release_requires_numeric_app_id(tmp: Path, fakebin: P
     validate_call = next(call for call in asc_calls if call and call[0] == "validate")
     app_index = validate_call.index("--app") + 1
     _check(validate_call[app_index] == ASC_APP_ID, "validation helper uses the numeric App Store Connect app id")
+    version_index = validate_call.index("--version") + 1
+    _check(
+        validate_call[version_index] == APPSTORE_MARKETING_VERSION,
+        "validation helper defaults to the App Store marketing version",
+    )
 
     bad_env = _base_env(tmp / "bad-app", fakebin)
     bad_result = _run(
@@ -582,7 +892,7 @@ def test_validate_appstore_release_requires_numeric_app_id(tmp: Path, fakebin: P
             "--app",
             APPSTORE_BUNDLE_ID,
             "--version",
-            "1.0.4",
+            APPSTORE_MARKETING_VERSION,
         ],
         env=bad_env,
         tmp=tmp / "bad-app",
@@ -597,6 +907,10 @@ def main() -> None:
         tmp = Path(temp_dir)
         fakebin = tmp / "bin"
         _install_fake_tools(fakebin)
+        test_upload_beta_lane_uses_beta_marketing_version(tmp / "beta-upload-test", fakebin)
+        test_upload_beta_archive_path_accepts_marketing_version_override(tmp / "beta-archive-override-test", fakebin)
+        test_upload_beta_auto_version_uses_checked_in_beta_floor(tmp / "beta-auto-version-test", fakebin)
+        test_bump_ios_version_accepts_trailing_appstore_lane(tmp / "version-bump-test", fakebin)
         test_upload_appstore_lane_uses_production_bundle_id(tmp / "upload-test", fakebin)
         test_upload_appstore_checks_asc_app_bundle_id_before_upload(tmp / "upload-live-test", fakebin)
         test_profile_installer_accepts_production_profile_by_default(tmp / "profile-test", fakebin)


### PR DESCRIPTION
## Summary
- Add independent checked-in iOS beta and App Store marketing versions: beta stays 1.0.4, App Store starts at 1.0.0.
- Stamp and verify the selected lane marketing version in the archive before export/upload.
- Update App Store validation, CI summaries, release docs, and the iOS lane simulation test.

## Testing
- python3 tests/test_ios_appstore_lane_identity.py
- bash -n ios/scripts/upload-testflight.sh ios/scripts/cloud-testflight.sh ios/scripts/validate-app-store-release.sh ios/scripts/bump-ios-version.sh ios/scripts/upload-app-store.sh ios/scripts/set-testflight-notes.sh
- python3 -m py_compile tests/test_ios_appstore_lane_identity.py
- git diff --check

## Notes
- Metadata/workflow change only. No tagged runtime reload needed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7854"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786300668&installation_id=133855650&pr_number=7854&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7854&signature=696839e2428edbcdb40168b7e63f2926449d3c212c0b8a77ac199e0d2a0a6d57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes release/version stamping and pre-export guards on TestFlight and App Store upload paths; mistakes could block uploads or ship the wrong CFBundleShortVersionString, but scope is tooling and config with expanded automated tests.
> 
> **Overview**
> Introduces **independent** TestFlight beta and production App Store marketing versions so beta can stay on an already-approved line (e.g. `1.0.4`) while the first App Store upload can ship as `1.0.0`.
> 
> `ios/Config/Shared.xcconfig` now defines `CMUX_IOS_BETA_MARKETING_VERSION` and `CMUX_IOS_APPSTORE_MARKETING_VERSION`, with `MARKETING_VERSION` aliasing the beta value for normal Xcode builds. **`upload-testflight.sh`** picks the lane version, stamps it at archive time, and **fails closed** if a reused archive’s `CFBundleShortVersionString` does not match. Beta **`--auto-version`** floors on the greater of the latest `ios-v*` tag and the checked-in beta version.
> 
> **`bump-ios-version.sh`** gains `--lane beta|appstore`; **`validate-app-store-release.sh`** and the App Store workflow default to the App Store key. **`cloud-testflight.sh`** pins `BETA_MARKETING_VERSION` before fleet/local archives. Docs, changelog wording, and **`test_ios_appstore_lane_identity.py`** are updated for lane-specific stamping and validation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6014d8ae6882524b616450c51ce2917a7c7eda54. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Split iOS beta and App Store marketing versions and make each lane stamp and enforce its own `MARKETING_VERSION` at archive time. Prevents wrong-version uploads and keeps beta and production release lines independent.

- **New Features**
  - Added `CMUX_IOS_BETA_MARKETING_VERSION` and `CMUX_IOS_APPSTORE_MARKETING_VERSION` in `ios/Config/Shared.xcconfig`; `MARKETING_VERSION` defaults to the beta value.
  - Both lanes stamp their lane marketing version during archive and refuse export/upload if the archive’s `CFBundleShortVersionString` is invalid or mismatched; final IPAs keep the lane’s version.
  - `--auto-version` (beta-only) sets the next patch over the greater of the latest `ios-vX.Y.Z` tag or the checked-in beta version; never decreases and fails closed if it can’t compute a version. App Store lane rejects `--auto-version`.
  - Tooling: `cloud-testflight.sh` pins `BETA_MARKETING_VERSION` early; `validate-app-store-release.sh` and the App Store workflow default to `CMUX_IOS_APPSTORE_MARKETING_VERSION`; `bump-ios-version.sh --lane beta|appstore` updates the targeted lane and accepts trailing `--lane`; workflows/docs reference the new keys. Tests cover lane stamping in archives/IPAs, archive guards, auto-version flooring, validation defaults, and the bump helper.

- **Migration**
  - Use `ios/scripts/bump-ios-version.sh --lane beta|appstore` to bump the correct lane.
  - Keep the top `ios/CHANGELOG.md` entry equal to `CMUX_IOS_BETA_MARKETING_VERSION`. No runtime changes.

<sup>Written for commit 6014d8ae6882524b616450c51ce2917a7c7eda54. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added separate, lane-aware iOS marketing versions for beta vs App Store, with updated version bumping and distribution behavior.
* **Documentation**
  * Updated iOS App Store/Review, TestFlight, and identity checklist guidance to reference the new configuration-driven marketing version variables.
* **Bug Fixes**
  * Improved App Store/TestFlight validation to derive and verify the correct lane marketing version and fail fast on missing/invalid values.
* **Tests**
  * Expanded automated coverage for beta lanes, overrides, and beta auto-version floor logic.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->