### PR TITLE
Defer theme-frame portal installation past SwiftUI layout

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8841,7 +8841,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             cmuxConfigStore: cmuxConfigStore
         )
         publishCmuxWindowLifecycle(name: "window.created", windowId: windowId, origin: "create")
-        installFileDropOverlay(on: window, tabManager: tabManager)
+        installFileDropOverlayWhenReady(on: window, tabManager: tabManager)
         if !shouldActivate || TerminalController.shouldSuppressSocketCommandActivation() {
             window.orderFront(nil)
             if shouldActivate, TerminalController.socketCommandAllowsInAppFocusMutations() {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -146,7 +146,11 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             hostingView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor),
             hostingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
         ])
-        _ = ensureInstalled()
+        // WindowAccessor can create this controller while SwiftUI is attaching
+        // its hosting view. Defer NSThemeFrame mutation until that update ends.
+        DispatchQueue.main.async { [weak self] in
+            _ = self?.ensureInstalled()
+        }
         installWindowKeyObservers()
     }
 
@@ -741,13 +745,15 @@ func installFileDropOverlayWhenReady(
     tabManager: TabManager,
     remainingAttempts: Int = 16
 ) {
-    guard !installFileDropOverlay(on: window, tabManager: tabManager),
-          remainingAttempts > 0 else { return }
+    guard remainingAttempts >= 0 else { return }
 
-    // Defer retrying until the next main-loop turn so we don't mutate the
-    // NSThemeFrame hierarchy while SwiftUI/AppKit is still attaching views.
+    // Always defer the first attempt as well as retries. Callers can reach this
+    // while SwiftUI/AppKit is still attaching the NSHostingView to NSThemeFrame;
+    // mutating that hierarchy synchronously causes layout re-entry warnings.
     DispatchQueue.main.async { [weak window, weak tabManager] in
         guard let window, let tabManager else { return }
+        guard !installFileDropOverlay(on: window, tabManager: tabManager),
+              remainingAttempts > 0 else { return }
         installFileDropOverlayWhenReady(
             on: window,
             tabManager: tabManager,

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -736,7 +736,7 @@ func installFileDropOverlay(on window: NSWindow, tabManager: TabManager) -> Bool
 }
 
 @MainActor
-private func installFileDropOverlayWhenReady(
+func installFileDropOverlayWhenReady(
     on window: NSWindow,
     tabManager: TabManager,
     remainingAttempts: Int = 16

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -1997,6 +1997,25 @@ enum TerminalWindowPortalRegistry {
         expectedGeneration: UInt64? = nil,
         deferLayoutSynchronization: Bool = false
     ) {
+        if deferLayoutSynchronization {
+            // HostContainerView can move into its window while SwiftUI is still
+            // rendering. Defer portal creation itself, not only layout sync, so
+            // ensureInstalled does not mutate NSThemeFrame re-entrantly.
+            DispatchQueue.main.async { [weak hostedView, weak anchorView] in
+                guard let hostedView, let anchorView else { return }
+                bind(
+                    hostedView: hostedView,
+                    to: anchorView,
+                    visibleInUI: visibleInUI,
+                    zPriority: zPriority,
+                    expectedSurfaceId: expectedSurfaceId,
+                    expectedGeneration: expectedGeneration,
+                    deferLayoutSynchronization: false
+                )
+            }
+            return
+        }
+
         guard let window = anchorView.window else { return }
 
         let windowId = ObjectIdentifier(window)

--- a/cmuxTests/FileDropOverlayViewTests.swift
+++ b/cmuxTests/FileDropOverlayViewTests.swift
@@ -156,6 +156,34 @@ final class FileDropOverlayViewTests: XCTestCase {
         )
     }
 
+    func testScheduledOverlayInstallationDoesNotMutateThemeFrameSynchronously() {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 340),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        let tabManager = TabManager()
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+
+        installFileDropOverlayWhenReady(on: window, tabManager: tabManager)
+
+        XCTAssertNil(
+            objc_getAssociatedObject(window, &fileDropOverlayKey) as? FileDropOverlayView,
+            "Scheduling from window creation must not mutate NSThemeFrame synchronously"
+        )
+
+        RunLoop.current.run(until: Date().addingTimeInterval(0.05))
+
+        XCTAssertNotNil(
+            objc_getAssociatedObject(window, &fileDropOverlayKey) as? FileDropOverlayView,
+            "The overlay should be installed on a later main-loop turn"
+        )
+    }
+
     func testOverlayResolvesPortalHostedBrowserWebViewForFileDrops() {
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 420, height: 280),


### PR DESCRIPTION
## Summary
- defer FileDropOverlayView installation from AppDelegate window creation
- defer command palette overlay installation until the next main-loop turn
- defer terminal portal creation, not just geometry synchronization, when binding from SwiftUI view attachment
- add a regression test proving scheduled file-drop installation does not mutate NSThemeFrame synchronously

## Reproduction
On macOS 26.6 with cmux 0.64.17, fresh app startup repeatedly logged `NSHostingView is being laid out reentrantly while rendering its SwiftUI content`. AppKit stacks identified synchronous NSThemeFrame mutations from FileDropOverlayView, CommandPaletteOverlayContainerView, and WindowTerminalHostView.

## Verification
- tagged Debug build: `./scripts/reload.sh --tag fix-layout-reentry`
- tagged socket: PONG; terminal workspace and surface created successfully
- focused FileDropOverlayViewTests retry: 4 tests passed, including the new regression test
- fresh tagged-app system log after all three changes: zero `NSHostingView is being laid out reentrantly` events
- Ghostty file-drop and portal behavior remained operational
- `git diff --check` passes

The focused xcodebuild invocation initially encountered the existing ContentView fixture missing SidebarUnreadModel, then its retry executed all four selected tests successfully. No user-facing strings changed; localization audit is not applicable.

## Commit structure
1. regression test/access seam (red on the original synchronous implementation)
2. behavior fix (green)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7878"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786349292&installation_id=133855650&pr_number=7878&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7878&signature=40e97511bb53f8d09f570454f00659b936be442c7b4ae70e13fae4039330ce4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Timing-only deferrals on the main queue; behavior should match after the next turn, with regression coverage for file-drop scheduling.
> 
> **Overview**
> Fixes **NSHostingView reentrant layout** warnings by moving **NSThemeFrame** mutations off the synchronous SwiftUI/AppKit attachment path.
> 
> **Window creation** now schedules file-drop overlay installation via `installFileDropOverlayWhenReady` instead of installing immediately. **Command palette** overlay setup in `ContentView` defers `ensureInstalled()` to the next main-loop turn. **`installFileDropOverlayWhenReady`** always asyncs the first attempt (not only retries) and exposes the helper at module scope for tests.
> 
> **Terminal portal binding** with `deferLayoutSynchronization: true` now defers the entire `TerminalWindowPortalRegistry.bind` call—not just geometry sync—so `ensureInstalled` does not reparent into the theme frame during SwiftUI rendering.
> 
> Adds **`testScheduledOverlayInstallationDoesNotMutateThemeFrameSynchronously`** to assert no associated overlay exists until after a run-loop spin.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 05d0becb5d5d0eca3ca35cdd3d52951362ab1497. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Defer all theme-frame portal and overlay installs to the next run loop so SwiftUI can finish layout, removing re-entrant layout warnings on startup while keeping file drop and terminal portals working.

- **Bug Fixes**
  - File drop: App startup now calls `installFileDropOverlayWhenReady`, deferring the first attempt and retries on the main queue to avoid synchronous `NSThemeFrame` mutation.
  - Command palette: `ensureInstalled()` is now scheduled with `DispatchQueue.main.async` when the hosting view is attached.
  - Terminal portal: when `deferLayoutSynchronization` is true, portal creation is also deferred before binding.
  - Added a regression test to confirm scheduled file-drop install does not mutate `NSThemeFrame` synchronously.

<sup>Written for commit 05d0becb5d5d0eca3ca35cdd3d52951362ab1497. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file-drop overlay installation timing to prevent layout and window-state issues.
  * Improved terminal portal setup during SwiftUI/AppKit layout transitions.

* **Tests**
  * Added coverage confirming file-drop overlays are installed asynchronously after the main run loop advances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->