### PR TITLE
Fix workspace rename default target

### DIFF
--- a/CLI/WorkspaceLoadingArguments.swift
+++ b/CLI/WorkspaceLoadingArguments.swift
@@ -162,14 +162,14 @@ extension CMUXCLI {
             key = manual
         }
 
-        let windowRaw = parsed.window ?? windowId
-        let workspaceArg = parsed.workspace ?? Self.callerWorkspaceForSurfaceHandle(nil, windowRaw: windowRaw)
-        let winId = try normalizeWindowHandle(windowRaw, client: client)
-        let wsId = try resolveWorkspaceId(
-            workspaceArg,
+        let target = try resolveWorkspaceTarget(
+            workspaceOption: parsed.workspace,
+            positional: nil,
+            windowOption: parsed.window,
             client: client,
-            windowHandle: winId
+            windowOverride: windowId
         )
+        let wsId = target.workspaceId
 
         let response = try sendV1Command(
             "workspace_loading \(key) \(parsed.turnOn ? "on" : "off") --tab=\(wsId)",

--- a/CLI/WorkspaceLoadingArguments.swift
+++ b/CLI/WorkspaceLoadingArguments.swift
@@ -19,8 +19,11 @@ extension CMUXCLI {
         windowOverride: String?
     ) throws -> (workspaceId: String, windowId: String?) {
         let windowId = try normalizeWindowHandle(windowOption ?? windowOverride, client: client)
+        let callerWorkspace = windowId == nil
+            ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"]
+            : nil
         let workspaceId = try resolveWorkspaceId(
-            workspaceOption ?? positional,
+            workspaceOption ?? positional ?? callerWorkspace,
             client: client,
             windowHandle: windowId
         )
@@ -38,7 +41,7 @@ extension CMUXCLI {
     ) throws -> (workspaceId: String, windowId: String?, remaining: [String]) {
         let (workspaceOption, argsAfterWorkspace) = parseOption(commandArgs, name: "--workspace")
         let (windowOption, remaining) = parseOption(argsAfterWorkspace, name: "--window")
-        let positional = remaining.first { $0 != "--" && !$0.hasPrefix("--") }
+        let positional = remaining.first { !$0.hasPrefix("--") }
         let target = try resolveWorkspaceTarget(
             workspaceOption: workspaceOption,
             positional: positional,

--- a/CLI/WorkspaceLoadingArguments.swift
+++ b/CLI/WorkspaceLoadingArguments.swift
@@ -8,12 +8,6 @@ struct WorkspaceLoadingArguments {
 }
 
 extension CMUXCLI {
-    struct WorkspaceNamespaceTarget {
-        let workspaceId: String
-        let windowId: String?
-        let remaining: [String]
-    }
-
     /// Single source of truth for commands whose workspace target is optional.
     /// Explicit windows suppress caller context because the caller may belong to
     /// another window; `resolveWorkspaceId` then selects that window's workspace.
@@ -41,7 +35,7 @@ extension CMUXCLI {
         commandArgs: [String],
         client: SocketClient,
         windowOverride: String?
-    ) throws -> WorkspaceNamespaceTarget {
+    ) throws -> (workspaceId: String, windowId: String?, remaining: [String]) {
         let (workspaceOption, argsAfterWorkspace) = parseOption(commandArgs, name: "--workspace")
         let (windowOption, remaining) = parseOption(argsAfterWorkspace, name: "--window")
         let positional = remaining.first { $0 != "--" && !$0.hasPrefix("--") }
@@ -52,11 +46,7 @@ extension CMUXCLI {
             client: client,
             windowOverride: windowOverride
         )
-        return WorkspaceNamespaceTarget(
-            workspaceId: target.workspaceId,
-            windowId: target.windowId,
-            remaining: remaining
-        )
+        return (target.workspaceId, target.windowId, remaining)
     }
 
     func validateWorkspaceLoadingCommandBeforeSocket(

--- a/CLI/WorkspaceLoadingArguments.swift
+++ b/CLI/WorkspaceLoadingArguments.swift
@@ -8,6 +8,57 @@ struct WorkspaceLoadingArguments {
 }
 
 extension CMUXCLI {
+    struct WorkspaceNamespaceTarget {
+        let workspaceId: String
+        let windowId: String?
+        let remaining: [String]
+    }
+
+    /// Single source of truth for commands whose workspace target is optional.
+    /// Explicit windows suppress caller context because the caller may belong to
+    /// another window; `resolveWorkspaceId` then selects that window's workspace.
+    func resolveWorkspaceTarget(
+        workspaceOption: String?,
+        positional: String?,
+        windowOption: String?,
+        client: SocketClient,
+        windowOverride: String?
+    ) throws -> (workspaceId: String, windowId: String?) {
+        let windowId = try normalizeWindowHandle(windowOption ?? windowOverride, client: client)
+        let workspaceId = try resolveWorkspaceId(
+            workspaceOption ?? positional,
+            client: client,
+            windowHandle: windowId
+        )
+        return (workspaceId, windowId)
+    }
+
+    /// Resolve the common target grammar for `cmux workspace <subcommand>`:
+    /// `--workspace`, then a positional handle, then the invoking workspace,
+    /// then the selected workspace. An explicit window suppresses caller context
+    /// and resolves against that window's selection.
+    func resolveWorkspaceNamespaceTarget(
+        commandArgs: [String],
+        client: SocketClient,
+        windowOverride: String?
+    ) throws -> WorkspaceNamespaceTarget {
+        let (workspaceOption, argsAfterWorkspace) = parseOption(commandArgs, name: "--workspace")
+        let (windowOption, remaining) = parseOption(argsAfterWorkspace, name: "--window")
+        let positional = remaining.first { $0 != "--" && !$0.hasPrefix("--") }
+        let target = try resolveWorkspaceTarget(
+            workspaceOption: workspaceOption,
+            positional: positional,
+            windowOption: windowOption,
+            client: client,
+            windowOverride: windowOverride
+        )
+        return WorkspaceNamespaceTarget(
+            workspaceId: target.workspaceId,
+            windowId: target.windowId,
+            remaining: remaining
+        )
+    }
+
     func validateWorkspaceLoadingCommandBeforeSocket(
         command: String,
         commandArgs: [String]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -4374,7 +4374,8 @@ struct CMUXCLI {
                 commandArgs: commandArgs,
                 client: client,
                 jsonOutput: jsonOutput,
-                idFormat: idFormat
+                idFormat: idFormat,
+                windowOverride: windowId
             )
 
         case "workspace":
@@ -7921,7 +7922,8 @@ struct CMUXCLI {
         commandArgs: [String],
         client: SocketClient,
         jsonOutput: Bool,
-        idFormat: CLIIDFormat
+        idFormat: CLIIDFormat,
+        windowOverride: String?
     ) throws {
         guard let sub = commandArgs.first?.lowercased() else {
             throw CLIError(message: "canvas requires a subcommand. Try: info, mode, set-frame, align, reveal, overview, zoom, set-viewport, new-pane")
@@ -7946,7 +7948,7 @@ struct CMUXCLI {
             positional: nil,
             windowOption: nil,
             client: client,
-            windowOverride: nil
+            windowOverride: windowOverride
         )
         var params: [String: Any] = ["workspace_id": workspaceTarget.workspaceId]
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7634,57 +7634,6 @@ struct CMUXCLI {
         return "\(value.prefix(2))••••"
     }
 
-    private struct WorkspaceNamespaceTarget {
-        let workspaceId: String
-        let windowId: String?
-        let remaining: [String]
-    }
-
-    /// Single source of truth for commands whose workspace target is optional.
-    /// Explicit windows suppress caller context because the caller may belong to
-    /// another window; `resolveWorkspaceId` then selects that window's workspace.
-    func resolveWorkspaceTarget(
-        workspaceOption: String?,
-        positional: String?,
-        windowOption: String?,
-        client: SocketClient,
-        windowOverride: String?
-    ) throws -> (workspaceId: String, windowId: String?) {
-        let windowId = try normalizeWindowHandle(windowOption ?? windowOverride, client: client)
-        let workspaceId = try resolveWorkspaceId(
-            workspaceOption ?? positional,
-            client: client,
-            windowHandle: windowId
-        )
-        return (workspaceId, windowId)
-    }
-
-    /// Resolve the common target grammar for `cmux workspace <subcommand>`:
-    /// `--workspace`, then a positional handle, then the invoking workspace,
-    /// then the selected workspace. An explicit window suppresses caller context
-    /// and resolves against that window's selection.
-    private func resolveWorkspaceNamespaceTarget(
-        commandArgs: [String],
-        client: SocketClient,
-        windowOverride: String?
-    ) throws -> WorkspaceNamespaceTarget {
-        let (workspaceOption, argsAfterWorkspace) = parseOption(commandArgs, name: "--workspace")
-        let (windowOption, remaining) = parseOption(argsAfterWorkspace, name: "--window")
-        let positional = remaining.first { $0 != "--" && !$0.hasPrefix("--") }
-        let target = try resolveWorkspaceTarget(
-            workspaceOption: workspaceOption,
-            positional: positional,
-            windowOption: windowOption,
-            client: client,
-            windowOverride: windowOverride
-        )
-        return WorkspaceNamespaceTarget(
-            workspaceId: target.workspaceId,
-            windowId: target.windowId,
-            remaining: remaining
-        )
-    }
-
     /// `cmux workspace env [<handle>] [--mask]` — print a workspace's configured
     /// environment variables (issue #5995). Resolves the positional/`--workspace`
     /// handle, falling back to the caller's workspace and then the selected one.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7634,10 +7634,61 @@ struct CMUXCLI {
         return "\(value.prefix(2))••••"
     }
 
+    private struct WorkspaceNamespaceTarget {
+        let workspaceId: String
+        let windowId: String?
+        let remaining: [String]
+    }
+
+    /// Single source of truth for commands whose workspace target is optional.
+    /// Explicit windows suppress caller context because the caller may belong to
+    /// another window; `resolveWorkspaceId` then selects that window's workspace.
+    func resolveWorkspaceTarget(
+        workspaceOption: String?,
+        positional: String?,
+        windowOption: String?,
+        client: SocketClient,
+        windowOverride: String?
+    ) throws -> (workspaceId: String, windowId: String?) {
+        let windowId = try normalizeWindowHandle(windowOption ?? windowOverride, client: client)
+        let workspaceId = try resolveWorkspaceId(
+            workspaceOption ?? positional,
+            client: client,
+            windowHandle: windowId
+        )
+        return (workspaceId, windowId)
+    }
+
+    /// Resolve the common target grammar for `cmux workspace <subcommand>`:
+    /// `--workspace`, then a positional handle, then the invoking workspace,
+    /// then the selected workspace. An explicit window suppresses caller context
+    /// and resolves against that window's selection.
+    private func resolveWorkspaceNamespaceTarget(
+        commandArgs: [String],
+        client: SocketClient,
+        windowOverride: String?
+    ) throws -> WorkspaceNamespaceTarget {
+        let (workspaceOption, argsAfterWorkspace) = parseOption(commandArgs, name: "--workspace")
+        let (windowOption, remaining) = parseOption(argsAfterWorkspace, name: "--window")
+        let positional = remaining.first { $0 != "--" && !$0.hasPrefix("--") }
+        let target = try resolveWorkspaceTarget(
+            workspaceOption: workspaceOption,
+            positional: positional,
+            windowOption: windowOption,
+            client: client,
+            windowOverride: windowOverride
+        )
+        return WorkspaceNamespaceTarget(
+            workspaceId: target.workspaceId,
+            windowId: target.windowId,
+            remaining: remaining
+        )
+    }
+
     /// `cmux workspace env [<handle>] [--mask]` — print a workspace's configured
     /// environment variables (issue #5995). Resolves the positional/`--workspace`
-    /// handle, falling back to the selected workspace. `--mask` redacts values so
-    /// secrets aren't echoed in full.
+    /// handle, falling back to the caller's workspace and then the selected one.
+    /// `--mask` redacts values so secrets aren't echoed in full.
     private func runWorkspaceEnvCommand(
         commandArgs: [String],
         client: SocketClient,
@@ -7649,9 +7700,12 @@ struct CMUXCLI {
         let mask = rest.contains("--mask")
         rest.removeAll { $0 == "--mask" }
 
-        let (workspaceArg, rem0) = parseOption(rest, name: "--workspace")
-        let (_, rem1) = parseOption(rem0, name: "--window")
-        if let unknown = rem1.first(where: { $0.hasPrefix("--") }) {
+        let target = try resolveWorkspaceNamespaceTarget(
+            commandArgs: rest,
+            client: client,
+            windowOverride: windowOverride
+        )
+        if let unknown = target.remaining.first(where: { $0.hasPrefix("--") }) {
             throw CLIError(message: String(
                 format: String(
                     localized: "cli.workspace.env.error.unknownFlag",
@@ -7661,20 +7715,9 @@ struct CMUXCLI {
                 unknown
             ))
         }
-        let positional = rem1.first(where: { !$0.hasPrefix("--") })
-        let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride)
-        // Match reconnect/disconnect: default to the caller's workspace
-        // ($CMUX_WORKSPACE_ID) before the selected one, but only when no explicit
-        // --window is given (the caller's workspace may live in another window).
-        let target = workspaceArg
-            ?? positional
-            ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-
         var params: [String: Any] = [:]
-        let winId = try normalizeWindowHandle(windowRaw, client: client)
-        if let winId { params["window_id"] = winId }
-        let wsId = try normalizeWorkspaceHandle(target, client: client, windowHandle: winId)
-        if let wsId { params["workspace_id"] = wsId }
+        if let windowId = target.windowId { params["window_id"] = windowId }
+        params["workspace_id"] = target.workspaceId
 
         let payload = try client.sendV2(method: "workspace.env", params: params)
         let rawEnv = (payload["env"] as? [String: Any]) ?? [:]
@@ -7715,27 +7758,32 @@ struct CMUXCLI {
         windowOverride: String?,
         requireWorkspaceFlag: Bool
     ) throws {
-        let target: String?
+        let winId: String?
+        let wsId: String
         if requireWorkspaceFlag {
             guard let workspaceRaw = optionValue(commandArgs, name: "--workspace") else {
                 throw CLIError(message: "\(commandName) requires --workspace")
             }
-            target = workspaceRaw
+            winId = try normalizeWindowHandle(
+                windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride),
+                client: client
+            )
+            wsId = try resolveWorkspaceId(workspaceRaw, client: client, windowHandle: winId)
         } else {
-            let (workspaceArg, rem0) = parseOption(commandArgs, name: "--workspace")
-            let (_, rem1) = parseOption(rem0, name: "--window")
-            target = workspaceArg ?? rem1.first(where: { !$0.hasPrefix("--") })
+            let resolved = try resolveWorkspaceNamespaceTarget(
+                commandArgs: commandArgs,
+                client: client,
+                windowOverride: windowOverride
+            )
+            winId = resolved.windowId
+            wsId = resolved.workspaceId
         }
 
-        var params: [String: Any] = [:]
-        let winId = try normalizeWindowHandle(windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride), client: client)
+        var params: [String: Any] = ["workspace_id": wsId]
         if let winId { params["window_id"] = winId }
-        let wsId = try normalizeWorkspaceHandle(target, client: client, windowHandle: winId)
-        if let wsId { params["workspace_id"] = wsId }
         let payload = try client.sendV2(method: "workspace.close", params: params)
-        if let closedWorkspaceId = (payload["workspace_id"] as? String) ?? wsId {
-            try? tmuxPruneCompatWorkspaceState(workspaceId: closedWorkspaceId)
-        }
+        let closedWorkspaceId = (payload["workspace_id"] as? String) ?? wsId
+        try? tmuxPruneCompatWorkspaceState(workspaceId: closedWorkspaceId)
         printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
     }
 
@@ -7748,30 +7796,29 @@ struct CMUXCLI {
         windowOverride: String?,
         requireWorkspaceFlag: Bool
     ) throws {
-        let target: String?
+        let winId: String?
+        let wsId: String
         if requireWorkspaceFlag {
             guard let workspaceRaw = optionValue(commandArgs, name: "--workspace") else {
                 throw CLIError(message: "\(commandName) requires --workspace")
             }
-            target = workspaceRaw
+            winId = try normalizeWindowHandle(
+                windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride),
+                client: client
+            )
+            wsId = try resolveWorkspaceId(workspaceRaw, client: client, windowHandle: winId)
         } else {
-            let (workspaceArg, rem0) = parseOption(commandArgs, name: "--workspace")
-            let (_, rem1) = parseOption(rem0, name: "--window")
-            target = workspaceArg ?? rem1.first(where: { !$0.hasPrefix("--") })
+            let resolved = try resolveWorkspaceNamespaceTarget(
+                commandArgs: commandArgs,
+                client: client,
+                windowOverride: windowOverride
+            )
+            winId = resolved.windowId
+            wsId = resolved.workspaceId
         }
 
-        var params: [String: Any] = [:]
-        let winId = try normalizeWindowHandle(windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride), client: client)
+        var params: [String: Any] = ["workspace_id": wsId]
         if let winId { params["window_id"] = winId }
-        let wsId = try normalizeWorkspaceHandle(target, client: client, windowHandle: winId)
-        if !requireWorkspaceFlag {
-            guard let wsId else {
-                throw CLIError(message: "\(commandName): could not resolve workspace handle")
-            }
-            params["workspace_id"] = wsId
-        } else if let wsId {
-            params["workspace_id"] = wsId
-        }
         let payload = try client.sendV2(method: "workspace.select", params: params)
         printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: v2OKSummary(payload, idFormat: idFormat, kinds: ["workspace"]))
     }
@@ -7805,19 +7852,17 @@ struct CMUXCLI {
 
         case .namespace:
             let (titleOpt, rem0) = parseOption(commandArgs, name: "--title")
-            let (workspaceArg, rem1) = parseOption(rem0, name: "--workspace")
-            let (_, rem2) = parseOption(rem1, name: "--window")
-            let positional = rem2.first(where: { !$0.hasPrefix("--") })
             guard let titleOpt else {
                 throw CLIError(message: "\(commandName) requires --title <new>")
             }
             title = titleOpt
-            let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride)
-            let target = workspaceArg
-                ?? positional
-                ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-            winId = try normalizeWindowHandle(windowRaw, client: client)
-            wsId = try resolveWorkspaceId(target, client: client, windowHandle: winId)
+            let target = try resolveWorkspaceNamespaceTarget(
+                commandArgs: rem0,
+                client: client,
+                windowOverride: windowOverride
+            )
+            winId = target.windowId
+            wsId = target.workspaceId
         }
 
         var params: [String: Any] = ["title": title, "workspace_id": wsId]
@@ -7947,11 +7992,14 @@ struct CMUXCLI {
             }
         }
 
-        var params: [String: Any] = [:]
-        if let workspaceRaw = optionValue(rest, name: "--workspace"),
-           let wsId = try normalizeWorkspaceHandle(workspaceRaw, client: client) {
-            params["workspace_id"] = wsId
-        }
+        let workspaceTarget = try resolveWorkspaceTarget(
+            workspaceOption: optionValue(rest, name: "--workspace"),
+            positional: nil,
+            windowOption: nil,
+            client: client,
+            windowOverride: nil
+        )
+        var params: [String: Any] = ["workspace_id": workspaceTarget.workspaceId]
 
         func surfaceParam(positional: String?, required: Bool) throws {
             let raw = optionValue(rest, name: "--surface") ?? positional
@@ -8226,23 +8274,13 @@ struct CMUXCLI {
         idFormat: CLIIDFormat,
         windowOverride: String?
     ) throws {
-        let (workspaceArg, rem0) = parseOption(commandArgs, name: "--workspace")
-        let (_, rem1) = parseOption(rem0, name: "--window")
-        let positional = rem1.first(where: { !$0.hasPrefix("--") })
-        let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride)
-        // With an explicit --window and no workspace argument, target that
-        // window's selected workspace on the server instead of the caller's
-        // CMUX_WORKSPACE_ID, which may live in a different window.
-        let target = workspaceArg
-            ?? positional
-            ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
-
-        var params: [String: Any] = [:]
-        let winId = try normalizeWindowHandle(windowRaw, client: client)
-        if let winId { params["window_id"] = winId }
-        if let wsId = try normalizeWorkspaceHandle(target, client: client, windowHandle: winId) {
-            params["workspace_id"] = wsId
-        }
+        let target = try resolveWorkspaceNamespaceTarget(
+            commandArgs: commandArgs,
+            client: client,
+            windowOverride: windowOverride
+        )
+        var params: [String: Any] = ["workspace_id": target.workspaceId]
+        if let windowId = target.windowId { params["window_id"] = windowId }
         let payload = try client.sendV2(method: method, params: params)
         printV2Payload(
             payload,
@@ -15772,16 +15810,16 @@ struct CMUXCLI {
               env [workspace] [--mask]
                                       Print a workspace's configured environment
                                       variables (--mask redacts the values)
-              close <workspace>       Close a workspace
-              rename <workspace> --title <new>
-              select <workspace>      Make a workspace active
+              close [workspace]       Close a workspace
+              rename [workspace] --title <new>
+              select [workspace]      Make a workspace active
               reconnect [workspace]   Reconnect a remote (SSH) workspace, including one
                                       whose automatic reconnect paused because the host
                                       was unreachable
               disconnect [workspace]  Stop a remote (SSH) workspace's connection
               loading <on|off> [--id <name>] Toggle the workspace loading spinner.
               group <subcommand>      Workspace group operations (see cmux workspace-group --help)
-            env/reconnect/disconnect accept a positional handle or --workspace
+            close/rename/select/env/reconnect/disconnect accept a positional handle or --workspace
             <id|ref|index>, defaulting to the caller's workspace, then the
             selected one (of --window's window when given).
             Examples:

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7808,16 +7808,16 @@ struct CMUXCLI {
             let (workspaceArg, rem1) = parseOption(rem0, name: "--workspace")
             let (_, rem2) = parseOption(rem1, name: "--window")
             let positional = rem2.first(where: { !$0.hasPrefix("--") })
-            let target = workspaceArg ?? positional
             guard let titleOpt else {
                 throw CLIError(message: "\(commandName) requires --title <new>")
             }
             title = titleOpt
-            winId = try normalizeWindowHandle(windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride), client: client)
-            guard let normalizedWorkspaceId = try normalizeWorkspaceHandle(target, client: client, windowHandle: winId) else {
-                throw CLIError(message: "\(commandName): could not resolve workspace handle")
-            }
-            wsId = normalizedWorkspaceId
+            let windowRaw = windowFromArgsOrOverride(commandArgs, windowOverride: windowOverride)
+            let target = workspaceArg
+                ?? positional
+                ?? (windowRaw == nil ? ProcessInfo.processInfo.environment["CMUX_WORKSPACE_ID"] : nil)
+            winId = try normalizeWindowHandle(windowRaw, client: client)
+            wsId = try resolveWorkspaceId(target, client: client, windowHandle: winId)
         }
 
         var params: [String: Any] = ["title": title, "workspace_id": wsId]

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -339,6 +339,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		CE7000000000000000000001 /* ClaudeWrapperResumeEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE7000000000000000000002 /* ClaudeWrapperResumeEnvironmentTests.swift */; };
 		A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */; };
 		CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */; };
+		CA11E4D1FA017DE500000B101 /* CLICallerWorkspaceDefaultTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA11E4D1FA017DE500000F102 /* CLICallerWorkspaceDefaultTestSupport.swift */; };
 		C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */; };
 		C0D3F1F10000000000000103 /* CLICodexHookTimeoutRegressionTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F10000000000000104 /* CLICodexHookTimeoutRegressionTestSupport.swift */; };
 		C6711A010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6711B010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift */; };
@@ -2108,6 +2109,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		CE7000000000000000000002 /* ClaudeWrapperResumeEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClaudeWrapperResumeEnvironmentTests.swift; sourceTree = "<group>"; };
 		A5D4120EA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIAuthAliasTests.swift; sourceTree = "<group>"; };
 		CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICallerWorkspaceDefaultTests.swift; sourceTree = "<group>"; };
+		CA11E4D1FA017DE500000F102 /* CLICallerWorkspaceDefaultTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICallerWorkspaceDefaultTestSupport.swift; sourceTree = "<group>"; };
 		C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTests.swift; sourceTree = "<group>"; };
 		C0D3F1F10000000000000104 /* CLICodexHookTimeoutRegressionTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTestSupport.swift; sourceTree = "<group>"; };
 		C6711B010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexWeakEnvironmentRestoreBindingTests.swift; sourceTree = "<group>"; };
@@ -5014,6 +5016,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					773600000000000000000002 /* CLIWindowCommandMockServer.swift */,
 					773600000000000000000004 /* CLIWindowHandleRoutingTests.swift */,
 					CA11E4D0FA017DE500000F102 /* CLICallerWorkspaceDefaultTests.swift */,
+					CA11E4D1FA017DE500000F102 /* CLICallerWorkspaceDefaultTestSupport.swift */,
 					C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */,
 					C0DE64950000000000000006 /* CMUXCLISessionsListTests.swift */,
 					C0DE6495000000000000000A /* CMUXCLISessionsListForkDiagnosticsTests.swift */,
@@ -6938,6 +6941,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CE7000000000000000000001 /* ClaudeWrapperResumeEnvironmentTests.swift in Sources */,
 				A5D4120DA1B2C3D4E5F60718 /* CLIAuthAliasTests.swift in Sources */,
 					CA11E4D0FA017DE500000B101 /* CLICallerWorkspaceDefaultTests.swift in Sources */,
+					CA11E4D1FA017DE500000B101 /* CLICallerWorkspaceDefaultTestSupport.swift in Sources */,
 				C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */,
 				C0D3F1F10000000000000103 /* CLICodexHookTimeoutRegressionTestSupport.swift in Sources */,
 				C6711A010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift in Sources */,

--- a/cmuxTests/CLICallerWorkspaceDefaultTestSupport.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTestSupport.swift
@@ -1,0 +1,179 @@
+import Darwin
+import Foundation
+
+extension CLICallerWorkspaceDefaultTests {
+    static func bundledCLIPath() throws -> String {
+        try BundledCLITestSupport.bundledCLIPath(for: CLICallerWorkspaceDefaultBundleToken.self)
+    }
+
+    static func makeSocketPath(_ name: String) -> String {
+        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
+        return URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("cli-\(name.prefix(6))-\(shortID).sock")
+            .path
+    }
+
+    static func bindUnixSocket(at path: String) throws -> Int32 {
+        unlink(path)
+        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
+        guard fd >= 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        var addr = sockaddr_un()
+        addr.sun_family = sa_family_t(AF_UNIX)
+        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
+        let utf8 = Array(path.utf8)
+        guard utf8.count < maxPathLength else {
+            Darwin.close(fd)
+            throw NSError(domain: "cmux.tests", code: Int(ENAMETOOLONG), userInfo: [
+                NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)",
+            ])
+        }
+        withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
+            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
+                for index in 0..<utf8.count {
+                    buffer[index] = CChar(bitPattern: utf8[index])
+                }
+                buffer[utf8.count] = 0
+            }
+        }
+
+        let bindResult = withUnsafePointer(to: &addr) { pointer in
+            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
+            }
+        }
+        guard bindResult == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard Darwin.listen(fd, 1) == 0 else {
+            Darwin.close(fd)
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        return fd
+    }
+
+    static func startMockServer(
+        listenerFD: Int32,
+        state: ServerState,
+        handler: @escaping @Sendable (String) -> String
+    ) -> DispatchSemaphore {
+        let handled = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            defer { handled.signal() }
+
+            var clientAddr = sockaddr_un()
+            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
+            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { pointer in
+                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
+                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
+                }
+            }
+            guard clientFD >= 0 else {
+                state.recordError("mock socket server failed to accept a client")
+                return
+            }
+            defer { Darwin.close(clientFD) }
+
+            var pending = Data()
+            var buffer = [UInt8](repeating: 0, count: 4096)
+            while true {
+                let count = Darwin.read(clientFD, &buffer, buffer.count)
+                if count < 0 {
+                    if errno == EINTR { continue }
+                    state.recordError("mock socket server read failed with errno \(errno)")
+                    return
+                }
+                if count == 0 { return }
+                pending.append(buffer, count: count)
+
+                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
+                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
+                    pending.removeSubrange(0...newlineRange.lowerBound)
+                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
+                    state.record(line)
+                    let response = handler(line) + "\n"
+                    _ = response.withCString { pointer in
+                        Darwin.write(clientFD, pointer, strlen(pointer))
+                    }
+                }
+            }
+        }
+        return handled
+    }
+
+    static func v2Response(
+        id: String,
+        ok: Bool,
+        result: [String: Any]? = nil,
+        error: [String: Any]? = nil
+    ) -> String {
+        var payload: [String: Any] = ["id": id, "ok": ok]
+        if let result { payload["result"] = result }
+        if let error { payload["error"] = error }
+        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
+        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
+    }
+
+    static func malformedRequestResponse(id: String? = nil, raw: String) -> String {
+        v2Response(
+            id: id ?? "unknown",
+            ok: false,
+            error: ["code": "malformed_request", "message": "invalid or non-JSON payload", "raw": raw]
+        )
+    }
+
+    static func jsonObject(_ line: String) -> [String: Any]? {
+        guard let data = line.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
+    }
+
+    static func runProcess(
+        executablePath: String,
+        arguments: [String],
+        environment: [String: String],
+        timeout: TimeInterval
+    ) -> ProcessRunResult {
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: executablePath)
+        process.arguments = arguments
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            return ProcessRunResult(status: -1, stdout: "", stderr: String(describing: error), timedOut: false)
+        }
+
+        let exitSignal = DispatchSemaphore(value: 0)
+        DispatchQueue.global(qos: .userInitiated).async {
+            process.waitUntilExit()
+            exitSignal.signal()
+        }
+
+        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exitSignal.wait(timeout: .now() + 1)
+            }
+        }
+
+        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        return ProcessRunResult(
+            status: process.isRunning ? SIGKILL : process.terminationStatus,
+            stdout: stdout,
+            stderr: stderr,
+            timedOut: timedOut
+        )
+    }
+}

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -45,6 +45,27 @@ struct CLICallerWorkspaceDefaultTests {
         }
     }
 
+    /// An explicit window changes the defaulting scope: the caller workspace may
+    /// belong to another window, so the target must be that window's selection.
+    @Test func workspaceNamespaceExplicitWindowDefaultsWithinThatWindow() throws {
+        let windowId = "77777777-7777-7777-7777-777777777777"
+        let (requests, result) = try runWorkspaceNamespaceCommand(
+            arguments: ["workspace", "rename", "--window", windowId, "--title", "renamed"],
+            expectedMethod: "workspace.rename",
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: Self.callerWorkspaceId
+        )
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(methods == ["workspace.current", "workspace.rename"])
+        let currentParams = try #require(requests.first?["params"] as? [String: Any])
+        #expect(currentParams["window_id"] as? String == windowId)
+        let renameParams = try #require(requests.last?["params"] as? [String: Any])
+        #expect(renameParams["window_id"] as? String == windowId)
+        #expect(renameParams["workspace_id"] as? String == Self.focusedWorkspaceId)
+    }
+
     /// A blank `--workspace` from a caller pane must target the caller's workspace and
     /// must never consult `workspace.current` (the focused workspace).
     @Test func blankWorkspaceArgDefaultsToCallerWorkspace() throws {

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -66,6 +66,42 @@ struct CLICallerWorkspaceDefaultTests {
         #expect(renameParams["workspace_id"] as? String == Self.focusedWorkspaceId)
     }
 
+    /// A global window override must reach canvas commands just like a namespace-local
+    /// `--window`, instead of being discarded and leaving canvas scoped to the caller.
+    @Test func canvasGlobalWindowDefaultsWithinThatWindow() throws {
+        let windowId = "77777777-7777-7777-7777-777777777777"
+        let (requests, result) = try runWorkspaceNamespaceCommand(
+            arguments: ["--window", windowId, "canvas", "info"],
+            expectedMethod: "canvas.info",
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: Self.callerWorkspaceId
+        )
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(methods == ["workspace.current", "canvas.info"])
+        let currentParams = try #require(requests.first?["params"] as? [String: Any])
+        #expect(currentParams["window_id"] as? String == windowId)
+        let canvasParams = try #require(requests.last?["params"] as? [String: Any])
+        #expect(canvasParams["workspace_id"] as? String == Self.focusedWorkspaceId)
+    }
+
+    /// A malformed injected caller ID must fail closed rather than being treated as
+    /// absent and silently redirecting a mutating command to the focused workspace.
+    @Test func malformedCallerWorkspaceFailsClosed() throws {
+        let (requests, result) = try runWorkspaceNamespaceCommand(
+            arguments: ["workspace", "rename", "--title", "renamed"],
+            expectedMethod: "workspace.rename",
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: "malformed-caller-workspace"
+        )
+
+        #expect(result.status != 0, Comment(rawValue: "expected nonzero exit, got \(result.status)"))
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(!methods.contains("workspace.current"), Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("workspace.rename"), Comment(rawValue: methods.joined(separator: ",")))
+    }
+
     /// A blank `--workspace` from a caller pane must target the caller's workspace and
     /// must never consult `workspace.current` (the focused workspace).
     @Test func blankWorkspaceArgDefaultsToCallerWorkspace() throws {

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -16,7 +16,7 @@ import Testing
 struct CLICallerWorkspaceDefaultTests {
     /// Every noun-style workspace command that permits an omitted target must use
     /// the invoking terminal's workspace instead of global foreground selection.
-    @Test func workspaceNamespaceCommandsDefaultToCallerWorkspace() throws {
+    @Test func workspaceScopedNamespaceCommandsDefaultToCallerWorkspace() throws {
         let cases: [(arguments: [String], method: String)] = [
             (["workspace", "env"], "workspace.env"),
             (["workspace", "close"], "workspace.close"),
@@ -24,6 +24,7 @@ struct CLICallerWorkspaceDefaultTests {
             (["workspace", "rename", "--title", "renamed"], "workspace.rename"),
             (["workspace", "reconnect"], "workspace.remote.reconnect"),
             (["workspace", "disconnect"], "workspace.remote.disconnect"),
+            (["canvas", "info"], "canvas.info"),
         ]
 
         for testCase in cases {

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -14,22 +14,34 @@ import Testing
 /// visible workspace rather than the agent's own.
 @Suite(.serialized)
 struct CLICallerWorkspaceDefaultTests {
-    /// `workspace rename --title` omits the target by design. It must rename the
-    /// invoking terminal's workspace, matching the legacy `rename-workspace` alias.
-    @Test func workspaceRenameWithoutTargetDefaultsToCallerWorkspace() throws {
-        let (requests, result) = try runWorkspaceRename(
-            focusedWorkspaceId: Self.focusedWorkspaceId,
-            callerWorkspaceId: Self.callerWorkspaceId
-        )
-        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+    /// Every noun-style workspace command that permits an omitted target must use
+    /// the invoking terminal's workspace instead of global foreground selection.
+    @Test func workspaceNamespaceCommandsDefaultToCallerWorkspace() throws {
+        let cases: [(arguments: [String], method: String)] = [
+            (["workspace", "env"], "workspace.env"),
+            (["workspace", "close"], "workspace.close"),
+            (["workspace", "select"], "workspace.select"),
+            (["workspace", "rename", "--title", "renamed"], "workspace.rename"),
+            (["workspace", "reconnect"], "workspace.remote.reconnect"),
+            (["workspace", "disconnect"], "workspace.remote.disconnect"),
+        ]
 
-        let methods = requests.compactMap { $0["method"] as? String }
-        #expect(methods == ["workspace.rename"], Comment(rawValue: methods.joined(separator: ",")))
-        #expect(!methods.contains("workspace.current"))
+        for testCase in cases {
+            let (requests, result) = try runWorkspaceNamespaceCommand(
+                arguments: testCase.arguments,
+                expectedMethod: testCase.method,
+                focusedWorkspaceId: Self.focusedWorkspaceId,
+                callerWorkspaceId: Self.callerWorkspaceId
+            )
+            #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
 
-        let params = try #require(requests.first?["params"] as? [String: Any])
-        #expect(params["workspace_id"] as? String == Self.callerWorkspaceId)
-        #expect(params["title"] as? String == "renamed")
+            let methods = requests.compactMap { $0["method"] as? String }
+            #expect(methods == [testCase.method], Comment(rawValue: methods.joined(separator: ",")))
+            #expect(!methods.contains("workspace.current"))
+
+            let params = try #require(requests.first?["params"] as? [String: Any])
+            #expect(params["workspace_id"] as? String == Self.callerWorkspaceId)
+        }
     }
 
     /// A blank `--workspace` from a caller pane must target the caller's workspace and
@@ -152,7 +164,9 @@ struct CLICallerWorkspaceDefaultTests {
         return (try state.requestObjects(), result)
     }
 
-    private func runWorkspaceRename(
+    private func runWorkspaceNamespaceCommand(
+        arguments: [String],
+        expectedMethod: String,
         focusedWorkspaceId: String,
         callerWorkspaceId: String
     ) throws -> ([[String: Any]], ProcessRunResult) {
@@ -173,8 +187,12 @@ struct CLICallerWorkspaceDefaultTests {
             switch method {
             case "workspace.current":
                 return Self.v2Response(id: id, ok: true, result: ["workspace_id": focusedWorkspaceId])
-            case "workspace.rename":
-                return Self.v2Response(id: id, ok: true, result: ["workspace_id": callerWorkspaceId])
+            case expectedMethod:
+                return Self.v2Response(
+                    id: id,
+                    ok: true,
+                    result: ["workspace_id": callerWorkspaceId, "env": [String: String]()]
+                )
             default:
                 return Self.v2Response(
                     id: id,
@@ -186,7 +204,7 @@ struct CLICallerWorkspaceDefaultTests {
 
         let result = Self.runProcess(
             executablePath: try Self.bundledCLIPath(),
-            arguments: ["workspace", "rename", "--title", "renamed"],
+            arguments: arguments,
             environment: cliEnvironment(socketPath: socketPath, callerWorkspaceId: callerWorkspaceId),
             timeout: 5
         )

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -296,10 +296,10 @@ struct CLICallerWorkspaceDefaultTests {
     private static let focusedWorkspaceId = "99999999-9999-9999-9999-999999999999"
     private static let otherWorkspaceId = "44444444-4444-4444-4444-444444444444"
 
-    private final class CLICallerWorkspaceDefaultBundleToken {}
+    final class CLICallerWorkspaceDefaultBundleToken {}
 
     // Records socket callbacks from a background queue; `lock` guards both arrays.
-    private final class ServerState: @unchecked Sendable {
+    final class ServerState: @unchecked Sendable {
         private let lock = NSLock()
         private var requestLines: [String] = []
         private var errors: [String] = []
@@ -332,185 +332,11 @@ struct CLICallerWorkspaceDefaultTests {
         }
     }
 
-    private struct ProcessRunResult {
+    struct ProcessRunResult {
         let status: Int32
         let stdout: String
         let stderr: String
         let timedOut: Bool
     }
 
-    private static func bundledCLIPath() throws -> String {
-        try BundledCLITestSupport.bundledCLIPath(for: CLICallerWorkspaceDefaultBundleToken.self)
-    }
-
-    private static func makeSocketPath(_ name: String) -> String {
-        let shortID = UUID().uuidString.replacingOccurrences(of: "-", with: "").prefix(8)
-        return URL(fileURLWithPath: NSTemporaryDirectory())
-            .appendingPathComponent("cli-\(name.prefix(6))-\(shortID).sock")
-            .path
-    }
-
-    private static func bindUnixSocket(at path: String) throws -> Int32 {
-        unlink(path)
-        let fd = Darwin.socket(AF_UNIX, SOCK_STREAM, 0)
-        guard fd >= 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-
-        var addr = sockaddr_un()
-        addr.sun_family = sa_family_t(AF_UNIX)
-        let maxPathLength = MemoryLayout.size(ofValue: addr.sun_path)
-        let utf8 = Array(path.utf8)
-        guard utf8.count < maxPathLength else {
-            Darwin.close(fd)
-            throw NSError(domain: "cmux.tests", code: Int(ENAMETOOLONG), userInfo: [
-                NSLocalizedDescriptionKey: "Unix socket path is too long: \(path)",
-            ])
-        }
-        withUnsafeMutablePointer(to: &addr.sun_path) { pointer in
-            pointer.withMemoryRebound(to: CChar.self, capacity: maxPathLength) { buffer in
-                for index in 0..<utf8.count {
-                    buffer[index] = CChar(bitPattern: utf8[index])
-                }
-                buffer[utf8.count] = 0
-            }
-        }
-
-        let bindResult = withUnsafePointer(to: &addr) { pointer in
-            pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                Darwin.bind(fd, sockaddrPtr, socklen_t(MemoryLayout<sockaddr_un>.size))
-            }
-        }
-        guard bindResult == 0 else {
-            Darwin.close(fd)
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-        guard Darwin.listen(fd, 1) == 0 else {
-            Darwin.close(fd)
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
-        }
-        return fd
-    }
-
-    private static func startMockServer(
-        listenerFD: Int32,
-        state: ServerState,
-        handler: @escaping @Sendable (String) -> String
-    ) -> DispatchSemaphore {
-        let handled = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            defer { handled.signal() }
-
-            var clientAddr = sockaddr_un()
-            var clientAddrLen = socklen_t(MemoryLayout<sockaddr_un>.size)
-            let clientFD = withUnsafeMutablePointer(to: &clientAddr) { pointer in
-                pointer.withMemoryRebound(to: sockaddr.self, capacity: 1) { sockaddrPtr in
-                    Darwin.accept(listenerFD, sockaddrPtr, &clientAddrLen)
-                }
-            }
-            guard clientFD >= 0 else {
-                state.recordError("mock socket server failed to accept a client")
-                return
-            }
-            defer { Darwin.close(clientFD) }
-
-            var pending = Data()
-            var buffer = [UInt8](repeating: 0, count: 4096)
-            while true {
-                let count = Darwin.read(clientFD, &buffer, buffer.count)
-                if count < 0 {
-                    if errno == EINTR { continue }
-                    state.recordError("mock socket server read failed with errno \(errno)")
-                    return
-                }
-                if count == 0 { return }
-                pending.append(buffer, count: count)
-
-                while let newlineRange = pending.firstRange(of: Data([0x0A])) {
-                    let lineData = pending.subdata(in: 0..<newlineRange.lowerBound)
-                    pending.removeSubrange(0...newlineRange.lowerBound)
-                    guard let line = String(data: lineData, encoding: .utf8) else { continue }
-                    state.record(line)
-                    let response = handler(line) + "\n"
-                    _ = response.withCString { pointer in
-                        Darwin.write(clientFD, pointer, strlen(pointer))
-                    }
-                }
-            }
-        }
-        return handled
-    }
-
-    private static func v2Response(
-        id: String,
-        ok: Bool,
-        result: [String: Any]? = nil,
-        error: [String: Any]? = nil
-    ) -> String {
-        var payload: [String: Any] = ["id": id, "ok": ok]
-        if let result { payload["result"] = result }
-        if let error { payload["error"] = error }
-        let data = try? JSONSerialization.data(withJSONObject: payload, options: [])
-        return String(data: data ?? Data("{}".utf8), encoding: .utf8) ?? "{}"
-    }
-
-    private static func malformedRequestResponse(id: String? = nil, raw: String) -> String {
-        v2Response(
-            id: id ?? "unknown",
-            ok: false,
-            error: ["code": "malformed_request", "message": "invalid or non-JSON payload", "raw": raw]
-        )
-    }
-
-    private static func jsonObject(_ line: String) -> [String: Any]? {
-        guard let data = line.data(using: .utf8) else { return nil }
-        return try? JSONSerialization.jsonObject(with: data, options: []) as? [String: Any]
-    }
-
-    private static func runProcess(
-        executablePath: String,
-        arguments: [String],
-        environment: [String: String],
-        timeout: TimeInterval
-    ) -> ProcessRunResult {
-        let process = Process()
-        let stdoutPipe = Pipe()
-        let stderrPipe = Pipe()
-        process.executableURL = URL(fileURLWithPath: executablePath)
-        process.arguments = arguments
-        process.environment = environment
-        process.standardInput = FileHandle.nullDevice
-        process.standardOutput = stdoutPipe
-        process.standardError = stderrPipe
-
-        do {
-            try process.run()
-        } catch {
-            return ProcessRunResult(status: -1, stdout: "", stderr: String(describing: error), timedOut: false)
-        }
-
-        let exitSignal = DispatchSemaphore(value: 0)
-        DispatchQueue.global(qos: .userInitiated).async {
-            process.waitUntilExit()
-            exitSignal.signal()
-        }
-
-        let timedOut = exitSignal.wait(timeout: .now() + timeout) == .timedOut
-        if timedOut {
-            process.terminate()
-            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
-                kill(process.processIdentifier, SIGKILL)
-                _ = exitSignal.wait(timeout: .now() + 1)
-            }
-        }
-
-        let stdout = String(data: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        let stderr = String(data: stderrPipe.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
-        return ProcessRunResult(
-            status: process.isRunning ? SIGKILL : process.terminationStatus,
-            stdout: stdout,
-            stderr: stderr,
-            timedOut: timedOut
-        )
-    }
 }

--- a/cmuxTests/CLICallerWorkspaceDefaultTests.swift
+++ b/cmuxTests/CLICallerWorkspaceDefaultTests.swift
@@ -14,6 +14,24 @@ import Testing
 /// visible workspace rather than the agent's own.
 @Suite(.serialized)
 struct CLICallerWorkspaceDefaultTests {
+    /// `workspace rename --title` omits the target by design. It must rename the
+    /// invoking terminal's workspace, matching the legacy `rename-workspace` alias.
+    @Test func workspaceRenameWithoutTargetDefaultsToCallerWorkspace() throws {
+        let (requests, result) = try runWorkspaceRename(
+            focusedWorkspaceId: Self.focusedWorkspaceId,
+            callerWorkspaceId: Self.callerWorkspaceId
+        )
+        #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+
+        let methods = requests.compactMap { $0["method"] as? String }
+        #expect(methods == ["workspace.rename"], Comment(rawValue: methods.joined(separator: ",")))
+        #expect(!methods.contains("workspace.current"))
+
+        let params = try #require(requests.first?["params"] as? [String: Any])
+        #expect(params["workspace_id"] as? String == Self.callerWorkspaceId)
+        #expect(params["title"] as? String == "renamed")
+    }
+
     /// A blank `--workspace` from a caller pane must target the caller's workspace and
     /// must never consult `workspace.current` (the focused workspace).
     @Test func blankWorkspaceArgDefaultsToCallerWorkspace() throws {
@@ -123,6 +141,52 @@ struct CLICallerWorkspaceDefaultTests {
         let result = Self.runProcess(
             executablePath: try Self.bundledCLIPath(),
             arguments: ["mark-notification-read", "--workspace", workspaceArgument],
+            environment: cliEnvironment(socketPath: socketPath, callerWorkspaceId: callerWorkspaceId),
+            timeout: 5
+        )
+
+        #expect(handled.wait(timeout: .now() + 5) == .success)
+        #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
+        #expect(!result.timedOut, Comment(rawValue: result.stderr))
+
+        return (try state.requestObjects(), result)
+    }
+
+    private func runWorkspaceRename(
+        focusedWorkspaceId: String,
+        callerWorkspaceId: String
+    ) throws -> ([[String: Any]], ProcessRunResult) {
+        let socketPath = Self.makeSocketPath("rename-ws")
+        let listenerFD = try Self.bindUnixSocket(at: socketPath)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+        }
+
+        let state = ServerState()
+        let handled = Self.startMockServer(listenerFD: listenerFD, state: state) { line in
+            guard let payload = Self.jsonObject(line),
+                  let id = payload["id"] as? String,
+                  let method = payload["method"] as? String else {
+                return Self.malformedRequestResponse(raw: line)
+            }
+            switch method {
+            case "workspace.current":
+                return Self.v2Response(id: id, ok: true, result: ["workspace_id": focusedWorkspaceId])
+            case "workspace.rename":
+                return Self.v2Response(id: id, ok: true, result: ["workspace_id": callerWorkspaceId])
+            default:
+                return Self.v2Response(
+                    id: id,
+                    ok: false,
+                    error: ["code": "unexpected_method", "message": method]
+                )
+            }
+        }
+
+        let result = Self.runProcess(
+            executablePath: try Self.bundledCLIPath(),
+            arguments: ["workspace", "rename", "--title", "renamed"],
             environment: cliEnvironment(socketPath: socketPath, callerWorkspaceId: callerWorkspaceId),
             timeout: 5
         )


### PR DESCRIPTION
## Summary
- Centralize optional workspace target resolution for noun-style CLI commands.
- Default workspace and canvas operations to the invoking workspace, then the selected workspace.
- Preserve explicit workspace and explicit-window precedence.
- Document optional targets in every supported CLI help locale.

## Testing
- `xcrun swiftc -frontend -parse CLI/cmux.swift CLI/WorkspaceLoadingArguments.swift`
- `jq empty Resources/Localizable.xcstrings`
- Blacksmith tagged build: https://github.com/manaflow-ai/cmux/actions/runs/29134776978
- Tagged preflight `wsrnm`: rename/env/select/canvas/loading passed inside caller workspace; no-target close closed a temporary caller workspace and preserved the original.
- Focused fleet XCTest was blocked before Xcode because the selected host lacks Zig; PR CI owns automated tests.

## Issues
- Related: user-reported CLI target-resolution inconsistency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default targeting for mutating workspace/canvas CLI commands when no handle is given, which fixes agent-pane misrouting but alters behavior for scripts that relied on the focused workspace.
> 
> **Overview**
> Introduces **`resolveWorkspaceTarget`** and **`resolveWorkspaceNamespaceTarget`** as the shared resolution path for noun-style commands: **`--workspace`**, then a positional handle, then **`CMUX_WORKSPACE_ID`**, then the selected workspace. When **`--window`** (or a global window override) is set, caller workspace context is skipped so the target is that window's selection.
> 
> **`cmux workspace`** subcommands (**env**, **close**, **select**, **rename**, **reconnect**, **disconnect**) and **`workspace loading`** are wired through these helpers instead of duplicated parsing. **`cmux canvas`** now receives **`windowOverride`** from the top-level router and always sends a resolved **`workspace_id`**. Help strings in **`Localizable.xcstrings`** mark **close** / **rename** / **select** workspace arguments as optional and document the shared defaulting rules.
> 
> Regression coverage adds integration tests for caller-default behavior, explicit-window scoping (including global **`--window`** before **canvas**), and fail-closed behavior for malformed caller IDs; mock-server helpers move to **`CLICallerWorkspaceDefaultTestSupport.swift`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3fe5a8aecc7427090e352b290f79287b100d76cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Workspace-scoped CLI commands can omit the workspace identifier and now default to the caller workspace context.
  - Improved, consistent workspace/window scoping for namespace actions like **close**, **select**, and **rename**.
- **Bug Fixes**
  - Fixed request targeting when **--window** is provided, ensuring the correct workspace/window is used.
  - Stricter handling of unknown flags and more reliable workspace/window resolution.
- **Documentation**
  - Updated localized CLI help to show workspace as optional (`[workspace]`) for relevant subcommands and to clarify accepted argument formats.
- **Tests**
  - Added regression tests covering default caller-workspace behavior, **--window** scoping, and failure handling with malformed data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->