### PR TITLE
Target feature flags by build channel

### DIFF
--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -193,7 +193,9 @@ final class CmuxFeatureFlags {
                 self?.applyLoadedFlags()
             }
         }
-        PostHogSDK.shared.reloadFeatureFlags()
+        // PostHogAnalytics reloads after installing its build-channel
+        // evaluation context. Starting a request here would race that setup
+        // during launch and could cache a result for the wrong channel.
     }
 
     func effectiveValue(for definition: CmuxFeatureFlagDefinition) -> Bool {

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -120,6 +120,7 @@ final class PostHogAnalytics: @unchecked Sendable {
         let config = PostHogConfig(apiKey: apiKey, host: host)
         config.captureApplicationLifecycleEvents = false
         config.captureScreenViews = false
+        config.preloadFeatureFlags = false
 #if DEBUG
         config.debug = ProcessInfo.processInfo.environment["CMUX_POSTHOG_DEBUG"] == "1"
 #endif

--- a/Sources/PostHogAnalytics.swift
+++ b/Sources/PostHogAnalytics.swift
@@ -130,9 +130,23 @@ final class PostHogAnalytics: @unchecked Sendable {
         // break events down by released app version/build.
         PostHogSDK.shared.register(Self.superProperties(infoDictionary: Bundle.main.infoDictionary ?? [:]))
 
+        // Feature-flag evaluation does not use registered event properties.
+        // Send the immutable build channel explicitly, before the first flag
+        // reload, so a PostHog rule can enable a flag for Nightly without
+        // changing the Stable app (or vice versa).
+        PostHogSDK.shared.setPersonPropertiesForFlags(
+            Self.featureFlagEvaluationProperties(buildFlavor: BuildFlavor.current),
+            reloadFeatureFlags: false
+        )
+
         // The SDK automatically generates and persists an anonymous distinct ID.
 
         didStart = true
+
+        // CmuxFeatureFlags installs its observer during app launch, before
+        // analytics initialization reaches this point. Reload only after the
+        // build-channel evaluation context is ready.
+        PostHogSDK.shared.reloadFeatureFlags()
 
         scheduleActiveCheckTimer()
     }
@@ -242,6 +256,13 @@ final class PostHogAnalytics: @unchecked Sendable {
         var properties: [String: Any] = ["platform": "cmuxterm"]
         properties.merge(versionProperties(infoDictionary: infoDictionary)) { _, new in new }
         return properties
+    }
+
+    /// Properties sent only with feature-flag evaluation. In PostHog, target
+    /// the `cmux_build_channel` person property with `nightly` or `stable` to
+    /// roll a flag out to one desktop release channel independently.
+    nonisolated static func featureFlagEvaluationProperties(buildFlavor: BuildFlavor) -> [String: Any] {
+        ["cmux_build_channel": buildFlavor.rawValue]
     }
 
     nonisolated static func dailyActiveProperties(

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -161,15 +161,14 @@ struct PostHogAnalyticsPropertiesTests {
 
     @Test("feature-flag evaluation identifies the app build channel")
     func featureFlagEvaluationPropertiesSeparateReleaseChannels() {
-        #expect(PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .stable) == [
-            "cmux_build_channel": "stable",
-        ])
-        #expect(PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .nightly) == [
-            "cmux_build_channel": "nightly",
-        ])
-        #expect(PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .dev) == [
-            "cmux_build_channel": "dev",
-        ])
+        let stable = PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .stable)
+        let nightly = PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .nightly)
+        let dev = PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .dev)
+
+        #expect(stable.count == 1)
+        #expect(stable["cmux_build_channel"] as? String == "stable")
+        #expect(nightly["cmux_build_channel"] as? String == "nightly")
+        #expect(dev["cmux_build_channel"] as? String == "dev")
     }
 
     @Test

--- a/cmuxTests/PostHogAnalyticsPropertiesTests.swift
+++ b/cmuxTests/PostHogAnalyticsPropertiesTests.swift
@@ -159,6 +159,19 @@ struct PostHogAnalyticsPropertiesTests {
         #expect(properties["app_build"] as? String == "230")
     }
 
+    @Test("feature-flag evaluation identifies the app build channel")
+    func featureFlagEvaluationPropertiesSeparateReleaseChannels() {
+        #expect(PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .stable) == [
+            "cmux_build_channel": "stable",
+        ])
+        #expect(PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .nightly) == [
+            "cmux_build_channel": "nightly",
+        ])
+        #expect(PostHogAnalytics.featureFlagEvaluationProperties(buildFlavor: .dev) == [
+            "cmux_build_channel": "dev",
+        ])
+    }
+
     @Test
     func hourlyActivePropertiesIncludeVersionAndBuild() {
         let properties = PostHogAnalytics.hourlyActiveProperties(


### PR DESCRIPTION
Adds `cmux_build_channel` to PostHog feature-flag evaluation as `stable`, `nightly`, or `dev`.

PostHog rules can now target Nightly independently from the production app. The SDK reloads flags only after the channel property is installed.

Test: `./scripts/lint-feature-flags.py`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7859"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786312038&installation_id=133855650&pr_number=7859&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7859&signature=57a56fe45dd3cf9bc318cdb29d78fe8a2f9345ad4ffade768c15cec8445d6137"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes launch-time feature-flag fetch ordering and evaluation context; a mistake could cache wrong flag values per channel at startup, affecting gated release UI.
> 
> **Overview**
> PostHog feature-flag evaluation now receives **`cmux_build_channel`** (`stable`, `nightly`, or `dev`) via `setPersonPropertiesForFlags`, so dashboard rules can roll flags out to one desktop release channel without affecting the others.
> 
> **Startup ordering** is tightened: SDK **`preloadFeatureFlags`** is off, **`CmuxFeatureFlags.start()`** no longer calls **`reloadFeatureFlags`** (that could run before the channel property was set), and **`PostHogAnalytics`** sets the channel property then performs a single **`reloadFeatureFlags`** after analytics setup. A small **`featureFlagEvaluationProperties(buildFlavor:)`** helper documents the PostHog person property; tests assert the three channel values.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87080c701327974186e062c6060ffc8bb8f144eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables build-channel targeting for `PostHog` feature flags so rules can target `stable`, `nightly`, or `dev` without affecting other channels. Defers flag loading until the build-channel context is set to avoid wrong early evaluations.

- **New Features**
  - Sends `cmux_build_channel` for flag evaluation via `featureFlagEvaluationProperties(buildFlavor:)`.
  - Disables SDK flag preloading (`config.preloadFeatureFlags = false`) and reloads flags only after setting the channel; `CmuxFeatureFlags.start()` no longer triggers an early `PostHogSDK.reloadFeatureFlags()`.

- **Migration**
  - In `PostHog`, target the `cmux_build_channel` person property with `nightly`, `stable`, or `dev` to scope rollouts by desktop release channel.

<sup>Written for commit 87080c701327974186e062c6060ffc8bb8f144eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature-flag initialization during app launch to avoid race conditions and ensure flags are evaluated with the correct build channel.
  * Updated analytics startup to apply build-specific evaluation settings before triggering a feature-flag refresh.
* **Tests**
  * Added unit test coverage confirming feature-flag evaluation properties are set correctly for stable, nightly, and development build flavors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->