### PR TITLE
cmux-tui: yazi-inspired file browser as the default sidebar

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -907,13 +907,18 @@ impl App {
         {
             return false;
         }
+        // The cwd follow can be a synchronous socket round-trip for remote
+        // sessions; the event loop ticks up to ~33x/sec, so gate it behind the
+        // same 2s refresh cadence as the directory reload.
+        let now = Instant::now();
         let mut changed = false;
-        if !self.sidebar_files.is_pinned()
+        if self.sidebar_files.refresh_due(now)
+            && !self.sidebar_files.is_pinned()
             && let Some(cwd) = self.focused_surface_cwd()
         {
             changed |= self.sidebar_files.follow_focused_cwd(&cwd);
         }
-        changed | self.sidebar_files.tick(Instant::now())
+        changed | self.sidebar_files.tick(now)
     }
 
     fn write_window_title(&self, title: &str) -> anyhow::Result<()> {

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -8,6 +8,7 @@
 
 use std::collections::HashMap;
 use std::io::Write;
+use std::path::PathBuf;
 use std::sync::mpsc::{Receiver, RecvTimeoutError, channel};
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
@@ -31,9 +32,10 @@ use ratatui::Terminal as RatatuiTerminal;
 use ratatui::backend::CrosstermBackend;
 
 use crate::browser_input::{BrowserInputDispatcher, BrowserInputEvent, BrowserInputKind};
-use crate::config::{Action, ChromeTheme, Config, ScrollbarPosition};
+use crate::config::{Action, ChromeTheme, Config, ScrollbarPosition, SidebarView};
 use crate::keys;
 use crate::session::{Session, SurfaceHandle, TreeView};
+use crate::sidebar_files::{FileBrowser, FileCommand, file_url, shell_single_quote};
 use crate::ui::graphics::GraphicPlacement;
 use crate::ui::graphics_writer::GraphicsWriter;
 use crate::ui::input::{InputEvent, TextInput};
@@ -73,6 +75,10 @@ pub enum Hit {
         id: WorkspaceId,
     },
     NewWorkspace,
+    /// A visible row in the built-in file browser.
+    SidebarFile {
+        index: usize,
+    },
     /// Status-bar screen entry.
     ScreenEntry {
         index: usize,
@@ -390,6 +396,10 @@ pub struct App {
     pub session_label: String,
     pub sidebar_visible: bool,
     pub sidebar_focused: bool,
+    pub sidebar_view: SidebarView,
+    pub sidebar_files: FileBrowser,
+    pub sidebar_workspace_selection: usize,
+    sidebar_followed_surface: Option<SurfaceId>,
     /// Width of the sidebar in the current frame (0 when hidden).
     pub sidebar_width: u16,
     pub sidebar_plugin_surface: Option<SurfaceId>,
@@ -638,6 +648,8 @@ pub fn run(
     let graphics_writer =
         if graphics_supported { Some(GraphicsWriter::spawn(stdout_lock.clone())?) } else { None };
 
+    let sidebar_view = config.sidebar.view;
+    let fallback_cwd = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
     let mut app = App {
         session,
         config,
@@ -652,6 +664,10 @@ pub fn run(
         session_label,
         sidebar_visible: true,
         sidebar_focused: false,
+        sidebar_view,
+        sidebar_files: FileBrowser::new(fallback_cwd),
+        sidebar_workspace_selection: 0,
+        sidebar_followed_surface: None,
         sidebar_width: 0,
         sidebar_plugin_surface: None,
         sidebar_plugin_error: None,
@@ -734,6 +750,9 @@ impl App {
                         action = action.merge(RenderAction::Draw);
                     }
                     if self.expire_toast() {
+                        action = action.merge(RenderAction::Draw);
+                    }
+                    if self.tick_sidebar_files() {
                         action = action.merge(RenderAction::Draw);
                     }
                     None
@@ -855,7 +874,46 @@ impl App {
         let mut config = crate::config::load();
         config.apply_chrome_defaults(self.chrome);
         self.session.apply_config(&config);
+        self.sidebar_view = config.sidebar.view;
         self.config = config;
+        self.sidebar_followed_surface = None;
+    }
+
+    fn focused_surface_cwd(&self) -> Option<PathBuf> {
+        let surface = self.tree.active_surface()?;
+        self.session.surface_cwd(surface).map(PathBuf::from)
+    }
+
+    fn sync_sidebar_files_to_focus(&mut self, force: bool) -> bool {
+        if self.config.sidebar.plugin.is_some()
+            || self.sidebar_view != SidebarView::Files
+            || self.sidebar_files.is_pinned()
+        {
+            return false;
+        }
+        let focused = self.tree.active_surface();
+        if !force && focused == self.sidebar_followed_surface {
+            return false;
+        }
+        self.sidebar_followed_surface = focused;
+        let Some(cwd) = self.focused_surface_cwd() else { return false };
+        self.sidebar_files.follow_focused_cwd(&cwd)
+    }
+
+    fn tick_sidebar_files(&mut self) -> bool {
+        if self.config.sidebar.plugin.is_some()
+            || self.sidebar_view != SidebarView::Files
+            || !self.sidebar_visible
+        {
+            return false;
+        }
+        let mut changed = false;
+        if !self.sidebar_files.is_pinned()
+            && let Some(cwd) = self.focused_surface_cwd()
+        {
+            changed |= self.sidebar_files.follow_focused_cwd(&cwd);
+        }
+        changed | self.sidebar_files.tick(Instant::now())
     }
 
     fn write_window_title(&self, title: &str) -> anyhow::Result<()> {
@@ -878,6 +936,9 @@ impl App {
             width,
             self.sidebar_width_override,
         );
+        if self.sidebar_width == 0 {
+            self.sidebar_focused = false;
+        }
         let area = Rect {
             x: self.sidebar_width,
             y: 0,
@@ -887,6 +948,9 @@ impl App {
         self.content_area = area;
         self.sync_sidebar_plugin(false);
         self.tree = self.session.tree();
+        self.sidebar_workspace_selection =
+            self.sidebar_workspace_selection.min(self.tree.workspaces.len().saturating_sub(1));
+        self.sync_sidebar_files_to_focus(false);
         let layout = self
             .tree
             .active_screen()
@@ -943,7 +1007,13 @@ impl App {
     }
 
     fn sync_sidebar_plugin(&mut self, relaunch: bool) {
-        if self.config.sidebar.plugin.is_none() || self.sidebar_width < 3 || !self.sidebar_visible {
+        if self.config.sidebar.plugin.is_none() {
+            self.sidebar_plugin_surface = None;
+            self.sidebar_plugin_error = None;
+            self.sidebar_plugin_retry_after_ms = None;
+            return;
+        }
+        if self.sidebar_width < 3 || !self.sidebar_visible {
             self.sidebar_plugin_surface = None;
             self.sidebar_plugin_error = None;
             self.sidebar_plugin_retry_after_ms = None;
@@ -1031,8 +1101,15 @@ impl App {
                     state.input.insert_str(&text);
                     Ok(RenderAction::Draw)
                 } else if self.sidebar_focused {
-                    self.paste_sidebar(&text);
-                    Ok(RenderAction::None)
+                    if self.config.sidebar.plugin.is_some() {
+                        self.paste_sidebar(&text);
+                        Ok(RenderAction::None)
+                    } else {
+                        if self.sidebar_view == SidebarView::Files {
+                            self.sidebar_files.insert_filter_text(&text);
+                        }
+                        Ok(RenderAction::Draw)
+                    }
                 } else {
                     self.paste(&text);
                     Ok(RenderAction::None)
@@ -1202,8 +1279,11 @@ impl App {
             return Ok(RenderAction::Draw);
         }
         if self.sidebar_focused {
-            self.forward_sidebar_key(&key);
-            return Ok(RenderAction::None);
+            if self.config.sidebar.plugin.is_some() {
+                self.forward_sidebar_key(&key);
+                return Ok(RenderAction::None);
+            }
+            return self.handle_builtin_sidebar_key(&key);
         }
         if let Some(action) = self.config.keys.modeless_action_for(&key) {
             return self.run_action(action);
@@ -1212,6 +1292,89 @@ impl App {
         self.selection = None;
         self.forward_key(&key);
         Ok(RenderAction::None)
+    }
+
+    fn handle_builtin_sidebar_key(&mut self, key: &KeyEvent) -> anyhow::Result<RenderAction> {
+        if key.code == KeyCode::Tab {
+            return self.run_action(Action::ToggleSidebarView);
+        }
+        match self.sidebar_view {
+            SidebarView::Files => {
+                if let Some(command) = self.sidebar_files.handle_key(key) {
+                    self.run_file_command(command);
+                }
+            }
+            SidebarView::Workspaces => match key.code {
+                KeyCode::Up => {
+                    self.sidebar_workspace_selection =
+                        self.sidebar_workspace_selection.saturating_sub(1);
+                }
+                KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.sidebar_workspace_selection =
+                        self.sidebar_workspace_selection.saturating_sub(1);
+                }
+                KeyCode::Down => {
+                    self.sidebar_workspace_selection = (self.sidebar_workspace_selection + 1)
+                        .min(self.tree.workspaces.len().saturating_sub(1));
+                }
+                KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                    self.sidebar_workspace_selection = (self.sidebar_workspace_selection + 1)
+                        .min(self.tree.workspaces.len().saturating_sub(1));
+                }
+                KeyCode::Enter => {
+                    self.session.select_workspace(Some(self.sidebar_workspace_selection), None);
+                }
+                _ => {}
+            },
+        }
+        Ok(RenderAction::Draw)
+    }
+
+    fn run_file_command(&mut self, command: FileCommand) {
+        let result = match command {
+            FileCommand::Reroot => {
+                let cwd = self
+                    .focused_surface_cwd()
+                    .unwrap_or_else(|| self.sidebar_files.fallback_cwd().to_path_buf());
+                self.sidebar_files.reroot(cwd);
+                self.sidebar_followed_surface = self.tree.active_surface();
+                return;
+            }
+            FileCommand::Cd(path) => {
+                let Some(surface) = self.active_surface() else {
+                    self.sidebar_files.set_message("no focused pane");
+                    return;
+                };
+                let quoted = shell_single_quote(&path.to_string_lossy());
+                self.session.send_bytes(surface, format!("cd {quoted}\n").as_bytes())
+            }
+            FileCommand::OpenEditor(path) => {
+                let editor = std::env::var("EDITOR")
+                    .ok()
+                    .filter(|value| !value.is_empty())
+                    .unwrap_or_else(|| "vi".to_string());
+                let cwd = path
+                    .parent()
+                    .unwrap_or_else(|| std::path::Path::new("/"))
+                    .to_string_lossy()
+                    .into_owned();
+                self.session.run_command(
+                    vec![editor, path.to_string_lossy().into_owned()],
+                    self.active_pane(),
+                    Some(cwd),
+                    None,
+                )
+            }
+            FileCommand::OpenBrowser(path) => self.session.new_browser_tab(
+                file_url(&path),
+                self.active_pane(),
+                self.browser_tab_size_hint(self.active_pane()),
+            ),
+        };
+        match result {
+            Ok(()) => self.sidebar_files.set_message("sent to focused pane"),
+            Err(error) => self.sidebar_files.set_message(error.to_string()),
+        }
     }
 
     /// Commit the open rename dialog (Enter or the OK button).
@@ -1447,6 +1610,7 @@ impl App {
                     self.sidebar_focused = false;
                 }
             }
+            Action::ToggleSidebarView => self.toggle_sidebar_view(),
             Action::FocusSidebar => self.toggle_sidebar_focus(),
             Action::FocusLeft => self.move_focus(-1, 0),
             Action::FocusRight => self.move_focus(1, 0),
@@ -1772,17 +1936,41 @@ impl App {
             self.sidebar_focused = false;
             return;
         }
-        if self.config.sidebar.plugin.is_none() {
-            return;
-        }
         self.sidebar_visible = true;
-        self.sync_sidebar_plugin(true);
-        if self.sidebar_plugin_surface.is_some() {
+        if self.config.sidebar.plugin.is_some() {
+            self.sync_sidebar_plugin(true);
+        }
+        if self.config.sidebar.plugin.is_none() || self.sidebar_plugin_surface.is_some() {
             self.sidebar_focused = true;
+            if self.config.sidebar.plugin.is_none() {
+                if self.sidebar_view == SidebarView::Workspaces {
+                    self.sidebar_workspace_selection = self.tree.active_workspace;
+                } else if !self.sync_sidebar_files_to_focus(true) {
+                    self.sidebar_files.refresh();
+                }
+            }
             self.menu = None;
             self.prompt = None;
             self.omnibar = None;
             self.selection = None;
+        }
+    }
+
+    fn toggle_sidebar_view(&mut self) {
+        self.sidebar_view = self.sidebar_view.toggled();
+        if self.config.sidebar.plugin.is_some() {
+            return;
+        }
+        match self.sidebar_view {
+            SidebarView::Files => {
+                self.sidebar_followed_surface = None;
+                if !self.sync_sidebar_files_to_focus(true) {
+                    self.sidebar_files.refresh();
+                }
+            }
+            SidebarView::Workspaces => {
+                self.sidebar_workspace_selection = self.tree.active_workspace;
+            }
         }
     }
 
@@ -2253,10 +2441,12 @@ impl App {
 
         if let Some(hit) = self.hit_at(x, y) {
             match hit {
-                Hit::Workspace { id, .. } => {
+                Hit::Workspace { index, id } => {
+                    self.sidebar_workspace_selection = index;
                     self.drag = Some(Drag::WorkspaceArm { workspace: id, at: (x, y) });
                 }
                 Hit::NewWorkspace => self.new_workspace()?,
+                Hit::SidebarFile { index } => self.sidebar_files.select(index),
                 Hit::ScreenEntry { index, .. } => {
                     self.session.select_screen(Some(index), None);
                 }
@@ -2881,17 +3071,20 @@ mod tests {
         pane_parts_for_rect,
     };
     use std::collections::HashMap;
+    use std::path::PathBuf;
     use std::sync::{Arc, Mutex};
 
     use cmux_tui_core::{BrowserStatus, Mux, Node, Rect, SurfaceKind, SurfaceOptions};
+    use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
     use ghostty_vt::{KeyEncoder, RenderState};
     use ratatui::Terminal;
     use ratatui::backend::TestBackend;
 
     use crate::browser_input::BrowserInputDispatcher;
-    use crate::config::{ChromeTheme, Config, ScrollbarPosition};
+    use crate::config::{Action, ChromeTheme, Config, ScrollbarPosition, SidebarView};
     use crate::session::tree::{PaneView, ScreenView, TabNotificationView, TabView, WorkspaceView};
     use crate::session::{Session, TreeView};
+    use crate::sidebar_files::FileBrowser;
 
     #[test]
     fn browser_omnibar_reduces_content_rect_for_graphics_and_input() {
@@ -2946,6 +3139,7 @@ mod tests {
         let surface = mux.new_workspace(Some("work".to_string()), Some((20, 8))).unwrap();
         let mut app = test_app(Session::Local(mux.clone()));
         app.sidebar_width = 12;
+        app.sidebar_view = SidebarView::Workspaces;
         app.tree = notify_tree(surface.id, true);
         app.pane_areas.push(PaneArea {
             pane: 2,
@@ -3026,6 +3220,96 @@ mod tests {
         mux.close_surface(surface.id);
     }
 
+    #[test]
+    fn files_sidebar_renders_temp_directory_and_unread_header_badge() {
+        let temp = test_temp_dir("draw-files");
+        std::fs::write(temp.join("known-sidebar-file.txt"), "hello").unwrap();
+        let (mux, surface) = test_mux("files-sidebar-draw-test", Some(&temp));
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_width = 24;
+        app.sidebar_files = FileBrowser::new(temp.clone());
+        app.tree = notify_tree(surface.id, true);
+
+        let mut terminal = Terminal::new(TestBackend::new(50, 12)).unwrap();
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+        let text = buffer_text(terminal.backend().buffer());
+        assert!(text.contains("known-sidebar-file"), "{text}");
+        assert!(text.lines().next().is_some_and(|line| line.contains("• 1")), "{text}");
+
+        mux.close_surface(surface.id);
+        std::fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn focused_sidebar_tab_toggles_builtin_views_and_back() {
+        let temp = test_temp_dir("toggle-view");
+        std::fs::write(temp.join("toggle-marker.txt"), "hello").unwrap();
+        let (mux, surface) = test_mux("sidebar-toggle-test", Some(&temp));
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_width = 24;
+        app.sidebar_files = FileBrowser::new(temp.clone());
+        app.tree = notify_tree(surface.id, false);
+        app.sidebar_focused = true;
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).unwrap();
+        assert_eq!(app.sidebar_view, SidebarView::Workspaces);
+        let mut terminal = Terminal::new(TestBackend::new(50, 12)).unwrap();
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+        assert!(buffer_text(terminal.backend().buffer()).contains("workspaces"));
+
+        app.handle_key(KeyEvent::new(KeyCode::Tab, KeyModifiers::NONE)).unwrap();
+        assert_eq!(app.sidebar_view, SidebarView::Files);
+        let mut terminal = Terminal::new(TestBackend::new(50, 12)).unwrap();
+        terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+        assert!(buffer_text(terminal.backend().buffer()).contains("toggle-marker"));
+
+        mux.close_surface(surface.id);
+        std::fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn focus_sidebar_focuses_builtin_sidebar() {
+        let (mux, surface) = test_mux("focus-builtin-sidebar-test", None);
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.tree = notify_tree(surface.id, false);
+        app.sidebar_visible = false;
+
+        app.run_action(Action::FocusSidebar).unwrap();
+        assert!(app.sidebar_visible);
+        assert!(app.sidebar_focused);
+
+        app.run_action(Action::FocusSidebar).unwrap();
+        assert!(!app.sidebar_focused);
+        mux.close_surface(surface.id);
+    }
+
+    #[test]
+    fn builtin_sidebar_registers_resize_hit_in_both_views() {
+        let temp = test_temp_dir("resize-hit");
+        let (mux, surface) = test_mux("builtin-sidebar-resize-test", Some(&temp));
+        let mut app = test_app(Session::Local(mux.clone()));
+        app.sidebar_width = 18;
+        app.sidebar_files = FileBrowser::new(temp.clone());
+        app.tree = notify_tree(surface.id, false);
+
+        for view in [SidebarView::Files, SidebarView::Workspaces] {
+            app.sidebar_view = view;
+            let mut terminal = Terminal::new(TestBackend::new(50, 12)).unwrap();
+            terminal.draw(|frame| crate::ui::draw(&mut app, frame)).unwrap();
+            assert!(
+                app.hits.iter().any(|(rect, hit)| {
+                    matches!(hit, super::Hit::SidebarResize)
+                        && rect.x == app.sidebar_width - 1
+                        && rect.width == 1
+                }),
+                "missing resize hit in {view:?} view"
+            );
+        }
+
+        mux.close_surface(surface.id);
+        std::fs::remove_dir_all(temp).unwrap();
+    }
+
     fn test_app(session: Session) -> App {
         App {
             session,
@@ -3041,6 +3325,10 @@ mod tests {
             session_label: "test".to_string(),
             sidebar_visible: true,
             sidebar_focused: false,
+            sidebar_view: SidebarView::Files,
+            sidebar_files: FileBrowser::new(std::env::temp_dir()),
+            sidebar_workspace_selection: 0,
+            sidebar_followed_surface: None,
             sidebar_width: 0,
             sidebar_plugin_surface: None,
             sidebar_plugin_error: None,
@@ -3107,5 +3395,43 @@ mod tests {
 
     fn row_contains(buffer: &ratatui::buffer::Buffer, y: u16, needle: &str) -> bool {
         (0..buffer.area.width).any(|x| buffer[(x, y)].symbol() == needle)
+    }
+
+    fn buffer_text(buffer: &ratatui::buffer::Buffer) -> String {
+        (0..buffer.area.height)
+            .map(|y| (0..buffer.area.width).map(|x| buffer[(x, y)].symbol()).collect::<String>())
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn test_temp_dir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "cmux-tui-app-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        std::fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    fn test_mux(
+        name: &str,
+        cwd: Option<&std::path::Path>,
+    ) -> (Arc<Mux>, Arc<cmux_tui_core::Surface>) {
+        let mux = Mux::new(
+            name,
+            SurfaceOptions {
+                command: Some(vec![
+                    "/bin/sh".to_string(),
+                    "-c".to_string(),
+                    "sleep 30".to_string(),
+                ]),
+                cwd: cwd.map(|path| path.to_string_lossy().into_owned()),
+                ..Default::default()
+            },
+        );
+        let surface = mux.new_workspace(Some("work".to_string()), Some((20, 8))).unwrap();
+        (mux, surface)
     }
 }

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -27,6 +27,7 @@
 //!     "agents": ["claude", "codex", "opencode", "pi"]
 //!   },
 //!   "sidebar": {
+//!     "view": "files",
 //!     "width": 22,
 //!     "max_width": 0,
 //!     "plugin": {
@@ -74,7 +75,7 @@
 //! `close-pane`, `rename-tab` (alias: `rename-pane`), `rename-screen`,
 //! `rename-workspace`, `close-screen`, `prev-screen`, `next-screen`,
 //! `select-screen-0` through `select-screen-9`, `new-screen`,
-//! `next-workspace`, `new-workspace`, `toggle-sidebar`, `focus-sidebar`,
+//! `next-workspace`, `new-workspace`, `toggle-sidebar`, `toggle-sidebar-view`, `focus-sidebar`,
 //! `focus-left`, `focus-right`, `focus-up`, `focus-down`, `focus-next-pane`,
 //! `swap-pane-prev`, `swap-pane-next`, `zoom-pane`, `resize-grow`,
 //! `resize-shrink`, `scroll-up`, `scroll-down`, `browser-back`,
@@ -351,6 +352,7 @@ struct RawTabs {
 #[derive(Debug, Default, Deserialize)]
 #[serde(deny_unknown_fields)]
 struct RawSidebar {
+    view: Option<String>,
     width: Option<u16>,
     max_width: Option<u16>,
     plugin: Option<RawSidebarPlugin>,
@@ -485,6 +487,8 @@ impl Default for Tabs {
 /// Sidebar behavior.
 #[derive(Debug, Clone)]
 pub struct Sidebar {
+    /// Built-in view used when `plugin` is unset. The default is the file browser.
+    pub view: SidebarView,
     pub width: u16,
     pub max_width: u16,
     pub plugin: Option<SidebarPluginOptions>,
@@ -492,7 +496,33 @@ pub struct Sidebar {
 
 impl Default for Sidebar {
     fn default() -> Self {
-        Sidebar { width: 22, max_width: 0, plugin: None }
+        Sidebar { view: SidebarView::Files, width: 22, max_width: 0, plugin: None }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SidebarView {
+    #[default]
+    Files,
+    Workspaces,
+}
+
+impl SidebarView {
+    pub fn toggled(self) -> Self {
+        match self {
+            Self::Files => Self::Workspaces,
+            Self::Workspaces => Self::Files,
+        }
+    }
+}
+
+fn parse_sidebar_view(value: &str) -> Result<SidebarView, String> {
+    match value {
+        "files" => Ok(SidebarView::Files),
+        "workspaces" => Ok(SidebarView::Workspaces),
+        _ => Err(format!(
+            "cmux-tui: ignoring unknown sidebar.view {value:?}; expected \"files\" or \"workspaces\""
+        )),
     }
 }
 
@@ -547,6 +577,7 @@ pub enum Action {
     NextWorkspace,
     NewWorkspace,
     ToggleSidebar,
+    ToggleSidebarView,
     FocusSidebar,
     FocusLeft,
     FocusRight,
@@ -591,6 +622,7 @@ impl Action {
             Action::NextWorkspace => "next-workspace".to_string(),
             Action::NewWorkspace => "new-workspace".to_string(),
             Action::ToggleSidebar => "toggle-sidebar".to_string(),
+            Action::ToggleSidebarView => "toggle-sidebar-view".to_string(),
             Action::FocusSidebar => "focus-sidebar".to_string(),
             Action::FocusLeft => "focus-left".to_string(),
             Action::FocusRight => "focus-right".to_string(),
@@ -695,6 +727,7 @@ impl Default for Keys {
                 bind(KeyCode::Char('w'), Action::NextWorkspace),
                 bind(KeyCode::Char('W'), Action::NewWorkspace),
                 bind(KeyCode::Char('s'), Action::ToggleSidebar),
+                bind(KeyCode::Char('e'), Action::ToggleSidebarView),
                 bind(KeyCode::Char('S'), Action::FocusSidebar),
                 bind(KeyCode::Char('o'), Action::FocusNextPane),
                 bind(KeyCode::Char('h'), Action::FocusLeft),
@@ -851,6 +884,7 @@ fn all_actions() -> &'static [Action] {
         Action::NextWorkspace,
         Action::NewWorkspace,
         Action::ToggleSidebar,
+        Action::ToggleSidebarView,
         Action::FocusSidebar,
         Action::FocusLeft,
         Action::FocusRight,
@@ -1037,6 +1071,12 @@ pub fn load() -> Config {
     }
     if let Some(w) = raw.sidebar.width {
         config.sidebar.width = w.clamp(10, 60);
+    }
+    if let Some(view) = raw.sidebar.view {
+        match parse_sidebar_view(&view) {
+            Ok(view) => config.sidebar.view = view,
+            Err(warning) => eprintln!("{warning}"),
+        }
     }
     if let Some(w) = raw.sidebar.max_width {
         config.sidebar.max_width = w;
@@ -1452,6 +1492,7 @@ mod tests {
                 },
                 "tabs": {"min_width": 9, "solid_background": false},
                 "sidebar": {
+                    "view": "workspaces",
                     "width": 30,
                     "max_width": 38,
                     "plugin": {
@@ -1488,6 +1529,7 @@ mod tests {
         assert!(!config.tabs.solid_background);
         assert_eq!(config.sidebar.width, 30);
         assert_eq!(config.sidebar.max_width, 38);
+        assert_eq!(config.sidebar.view, SidebarView::Workspaces);
         let plugin = config.sidebar.plugin.as_ref().expect("sidebar plugin config");
         assert_eq!(plugin.command, vec!["/tmp/sidebar-plugin", "--mode", "test"]);
         assert_eq!(plugin.cwd.as_deref(), Some("/tmp"));
@@ -1589,6 +1631,21 @@ mod tests {
     }
 
     #[test]
+    fn sidebar_view_defaults_parses_and_unknown_values_fall_back_with_warning() {
+        assert_eq!(Sidebar::default().view, SidebarView::Files);
+        assert_eq!(parse_sidebar_view("files"), Ok(SidebarView::Files));
+        assert_eq!(parse_sidebar_view("workspaces"), Ok(SidebarView::Workspaces));
+
+        let warning = parse_sidebar_view("tree").unwrap_err();
+        assert!(warning.contains("unknown sidebar.view \"tree\""));
+        let mut sidebar = Sidebar::default();
+        if let Ok(view) = parse_sidebar_view("tree") {
+            sidebar.view = view;
+        }
+        assert_eq!(sidebar.view, SidebarView::Files);
+    }
+
+    #[test]
     fn tmux_close_pane_flip_is_default() {
         let keys = Keys::default();
         assert_eq!(
@@ -1609,6 +1666,7 @@ mod tests {
             ("swap-pane-prev", Action::SwapPanePrev),
             ("swap-pane-next", Action::SwapPaneNext),
             ("scroll-up", Action::ScrollUp),
+            ("toggle-sidebar-view", Action::ToggleSidebarView),
         ];
         for (name, action) in cases {
             let mut keys = Keys::default();

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -14,6 +14,7 @@ mod host_colors;
 mod keys;
 mod plugin_manager;
 mod session;
+mod sidebar_files;
 mod ui;
 
 use std::path::PathBuf;
@@ -59,19 +60,20 @@ OPTIONS:
   -V, --version      Print the cmux-tui version.
 
 KEYS (prefix: Ctrl-b)
-  c  new tab in pane   B    new browser tab    n/p  next/prev tab
-  1-9  select tab
-  %  split right       \"  split down          x    close tab
-  ,  rename pane       $    rename workspace
-  Tab  next screen     S    new screen
+  t  new tab in pane   B    new browser tab    Tab/BackTab  next/prev tab
+  1-9  select screen
+  %  split right       \"  split down          x/X  close pane/tab
+  ,  rename screen     $    rename workspace   c    new screen
+  n/p  next/prev screen
   h/j/k/l or arrows    move focus              d    quit (attach: detach)
   w  next workspace    W    new workspace       s    toggle sidebar
+  e  toggle sidebar view                       S    focus sidebar
   <  browser back      >    browser forward     r/u  browser reload/edit URL
   Ctrl-b  send a literal Ctrl-b
 
 MOUSE
   Right-click a pane for rename/new tab/split/close; right-click a
-  sidebar workspace or a status-bar screen for rename/close. Click
+  workspace-sidebar row or a status-bar screen for rename/close. Click
   tab-bar entries to switch tabs (+ for a new tab), and status-bar
   screen entries to switch screens (+ for a new screen).
 

--- a/cmux-tui/crates/cmux-tui/src/session/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/session/mod.rs
@@ -203,6 +203,53 @@ impl Session {
         }
     }
 
+    pub fn run_command(
+        &self,
+        argv: Vec<String>,
+        pane: Option<PaneId>,
+        cwd: Option<String>,
+        size: Option<(u16, u16)>,
+    ) -> anyhow::Result<()> {
+        match self {
+            Session::Local(mux) => {
+                mux.run_command_surface(argv, pane, false, cwd, None, size).map(|_| ())
+            }
+            Session::Remote(remote) => remote
+                .request(with_size(
+                    json!({"cmd": "run", "argv": argv, "pane": pane, "cwd": cwd}),
+                    size,
+                ))
+                .map(|_| ()),
+        }
+    }
+
+    pub fn send_bytes(&self, surface: SurfaceId, bytes: &[u8]) -> anyhow::Result<()> {
+        match self {
+            Session::Local(mux) => mux
+                .surface(surface)
+                .ok_or_else(|| anyhow::anyhow!("unknown surface {surface}"))?
+                .write_bytes(bytes)
+                .map_err(Into::into),
+            Session::Remote(remote) => {
+                remote.send_bytes(surface, bytes);
+                Ok(())
+            }
+        }
+    }
+
+    pub fn surface_cwd(&self, surface: SurfaceId) -> Option<String> {
+        match self {
+            Session::Local(mux) => mux
+                .surface(surface)
+                .and_then(|surface| surface.pwd().or_else(|| surface.spawn_cwd())),
+            Session::Remote(remote) => {
+                remote.request(json!({"cmd": "process-info", "surface": surface})).ok().and_then(
+                    |data| data.get("cwd").and_then(serde_json::Value::as_str).map(str::to_owned),
+                )
+            }
+        }
+    }
+
     pub fn new_browser_tab(
         &self,
         url: String,

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/files.rs
@@ -1,0 +1,145 @@
+use std::{
+    cmp::Ordering,
+    fs,
+    path::{Path, PathBuf},
+};
+
+use anyhow::{Context, Result};
+
+#[derive(Debug, Clone, Copy, Eq, PartialEq)]
+pub enum EntryKind {
+    Directory,
+    File,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct FileEntry {
+    pub name: String,
+    pub path: PathBuf,
+    pub kind: EntryKind,
+}
+
+impl FileEntry {
+    pub fn is_dir(&self) -> bool {
+        self.kind == EntryKind::Directory
+    }
+}
+
+pub fn list_directory(directory: &Path, show_hidden: bool) -> Result<Vec<FileEntry>> {
+    let read_dir = fs::read_dir(directory)
+        .with_context(|| format!("cannot read directory {}", directory.display()))?;
+    let mut entries = Vec::new();
+
+    for item in read_dir {
+        let item = item.with_context(|| format!("cannot read entry in {}", directory.display()))?;
+        let name = item.file_name().to_string_lossy().into_owned();
+        if !show_hidden && name.starts_with('.') {
+            continue;
+        }
+        let kind = if item
+            .file_type()
+            .with_context(|| format!("cannot inspect {}", item.path().display()))?
+            .is_dir()
+        {
+            EntryKind::Directory
+        } else {
+            EntryKind::File
+        };
+        entries.push(FileEntry { name, path: item.path(), kind });
+    }
+
+    entries.sort_by(compare_entries);
+    Ok(entries)
+}
+
+fn compare_entries(left: &FileEntry, right: &FileEntry) -> Ordering {
+    let kind_order = match (left.kind, right.kind) {
+        (EntryKind::Directory, EntryKind::File) => Ordering::Less,
+        (EntryKind::File, EntryKind::Directory) => Ordering::Greater,
+        _ => Ordering::Equal,
+    };
+    kind_order.then_with(|| {
+        left.name
+            .to_lowercase()
+            .cmp(&right.name.to_lowercase())
+            .then_with(|| left.name.cmp(&right.name))
+    })
+}
+
+pub fn filtered_indices(entries: &[FileEntry], query: &str) -> Vec<usize> {
+    let query = query.to_lowercase();
+    entries
+        .iter()
+        .enumerate()
+        .filter_map(|(index, entry)| entry.name.to_lowercase().contains(&query).then_some(index))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{create_dir, write};
+
+    use super::*;
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "cmux-tui-sidebar-files-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn lists_directories_first_and_sorts_each_kind() {
+        let temp = temp_dir("sort");
+        create_dir(temp.join("z-dir")).unwrap();
+        create_dir(temp.join("A-dir")).unwrap();
+        write(temp.join("z-file"), "").unwrap();
+        write(temp.join("B-file"), "").unwrap();
+
+        let entries = list_directory(&temp, false).unwrap();
+        let actual =
+            entries.iter().map(|entry| (entry.name.as_str(), entry.kind)).collect::<Vec<_>>();
+        assert_eq!(
+            actual,
+            vec![
+                ("A-dir", EntryKind::Directory),
+                ("z-dir", EntryKind::Directory),
+                ("B-file", EntryKind::File),
+                ("z-file", EntryKind::File),
+            ]
+        );
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn hides_dotfiles_until_enabled() {
+        let temp = temp_dir("hidden");
+        create_dir(temp.join(".config")).unwrap();
+        write(temp.join(".env"), "").unwrap();
+        write(temp.join("visible"), "").unwrap();
+
+        let hidden = list_directory(&temp, false).unwrap();
+        assert_eq!(hidden.len(), 1);
+        assert_eq!(hidden[0].name, "visible");
+
+        let shown = list_directory(&temp, true).unwrap();
+        assert_eq!(shown.len(), 3);
+        assert_eq!(shown[0].name, ".config");
+        assert_eq!(shown[1].name, ".env");
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn filters_case_insensitively() {
+        let entries = vec![
+            FileEntry { name: "ReadMe.md".into(), path: "ReadMe.md".into(), kind: EntryKind::File },
+            FileEntry { name: "src".into(), path: "src".into(), kind: EntryKind::Directory },
+        ];
+        assert_eq!(filtered_indices(&entries, "README"), vec![0]);
+        assert_eq!(filtered_indices(&entries, "r"), vec![0, 1]);
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -128,8 +128,12 @@ impl FileBrowser {
         self.reload_directory();
     }
 
+    pub fn refresh_due(&self, now: Instant) -> bool {
+        now.duration_since(self.last_refresh) >= REFRESH_EVERY
+    }
+
     pub fn tick(&mut self, now: Instant) -> bool {
-        if now.duration_since(self.last_refresh) < REFRESH_EVERY {
+        if !self.refresh_due(now) {
             return false;
         }
         self.reload_directory();
@@ -142,6 +146,10 @@ impl FileBrowser {
             return self.handle_filter_key(key);
         }
 
+        // Only plain (or shifted) character keys act; control/alt chords must
+        // never fall through to actions (Ctrl-C reaching the 'c' arm would cd
+        // the user's shell). ctrl+j/k are the explicit exceptions.
+        let plain = key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT;
         match key.code {
             KeyCode::Up => self.move_selection(-1),
             KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
@@ -153,15 +161,16 @@ impl FileBrowser {
             }
             KeyCode::Right => self.descend_selected(),
             KeyCode::Enter => return self.activate_selected(),
-            KeyCode::Left | KeyCode::Char('h') => self.go_parent(),
-            KeyCode::Char('.') => {
+            KeyCode::Left => self.go_parent(),
+            KeyCode::Char('h') if plain => self.go_parent(),
+            KeyCode::Char('.') if plain => {
                 self.show_hidden = !self.show_hidden;
                 self.reload_directory();
             }
-            KeyCode::Char('/') => self.filter_mode = true,
-            KeyCode::Char('~') => return Some(FileCommand::Reroot),
-            KeyCode::Char('c') => return self.cd_selected(),
-            KeyCode::Char('o') => return self.browser_selected(),
+            KeyCode::Char('/') if plain => self.filter_mode = true,
+            KeyCode::Char('~') if plain => return Some(FileCommand::Reroot),
+            KeyCode::Char('c') if plain => return self.cd_selected(),
+            KeyCode::Char('o') if plain => return self.browser_selected(),
             _ => {}
         }
         None
@@ -339,6 +348,21 @@ mod tests {
 
     fn key(code: KeyCode) -> KeyEvent {
         KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    #[test]
+    fn control_chords_never_trigger_character_actions() {
+        // Regression: Ctrl-C fell through to the 'c' arm and cd'd the shell.
+        let dir = temp_dir("ctrl-chords");
+        create_dir(dir.join("sub")).unwrap();
+        let mut browser = FileBrowser::new(dir.clone());
+        browser.reload_directory();
+        for ch in ['c', 'o', 'h', '.', '/', '~'] {
+            let ev = KeyEvent::new(KeyCode::Char(ch), KeyModifiers::CONTROL);
+            assert!(browser.handle_key(&ev).is_none(), "ctrl+{ch} must be inert");
+        }
+        assert!(!browser.filter_mode, "ctrl+/ must not enter filter mode");
+        std::fs::remove_dir_all(&dir).ok();
     }
 
     fn temp_dir(name: &str) -> PathBuf {

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -1,0 +1,416 @@
+mod files;
+mod navigation;
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, Instant};
+
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+
+pub use files::FileEntry;
+use files::{filtered_indices, list_directory};
+use navigation::Navigation;
+
+const REFRESH_EVERY: Duration = Duration::from_secs(2);
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum FileCommand {
+    Cd(PathBuf),
+    OpenEditor(PathBuf),
+    OpenBrowser(PathBuf),
+    Reroot,
+}
+
+pub struct FileBrowser {
+    navigation: Navigation,
+    fallback_cwd: PathBuf,
+    entries: Vec<FileEntry>,
+    visible: Vec<usize>,
+    selected: usize,
+    show_hidden: bool,
+    filter_mode: bool,
+    query: String,
+    listing_error: Option<String>,
+    message: Option<String>,
+    last_refresh: Instant,
+}
+
+impl FileBrowser {
+    pub fn new(fallback_cwd: PathBuf) -> Self {
+        let mut browser = Self {
+            navigation: Navigation::new(fallback_cwd.clone()),
+            fallback_cwd,
+            entries: Vec::new(),
+            visible: Vec::new(),
+            selected: 0,
+            show_hidden: false,
+            filter_mode: false,
+            query: String::new(),
+            listing_error: None,
+            message: None,
+            last_refresh: Instant::now(),
+        };
+        browser.reload_directory();
+        browser
+    }
+
+    pub fn current_dir(&self) -> &Path {
+        self.navigation.current_dir()
+    }
+
+    pub fn fallback_cwd(&self) -> &Path {
+        &self.fallback_cwd
+    }
+
+    pub fn is_pinned(&self) -> bool {
+        self.navigation.is_pinned()
+    }
+
+    pub fn visible_entries(&self) -> impl Iterator<Item = &FileEntry> {
+        self.visible.iter().map(|index| &self.entries[*index])
+    }
+
+    pub fn total_len(&self) -> usize {
+        self.entries.len()
+    }
+
+    pub fn selected(&self) -> usize {
+        self.selected
+    }
+
+    pub fn show_hidden(&self) -> bool {
+        self.show_hidden
+    }
+
+    pub fn filter_mode(&self) -> bool {
+        self.filter_mode
+    }
+
+    pub fn query(&self) -> &str {
+        &self.query
+    }
+
+    pub fn listing_error(&self) -> Option<&str> {
+        self.listing_error.as_deref()
+    }
+
+    pub fn message(&self) -> Option<&str> {
+        self.message.as_deref()
+    }
+
+    pub fn select(&mut self, index: usize) {
+        if self.visible.is_empty() {
+            self.selected = 0;
+        } else {
+            self.selected = index.min(self.visible.len() - 1);
+        }
+    }
+
+    pub fn set_message(&mut self, message: impl Into<String>) {
+        self.message = Some(message.into());
+    }
+
+    pub fn follow_focused_cwd(&mut self, directory: &Path) -> bool {
+        if !self.navigation.follow_focused_cwd(directory) {
+            return false;
+        }
+        self.query.clear();
+        self.reload_directory();
+        true
+    }
+
+    pub fn reroot(&mut self, directory: PathBuf) {
+        self.navigation.reroot(directory);
+        self.query.clear();
+        self.reload_directory();
+    }
+
+    pub fn refresh(&mut self) {
+        self.reload_directory();
+    }
+
+    pub fn tick(&mut self, now: Instant) -> bool {
+        if now.duration_since(self.last_refresh) < REFRESH_EVERY {
+            return false;
+        }
+        self.reload_directory();
+        true
+    }
+
+    pub fn handle_key(&mut self, key: &KeyEvent) -> Option<FileCommand> {
+        self.message = None;
+        if self.filter_mode {
+            return self.handle_filter_key(key);
+        }
+
+        match key.code {
+            KeyCode::Up => self.move_selection(-1),
+            KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.move_selection(-1);
+            }
+            KeyCode::Down => self.move_selection(1),
+            KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.move_selection(1);
+            }
+            KeyCode::Right => self.descend_selected(),
+            KeyCode::Enter => return self.activate_selected(),
+            KeyCode::Left | KeyCode::Char('h') => self.go_parent(),
+            KeyCode::Char('.') => {
+                self.show_hidden = !self.show_hidden;
+                self.reload_directory();
+            }
+            KeyCode::Char('/') => self.filter_mode = true,
+            KeyCode::Char('~') => return Some(FileCommand::Reroot),
+            KeyCode::Char('c') => return self.cd_selected(),
+            KeyCode::Char('o') => return self.browser_selected(),
+            _ => {}
+        }
+        None
+    }
+
+    pub fn insert_filter_text(&mut self, text: &str) -> bool {
+        if !self.filter_mode || text.is_empty() {
+            return false;
+        }
+        let keep = self.selected_entry().map(|entry| entry.path);
+        self.query.extend(text.chars().filter(|ch| !ch.is_control()));
+        self.apply_filter(keep.as_deref());
+        true
+    }
+
+    fn handle_filter_key(&mut self, key: &KeyEvent) -> Option<FileCommand> {
+        match key.code {
+            KeyCode::Esc if !self.query.is_empty() => {
+                let keep = self.selected_entry().map(|entry| entry.path);
+                self.query.clear();
+                self.apply_filter(keep.as_deref());
+            }
+            KeyCode::Esc => self.filter_mode = false,
+            KeyCode::Enter => {
+                self.filter_mode = false;
+                return self.activate_selected();
+            }
+            KeyCode::Right => {
+                self.filter_mode = false;
+                self.descend_selected();
+            }
+            KeyCode::Backspace => {
+                let keep = self.selected_entry().map(|entry| entry.path);
+                self.query.pop();
+                self.apply_filter(keep.as_deref());
+            }
+            KeyCode::Up => self.move_selection(-1),
+            KeyCode::Down => self.move_selection(1),
+            KeyCode::Char('k') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.move_selection(-1);
+            }
+            KeyCode::Char('j') if key.modifiers.contains(KeyModifiers::CONTROL) => {
+                self.move_selection(1);
+            }
+            KeyCode::Char(ch)
+                if key.modifiers.is_empty() || key.modifiers == KeyModifiers::SHIFT =>
+            {
+                let keep = self.selected_entry().map(|entry| entry.path);
+                self.query.push(ch);
+                self.apply_filter(keep.as_deref());
+            }
+            _ => {}
+        }
+        None
+    }
+
+    fn move_selection(&mut self, delta: isize) {
+        if self.visible.is_empty() {
+            self.selected = 0;
+        } else {
+            self.selected = self.selected.saturating_add_signed(delta).min(self.visible.len() - 1);
+        }
+    }
+
+    fn selected_entry(&self) -> Option<FileEntry> {
+        self.visible.get(self.selected).map(|index| self.entries[*index].clone())
+    }
+
+    fn descend_selected(&mut self) {
+        if let Some(entry) = self.selected_entry().filter(FileEntry::is_dir) {
+            self.navigation.navigate(entry.path);
+            self.query.clear();
+            self.reload_directory();
+        }
+    }
+
+    fn go_parent(&mut self) {
+        if let Some(parent) = self.navigation.current_dir().parent() {
+            self.navigation.navigate(parent.to_path_buf());
+            self.query.clear();
+            self.reload_directory();
+        }
+    }
+
+    fn activate_selected(&mut self) -> Option<FileCommand> {
+        let entry = self.selected_entry()?;
+        if entry.is_dir() {
+            self.navigation.navigate(entry.path);
+            self.query.clear();
+            self.reload_directory();
+            return None;
+        }
+        Some(FileCommand::OpenEditor(entry.path))
+    }
+
+    fn cd_selected(&mut self) -> Option<FileCommand> {
+        let Some(entry) = self.selected_entry().filter(FileEntry::is_dir) else {
+            self.set_message("select a directory to send cd");
+            return None;
+        };
+        Some(FileCommand::Cd(entry.path))
+    }
+
+    fn browser_selected(&mut self) -> Option<FileCommand> {
+        let Some(entry) = self.selected_entry().filter(|entry| !entry.is_dir()) else {
+            self.set_message("select an .html or .md file to open");
+            return None;
+        };
+        let supported =
+            entry.path.extension().and_then(|extension| extension.to_str()).is_some_and(
+                |extension| {
+                    extension.eq_ignore_ascii_case("html") || extension.eq_ignore_ascii_case("md")
+                },
+            );
+        if !supported {
+            self.set_message("only .html and .md files open in a browser");
+            return None;
+        }
+        Some(FileCommand::OpenBrowser(entry.path))
+    }
+
+    fn reload_directory(&mut self) {
+        let selected_path = self.selected_entry().map(|entry| entry.path);
+        match list_directory(self.navigation.current_dir(), self.show_hidden) {
+            Ok(entries) => {
+                self.entries = entries;
+                self.listing_error = None;
+            }
+            Err(error) => {
+                self.entries.clear();
+                self.listing_error = Some(error.to_string());
+            }
+        }
+        self.last_refresh = Instant::now();
+        self.apply_filter(selected_path.as_deref());
+    }
+
+    fn apply_filter(&mut self, selected_path: Option<&Path>) {
+        self.visible = filtered_indices(&self.entries, &self.query);
+        self.selected = selected_path
+            .and_then(|path| {
+                self.visible.iter().position(|index| self.entries[*index].path == path)
+            })
+            .unwrap_or_else(|| {
+                if self.visible.is_empty() { 0 } else { self.selected.min(self.visible.len() - 1) }
+            });
+    }
+}
+
+pub fn shell_single_quote(value: &str) -> String {
+    format!("'{}'", value.replace('\'', "'\\''"))
+}
+
+pub fn file_url(path: &Path) -> String {
+    let text = path.to_string_lossy();
+    let mut url = String::from("file://");
+    for byte in text.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' | b'/' => {
+                url.push(char::from(byte));
+            }
+            _ => url.push_str(&format!("%{byte:02X}")),
+        }
+    }
+    url
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, create_dir, write};
+
+    use crossterm::event::{KeyEvent, KeyModifiers};
+
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    fn temp_dir(name: &str) -> PathBuf {
+        let path = std::env::temp_dir().join(format!(
+            "cmux-tui-file-browser-{name}-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).unwrap();
+        path
+    }
+
+    #[test]
+    fn filter_edits_keep_selection_identity_and_escape_clears_before_exiting() {
+        let temp = temp_dir("filter");
+        write(temp.join("alpha"), "").unwrap();
+        write(temp.join("beta"), "").unwrap();
+        write(temp.join("gamma"), "").unwrap();
+        let mut browser = FileBrowser::new(temp.clone());
+        browser.select(1);
+
+        browser.handle_key(&key(KeyCode::Char('/')));
+        browser.handle_key(&key(KeyCode::Char('e')));
+        assert!(browser.filter_mode());
+        assert_eq!(browser.visible_entries().count(), 1);
+        assert_eq!(browser.visible_entries().next().unwrap().name, "beta");
+
+        browser.handle_key(&key(KeyCode::Esc));
+        assert!(browser.filter_mode());
+        assert_eq!(browser.query(), "");
+        assert_eq!(browser.visible_entries().nth(browser.selected()).unwrap().name, "beta");
+
+        browser.handle_key(&key(KeyCode::Esc));
+        assert!(!browser.filter_mode());
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn enter_and_right_act_on_the_filtered_selection() {
+        let temp = temp_dir("activate");
+        create_dir(temp.join("docs")).unwrap();
+        write(temp.join("notes.md"), "").unwrap();
+        let mut browser = FileBrowser::new(temp.clone());
+
+        browser.handle_key(&key(KeyCode::Char('/')));
+        for ch in "notes".chars() {
+            browser.handle_key(&key(KeyCode::Char(ch)));
+        }
+        assert_eq!(
+            browser.handle_key(&key(KeyCode::Enter)),
+            Some(FileCommand::OpenEditor(temp.join("notes.md")))
+        );
+
+        let mut browser = FileBrowser::new(temp.clone());
+        browser.handle_key(&key(KeyCode::Char('/')));
+        for ch in "docs".chars() {
+            browser.handle_key(&key(KeyCode::Char(ch)));
+        }
+        browser.handle_key(&key(KeyCode::Right));
+        assert_eq!(browser.current_dir(), temp.join("docs"));
+        assert!(!browser.filter_mode());
+        fs::remove_dir_all(temp).unwrap();
+    }
+
+    #[test]
+    fn quotes_shell_paths_with_apostrophes() {
+        assert_eq!(shell_single_quote("/tmp/a'b"), "'/tmp/a'\\''b'");
+    }
+
+    #[test]
+    fn creates_percent_encoded_file_url() {
+        assert_eq!(file_url(Path::new("/tmp/a file#1.md")), "file:///tmp/a%20file%231.md");
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/mod.rs
@@ -362,7 +362,7 @@ mod tests {
             assert!(browser.handle_key(&ev).is_none(), "ctrl+{ch} must be inert");
         }
         assert!(!browser.filter_mode, "ctrl+/ must not enter filter mode");
-        std::fs::remove_dir_all(&dir).ok();
+        fs::remove_dir_all(&dir).ok();
     }
 
     fn temp_dir(name: &str) -> PathBuf {

--- a/cmux-tui/crates/cmux-tui/src/sidebar_files/navigation.rs
+++ b/cmux-tui/crates/cmux-tui/src/sidebar_files/navigation.rs
@@ -1,0 +1,82 @@
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct Navigation {
+    current_dir: PathBuf,
+    pinned: bool,
+}
+
+impl Navigation {
+    pub fn new(current_dir: PathBuf) -> Self {
+        Self { current_dir, pinned: false }
+    }
+
+    pub fn current_dir(&self) -> &Path {
+        &self.current_dir
+    }
+
+    pub fn is_pinned(&self) -> bool {
+        self.pinned
+    }
+
+    pub fn navigate(&mut self, directory: PathBuf) -> bool {
+        let changed = self.current_dir != directory;
+        self.current_dir = directory;
+        self.pinned = true;
+        changed
+    }
+
+    pub fn follow_focused_cwd(&mut self, directory: &Path) -> bool {
+        if self.pinned || self.current_dir == directory {
+            return false;
+        }
+        self.current_dir = directory.to_path_buf();
+        true
+    }
+
+    pub fn reroot(&mut self, directory: PathBuf) -> bool {
+        let changed = self.current_dir != directory;
+        self.current_dir = directory;
+        self.pinned = false;
+        changed
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, create_dir};
+
+    use super::*;
+
+    #[test]
+    fn follows_until_navigation_pins_then_reroot_unpins() {
+        let temp = std::env::temp_dir().join(format!(
+            "cmux-tui-sidebar-navigation-{}-{:?}",
+            std::process::id(),
+            std::thread::current().id()
+        ));
+        let _ = fs::remove_dir_all(&temp);
+        fs::create_dir_all(&temp).unwrap();
+        let first = temp.join("first");
+        let second = temp.join("second");
+        let manual = temp.join("manual");
+        create_dir(&first).unwrap();
+        create_dir(&second).unwrap();
+        create_dir(&manual).unwrap();
+
+        let mut navigation = Navigation::new(first.clone());
+        assert!(navigation.follow_focused_cwd(&second));
+        assert_eq!(navigation.current_dir(), second);
+
+        assert!(navigation.navigate(manual.clone()));
+        assert!(navigation.is_pinned());
+        assert!(!navigation.follow_focused_cwd(&first));
+        assert_eq!(navigation.current_dir(), manual);
+
+        assert!(navigation.reroot(first.clone()));
+        assert!(!navigation.is_pinned());
+        assert_eq!(navigation.current_dir(), first);
+        assert!(navigation.follow_focused_cwd(&second));
+        fs::remove_dir_all(temp).unwrap();
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/ui/mod.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/mod.rs
@@ -141,3 +141,36 @@ pub(crate) fn truncate(s: &str, max: usize) -> String {
         out
     }
 }
+
+pub(crate) fn middle_truncate(input: &str, max_chars: usize) -> String {
+    let chars = input.chars().collect::<Vec<_>>();
+    if chars.len() <= max_chars {
+        return input.to_string();
+    }
+    if max_chars == 0 {
+        return String::new();
+    }
+    if max_chars <= 3 {
+        return ".".repeat(max_chars);
+    }
+    let keep = max_chars - 3;
+    let front = keep.div_ceil(2);
+    let back = keep / 2;
+    let mut output = chars[..front].iter().collect::<String>();
+    output.push_str("...");
+    output.extend(&chars[chars.len() - back..]);
+    output
+}
+
+#[cfg(test)]
+mod tests {
+    use super::middle_truncate;
+
+    #[test]
+    fn middle_truncates_for_narrow_columns() {
+        assert_eq!(middle_truncate("abcdefghi", 7), "ab...hi");
+        assert_eq!(middle_truncate("abcdefghi", 3), "...");
+        assert_eq!(middle_truncate("abc", 3), "abc");
+        assert_eq!(middle_truncate("abc", 0), "");
+    }
+}

--- a/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/sidebar.rs
@@ -1,17 +1,15 @@
-//! Left sidebar: a "workspaces" header (with a blank line under it),
-//! then two lines per workspace (name, then the active pane's title)
-//! with a blank line between workspaces, and a new-workspace row at the
-//! end. Uses the terminal's default background so it blends with pane
-//! content; only the active workspace rows get a highlight. Owns its
-//! full column including the status-bar row (the status bar starts
-//! after the sidebar). Rebuilds the click hit map as it draws.
+//! Left sidebar renderer for the built-in files/workspaces views and the
+//! external plugin PTY. Owns its full column including the status-bar row
+//! (the status bar starts after the sidebar) and rebuilds the click hit map
+//! as it draws.
 
 use cmux_tui_core::Rect;
 use ratatui::Frame;
 use ratatui::style::{Color, Modifier, Style};
 
-use super::truncate;
+use super::{middle_truncate, truncate};
 use crate::app::{App, Hit};
+use crate::config::SidebarView;
 
 /// The color of a workspace's unread indicator, or `None` when nothing is
 /// unread. Mirrors the tab-bar severity cue (`error` > `warning` > `info`)
@@ -39,7 +37,10 @@ pub fn draw(app: &mut App, frame: &mut Frame) {
         draw_plugin(app, frame);
         return;
     }
-    draw_builtin(app, frame);
+    match app.sidebar_view {
+        SidebarView::Files => draw_files(app, frame),
+        SidebarView::Workspaces => draw_workspaces(app, frame),
+    }
 }
 
 fn draw_plugin(app: &mut App, frame: &mut Frame) {
@@ -103,7 +104,7 @@ fn draw_plugin(app: &mut App, frame: &mut Frame) {
     }
 }
 
-fn draw_builtin(app: &mut App, frame: &mut Frame) {
+fn draw_workspaces(app: &mut App, frame: &mut Frame) {
     let area = frame.area();
     let width = app.sidebar_width;
     let height = area.height;
@@ -156,20 +157,24 @@ fn draw_builtin(app: &mut App, frame: &mut Frame) {
             break;
         }
         let active = i == app.tree.active_workspace;
-        let mut style = if active { active_style } else { base };
+        let focused_selection = app.sidebar_focused && i == app.sidebar_workspace_selection;
+        let highlighted = active || focused_selection;
+        let mut style = if highlighted { active_style } else { base };
         if workspace_drag.is_some_and(|(id, _)| id == ws.id) {
             style = style.add_modifier(Modifier::DIM);
         }
         // The active highlight paints the full rows, and the rail marks
         // BOTH lines of the entry in the configured color.
-        if active {
+        if highlighted {
             for x in 0..width - 1 {
                 buf[(x, y)].set_style(active_style);
                 buf[(x, y + 1)].set_style(active_style);
             }
-            let rail_style = active_style.fg(rail);
-            buf[(0, y)].set_symbol("▎").set_style(rail_style);
-            buf[(0, y + 1)].set_symbol("▎").set_style(rail_style);
+            if active {
+                let rail_style = active_style.fg(rail);
+                buf[(0, y)].set_symbol("▎").set_style(rail_style);
+                buf[(0, y + 1)].set_symbol("▎").set_style(rail_style);
+            }
         }
         if content_w > 1
             && let Some(color) = workspace_unread_color(&app.config.theme, ws)
@@ -189,7 +194,7 @@ fn draw_builtin(app: &mut App, frame: &mut Frame) {
         } else {
             format!("  {}", truncate(title, content_w.saturating_sub(3)))
         };
-        let sub_style = if active { active_style.add_modifier(Modifier::DIM) } else { dim };
+        let sub_style = if highlighted { active_style.add_modifier(Modifier::DIM) } else { dim };
         set_line_from(buf, 1, y + 1, subtitle.trim_start(), sub_style);
         hits.push((row_rect(y + 1), Hit::Workspace { index: i, id: ws.id }));
         y += 3; // two content lines + one blank separator line
@@ -212,4 +217,157 @@ fn draw_builtin(app: &mut App, frame: &mut Frame) {
     }
     hits.push((Rect { x: width - 1, y: 0, width: 1, height }, Hit::SidebarResize));
     app.hits.extend(hits);
+}
+
+fn draw_files(app: &mut App, frame: &mut Frame) {
+    let area = frame.area();
+    let width = app.sidebar_width;
+    let height = area.height;
+    if width < 3 || height == 0 {
+        return;
+    }
+    let content_width = width - 1;
+    let content_w = content_width as usize;
+    let chrome = app.chrome;
+    let base = Style::default();
+    let dim = base.fg(chrome.sidebar_dim_fg);
+    let selected_bg = if app.config.theme_overrides.sidebar_active_bg {
+        app.config.theme.sidebar_active_bg
+    } else {
+        chrome.sidebar_selected_bg
+    };
+    let selected_style = Style::default()
+        .bg(selected_bg)
+        .fg(chrome.sidebar_selected_fg)
+        .add_modifier(Modifier::BOLD);
+    let border = base.fg(if app.sidebar_focused {
+        app.config.theme.border_active
+    } else {
+        chrome.sidebar_border
+    });
+
+    let entries = app
+        .sidebar_files
+        .visible_entries()
+        .map(|entry| (entry.name.clone(), entry.is_dir()))
+        .collect::<Vec<_>>();
+    let selected = app.sidebar_files.selected();
+    let current_dir = app.sidebar_files.current_dir().to_string_lossy().into_owned();
+    let pinned = app.sidebar_files.is_pinned();
+    let filter_mode = app.sidebar_files.filter_mode();
+    let query = app.sidebar_files.query().to_string();
+    let show_hidden = app.sidebar_files.show_hidden();
+    let total = app.sidebar_files.total_len();
+    let listing_error = app.sidebar_files.listing_error().map(str::to_owned);
+    let message = app.sidebar_files.message().map(str::to_owned);
+    let unread = unread_summary(app);
+
+    let buf = frame.buffer_mut();
+    for y in 0..height {
+        for x in 0..content_width {
+            buf[(x, y)].set_symbol(" ").set_style(base);
+        }
+        buf[(width - 1, y)].set_symbol("│").set_style(border);
+    }
+
+    let marker = if pinned { "● " } else { "  " };
+    buf.set_stringn(0, 0, marker, content_w, dim);
+    let badge = unread.map(|(count, _)| format!("• {count}"));
+    let badge_width = badge.as_ref().map(|text| text.chars().count()).unwrap_or(0);
+    let path_width = content_w.saturating_sub(2 + badge_width + usize::from(badge_width > 0));
+    let path = middle_truncate(&current_dir, path_width);
+    buf.set_stringn(2, 0, &path, path_width, base.add_modifier(Modifier::BOLD));
+    if let (Some(text), Some((_, color))) = (badge, unread) {
+        let badge_x = content_width.saturating_sub(text.chars().count() as u16);
+        buf.set_stringn(
+            badge_x,
+            0,
+            &text,
+            text.chars().count(),
+            base.fg(color).add_modifier(Modifier::BOLD),
+        );
+    }
+
+    let body_start = 1;
+    let body_height = height.saturating_sub(2) as usize;
+    let mut hits = Vec::new();
+    if let Some(error) = listing_error {
+        if body_height > 0 {
+            buf.set_stringn(0, body_start, truncate(&error, content_w), content_w, dim);
+        }
+    } else if entries.is_empty() {
+        if body_height > 0 {
+            buf.set_stringn(0, body_start, " No files", content_w, dim);
+        }
+    } else {
+        let offset = file_scroll_offset(selected, body_height, entries.len());
+        for (line, (name, is_dir)) in entries.iter().skip(offset).take(body_height).enumerate() {
+            let y = body_start + line as u16;
+            let row_index = offset + line;
+            let style = if row_index == selected { selected_style } else { base };
+            if row_index == selected {
+                for x in 0..content_width {
+                    buf[(x, y)].set_style(style);
+                }
+            }
+            let prefix = if *is_dir { "▸ " } else { "  " };
+            buf.set_stringn(0, y, prefix, content_w, style.add_modifier(Modifier::DIM));
+            let name_width = content_w.saturating_sub(2);
+            buf.set_stringn(2, y, truncate(name, name_width), name_width, style);
+            hits.push((
+                Rect { x: 0, y, width: content_width, height: 1 },
+                Hit::SidebarFile { index: row_index },
+            ));
+        }
+    }
+
+    if height > 1 {
+        let footer = if filter_mode {
+            format!("/{query}█")
+        } else if let Some(message) = message {
+            message
+        } else {
+            format!(
+                "{}/{}  .:{}  / filter",
+                entries.len(),
+                total,
+                if show_hidden { "on" } else { "off" }
+            )
+        };
+        buf.set_stringn(0, height - 1, truncate(&footer, content_w), content_w, dim);
+    }
+    hits.push((Rect { x: width - 1, y: 0, width: 1, height }, Hit::SidebarResize));
+    app.hits.extend(hits);
+}
+
+fn unread_summary(app: &App) -> Option<(usize, Color)> {
+    let mut count = 0;
+    let mut highest = None;
+    for notification in app
+        .tree
+        .workspaces
+        .iter()
+        .flat_map(|workspace| workspace.screens.iter())
+        .flat_map(|screen| screen.panes.iter())
+        .flat_map(|pane| pane.tabs.iter())
+        .filter_map(|tab| tab.notification.filter(|notification| notification.unread))
+    {
+        count += 1;
+        let ranked = match notification.level {
+            "error" => (2u8, app.config.theme.notification_error),
+            "warning" => (1, app.config.theme.notification_warning),
+            _ => (0, app.config.theme.notification_info),
+        };
+        if highest.is_none_or(|current: (u8, Color)| ranked.0 > current.0) {
+            highest = Some(ranked);
+        }
+    }
+    highest.map(|(_, color)| (count, color))
+}
+
+fn file_scroll_offset(selected: usize, visible_height: usize, total: usize) -> usize {
+    if visible_height == 0 || total <= visible_height || selected < visible_height {
+        return 0;
+    }
+    (selected + 1).saturating_sub(visible_height).min(total - visible_height)
 }

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -36,8 +36,11 @@ Tabs are numbered by default. A recognized agent program can appear after the nu
 
 ## Sidebar
 
+The built-in sidebar now defaults to the file browser. To preserve the previous workspace-list default, set `"sidebar": {"view": "workspaces"}`. `Tab` toggles the built-in view while the sidebar is focused, and the configurable `toggle-sidebar-view` action toggles it from anywhere. A configured `sidebar.plugin` still replaces either built-in view.
+
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
+| `sidebar.view` | `"files"` or `"workspaces"` | `"files"` | Built-in sidebar view when `sidebar.plugin` is unset |
 | `sidebar.width` | integer | `22` | Sidebar width, clamped to 10 through 60 on load |
 | `sidebar.max_width` | integer | `0` | Maximum live drag width; `0` means no configured maximum |
 | `sidebar.plugin.command` | array of strings | unset | External sidebar plugin argv; when set, the sidebar hosts this program in a PTY instead of the built-in list |
@@ -119,7 +122,8 @@ The default launched profile is `~/Library/Application Support/cmux-tui/chrome-p
 | `keys.next-workspace` | chord string or array or `"none"` | `"w"` | Next workspace |
 | `keys.new-workspace` | chord string or array or `"none"` | `"W"` | New workspace |
 | `keys.toggle-sidebar` | chord string or array or `"none"` | `"s"` | Toggle sidebar |
-| `keys.focus-sidebar` | chord string or array or `"none"` | `"S"` | Focus the sidebar plugin (keys forward to it; prefix returns) |
+| `keys.toggle-sidebar-view` | chord string or array or `"none"` | `"e"` | Toggle the built-in files/workspaces view; a plugin still takes precedence |
+| `keys.focus-sidebar` | chord string or array or `"none"` | `"S"` | Focus the built-in sidebar or sidebar plugin; a prefixed command returns focus to the pane |
 | `keys.focus-next-pane` | chord string or array or `"none"` | `"o"` | Cycle to the next pane in the current screen |
 | `keys.focus-left` | chord string or array or `"none"` | `["h","left","alt+h","alt+left"]` | Focus left |
 | `keys.focus-right` | chord string or array or `"none"` | `["l","right","alt+l","alt+right"]` | Focus right |
@@ -171,6 +175,7 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "agents": ["claude", "codex", "opencode", "pi"]
   },
   "sidebar": {
+    "view": "files",
     "width": 24,
     "max_width": 40
   },
@@ -199,6 +204,7 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
     "prev-screen": ["p", "alt+["],
     "rename-tab": "r",
     "rename-screen": ",",
+    "toggle-sidebar-view": "e",
     "focus-left": ["h", "left", "alt+h", "alt+left"],
     "focus-right": ["l", "right", "alt+l", "alt+right"],
     "close-pane": "x",

--- a/cmux-tui/docs/keyboard.md
+++ b/cmux-tui/docs/keyboard.md
@@ -38,8 +38,9 @@ These defaults come from `Keys::default`.
 | `Ctrl-b }` | Swap the active pane with the next pane |
 | `Ctrl-b w` | Next workspace |
 | `Ctrl-b W` | New workspace |
-| `Ctrl-b s` | Toggle the workspace sidebar |
-| `Ctrl-b S` | Focus the sidebar plugin (when `sidebar.plugin` is configured; keys forward to it, `Ctrl-b` returns focus) |
+| `Ctrl-b s` | Show or hide the sidebar |
+| `Ctrl-b e` | Toggle the built-in sidebar between files and workspaces |
+| `Ctrl-b S` | Focus the built-in sidebar or configured sidebar plugin; a prefixed command returns focus to the pane |
 | `Ctrl-b h` or `Ctrl-b Left` | Focus left |
 | `Alt-h` or `Alt-Left` | Focus left |
 | `Ctrl-b l` or `Ctrl-b Right` | Focus right |
@@ -60,6 +61,12 @@ The screen bindings intentionally use tmux verbs: `c` creates a screen, `n` and 
 `Ctrl-b x` now follows tmux and closes the active pane. `Ctrl-b X` closes the active tab. Restore the old cmux behavior with `"close-tab": "x"` and `"close-pane": "X"` in `cmux-tui.json`.
 
 `Ctrl-b ]` is unbound because cmux has no paste-buffer concept. `Ctrl-b q` is unbound because there is no pane-number quick-jump overlay yet.
+
+## Focused Sidebar
+
+When the built-in sidebar is focused, `Tab` toggles files/workspaces without leaving sidebar focus. In the files view, Up/Down and Ctrl-J/Ctrl-K move the selection, Right descends into a directory, Enter descends or opens a file in a new `$EDITOR` tab, Left goes to the parent, `c` sends a safely quoted `cd` to the focused pane, `o` opens `.html` and `.md` files in a browser tab, `.` toggles dotfiles, `/` enters filter mode, and `~` follows the focused pane cwd again. Esc clears a nonempty filter before leaving filter mode.
+
+In the workspaces view, Up/Down move the selection and Enter activates it. Any normal prefixed command leaves sidebar focus and runs through the usual action table; `prefix S` only returns focus to the pane. A configured sidebar plugin keeps its existing PTY forwarding behavior.
 
 ## Modeless Alt Layer
 
@@ -141,6 +148,7 @@ new-screen
 next-workspace
 new-workspace
 toggle-sidebar
+toggle-sidebar-view
 focus-sidebar
 focus-left
 focus-right

--- a/cmux-tui/docs/mouse.md
+++ b/cmux-tui/docs/mouse.md
@@ -2,7 +2,9 @@
 
 ## Click Targets
 
-The sidebar shows a `workspaces` header, two rows per workspace, and `+ new workspace`. Click either row of a workspace to select it. Click `+ new workspace` to create one. Drag the sidebar's right border to set a session-local width override. Configured `sidebar.max_width` limits the drag width when it is greater than zero, and the TUI still leaves at least 40 columns for panes.
+The default files sidebar shows the focused pane's cwd, one row per directory/file, and a count or filter footer. A single click selects a file row. Crossterm's mouse events do not expose an existing double-click concept here, so clicks do not open or descend; use Enter or Right while the sidebar is focused. Toggle to the workspaces view with focused-sidebar `Tab` or the `toggle-sidebar-view` action.
+
+The workspaces view shows a `workspaces` header, two rows per workspace, and `+ new workspace`. Click either row of a workspace to select it. Click `+ new workspace` to create one. Drag the sidebar's right border in either built-in view to set a session-local width override. Configured `sidebar.max_width` limits the drag width when it is greater than zero, and the TUI still leaves at least 40 columns for panes.
 
 Each pane has a border box. Click inside a pane to focus it. The top border is the tab bar: click a tab chip to select it, click `+` to create a PTY tab, click `‹` or `›` to scroll overflowing tabs, or wheel over the bar to scroll tab chips while keeping the active tab visible.
 
@@ -12,7 +14,7 @@ The status bar lists screens for the active workspace. Click a screen segment to
 
 Drag a tab chip to reorder it within the same pane. Drag it to another pane's tab bar to move the tab across panes. The dragged tab is dimmed, and the target insertion point is shown with a `▌` marker.
 
-Drag a workspace entry in the sidebar to reorder workspaces. The drop position is shown with a horizontal `─` marker.
+In the workspaces view, drag a workspace entry to reorder workspaces. The drop position is shown with a horizontal `─` marker.
 
 ## Scrollbars
 

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -135,6 +135,10 @@ pid, fd = pty.fork()
 if pid == 0:
     os.chdir(tmpdir.name)
     os.environ["TERM"] = "xterm-256color"
+    # Hermetic shell: zsh/bash init on CI runners can report a different pwd
+    # (which the files sidebar follows); /bin/sh reports nothing, so the
+    # sidebar deterministically roots at the spawn cwd (this tmpdir).
+    os.environ["SHELL"] = "/bin/sh"
     os.environ["CMUX_MUX_CDP_URL"] = "http://127.0.0.1:1/"
     os.environ.pop("NO_COLOR", None)
     os.execv(BIN, [BIN, "--session", SESSION, "--socket", SOCK])
@@ -397,9 +401,8 @@ print("prefix-S returns focus to the pane ok")
 with open(config_path, "w", encoding="utf-8") as f:
     json.dump({"sidebar": {"width": 22}}, f)
 assert rpc({"id": 31, "cmd": "reload-config"})["ok"]
-drain(1.0)
-snapshot = render_text_snapshot(output)
-assert sidebar_marker in snapshot, snapshot[-1200:]
+# The cwd follow runs on a 2s cadence; wait event-driven rather than a fixed drain.
+wait_render_contains(sidebar_marker)
 print("sidebar plugin config reload falls back to default files sidebar ok")
 os.write(fd, b"\x02S")
 drain(0.4)

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -139,6 +139,9 @@ if pid == 0:
     # (which the files sidebar follows); /bin/sh reports nothing, so the
     # sidebar deterministically roots at the spawn cwd (this tmpdir).
     os.environ["SHELL"] = "/bin/sh"
+    # Pane surfaces spawn at home_dir() when no cwd is configured; point HOME
+    # at the tmpdir so the files sidebar roots where the marker is seeded.
+    os.environ["HOME"] = tmpdir.name
     os.environ["CMUX_MUX_CDP_URL"] = "http://127.0.0.1:1/"
     os.environ.pop("NO_COLOR", None)
     os.execv(BIN, [BIN, "--session", SESSION, "--socket", SOCK])

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -110,6 +110,9 @@ SOCK = discover_socket_path()
 
 tmpdir = tempfile.TemporaryDirectory(prefix="cmux-tui-smoke-")
 config_path = os.path.join(tmpdir.name, "cmux-tui.json")
+sidebar_marker = "tui-file.txt"
+with open(os.path.join(tmpdir.name, sidebar_marker), "w", encoding="utf-8") as f:
+    f.write("file sidebar smoke marker\n")
 with open(config_path, "w", encoding="utf-8") as f:
     json.dump(
         {
@@ -130,6 +133,7 @@ os.environ["CMUX_TUI_CONFIG"] = config_path
 
 pid, fd = pty.fork()
 if pid == 0:
+    os.chdir(tmpdir.name)
     os.environ["TERM"] = "xterm-256color"
     os.environ["CMUX_MUX_CDP_URL"] = "http://127.0.0.1:1/"
     os.environ.pop("NO_COLOR", None)
@@ -394,8 +398,15 @@ with open(config_path, "w", encoding="utf-8") as f:
     json.dump({"sidebar": {"width": 22}}, f)
 assert rpc({"id": 31, "cmd": "reload-config"})["ok"]
 drain(1.0)
+snapshot = render_text_snapshot(output)
+assert sidebar_marker in snapshot, snapshot[-1200:]
+print("sidebar plugin config reload falls back to default files sidebar ok")
+os.write(fd, b"\x02S")
+drain(0.4)
+os.write(fd, b"\t")
+drain(0.5)
 assert "workspaces" in render_text_snapshot(output), output[-1200:]
-print("sidebar plugin config reload falls back to built-in sidebar ok")
+print("focused sidebar Tab toggles files to workspaces ok")
 
 # Prefix-B creates a browser tab immediately and focuses its in-pane
 # omnibar. The dead CDP endpoint keeps this Chrome-free and fast.

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -1,6 +1,6 @@
 import os, pty, select, socket, json, time, sys, signal, subprocess, re, tempfile
 
-BIN = os.environ.get("CMUX_TUI_BIN", "target/debug/cmux-tui")
+BIN = os.path.abspath(os.environ.get("CMUX_TUI_BIN", "target/debug/cmux-tui"))
 SESSION = f"smoke-{os.getpid()}"
 SOCK = None
 CONTROL_SOCKET_RE = re.compile(r"control socket at (.+)$")

--- a/cmux-tui/spec/plugins.md
+++ b/cmux-tui/spec/plugins.md
@@ -21,7 +21,7 @@ A sidebar plugin is an executable terminal program. The mux server starts it ins
 }
 ```
 
-When `sidebar.plugin` is absent, the built-in workspace sidebar is used. When present, the plugin replaces the built-in sidebar. In a local TUI session, `reload-config` applies this key through the existing config reload path. A headless server or attached-client setup may require restarting the server process so the server, not the attach client, picks up the plugin command.
+When `sidebar.plugin` is absent, the built-in view selected by `sidebar.view` is used (`files` by default, or `workspaces`). When present, the plugin replaces either built-in view. In a local TUI session, `reload-config` applies this key through the existing config reload path. A headless server or attached-client setup may require restarting the server process so the server, not the attach client, picks up the plugin command.
 
 The sidebar content PTY is sized to the sidebar content cells. The host TUI keeps one separator/focus-border column at the right edge. Resizes use normal PTY resizing (`TIOCSWINSZ` on Unix), so plugins observe the standard terminal resize behavior and `SIGWINCH`; there is no plugin-specific resize protocol.
 
@@ -46,7 +46,7 @@ If the plugin exits or fails to start, the TUI renders a visible error message i
 
 ### Focus And Input
 
-`focus-sidebar` is the keyboard action for focusing the sidebar plugin. The default binding is `prefix S`.
+When a plugin is configured, `focus-sidebar` focuses its PTY. The default binding is `prefix S`.
 
 While the sidebar is focused, key and paste input are forwarded as PTY bytes using the same key encoder and terminal-mode state as pane PTYs. The global prefix chord is the escape hatch back to cmux:
 


### PR DESCRIPTION
The built-in sidebar gains two views: a yazi-inspired file browser (new default) and the existing workspace list (Tab toggles while focused; prefix e from anywhere; sidebar.view config restores the old default; sidebar.plugin still overrides everything). The files view ports the judged cmux-sidebar-files plugin logic natively — in-process Session actions instead of socket commands — including the injection-safe cd quoting and filter fixes, with the plugin's unit tests. Notifications stay visible in files view via a header unread badge. Smoke updated for the new default. Local compile blocked (host zig issue; coder type-checked via a build-script bypass + clippy) — CI gates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7885"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786359496&installation_id=133855650&pr_number=7885&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7885&signature=f9eb5aef26c15eca6ed2d5506bb431e231abf88cd6dda6fb2257a4dc8e966b8d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default UX and send shell commands (`cd`, editor spawn) to focused panes; mitigations include single-quote escaping and modifier-gated keys, but remote cwd polling adds session I/O on the event loop.
> 
> **Overview**
> The built-in sidebar is no longer workspace-only: **`sidebar.view`** defaults to **files**, with the previous list available as **`workspaces`** (`"sidebar": {"view": "workspaces"}` restores the old default). **`toggle-sidebar-view`** (default `Ctrl-b e`) and **Tab** while the sidebar is focused switch views; a configured **`sidebar.plugin`** still replaces either built-in view.
> 
> A new **`sidebar_files`** stack drives the Files UI: directory listing/filtering, pin vs follow-focused-pane **cwd** (2s refresh, including remote **`surface_cwd`**), and keyboard routing that ignores Ctrl/Alt chords on letter keys. File actions run in-process via new **`Session`** helpers (**`send_bytes`**, **`run_command`**, **`surface_cwd`**): quoted **`cd`** to the focused pane, **`$EDITOR`** for files, browser tabs for `.html`/`.md`. **`focus-sidebar`** works without a plugin; paste and keys go to the built-in sidebar when focused.
> 
> Rendering adds **`draw_files`** (path header, unread badge, click **`Hit::SidebarFile`**), workspace keyboard selection when focused, and **`middle_truncate`** for narrow paths. Docs, smoke (hermetic cwd + event-driven file marker), and unit/integration tests cover toggling, resize hits, and plugin fallback on config reload.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4d69654b1e32d7548cc9fced36419eaf8aac5472. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made a yazi‑inspired file browser the default built‑in sidebar with a fast toggle between Files and Workspaces; `sidebar.plugin` still overrides. Adds safe in‑process file actions, an unread header badge, input hardening, and a gated 2s follow/refresh cadence.

- **New Features**
  - Files: fast in‑process listing/sort, dotfiles toggle, parent/descend, `/` filter with stable selection, `~` to re‑root/follow; follows focused pane cwd until pinned (2s refresh).
  - Actions: safely quoted `cd` to the focused pane, open in `$EDITOR`, open `.html`/`.md` in a browser tab.
  - Navigation: Up/Down or Ctrl‑K/J to move, Right/Enter to descend/open, Left to parent; single‑click selects; paste edits the filter; Ctrl/Alt character chords are inert.
  - Workspaces: Up/Down to move, Enter to activate when focused.
  - Toggle views: `Tab` while the sidebar is focused, or the `toggle-sidebar-view` action (default `prefix e`) from anywhere.
  - Focus/UI: `focus-sidebar` (`prefix S`) focuses the built‑in sidebar when no plugin is configured; header shows an unread count badge; long paths are middle‑truncated; drag‑resize and width limits unchanged.
  - Dev/Smoke: hermetic `SHELL=/bin/sh`, `HOME` pinned to the tmpdir, BIN path made absolute, and an event‑driven wait for the files‑sidebar marker to avoid PWD races and timing flakiness.

- **Migration**
  - The default switched from Workspaces to Files. To keep the old default, set `"sidebar": {"view": "workspaces"}`.
  - `sidebar.plugin` continues to take precedence over both built‑in views.

<sup>Written for commit 4d69654b1e32d7548cc9fced36419eaf8aac5472. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a built-in **Files** sidebar with directory browsing, filter/search mode, hidden-file toggle, keyboard navigation, and clickable row selection.
  * Added **Files/Workspaces** sidebar switching via **Tab** and the new `toggle-sidebar-view` action, including unread badges in the Files view.
* **Bug Fixes**
  * Improved sidebar focus/selection synchronization across sidebar resizing and pane working-directory changes.
* **Documentation**
  * Updated configuration, keyboard, and mouse docs to describe the new sidebar view mode and bindings; refreshed plugin/sidebar contract wording.
* **Tests**
  * Expanded sidebar rendering, view toggling, and resize-hit coverage; updated smoke-test expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->