### PR TITLE
Fix OG image locale redirect

### DIFF
--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -1,6 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import createMiddleware from "next-intl/middleware";
-import { routing } from "./i18n/routing";
+import { locales, routing } from "./i18n/routing";
 import { isAgentPageVariantPath } from "./app/lib/agent-page-paths";
 import {
   featureWorkflowContentLocales,
@@ -47,6 +47,10 @@ export default function middleware(request: NextRequest) {
   }
 
   if (pathname === "/app-pro-welcome" || pathname === "/app-pro-welcome/") {
+    return NextResponse.next();
+  }
+
+  if (isNextMetadataFileRoute(pathname)) {
     return NextResponse.next();
   }
 
@@ -126,6 +130,30 @@ function setFeatureWorkflowDocLinkHeader(
 
 function requestOrigin(request: NextRequest) {
   return request.nextUrl.origin;
+}
+
+const localeSet = new Set<string>(locales);
+const metadataRouteNames = [
+  "opengraph-image",
+  "twitter-image",
+  "icon",
+  "apple-icon",
+] as const;
+
+function isNextMetadataFileRoute(pathname: string) {
+  const segments = pathname.split("/").filter(Boolean);
+  if (segments.length === 0 || segments.length > 2) {
+    return false;
+  }
+
+  const routeSegment =
+    segments.length === 2 && localeSet.has(segments[0])
+      ? segments[1]
+      : segments[0];
+
+  return metadataRouteNames.some(
+    (name) => routeSegment === name || routeSegment.startsWith(`${name}-`),
+  );
 }
 
 export const config = {

--- a/web/tests/proxy-metadata-routes.test.ts
+++ b/web/tests/proxy-metadata-routes.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from "bun:test";
+import { NextRequest } from "next/server";
+import middleware from "../proxy";
+
+function request(path: string) {
+  return new NextRequest(`https://cmux.test${path}`, {
+    headers: { host: "cmux.test" },
+  });
+}
+
+describe("proxy metadata routes", () => {
+  test("does not redirect locale-prefixed Next metadata image routes", () => {
+    for (const path of [
+      "/en/opengraph-image-e6it15?f656b4354be9c5cd",
+      "/ja/opengraph-image-e6it15?f656b4354be9c5cd",
+      "/en/twitter-image-e6it15?f656b4354be9c5cd",
+      "/en/icon?f656b4354be9c5cd",
+      "/en/apple-icon?f656b4354be9c5cd",
+    ]) {
+      const response = middleware(request(path));
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("location")).toBeNull();
+    }
+  });
+
+  test("keeps default-locale redirects for normal pages", () => {
+    const response = middleware(request("/en/docs"));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get("location")).toBe("https://cmux.test/docs");
+  });
+});

--- a/web/tests/proxy-metadata-routes.test.ts
+++ b/web/tests/proxy-metadata-routes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
+import { locales } from "../i18n/routing";
 import middleware from "../proxy";
 
 function request(path: string) {
@@ -11,11 +12,12 @@ function request(path: string) {
 describe("proxy metadata routes", () => {
   test("does not redirect locale-prefixed Next metadata image routes", () => {
     for (const path of [
-      "/en/opengraph-image-e6it15?f656b4354be9c5cd",
-      "/ja/opengraph-image-e6it15?f656b4354be9c5cd",
       "/en/twitter-image-e6it15?f656b4354be9c5cd",
       "/en/icon?f656b4354be9c5cd",
       "/en/apple-icon?f656b4354be9c5cd",
+      ...locales.map(
+        (locale) => `/${locale}/opengraph-image-e6it15?f656b4354be9c5cd`,
+      ),
     ]) {
       const response = middleware(request(path));
 


### PR DESCRIPTION
Closes #7865

## Root Cause

The landing page Open Graph image route lives under the `[locale]` app segment, so Next emits metadata image URLs such as `/en/opengraph-image-e6it15?...` for the default locale. The `next-intl` proxy uses `localePrefix: "as-needed"`, so default-locale paths like `/en/*` are redirected to `/*`. Scrapers that do not follow redirects therefore never fetch the PNG behind `og:image` / `twitter:image`.

## Fix

Bypass the locale middleware for Next metadata file routes (`opengraph-image*`, `twitter-image*`, `icon*`, `apple-icon*`) while leaving normal default-locale page redirects intact.

## Local Runtime Proof

Built with `bun run build`, then served with `next start` under Node v24.18.0 on `localhost:3138`. The HTML uses `https://cmux.com` as `metadataBase`, so the image fetches below use the emitted URL path on the local origin.

```text
$ curl -fsSL http://localhost:3138/ | grep -o 'property="og:image" content="[^"]*"'
property="og:image" content="https://cmux.com/en/opengraph-image-e6it15?f656b4354be9c5cd"
$ curl -fsSL http://localhost:3138/ | grep -o 'name="twitter:image" content="[^"]*"'
name="twitter:image" content="https://cmux.com/en/opengraph-image-e6it15?f656b4354be9c5cd"

$ curl -sS -D - -o /tmp/cmux-og-default.png "http://localhost:3138/en/opengraph-image-e6it15?f656b4354be9c5cd"
HTTP/1.1 200 OK
content-type: image/png
Downloaded bytes: 1320261

$ curl -sS -D - -o /tmp/cmux-twitter-default.png "http://localhost:3138/en/opengraph-image-e6it15?f656b4354be9c5cd"
HTTP/1.1 200 OK
content-type: image/png
Downloaded bytes: 1320261

$ curl -fsSL http://localhost:3138/ja | grep -o 'property="og:image" content="[^"]*"'
property="og:image" content="https://cmux.com/ja/opengraph-image-e6it15?f656b4354be9c5cd"
$ curl -fsSL http://localhost:3138/ja | grep -o 'name="twitter:image" content="[^"]*"'
name="twitter:image" content="https://cmux.com/ja/opengraph-image-e6it15?f656b4354be9c5cd"

$ curl -sS -D - -o /tmp/cmux-og-ja.png "http://localhost:3138/ja/opengraph-image-e6it15?f656b4354be9c5cd"
HTTP/1.1 200 OK
content-type: image/png
Downloaded bytes: 1320261

$ curl -sS -D - -o /tmp/cmux-twitter-ja.png "http://localhost:3138/ja/opengraph-image-e6it15?f656b4354be9c5cd"
HTTP/1.1 200 OK
content-type: image/png
Downloaded bytes: 1320261

$ curl -sI http://localhost:3138/en/docs
HTTP/1.1 307 Temporary Redirect
location: /docs
```

## Validation

- `bun test` passes: 574 pass, 91 skip
- `bun run typecheck` passes
- `bun run build` passes
- `bun run lint -- proxy.ts tests/proxy-metadata-routes.test.ts` passes
- `bun run lint` currently fails on unrelated pre-existing files outside this change set, including `pro-welcome-banner.tsx`, billing pages, and vault session pages.

## Localization

No user-facing copy changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7866"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786315983&installation_id=133855650&pr_number=7866&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7866&signature=e21c7f111b326a1b51fedaf9d66ee48b04a17b8e734aab6182de69a356ace85f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow middleware bypass with tests; only affects metadata asset paths, not page routing or auth.
> 
> **Overview**
> Fixes broken **OG/Twitter previews** when scrapers request the exact `og:image` URL (often `/en/opengraph-image-…`) and do not follow redirects.
> 
> The proxy now **short-circuits `next-intl`** for Next metadata file routes (`opengraph-image*`, `twitter-image*`, `icon*`, `apple-icon*`), including optional locale prefixes, via `isNextMetadataFileRoute` and `NextResponse.next()`. **Normal pages** such as `/en/docs` still get the default-locale **307** to `/docs`.
> 
> Adds **`proxy-metadata-routes.test.ts`** to assert metadata URLs return **200** with no `Location` header and that regular locale redirects are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da99f315c8cf7daa51a79d240c54e5697376af97. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Avoid redirecting Next metadata image routes under the default locale so OG/Twitter images load reliably for scrapers. We bypass the `next-intl` middleware for `opengraph-image*`, `twitter-image*`, `icon*`, and `apple-icon*`, while keeping normal page redirects.

- **Bug Fixes**
  - Add `isNextMetadataFileRoute` in the proxy to skip locale rewriting for metadata routes (with or without a locale segment).
  - Add tests to ensure metadata routes return 200 and default-locale redirects still apply to normal pages.

<sup>Written for commit da99f315c8cf7daa51a79d240c54e5697376af97. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metadata assets—such as OpenGraph, Twitter, and icon images—not loading correctly on localized routes.
  * Preserved existing locale redirects for standard pages.

* **Tests**
  * Added coverage for localized metadata routes and normal page redirection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->