### PR TITLE
iroh transport P5: default-on, Tailscale publication toggle, transport visibility

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -28,6 +28,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     ///   - ticket: The attach ticket authorizing requests.
     ///   - allowsStackAuthFallback: When `true`, falls back to a Stack Auth token
     ///     on routes that allow it once the attach ticket no longer covers a request.
+    ///   - transportConnectObserver: Optional observer for the underlying transport
+    ///     attempt, success, and failure lifecycle.
     public init(
         runtime: any MobileSyncRuntime,
         route: CmxAttachRoute,
@@ -38,7 +40,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         stackTokenForceRefreshGate: RPCStackTokenGate? = nil,
         abandonedConnectCleanupTimeoutNanoseconds: UInt64 = 1_000_000_000,
         lateAbandonedConnectCloseTimeoutNanoseconds: UInt64 = 5_000_000_000,
-        stackTokenGateResetNanoseconds: UInt64 = 30_000_000_000
+        stackTokenGateResetNanoseconds: UInt64 = 30_000_000_000,
+        transportConnectObserver: (@Sendable (MobileRPCTransportConnectEvent) async -> Void)? = nil
     ) {
         self.runtime = runtime
         self.route = route
@@ -55,7 +58,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             lateAbandonedConnectCloseTimeoutNanoseconds: lateAbandonedConnectCloseTimeoutNanoseconds,
             makeTransport: { [route, runtime] in
                 try runtime.transportFactory.makeTransport(for: route)
-            }
+            },
+            transportConnectObserver: transportConnectObserver
         )
     }
 

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -4,6 +4,7 @@ import Foundation
 actor MobileCoreRPCSession {
     typealias TransportFactory = @Sendable () throws -> any CmxByteTransport
     typealias ConnectedCandidateHook = @Sendable (_ candidate: any CmxByteTransport) async -> Void
+    typealias TransportConnectObserver = @Sendable (MobileRPCTransportConnectEvent) async -> Void
     typealias PendingContinuation = CheckedContinuation<Result<Data, MobileShellConnectionError>, Never>
     typealias ConnectingTask = (id: UUID, lease: MobileRPCConnectAttemptLease?, task: Task<any CmxByteTransport, any Error>, waiters: Set<UUID>, completed: Bool)
     static let defaultAbandonedConnectCleanupTimeoutNanoseconds: UInt64 = 1_000_000_000
@@ -32,6 +33,7 @@ actor MobileCoreRPCSession {
     let lateAbandonedConnectCloseTimeoutNanoseconds: UInt64
     private let makeTransport: TransportFactory
     private let didReceiveConnectedCandidate: ConnectedCandidateHook?
+    private let transportConnectObserver: TransportConnectObserver?
     private var transport: (any CmxByteTransport)?
     private var connectionTask: ConnectingTask?
     private var installedConnectionID: UUID?
@@ -54,7 +56,8 @@ actor MobileCoreRPCSession {
         abandonedConnectCleanupTimeoutNanoseconds: UInt64 = 1_000_000_000,
         lateAbandonedConnectCloseTimeoutNanoseconds: UInt64 = 5_000_000_000,
         makeTransport: @escaping TransportFactory,
-        didReceiveConnectedCandidate: ConnectedCandidateHook? = nil
+        didReceiveConnectedCandidate: ConnectedCandidateHook? = nil,
+        transportConnectObserver: TransportConnectObserver? = nil
     ) {
         self.connectAttemptKey = connectAttemptKey
         self.connectAttemptRegistry = connectAttemptRegistry
@@ -62,6 +65,7 @@ actor MobileCoreRPCSession {
         self.lateAbandonedConnectCloseTimeoutNanoseconds = lateAbandonedConnectCloseTimeoutNanoseconds
         self.makeTransport = makeTransport
         self.didReceiveConnectedCandidate = didReceiveConnectedCandidate
+        self.transportConnectObserver = transportConnectObserver
     }
 
     deinit {
@@ -202,22 +206,45 @@ actor MobileCoreRPCSession {
             } else {
                 connectLease = .untracked
             }
+            let connectStartedAt = ContinuousClock.now
+            await transportConnectObserver?(.attempt)
             let candidate: any CmxByteTransport
             do {
                 candidate = try makeTransport()
             } catch {
+                await transportConnectObserver?(
+                    .failed(
+                        error: error,
+                        elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt)
+                    )
+                )
                 await connectAttemptRegistry.clearFinishedConnect(lease: connectLease)
                 throw error
             }
             connectionID = UUID()
+            let transportConnectObserver = transportConnectObserver
             task = Task.detached {
-                try await withTaskCancellationHandler {
-                    try await candidate.connect()
-                    return candidate
-                } onCancel: {
-                    Task {
-                        await candidate.close()
+                do {
+                    let connected = try await withTaskCancellationHandler {
+                        try await candidate.connect()
+                        return candidate
+                    } onCancel: {
+                        Task {
+                            await candidate.close()
+                        }
                     }
+                    await transportConnectObserver?(
+                        .connected(elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt))
+                    )
+                    return connected
+                } catch {
+                    await transportConnectObserver?(
+                        .failed(
+                            error: error,
+                            elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt)
+                        )
+                    )
+                    throw error
                 }
             }
             connectionTask = (id: connectionID, lease: connectLease, task: task, waiters: [waiterID], completed: false)
@@ -297,6 +324,13 @@ actor MobileCoreRPCSession {
             throw CancellationError()
         }
         return candidate
+    }
+
+    private static func elapsedMilliseconds(since start: ContinuousClock.Instant) -> Int {
+        let components = start.duration(to: .now).components
+        let milliseconds = components.seconds * 1_000
+            + components.attoseconds / 1_000_000_000_000_000
+        return max(0, Int(milliseconds))
     }
 
     private func cancelConnectingWaiter(id connectionID: UUID, waiterID: UUID) async {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCTransportConnectEvent.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCTransportConnectEvent.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A lifecycle event for one underlying mobile transport connection attempt.
+public enum MobileRPCTransportConnectEvent: Sendable {
+    /// The transport factory is about to build and dial its route.
+    case attempt
+    /// The underlying byte transport connected successfully.
+    /// - Parameter elapsedMilliseconds: Whole milliseconds since the attempt began.
+    case connected(elapsedMilliseconds: Int)
+    /// The transport factory or underlying byte transport failed.
+    /// - Parameters:
+    ///   - error: The transport construction or connection error.
+    ///   - elapsedMilliseconds: Whole milliseconds since the attempt began.
+    case failed(error: any Error, elapsedMilliseconds: Int)
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -622,6 +622,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// The injected, fire-and-forget product-analytics emitter. Defaults to
     /// ``NoopAnalytics`` so previews/tests inject nothing.
     private let analytics: any AnalyticsEmitting
+    let dialLog: @Sendable (String) async -> Void
     let connectAttemptRegistry = MobileRPCConnectAttemptRegistry()
     let stackTokenGate = RPCStackTokenGate()
     let stackTokenForceRefreshGate = RPCStackTokenGate()
@@ -882,6 +883,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Create a mobile shell store with injectable runtime services for app
     /// composition, previews, and package tests.
+    /// - Parameter dialLog: Optional ordered dial-log sink. The production
+    ///   default writes through ``MobileDebugLog/anchormux(_:)``.
     public init(
         runtime: (any MobileSyncRuntime)? = nil,
         isSignedIn: Bool = false,
@@ -905,6 +908,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         forgottenMacStore: any PairedMacForgottenStoring = InMemoryPairedMacForgottenStore(),
         analytics: any AnalyticsEmitting = NoopAnalytics(),
         diagnosticLog: DiagnosticLog? = nil,
+        dialLog: (@Sendable (String) async -> Void)? = nil,
         feedbackEmailSubmitter: (any MobileFeedbackEmailSubmitting)? = nil,
         feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp },
         draftStore: (any TerminalDraftStoring)? = nil,
@@ -928,6 +932,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.forgottenMacStore = forgottenMacStore
         self.analytics = analytics
         self.diagnosticLog = diagnosticLog
+        self.dialLog = dialLog ?? { message in MobileDebugLog.anchormux(message) }
         self.feedbackEmailSubmitter = feedbackEmailSubmitter
         self.feedbackStampProvider = feedbackStampProvider
         // Distinguish "key absent" (an install that predates the hint and may
@@ -4979,7 +4984,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// when it returned without connecting and without throwing
     /// (`.noSupportedRoute`), so callers record the matching analytics reason.
     @discardableResult
-    private func connect(
+    func connect(
         ticket: CmxAttachTicket,
         allowsStackAuthFallback: Bool? = nil,
         pairedMacDeviceID: String? = nil,
@@ -5039,9 +5044,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         var lastError: (any Error)?
         for (routeIndex, route) in supportedRoutes.enumerated() {
             activeRoute = route
-            mobileShellLog.info(
-                "mobile attach route attempt index=\(routeIndex + 1, privacy: .public) id=\(route.id, privacy: .public) kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)"
-            )
+            let attemptIndex = routeIndex + 1
+            let routeID = route.id
+            let routeKind = route.kind.rawValue
+            let endpointSummary = Self.mobileDialEndpointSummary(route.endpoint)
+            let dialLog = dialLog
             let client = MobileCoreRPCClient(
                 runtime: runtime,
                 route: route,
@@ -5050,7 +5057,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     ?? MobileShellRouteAuthPolicy.routeAllowsStackAuth(route),
                 connectAttemptRegistry: connectAttemptRegistry,
                 stackTokenGate: stackTokenGate,
-                stackTokenForceRefreshGate: stackTokenForceRefreshGate
+                stackTokenForceRefreshGate: stackTokenForceRefreshGate,
+                transportConnectObserver: { event in
+                    let line: String
+                    switch event {
+                    case .attempt:
+                        line = "mobile.dial.attempt index=\(attemptIndex) route_id=\(routeID) kind=\(routeKind) endpoint=\(endpointSummary)"
+                    case .connected(let elapsedMilliseconds):
+                        line = "mobile.dial.connected index=\(attemptIndex) route_id=\(routeID) kind=\(routeKind) elapsed_ms=\(elapsedMilliseconds)"
+                    case let .failed(error, elapsedMilliseconds):
+                        line = "mobile.dial.failed index=\(attemptIndex) route_id=\(routeID) kind=\(routeKind) failure_kind=\(Self.mobileDialFailureKind(error)) elapsed_ms=\(elapsedMilliseconds)"
+                    }
+                    await dialLog(line)
+                }
             )
             for workspaceListRequest in workspaceListRequests {
                 do {
@@ -5159,6 +5178,57 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
         diagnosticLog?.record(DiagnosticEvent(.pairFail))
         throw lastError ?? MobileShellConnectionError.connectionClosed
+    }
+
+    nonisolated private static func mobileDialEndpointSummary(_ endpoint: CmxAttachEndpoint) -> String {
+        switch endpoint {
+        case let .hostPort(host, port):
+            return "\(host):\(port)"
+        case let .peer(id, relayHint, _, relayURL):
+            let endpointPrefix = String(id.prefix(8))
+            let relayHost = relayURL.flatMap { URL(string: $0)?.host }
+                ?? relayHint.flatMap { hint in
+                    URL(string: hint)?.host ?? URL(string: "https://\(hint)")?.host
+                }
+                ?? "none"
+            return "peer:\(endpointPrefix),relay:\(relayHost)"
+        case .url:
+            return "url:redacted"
+        }
+    }
+
+    nonisolated private static func mobileDialFailureKind(_ error: any Error) -> String {
+        if let error = error as? CmxNetworkByteTransportError {
+            switch error {
+            case .connectionTimedOut:
+                return "timedOut"
+            case .connectionFailed(_, let kind):
+                return mobileDialFailureKind(kind)
+            default:
+                return "transport_error:\(String(describing: type(of: error)))"
+            }
+        }
+        if let error = error as? CmxIrohByteTransportError {
+            switch error {
+            case .endpointBindFailed(_, let kind), .connectionFailed(_, let kind):
+                return mobileDialFailureKind(kind)
+            default:
+                return "transport_error:\(String(describing: type(of: error)))"
+            }
+        }
+        return "transport_error:\(String(describing: type(of: error)))"
+    }
+
+    nonisolated private static func mobileDialFailureKind(_ kind: CmxConnectFailureKind) -> String {
+        switch kind {
+        case .connectionRefused: "connectionRefused"
+        case .hostUnreachable: "hostUnreachable"
+        case .timedOut: "timedOut"
+        case .permissionDenied: "permissionDenied"
+        case .dnsFailed: "dnsFailed"
+        case .secureChannelFailed: "secureChannelFailed"
+        case .generic: "generic"
+        }
     }
 
     private struct WorkspaceListRequest {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -5030,10 +5030,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // disable auth for a trusted Tailscale/loopback/iroh route.
         let routeAllowsStackAuthFallbackOverride = allowsStackAuthFallback
         let connectionAttemptStartedAt = pairingAttemptStartedAt
+        let routeOrder = supportedRoutes.enumerated()
+            .map { index, route in
+                "\(index + 1):id=\(route.id),kind=\(route.kind.rawValue)"
+            }
+            .joined(separator: " ")
+        mobileShellLog.info("mobile attach route order \(routeOrder, privacy: .public)")
         var lastError: (any Error)?
-        for route in supportedRoutes {
+        for (routeIndex, route) in supportedRoutes.enumerated() {
             activeRoute = route
-            mobileShellLog.info("pairing trying route kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)")
+            mobileShellLog.info(
+                "mobile attach route attempt index=\(routeIndex + 1, privacy: .public) id=\(route.id, privacy: .public) kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)"
+            )
             let client = MobileCoreRPCClient(
                 runtime: runtime,
                 route: route,
@@ -5064,6 +5072,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     )
                     let response = try MobileSyncWorkspaceListResponse.decode(resultData)
                     guard isConnectCurrent() else { return nil }
+                    mobileShellLog.info(
+                        "mobile attach route connected id=\(route.id, privacy: .public) kind=\(route.kind.rawValue, privacy: .public)"
+                    )
                     await persistPairedMacFromTicket(ticket, ifStillCurrent: isConnectCurrent)
                     guard isConnectCurrent() else { return nil }
                     replaceRemoteClient(with: client)
@@ -5117,7 +5128,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         connections[resolvedForegroundMacID] = MacConnection(
                             macDeviceID: resolvedForegroundMacID,
                             ticket: ticket,
-                            route: firstRoute,
+                            route: route,
                             client: client,
                             generation: generation
                         )

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticFailingTransport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticFailingTransport.swift
@@ -1,0 +1,13 @@
+import CMUXMobileCore
+import CmuxMobileTransport
+import Foundation
+
+actor DialDiagnosticFailingTransport: CmxByteTransport {
+    func connect() async throws {
+        throw CmxIrohByteTransportError.connectionFailed("sensitive transport detail", .hostUnreachable)
+    }
+
+    func receive() async throws -> Data? { nil }
+    func send(_ data: Data) async throws {}
+    func close() async {}
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticRecorder.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticRecorder.swift
@@ -1,0 +1,11 @@
+actor DialDiagnosticRecorder {
+    private var recordedLines: [String] = []
+
+    func record(_ line: String) {
+        recordedLines.append(line)
+    }
+
+    func lines() -> [String] {
+        recordedLines
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticTransportFactory.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticTransportFactory.swift
@@ -1,0 +1,13 @@
+import CMUXMobileCore
+
+struct DialDiagnosticTransportFactory: CmxByteTransportFactory {
+    let router: LivenessHostRouter
+    let failingRouteID: String
+
+    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        if route.id == failingRouteID {
+            return DialDiagnosticFailingTransport()
+        }
+        return LivenessTransport(router: router)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileDialDiagnosticsTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileDialDiagnosticsTests.swift
@@ -1,0 +1,67 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Suite struct MobileDialDiagnosticsTests {
+    @Test func diagnosticsFollowIrohThenTailscalePriorityOrder() async throws {
+        let irohRoute = try CmxAttachRoute(
+            id: "iroh-primary",
+            kind: .iroh,
+            endpoint: .peer(
+                id: "1234567890-full-endpoint-id",
+                relayHint: nil,
+                directAddrs: [],
+                relayURL: "https://relay.example.com/path?token=never-log-this"
+            ),
+            priority: 1
+        )
+        let tailscaleRoute = try CmxAttachRoute(
+            id: "tailscale-fallback",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.71.210.41", port: CmxMobileDefaults.defaultHostPort),
+            priority: 2
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [tailscaleRoute, irohRoute]
+        )
+        let router = LivenessHostRouter()
+        let recorder = DialDiagnosticRecorder()
+        let runtime = LivenessTestRuntime(
+            transportFactory: DialDiagnosticTransportFactory(
+                router: router,
+                failingRouteID: irohRoute.id
+            ),
+            now: Date.init,
+            supportedRouteKinds: [.iroh, .tailscale]
+        )
+        let store = MobileShellComposite(
+            runtime: runtime,
+            isSignedIn: true,
+            dialLog: { line in await recorder.record(line) }
+        )
+
+        _ = try await store.connect(ticket: ticket)
+
+        let lines = await recorder.lines()
+        #expect(lines.count == 4)
+        guard lines.count == 4 else {
+            Issue.record("unexpected dial diagnostics: \(lines)")
+            return
+        }
+        #expect(lines[0] == "mobile.dial.attempt index=1 route_id=iroh-primary kind=iroh endpoint=peer:12345678,relay:relay.example.com")
+        #expect(lines[1].hasPrefix("mobile.dial.failed index=1 route_id=iroh-primary kind=iroh failure_kind=hostUnreachable elapsed_ms="))
+        #expect(lines[2] == "mobile.dial.attempt index=2 route_id=tailscale-fallback kind=tailscale endpoint=100.71.210.41:\(CmxMobileDefaults.defaultHostPort)")
+        #expect(lines[3].hasPrefix("mobile.dial.connected index=2 route_id=tailscale-fallback kind=tailscale elapsed_ms="))
+        let combined = lines.joined(separator: "\n")
+        #expect(!combined.contains("1234567890-full-endpoint-id"))
+        #expect(!combined.contains("never-log-this"))
+        #expect(!combined.contains("sensitive transport detail"))
+        #expect(store.connectionState == .connected)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CmxAttachTransportKind+MobileDisplay.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CmxAttachTransportKind+MobileDisplay.swift
@@ -1,0 +1,35 @@
+import CMUXMobileCore
+import CmuxMobileSupport
+import Foundation
+
+extension CmxAttachTransportKind {
+    var mobileDisplayLabel: String {
+        switch self {
+        case .iroh:
+            return L10n.string("mobile.connection.transport.iroh", defaultValue: "Iroh")
+        case .tailscale:
+            return L10n.string("mobile.connection.transport.tailscale", defaultValue: "Tailscale")
+        case .debugLoopback:
+            return L10n.string("mobile.connection.transport.loopback", defaultValue: "Loopback")
+        case .websocket:
+            return L10n.string("mobile.connection.transport.websocket", defaultValue: "WebSocket")
+        }
+    }
+
+    func mobileToolbarSubtitle(terminalName: String?) -> String {
+        let label = mobileDisplayLabel
+        guard let terminalName,
+              !terminalName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            let format = L10n.string(
+                "mobile.connection.transportOnlyFormat",
+                defaultValue: "Connected via %@"
+            )
+            return String(format: format, label)
+        }
+        let format = L10n.string(
+            "mobile.connection.terminalTransportFormat",
+            defaultValue: "%@ via %@"
+        )
+        return String(format: format, terminalName, label)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatus+Display.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatus+Display.swift
@@ -1,5 +1,7 @@
+import CMUXMobileCore
 import CmuxMobileShellModel
 import CmuxMobileSupport
+import Foundation
 import SwiftUI
 
 /// Display-only derivations of ``MobileMacConnectionStatus`` used by the
@@ -26,6 +28,31 @@ extension MobileMacConnectionStatus {
             return L10n.string("mobile.connection.reconnectingDescription", defaultValue: "Trying to reach the selected cmux build.")
         case .unavailable:
             return L10n.string("mobile.connection.unavailableDescription", defaultValue: "The live connection dropped. The selected cmux build may still be online. Tap Reconnect.")
+        }
+    }
+
+    func description(transportKind: CmxAttachTransportKind?) -> String {
+        guard let transportKind else { return description }
+        let label = transportKind.mobileDisplayLabel
+        switch self {
+        case .connected:
+            let format = L10n.string(
+                "mobile.connection.connectedViaFormat",
+                defaultValue: "Live terminal sync is active over %@."
+            )
+            return String(format: format, label)
+        case .reconnecting:
+            let format = L10n.string(
+                "mobile.connection.reconnectingViaFormat",
+                defaultValue: "Trying to restore the %@ connection."
+            )
+            return String(format: format, label)
+        case .unavailable:
+            let format = L10n.string(
+                "mobile.connection.unavailableViaFormat",
+                defaultValue: "The %@ connection dropped. Tap Reconnect."
+            )
+            return String(format: format, label)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatusPill.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatusPill.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobileShellModel
 import SwiftUI
 
@@ -7,6 +8,7 @@ import SwiftUI
 struct MobileMacConnectionStatusPill: View {
     let host: String
     let status: MobileMacConnectionStatus
+    var activeTransportKind: CmxAttachTransportKind?
 
     var body: some View {
         // Only surface the pill for problem states (reconnecting / offline).
@@ -17,7 +19,7 @@ struct MobileMacConnectionStatusPill: View {
                     .fill(status.tintColor)
                     .frame(width: 8, height: 8)
 
-                Text(status.label)
+                Text(pillLabel)
                     .font(.caption.weight(.semibold))
                     .foregroundStyle(.white)
                     .lineLimit(1)
@@ -26,8 +28,13 @@ struct MobileMacConnectionStatusPill: View {
             .padding(.vertical, 7)
             .background(.black.opacity(0.78), in: Capsule())
             .accessibilityElement(children: .combine)
-            .accessibilityLabel(host.isEmpty ? status.label : "\(host), \(status.label)")
+            .accessibilityLabel(host.isEmpty ? pillLabel : "\(host), \(pillLabel)")
             .accessibilityIdentifier("MobileTerminalMacConnectionStatus")
         }
+    }
+
+    private var pillLabel: String {
+        guard let activeTransportKind else { return status.label }
+        return activeTransportKind.mobileToolbarSubtitle(terminalName: status.label)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatusRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatusRow.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobileShellModel
 import CmuxMobileSupport
 import SwiftUI
@@ -11,6 +12,7 @@ import SwiftUI
 struct MobileMacConnectionStatusRow: View {
     let host: String
     let status: MobileMacConnectionStatus
+    var activeTransportKind: CmxAttachTransportKind?
     var showsSpinner = false
     var titleOverride: String?
     var descriptionOverride: String?
@@ -45,7 +47,7 @@ struct MobileMacConnectionStatusRow: View {
                         .foregroundStyle(.primary)
                         .lineLimit(1)
 
-                    Text(descriptionOverride ?? (host.isEmpty ? status.description : host))
+                    Text(descriptionOverride ?? defaultDescription)
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .fixedSize(horizontal: false, vertical: true)
@@ -89,5 +91,17 @@ struct MobileMacConnectionStatusRow: View {
         .padding(.vertical, 8)
         .accessibilityElement(children: hasActions ? .contain : .combine)
         .accessibilityIdentifier("MobileMacConnectionStatus")
+    }
+
+    private var defaultDescription: String {
+        if status == .connected || host.isEmpty {
+            return status.description(transportKind: activeTransportKind)
+        }
+        guard let activeTransportKind else { return host }
+        let format = L10n.string(
+            "mobile.connection.hostTransportFormat",
+            defaultValue: "%@ - %@"
+        )
+        return String(format: format, host, activeTransportKind.mobileDisplayLabel)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingPage.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/OnboardingPage.swift
@@ -58,12 +58,9 @@ struct OnboardingPage: Sendable {
                 "mobile.onboarding.connectTitle",
                 defaultValue: "A private link to your Mac"
             ),
-            // Honest about the path: the phone reaches the Mac directly, the
-            // recommended way is Tailscale (which the standard QR pairing needs),
-            // and same-Wi-Fi manual pairing exists but is unencrypted.
             body: L10n.string(
                 "mobile.onboarding.connectBody",
-                defaultValue: "Your phone has to reach your Mac over the network. The simplest private path is Tailscale: both devices join the same tailnet and connect directly, with no cloud relay. On the same Wi-Fi you can instead type the Mac's local address by hand, but that link is unencrypted, so Tailscale is recommended."
+                defaultValue: "cmux tries an encrypted Iroh connection first, so pairing usually works as long as both devices are online and signed in. You can also publish Tailscale or LAN routes as a fallback."
             )
         )
     }
@@ -73,16 +70,16 @@ struct OnboardingPage: Sendable {
             systemImage: "point.3.connected.trianglepath.dotted",
             title: L10n.string(
                 "mobile.onboarding.tailscaleTitle",
-                defaultValue: "Put both devices on Tailscale"
+                defaultValue: "Optional fallback: Tailscale"
             ),
             body: L10n.string(
                 "mobile.onboarding.tailscaleBody",
-                defaultValue: "Tailscale is a free app that gives your devices a private network. Do this once, on both the phone and the Mac."
+                defaultValue: "Iroh is the default transport. Tailscale can add a private fallback route if your network blocks Iroh or you are connecting from an older cmux build."
             ),
             checklist: [
                 L10n.string(
                     "mobile.onboarding.tailscaleStep1",
-                    defaultValue: "Install Tailscale on this phone and on your Mac."
+                    defaultValue: "Install Tailscale on this phone and on your Mac only if you want the fallback route."
                 ),
                 L10n.string(
                     "mobile.onboarding.tailscaleStep2",
@@ -90,7 +87,7 @@ struct OnboardingPage: Sendable {
                 ),
                 L10n.string(
                     "mobile.onboarding.tailscaleStep3",
-                    defaultValue: "Keep both signed in to the same cmux account too. Pairing checks that they match."
+                    defaultValue: "Leave Also Publish Tailscale/LAN Routes on in Mac Settings when you want that fallback."
                 ),
             ],
             links: [

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpGateContent.swift
@@ -47,7 +47,7 @@ struct SetupHelpGateContent {
                 title: L10n.string("mobile.setupHelp.unreachableTitle", defaultValue: "Wake the computer"),
                 body: L10n.string(
                     "mobile.setupHelp.unreachableBody",
-                    defaultValue: "You have paired this computer before but it is not reachable now. Wake it, make sure cmux is running, and confirm both devices are on the same tailnet or Wi-Fi. Then reconnect."
+                    defaultValue: "You have paired this computer before but it is not reachable now. Wake it, make sure cmux is running, and confirm both devices are online. If you rely on a fallback route, also check Tailscale or Wi-Fi. Then reconnect."
                 ),
                 link: nil,
                 identifierSuffix: "macUnreachable",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/SetupHelpView.swift
@@ -17,9 +17,8 @@ import SwiftUI
 /// known paired Mac) to pick which gate to highlight, and renders static
 /// guidance for each of the four setup gates classified by
 /// ``MobileSetupGuidancePolicy``. The honest network section states the real
-/// constraint: QR pairing needs Tailscale on the Mac, and same-Wi-Fi without
-/// Tailscale only works by typing the Mac's local address by hand over an
-/// unencrypted link.
+/// constraint: pairing normally uses Iroh first, while Tailscale/LAN routes are
+/// optional fallback paths and same-Wi-Fi manual entry is unencrypted.
 struct SetupHelpView: View {
     /// The gate to emphasize, or `nil` when the user has no current blocker (for
     /// example Settings opened while connected). When set, that gate floats to the
@@ -126,7 +125,7 @@ struct SetupHelpView: View {
             VStack(alignment: .leading, spacing: 8) {
                 Text(L10n.string(
                     "mobile.setupHelp.networkBody",
-                    defaultValue: "Scanning the computer's QR code needs Tailscale: the computer only shows a code when it has a Tailscale address your phone can reach. Install Tailscale on both, sign both in to the same tailnet, and the code appears."
+                    defaultValue: "Scanning the computer's QR code normally uses Iroh first. Keep cmux open on the computer and make sure both devices are online. Tailscale is optional and only needed as a fallback route."
                 ))
                 .font(.subheadline)
                 .foregroundStyle(.secondary)
@@ -152,7 +151,7 @@ struct SetupHelpView: View {
 
                 Text(L10n.string(
                     "mobile.setupHelp.lanBody",
-                    defaultValue: "No Tailscale? On the same Wi-Fi you can still connect by typing the computer's local address and port by hand in Add Computer. That link is unencrypted, so only use it on a network you trust."
+                    defaultValue: "On the same Wi-Fi you can still connect by typing the computer's local address and port by hand in Add Computer. That link is unencrypted, so only use it on a network you trust."
                 ))
                 .font(.footnote)
                 .foregroundStyle(.secondary)
@@ -169,7 +168,7 @@ struct SetupHelpView: View {
         } footer: {
             Text(L10n.string(
                 "mobile.setupHelp.sameAccountFooter",
-                defaultValue: "The computer and this phone must be signed in to the same cmux account, and on the same tailnet (or the same Wi-Fi for a manual local connection)."
+                defaultValue: "The computer and this phone must be signed in to the same cmux account. Tailscale or same-Wi-Fi routing is only needed for fallback/manual connections."
             ))
         }
         .accessibilityIdentifier("MobileSetupHelpNetworkSection")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TailscaleInactiveCallout.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TailscaleInactiveCallout.swift
@@ -66,12 +66,12 @@ struct TailscaleInactiveCallout: View {
         case .pairing:
             return L10n.string(
                 "mobile.tailscale.pairingHelp",
-                defaultValue: "QR pairing usually needs both devices on the same Tailscale network. Turn Tailscale on first, or pair by host and port on a trusted local network."
+                defaultValue: "Iroh pairing can work without Tailscale. Turn Tailscale on only if you are using the Tailscale fallback route."
             )
         case .disconnected:
             return L10n.string(
                 "mobile.tailscale.disconnectedHelp",
-                defaultValue: "Your Mac may be unreachable because Tailscale is off here. Turn it on, then try again."
+                defaultValue: "Iroh is tried first. If this Mac was using the Tailscale fallback route, turn Tailscale on, then try again."
             )
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailContainer.swift
@@ -41,6 +41,7 @@ struct WorkspaceDetailContainer: View {
                 WorkspaceDetailView(
                     host: store.connectedHostName,
                     connectionStatus: workspace.macConnectionStatus ?? store.macConnectionStatus,
+                    activeTransportKind: store.activeRoute?.kind,
                     workspace: workspace,
                     store: store,
                     createWorkspace: createWorkspace,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+DerivedState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+DerivedState.swift
@@ -10,7 +10,12 @@ extension WorkspaceDetailView {
 
     var selectedToolbarSubtitle: String? {
         guard let selectedTerminalID = store.selectedTerminalID else { return nil }
-        return workspace.terminals.first { $0.id == selectedTerminalID }?.name
+        let terminalName = workspace.terminals.first { $0.id == selectedTerminalID }?.name
+        guard connectionStatus == .connected,
+              let activeTransportKind else {
+            return terminalName
+        }
+        return activeTransportKind.mobileToolbarSubtitle(terminalName: terminalName)
     }
 
     var terminalTopPadding: CGFloat { 4 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxAgentChat
 import CmuxAgentChatUI
 import CmuxMobileBrowser
@@ -17,6 +18,7 @@ import AppKit
 struct WorkspaceDetailView: View {
     let host: String
     let connectionStatus: MobileMacConnectionStatus
+    var activeTransportKind: CmxAttachTransportKind? = nil
     let workspace: MobileWorkspacePreview
     @Bindable var store: CMUXMobileShellStore
     let createWorkspace: () -> Void
@@ -249,7 +251,11 @@ struct WorkspaceDetailView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .overlay(alignment: .topLeading) {
-            MobileMacConnectionStatusPill(host: host, status: connectionStatus)
+            MobileMacConnectionStatusPill(
+                host: host,
+                status: connectionStatus,
+                activeTransportKind: activeTransportKind
+            )
                 .padding(.top, 10)
                 .padding(.leading, 10)
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobileShell
 import CmuxMobileShellModel
 import CmuxMobileSupport
@@ -16,6 +17,7 @@ struct WorkspaceListView: View {
     let selectedWorkspaceID: MobileWorkspacePreview.ID?
     let host: String
     let connectionStatus: MobileMacConnectionStatus
+    var activeTransportKind: CmxAttachTransportKind? = nil
     let navigationStyle: WorkspaceNavigationStyle
     var showsNavigationToolbar = true
     /// Whether workspace-row titles wrap (multi-line) instead of truncating to a
@@ -249,6 +251,7 @@ struct WorkspaceListView: View {
                     MobileMacConnectionStatusRow(
                         host: host,
                         status: connectionStatus,
+                        activeTransportKind: activeTransportKind,
                         showsSpinner: isInitialConnectionLoading,
                         titleOverride: initialConnectionTimedOut
                             ? L10n.string("mobile.loading.timeout.title", defaultValue: "Still loading")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import Foundation
 import CmuxMobileShell
 import CmuxMobileShellModel
@@ -50,6 +51,10 @@ struct WorkspaceShellView: View {
             return .reconnecting
         }
         return store.workspaceListConnectionStatus
+    }
+
+    private var activeTransportKind: CmxAttachTransportKind? {
+        store.activeRoute?.kind
     }
 
     private var canCreateWorkspaceOnForegroundConnection: Bool {
@@ -111,6 +116,7 @@ struct WorkspaceShellView: View {
                 selectedWorkspaceID: store.selectedWorkspaceID,
                 host: store.connectedHostName,
                 connectionStatus: listConnectionStatus,
+                activeTransportKind: activeTransportKind,
                 navigationStyle: .push,
                 showsNavigationToolbar: compactNavigationPath.isEmpty,
                 wrapWorkspaceTitles: displaySettings.wrapWorkspaceTitles,
@@ -215,6 +221,7 @@ struct WorkspaceShellView: View {
                 selectedWorkspaceID: store.selectedWorkspaceID,
                 host: store.connectedHostName,
                 connectionStatus: listConnectionStatus,
+                activeTransportKind: activeTransportKind,
                 navigationStyle: .sidebar,
                 wrapWorkspaceTitles: displaySettings.wrapWorkspaceTitles,
                 previewLineLimit: displaySettings.workspacePreviewLineCount,

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListConnectionChromeTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/WorkspaceListConnectionChromeTests.swift
@@ -1,3 +1,4 @@
+import CMUXMobileCore
 import CmuxMobileShellModel
 import SwiftUI
 import Testing
@@ -5,6 +6,19 @@ import Testing
 
 @MainActor
 @Suite struct WorkspaceListConnectionChromeTests {
+    @Test func transportLabelsDescribeLiveIrohSession() {
+        #expect(CmxAttachTransportKind.iroh.mobileDisplayLabel == "Iroh")
+        #expect(CmxAttachTransportKind.iroh.mobileToolbarSubtitle(terminalName: "zsh") == "zsh via Iroh")
+        #expect(CmxAttachTransportKind.iroh.mobileToolbarSubtitle(terminalName: nil) == "Connected via Iroh")
+        #expect(MobileMacConnectionStatus.connected.description(transportKind: .iroh) == "Live terminal sync is active over Iroh.")
+    }
+
+    @Test func transportLabelsDescribeLiveTailscaleSession() {
+        #expect(CmxAttachTransportKind.tailscale.mobileDisplayLabel == "Tailscale")
+        #expect(CmxAttachTransportKind.tailscale.mobileToolbarSubtitle(terminalName: "agent") == "agent via Tailscale")
+        #expect(MobileMacConnectionStatus.reconnecting.description(transportKind: .tailscale) == "Trying to restore the Tailscale connection.")
+    }
+
     @Test func reconnectingRecoveryShowsMacStatusRow() {
         #expect(chrome(
             isRecoveringConnection: true,

--- a/Packages/iOS/CmuxMobileTransport/Package.swift
+++ b/Packages/iOS/CmuxMobileTransport/Package.swift
@@ -18,13 +18,8 @@ let package = Package(
         .package(path: "../../Shared/CMUXMobileCore"),
     ],
     targets: [
-        .binaryTarget(
-            name: "CmuxIrohFFI",
-            path: "../../../CmuxIrohFFI.xcframework"
-        ),
         .target(
             name: "CmuxIrohC",
-            dependencies: ["CmuxIrohFFI"],
             publicHeadersPath: "include"
         ),
         .target(

--- a/Packages/iOS/CmuxMobileTransport/Package.swift
+++ b/Packages/iOS/CmuxMobileTransport/Package.swift
@@ -1,6 +1,15 @@
 // swift-tools-version: 6.0
 
+import Foundation
 import PackageDescription
+
+let packageDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+let repositoryDirectory = packageDirectory
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+let irohMacOSLibraryDirectory = repositoryDirectory
+    .appending(path: "CmuxIrohFFI.xcframework/macos-arm64_x86_64").path
 
 let package = Package(
     name: "CmuxMobileTransport",
@@ -20,7 +29,14 @@ let package = Package(
     targets: [
         .target(
             name: "CmuxIrohC",
-            publicHeadersPath: "include"
+            publicHeadersPath: "include",
+            linkerSettings: [
+                .unsafeFlags(
+                    ["-L", irohMacOSLibraryDirectory],
+                    .when(platforms: [.macOS])
+                ),
+                .linkedLibrary("cmux_iroh_ffi", .when(platforms: [.macOS])),
+            ]
         ),
         .target(
             name: "CmuxMobileTransport",

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohByteTransport.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohByteTransport.swift
@@ -69,6 +69,7 @@ public actor CmxIrohByteTransport: CmxByteTransport {
     private let endpointManager: CmxIrohEndpointManager
     private let ffiClient: any CmxIrohFFIClient
     private let maximumReceiveLength: Int
+    private let connectTimeoutNanoseconds: UInt64
     private let connectTimeoutMilliseconds: UInt64
     private var state: State = .idle
 
@@ -116,6 +117,7 @@ public actor CmxIrohByteTransport: CmxByteTransport {
         self.endpointManager = endpointManager
         self.ffiClient = ffiClient
         self.maximumReceiveLength = maximumReceiveLength
+        self.connectTimeoutNanoseconds = connectTimeoutNanoseconds
         self.connectTimeoutMilliseconds = max(1, connectTimeoutNanoseconds / 1_000_000)
     }
 
@@ -131,19 +133,74 @@ public actor CmxIrohByteTransport: CmxByteTransport {
             throw CmxIrohByteTransportError.alreadyClosed
         }
 
-        let endpoint = try await endpointManager.boundEndpoint()
+        let connectStartedAt = DispatchTime.now().uptimeNanoseconds
+        let endpoint = try await boundEndpointBeforeDeadline()
+        let elapsed = DispatchTime.now().uptimeNanoseconds - connectStartedAt
+        guard elapsed < connectTimeoutNanoseconds else {
+            throw CmxIrohByteTransportError.endpointBindFailed(
+                "iroh endpoint key load timed out",
+                .timedOut
+            )
+        }
+        let remainingTimeoutMilliseconds = max(
+            1,
+            (connectTimeoutNanoseconds - elapsed) / 1_000_000
+        )
         do {
             let connection = try ffiClient.connect(
                 endpoint: endpoint,
                 peerID: peerID,
                 relayURL: relayURL,
                 directAddrs: directAddrs,
-                timeoutMilliseconds: connectTimeoutMilliseconds
+                timeoutMilliseconds: min(connectTimeoutMilliseconds, remainingTimeoutMilliseconds)
             )
             state = .ready(connection)
         } catch let failure as CmxIrohFailure {
             throw CmxIrohByteTransportError.connectFailed(failure)
         }
+    }
+
+    private func boundEndpointBeforeDeadline() async throws -> CmxIrohEndpointReference {
+        let endpointManager = endpointManager
+        let timeoutNanoseconds = connectTimeoutNanoseconds
+        let stream = AsyncThrowingStream<CmxIrohEndpointReference, any Error> { continuation in
+            let endpointTask = Task.detached(priority: .userInitiated) {
+                do {
+                    continuation.yield(try await endpointManager.boundEndpoint())
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            let timeoutTask = Task {
+                do {
+                    let capped = min(timeoutNanoseconds, UInt64(Int64.max))
+                    // Genuine connect deadline: endpoint key loading and binding
+                    // share the same budget as the subsequent peer dial.
+                    try await ContinuousClock().sleep(for: .nanoseconds(Int64(capped)))
+                } catch {
+                    return
+                }
+                continuation.finish(throwing: CmxIrohByteTransportError.endpointBindFailed(
+                    "iroh endpoint key load timed out",
+                    .timedOut
+                ))
+            }
+            continuation.onTermination = { _ in
+                endpointTask.cancel()
+                timeoutTask.cancel()
+            }
+        }
+        for try await endpoint in stream {
+            return endpoint
+        }
+        if Task.isCancelled {
+            throw CancellationError()
+        }
+        throw CmxIrohByteTransportError.endpointBindFailed(
+            "iroh endpoint key load timed out",
+            .timedOut
+        )
     }
 
     /// Receives the next chunk of bytes, or `nil` at end of stream.

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohEndpointManager.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/CmxIrohEndpointManager.swift
@@ -11,6 +11,8 @@ public actor CmxIrohEndpointManager {
     private let enableRelay: Bool
     private let acceptConnections: Bool
     private var endpoint: CmxIrohEndpointReference?
+    private var bindingGeneration = UUID()
+    private var bindingTask: Task<CmxIrohEndpointReference, any Error>?
 
     /// Creates a production endpoint manager using the iOS Keychain.
     public init(
@@ -41,26 +43,61 @@ public actor CmxIrohEndpointManager {
         self.acceptConnections = acceptConnections
     }
 
-    func boundEndpoint() throws -> CmxIrohEndpointReference {
+    func boundEndpoint() async throws -> CmxIrohEndpointReference {
         if let endpoint {
             return endpoint
         }
-        let secretKey = try keyProvider.secretKey()
+
+        let generation: UUID
+        let task: Task<CmxIrohEndpointReference, any Error>
+        if let bindingTask {
+            generation = bindingGeneration
+            task = bindingTask
+        } else {
+            generation = UUID()
+            bindingGeneration = generation
+            let keyProvider = keyProvider
+            let ffiClient = ffiClient
+            let enableRelay = enableRelay
+            let acceptConnections = acceptConnections
+            task = Task.detached(priority: .userInitiated) {
+                let secretKey = try keyProvider.secretKey()
+                do {
+                    return try ffiClient.bindEndpoint(
+                        secretKey: secretKey,
+                        enableRelay: enableRelay,
+                        acceptConnections: acceptConnections
+                    )
+                } catch let failure as CmxIrohFailure {
+                    throw CmxIrohByteTransportError.bindFailed(failure)
+                }
+            }
+            bindingTask = task
+        }
+
         do {
-            let endpoint = try ffiClient.bindEndpoint(
-                secretKey: secretKey,
-                enableRelay: enableRelay,
-                acceptConnections: acceptConnections
-            )
-            self.endpoint = endpoint
-            return endpoint
-        } catch let failure as CmxIrohFailure {
-            throw CmxIrohByteTransportError.bindFailed(failure)
+            let candidate = try await task.value
+            guard generation == bindingGeneration else {
+                ffiClient.close(endpoint: candidate)
+                throw CancellationError()
+            }
+            bindingTask = nil
+            endpoint = candidate
+            try Task.checkCancellation()
+            return candidate
+        } catch {
+            if generation == bindingGeneration {
+                bindingTask = nil
+            }
+            throw error
         }
     }
 
     /// Closes and forgets the current bound endpoint, if any.
     public func closeEndpoint() {
+        bindingTask?.cancel()
+        bindingTask = nil
+        bindingGeneration = UUID()
         guard let endpoint else {
             return
         }

--- a/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/MobileIrohTransportFlag.swift
+++ b/Packages/iOS/CmuxMobileTransport/Sources/CmuxMobileTransport/MobileIrohTransportFlag.swift
@@ -2,9 +2,10 @@ public import Foundation
 
 /// Feature flag for the iOS iroh transport lane.
 ///
-/// Resolution order is environment override, UserDefaults override, then build
-/// flavor. DEBUG defaults on for dogfood and package tests; Release defaults
-/// off until the rollout slice flips it.
+/// Resolution order is environment override, UserDefaults override, then the
+/// rollout default. Iroh now defaults on in every build; the old parameterized
+/// build-flavor input remains only for source compatibility with P3 tests and
+/// callers.
 public struct MobileIrohTransportFlag: Sendable, Equatable {
     /// Environment variable override for dogfood and tagged builds.
     public static let envKey = "CMUX_MOBILE_IROH_TRANSPORT"
@@ -19,7 +20,7 @@ public struct MobileIrohTransportFlag: Sendable, Equatable {
         self.isEnabled = isEnabled
     }
 
-    /// Resolves the flag from environment, defaults, and build flavor.
+    /// Resolves the flag from environment, defaults, and the default-on rollout.
     public static func resolved(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard,
@@ -38,7 +39,7 @@ public struct MobileIrohTransportFlag: Sendable, Equatable {
         if defaults.object(forKey: defaultsKey) != nil {
             return MobileIrohTransportFlag(isEnabled: defaults.bool(forKey: defaultsKey))
         }
-        return MobileIrohTransportFlag(isEnabled: isDebugBuild)
+        return MobileIrohTransportFlag(isEnabled: true)
     }
 
     /// Compile-time build flavor, parameterized above for tests.

--- a/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxIrohByteTransportTests.swift
+++ b/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxIrohByteTransportTests.swift
@@ -107,6 +107,38 @@ import Testing
         #expect(ffi.closedConnectionCount() == 1)
     }
 
+    @Test func hangingKeychainLoadIsBoundedByConnectDeadline() async throws {
+        let store = HangingIrohSecretStore()
+        let ffi = FakeIrohFFIClient()
+        let manager = CmxIrohEndpointManager(
+            keyProvider: CmxIrohSecretKeyProvider(
+                store: store,
+                generate: { Data(repeating: 9, count: 32) }
+            ),
+            ffiClient: ffi
+        )
+        let transport = try CmxIrohByteTransport(
+            route: peerRoute(endpointID: "peer-timeout"),
+            endpointManager: manager,
+            ffiClient: ffi,
+            connectTimeoutNanoseconds: 10_000_000
+        )
+        defer { store.unblock() }
+
+        do {
+            try await transport.connect()
+            Issue.record("connect should time out while the keychain load is blocked")
+        } catch let error as CmxIrohByteTransportError {
+            guard case let .endpointBindFailed(_, kind) = error else {
+                Issue.record("expected endpoint bind timeout, got \(error)")
+                return
+            }
+            #expect(kind == .timedOut)
+        } catch {
+            Issue.record("expected CmxIrohByteTransportError, got \(error)")
+        }
+    }
+
     @Test func localIrohLoopbackEchoesBytes() async throws {
         let packageURL = URL(filePath: #filePath)
             .deletingLastPathComponent()
@@ -183,6 +215,21 @@ private final class InMemoryIrohSecretStore: CmxIrohSecretKeyStoring, @unchecked
 
     func saveSecretKey(_ key: Data) throws {
         self.key = key
+    }
+}
+
+private final class HangingIrohSecretStore: CmxIrohSecretKeyStoring, @unchecked Sendable {
+    private let gate = DispatchSemaphore(value: 0)
+
+    func loadSecretKey() throws -> Data? {
+        gate.wait()
+        return Data(repeating: 4, count: 32)
+    }
+
+    func saveSecretKey(_ key: Data) throws {}
+
+    func unblock() {
+        gate.signal()
     }
 }
 

--- a/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxIrohByteTransportTests.swift
+++ b/Packages/iOS/CmuxMobileTransport/Tests/CmuxMobileTransportTests/CmxIrohByteTransportTests.swift
@@ -4,6 +4,39 @@ import Testing
 @testable import CmuxMobileTransport
 
 @Suite struct CmxIrohByteTransportTests {
+    @Test func mobileIrohTransportDefaultsOnInRelease() {
+        let suiteName = "MobileIrohTransportFlag.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(MobileIrohTransportFlag.resolved(
+            environment: [:],
+            defaults: defaults,
+            isDebugBuild: false
+        ).isEnabled)
+    }
+
+    @Test func mobileIrohTransportCanBeDisabledByUserDefaults() {
+        let suiteName = "MobileIrohTransportFlag.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(false, forKey: MobileIrohTransportFlag.defaultsKey)
+
+        #expect(!MobileIrohTransportFlag.resolved(environment: [:], defaults: defaults).isEnabled)
+    }
+
+    @Test func mobileIrohTransportEnvironmentOverrideWins() {
+        let suiteName = "MobileIrohTransportFlag.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(true, forKey: MobileIrohTransportFlag.defaultsKey)
+
+        #expect(!MobileIrohTransportFlag.resolved(
+            environment: [MobileIrohTransportFlag.envKey: "false"],
+            defaults: defaults
+        ).isEnabled)
+    }
+
     @Test func routeFactoryRegistersIrohPeerRoutes() throws {
         let ffi = FakeIrohFFIClient()
         let manager = CmxIrohEndpointManager(

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/MobileCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/MobileCatalogSection.swift
@@ -20,6 +20,27 @@ public struct MobileCatalogSection: SettingCatalogSection {
     private static let iOSPairingHostDefault = false
     #endif
 
+    /// Enables the default iroh transport listener and route for iOS pairing.
+    ///
+    /// This reuses the original rollout flag storage key so existing dogfood
+    /// overrides keep working, but the fallback default is now ON in every build.
+    public let iOSPairingIrohTransport = DefaultsKey<Bool>(
+        id: "mobile.iOSPairingHost.irohTransport.enabled",
+        defaultValue: true,
+        userDefaultsKey: "mobileIrohTransport"
+    )
+
+    /// Publishes Tailscale/LAN host:port routes in addition to the iroh route.
+    ///
+    /// Defaults ON during rollout so older iOS builds that only know the TCP
+    /// route can still connect. Turning it OFF leaves iroh as the only
+    /// production route (plus debug loopback in DEBUG builds).
+    public let iOSPairingPublishesTailscaleRoutes = DefaultsKey<Bool>(
+        id: "mobile.iOSPairingHost.publishTailscaleRoutes",
+        defaultValue: true,
+        userDefaultsKey: "mobile.iOSPairingHost.publishTailscaleRoutes"
+    )
+
     /// TCP port the Mac-side iOS pairing listener prefers to bind.
     ///
     /// This is a *preference*: if the port is already in use the listener

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SettingCatalogTests.swift
@@ -92,8 +92,16 @@ struct SettingCatalogTests {
         #expect(ids.contains("paneBorderColor"))
         #expect(ids.contains("activePaneBorderColor"))
         #expect(ids.contains("mobile.iOSPairingHost.enabled"))
+        #expect(ids.contains("mobile.iOSPairingHost.irohTransport.enabled"))
+        #expect(ids.contains("mobile.iOSPairingHost.publishTailscaleRoutes"))
         #expect(ids.contains("automation.socketControlMode"))
         #expect(ids.contains("automation.socketPassword"))
+    }
+
+    @Test func mobileIrohRolloutDefaultsAreOn() {
+        let mobile = SettingCatalog().mobile
+        #expect(mobile.iOSPairingIrohTransport.defaultValue)
+        #expect(mobile.iOSPairingPublishesTailscaleRoutes.defaultValue)
     }
 
     @Test func keyIdsMatchTheirSectionPrefix() {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingStatusSnapshot.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/MobilePairingStatusSnapshot.swift
@@ -31,6 +31,9 @@ public struct MobilePairingStatusSnapshot: Sendable, Equatable {
     /// Number of iOS devices currently connected.
     public let activeConnectionCount: Int
 
+    /// Localized transport labels currently used by attached iOS devices.
+    public let activeTransportLabels: [String]
+
     /// The addresses the iOS app can use to reach this Mac.
     public let routes: [MobilePairingRoute]
 
@@ -43,6 +46,7 @@ public struct MobilePairingStatusSnapshot: Sendable, Equatable {
     ///   - usesEphemeralFallback: True when the bound port differs from the
     ///     configured port because the configured port was unavailable.
     ///   - activeConnectionCount: Number of connected iOS devices.
+    ///   - activeTransportLabels: Localized transport labels currently in use.
     ///   - routes: Addresses the iOS app can use to reach this Mac.
     public init(
         isRunning: Bool,
@@ -50,6 +54,7 @@ public struct MobilePairingStatusSnapshot: Sendable, Equatable {
         boundPort: Int?,
         usesEphemeralFallback: Bool,
         activeConnectionCount: Int,
+        activeTransportLabels: [String] = [],
         routes: [MobilePairingRoute]
     ) {
         self.isRunning = isRunning
@@ -57,6 +62,7 @@ public struct MobilePairingStatusSnapshot: Sendable, Equatable {
         self.boundPort = boundPort
         self.usesEphemeralFallback = usesEphemeralFallback
         self.activeConnectionCount = activeConnectionCount
+        self.activeTransportLabels = activeTransportLabels
         self.routes = routes
     }
 }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -186,6 +186,8 @@ extension Array where Element == CuratedSettingEntry {
             // Mobile
             .init(section: .mobile, id: "pairDevice", title: "Pair a Device", synonyms: "pair pairing add device qr qr code scan iphone ipad ios mobile tailscale connect onboarding sign in"),
             .init(section: .mobile, id: "iOSPairingHost", title: "iOS Pairing", synonyms: "ios iphone ipad mobile pairing local network permission sync"),
+            .init(section: .mobile, id: "iOSPairingIrohTransport", title: String(localized: "settings.mobile.iOSPairingIrohTransport", defaultValue: "Use Iroh Transport"), synonyms: "mobile.iOSPairingHost.irohTransport.enabled iroh quic vpn-free encrypted mobile pairing route transport"),
+            .init(section: .mobile, id: "iOSPairingPublishesTailscaleRoutes", title: String(localized: "settings.mobile.iOSPairingPublishesTailscaleRoutes", defaultValue: "Also Publish Tailscale/LAN Routes"), synonyms: "mobile.iOSPairingHost.publishTailscaleRoutes tailscale lan fallback route routes mobile pairing"),
             .init(section: .mobile, id: "iOSPairingPort", title: String(localized: "settings.mobile.port", defaultValue: "Pairing Port"), synonyms: "mobile.iOSPairingHost.port ios iphone mobile pairing port tcp listener firewall conflict"),
             .init(section: .mobile, id: "iOSPairingDisplayName", title: String(localized: "settings.mobile.displayName", defaultValue: "Display Name"), synonyms: "mobile.iOSPairingHost.displayName ios iphone mobile pairing display name mac hostname device label"),
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/MobileSection.swift
@@ -9,6 +9,8 @@ import SwiftUI
 @MainActor
 public struct MobileSection: View {
     @State private var iOSPairingHost: DefaultsValueModel<Bool>
+    @State private var irohTransport: DefaultsValueModel<Bool>
+    @State private var publishTailscaleRoutes: DefaultsValueModel<Bool>
     @State private var port: DefaultsValueModel<Int>
     @State private var displayName: DefaultsValueModel<String>
     @State private var status: MobilePairingStatusModel
@@ -43,6 +45,8 @@ public struct MobileSection: View {
         hostActions: SettingsHostActions
     ) {
         _iOSPairingHost = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.mobile.iOSPairingHost))
+        _irohTransport = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.mobile.iOSPairingIrohTransport))
+        _publishTailscaleRoutes = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.mobile.iOSPairingPublishesTailscaleRoutes))
         _port = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.mobile.iOSPairingPort))
         _displayName = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.mobile.iOSPairingDisplayName))
         _status = State(initialValue: MobilePairingStatusModel(hostActions: hostActions))
@@ -74,6 +78,10 @@ public struct MobileSection: View {
                 SettingsCardDivider()
                 iOSPairingHostRow
                 SettingsCardDivider()
+                irohTransportRow
+                SettingsCardDivider()
+                publishTailscaleRoutesRow
+                SettingsCardDivider()
                 portRow
                 boundPortStatusRow
                 SettingsCardDivider()
@@ -94,6 +102,8 @@ public struct MobileSection: View {
     private func startObservingSettings() {
         let models: [any SettingObservationStarting] = [
             iOSPairingHost,
+            irohTransport,
+            publishTailscaleRoutes,
             port,
             displayName,
             status,
@@ -132,6 +142,40 @@ public struct MobileSection: View {
                 .labelsHidden()
                 .controlSize(.small)
                 .accessibilityIdentifier("SettingsMobileIOSPairingHostToggle")
+        }
+    }
+
+    @ViewBuilder
+    private var irohTransportRow: some View {
+        SettingsCardRow(
+            configurationReview: .settingsOnly,
+            searchAnchorID: "setting:mobile:iOSPairingIrohTransport",
+            String(localized: "settings.mobile.iOSPairingIrohTransport", defaultValue: "Use Iroh Transport"),
+            subtitle: irohTransport.current
+                ? String(localized: "settings.mobile.iOSPairingIrohTransport.subtitleOn", defaultValue: "Publishes the encrypted Iroh route first for iOS pairing and terminal sync.")
+                : String(localized: "settings.mobile.iOSPairingIrohTransport.subtitleOff", defaultValue: "Disables the encrypted Iroh route; iOS can still use published Tailscale/LAN routes.")
+        ) {
+            Toggle("", isOn: Binding(get: { irohTransport.current }, set: { irohTransport.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsMobileIOSPairingIrohTransportToggle")
+        }
+    }
+
+    @ViewBuilder
+    private var publishTailscaleRoutesRow: some View {
+        SettingsCardRow(
+            configurationReview: .settingsOnly,
+            searchAnchorID: "setting:mobile:iOSPairingPublishesTailscaleRoutes",
+            String(localized: "settings.mobile.iOSPairingPublishesTailscaleRoutes", defaultValue: "Also Publish Tailscale/LAN Routes"),
+            subtitle: publishTailscaleRoutes.current
+                ? String(localized: "settings.mobile.iOSPairingPublishesTailscaleRoutes.subtitleOn", defaultValue: "Publishes Tailscale and LAN fallback routes after the preferred Iroh route.")
+                : String(localized: "settings.mobile.iOSPairingPublishesTailscaleRoutes.subtitleOff", defaultValue: "Only Iroh routes are published for production pairing.")
+        ) {
+            Toggle("", isOn: Binding(get: { publishTailscaleRoutes.current }, set: { publishTailscaleRoutes.set($0) }))
+                .labelsHidden()
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsMobileIOSPairingPublishesTailscaleRoutesToggle")
         }
     }
 
@@ -293,7 +337,31 @@ public struct MobileSection: View {
                 .monospacedDigit()
                 .foregroundStyle(.secondary)
         }
+        activeTransportRow(snapshot)
         routesView(snapshot)
+    }
+
+    @ViewBuilder
+    private func activeTransportRow(_ snapshot: MobilePairingStatusSnapshot?) -> some View {
+        SettingsCardRow(
+            configurationReview: .settingsOnly,
+            searchAnchorID: "setting:mobile:activeTransport",
+            String(localized: "settings.mobile.activeTransport", defaultValue: "Active Transport"),
+            subtitle: String(localized: "settings.mobile.activeTransport.subtitle", defaultValue: "Transport currently used by attached iOS sessions.")
+        ) {
+            Text(activeTransportText(snapshot))
+                .cmuxFont(size: 13, weight: .medium)
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func activeTransportText(_ snapshot: MobilePairingStatusSnapshot?) -> String {
+        guard let snapshot,
+              snapshot.activeConnectionCount > 0,
+              !snapshot.activeTransportLabels.isEmpty else {
+            return String(localized: "settings.mobile.activeTransport.none", defaultValue: "None")
+        }
+        return snapshot.activeTransportLabels.joined(separator: ", ")
     }
 
     @ViewBuilder
@@ -302,7 +370,7 @@ public struct MobileSection: View {
             if snapshot.routes.isEmpty {
                 SettingsCardNote(String(
                     localized: "settings.mobile.routes.empty",
-                    defaultValue: "No reachable addresses yet. Pairing over the network needs Tailscale running on this Mac."
+                    defaultValue: "No reachable routes yet. Keep cmux open and online, or enable the Tailscale/LAN fallback routes."
                 ))
             } else {
                 VStack(alignment: .leading, spacing: 4) {

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -147,6 +147,8 @@ struct SettingsRowAnchorResolutionTests {
         "setting:account:account",
         "setting:mobile:pairDevice",
         "setting:mobile:iOSPairingHost",
+        "setting:mobile:iOSPairingIrohTransport",
+        "setting:mobile:iOSPairingPublishesTailscaleRoutes",
         "setting:mobile:iOSPairingPort",
         "setting:mobile:iOSPairingDisplayName",
         "setting:betaFeatures:feed",

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -323,6 +323,7 @@ final class HostSettingsActions: SettingsHostActions {
             boundPort: status.port,
             usesEphemeralFallback: status.usesEphemeralFallback,
             activeConnectionCount: status.activeConnectionCount,
+            activeTransportLabels: activeTransportLabels(from: status.activeTransportCounts),
             routes: routes
         )
     }
@@ -357,6 +358,14 @@ final class HostSettingsActions: SettingsHostActions {
             return String(localized: "settings.mobile.route.iroh", defaultValue: "Iroh")
         case .websocket:
             return String(localized: "settings.mobile.route.websocket", defaultValue: "WebSocket")
+        }
+    }
+
+    private static func activeTransportLabels(from counts: [CmxAttachTransportKind: Int]) -> [String] {
+        let displayOrder: [CmxAttachTransportKind] = [.iroh, .tailscale, .debugLoopback, .websocket]
+        return displayOrder.compactMap { kind in
+            guard (counts[kind] ?? 0) > 0 else { return nil }
+            return routeKindLabel(kind)
         }
     }
 

--- a/Sources/Mobile/MobileHostIrohFlag.swift
+++ b/Sources/Mobile/MobileHostIrohFlag.swift
@@ -1,8 +1,10 @@
 import Foundation
+import CmuxSettings
 
 struct MobileHostIrohFlag: Sendable, Equatable {
     static let envKey = "CMUX_MOBILE_IROH_TRANSPORT"
-    static let defaultsKey = "mobileIrohTransport"
+    static let catalogKey = SettingCatalog().mobile.iOSPairingIrohTransport
+    static let defaultsKey = catalogKey.userDefaultsKey
 
     let isEnabled: Bool
 
@@ -25,7 +27,7 @@ struct MobileHostIrohFlag: Sendable, Equatable {
         if defaults.object(forKey: defaultsKey) != nil {
             return MobileHostIrohFlag(isEnabled: defaults.bool(forKey: defaultsKey))
         }
-        return MobileHostIrohFlag(isEnabled: isDebugBuild)
+        return MobileHostIrohFlag(isEnabled: catalogKey.defaultValue)
     }
 
     static var isDebugBuild: Bool {

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -171,6 +171,7 @@ private final class MobileHostConnectionRegistry: @unchecked Sendable {
 private enum MobileHostPublicStatusCache {
     private static let lock = NSLock()
     private nonisolated(unsafe) static var routes: [CmxAttachRoute] = []
+    private nonisolated(unsafe) static var irohLaneState: MobileHostIrohLaneState = .inactive
 
     static func update(routes nextRoutes: [CmxAttachRoute]) {
         lock.lock()
@@ -179,15 +180,29 @@ private enum MobileHostPublicStatusCache {
         NotificationCenter.default.post(name: .mobileHostStatusDidChange, object: nil)
     }
 
+    static func update(irohLaneState nextState: MobileHostIrohLaneState) {
+        lock.lock()
+        irohLaneState = nextState
+        lock.unlock()
+        NotificationCenter.default.post(name: .mobileHostStatusDidChange, object: nil)
+    }
+
     static func result(includeIdentity: Bool = false) -> MobileHostRPCResult {
         lock.lock()
         let cachedRoutes = routes
+        let cachedIrohLaneState = irohLaneState
         lock.unlock()
         let routesPayload = cachedRoutes.map(\.mobileHostJSONObject)
         return .ok(
             includeIdentity
-                ? MobileHostService.identityStatusPayload(routesPayload: routesPayload)
-                : MobileHostService.publicStatusPayload(routesPayload: routesPayload)
+                ? MobileHostService.identityStatusPayload(
+                    routesPayload: routesPayload,
+                    irohLaneState: cachedIrohLaneState
+                )
+                : MobileHostService.publicStatusPayload(
+                    routesPayload: routesPayload,
+                    irohLaneState: cachedIrohLaneState
+                )
         )
     }
 }
@@ -258,6 +273,14 @@ enum MobileHostRequestActivity {
     #endif
 }
 
+enum MobileHostIrohLaneState: String, Sendable, Equatable {
+    case inactive
+    case starting
+    case active
+    case unavailableKeychain = "unavailable_keychain"
+    case unavailableBind = "unavailable_bind"
+}
+
 struct MobileHostServiceStatus {
     let isRunning: Bool
     let port: Int?
@@ -269,6 +292,7 @@ struct MobileHostServiceStatus {
     let routes: [CmxAttachRoute]
     let activeConnectionCount: Int
     let activeTransportCounts: [CmxAttachTransportKind: Int]
+    let irohLaneState: MobileHostIrohLaneState
     let lastErrorDescription: String?
 
     var payload: [String: Any] {
@@ -282,6 +306,7 @@ struct MobileHostServiceStatus {
             "active_transport_counts": Dictionary(
                 uniqueKeysWithValues: activeTransportCounts.map { ($0.key.rawValue, $0.value) }
             ),
+            "iroh_lane_state": irohLaneState.rawValue,
             "last_error": lastErrorDescription ?? NSNull()
         ]
     }
@@ -324,7 +349,10 @@ final class MobileHostService {
     /// (`mac_device_id`, `mac_display_name`) is never on this unauthenticated
     /// surface — see ``networkStatusResult(for:)`` for the verified-caller
     /// reply that carries it.
-    nonisolated static func publicStatusPayload(routesPayload: [[String: Any]]) -> [String: Any] {
+    nonisolated static func publicStatusPayload(
+        routesPayload: [[String: Any]],
+        irohLaneState: MobileHostIrohLaneState = .inactive
+    ) -> [String: Any] {
         // The Mac's resolved terminal theme is caller-independent, so it rides
         // the public payload (identity merges on top). `GhosttyConfig.load()`
         // resolves named ghostty themes, cmux's managed defaults, and explicit
@@ -334,6 +362,7 @@ final class MobileHostService {
         let theme = TerminalTheme(ghosttyConfig: GhosttyConfig.load())
         return [
             "routes": routesPayload,
+            "iroh_lane_state": irohLaneState.rawValue,
             "terminal_fidelity": "render_grid",
             "capabilities": mobileHostCapabilities,
             "theme": theme.mobileHostJSONObject,
@@ -345,8 +374,14 @@ final class MobileHostService {
     /// the display name or the device id, so this reply is where a freshly
     /// paired phone learns what to call this Mac and which paired-Mac record
     /// the connection belongs to.
-    nonisolated static func identityStatusPayload(routesPayload: [[String: Any]]) -> [String: Any] {
-        var payload = publicStatusPayload(routesPayload: routesPayload)
+    nonisolated static func identityStatusPayload(
+        routesPayload: [[String: Any]],
+        irohLaneState: MobileHostIrohLaneState = .inactive
+    ) -> [String: Any] {
+        var payload = publicStatusPayload(
+            routesPayload: routesPayload,
+            irohLaneState: irohLaneState
+        )
         payload["mac_device_id"] = MobileHostIdentity.deviceID()
         if let displayName = MobileHostIdentity.displayName() {
             payload["mac_display_name"] = displayName
@@ -404,14 +439,18 @@ final class MobileHostService {
     private let ticketStore = MobileAttachTicketStore()
     private let irohFFIClient: any MobileHostIrohFFIClient
     private let irohSecretKeyProvider: MobileHostIrohSecretKeyProvider
+    private let isListeningEnabledProvider: @Sendable () -> Bool
     private var listener: NWListener?
     private var listenerGeneration = UUID()
     private var listenerUsesEphemeralFallback = false
     private var listenerPort: Int?
     private var irohEndpoint: MobileHostIrohEndpointReference?
     private var irohEndpointGeneration = UUID()
+    private var irohStartupGeneration = UUID()
+    private var irohStartupTask: Task<Void, Never>?
     private var irohAcceptTask: Task<Void, Never>?
     private var irohRoute: CmxAttachRoute?
+    private var irohLaneState: MobileHostIrohLaneState = .inactive
     /// The preferred port the active start-sequence targeted (regardless of an
     /// ephemeral fallback). Used to decide whether a settings change needs a
     /// restart. `nil` while stopped.
@@ -434,9 +473,10 @@ final class MobileHostService {
     private var debugAcceptedStackAuthToken: String?
     #endif
 
-    private init(
+    init(
         irohFFIClient: any MobileHostIrohFFIClient = MobileHostIrohSystemFFIClient(),
-        irohSecretKeyProvider: MobileHostIrohSecretKeyProvider? = nil
+        irohSecretKeyProvider: MobileHostIrohSecretKeyProvider? = nil,
+        isListeningEnabled: @escaping @Sendable () -> Bool = { MobileHostService.isListeningEnabled }
     ) {
         let resolvedIrohFFIClient = irohFFIClient
         self.irohFFIClient = resolvedIrohFFIClient
@@ -444,6 +484,7 @@ final class MobileHostService {
             store: MobileHostIrohKeychainSecretStore(),
             generate: { try resolvedIrohFFIClient.generateSecretKey() }
         )
+        self.isListeningEnabledProvider = isListeningEnabled
     }
 
     /// Inject the auth dependency. Call once at the composition root.
@@ -782,7 +823,7 @@ final class MobileHostService {
     }
 
     func start() {
-        guard Self.isListeningEnabled else {
+        guard isListeningEnabledProvider() else {
             #if DEBUG
             if Self.canPublishRoutesWithoutListenerForXCTest(defaults: .standard) {
                 publishRoutesWithoutListenerForXCTest()
@@ -792,13 +833,10 @@ final class MobileHostService {
             mobileHostLog.info("mobile host listener disabled; not binding")
             return
         }
-        guard listener == nil else {
-            startIrohEndpointIfNeeded()
-            return
+        if listener == nil {
+            startListener(usePreferredPort: true)
         }
-
         startIrohEndpointIfNeeded()
-        startListener(usePreferredPort: true)
     }
 
     #if DEBUG
@@ -877,45 +915,113 @@ final class MobileHostService {
 
     private func startIrohEndpointIfNeeded() {
         guard MobileHostIrohFlag.resolved().isEnabled else {
+            setIrohLaneState(.inactive)
             return
         }
-        guard irohEndpoint == nil else {
+        guard irohEndpoint == nil, irohStartupTask == nil else {
             return
         }
-        do {
-            let secretKey = try irohSecretKeyProvider.secretKey()
-            let endpoint = try irohFFIClient.bindEndpoint(
-                secretKey: secretKey,
-                enableRelay: true,
-                acceptConnections: true
+        let startupGeneration = UUID()
+        irohStartupGeneration = startupGeneration
+        setIrohLaneState(.starting)
+        let keyProvider = irohSecretKeyProvider
+        let ffiClient = irohFFIClient
+        irohStartupTask = Task.detached(priority: .userInitiated) { [weak self] in
+            let secretKey: Data
+            do {
+                secretKey = try keyProvider.secretKey()
+            } catch {
+                await self?.finishIrohKeyLoadFailure(error, generation: startupGeneration)
+                return
+            }
+            guard !Task.isCancelled else { return }
+
+            let endpoint: MobileHostIrohEndpointReference
+            do {
+                endpoint = try ffiClient.bindEndpoint(
+                    secretKey: secretKey,
+                    enableRelay: true,
+                    acceptConnections: true
+                )
+            } catch {
+                await self?.finishIrohBindFailure(error, generation: startupGeneration)
+                return
+            }
+            guard let self else {
+                ffiClient.close(endpoint: endpoint)
+                return
+            }
+            await self.finishIrohStartup(
+                endpoint: endpoint,
+                generation: startupGeneration
             )
-            let generation = UUID()
-            irohEndpoint = endpoint
-            irohEndpointGeneration = generation
-            irohRoute = route(forIrohEndpoint: endpoint) ?? irohRoute
-            startIrohAcceptLoop(endpoint: endpoint, generation: generation)
-            if listenerPort == nil {
-                MobileHostPublicStatusCache.update(routes: resolvedRoutesForCurrentHost())
-            }
-            if let endpointID = irohFFIClient.endpointID(endpoint) {
-                mobileHostLog.info("mobile host iroh endpoint ready \(endpointID, privacy: .public)")
-            } else {
-                mobileHostLog.info("mobile host iroh endpoint ready")
-            }
-        } catch {
-            irohEndpoint = nil
-            irohRoute = nil
-            mobileHostLog.error("mobile host iroh endpoint failed to bind: \(String(describing: error), privacy: .public)")
         }
     }
 
+    private func finishIrohKeyLoadFailure(_ error: any Error, generation: UUID) {
+        guard generation == irohStartupGeneration else { return }
+        irohStartupTask = nil
+        irohEndpoint = nil
+        irohRoute = nil
+        setIrohLaneState(.unavailableKeychain)
+        mobileHostLog.error("mobile host iroh endpoint unavailable (keychain): \(String(describing: error), privacy: .public)")
+        #if DEBUG
+        cmuxDebugLog("mobile.host.iroh unavailable=keychain error=\(String(describing: error))")
+        #endif
+    }
+
+    private func finishIrohBindFailure(_ error: any Error, generation: UUID) {
+        guard generation == irohStartupGeneration else { return }
+        irohStartupTask = nil
+        irohEndpoint = nil
+        irohRoute = nil
+        setIrohLaneState(.unavailableBind)
+        mobileHostLog.error("mobile host iroh endpoint failed to bind: \(String(describing: error), privacy: .public)")
+        #if DEBUG
+        cmuxDebugLog("mobile.host.iroh unavailable=bind error=\(String(describing: error))")
+        #endif
+    }
+
+    private func finishIrohStartup(
+        endpoint: MobileHostIrohEndpointReference,
+        generation: UUID
+    ) {
+        guard generation == irohStartupGeneration, !Task.isCancelled else {
+            irohFFIClient.close(endpoint: endpoint)
+            return
+        }
+        irohStartupTask = nil
+        let endpointGeneration = UUID()
+        irohEndpoint = endpoint
+        irohEndpointGeneration = endpointGeneration
+        irohRoute = route(forIrohEndpoint: endpoint) ?? irohRoute
+        setIrohLaneState(.active)
+        startIrohAcceptLoop(endpoint: endpoint, generation: endpointGeneration)
+        MobileHostPublicStatusCache.update(routes: resolvedRoutesForCurrentHost())
+        if let endpointID = irohFFIClient.endpointID(endpoint) {
+            mobileHostLog.info("mobile host iroh endpoint ready \(endpointID, privacy: .public)")
+        } else {
+            mobileHostLog.info("mobile host iroh endpoint ready")
+        }
+    }
+
+    private func setIrohLaneState(_ state: MobileHostIrohLaneState) {
+        guard irohLaneState != state else { return }
+        irohLaneState = state
+        MobileHostPublicStatusCache.update(irohLaneState: state)
+    }
+
     private func stopIrohEndpoint() {
+        irohStartupTask?.cancel()
+        irohStartupTask = nil
+        irohStartupGeneration = UUID()
         irohAcceptTask?.cancel()
         irohAcceptTask = nil
         irohEndpointGeneration = UUID()
         let endpoint = irohEndpoint
         irohEndpoint = nil
         irohRoute = nil
+        setIrohLaneState(.inactive)
         if let endpoint {
             irohFFIClient.close(endpoint: endpoint)
         }
@@ -1138,6 +1244,7 @@ final class MobileHostService {
             routes: routes,
             activeConnectionCount: MobileHostConnectionRegistry.shared.count,
             activeTransportCounts: MobileHostConnectionRegistry.shared.transportCounts,
+            irohLaneState: irohLaneState,
             lastErrorDescription: lastErrorDescription
         )
     }
@@ -1161,7 +1268,7 @@ final class MobileHostService {
             ?? Self.configuredPort(defaults: defaults)
         switch Self.syncDecision(
             enabled: Self.isListeningEnabled(defaults: defaults),
-            listenerRunning: listener != nil || irohEndpoint != nil,
+            listenerRunning: listener != nil || irohEndpoint != nil || irohStartupTask != nil,
             desiredPort: desiredPort,
             appliedPort: appliedPreferredPort
         ) {
@@ -1184,7 +1291,7 @@ final class MobileHostService {
     }
 
     private func republishRoutesForCurrentHost() {
-        guard listener != nil || irohEndpoint != nil else { return }
+        guard listener != nil || irohEndpoint != nil || irohStartupTask != nil else { return }
         MobileHostPublicStatusCache.update(routes: resolvedRoutesForCurrentHost())
     }
 
@@ -1192,7 +1299,7 @@ final class MobileHostService {
         guard Self.isListeningEnabled(defaults: defaults) else { return }
         if MobileHostIrohFlag.resolved(defaults: defaults).isEnabled {
             startIrohEndpointIfNeeded()
-        } else if irohEndpoint != nil {
+        } else if irohEndpoint != nil || irohStartupTask != nil {
             stopIrohEndpoint()
         }
     }
@@ -1861,6 +1968,10 @@ final class MobileHostService {
 
 #if DEBUG
 extension MobileHostService {
+    func debugWaitForIrohStartupForTesting() async {
+        await irohStartupTask?.value
+    }
+
     func debugResetMobileLifecycleStateForTesting() {
         stopIrohEndpoint()
         listenerGeneration = UUID()

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -97,8 +97,13 @@ private enum MobileHostEventSubscriptionTracker {
 private final class MobileHostConnectionRegistry: @unchecked Sendable {
     static let shared = MobileHostConnectionRegistry()
 
+    private struct Entry {
+        let connection: MobileHostConnection
+        let transportKind: CmxAttachTransportKind
+    }
+
     private let lock = NSLock()
-    private var connections: [UUID: MobileHostConnection] = [:]
+    private var connections: [UUID: Entry] = [:]
 
     var count: Int {
         lock.lock()
@@ -106,13 +111,26 @@ private final class MobileHostConnectionRegistry: @unchecked Sendable {
         return connections.count
     }
 
-    func insert(_ connection: MobileHostConnection, id: UUID, limit: Int) -> Bool {
+    var transportCounts: [CmxAttachTransportKind: Int] {
+        lock.lock()
+        defer { lock.unlock() }
+        return connections.values.reduce(into: [:]) { counts, entry in
+            counts[entry.transportKind, default: 0] += 1
+        }
+    }
+
+    func insert(
+        _ connection: MobileHostConnection,
+        id: UUID,
+        transportKind: CmxAttachTransportKind,
+        limit: Int
+    ) -> Bool {
         lock.lock()
         guard connections.count < limit else {
             lock.unlock()
             return false
         }
-        connections[id] = connection
+        connections[id] = Entry(connection: connection, transportKind: transportKind)
         lock.unlock()
         // Notify after the authoritative count actually changes (this registry
         // backs `MobileHostServiceStatus.activeConnectionCount`), so the Mobile
@@ -132,7 +150,7 @@ private final class MobileHostConnectionRegistry: @unchecked Sendable {
 
     func removeAll() -> [MobileHostConnection] {
         lock.lock()
-        let values = Array(connections.values)
+        let values = connections.values.map(\.connection)
         connections.removeAll()
         lock.unlock()
         if !values.isEmpty {
@@ -146,7 +164,7 @@ private final class MobileHostConnectionRegistry: @unchecked Sendable {
     func snapshot() -> [MobileHostConnection] {
         lock.lock()
         defer { lock.unlock() }
-        return Array(connections.values)
+        return connections.values.map(\.connection)
     }
 }
 
@@ -250,6 +268,7 @@ struct MobileHostServiceStatus {
     let usesEphemeralFallback: Bool
     let routes: [CmxAttachRoute]
     let activeConnectionCount: Int
+    let activeTransportCounts: [CmxAttachTransportKind: Int]
     let lastErrorDescription: String?
 
     var payload: [String: Any] {
@@ -260,6 +279,9 @@ struct MobileHostServiceStatus {
             "uses_ephemeral_fallback": usesEphemeralFallback,
             "routes": routes.map(\.mobileHostJSONObject),
             "active_connection_count": activeConnectionCount,
+            "active_transport_counts": Dictionary(
+                uniqueKeysWithValues: activeTransportCounts.map { ($0.key.rawValue, $0.value) }
+            ),
             "last_error": lastErrorDescription ?? NSNull()
         ]
     }
@@ -518,6 +540,22 @@ final class MobileHostService {
 
     /// User-default key for the preferred iOS pairing listener port.
     nonisolated static let portDefaultsKey = SettingCatalog().mobile.iOSPairingPort.userDefaultsKey
+
+    /// User-default key for the rollout-compatible Tailscale/LAN route
+    /// publication toggle.
+    nonisolated static let publishTailscaleRoutesDefaultsKey = SettingCatalog().mobile.iOSPairingPublishesTailscaleRoutes.userDefaultsKey
+
+    /// Whether TCP host:port routes should be published alongside iroh.
+    ///
+    /// Defaults ON for rollout compatibility with older iOS clients that only
+    /// support the Tailscale/LAN lane.
+    nonisolated static func publishesTailscaleRoutes(defaults: UserDefaults = .standard) -> Bool {
+        let key = SettingCatalog().mobile.iOSPairingPublishesTailscaleRoutes
+        if defaults.object(forKey: key.userDefaultsKey) != nil {
+            return defaults.bool(forKey: key.userDefaultsKey)
+        }
+        return key.defaultValue
+    }
 
     /// The preferred TCP port the listener should try to bind, read from
     /// settings.
@@ -903,6 +941,7 @@ final class MobileHostService {
                     )
                     Self.acceptByteConnectionOffMain(
                         byteConnection,
+                        transportKind: .iroh,
                         canAccept: {
                             await MobileHostService.shared.canAcceptIrohConnection(generation: generation)
                         }
@@ -946,7 +985,8 @@ final class MobileHostService {
     private func resolvedRoutes(port: Int) -> [CmxAttachRoute] {
         routeResolver.routes(
             port: port,
-            irohRoute: currentIrohRoute()
+            irohRoute: currentIrohRoute(),
+            publishTailscaleRoutes: Self.publishesTailscaleRoutes()
         ).routes
     }
 
@@ -954,7 +994,8 @@ final class MobileHostService {
         routeResolver.routes(
             port: port,
             irohRoute: currentIrohRoute(),
-            tailscaleHosts: tailscaleHosts
+            tailscaleHosts: tailscaleHosts,
+            publishTailscaleRoutes: Self.publishesTailscaleRoutes()
         ).routes
     }
 
@@ -1096,6 +1137,7 @@ final class MobileHostService {
             usesEphemeralFallback: isRunning && listenerUsesEphemeralFallback,
             routes: routes,
             activeConnectionCount: MobileHostConnectionRegistry.shared.count,
+            activeTransportCounts: MobileHostConnectionRegistry.shared.transportCounts,
             lastErrorDescription: lastErrorDescription
         )
     }
@@ -1132,11 +1174,27 @@ final class MobileHostService {
         case .restart:
             restart()
         }
+        syncIrohEndpointToSettings(defaults: defaults)
+        republishRoutesForCurrentHost()
     }
 
     private func restart() {
         stop()
         start()
+    }
+
+    private func republishRoutesForCurrentHost() {
+        guard listener != nil || irohEndpoint != nil else { return }
+        MobileHostPublicStatusCache.update(routes: resolvedRoutesForCurrentHost())
+    }
+
+    private func syncIrohEndpointToSettings(defaults: UserDefaults) {
+        guard Self.isListeningEnabled(defaults: defaults) else { return }
+        if MobileHostIrohFlag.resolved(defaults: defaults).isEnabled {
+            startIrohEndpointIfNeeded()
+        } else if irohEndpoint != nil {
+            stopIrohEndpoint()
+        }
     }
 
     nonisolated private static func acceptConnectionOffMain(
@@ -1170,6 +1228,7 @@ final class MobileHostService {
 
             Self.acceptByteConnectionOffMain(
                 MobileHostNWConnectionAdapter(connection: connection),
+                transportKind: Self.isLoopbackConnection(connection) ? .debugLoopback : .tailscale,
                 canAccept: {
                     await MobileHostService.shared.canAcceptConnection(generation: generation)
                 }
@@ -1179,6 +1238,7 @@ final class MobileHostService {
 
     nonisolated private static func acceptByteConnectionOffMain(
         _ byteConnection: any MobileHostByteConnection,
+        transportKind: CmxAttachTransportKind,
         canAccept: @escaping @Sendable () async -> Bool
     ) {
         Task.detached(priority: .userInitiated) {
@@ -1225,6 +1285,7 @@ final class MobileHostService {
             guard MobileHostConnectionRegistry.shared.insert(
                 session,
                 id: id,
+                transportKind: transportKind,
                 limit: Self.maximumActiveConnectionCount
             ) else {
                 mobileHostLog.error("mobile host rejected connection because active connection limit was reached")

--- a/Sources/Mobile/MobileRouteResolver.swift
+++ b/Sources/Mobile/MobileRouteResolver.swift
@@ -28,25 +28,49 @@ final class MobileRouteResolver: @unchecked Sendable {
         port: Int,
         now: Date = Date(),
         irohRoute: CmxAttachRoute? = nil,
+        publishTailscaleRoutes: Bool = true,
         immediateHosts: () -> [String] = { MobileRouteResolver.tailscaleRouteHosts(resolveDNS: false) }
     ) -> MobileHostRouteSnapshot {
+        guard publishTailscaleRoutes else {
+            return routes(
+                port: port,
+                irohRoute: irohRoute,
+                tailscaleHosts: [],
+                publishTailscaleRoutes: false
+            )
+        }
         refreshTailscaleRoutes()
         let cachedHosts = resolvedTailscaleRouteHostsFromCache(now: now) ?? []
         return routes(
             port: port,
             irohRoute: irohRoute,
-            tailscaleHosts: Self.deduplicatedHosts(cachedHosts + immediateHosts())
+            tailscaleHosts: Self.deduplicatedHosts(cachedHosts + immediateHosts()),
+            publishTailscaleRoutes: publishTailscaleRoutes
         )
     }
 
     func routesResolvingTailscaleDNS(
         port: Int,
         irohRoute: CmxAttachRoute? = nil,
+        publishTailscaleRoutes: Bool = true,
         resolveHosts: @escaping @Sendable () -> [String] = { MobileRouteResolver.tailscaleRouteHosts(resolveDNS: true) },
         now: Date = Date()
     ) async -> MobileHostRouteSnapshot {
+        guard publishTailscaleRoutes else {
+            return routes(
+                port: port,
+                irohRoute: irohRoute,
+                tailscaleHosts: [],
+                publishTailscaleRoutes: false
+            )
+        }
         let hosts = await resolvedTailscaleRouteHosts(resolveHosts: resolveHosts, now: now)
-        return routes(port: port, irohRoute: irohRoute, tailscaleHosts: hosts)
+        return routes(
+            port: port,
+            irohRoute: irohRoute,
+            tailscaleHosts: hosts,
+            publishTailscaleRoutes: publishTailscaleRoutes
+        )
     }
 
     /// Drop the resolved-host cache and orphan any in-flight resolution.
@@ -70,7 +94,8 @@ final class MobileRouteResolver: @unchecked Sendable {
     func routes(
         port: Int,
         irohRoute: CmxAttachRoute? = nil,
-        tailscaleHosts: [String]
+        tailscaleHosts: [String],
+        publishTailscaleRoutes: Bool = true
     ) -> MobileHostRouteSnapshot {
         var resolved: [CmxAttachRoute] = []
 
@@ -89,17 +114,19 @@ final class MobileRouteResolver: @unchecked Sendable {
             resolved.append(irohRoute)
         }
 
-        for (index, tailscaleHost) in tailscaleHosts.enumerated() {
-            let id = index == 0
-                ? CmxAttachTransportKind.tailscale.rawValue
-                : "\(CmxAttachTransportKind.tailscale.rawValue)_\(index + 1)"
-            if let tailscaleRoute = try? CmxAttachRoute(
-                id: id,
-                kind: .tailscale,
-                endpoint: .hostPort(host: tailscaleHost, port: port),
-                priority: 10 + (index * 10)
-            ) {
-                resolved.append(tailscaleRoute)
+        if publishTailscaleRoutes {
+            for (index, tailscaleHost) in tailscaleHosts.enumerated() {
+                let id = index == 0
+                    ? CmxAttachTransportKind.tailscale.rawValue
+                    : "\(CmxAttachTransportKind.tailscale.rawValue)_\(index + 1)"
+                if let tailscaleRoute = try? CmxAttachRoute(
+                    id: id,
+                    kind: .tailscale,
+                    endpoint: .hostPort(host: tailscaleHost, port: port),
+                    priority: 10 + (index * 10)
+                ) {
+                    resolved.append(tailscaleRoute)
+                }
             }
         }
 

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -14195,7 +14195,8 @@ class TerminalController {
         let capabilities = MobileHostService.mobileHostCapabilities
         guard includePrivateMetadata else {
             return .ok(MobileHostService.publicStatusPayload(
-                routesPayload: status.routes.map(\.mobileHostJSONObject)
+                routesPayload: status.routes.map(\.mobileHostJSONObject),
+                irohLaneState: status.irohLaneState
             ))
         }
 

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -246,6 +246,52 @@ struct MobileHostAuthorizationTests {
         #expect(preferred?.kind == .iroh)
     }
 
+    @Test func testMobileRouteResolverCanPublishOnlyIrohRoute() throws {
+        let resolver = MobileRouteResolver()
+        let irohRoute = try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                id: "peer-abcdef",
+                relayHint: nil,
+                directAddrs: ["192.0.2.10:443"],
+                relayURL: "https://relay.example.com"
+            ),
+            priority: 5
+        )
+        let snapshot = resolver.routes(
+            port: 61234,
+            irohRoute: irohRoute,
+            tailscaleHosts: ["100.71.210.41"],
+            publishTailscaleRoutes: false
+        )
+
+        #expect(snapshot.routes.contains { $0.kind == .iroh })
+        #expect(!snapshot.routes.contains { $0.kind == .tailscale })
+        #if DEBUG
+        #expect(snapshot.routes.contains { $0.kind == .debugLoopback })
+        #endif
+    }
+
+    @Test func testMobileHostIrohAndTailscaleRouteSettingsDefaultOn() {
+        let suiteName = "MobileHostSettings.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        #expect(MobileHostIrohFlag.resolved(defaults: defaults).isEnabled)
+        #expect(MobileHostService.publishesTailscaleRoutes(defaults: defaults))
+    }
+
+    @Test func testMobileHostTailscaleRouteSettingCanDisableFallbackRoutes() {
+        let suiteName = "MobileHostSettings.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(false, forKey: MobileHostService.publishTailscaleRoutesDefaultsKey)
+
+        #expect(!MobileHostService.publishesTailscaleRoutes(defaults: defaults))
+    }
+
     @Test func testMobileRouteResolverOmitsIrohWhenNoEndpointRouteIsAvailable() throws {
         let resolver = MobileRouteResolver()
         let snapshot = resolver.routes(
@@ -277,6 +323,7 @@ struct MobileHostAuthorizationTests {
                 ),
             ],
             activeConnectionCount: 0,
+            activeTransportCounts: [.iroh: 1],
             lastErrorDescription: nil
         )
 
@@ -284,6 +331,7 @@ struct MobileHostAuthorizationTests {
         let route = try #require(snapshot.routes.first)
         #expect(route.kindLabel == String(localized: "settings.mobile.route.iroh", defaultValue: "Iroh"))
         #expect(route.endpoint == "peer-abcdef1 - relay.example.com")
+        #expect(snapshot.activeTransportLabels == [String(localized: "settings.mobile.route.iroh", defaultValue: "Iroh")])
     }
 
     @Test func testMobileRouteResolverAwaitsMagicDNSForPublicStatusRoutes() async throws {

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -324,6 +324,7 @@ struct MobileHostAuthorizationTests {
             ],
             activeConnectionCount: 0,
             activeTransportCounts: [.iroh: 1],
+            irohLaneState: .active,
             lastErrorDescription: nil
         )
 

--- a/cmuxTests/MobileHostIrohSecretKeyTests.swift
+++ b/cmuxTests/MobileHostIrohSecretKeyTests.swift
@@ -7,7 +7,8 @@ import Testing
 @testable import cmux
 #endif
 
-@Suite("Mobile host iroh secret key")
+@Suite("Mobile host iroh secret key", .serialized)
+@MainActor
 struct MobileHostIrohSecretKeyTests {
     private let keyLength = 32
 
@@ -46,6 +47,119 @@ struct MobileHostIrohSecretKeyTests {
             try provider.secretKey()
         }
     }
+
+    @Test func hostStartPublishesTCPRoutesWhileSecretKeyLoadHangs() async throws {
+        let store = HangingSecretKeyStore()
+        let service = MobileHostService(
+            irohFFIClient: UnusedMobileHostIrohFFIClient(),
+            irohSecretKeyProvider: MobileHostIrohSecretKeyProvider(
+                store: store,
+                generate: { Data(repeating: 7, count: 32) }
+            ),
+            isListeningEnabled: { true }
+        )
+        defer {
+            store.unblock()
+            service.stop()
+        }
+
+        service.start()
+        #expect(store.waitUntilLoadStarts())
+        let status = await service.ensureListeningAndReady()
+
+        #expect(status.isRunning)
+        #expect(status.port != nil)
+        #expect(status.routes.contains { $0.kind != .iroh })
+        #expect(!status.routes.contains { $0.kind == .iroh })
+        #expect(status.irohLaneState == .starting)
+    }
+
+    @Test func hostDegradesToTCPRoutesWhenSecretKeyLoadFails() async {
+        let service = MobileHostService(
+            irohFFIClient: UnusedMobileHostIrohFFIClient(),
+            irohSecretKeyProvider: MobileHostIrohSecretKeyProvider(
+                store: FailingSecretKeyStore(),
+                generate: { Data(repeating: 8, count: 32) }
+            ),
+            isListeningEnabled: { true }
+        )
+        defer { service.stop() }
+
+        service.start()
+        await service.debugWaitForIrohStartupForTesting()
+        let status = await service.ensureListeningAndReady()
+
+        #expect(status.isRunning)
+        #expect(status.routes.contains { $0.kind != .iroh })
+        #expect(!status.routes.contains { $0.kind == .iroh })
+        #expect(status.irohLaneState == .unavailableKeychain)
+        #expect(status.payload["iroh_lane_state"] as? String == "unavailable_keychain")
+    }
+}
+
+private enum ExpectedSecretKeyFailure: Error {
+    case failed
+}
+
+private struct FailingSecretKeyStore: MobileHostIrohSecretKeyStoring {
+    func loadSecretKey() throws -> Data? {
+        throw ExpectedSecretKeyFailure.failed
+    }
+
+    func saveSecretKey(_ key: Data) throws {
+        Issue.record("save should not run after a failed key load")
+    }
+}
+
+private final class HangingSecretKeyStore: MobileHostIrohSecretKeyStoring, @unchecked Sendable {
+    private let started = DispatchSemaphore(value: 0)
+    private let gate = DispatchSemaphore(value: 0)
+
+    func loadSecretKey() throws -> Data? {
+        started.signal()
+        gate.wait()
+        return Data(repeating: 1, count: 32)
+    }
+
+    func saveSecretKey(_ key: Data) throws {
+        Issue.record("save should not run when a stored key exists")
+    }
+
+    func waitUntilLoadStarts() -> Bool {
+        started.wait(timeout: .now() + 2) == .success
+    }
+
+    func unblock() {
+        gate.signal()
+    }
+}
+
+private struct UnusedMobileHostIrohFFIClient: MobileHostIrohFFIClient {
+    func generateSecretKey() throws -> Data { Data(repeating: 2, count: 32) }
+
+    func bindEndpoint(
+        secretKey: Data,
+        enableRelay: Bool,
+        acceptConnections: Bool
+    ) throws -> MobileHostIrohEndpointReference {
+        Issue.record("bind should not run while the key load is blocked or failed")
+        throw ExpectedSecretKeyFailure.failed
+    }
+
+    func endpointID(_ endpoint: MobileHostIrohEndpointReference) -> String? { nil }
+    func routeJSON(_ endpoint: MobileHostIrohEndpointReference) -> String? { nil }
+
+    func accept(
+        endpoint: MobileHostIrohEndpointReference,
+        timeoutMilliseconds: UInt64
+    ) throws -> MobileHostIrohConnectionReference {
+        throw ExpectedSecretKeyFailure.failed
+    }
+
+    func receive(connection: MobileHostIrohConnectionReference, maximumLength: Int) throws -> Data? { nil }
+    func send(connection: MobileHostIrohConnectionReference, data: Data) throws {}
+    func close(connection: MobileHostIrohConnectionReference) {}
+    func close(endpoint: MobileHostIrohEndpointReference) {}
 }
 
 private final class LockedCounter: @unchecked Sendable {

--- a/docs/ios-swift-mobile-plan.md
+++ b/docs/ios-swift-mobile-plan.md
@@ -7,15 +7,16 @@ Goal: ship the iOS path from current cmux main with Swift-owned app, session, tr
 - Current main pins `ghostty` to `22fa801f88f96fa842e54ecce6c34a5d36003d19`.
 - The first production slice should use only main Ghostty APIs. Fork-only helpers such as an active-screen getter or text snapshot helper are useful learnings, but they should not block the Swift rewrite.
 - Main's current mobile host snapshot is not sufficient for Zig-parity terminal rendering. It emits `fidelity: text_vt` with `styled_cells_unavailable`, so iOS can preserve layout but cannot reproduce ANSI/TUI colors until the Mac host exports real styled cells from Ghostty.
-- The original Zig/Tailscale branch remains useful for dogfooding behavior and shell UX. It should not be the production base.
+- The original Zig/Tailscale branch remains useful for dogfooding behavior and shell UX. It is not the production base.
+- Current rollout status: Iroh is the default mobile transport. Mac hosts still publish Tailscale/LAN routes by default as a lower-priority compatibility fallback, and Mac Settings can disable those fallback routes.
 
 ## Architecture
 
 - `Packages/Shared/CMUXMobileCore` owns the cross-platform Swift protocol layer: attach tickets, routes, frame codec, and Ghostty snapshot models.
 - The iOS shell depends on `CMUXMobileCore` and a `CmxByteTransport`, not on Tailscale, Iroh, WebSocket, or daemon details.
-- The Mac host publishes a `CmxAttachTicket` with one or more `CmxAttachRoute` values. iOS chooses the first supported route.
-- Tailscale ships first as a Swift `Network` transport over the tailnet host and port.
-- Iroh is added as another `CmxByteTransport` implementation. The shell and terminal session do not change. A minimal Rust edge is acceptable for the Iroh endpoint/dialer if the Swift code keeps owning route selection, attach-ticket decoding, framing, auth, and app state.
+- The Mac host publishes a `CmxAttachTicket` with one or more `CmxAttachRoute` values. iOS dials supported routes in priority order and logs each attempt.
+- Iroh is the primary `CmxByteTransport` implementation. The shell and terminal session do not change. A minimal Rust edge is acceptable for the Iroh endpoint/dialer if the Swift code keeps owning route selection, attach-ticket decoding, framing, auth, and app state.
+- Tailscale/LAN routes use the Swift `Network` transport over host and port. They remain an optional, lower-priority fallback for rollout compatibility and manual recovery.
 - Rivet can store workspace/device presence and issue attach tickets. It should not carry hot PTY bytes in the first production design.
 
 ## Iroh Experiment
@@ -36,7 +37,8 @@ Central workspace storage should keep durable records for workspace id, display 
 
 1. Land `CMUXMobileCore` with route selection, frame codec, snapshot schema, and tests.
 2. Copy the proven SwiftUI shell into `ios/` and wire it to `CmxByteTransport`.
-3. Add a Mac Tailscale listener that emits attach tickets and streams framed terminal bytes.
+3. Add a Mac mobile listener that emits attach tickets and streams framed terminal bytes, with Tailscale/LAN as the initial TCP lane.
 4. Replace the Mac `text_vt` terminal snapshot path with a Swift-owned styled-cell exporter from Ghostty so iOS receives foreground/background/bold/inverse/underline data instead of plain text.
 5. Add Iroh behind the same transport factory, using the Rust spike only for the endpoint/dialer until a Swift-native path exists.
+7. Default Iroh on for iOS and Mac mobile hosts, keep Tailscale/LAN fallback route publication default-on, and expose active transport in diagnostics/UI.
 6. Add auth expiry, reconnect, backpressure, logging, and CI coverage before release.

--- a/docs/pro-badge-options.html
+++ b/docs/pro-badge-options.html
@@ -201,7 +201,7 @@
 
   <h2>Pricing page (web)</h2>
   <div class="card">
-    <p><strong>/pricing</strong> — Free / Pro / Team / Enterprise, adopted from PR #6791. Pro is <strong>$30/mo billed annually</strong> ($360/yr, the checkout default), $45/mo month-to-month. CTA one-clicks into Stack hosted checkout when the checkout flag is on; download link otherwise. Hosted-networking and Vault copy are flagged off until they ship (Tailscale still required).</p>
+    <p><strong>/pricing</strong> — Free / Pro / Team / Enterprise, adopted from PR #6791. Pro is <strong>$30/mo billed annually</strong> ($360/yr, the checkout default), $45/mo month-to-month. CTA one-clicks into Stack hosted checkout when the checkout flag is on; download link otherwise. Hosted-networking and Vault copy are flagged off until they ship (Iroh is default; Tailscale remains an optional fallback).</p>
   </div>
 </div>
 </body>

--- a/ios/cmux-ios.xcodeproj/project.pbxproj
+++ b/ios/cmux-ios.xcodeproj/project.pbxproj
@@ -13,7 +13,6 @@
 		8B8A10F02DF5000000A66F90 /* CmuxAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B8A10F12DF5000000A66F90 /* CmuxAppDelegate.swift */; };
 		8B41F6832DEDD23B001A66F9 /* cmuxFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6822DEDD23B001A66F9 /* cmuxFeature */; };
 		8B41F6852DEDD25C001A66F9 /* cmuxFeature in Frameworks */ = {isa = PBXBuildFile; productRef = 8B41F6842DEDD25C001A66F9 /* cmuxFeature */; };
-		C1F00200C1F00200C1F00200 /* CmuxIrohFFI.xcframework in Frameworks */ = {isa = PBXBuildFile; fileRef = C1F00201C1F00201C1F00201 /* CmuxIrohFFI.xcframework */; };
 		8B7E20012DF3A00100A66F90 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = 8B7E20032DF3A00100A66F90 /* CMUXMobileCore */; };
 		8B7E20022DF3A00100A66F90 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = 8B7E20042DF3A00100A66F90 /* CMUXMobileCore */; };
 		8B7E20052DF3A00100A66F90 /* CmuxMobileTransport in Frameworks */ = {isa = PBXBuildFile; productRef = 8B7E20062DF3A00100A66F90 /* CmuxMobileTransport */; };
@@ -58,7 +57,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				8B41F6852DEDD25C001A66F9 /* cmuxFeature in Frameworks */,
-				C1F00200C1F00200C1F00200 /* CmuxIrohFFI.xcframework in Frameworks */,
 				8B7E20012DF3A00100A66F90 /* CMUXMobileCore in Frameworks */,
 				8B7E20052DF3A00100A66F90 /* CmuxMobileTransport in Frameworks */,
 			);
@@ -413,6 +411,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../native/cmux-iroh/include",
+				);
 				INFOPLIST_FILE = Config/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "$(PRODUCT_DISPLAY_NAME)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -422,6 +424,14 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../CmuxIrohFFI.xcframework/ios-arm64",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../CmuxIrohFFI.xcframework/ios-arm64-simulator",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -430,8 +440,13 @@
 					Security,
 					"-framework",
 					Network,
+					"-lcmux_iroh_ffi",
 				);
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../native/cmux-iroh/include",
+				);
 				SWIFT_VERSION = 5.0;
 			};
 			name = Debug;
@@ -445,6 +460,10 @@
 				CODE_SIGN_STYLE = Automatic;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = NO;
+				HEADER_SEARCH_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../native/cmux-iroh/include",
+				);
 				INFOPLIST_FILE = Config/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "$(PRODUCT_DISPLAY_NAME)";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -454,6 +473,14 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphoneos*]" = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../CmuxIrohFFI.xcframework/ios-arm64",
+				);
+				"LIBRARY_SEARCH_PATHS[sdk=iphonesimulator*]" = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../CmuxIrohFFI.xcframework/ios-arm64-simulator",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -462,8 +489,13 @@
 					Security,
 					"-framework",
 					Network,
+					"-lcmux_iroh_ffi",
 				);
 				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_INCLUDE_PATHS = (
+					"$(inherited)",
+					"$(PROJECT_DIR)/../native/cmux-iroh/include",
+				);
 				SWIFT_VERSION = 5.0;
 			};
 			name = Release;

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1888,6 +1888,40 @@
         }
       }
     },
+    "mobile.connection.connectedViaFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Live terminal sync is active over %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 経由でライブターミナル同期が有効です。"
+          }
+        }
+      }
+    },
+    "mobile.connection.hostTransportFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ - %@"
+          }
+        }
+      }
+    },
     "mobile.connection.reconnecting": {
       "extractionState": "manual",
       "localizations": {
@@ -1922,6 +1956,125 @@
         }
       }
     },
+    "mobile.connection.reconnectingViaFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Trying to restore the %@ connection."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 接続を復元しようとしています。"
+          }
+        }
+      }
+    },
+    "mobile.connection.terminalTransportFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ via %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@（%@）"
+          }
+        }
+      }
+    },
+    "mobile.connection.transport.iroh": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Iroh"
+          }
+        }
+      }
+    },
+    "mobile.connection.transport.loopback": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loopback"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ループバック"
+          }
+        }
+      }
+    },
+    "mobile.connection.transport.tailscale": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tailscale"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tailscale"
+          }
+        }
+      }
+    },
+    "mobile.connection.transport.websocket": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebSocket"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "WebSocket"
+          }
+        }
+      }
+    },
+    "mobile.connection.transportOnlyFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Connected via %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ で接続済み"
+          }
+        }
+      }
+    },
     "mobile.connection.unavailable": {
       "extractionState": "manual",
       "localizations": {
@@ -1952,6 +2105,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "ライブ接続が切断されました。選択した cmux ビルドはまだオンラインの可能性があります。再接続をタップしてください。"
+          }
+        }
+      }
+    },
+    "mobile.connection.unavailableViaFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The %@ connection dropped. Tap Reconnect."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 接続が切断されました。再接続をタップしてください。"
           }
         }
       }
@@ -2693,13 +2863,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Your phone has to reach your Mac over the network. The simplest private path is Tailscale: both devices join the same tailnet and connect directly, with no cloud relay. On the same Wi-Fi you can instead type the Mac's local address by hand, but that link is unencrypted, so Tailscale is recommended."
+            "value": "cmux tries an encrypted Iroh connection first, so pairing usually works as long as both devices are online and signed in. You can also publish Tailscale or LAN routes as a fallback."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "iPhoneはネットワーク経由でMacに届く必要があります。最もシンプルでプライベートな方法はTailscaleです。両方の端末を同じtailnetに参加させると、クラウド中継なしで直接つながります。同じWi-Fiなら、Macのローカルアドレスを手入力して接続することもできますが、その接続は暗号化されないため、Tailscaleをおすすめします。"
+            "value": "cmux はまず暗号化された Iroh 接続を試すため、両方の端末がオンラインでサインイン済みなら通常はペアリングできます。フォールバックとして Tailscale または LAN ルートも公開できます。"
           }
         }
       }
@@ -2829,13 +2999,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tailscale is a free app that gives your devices a private network. Do this once, on both the phone and the Mac."
+            "value": "Iroh is the default transport. Tailscale can add a private fallback route if your network blocks Iroh or you are connecting from an older cmux build."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tailscaleは、端末同士をプライベートなネットワークでつなぐ無料アプリです。iPhoneとMacの両方で一度だけ設定してください。"
+            "value": "Iroh が既定のトランスポートです。ネットワークが Iroh をブロックする場合や古い cmux ビルドから接続する場合、Tailscale でプライベートなフォールバックルートを追加できます。"
           }
         }
       }
@@ -2863,13 +3033,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Install Tailscale on this phone and on your Mac."
+            "value": "Install Tailscale on this phone and on your Mac only if you want the fallback route."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "この端末とMacの両方にTailscaleをインストールします。"
+            "value": "フォールバックルートを使いたい場合にだけ、この端末と Mac の両方に Tailscale をインストールします。"
           }
         }
       }
@@ -2897,13 +3067,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keep both signed in to the same cmux account too. Pairing checks that they match."
+            "value": "Leave Also Publish Tailscale/LAN Routes on in Mac Settings when you want that fallback."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "両方を同じcmuxアカウントでもサインインしておきます。ペアリング時に一致を確認します。"
+            "value": "そのフォールバックを使う場合は、Mac の設定で「Tailscale/LAN ルートも公開」をオンのままにします。"
           }
         }
       }
@@ -2914,13 +3084,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Put both devices on Tailscale"
+            "value": "Optional fallback: Tailscale"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "両方の端末をTailscaleに入れる"
+            "value": "任意のフォールバック: Tailscale"
           }
         }
       }
@@ -3186,13 +3356,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No response from %@:%d. Your Mac may be asleep or off Tailscale. Make sure it's awake and on the same Tailscale network."
+            "value": "No response from %@:%d. Your Mac may be asleep or the fallback route may be unavailable. Make sure cmux is open and the route is reachable."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@:%d から応答がありません。Macがスリープしているか、Tailscaleに接続されていない可能性があります。Macがスリープしておらず、同じTailscaleネットワーク上にあることを確認してください。"
+            "value": "%@:%d から応答がありません。Mac がスリープしているか、フォールバックルートを利用できない可能性があります。cmux が開いていて、ルートに到達できることを確認してください。"
           }
         }
       }
@@ -3254,13 +3424,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Couldn't resolve %@. Check that Tailscale is connected on both devices."
+            "value": "Couldn't resolve %@. Check that the fallback route is online; if it is a Tailscale name, make sure Tailscale is connected on both devices."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@ を解決できませんでした。両方の端末でTailscaleが接続されていることを確認してください。"
+            "value": "%@ を解決できませんでした。フォールバックルートがオンラインであることを確認してください。Tailscale 名の場合は、両方の端末で Tailscale が接続されていることを確認してください。"
           }
         }
       }
@@ -3424,13 +3594,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Check that this phone and your Mac are on the same Wi-Fi or both running Tailscale, that the Mac is awake, and that cmux is open on it."
+            "value": "Check that the Mac is awake, cmux is open on it, and both devices are online. If this was a fallback route, also check Wi-Fi or Tailscale."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このスマートフォンとMacが同じWi-Fi上にあるか、両方でTailscaleが動作していること、Macがスリープしていないこと、Macでcmuxが開いていることを確認してください。"
+            "value": "Mac がスリープしておらず、Mac で cmux が開いていて、両方の端末がオンラインであることを確認してください。フォールバックルートだった場合は、Wi-Fi または Tailscale も確認してください。"
           }
         }
       }
@@ -3492,13 +3662,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Can't reach %@:%d. Make sure your Mac is awake and on the same Tailscale network as this device."
+            "value": "Can't reach %@:%d. Make sure your Mac is awake, cmux is open, and the fallback route is reachable."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "%@:%d に接続できません。Macがスリープしておらず、この端末と同じTailscaleネットワーク上にあることを確認してください。"
+            "value": "%@:%d に接続できません。Mac がスリープしておらず、cmux が開いていて、フォールバックルートに到達できることを確認してください。"
           }
         }
       }
@@ -3628,13 +3798,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "This code points at the Mac itself (localhost), so your iPhone can't use it. Set up Tailscale on the Mac, then scan a fresh code."
+            "value": "This code points at the Mac itself (localhost), so your iPhone can't use it. Refresh Mobile Connect so it can publish an Iroh route, or set up Tailscale and scan a fresh code."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このコードは Mac 自身（localhost）を指しているため、iPhone からは使えません。Mac に Tailscale を設定してから、新しいコードをスキャンしてください。"
+            "value": "このコードは Mac 自身（localhost）を指しているため、iPhone からは使えません。Mobile Connect を更新して Iroh ルートを公開するか、Tailscale を設定してから新しいコードをスキャンしてください。"
           }
         }
       }
@@ -4886,13 +5056,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No Tailscale? On the same Wi-Fi you can still connect by typing the computer's local address and port by hand in Add Computer. That link is unencrypted, so only use it on a network you trust."
+            "value": "On the same Wi-Fi you can still connect by typing the computer's local address and port by hand in Add Computer. That link is unencrypted, so only use it on a network you trust."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tailscaleがない場合でも、同じWi-Fiなら、「コンピュータを追加」でコンピュータのローカルアドレスとポートを手入力して接続できます。その接続は暗号化されないため、信頼できるネットワークでのみ使用してください。"
+            "value": "同じ Wi-Fi 上なら、「コンピュータを追加」でコンピュータのローカルアドレスとポートを手入力して接続することもできます。その接続は暗号化されないため、信頼できるネットワークでのみ使用してください。"
           }
         }
       }
@@ -4988,13 +5158,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Scanning the computer's QR code needs Tailscale: the computer only shows a code when it has a Tailscale address your phone can reach. Install Tailscale on both, sign both in to the same tailnet, and the code appears."
+            "value": "Scanning the computer's QR code normally uses Iroh first. Keep cmux open on the computer and make sure both devices are online. Tailscale is optional and only needed as a fallback route."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータのQRコードをスキャンするにはTailscaleが必要です。コンピュータは、iPhoneから届くTailscaleアドレスを持っているときだけコードを表示します。両方にTailscaleをインストールし、同じtailnetでサインインすると、コードが表示されます。"
+            "value": "コンピュータの QR コードをスキャンすると、通常はまず Iroh を使用します。コンピュータで cmux を開いたままにし、両方の端末がオンラインであることを確認してください。Tailscale は任意で、フォールバックルートとしてのみ必要です。"
           }
         }
       }
@@ -5022,13 +5192,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The computer and this phone must be signed in to the same cmux account, and on the same tailnet (or the same Wi-Fi for a manual local connection)."
+            "value": "The computer and this phone must be signed in to the same cmux account. Tailscale or same-Wi-Fi routing is only needed for fallback/manual connections."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "コンピュータとこの端末は、同じcmuxアカウントでサインインし、同じtailnet（手動でローカル接続する場合は同じWi-Fi）にある必要があります。"
+            "value": "コンピュータとこの端末は同じ cmux アカウントでサインインしている必要があります。Tailscale または同じ Wi-Fi のルーティングは、フォールバックまたは手動接続の場合にのみ必要です。"
           }
         }
       }
@@ -5124,13 +5294,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "You have paired this computer before but it is not reachable now. Wake it, make sure cmux is running, and confirm both devices are on the same tailnet or Wi-Fi. Then reconnect."
+            "value": "You have paired this computer before but it is not reachable now. Wake it, make sure cmux is running, and confirm both devices are online. If you rely on a fallback route, also check Tailscale or Wi-Fi. Then reconnect."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このコンピュータは以前ペアリング済みですが、今は届きません。コンピュータを起こし、cmuxが起動していることを確認し、両方の端末が同じtailnetまたはWi-Fiにあることを確かめてから再接続してください。"
+            "value": "このコンピュータは以前ペアリング済みですが、今は到達できません。コンピュータを起こし、cmux が起動していて、両方の端末がオンラインであることを確認してください。フォールバックルートに依存している場合は、Tailscale または Wi-Fi も確認してから再接続してください。"
           }
         }
       }
@@ -5668,13 +5838,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Your Mac may be unreachable because Tailscale is off here. Turn it on, then try again."
+            "value": "Iroh is tried first. If this Mac was using the Tailscale fallback route, turn Tailscale on, then try again."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "このデバイスで Tailscale がオフのため、Mac に接続できない可能性があります。Tailscale をオンにしてから、もう一度お試しください。"
+            "value": "まず Iroh が試されます。この Mac が Tailscale フォールバックルートを使用していた場合は、Tailscale をオンにしてからもう一度お試しください。"
           }
         }
       }
@@ -5719,13 +5889,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "QR pairing usually needs both devices on the same Tailscale network. Turn Tailscale on first, or pair by host and port on a trusted local network."
+            "value": "Iroh pairing can work without Tailscale. Turn Tailscale on only if you are using the Tailscale fallback route."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "QR ペアリングには通常、両方のデバイスが同じ Tailscale ネットワークに接続されている必要があります。まず Tailscale をオンにするか、信頼できるローカルネットワーク上でホストとポートを指定してペアリングしてください。"
+            "value": "Iroh ペアリングは Tailscale なしでも動作します。Tailscale フォールバックルートを使用する場合にだけ、Tailscale をオンにしてください。"
           }
         }
       }

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1,10 +1,10 @@
 {
   "ios": {
     "metaTitle": "cmux iOS — your terminals on iPhone and iPad",
-    "metaDescription": "The cmux iOS app mirrors your Mac terminals to iPhone and iPad in realtime, over your own Tailscale or local network. Drive your coding agents from anywhere.",
+    "metaDescription": "The cmux iOS app mirrors your Mac terminals to iPhone and iPad in realtime over Iroh, with optional Tailscale or local-network fallback. Drive your coding agents from anywhere.",
     "title": "cmux iOS",
     "tagline": "Your terminals, in your pocket.",
-    "subtitle": "The cmux iOS app mirrors your Mac terminals to iPhone and iPad in realtime. Drive your coding agents, watch builds, and switch workspaces from anywhere, over your own Tailscale or local network.",
+    "subtitle": "The cmux iOS app mirrors your Mac terminals to iPhone and iPad in realtime. Drive your coding agents, watch builds, and switch workspaces from anywhere over Iroh, with optional Tailscale or local-network fallback.",
     "ctaBeta": "Download on TestFlight",
     "ctaDocs": "Read the iOS docs",
     "screenshotAlt": "cmux iOS app showing a live agent terminal",
@@ -12,7 +12,7 @@
     "realtimeSync": "Realtime sync",
     "realtimeSyncDesc": ": your terminals stream to iPhone and iPad the instant they change",
     "byoNetwork": "Bring your own network",
-    "byoNetworkDesc": ": connect over your own Tailscale or local network, with no servers in between",
+    "byoNetworkDesc": ": connect over Iroh, with Tailscale or local-network fallback when you need it",
     "verticalTabs": "Vertical tabs",
     "verticalTabsDesc": ": every workspace one tap away, just like the desktop",
     "notifications": "Agent notifications",
@@ -22,7 +22,7 @@
     "native": "Native and fast",
     "nativeDesc": ": GPU-accelerated rendering on the same engine as the Mac app",
     "howTitle": "How it works",
-    "howBody": "Pair your iPhone with your Mac from the Mobile Connect window, then attach to any workspace. The connection runs over your own Tailscale or local network, so your terminals never touch a third-party server.",
+    "howBody": "Pair your iPhone with your Mac from the Mobile Connect window, then attach to any workspace. cmux tries Iroh first and can publish Tailscale or local-network fallback routes, so your terminals never touch a third-party server.",
     "galleryTitle": "Run anything in your terminal",
     "backToMac": "cmux for Mac",
     "galleryItemAlt": "{name} running in a cmux terminal on iPhone"
@@ -598,7 +598,7 @@
         },
         {
           "q": "Do I still need Tailscale for the iOS app?",
-          "a": "Yes, for now. Pair your iPhone with your Mac over your own networking, like Tailscale, on any plan; Enterprise can self-host. Hosted networking with zero setup is on the roadmap."
+          "a": "No. cmux tries Iroh first. Tailscale remains useful as an optional fallback route on any plan; Enterprise can self-host. Hosted networking with zero setup is on the roadmap."
         },
         {
           "q": "How does billing work?",
@@ -2574,7 +2574,7 @@
     },
     "ios": {
       "metaTitle": "iOS App",
-      "metaDescription": "Set up the cmux iOS companion app: TestFlight access, bring-your-own networking with Tailscale or WireGuard, pairing, notifications, and what data cmux stores.",
+      "metaDescription": "Set up the cmux iOS companion app: TestFlight access, Iroh transport with optional Tailscale or WireGuard fallback, pairing, notifications, and what data cmux stores.",
       "title": "iOS App",
       "intro": "The cmux iOS app is a companion for your Mac. Pair your iPhone or iPad with a Mac running cmux and attach to your terminals from your phone, with optional forwarding of terminal notifications.",
       "betaNote": "The iOS app is in beta. It ships on TestFlight as cmux BETA.",
@@ -2584,11 +2584,11 @@
       "prereqIntro": "Before you start, you need:",
       "prereq1": "A Mac running cmux and signed in.",
       "prereq2": "An iPhone or iPad with the cmux BETA app installed from TestFlight.",
-      "prereq3": "A network path from your phone to your Mac (see Bring your own networking below).",
-      "networkingTitle": "Bring your own networking",
-      "networkingDesc": "cmux does not provide networking out of the box. The terminal stream flows directly between your phone and your Mac, so your phone has to be able to reach your Mac on the network. The simplest way is a private overlay network.",
-      "tailscaleTitle": "Tailscale (recommended)",
-      "tailscaleDesc": "Install <link>Tailscale</link> on both your Mac and your phone and sign in to the same tailnet. Your phone can then reach your Mac by its tailnet address from anywhere, with no port forwarding.",
+      "prereq3": "Both devices online. Optional fallback routes can use Tailscale, WireGuard, or a trusted local network.",
+      "networkingTitle": "Transport and fallback networking",
+      "networkingDesc": "cmux tries an encrypted Iroh route first. The terminal stream still flows directly between your phone and your Mac, and you can publish fallback routes when a network blocks Iroh or an older build needs TCP.",
+      "tailscaleTitle": "Tailscale (optional fallback)",
+      "tailscaleDesc": "Install <link>Tailscale</link> on both your Mac and your phone and sign in to the same tailnet if you want a private fallback route. Your phone can then reach your Mac by its tailnet address from anywhere, with no port forwarding.",
       "wireguardTitle": "WireGuard",
       "wireguardDesc": "If you already run <link>WireGuard</link>, put your Mac and phone on the same network and use the Mac's WireGuard address.",
       "networkingNote": "Whichever you choose, the connection is yours. cmux does not proxy or relay terminal traffic between your devices.",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -1,10 +1,10 @@
 {
   "ios": {
     "metaTitle": "cmux iOS — iPhone と iPad でターミナルを",
-    "metaDescription": "cmux iOS アプリは、Mac のターミナルを自分の Tailscale やローカルネットワーク経由で iPhone・iPad にリアルタイムでミラーリング。どこからでもコーディングエージェントを操作できます。",
+    "metaDescription": "cmux iOS アプリは、Iroh 経由で Mac のターミナルを iPhone・iPad にリアルタイムでミラーリングし、任意で Tailscale やローカルネットワークをフォールバックにできます。どこからでもコーディングエージェントを操作できます。",
     "title": "cmux iOS",
     "tagline": "ターミナルを、ポケットに。",
-    "subtitle": "cmux iOS アプリは、Mac のターミナルを iPhone と iPad にリアルタイムでミラーリングします。自分の Tailscale やローカルネットワーク経由で、どこからでもコーディングエージェントの操作、ビルドの確認、ワークスペースの切り替えができます。",
+    "subtitle": "cmux iOS アプリは、Mac のターミナルを iPhone と iPad にリアルタイムでミラーリングします。Iroh 経由で、任意の Tailscale やローカルネットワークのフォールバックも使いながら、どこからでもコーディングエージェントの操作、ビルドの確認、ワークスペースの切り替えができます。",
     "ctaBeta": "TestFlight でダウンロード",
     "ctaDocs": "iOS ドキュメントを読む",
     "screenshotAlt": "ライブのエージェントターミナルを表示する cmux iOS アプリ",
@@ -12,7 +12,7 @@
     "realtimeSync": "リアルタイム同期",
     "realtimeSyncDesc": "：ターミナルの変化が即座に iPhone・iPad にストリーミングされます",
     "byoNetwork": "自分のネットワークを利用",
-    "byoNetworkDesc": "：間にサーバーを挟まず、自分の Tailscale やローカルネットワークで接続",
+    "byoNetworkDesc": "：Iroh で接続し、必要な場合は Tailscale やローカルネットワークをフォールバックにできます",
     "verticalTabs": "垂直タブ",
     "verticalTabsDesc": "：デスクトップと同じく、すべてのワークスペースにワンタップで",
     "notifications": "エージェント通知",
@@ -22,7 +22,7 @@
     "native": "ネイティブで高速",
     "nativeDesc": "：Mac アプリと同じエンジンによる GPU アクセラレーションレンダリング",
     "howTitle": "仕組み",
-    "howBody": "Mobile Connect ウィンドウから iPhone と Mac をペアリングし、任意のワークスペースにアタッチします。接続は自分の Tailscale やローカルネットワーク経由で行われるため、ターミナルが第三者のサーバーを経由することはありません。",
+    "howBody": "Mobile Connect ウィンドウから iPhone と Mac をペアリングし、任意のワークスペースにアタッチします。cmux はまず Iroh を試し、Tailscale やローカルネットワークのフォールバックルートも公開できるため、ターミナルが第三者のサーバーを経由することはありません。",
     "galleryTitle": "ターミナルで動くものは何でも",
     "backToMac": "cmux for Mac",
     "galleryItemAlt": "iPhone の cmux ターミナルで動作する {name}"
@@ -598,7 +598,7 @@
         },
         {
           "q": "iOS アプリにまだ Tailscale が必要ですか?",
-          "a": "はい、現時点では必要です。どのプランでも Tailscale などお使いのネットワーク経由で iPhone と Mac をペアリングできます。Enterprise ではセルフホストも可能です。設定不要のホスト型ネットワークはロードマップにあります。"
+          "a": "いいえ。cmux はまず Iroh を試します。Tailscale はどのプランでも任意のフォールバックルートとして引き続き便利です。Enterprise ではセルフホストも可能です。設定不要のホスト型ネットワークはロードマップにあります。"
         },
         {
           "q": "課金はどのように行われますか?",
@@ -2485,7 +2485,7 @@
     },
     "ios": {
       "metaTitle": "iOSアプリ",
-      "metaDescription": "cmux iOSコンパニオンアプリのセットアップ：TestFlightでの入手、TailscaleまたはWireGuardによる持ち込みネットワーク、ペアリング、通知、cmuxが保存するデータについて。",
+      "metaDescription": "cmux iOSコンパニオンアプリのセットアップ：TestFlightでの入手、Iroh トランスポートと任意の Tailscale または WireGuard フォールバック、ペアリング、通知、cmuxが保存するデータについて。",
       "title": "iOSアプリ",
       "intro": "cmux iOSアプリはMacのコンパニオンです。cmuxを実行しているMacとiPhoneまたはiPadをペアリングし、スマートフォンからターミナルにアタッチできます。ターミナル通知の転送もオプションで利用できます。",
       "betaNote": "iOSアプリはベータ版です。TestFlightで「cmux BETA」として提供されています。",
@@ -2495,11 +2495,11 @@
       "prereqIntro": "始める前に、次のものが必要です：",
       "prereq1": "cmuxを実行し、サインイン済みのMac。",
       "prereq2": "TestFlightからcmux BETAアプリをインストールしたiPhoneまたはiPad。",
-      "prereq3": "スマートフォンからMacへのネットワーク経路（下記の「持ち込みネットワーク」を参照）。",
-      "networkingTitle": "持ち込みネットワーク",
-      "networkingDesc": "cmuxはネットワーク機能を標準では提供しません。ターミナルのストリームはスマートフォンとMacの間を直接流れるため、スマートフォンがネットワーク上でMacに到達できる必要があります。最も簡単なのはプライベートなオーバーレイネットワークです。",
-      "tailscaleTitle": "Tailscale（推奨）",
-      "tailscaleDesc": "Macとスマートフォンの両方に<link>Tailscale</link>をインストールし、同じtailnetにサインインします。これでスマートフォンはどこからでも、ポート転送なしでMacのtailnetアドレスに到達できます。",
+      "prereq3": "両方の端末がオンラインであること。任意のフォールバックルートには Tailscale、WireGuard、または信頼できるローカルネットワークを使用できます。",
+      "networkingTitle": "トランスポートとフォールバックネットワーク",
+      "networkingDesc": "cmux はまず暗号化された Iroh ルートを試します。ターミナルのストリームは引き続きスマートフォンと Mac の間を直接流れます。ネットワークが Iroh をブロックする場合や古いビルドが TCP を必要とする場合は、フォールバックルートを公開できます。",
+      "tailscaleTitle": "Tailscale（任意のフォールバック）",
+      "tailscaleDesc": "プライベートなフォールバックルートが必要な場合は、Mac とスマートフォンの両方に<link>Tailscale</link>をインストールし、同じ tailnet にサインインします。これによりスマートフォンはどこからでも、ポート転送なしで Mac の tailnet アドレスに到達できます。",
       "wireguardTitle": "WireGuard",
       "wireguardDesc": "すでに<link>WireGuard</link>を運用している場合は、Macとスマートフォンを同じネットワークに置き、MacのWireGuardアドレスを使用します。",
       "networkingNote": "どちらを選んでも、接続はあなた自身のものです。cmuxはデバイス間のターミナルトラフィックをプロキシしたり中継したりしません。",


### PR DESCRIPTION
Implements delivery-plan step 5 of https://github.com/manaflow-ai/cmux/blob/main/plans/feat-ios-iroh/DESIGN.md, completing the stack on https://github.com/manaflow-ai/cmux/pull/7830. This head contains the ENTIRE iroh capability suite (P2 FFI packaging + P3 phone dial lane + P4 Mac host lane + this) so the whole feature verifies from one build.

iroh becomes default-on on both apps (phone flag and Mac host lane; env/defaults escape hatches retained). New Mac Settings Mobile toggles: "Use Iroh transport" and "Also publish Tailscale/LAN routes" (default ON for rollout compat; OFF publishes iroh-only tickets). Active-transport visibility: Mac Settings diagnostics show the live session transport; iOS connection chrome names the transport (Iroh/Tailscale/loopback/WebSocket) in connected, reconnecting, and unavailable states. Attach path logs ordered dial attempts per route id/kind for acceptance evidence. Onboarding/setup copy demoted from install-Tailscale to iroh-first with Tailscale as optional fallback (docs + web messages updated). All new strings localized en+ja (keys audited by JSON parse).

Verified: swift test green across touched packages; cmux + cmux-unit tagged compiles; iOS workspace arm64 sim build; pbxproj test-wiring lint; clean-build compile of the merged head (includes the P3/P4 CI fixes: xcframework provisioning for mobile-core-package, Package.resolved policy for the iOS workspace lockfile, modulemap collision fix). Known pre-existing gap: CmuxMobileShellUI standalone swift test is blocked by that package's iOS-only platform metadata (predates this stack; covered by the workspace build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7855"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786303585&installation_id=133855650&pr_number=7855&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7855&signature=07a254b06e8b9a29546d723783fa451b9db6e9bf1a21bf042fc3e085f526bbbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes the default connection and route-publication behavior for iOS–Mac pairing across RPC, Iroh FFI, and host listener code—security-sensitive networking with broad product impact, though mitigated by settings flags and tests.
> 
> **Overview**
> Makes **Iroh the default** mobile pairing transport on iOS and the Mac host (still overridable via env/`UserDefaults`), and adds Mac Settings toggles for **Use Iroh Transport** and **Also Publish Tailscale/LAN Routes** (fallback routes default on; turning the latter off yields Iroh-only tickets via `MobileRouteResolver`).
> 
> Adds **ordered attach dial telemetry**: `MobileRPCTransportConnectEvent` flows from `MobileCoreRPCSession` through `MobileCoreRPCClient` into `MobileShellComposite` `mobile.dial.*` lines with redacted endpoints, plus tests for Iroh-then-Tailscale failover. **UI and diagnostics** surface the live transport (Iroh/Tailscale/etc.) on iOS chrome and Mac Mobile settings; Mac host tracks per-connection transport kinds and `iroh_lane_state` while starting Iroh asynchronously so TCP routes can publish if keychain/bind is slow or fails.
> 
> **Onboarding, setup help, web copy, and localizations** are updated to Iroh-first with Tailscale as optional fallback. iOS **Iroh linking** shifts to direct `cmux_iroh_ffi` library paths in the app project; connect success now records the **actual winning route** in the connection pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 22972eb40f4486f54699b805a4ec50f5a724319f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Iroh is now the default transport for iOS pairing and terminal sync, with optional Tailscale/LAN fallback. Also adds clearer transport visibility, ordered dial diagnostics, and a host-startup fix so Iroh keychain loading never blocks the Mac host.

- New Features
  - Default-on Iroh on iOS and Mac; env and `UserDefaults` overrides still work.
  - Mac Settings → Mobile: “Use Iroh Transport” and “Also Publish Tailscale/LAN Routes” (default ON); republish routes on change; diagnostics include an “Active Transport” summary.
  - iOS labels the live transport (Iroh/Tailscale/Loopback/WebSocket) in the connection pill, status row, and toolbar (“via <transport>” when connected).
  - Dial diagnostics: ordered route attempts with per-attempt lifecycle via `MobileRPCTransportConnectEvent` and an injectable `dialLog`; tests cover Iroh‑then‑Tailscale order and redaction.
  - Route publishing supports Iroh‑only tickets; copy updated to Iroh‑first across app, docs, and web; new en/ja strings and tests.
  - Host startup no longer waits on Iroh keychain load; TCP routes publish while the key is loading; regression test added.
  - Build: iOS Iroh modulemap collision resolved and standalone linking restored (P4 fixes merged).

- Migration
  - No action needed; Tailscale/LAN fallback stays ON by default for rollout and older clients.
  - To ship Iroh‑only tickets, turn off “Also Publish Tailscale/LAN Routes” (or set `mobile.iOSPairingHost.publishTailscaleRoutes=false`). To disable Iroh, turn off “Use Iroh Transport” or set `CMUX_MOBILE_IROH_TRANSPORT=false`.

<sup>Written for commit 22972eb40f4486f54699b805a4ec50f5a724319f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

