### PR TITLE
Fix Base documentation layout

### DIFF
--- a/web/app/[locale]/(landing)/docs/base/page.tsx
+++ b/web/app/[locale]/(landing)/docs/base/page.tsx
@@ -1,10 +1,10 @@
 import { getTranslations } from "next-intl/server";
 import { notFound } from "next/navigation";
-import { buildAlternates } from "../../../../i18n/seo";
-import { Callout } from "../../components/callout";
-import { CodeBlock } from "../../components/code-block";
-import { DocsHeading } from "../../components/docs-heading";
-import { baseDocsLocales } from "../../components/docs-nav-items";
+import { buildAlternates } from "../../../../../i18n/seo";
+import { Callout } from "../../../components/callout";
+import { CodeBlock } from "../../../components/code-block";
+import { DocsHeading } from "../../../components/docs-heading";
+import { baseDocsLocales } from "../../../components/docs-nav-items";
 
 function assertSupportedLocale(locale: string) {
   if (!baseDocsLocales.includes(locale as (typeof baseDocsLocales)[number])) {


### PR DESCRIPTION
Fixes `/docs/base` rendering outside the documentation route group.

The page now inherits the shared docs layout, including the site header, sidebar, pager, styling, and search metadata.

Verification: `cd web && bun test tests/docs-search-index.test.ts tests/docs-search-utils.test.ts && bun run typecheck`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7870"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786317654&installation_id=133855650&pr_number=7870&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7870&signature=b8ab409741ec98bc376e1a051f38721e5dacc03a6349456bdec9c367224ad4ba"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-path-only change on a documentation page with no runtime or security impact.
> 
> **Overview**
> **Fixes `/docs/base` so it uses the same docs chrome as other documentation pages** by correcting broken relative imports on `docs/base/page.tsx`.
> 
> The page now resolves `buildAlternates` from `i18n/seo` and shared docs UI (`Callout`, `CodeBlock`, `DocsHeading`, `baseDocsLocales`) from `[locale]/components` instead of incorrect shorter paths that pointed at the wrong tree level. No page content or routing logic changes—only import paths.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a064b939075e84b056c797915b75a9049b42353b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `/docs/base` rendering outside the docs route group so it now uses the shared docs layout and search metadata across locales.

- **Bug Fixes**
  - Moved the page into the docs route group and corrected relative imports to shared components and `i18n/seo`.
  - Restores the site header, sidebar, pager, and styling on `/docs/base`.

<sup>Written for commit a064b939075e84b056c797915b75a9049b42353b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed documentation page imports to ensure the base documentation page loads correctly without changing its content or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->