### PR TITLE
Fix workspace sidebar scroll CPU livelock

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12363,6 +12363,7 @@ struct VerticalTabsSidebar: View {
             unreadCount: liveUnreadCount,
             latestNotificationText: liveLatestNotificationText,
             showsAgentActivity: renderContext.showsAgentActivity,
+            isActive: tabManager.selectedTabId == tab.id,
             rowSpacing: tabRowSpacing,
             setSelectionToTabs: { selection = .tabs },
             selectedTabIds: $selectedTabIds,
@@ -13203,6 +13204,7 @@ struct TabItemView: View, Equatable {
         lhs.unreadCount == rhs.unreadCount &&
         lhs.latestNotificationText == rhs.latestNotificationText &&
         lhs.showsAgentActivity == rhs.showsAgentActivity &&
+        lhs.isActive == rhs.isActive &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
@@ -13248,6 +13250,7 @@ struct TabItemView: View, Equatable {
     let unreadCount: Int
     let latestNotificationText: String?
     let showsAgentActivity: Bool
+    let isActive: Bool
     let rowSpacing: CGFloat
     let setSelectionToTabs: () -> Void
     @Binding var selectedTabIds: Set<UUID>
@@ -13284,15 +13287,13 @@ struct TabItemView: View, Equatable {
     @State private var workspaceSnapshotStorage: SidebarWorkspaceSnapshotBuilder.Snapshot?
     // Fallback memo for the `workspaceSnapshot` getter: a plain box, not
     // observed state, so body evaluations can fill it without invalidating the
-    // row. Before onAppear seeds workspaceSnapshotStorage, every access used to
-    // rebuild the snapshot (a full bonsplit tree walk) — several times per
-    // mounted row per scroll.
+    // row. It also remains the initial snapshot source until a real observation
+    // update arrives, avoiding an @State write while LazyVStack is mounting and
+    // estimating a newly visible row.
     final class WorkspaceSnapshotScratch {
         var value: SidebarWorkspaceSnapshotBuilder.Snapshot?
     }
     @State private var workspaceSnapshotScratch = WorkspaceSnapshotScratch()
-    // Row-local selection projection: selectedTabId changes update only rows whose boolean flips.
-    @State private var observedIsActive: Bool?
     @State private var contextMenuState = SidebarTabItemContextMenuState()
     @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
     @State var workspaceFinderDirectoryOpenRequest: WorkspaceFinderDirectoryOpenRequest?
@@ -13360,10 +13361,6 @@ struct TabItemView: View, Equatable {
 
     private var activeTabIndicatorStyle: WorkspaceIndicatorStyle {
         settings.activeTabIndicatorStyle
-    }
-
-    private var isActive: Bool {
-        observedIsActive ?? (tabManager.selectedTabId == tab.id)
     }
 
     private var sidebarSelectionColorHex: String? {
@@ -14059,17 +14056,6 @@ struct TabItemView: View, Equatable {
                 isBottomEdge: true
             )
         }
-        .onAppear {
-            updateObservedActiveState(tabManager.selectedTabId == tab.id)
-            refreshWorkspaceSnapshot(force: true)
-        }
-        .onReceive(
-            tabManager.selectedTabIdPublisher
-                .map { $0 == tab.id }
-                .removeDuplicates()
-        ) { isSelected in
-            updateObservedActiveState(isSelected)
-        }
         .task(id: workspaceFinderDirectoryOpenRequest) {
             guard let request = workspaceFinderDirectoryOpenRequest else { return }
             await WorkspaceFinderDirectoryOpener.openInFinder(request.directoryURL)
@@ -14171,11 +14157,6 @@ struct TabItemView: View, Equatable {
         renameDraft = workspaceSnapshot.title
         renameBaselineHadUserCustomTitle = tab.effectiveCustomTitleSource == .user
         isEditing = true
-    }
-
-    private func updateObservedActiveState(_ isActive: Bool) {
-        guard observedIsActive != isActive else { return }
-        observedIsActive = isActive
     }
 
     func refreshWorkspaceSnapshot(force: Bool = false) {

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -42,8 +42,8 @@ final class SidebarLazyLayoutScaleTests {
         var workspaceSnapshotBuilds = 0
         // Snapshot builds bracketed by workspaceRowBody/workspaceRowBodyEnd,
         // i.e. synchronous work inside a single TabItemView.body evaluation.
-        // Builds outside the bracket (onAppear refresh, observation publishers)
-        // are legitimate and not counted here.
+        // Builds outside the bracket (observation publishers) are legitimate
+        // and not counted here.
         var insideWorkspaceRowBody = false
         var snapshotBuildsInCurrentRowBody = 0
         var maxSnapshotBuildsInOneRowBody = 0
@@ -265,12 +265,11 @@ final class SidebarLazyLayoutScaleTests {
 
     /// One TabItemView.body evaluation must build the workspace snapshot at
     /// most once. The snapshot is a full per-workspace projection (bonsplit
-    /// tree walk, git branch summaries, PR rows); until `onAppear` seeds
-    /// `workspaceSnapshotStorage`, every `workspaceSnapshot` access in the
-    /// first body evaluation used to rebuild it from scratch, so each row a
-    /// scroll mounts paid the walk several times over. Builds outside body
-    /// evaluations (onAppear refresh, observation publishers) are legitimate
-    /// and excluded by the probe bracket.
+    /// tree walk, git branch summaries, PR rows). Every `workspaceSnapshot`
+    /// access in the first body evaluation used to rebuild it from scratch, so
+    /// each row a scroll mounts paid the walk several times over. Builds
+    /// outside body evaluations from observation publishers are legitimate and
+    /// excluded by the probe bracket.
     @Test
     @MainActor
     func testRowBodyEvaluationBuildsWorkspaceSnapshotAtMostOnce() async throws {
@@ -289,8 +288,8 @@ final class SidebarLazyLayoutScaleTests {
             """
             A single TabItemView.body evaluation built the workspace snapshot \(worstBody) \
             times. The snapshot fallback in the `workspaceSnapshot` getter must memoize \
-            within a body evaluation; N accesses before onAppear seeds storage must not \
-            mean N bonsplit tree walks per mounted row.
+            within a body evaluation; N accesses before observation-backed storage is \
+            seeded must not mean N bonsplit tree walks per mounted row.
             """
         )
     }


### PR DESCRIPTION
## Summary

- What changed?
  - Kept the workspace sidebar's `LazyVStack` virtualization contract.
  - Removed the two row-local `@State` writes that ran from `TabItemView.onAppear` while the lazy stack was mounting and estimating newly visible rows.
  - Passed the active-selection projection into each row as immutable input and included it in the row's `Equatable` boundary.
  - Kept the non-observable snapshot scratch as the initial snapshot source until a real observation update arrives.
- Why?
  - The freeze was reproduced with a 30-workspace session in both a signed nightly and a current-source tagged build. Both reached sustained ~99% CPU after roughly two down/up scroll cycles.
  - Main-thread samples were dominated by `GraphHost.flushTransactions`, `LazyStack.measureEstimates`, `LazySubviewPlacements`, `ForEachState`, and row mounting. The 300-workspace harness also emitted SwiftUI's "Modifying state during view update" warning for the row mount writes.
  - Replacing `LazyVStack` with an eager stack is not safe: historical regressions and the scale suite require only viewport rows to be realized, because force-realizing 50–300 workspace rows creates O(N) layout work and can livelock the sidebar.

## Testing

- How did you test this change?
  - Built and exercised the three production `SidebarLazyLayoutScaleTests`; the xcresult recorded all three passing, including the 300-workspace viewport-realization, snapshot-build, and unread-storm convergence gates. The unchanged deliberately divergent geometry canary still crashes the test host on macOS 26.5.2, so the aggregate invocation exits 65 after those passes.
  - Ran 31 tests in `SidebarWorkspaceSnapshotRefreshPolicyTests`, `SidebarSelectedWorkspaceScrollPolicyTests`, and `SidebarWorkspaceRowInteractionStateTests`; all passed.
  - `scripts/check-sidebar-lazy-layout.py`
  - `python3 tests/test_ci_sidebar_lazy_layout_guard.py`
  - `scripts/check-pbxproj.sh`
  - `scripts/lint-pbxproj-test-wiring.sh`
  - `tests/test_ci_pbxproj_test_wiring.sh`
  - `git diff --check`
- What did you verify manually?
  - Built an isolated tagged app with `CMUX_SKIP_ZIG_BUILD=1 DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer ./scripts/reload.sh --tag scrollcpu`.
  - Restored the same 30-workspace session and drove the workspace sidebar down/up for five full cycles, then explicitly verified workspace 30 at the bottom and workspace 1 after returning to the top.
  - The app stayed responsive. Its PID peaked around 27% CPU during scrolling and repeatedly settled to single digits, instead of remaining at ~99% as it did before the fix.

## Demo Video

For UI or behavior changes, include a short demo video (GitHub upload, Loom, or other direct link).

- Video URL or attachment: N/A — verified with automated accessibility scrolling against the isolated tagged app while sampling only its process CPU.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar selection state handling for more reliable active-tab highlighting.
  * Reduced unnecessary workspace refreshes during sidebar layout and visibility estimation.
* **Tests**
  * Clarified validation for workspace snapshot reuse and excluded legitimate background snapshot builds from test counters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->