### PR TITLE
ts sdk: typed protocol + transports for building cmux-tui frontends

### DIFF
--- a/cmux-tui/bindings/typescript/README.md
+++ b/cmux-tui/bindings/typescript/README.md
@@ -1,35 +1,95 @@
 # cmux TypeScript Client
 
-Node.js client for the cmux-tui Unix-socket JSON-lines protocol.
+The typed client library for cmux-tui frontends. It exposes every implemented
+command and event in protocol v6, transport-independent request handling,
+browser-safe attach streams, and Node.js Unix-socket defaults.
 
-## Build
+## Install and build
 
 ```bash
-npm i cmux
-npm install
+npm install cmux
 npm run build
 ```
 
-The package has no runtime dependencies. Node 20 or newer is required.
+The package has no runtime dependencies. The Node entry requires Node 20 or
+newer. Browser bundles resolve the root `browser` export condition, and the
+same browser-safe surface is available explicitly from `cmux/browser`.
 
-## Usage
+## Building a frontend
+
+This example uses an existing xterm.js terminal and a cmux WebSocket endpoint.
+Attach payloads are decoded to `Uint8Array`, which xterm.js accepts directly.
 
 ```ts
-import { CmuxClient } from "cmux";
+import { Terminal } from "@xterm/xterm";
+import { CmuxClient, WebSocketTransport } from "cmux";
+const terminal = new Terminal();
+const transport = new WebSocketTransport("ws://127.0.0.1:9000/api/v1/ws");
+const client = new CmuxClient({ transport });
+const info = await client.identify();
+console.log(`cmux protocol ${info.protocol}`);
+const tree = await client.listWorkspaces();
+const workspace = tree.workspaces.find(({ active }) => active);
+const screen = workspace?.screens.find(({ active }) => active);
+const pane = screen?.panes.find((item) => "tabs" in item);
+const surface = pane && "tabs" in pane ? pane.tabs[pane.active_tab]?.surface : undefined;
+if (surface === undefined) throw new Error("No active surface");
+const stream = await client.attachSurface(surface);
+void (async () => {
+  for await (const event of stream) {
+    if (event.event === "vt-state" || event.event === "output") terminal.write(event.data);
+  }
+})();
+await client.send(surface, { bytes: new TextEncoder().encode("ls\r") });
+```
+
+`WebSocketTransport` uses the browser's global `WebSocket`. In Node, inject any
+compatible constructor without adding a runtime dependency to this package:
+
+```ts
+import WebSocket from "ws";
+import { CmuxClient, WebSocketTransport } from "cmux";
+
+const client = new CmuxClient({
+  transport: new WebSocketTransport("ws://127.0.0.1:9000/api/v1/ws", WebSocket),
+});
+```
+
+## Node Unix socket
+
+The default Node entry preserves the original zero-argument API:
+
+```ts
+import { CmuxClient } from "cmux/node";
 
 const client = new CmuxClient();
-const info = await client.identify();
 const created = await client.newWorkspace({ name: "sdk-demo", cols: 80, rows: 24 });
 await client.send(created.surface, { text: "echo hello\r" });
 console.log((await client.readScreen(created.surface)).text);
 await client.close();
 ```
 
-`new CmuxClient()` uses `CMUX_TUI_SOCKET` when set, then legacy
-`CMUX_MUX_SOCKET`, then the default session socket path.
+`new CmuxClient()` uses `CMUX_TUI_SOCKET`, then legacy `CMUX_MUX_SOCKET`, then
+the default session socket. Unix subscribe and attach streams retain dedicated
+connections; an injected transport can multiplex them on its main connection.
 
-## E2E
+## Raw typed requests
+
+Every command method delegates to the same generic escape hatch:
+
+```ts
+const result = await client.request({ cmd: "copy", surface: 1, mode: "screen" });
+```
+
+The `cmd` discriminator determines both required parameters and the successful
+response data type. `sendRaw()` remains available for untyped forward
+compatibility.
+
+## Verification
 
 ```bash
+npm ci
+npm run build
+npm test
 CMUX_TUI_SOCKET=/path/to/session.sock npm run e2e
 ```

--- a/cmux-tui/bindings/typescript/package.json
+++ b/cmux-tui/bindings/typescript/package.json
@@ -1,18 +1,47 @@
 {
   "name": "cmux",
   "version": "0.1.2",
-  "description": "Node.js client for the cmux-tui JSON-lines protocol",
+  "description": "Typed TypeScript client for cmux-tui frontends",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/manaflow-ai/cmux.git",
     "directory": "cmux-tui/bindings/typescript"
   },
   "homepage": "https://github.com/manaflow-ai/cmux/tree/main/cmux-tui/bindings/typescript",
-  "main": "dist/src/index.js",
-  "types": "dist/src/index.d.ts",
+  "type": "module",
+  "main": "./dist/src/index.js",
+  "types": "./dist/src/index.d.ts",
+  "exports": {
+    ".": {
+      "browser": {
+        "types": "./dist/src/browser.d.ts",
+        "import": "./dist/src/browser.js",
+        "default": "./dist/src/browser.js"
+      },
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "default": "./dist/src/index.js"
+    },
+    "./browser": {
+      "types": "./dist/src/browser.d.ts",
+      "import": "./dist/src/browser.js",
+      "default": "./dist/src/browser.js"
+    },
+    "./node": {
+      "types": "./dist/src/index.d.ts",
+      "import": "./dist/src/index.js",
+      "default": "./dist/src/index.js"
+    }
+  },
+  "sideEffects": false,
+  "files": [
+    "dist/src",
+    "README.md"
+  ],
   "scripts": {
     "build": "tsc",
-    "e2e": "tsc && node dist/e2e/e2e.js"
+    "test": "npm run build && node --test dist/test/*.test.js",
+    "e2e": "npm run build && node dist/e2e/e2e.js"
   },
   "engines": {
     "node": ">=20"

--- a/cmux-tui/bindings/typescript/src/base64.ts
+++ b/cmux-tui/bindings/typescript/src/base64.ts
@@ -1,0 +1,48 @@
+interface NodeBufferValue {
+  readonly length: number;
+  readonly [index: number]: number;
+  toString(encoding: "base64"): string;
+}
+
+interface NodeBufferConstructor {
+  from(value: Uint8Array): NodeBufferValue;
+  from(value: string, encoding: "base64"): NodeBufferValue;
+}
+
+function nodeBuffer(): NodeBufferConstructor | undefined {
+  return (globalThis as typeof globalThis & { Buffer?: NodeBufferConstructor }).Buffer;
+}
+
+/** Decodes standard base64 without requiring Node's `Buffer`. */
+export function decodeBase64(value: string): Uint8Array {
+  if (typeof globalThis.atob === "function") {
+    const decoded = globalThis.atob(value);
+    const bytes = new Uint8Array(decoded.length);
+    for (let index = 0; index < decoded.length; index += 1) bytes[index] = decoded.charCodeAt(index);
+    return bytes;
+  }
+
+  const Buffer = nodeBuffer();
+  if (!Buffer) throw new Error("base64 decoding is not available in this runtime");
+  const decoded = Buffer.from(value, "base64");
+  const bytes = new Uint8Array(decoded.length);
+  for (let index = 0; index < decoded.length; index += 1) bytes[index] = decoded[index];
+  return bytes;
+}
+
+/** Encodes bytes as standard base64 without requiring Node's `Buffer`. */
+export function encodeBase64(value: Uint8Array): string {
+  if (typeof globalThis.btoa === "function") {
+    let binary = "";
+    const chunkSize = 0x8000;
+    for (let offset = 0; offset < value.length; offset += chunkSize) {
+      const chunk = value.subarray(offset, Math.min(offset + chunkSize, value.length));
+      for (const byte of chunk) binary += String.fromCharCode(byte);
+    }
+    return globalThis.btoa(binary);
+  }
+
+  const Buffer = nodeBuffer();
+  if (!Buffer) throw new Error("base64 encoding is not available in this runtime");
+  return Buffer.from(value).toString("base64");
+}

--- a/cmux-tui/bindings/typescript/src/browser.ts
+++ b/cmux-tui/bindings/typescript/src/browser.ts
@@ -1,7 +1,8 @@
-export { CmuxClient, type ClientOptions } from "./node-client.js";
 export {
+  CmuxClient,
   CmuxStream,
   type CmuxClientOptions,
+  type CmuxClientOptions as ClientOptions,
   type NewBrowserTabOptions,
   type NewScreenOptions,
   type NewTabOptions,
@@ -13,7 +14,6 @@ export {
 } from "./client.js";
 export * from "./base64.js";
 export * from "./errors.js";
-export * from "./node-transport.js";
 export * from "./protocol/index.js";
 export * from "./transport.js";
 export * from "./websocket-transport.js";

--- a/cmux-tui/bindings/typescript/src/client.ts
+++ b/cmux-tui/bindings/typescript/src/client.ts
@@ -294,7 +294,14 @@ export class CmuxClient {
   }
 
   request<C extends CmuxRequest>(request: C): Promise<CmuxResponseData<C>>;
-  request<C extends CmuxCommand>(cmd: C, params?: CmuxRequestParams<C>): Promise<CmuxResponseDataFor<C>>;
+  // params is only optional when the command genuinely has no required params;
+  // otherwise `client.request("send")` would compile and fail server-side.
+  request<C extends CmuxCommand>(
+    cmd: C,
+    ...args: Record<string, never> extends CmuxRequestParams<C>
+      ? [params?: CmuxRequestParams<C>]
+      : [params: CmuxRequestParams<C>]
+  ): Promise<CmuxResponseDataFor<C>>;
   async request<C extends CmuxCommand>(
     requestOrCommand: CmuxRequest | C,
     params?: CmuxRequestParams<C>,

--- a/cmux-tui/bindings/typescript/src/client.ts
+++ b/cmux-tui/bindings/typescript/src/client.ts
@@ -1,149 +1,263 @@
-import { Buffer } from "node:buffer";
-import * as net from "node:net";
-import * as os from "node:os";
-import * as path from "node:path";
+import { decodeBase64, encodeBase64 } from "./base64.js";
 import {
+  CmuxCommandError,
+  CmuxConnectionError,
+  CmuxError,
+  CmuxProtocolError,
+  CmuxTimeoutError,
+} from "./errors.js";
+import type {
+  ApplyLayoutResult,
   AttachEvent,
-  ClientOptions,
+  CmuxCommand,
+  CmuxRequest,
+  CmuxRequestParams,
+  CmuxResponse,
+  CmuxResponseData,
+  CmuxResponseDataFor,
+  ColorHex,
+  CopyMode,
+  CopyResult,
+  DecodedAttachEvent,
   EmptyResult,
+  ExportLayoutResult,
+  Id,
+  IdKind,
+  IdRef,
+  IdsResult,
   IdentifyResult,
+  Json,
   JsonObject,
-  NewBrowserTabOptions,
-  NewScreenOptions,
-  NewTabOptions,
-  NewWorkspaceOptions,
+  ListAgentsResult,
+  NotificationLevel,
+  NotifyResult,
+  PaneDirection,
+  PaneNeighborResult,
+  PingResult,
+  ProcessInfoResult,
   ReadScreenResult,
-  SelectOptions,
-  SelectTabOptions,
-  SendOptions,
-  SplitOptions,
+  ReloadConfigResult,
+  ReportAgentResult,
+  RunResult,
+  SidebarPluginResult,
+  SplitDirection,
   SubscribeEvent,
   SurfaceResult,
   Tree,
+  UnknownEvent,
   VtStateResult,
-} from "./types.js";
-import { CmuxCommandError, CmuxConnectionError, CmuxProtocolError, CmuxTimeoutError } from "./errors.js";
+  WaitForResult,
+  ZoomPaneResult,
+  AgentReportSource,
+  AgentState,
+  DeclarativeLayout,
+  FocusDirectionResult,
+} from "./protocol/index.js";
+import type { Transport, Unsubscribe } from "./transport.js";
 
-type ResponseEnvelope = { id?: unknown; ok: true; data: unknown } | { id?: unknown; ok: false; error: string };
-type EventObject = { event: string; [key: string]: unknown };
-
-export function defaultSocketPath(session = "main"): string {
-  const base = process.env.TMPDIR || os.tmpdir();
-  return path.join(base, `cmux-tui-${process.getuid?.() ?? 0}`, `${session}.sock`);
+export interface CmuxClientOptions {
+  transport: Transport;
+  timeoutMs?: number;
+  allowProtocolV6Attach?: boolean;
+  /** Creates dedicated subscribe/attach transports when supplied. */
+  streamTransportFactory?: () => Transport;
 }
 
-export function envSocketPath(): string | undefined {
-  return process.env.CMUX_TUI_SOCKET || process.env.CMUX_MUX_SOCKET;
+export type NewTabOptions = CmuxRequestParams<"new-tab">;
+export type NewBrowserTabOptions = Omit<CmuxRequestParams<"new-browser-tab">, "url">;
+export type NewWorkspaceOptions = CmuxRequestParams<"new-workspace">;
+export type NewScreenOptions = CmuxRequestParams<"new-screen">;
+export type SplitOptions = Omit<CmuxRequestParams<"split">, "pane" | "dir">;
+export type SelectOptions = CmuxRequestParams<"select-screen">;
+export type SelectTabOptions = CmuxRequestParams<"select-tab">;
+export interface SendOptions { text?: string | null; bytes?: string | Uint8Array | null }
+
+interface PendingResponse {
+  resolve: (response: CmuxResponse<unknown>) => void;
+  reject: (error: Error) => void;
+  timer: ReturnType<typeof setTimeout>;
 }
 
-class JsonLineConnection {
-  private socket: net.Socket;
-  private buffer = "";
-  private lines: string[] = [];
-  private waiters: Array<{
-    active: boolean;
-    resolve: (line: string) => void;
-    reject: (error: Error) => void;
-  }> = [];
-  private closedError: Error | null = null;
+class MessageRouter {
+  private readonly pending = new Map<string, PendingResponse>();
+  private readonly eventHandlers = new Set<(event: UnknownEvent) => void>();
+  private readonly terminalHandlers = new Set<(error: Error) => void>();
+  private terminalError: Error | null = null;
 
-  private constructor(socket: net.Socket) {
-    this.socket = socket;
-    socket.setEncoding("utf8");
-    socket.on("data", (chunk: string) => this.onData(chunk));
-    socket.on("error", (err: Error) => this.closeWith(new CmuxConnectionError(`socket error: ${err.message}`)));
-    socket.on("close", () => this.closeWith(new CmuxConnectionError("session socket closed")));
+  constructor(readonly transport: Transport) {
+    transport.onMessage((json) => this.receive(json));
+    transport.onError((error) => this.terminate(this.connectionError(error)));
+    transport.onClose(() => this.terminate(new CmuxConnectionError("session transport closed")));
   }
 
-  static connect(socketPath: string): Promise<JsonLineConnection> {
+  send(request: JsonObject, timeoutMs: number): Promise<CmuxResponse<unknown>> {
+    const key = this.idKey(request.id);
+    if (this.terminalError) return Promise.reject(this.terminalError);
+    if (this.pending.has(key)) return Promise.reject(new CmuxProtocolError(`duplicate request id ${key}`));
+
     return new Promise((resolve, reject) => {
-      const socket = net.createConnection({ path: socketPath });
-      socket.once("connect", () => resolve(new JsonLineConnection(socket)));
-      socket.once("error", (err: Error) => reject(new CmuxConnectionError(`cannot connect to session socket ${socketPath}: ${err.message}`)));
-    });
-  }
-
-  send(value: JsonObject): Promise<void> {
-    const line = `${JSON.stringify(value)}\n`;
-    return new Promise((resolve, reject) => {
-      this.socket.write(line, "utf8", (err?: Error | null) => {
-        if (err) reject(new CmuxConnectionError(`socket write failed: ${err.message}`));
-        else resolve();
-      });
-    });
-  }
-
-  async recv(timeoutMs: number): Promise<JsonObject> {
-    const pending = this.nextLine();
-    const line = await withTimeout(pending.promise, timeoutMs, "session did not respond", pending.cancel);
-    try {
-      const value = JSON.parse(line) as unknown;
-      if (!value || typeof value !== "object" || Array.isArray(value)) {
-        throw new CmuxProtocolError("server sent non-object JSON line");
+      const timer = setTimeout(() => {
+        this.pending.delete(key);
+        reject(new CmuxTimeoutError("session did not respond"));
+      }, timeoutMs);
+      this.pending.set(key, { resolve, reject, timer });
+      try {
+        this.transport.send(JSON.stringify(request));
+      } catch (error) {
+        clearTimeout(timer);
+        this.pending.delete(key);
+        reject(this.connectionError(error));
       }
-      return value as JsonObject;
-    } catch (err) {
-      if (err instanceof CmuxProtocolError) throw err;
-      throw new CmuxProtocolError(`bad JSON from server: ${(err as Error).message}`);
+    });
+  }
+
+  onEvent(handler: (event: UnknownEvent) => void): Unsubscribe {
+    this.eventHandlers.add(handler);
+    return () => this.eventHandlers.delete(handler);
+  }
+
+  onTerminal(handler: (error: Error) => void): Unsubscribe {
+    this.terminalHandlers.add(handler);
+    if (this.terminalError) queueMicrotask(() => handler(this.terminalError!));
+    return () => this.terminalHandlers.delete(handler);
+  }
+
+  private receive(json: string): void {
+    let value: unknown;
+    try {
+      value = JSON.parse(json);
+    } catch (error) {
+      this.terminate(new CmuxProtocolError(`bad JSON from server: ${(error as Error).message}`));
+      return;
     }
+    if (!value || typeof value !== "object" || Array.isArray(value)) {
+      this.terminate(new CmuxProtocolError("server sent non-object JSON message"));
+      return;
+    }
+
+    const object = value as Record<string, unknown>;
+    if (typeof object.event === "string") {
+      for (const handler of this.eventHandlers) handler(object as UnknownEvent);
+      return;
+    }
+
+    const key = object.id === undefined ? this.pending.keys().next().value : this.idKey(object.id as Json);
+    if (key === undefined) return;
+    const pending = this.pending.get(key);
+    if (!pending) return;
+    clearTimeout(pending.timer);
+    this.pending.delete(key);
+    pending.resolve(object as unknown as CmuxResponse<unknown>);
+  }
+
+  private terminate(error: Error): void {
+    if (this.terminalError) return;
+    this.terminalError = error;
+    for (const pending of this.pending.values()) {
+      clearTimeout(pending.timer);
+      pending.reject(error);
+    }
+    this.pending.clear();
+    for (const handler of this.terminalHandlers) handler(error);
+  }
+
+  private idKey(id: Json | undefined): string {
+    return id === undefined ? "undefined" : JSON.stringify(id);
+  }
+
+  private connectionError(error: unknown): Error {
+    if (error instanceof CmuxError) return error;
+    return new CmuxConnectionError(error instanceof Error ? error.message : String(error));
+  }
+}
+
+interface StreamWaiter<T> {
+  active: boolean;
+  resolve: (event: T) => void;
+  reject: (error: Error) => void;
+}
+
+/** A closeable async event stream with optional per-read timeouts. */
+export class CmuxStream<T extends { event: string }> implements AsyncIterable<T> {
+  private readonly buffered: T[] = [];
+  private readonly waiters: StreamWaiter<T>[] = [];
+  private closed = false;
+  private endsAfterDrain = false;
+
+  constructor(
+    private readonly timeoutMs: number,
+    private readonly cleanup: () => void,
+  ) {}
+
+  async next(timeoutMs = this.timeoutMs): Promise<T> {
+    if (this.buffered.length > 0) {
+      const event = this.buffered.shift()!;
+      if (this.endsAfterDrain && this.buffered.length === 0) this.finish();
+      return event;
+    }
+    if (this.closed) throw new CmuxConnectionError("stream is closed");
+
+    const waiter: StreamWaiter<T> = {
+      active: true,
+      resolve: () => undefined,
+      reject: () => undefined,
+    };
+    const event = await new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(() => {
+        waiter.active = false;
+        reject(new CmuxTimeoutError("stream did not produce an event"));
+      }, timeoutMs);
+      waiter.resolve = (value) => {
+        clearTimeout(timer);
+        resolve(value);
+      };
+      waiter.reject = (error) => {
+        clearTimeout(timer);
+        reject(error);
+      };
+      this.waiters.push(waiter);
+    });
+    if (this.endsAfterDrain && this.buffered.length === 0) this.finish();
+    return event;
   }
 
   close(): void {
-    this.socket.destroy();
+    if (this.closed) return;
+    this.finish();
+    this.rejectWaiters(new CmuxConnectionError("stream is closed"));
   }
 
-  private nextLine(): { promise: Promise<string>; cancel: () => void } {
-    if (this.lines.length > 0) {
-      return { promise: Promise.resolve(this.lines.shift()!), cancel: () => undefined };
+  push(event: T, terminal = false): void {
+    if (this.closed) return;
+    let delivered = false;
+    while (this.waiters.length > 0) {
+      const waiter = this.waiters.shift()!;
+      if (!waiter.active) continue;
+      waiter.resolve(event);
+      delivered = true;
+      break;
     }
-    if (this.closedError) {
-      return { promise: Promise.reject(this.closedError), cancel: () => undefined };
-    }
-    const waiter: {
-      active: boolean;
-      resolve: (line: string) => void;
-      reject: (error: Error) => void;
-    } = {
-      active: true,
-      resolve: (_line: string) => {},
-      reject: (_error: Error) => {},
-    };
-    const promise = new Promise<string>((resolve, reject) => {
-      waiter.resolve = resolve;
-      waiter.reject = reject;
-    });
-    this.waiters.push(waiter);
-    return {
-      promise,
-      cancel: () => {
-        waiter.active = false;
-      },
-    };
+    if (!delivered) this.buffered.push(event);
+    if (terminal) this.endsAfterDrain = true;
   }
 
-  private onData(chunk: string): void {
-    this.buffer += chunk;
-    for (;;) {
-      const index = this.buffer.indexOf("\n");
-      if (index < 0) break;
-      const line = this.buffer.slice(0, index);
-      this.buffer = this.buffer.slice(index + 1);
-      if (line.trim() === "") continue;
-      let delivered = false;
-      while (this.waiters.length > 0) {
-        const waiter = this.waiters.shift()!;
-        if (!waiter.active) continue;
-        waiter.resolve(line);
-        delivered = true;
-        break;
-      }
-      if (!delivered) this.lines.push(line);
-    }
+  fail(error: Error): void {
+    if (this.closed) return;
+    this.finish();
+    this.rejectWaiters(error);
   }
 
-  private closeWith(error: Error): void {
-    if (this.closedError) return;
-    this.closedError = error;
+  async *[Symbol.asyncIterator](): AsyncIterator<T> {
+    while (!this.closed) yield await this.next();
+  }
+
+  private finish(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.cleanup();
+  }
+
+  private rejectWaiters(error: Error): void {
     while (this.waiters.length > 0) {
       const waiter = this.waiters.shift()!;
       if (waiter.active) waiter.reject(error);
@@ -151,172 +265,235 @@ class JsonLineConnection {
   }
 }
 
-export class CmuxStream<T extends EventObject> implements AsyncIterable<T> {
-  private readonly buffered: T[] = [];
-  private closed = false;
-
-  private constructor(
-    private readonly conn: JsonLineConnection,
-    private readonly timeoutMs: number,
-    buffered: T[],
-  ) {
-    this.buffered = buffered;
-  }
-
-  static async open<T extends EventObject>(
-    socketPath: string,
-    timeoutMs: number,
-    request: JsonObject,
-  ): Promise<CmuxStream<T>> {
-    const conn = await JsonLineConnection.connect(socketPath);
-    await conn.send(request);
-    const requestId = request.id;
-    const buffered: T[] = [];
-    for (;;) {
-      const value = await conn.recv(timeoutMs);
-      if (typeof value.event === "string") {
-        buffered.push(value as T);
-        continue;
-      }
-      if (value.id !== requestId) continue;
-      const response = value as ResponseEnvelope;
-      if (response.ok === true) return new CmuxStream(conn, timeoutMs, buffered);
-      throw new CmuxCommandError(response.error || "unknown error", response.id, response);
-    }
-  }
-
-  async next(timeoutMs = this.timeoutMs): Promise<T> {
-    if (this.closed) throw new CmuxConnectionError("stream is closed");
-    if (this.buffered.length > 0) return this.buffered.shift()!;
-    for (;;) {
-      const value = await this.conn.recv(timeoutMs);
-      if (typeof value.event !== "string") continue;
-      const event = value as T;
-      if (event.event === "detached") this.close();
-      return event;
-    }
-  }
-
-  close(): void {
-    if (!this.closed) {
-      this.closed = true;
-      this.conn.close();
-    }
-  }
-
-  async *[Symbol.asyncIterator](): AsyncIterator<T> {
-    while (!this.closed) {
-      yield await this.next();
-    }
-  }
-}
-
+/** Promise-based typed client for any cmux JSON transport. */
 export class CmuxClient {
-  readonly socketPath: string;
   readonly timeoutMs: number;
   readonly allowProtocolV6Attach: boolean;
-  private connPromise: Promise<JsonLineConnection>;
+  private readonly transport: Transport;
+  private readonly router: MessageRouter;
+  private readonly streamTransportFactory?: () => Transport;
   private nextRequestId = 1;
   private protocol: number | null = null;
 
-  constructor(options: ClientOptions = {}) {
-    this.socketPath = options.socketPath ?? envSocketPath() ?? defaultSocketPath(options.session ?? "main");
+  constructor(options: CmuxClientOptions) {
+    this.transport = options.transport;
     this.timeoutMs = options.timeoutMs ?? 10_000;
     this.allowProtocolV6Attach = options.allowProtocolV6Attach ?? true;
-    this.connPromise = JsonLineConnection.connect(this.socketPath);
+    this.streamTransportFactory = options.streamTransportFactory;
+    this.router = new MessageRouter(this.transport);
   }
 
   async close(): Promise<void> {
-    const conn = await this.connPromise;
-    conn.close();
+    this.transport.close();
   }
 
-  async sendRaw(obj: JsonObject): Promise<ResponseEnvelope> {
-    const payload = { ...obj };
+  async sendRaw(obj: JsonObject): Promise<CmuxResponse<unknown>> {
+    const payload = this.dropUndefined({ ...obj });
     if (!("id" in payload)) payload.id = this.nextId();
-    const requestId = payload.id;
-    const conn = await this.connPromise;
-    await conn.send(payload);
-    for (;;) {
-      const response = await conn.recv(this.timeoutMs);
-      if (typeof response.event === "string") continue;
-      if (response.id !== requestId && response.id !== undefined) continue;
-      return response as ResponseEnvelope;
-    }
+    return this.router.send(payload, this.timeoutMs);
   }
 
-  async request(cmd: string, params: JsonObject = {}): Promise<unknown> {
-    const response = await this.sendRaw({ id: this.nextId(), cmd, ...dropUndefined(params) });
-    if (response.ok === true) return response.data;
+  request<C extends CmuxRequest>(request: C): Promise<CmuxResponseData<C>>;
+  request<C extends CmuxCommand>(cmd: C, params?: CmuxRequestParams<C>): Promise<CmuxResponseDataFor<C>>;
+  async request<C extends CmuxCommand>(
+    requestOrCommand: CmuxRequest | C,
+    params?: CmuxRequestParams<C>,
+  ): Promise<CmuxResponseDataFor<C>> {
+    const request = typeof requestOrCommand === "string"
+      ? { cmd: requestOrCommand, ...(params ?? {}) }
+      : requestOrCommand;
+    const response = await this.sendRaw(request as unknown as JsonObject);
+    if (response.ok) return response.data as CmuxResponseDataFor<C>;
     throw new CmuxCommandError(response.error || "unknown error", response.id, response);
   }
 
   async identify(): Promise<IdentifyResult> {
-    const result = await this.request("identify") as IdentifyResult;
+    const result = await this.request("identify");
     this.protocol = result.protocol;
     return result;
   }
 
-  async listWorkspaces(): Promise<Tree> { return this.request("list-workspaces") as Promise<Tree>; }
-  async send(surface: number, options: SendOptions = {}): Promise<EmptyResult> {
-    const bytes = options.bytes instanceof Uint8Array ? Buffer.from(options.bytes).toString("base64") : options.bytes;
-    await this.request("send", dropUndefined({ surface, text: options.text, bytes }));
-    return {};
-  }
-  async readScreen(surface: number): Promise<ReadScreenResult> { return this.request("read-screen", { surface }) as Promise<ReadScreenResult>; }
-  async vtState(surface: number): Promise<VtStateResult> { return this.request("vt-state", { surface }) as Promise<VtStateResult>; }
-  async newTab(options: NewTabOptions = {}): Promise<SurfaceResult> { return this.request("new-tab", options as JsonObject) as Promise<SurfaceResult>; }
-  async newBrowserTab(url: string, options: NewBrowserTabOptions = {}): Promise<SurfaceResult> { return this.request("new-browser-tab", dropUndefined({ url, ...options })) as Promise<SurfaceResult>; }
-  async newWorkspace(options: NewWorkspaceOptions = {}): Promise<SurfaceResult> { return this.request("new-workspace", options as JsonObject) as Promise<SurfaceResult>; }
-  async newScreen(options: NewScreenOptions = {}): Promise<SurfaceResult> { return this.request("new-screen", options as JsonObject) as Promise<SurfaceResult>; }
-  async split(pane: number, dir: "right" | "down", options: SplitOptions = {}): Promise<SurfaceResult> { return this.request("split", dropUndefined({ pane, dir, ...options })) as Promise<SurfaceResult>; }
-  async setRatio(pane: number, dir: "right" | "down", ratio: number): Promise<EmptyResult> { await this.request("set-ratio", { pane, dir, ratio }); return {}; }
-  async setDefaultColors(fg?: string, bg?: string): Promise<EmptyResult> { await this.request("set-default-colors", dropUndefined({ fg, bg })); return {}; }
-  async closeSurface(surface: number): Promise<EmptyResult> { await this.request("close-surface", { surface }); return {}; }
-  async closePane(pane: number): Promise<EmptyResult> { await this.request("close-pane", { pane }); return {}; }
-  async closeScreen(screen: number): Promise<EmptyResult> { await this.request("close-screen", { screen }); return {}; }
-  async closeWorkspace(workspace: number): Promise<EmptyResult> { await this.request("close-workspace", { workspace }); return {}; }
-  async renamePane(pane: number, name: string): Promise<EmptyResult> { await this.request("rename-pane", { pane, name }); return {}; }
-  async renameSurface(surface: number, name: string): Promise<EmptyResult> { await this.request("rename-surface", { surface, name }); return {}; }
-  async renameScreen(screen: number, name: string): Promise<EmptyResult> { await this.request("rename-screen", { screen, name }); return {}; }
-  async renameWorkspace(workspace: number, name: string): Promise<EmptyResult> { await this.request("rename-workspace", { workspace, name }); return {}; }
-  async resizeSurface(surface: number, cols: number, rows: number): Promise<EmptyResult> { await this.request("resize-surface", { surface, cols, rows }); return {}; }
-  async focusPane(pane: number): Promise<EmptyResult> { await this.request("focus-pane", { pane }); return {}; }
-  async selectTab(options: SelectTabOptions = {}): Promise<EmptyResult> { await this.request("select-tab", options as JsonObject); return {}; }
-  async selectScreen(options: SelectOptions = {}): Promise<EmptyResult> { await this.request("select-screen", options as JsonObject); return {}; }
-  async selectWorkspace(options: SelectOptions = {}): Promise<EmptyResult> { await this.request("select-workspace", options as JsonObject); return {}; }
-  async moveTab(surface: number, pane: number, index: number): Promise<EmptyResult> { await this.request("move-tab", { surface, pane, index }); return {}; }
-  async moveWorkspace(workspace: number, index: number): Promise<EmptyResult> { await this.request("move-workspace", { workspace, index }); return {}; }
-  async scrollSurface(surface: number, delta: number): Promise<EmptyResult> { await this.request("scroll-surface", { surface, delta }); return {}; }
-
-  async subscribe(): Promise<CmuxStream<SubscribeEvent>> {
-    return CmuxStream.open<SubscribeEvent>(this.socketPath, this.timeoutMs, { id: this.nextId(), cmd: "subscribe" });
+  ping(): Promise<PingResult> { return this.request("ping"); }
+  reloadConfig(): Promise<ReloadConfigResult> { return this.request("reload-config"); }
+  setWindowTitle(title: string): Promise<EmptyResult> { return this.request("set-window-title", { title }); }
+  clearWindowTitle(): Promise<EmptyResult> { return this.request("clear-window-title"); }
+  listWorkspaces(): Promise<Tree> { return this.request("list-workspaces"); }
+  exportLayout(screen?: Id | null): Promise<ExportLayoutResult> { return this.request("export-layout", { screen }); }
+  applyLayout(layout: DeclarativeLayout, options: Omit<CmuxRequestParams<"apply-layout">, "layout"> = {}): Promise<ApplyLayoutResult> {
+    return this.request("apply-layout", { ...options, layout });
   }
 
-  async attachSurface(surface: number): Promise<CmuxStream<AttachEvent>> {
+  async send(surface: Id, options: SendOptions = {}): Promise<EmptyResult> {
+    const bytes = options.bytes instanceof Uint8Array ? encodeBase64(options.bytes) : options.bytes;
+    return this.request("send", { surface, text: options.text, bytes });
+  }
+
+  readScreen(surface: Id): Promise<ReadScreenResult> { return this.request("read-screen", { surface }); }
+  sidebarPlugin(cols: number, rows: number, relaunch?: boolean | null): Promise<SidebarPluginResult> {
+    return this.request("sidebar-plugin", { cols, rows, relaunch });
+  }
+  vtState(surface: Id): Promise<VtStateResult> { return this.request("vt-state", { surface }); }
+  newTab(options: NewTabOptions = {}): Promise<SurfaceResult> { return this.request("new-tab", options); }
+  newBrowserTab(url: string, options: NewBrowserTabOptions = {}): Promise<SurfaceResult> {
+    return this.request("new-browser-tab", { url, ...options });
+  }
+  newWorkspace(options: NewWorkspaceOptions = {}): Promise<SurfaceResult> { return this.request("new-workspace", options); }
+  newScreen(options: NewScreenOptions = {}): Promise<SurfaceResult> { return this.request("new-screen", options); }
+  split(pane: Id, dir: SplitDirection, options: SplitOptions = {}): Promise<SurfaceResult> {
+    return this.request("split", { pane, dir, ...options });
+  }
+  setRatio(pane: Id, dir: SplitDirection, ratio: number): Promise<EmptyResult> {
+    return this.request("set-ratio", { pane, dir, ratio });
+  }
+  paneNeighbor(pane: Id, dir: PaneDirection): Promise<PaneNeighborResult> {
+    return this.request("pane-neighbor", { pane, dir });
+  }
+  focusDirection(dir: PaneDirection, pane?: Id | null): Promise<FocusDirectionResult> {
+    return this.request("focus-direction", { pane, dir });
+  }
+  swapPane(params: CmuxRequestParams<"swap-pane">): Promise<EmptyResult> { return this.request("swap-pane", params); }
+  zoomPane(params: CmuxRequestParams<"zoom-pane"> = {}): Promise<ZoomPaneResult> { return this.request("zoom-pane", params); }
+  processInfo(surface: Id): Promise<ProcessInfoResult> { return this.request("process-info", { surface }); }
+  setDefaultColors(fg?: ColorHex | null, bg?: ColorHex | null): Promise<EmptyResult> {
+    return this.request("set-default-colors", { fg, bg });
+  }
+  closeSurface(surface: Id): Promise<EmptyResult> { return this.request("close-surface", { surface }); }
+  closePane(pane: Id): Promise<EmptyResult> { return this.request("close-pane", { pane }); }
+  closeScreen(screen: Id): Promise<EmptyResult> { return this.request("close-screen", { screen }); }
+  closeWorkspace(workspace: Id): Promise<EmptyResult> { return this.request("close-workspace", { workspace }); }
+  renamePane(pane: Id, name: string): Promise<EmptyResult> { return this.request("rename-pane", { pane, name }); }
+  renameSurface(surface: Id, name: string): Promise<EmptyResult> { return this.request("rename-surface", { surface, name }); }
+  renameScreen(screen: Id, name: string): Promise<EmptyResult> { return this.request("rename-screen", { screen, name }); }
+  renameWorkspace(workspace: Id, name: string): Promise<EmptyResult> { return this.request("rename-workspace", { workspace, name }); }
+  resizeSurface(surface: Id, cols: number, rows: number): Promise<EmptyResult> {
+    return this.request("resize-surface", { surface, cols, rows });
+  }
+  focusPane(pane: Id): Promise<EmptyResult> { return this.request("focus-pane", { pane }); }
+  selectTab(options: SelectTabOptions = {}): Promise<EmptyResult> { return this.request("select-tab", options); }
+  selectScreen(options: SelectOptions = {}): Promise<EmptyResult> { return this.request("select-screen", options); }
+  selectWorkspace(options: SelectOptions = {}): Promise<EmptyResult> { return this.request("select-workspace", options); }
+  moveTab(surface: Id, pane: Id, index: number): Promise<EmptyResult> { return this.request("move-tab", { surface, pane, index }); }
+  moveWorkspace(workspace: Id, index: number): Promise<EmptyResult> { return this.request("move-workspace", { workspace, index }); }
+  scrollSurface(surface: Id, delta: number): Promise<EmptyResult> { return this.request("scroll-surface", { surface, delta }); }
+
+  async subscribe(options: CmuxRequestParams<"subscribe"> = {}): Promise<CmuxStream<SubscribeEvent>> {
+    return this.openStream(
+      { cmd: "subscribe", ...options },
+      (event) => event as SubscribeEvent,
+      (event, dedicated) => dedicated || !this.attachOnlyEvent(event.event),
+    );
+  }
+
+  async attachSurface(surface: Id): Promise<CmuxStream<DecodedAttachEvent>> {
     const protocol = this.protocol ?? (await this.identify()).protocol;
     if (protocol > 6 || (protocol > 5 && !this.allowProtocolV6Attach)) {
       throw new CmuxProtocolError(`unsupported attach protocol ${protocol}`);
     }
-    return CmuxStream.open<AttachEvent>(this.socketPath, this.timeoutMs, { id: this.nextId(), cmd: "attach-surface", surface });
+    return this.openStream(
+      { cmd: "attach-surface", surface },
+      (event) => this.decodeAttachEvent(event as AttachEvent),
+      (event, dedicated) => dedicated || this.matchesAttachEvent(event, surface),
+      (event) => event.event === "detached",
+    );
+  }
+
+  waitFor(surface: IdRef, pattern: string, timeoutMs: number): Promise<WaitForResult> {
+    return this.request("wait-for", { surface, pattern, timeout_ms: timeoutMs });
+  }
+  run(options: CmuxRequestParams<"run">): Promise<RunResult> { return this.request("run", options); }
+  sendKey(surface: IdRef, keys: string[]): Promise<EmptyResult> { return this.request("send-key", { surface, keys }); }
+  copy(surface: IdRef, mode: CopyMode): Promise<CopyResult> { return this.request("copy", { surface, mode }); }
+  ids(kind?: IdKind | null): Promise<IdsResult> { return this.request("ids", { kind }); }
+  notify(
+    title: string,
+    body: string,
+    options: { level?: NotificationLevel | null; surface?: IdRef | null } = {},
+  ): Promise<NotifyResult> {
+    return this.request("notify", { title, body, ...options });
+  }
+  listAgents(options: CmuxRequestParams<"list-agents"> = {}): Promise<ListAgentsResult> {
+    return this.request("list-agents", options);
+  }
+  reportAgent(
+    surface: IdRef,
+    state: AgentState,
+    source: AgentReportSource,
+    session?: string | null,
+  ): Promise<ReportAgentResult> {
+    return this.request("report-agent", { surface, state, source, session });
+  }
+
+  private async openStream<T extends { event: string }>(
+    request: CmuxRequest,
+    map: (event: UnknownEvent) => T,
+    accept: (event: UnknownEvent, dedicated: boolean) => boolean,
+    terminal: (event: T) => boolean = () => false,
+  ): Promise<CmuxStream<T>> {
+    const dedicated = this.streamTransportFactory !== undefined;
+    const transport = this.streamTransportFactory?.() ?? this.transport;
+    const router = dedicated ? new MessageRouter(transport) : this.router;
+    let eventSubscription: Unsubscribe = () => undefined;
+    let terminalSubscription: Unsubscribe = () => undefined;
+    const stream = new CmuxStream<T>(this.timeoutMs, () => {
+      eventSubscription();
+      terminalSubscription();
+      if (dedicated) transport.close();
+    });
+    eventSubscription = router.onEvent((event) => {
+      if (!accept(event, dedicated)) return;
+      try {
+        const mapped = map(event);
+        stream.push(mapped, terminal(mapped));
+      } catch (error) {
+        stream.fail(new CmuxProtocolError(`invalid stream event: ${(error as Error).message}`));
+      }
+    });
+    terminalSubscription = router.onTerminal((error) => stream.fail(error));
+
+    const payload = this.dropUndefined({ id: this.nextId(), ...request });
+    const response = await router.send(payload, this.timeoutMs).catch((error) => {
+      stream.fail(error as Error);
+      throw error;
+    });
+    if (!response.ok) {
+      stream.close();
+      throw new CmuxCommandError(response.error || "unknown error", response.id, response);
+    }
+    return stream;
+  }
+
+  private decodeAttachEvent(event: AttachEvent): DecodedAttachEvent {
+    switch (event.event) {
+      case "vt-state": {
+        if (typeof event.data !== "string") throw new Error("vt-state data is not base64 text");
+        return { ...event, data: decodeBase64(event.data) } as DecodedAttachEvent;
+      }
+      case "output": {
+        if (typeof event.data !== "string") throw new Error("output data is not base64 text");
+        return { ...event, data: decodeBase64(event.data) } as DecodedAttachEvent;
+      }
+      case "resized": {
+        if (typeof event.replay !== "string") throw new Error("resized replay is not base64 text");
+        return { ...event, replay: decodeBase64(event.replay) } as DecodedAttachEvent;
+      }
+      default: return event as DecodedAttachEvent;
+    }
+  }
+
+  private matchesAttachEvent(event: UnknownEvent, surface: Id): boolean {
+    if (!("surface" in event) || event.surface !== surface) return false;
+    return this.attachOnlyEvent(event.event) || event.event === "scroll-changed";
+  }
+
+  private attachOnlyEvent(event: string): boolean {
+    return event === "vt-state" || event === "output" || event === "resized" || event === "detached";
+  }
+
+  private dropUndefined(value: Record<string, unknown>): JsonObject {
+    return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as JsonObject;
   }
 
   private nextId(): number {
     return this.nextRequestId++;
   }
-}
-
-function dropUndefined(value: Record<string, unknown>): JsonObject {
-  return Object.fromEntries(Object.entries(value).filter(([, item]) => item !== undefined)) as JsonObject;
-}
-
-function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string, onTimeout?: () => void): Promise<T> {
-  let timer: NodeJS.Timeout;
-  const timeout = new Promise<never>((_, reject) => {
-    timer = setTimeout(() => {
-      onTimeout?.();
-      reject(new CmuxTimeoutError(message));
-    }, timeoutMs);
-  });
-  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer!));
 }

--- a/cmux-tui/bindings/typescript/src/node-client.ts
+++ b/cmux-tui/bindings/typescript/src/node-client.ts
@@ -1,0 +1,33 @@
+import { CmuxClient as TransportCmuxClient, type CmuxClientOptions } from "./client.js";
+import { defaultSocketPath, envSocketPath, UnixSocketTransport } from "./node-transport.js";
+import type { Transport } from "./transport.js";
+
+/** Node.js client configuration, including Unix-socket defaults. */
+export interface ClientOptions {
+  socketPath?: string;
+  session?: string;
+  timeoutMs?: number;
+  allowProtocolV6Attach?: boolean;
+  /** Overrides the default Unix transport. */
+  transport?: Transport;
+  /** Overrides dedicated transports used for subscribe and attach streams. */
+  streamTransportFactory?: () => Transport;
+}
+
+/** Node.js cmux client with backward-compatible Unix-socket defaults. */
+export class CmuxClient extends TransportCmuxClient {
+  readonly socketPath: string;
+
+  constructor(options: ClientOptions = {}) {
+    const socketPath = options.socketPath ?? envSocketPath() ?? defaultSocketPath(options.session ?? "main");
+    const shared: CmuxClientOptions = {
+      transport: options.transport ?? new UnixSocketTransport(socketPath),
+      timeoutMs: options.timeoutMs,
+      allowProtocolV6Attach: options.allowProtocolV6Attach,
+      streamTransportFactory: options.streamTransportFactory
+        ?? (options.transport ? undefined : () => new UnixSocketTransport(socketPath)),
+    };
+    super(shared);
+    this.socketPath = socketPath;
+  }
+}

--- a/cmux-tui/bindings/typescript/src/node-transport.ts
+++ b/cmux-tui/bindings/typescript/src/node-transport.ts
@@ -1,0 +1,98 @@
+import * as net from "node:net";
+import * as os from "node:os";
+import * as path from "node:path";
+import { CmuxConnectionError } from "./errors.js";
+import type { Transport, Unsubscribe } from "./transport.js";
+
+/** Resolves the default Unix socket path for a session. */
+export function defaultSocketPath(session = "main"): string {
+  const base = process.env.TMPDIR || os.tmpdir();
+  return path.join(base, `cmux-tui-${process.getuid?.() ?? 0}`, `${session}.sock`);
+}
+
+/** Reads the current or legacy cmux-tui socket environment variable. */
+export function envSocketPath(): string | undefined {
+  return process.env.CMUX_TUI_SOCKET || process.env.CMUX_MUX_SOCKET;
+}
+
+/** Unix-socket JSON-lines transport for Node.js. */
+export class UnixSocketTransport implements Transport {
+  private readonly socket: net.Socket;
+  private readonly pending: string[] = [];
+  private readonly messageHandlers = new Set<(json: string) => void>();
+  private readonly closeHandlers = new Set<() => void>();
+  private readonly errorHandlers = new Set<(error: Error) => void>();
+  private buffer = "";
+  private connected = false;
+  private closed = false;
+
+  constructor(readonly socketPath: string) {
+    this.socket = net.createConnection({ path: socketPath });
+    this.socket.setEncoding("utf8");
+    this.socket.on("connect", () => {
+      this.connected = true;
+      while (this.pending.length > 0) this.write(this.pending.shift()!);
+    });
+    this.socket.on("data", (chunk: string) => this.receive(chunk));
+    this.socket.on("error", (error) => {
+      const prefix = this.connected ? "socket error" : `cannot connect to session socket ${this.socketPath}`;
+      this.fail(new CmuxConnectionError(`${prefix}: ${error.message}`));
+    });
+    this.socket.on("close", () => this.finish());
+  }
+
+  send(json: string): void {
+    if (this.closed) throw new CmuxConnectionError("session socket closed");
+    if (this.connected) this.write(json);
+    else this.pending.push(json);
+  }
+
+  onMessage(handler: (json: string) => void): Unsubscribe {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onClose(handler: () => void): Unsubscribe {
+    this.closeHandlers.add(handler);
+    if (this.closed) queueMicrotask(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
+  onError(handler: (error: Error) => void): Unsubscribe {
+    this.errorHandlers.add(handler);
+    return () => this.errorHandlers.delete(handler);
+  }
+
+  close(): void {
+    if (!this.closed) this.socket.destroy();
+  }
+
+  private write(json: string): void {
+    this.socket.write(`${json}\n`, "utf8", (error) => {
+      if (error) this.fail(new CmuxConnectionError(`socket write failed: ${error.message}`));
+    });
+  }
+
+  private receive(chunk: string): void {
+    this.buffer += chunk;
+    for (;;) {
+      const index = this.buffer.indexOf("\n");
+      if (index < 0) return;
+      const line = this.buffer.slice(0, index);
+      this.buffer = this.buffer.slice(index + 1);
+      if (line.trim() === "") continue;
+      for (const handler of this.messageHandlers) handler(line);
+    }
+  }
+
+  private fail(error: Error): void {
+    for (const handler of this.errorHandlers) handler(error);
+  }
+
+  private finish(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.pending.length = 0;
+    for (const handler of this.closeHandlers) handler();
+  }
+}

--- a/cmux-tui/bindings/typescript/src/protocol/commands.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/commands.ts
@@ -1,0 +1,384 @@
+import type {
+  AgentRecord,
+  AgentReportSource,
+  AgentState,
+  Base64,
+  CmuxRequestBase,
+  ColorHex,
+  EmptyResult,
+  Id,
+  IdRef,
+  NotificationLevel,
+  PaneDirection,
+  SplitDirection,
+} from "./common.js";
+import type { DeclarativeLayout, Layout, Tree } from "./tree.js";
+
+export interface IdentifyRequest extends CmuxRequestBase { cmd: "identify" }
+export interface IdentifyResult { app: "cmux-tui"; version: string; protocol: number; session: string; pid: number }
+
+export interface PingRequest extends CmuxRequestBase { cmd: "ping" }
+export interface PingResult { ok: true; version: string; protocol: number }
+
+export interface ReloadConfigRequest extends CmuxRequestBase { cmd: "reload-config" }
+export interface ReloadConfigResult { reloaded: true; path: string | null }
+
+export interface SetWindowTitleRequest extends CmuxRequestBase { cmd: "set-window-title"; title: string }
+export interface ClearWindowTitleRequest extends CmuxRequestBase { cmd: "clear-window-title" }
+
+export interface ListWorkspacesRequest extends CmuxRequestBase { cmd: "list-workspaces" }
+
+export interface ExportLayoutRequest extends CmuxRequestBase {
+  cmd: "export-layout";
+  screen?: Id | null;
+}
+export interface ExportedPane { pane: Id; surfaces: Id[] }
+export interface ExportLayoutResult { layout: Layout; panes: ExportedPane[] }
+
+export interface ApplyLayoutRequest extends CmuxRequestBase {
+  cmd: "apply-layout";
+  workspace?: Id | null;
+  name?: string | null;
+  layout: DeclarativeLayout;
+}
+export interface AppliedPane { pane: Id; surface: Id }
+export interface ApplyLayoutResult { screen: Id; panes: AppliedPane[] }
+
+export interface SendRequest extends CmuxRequestBase {
+  cmd: "send";
+  surface: Id;
+  /** When both are supplied, `text` is written before `bytes`. */
+  text?: string | null;
+  bytes?: Base64 | null;
+}
+
+export interface ReadScreenRequest extends CmuxRequestBase { cmd: "read-screen"; surface: Id }
+export interface ReadScreenResult { text: string }
+
+export interface SidebarPluginRequest extends CmuxRequestBase {
+  cmd: "sidebar-plugin";
+  cols: number;
+  rows: number;
+  relaunch?: boolean | null;
+}
+export interface SidebarPluginResult {
+  surface: Id | null;
+  error: string | null;
+  retry_after_ms: number | null;
+}
+
+export interface VtStateRequest extends CmuxRequestBase { cmd: "vt-state"; surface: Id }
+export interface VtStateResult { cols: number; rows: number; data: Base64 }
+
+export interface NewTabRequest extends CmuxRequestBase {
+  cmd: "new-tab";
+  pane?: Id | null;
+  cwd?: string | null;
+  /** `cols` is used only when paired with `rows`. */
+  cols?: number | null;
+  rows?: number | null;
+}
+
+export interface NewBrowserTabRequest extends CmuxRequestBase {
+  cmd: "new-browser-tab";
+  url: string;
+  pane?: Id | null;
+  cols?: number | null;
+  rows?: number | null;
+}
+
+export interface NewWorkspaceRequest extends CmuxRequestBase {
+  cmd: "new-workspace";
+  name?: string | null;
+  cols?: number | null;
+  rows?: number | null;
+}
+
+export interface NewScreenRequest extends CmuxRequestBase {
+  cmd: "new-screen";
+  workspace?: Id | null;
+  cols?: number | null;
+  rows?: number | null;
+}
+
+export interface SplitRequest extends CmuxRequestBase {
+  cmd: "split";
+  pane: Id;
+  dir: SplitDirection;
+  cols?: number | null;
+  rows?: number | null;
+}
+
+export interface SurfaceResult { surface: Id }
+
+export interface SetRatioRequest extends CmuxRequestBase {
+  cmd: "set-ratio";
+  pane: Id;
+  dir: SplitDirection;
+  /** The server clamps this value to `0.05..0.95`. */
+  ratio: number;
+}
+
+export interface PaneNeighborRequest extends CmuxRequestBase { cmd: "pane-neighbor"; pane: Id; dir: PaneDirection }
+export interface PaneNeighborResult { pane: Id | null }
+
+export interface FocusDirectionRequest extends CmuxRequestBase {
+  cmd: "focus-direction";
+  pane?: Id | null;
+  dir: PaneDirection;
+}
+export interface FocusDirectionResult { pane: Id }
+
+interface SwapPaneRequestBase extends CmuxRequestBase { cmd: "swap-pane"; pane: Id }
+export type SwapPaneRequest =
+  | (SwapPaneRequestBase & { dir: PaneDirection; target?: null })
+  | (SwapPaneRequestBase & { target: Id; dir?: null });
+
+export interface ZoomPaneRequest extends CmuxRequestBase {
+  cmd: "zoom-pane";
+  pane?: Id | null;
+  mode?: "toggle" | "on" | "off" | null;
+}
+export interface ZoomPaneResult { pane: Id; zoomed: boolean; zoomed_pane: Id | null }
+
+export interface ProcessInfoRequest extends CmuxRequestBase { cmd: "process-info"; surface: Id }
+export interface ProcessInfoResult { pid: number | null; command: string | null; cwd: string | null }
+
+export interface SetDefaultColorsRequest extends CmuxRequestBase {
+  cmd: "set-default-colors";
+  fg?: ColorHex | null;
+  bg?: ColorHex | null;
+}
+
+export interface CloseSurfaceRequest extends CmuxRequestBase { cmd: "close-surface"; surface: Id }
+export interface ClosePaneRequest extends CmuxRequestBase { cmd: "close-pane"; pane: Id }
+export interface CloseScreenRequest extends CmuxRequestBase { cmd: "close-screen"; screen: Id }
+export interface CloseWorkspaceRequest extends CmuxRequestBase { cmd: "close-workspace"; workspace: Id }
+
+export interface RenamePaneRequest extends CmuxRequestBase { cmd: "rename-pane"; pane: Id; name: string }
+export interface RenameSurfaceRequest extends CmuxRequestBase { cmd: "rename-surface"; surface: Id; name: string }
+export interface RenameScreenRequest extends CmuxRequestBase { cmd: "rename-screen"; screen: Id; name: string }
+export interface RenameWorkspaceRequest extends CmuxRequestBase { cmd: "rename-workspace"; workspace: Id; name: string }
+
+export interface ResizeSurfaceRequest extends CmuxRequestBase {
+  cmd: "resize-surface";
+  surface: Id;
+  cols: number;
+  rows: number;
+}
+
+export interface FocusPaneRequest extends CmuxRequestBase { cmd: "focus-pane"; pane: Id }
+
+export interface SelectTabRequest extends CmuxRequestBase {
+  cmd: "select-tab";
+  pane?: Id | null;
+  /** If both selectors are present, `index` wins. */
+  index?: number | null;
+  delta?: number | null;
+}
+
+export interface SelectScreenRequest extends CmuxRequestBase {
+  cmd: "select-screen";
+  /** If both selectors are present, `index` wins. */
+  index?: number | null;
+  delta?: number | null;
+}
+
+export interface SelectWorkspaceRequest extends CmuxRequestBase {
+  cmd: "select-workspace";
+  /** If both selectors are present, `index` wins. */
+  index?: number | null;
+  delta?: number | null;
+}
+
+export interface MoveTabRequest extends CmuxRequestBase { cmd: "move-tab"; surface: Id; pane: Id; index: number }
+export interface MoveWorkspaceRequest extends CmuxRequestBase { cmd: "move-workspace"; workspace: Id; index: number }
+export interface ScrollSurfaceRequest extends CmuxRequestBase { cmd: "scroll-surface"; surface: Id; delta: number }
+
+export interface SubscribeRequest extends CmuxRequestBase {
+  cmd: "subscribe";
+  /** Proposed protocol v6 event-name filter. */
+  events?: string[] | null;
+  /** Proposed protocol v6 surface filter. */
+  surfaces?: IdRef[] | null;
+}
+
+export interface AttachSurfaceRequest extends CmuxRequestBase { cmd: "attach-surface"; surface: Id }
+
+export interface WaitForRequest extends CmuxRequestBase {
+  cmd: "wait-for";
+  surface: IdRef;
+  pattern: string;
+  /** `0` performs one immediate check. */
+  timeout_ms: number;
+}
+export interface WaitForResult { matched: true; text: string; elapsed_ms: number }
+
+interface RunRequestBase extends CmuxRequestBase {
+  cmd: "run";
+  cwd?: string | null;
+  pane?: IdRef | null;
+  new_workspace?: boolean;
+  name?: string | null;
+  cols?: number | null;
+  rows?: number | null;
+}
+export type RunRequest =
+  | (RunRequestBase & { argv: string[]; command?: null })
+  | (RunRequestBase & { command: string; argv?: null });
+export interface RunResult { surface: Id; pane: Id; screen: Id; workspace: Id }
+
+export interface SendKeyRequest extends CmuxRequestBase { cmd: "send-key"; surface: IdRef; keys: string[] }
+
+export type CopyMode = "screen" | "selection" | "scrollback";
+export interface CopyRequest extends CmuxRequestBase { cmd: "copy"; surface: IdRef; mode: CopyMode }
+export interface CopyResult { text: string; mode: CopyMode }
+
+export type IdKind = "workspace" | "screen" | "pane" | "surface";
+export interface IdsRequest extends CmuxRequestBase { cmd: "ids"; kind?: IdKind | null }
+export interface IdMapping { kind: IdKind; id: Id; short_id: string }
+export interface IdsResult { ids: IdMapping[] }
+
+export interface NotifyRequest extends CmuxRequestBase {
+  cmd: "notify";
+  title: string;
+  body: string;
+  level?: NotificationLevel | null;
+  surface?: IdRef | null;
+}
+export interface NotifyResult { notification: Id }
+
+export interface ListAgentsRequest extends CmuxRequestBase {
+  cmd: "list-agents";
+  surface?: IdRef | null;
+  state?: AgentState | null;
+}
+export interface ListAgentsResult { agents: AgentRecord[] }
+
+export interface ReportAgentRequest extends CmuxRequestBase {
+  cmd: "report-agent";
+  surface: IdRef;
+  state: AgentState;
+  source: AgentReportSource;
+  session?: string | null;
+}
+export interface ReportAgentResult {
+  surface: Id;
+  state: AgentState;
+  source: AgentReportSource;
+  session: string | null;
+}
+
+/** Every implemented command request, discriminated by exact wire `cmd`. */
+export type CmuxRequest =
+  | IdentifyRequest
+  | PingRequest
+  | ReloadConfigRequest
+  | SetWindowTitleRequest
+  | ClearWindowTitleRequest
+  | ListWorkspacesRequest
+  | ExportLayoutRequest
+  | ApplyLayoutRequest
+  | SendRequest
+  | ReadScreenRequest
+  | SidebarPluginRequest
+  | VtStateRequest
+  | NewTabRequest
+  | NewBrowserTabRequest
+  | NewWorkspaceRequest
+  | NewScreenRequest
+  | SplitRequest
+  | SetRatioRequest
+  | PaneNeighborRequest
+  | FocusDirectionRequest
+  | SwapPaneRequest
+  | ZoomPaneRequest
+  | ProcessInfoRequest
+  | SetDefaultColorsRequest
+  | CloseSurfaceRequest
+  | ClosePaneRequest
+  | CloseScreenRequest
+  | CloseWorkspaceRequest
+  | RenamePaneRequest
+  | RenameSurfaceRequest
+  | RenameScreenRequest
+  | RenameWorkspaceRequest
+  | ResizeSurfaceRequest
+  | FocusPaneRequest
+  | SelectTabRequest
+  | SelectScreenRequest
+  | SelectWorkspaceRequest
+  | MoveTabRequest
+  | MoveWorkspaceRequest
+  | ScrollSurfaceRequest
+  | SubscribeRequest
+  | AttachSurfaceRequest
+  | WaitForRequest
+  | RunRequest
+  | SendKeyRequest
+  | CopyRequest
+  | IdsRequest
+  | NotifyRequest
+  | ListAgentsRequest
+  | ReportAgentRequest;
+
+/** Command name to successful response `data` mapping. */
+export interface CmuxResponseDataMap {
+  identify: IdentifyResult;
+  ping: PingResult;
+  "reload-config": ReloadConfigResult;
+  "set-window-title": EmptyResult;
+  "clear-window-title": EmptyResult;
+  "list-workspaces": Tree;
+  "export-layout": ExportLayoutResult;
+  "apply-layout": ApplyLayoutResult;
+  send: EmptyResult;
+  "read-screen": ReadScreenResult;
+  "sidebar-plugin": SidebarPluginResult;
+  "vt-state": VtStateResult;
+  "new-tab": SurfaceResult;
+  "new-browser-tab": SurfaceResult;
+  "new-workspace": SurfaceResult;
+  "new-screen": SurfaceResult;
+  split: SurfaceResult;
+  "set-ratio": EmptyResult;
+  "pane-neighbor": PaneNeighborResult;
+  "focus-direction": FocusDirectionResult;
+  "swap-pane": EmptyResult;
+  "zoom-pane": ZoomPaneResult;
+  "process-info": ProcessInfoResult;
+  "set-default-colors": EmptyResult;
+  "close-surface": EmptyResult;
+  "close-pane": EmptyResult;
+  "close-screen": EmptyResult;
+  "close-workspace": EmptyResult;
+  "rename-pane": EmptyResult;
+  "rename-surface": EmptyResult;
+  "rename-screen": EmptyResult;
+  "rename-workspace": EmptyResult;
+  "resize-surface": EmptyResult;
+  "focus-pane": EmptyResult;
+  "select-tab": EmptyResult;
+  "select-screen": EmptyResult;
+  "select-workspace": EmptyResult;
+  "move-tab": EmptyResult;
+  "move-workspace": EmptyResult;
+  "scroll-surface": EmptyResult;
+  subscribe: EmptyResult;
+  "attach-surface": EmptyResult;
+  "wait-for": WaitForResult;
+  run: RunResult;
+  "send-key": EmptyResult;
+  copy: CopyResult;
+  ids: IdsResult;
+  notify: NotifyResult;
+  "list-agents": ListAgentsResult;
+  "report-agent": ReportAgentResult;
+}
+
+export type CmuxCommand = keyof CmuxResponseDataMap;
+export type CmuxRequestFor<C extends CmuxCommand> = Extract<CmuxRequest, { cmd: C }>;
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, Extract<keyof T, K>> : never;
+export type CmuxRequestParams<C extends CmuxCommand> = DistributiveOmit<CmuxRequestFor<C>, "id" | "cmd">;
+export type CmuxResponseDataFor<C extends CmuxCommand> = CmuxResponseDataMap[C];
+export type CmuxResponseData<C extends CmuxRequest> = CmuxResponseDataFor<C["cmd"]>;

--- a/cmux-tui/bindings/typescript/src/protocol/common.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/common.ts
@@ -1,0 +1,85 @@
+/** A JSON value accepted by the cmux-tui protocol. */
+export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
+
+/** A JSON object accepted by the cmux-tui protocol. */
+export type JsonObject = { [key: string]: Json };
+
+/** An implemented numeric protocol identifier (`uint64` on the wire). */
+export type Id = number;
+
+/** A numeric id or proposed stable short id. */
+export type IdRef = Id | string;
+
+/** Standard base64 text. */
+export type Base64 = string;
+
+/** A `#rrggbb` color string. */
+export type ColorHex = `#${string}`;
+
+/** A terminal cell grid. */
+export interface Size {
+  cols: number;
+  rows: number;
+}
+
+/** The canonical empty command result. */
+export type EmptyResult = Record<string, never>;
+
+/** Fields common to every command request envelope. */
+export interface CmuxRequestBase {
+  id?: Json;
+  cmd: string;
+}
+
+/** A successful command response envelope. */
+export interface CmuxSuccessResponse<T = Json> {
+  id?: Json;
+  ok: true;
+  data: T;
+}
+
+/** A failed command response envelope. */
+export interface CmuxFailureResponse {
+  id?: Json;
+  ok: false;
+  error: string;
+}
+
+/** The canonical command response envelope. */
+export type CmuxResponse<T = Json> = CmuxSuccessResponse<T> | CmuxFailureResponse;
+
+/** Split orientation used by canonical and declarative layouts. */
+export type SplitDirection = "right" | "down";
+
+/** Four-way pane navigation direction. */
+export type PaneDirection = "left" | "right" | "up" | "down";
+
+/** Notification severity. */
+export type NotificationLevel = "info" | "warning" | "error";
+
+/** An agent's reported lifecycle state. */
+export type AgentState = "working" | "blocked" | "idle" | "done" | "unknown";
+
+/** The authority that produced an agent record. */
+export type AgentSource = "detected" | "socket" | "hook";
+
+/** A source accepted by `report-agent`. */
+export type AgentReportSource = "socket" | "hook";
+
+/** One authoritative agent status record. */
+export interface AgentRecord {
+  surface: Id;
+  state: AgentState;
+  source: AgentSource;
+  session: string | null;
+  updated_at_ms: number;
+}
+
+/** One posted mux notification. */
+export interface Notification {
+  notification: Id;
+  title: string;
+  body: string;
+  level: NotificationLevel;
+  surface: Id | null;
+}

--- a/cmux-tui/bindings/typescript/src/protocol/events.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/events.ts
@@ -1,0 +1,130 @@
+import type {
+  AgentSource,
+  AgentState,
+  Base64,
+  Id,
+  NotificationLevel,
+} from "./common.js";
+
+export interface TreeChangedEvent { event: "tree-changed" }
+export interface LayoutChangedEvent { event: "layout-changed"; screen: Id }
+export interface SurfaceOutputEvent { event: "surface-output"; surface: Id }
+
+/** `offset` is the row offset used by the scrollbar geometry. */
+export interface ScrollChangedEvent {
+  event: "scroll-changed";
+  surface: Id;
+  offset: number;
+  at_bottom: boolean;
+}
+
+export interface SurfaceResizedEvent { event: "surface-resized"; surface: Id; cols: number; rows: number }
+export interface SurfaceExitedEvent { event: "surface-exited"; surface: Id }
+export interface TitleChangedEvent { event: "title-changed"; surface: Id }
+export interface BellEvent { event: "bell"; surface: Id }
+
+export interface NotificationEvent {
+  event: "notification";
+  notification: Id;
+  title: string;
+  body: string;
+  level: NotificationLevel;
+  surface: Id | null;
+}
+
+export interface ConfigReloadRequestedEvent { event: "config-reload-requested" }
+export interface WindowTitleRequestedEvent { event: "window-title-requested"; title: string }
+export interface EmptyEvent { event: "empty" }
+
+/** Initial base64 VT replay for an attached PTY surface. */
+export interface VtStateEvent {
+  event: "vt-state";
+  surface: Id;
+  cols: number;
+  rows: number;
+  data: Base64;
+}
+
+/** Live base64 PTY bytes after the attach snapshot. */
+export interface OutputEvent { event: "output"; surface: Id; data: Base64 }
+
+/** A protocol v6 replay that replaces the existing terminal mirror. */
+export interface ResizedEvent {
+  event: "resized";
+  surface: Id;
+  cols: number;
+  rows: number;
+  replay: Base64;
+}
+
+export interface DetachedEvent { event: "detached"; surface: Id }
+
+/** Proposed event retained for forward-compatible protocol v6 clients. */
+export interface AgentStateChangedEvent {
+  event: "agent-state-changed";
+  surface: Id;
+  previous: AgentState | null;
+  state: AgentState;
+  source: AgentSource;
+  session: string | null;
+  updated_at_ms: number;
+}
+
+/** Proposed notification event shape with its creation timestamp. */
+export interface ProposedNotificationEvent extends NotificationEvent {
+  created_at_ms: number;
+}
+
+/** A forward-compatible event that is not known to this SDK version. */
+export interface UnknownEvent {
+  event: string;
+  [key: string]: unknown;
+}
+
+/** All currently implemented subscribe event payloads. */
+export type KnownSubscribeEvent =
+  | TreeChangedEvent
+  | LayoutChangedEvent
+  | SurfaceOutputEvent
+  | ScrollChangedEvent
+  | SurfaceResizedEvent
+  | SurfaceExitedEvent
+  | TitleChangedEvent
+  | BellEvent
+  | NotificationEvent
+  | ConfigReloadRequestedEvent
+  | WindowTitleRequestedEvent
+  | EmptyEvent;
+
+/** Subscribe events, including unknown future event names. */
+export type SubscribeEvent = KnownSubscribeEvent | UnknownEvent;
+
+/** All currently implemented attach event payloads. */
+export type KnownAttachEvent = VtStateEvent | OutputEvent | ResizedEvent | ScrollChangedEvent | DetachedEvent;
+
+/** Wire-format attach events, including unknown future event names. */
+export type AttachEvent = KnownAttachEvent | UnknownEvent;
+
+/** Every known implemented subscribe or attach event. */
+export type KnownCmuxEvent = KnownSubscribeEvent | KnownAttachEvent | AgentStateChangedEvent | ProposedNotificationEvent;
+
+/** Every cmux event, discriminated by `event`, with an unknown-event fallback. */
+export type CmuxEvent = KnownCmuxEvent | UnknownEvent;
+
+/** A decoded initial replay yielded by `attachSurface()`. */
+export interface DecodedVtStateEvent extends Omit<VtStateEvent, "data"> { data: Uint8Array }
+
+/** Decoded live PTY bytes yielded by `attachSurface()`. */
+export interface DecodedOutputEvent extends Omit<OutputEvent, "data"> { data: Uint8Array }
+
+/** A decoded replacement replay yielded by `attachSurface()`. */
+export interface DecodedResizedEvent extends Omit<ResizedEvent, "replay"> { replay: Uint8Array }
+
+/** Attach events as yielded by the client after base64 decoding. */
+export type DecodedAttachEvent =
+  | DecodedVtStateEvent
+  | DecodedOutputEvent
+  | DecodedResizedEvent
+  | ScrollChangedEvent
+  | DetachedEvent
+  | UnknownEvent;

--- a/cmux-tui/bindings/typescript/src/protocol/index.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/index.ts
@@ -1,0 +1,4 @@
+export * from "./common.js";
+export * from "./tree.js";
+export * from "./commands.js";
+export * from "./events.js";

--- a/cmux-tui/bindings/typescript/src/protocol/tree.ts
+++ b/cmux-tui/bindings/typescript/src/protocol/tree.ts
@@ -1,0 +1,69 @@
+import type { Id, Size, SplitDirection } from "./common.js";
+
+/** The canonical pane split tree. */
+export type Layout =
+  | { type: "leaf"; pane: Id }
+  | { type: "split"; dir: SplitDirection; ratio: number; a: Layout; b: Layout };
+
+/** A declarative split tree used by `apply-layout`. */
+export type DeclarativeLayout =
+  | { type: "leaf"; cwd?: string | null; command?: string[] | null }
+  | {
+      type: "split";
+      dir: SplitDirection;
+      ratio: number;
+      a: DeclarativeLayout;
+      b: DeclarativeLayout;
+    };
+
+/** A live PTY or browser tab. */
+export interface Tab {
+  surface: Id;
+  kind: "pty" | "browser";
+  browser_source: "external" | "launched" | null;
+  name: string | null;
+  title: string;
+  size: Size | null;
+  dead: boolean;
+}
+
+/** A live pane containing tabs. */
+export interface LivePane {
+  id: Id;
+  name: string | null;
+  active_tab: number;
+  tabs: Tab[];
+}
+
+/** A defensive placeholder for a tree leaf whose pane state is missing. */
+export interface DeadPane {
+  id: Id;
+  dead: true;
+}
+
+/** A pane in a tree snapshot. */
+export type Pane = LivePane | DeadPane;
+
+/** A named split-tree screen. */
+export interface Screen {
+  id: Id;
+  name: string | null;
+  active: boolean;
+  active_pane: Id;
+  zoomed_pane: Id | null;
+  layout: Layout;
+  panes: Pane[];
+}
+
+/** A workspace containing one or more screens. */
+export interface Workspace {
+  id: Id;
+  name: string;
+  active: boolean;
+  screens: Screen[];
+}
+
+/** The complete workspace, screen, pane, tab, and layout snapshot. */
+export interface Tree {
+  workspaces: Workspace[];
+}

--- a/cmux-tui/bindings/typescript/src/transport.ts
+++ b/cmux-tui/bindings/typescript/src/transport.ts
@@ -1,0 +1,16 @@
+/** Removes a transport event listener. */
+export type Unsubscribe = () => void;
+
+/** Transport-independent delivery of complete JSON messages. */
+export interface Transport {
+  /** Sends one complete JSON message. */
+  send(json: string): void;
+  /** Observes one complete received JSON message. */
+  onMessage(handler: (json: string) => void): Unsubscribe;
+  /** Observes transport closure. */
+  onClose(handler: () => void): Unsubscribe;
+  /** Observes transport failures. */
+  onError(handler: (error: Error) => void): Unsubscribe;
+  /** Closes the transport and releases its listeners. */
+  close(): void;
+}

--- a/cmux-tui/bindings/typescript/src/types.ts
+++ b/cmux-tui/bindings/typescript/src/types.ts
@@ -1,92 +1,14 @@
-export type Json = null | boolean | number | string | Json[] | { [key: string]: Json };
-export type JsonObject = { [key: string]: Json };
-
-export interface IdentifyResult {
-  app: string;
-  version: string;
-  protocol: number;
-  session: string;
-  pid: number;
-}
-
-export interface EmptyResult {}
-export interface SurfaceResult { surface: number }
-export interface ReadScreenResult { text: string }
-export interface VtStateResult { cols: number; rows: number; data: string }
-export interface Size { cols: number; rows: number }
-
-export type Layout =
-  | { type: "leaf"; pane: number }
-  | { type: "split"; dir: "right" | "down"; ratio: number; a: Layout; b: Layout };
-
-export type Pane =
-  | { id: number; name: string | null; active_tab: number; tabs: Tab[]; dead?: false }
-  | { id: number; dead: true; name?: null; active_tab?: 0; tabs?: [] };
-
-export interface Tab {
-  surface: number;
-  kind: "pty" | "browser" | string;
-  browser_source: "external" | "launched" | null | string;
-  name: string | null;
-  title: string;
-  size: Size | null;
-  dead: boolean;
-}
-
-export interface Screen {
-  id: number;
-  name: string | null;
-  active: boolean;
-  active_pane: number;
-  layout: Layout;
-  panes: Pane[];
-}
-
-export interface Workspace {
-  id: number;
-  name: string;
-  active: boolean;
-  screens: Screen[];
-}
-
-export interface Tree {
-  workspaces: Workspace[];
-}
-
-export type SubscribeEvent =
-  | { event: "tree-changed" }
-  | { event: "surface-output"; surface: number }
-  | { event: "surface-resized"; surface: number; cols: number; rows: number }
-  | { event: "surface-exited"; surface: number }
-  | { event: "title-changed"; surface: number }
-  | { event: "bell"; surface: number }
-  | { event: "empty" }
-  | UnknownEvent;
-
-export type AttachEvent =
-  | { event: "vt-state"; surface: number; cols: number; rows: number; data: string }
-  | { event: "output"; surface: number; data: string }
-  | { event: "resized"; surface: number; cols: number; rows: number; replay: string }
-  | { event: "detached"; surface: number }
-  | UnknownEvent;
-
-export interface UnknownEvent {
-  event: string;
-  [key: string]: unknown;
-}
-
-export interface ClientOptions {
-  socketPath?: string;
-  session?: string;
-  timeoutMs?: number;
-  allowProtocolV6Attach?: boolean;
-}
-
-export interface NewTabOptions { pane?: number; cwd?: string; cols?: number; rows?: number }
-export interface NewBrowserTabOptions { pane?: number; cols?: number; rows?: number }
-export interface NewWorkspaceOptions { name?: string; cols?: number; rows?: number }
-export interface NewScreenOptions { workspace?: number; cols?: number; rows?: number }
-export interface SplitOptions { cols?: number; rows?: number }
-export interface SendOptions { text?: string; bytes?: string | Uint8Array }
-export interface SelectOptions { index?: number; delta?: number }
-export interface SelectTabOptions extends SelectOptions { pane?: number }
+/** @deprecated Import protocol and client types from the package root. */
+export * from "./protocol/index.js";
+export type {
+  CmuxClientOptions,
+  NewBrowserTabOptions,
+  NewScreenOptions,
+  NewTabOptions,
+  NewWorkspaceOptions,
+  SelectOptions,
+  SelectTabOptions,
+  SendOptions,
+  SplitOptions,
+} from "./client.js";
+export type { ClientOptions } from "./node-client.js";

--- a/cmux-tui/bindings/typescript/src/websocket-transport.ts
+++ b/cmux-tui/bindings/typescript/src/websocket-transport.ts
@@ -1,0 +1,137 @@
+import type { Transport, Unsubscribe } from "./transport.js";
+
+interface WebSocketEventMap {
+  open: unknown;
+  message: { data: unknown };
+  close: unknown;
+  error: unknown;
+}
+
+/** The WebSocket subset used by `WebSocketTransport`. */
+export interface WebSocketLike {
+  readonly readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  addEventListener?<K extends keyof WebSocketEventMap>(
+    type: K,
+    listener: (event: WebSocketEventMap[K]) => void,
+  ): void;
+  removeEventListener?<K extends keyof WebSocketEventMap>(
+    type: K,
+    listener: (event: WebSocketEventMap[K]) => void,
+  ): void;
+  on?(type: string, listener: (...args: unknown[]) => void): void;
+  off?(type: string, listener: (...args: unknown[]) => void): void;
+}
+
+/** A browser- or Node-compatible WebSocket constructor. */
+export interface WebSocketConstructor {
+  new (url: string | URL, protocols?: string | string[]): WebSocketLike;
+}
+
+export interface WebSocketTransportOptions {
+  protocols?: string | string[];
+  /** Inject a compatible constructor such as the Node `ws` package. */
+  WebSocket?: WebSocketConstructor;
+}
+
+/** Sends and receives one JSON message per WebSocket text frame. */
+export class WebSocketTransport implements Transport {
+  private readonly socket: WebSocketLike;
+  private readonly pending: string[] = [];
+  private readonly messageHandlers = new Set<(json: string) => void>();
+  private readonly closeHandlers = new Set<() => void>();
+  private readonly errorHandlers = new Set<(error: Error) => void>();
+  private closed = false;
+
+  constructor(url: string | URL, options: WebSocketTransportOptions | WebSocketConstructor = {}) {
+    const normalized = typeof options === "function" ? { WebSocket: options } : options;
+    const Constructor = normalized.WebSocket ?? this.globalConstructor();
+    this.socket = new Constructor(url, normalized.protocols);
+    this.listen("open", () => this.flush());
+    this.listen("message", (event) => this.receive(event));
+    this.listen("error", (event) => this.fail(this.eventError(event)));
+    this.listen("close", () => this.finish());
+  }
+
+  send(json: string): void {
+    if (this.closed) throw new Error("WebSocket transport is closed");
+    if (this.socket.readyState === 1) this.socket.send(json);
+    else this.pending.push(json);
+  }
+
+  onMessage(handler: (json: string) => void): Unsubscribe {
+    this.messageHandlers.add(handler);
+    return () => this.messageHandlers.delete(handler);
+  }
+
+  onClose(handler: () => void): Unsubscribe {
+    this.closeHandlers.add(handler);
+    if (this.closed) queueMicrotask(handler);
+    return () => this.closeHandlers.delete(handler);
+  }
+
+  onError(handler: (error: Error) => void): Unsubscribe {
+    this.errorHandlers.add(handler);
+    return () => this.errorHandlers.delete(handler);
+  }
+
+  close(): void {
+    if (this.closed) return;
+    this.socket.close();
+  }
+
+  private globalConstructor(): WebSocketConstructor {
+    const Constructor = (globalThis as typeof globalThis & { WebSocket?: WebSocketConstructor }).WebSocket;
+    if (!Constructor) throw new Error("WebSocket is not available; inject a compatible constructor");
+    return Constructor;
+  }
+
+  private listen<K extends keyof WebSocketEventMap>(
+    type: K,
+    handler: (event: WebSocketEventMap[K]) => void,
+  ): void {
+    if (this.socket.addEventListener) {
+      this.socket.addEventListener(type, handler);
+      return;
+    }
+    if (this.socket.on) {
+      this.socket.on(type, handler as (...args: unknown[]) => void);
+      return;
+    }
+    throw new Error("injected WebSocket does not support event listeners");
+  }
+
+  private flush(): void {
+    if (this.closed) return;
+    while (this.pending.length > 0) this.socket.send(this.pending.shift()!);
+  }
+
+  private receive(event: WebSocketEventMap["message"] | unknown): void {
+    const data = event && typeof event === "object" && "data" in event ? (event as { data: unknown }).data : event;
+    if (typeof data !== "string") {
+      this.fail(new Error("WebSocket server sent a non-text frame"));
+      return;
+    }
+    for (const handler of this.messageHandlers) handler(data);
+  }
+
+  private eventError(event: unknown): Error {
+    if (event instanceof Error) return event;
+    if (event && typeof event === "object" && "error" in event && (event as { error?: unknown }).error instanceof Error) {
+      return (event as { error: Error }).error;
+    }
+    return new Error("WebSocket transport error");
+  }
+
+  private fail(error: Error): void {
+    for (const handler of this.errorHandlers) handler(error);
+  }
+
+  private finish(): void {
+    if (this.closed) return;
+    this.closed = true;
+    this.pending.length = 0;
+    for (const handler of this.closeHandlers) handler();
+  }
+}

--- a/cmux-tui/bindings/typescript/test/base64.test.ts
+++ b/cmux-tui/bindings/typescript/test/base64.test.ts
@@ -1,0 +1,24 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { decodeBase64, encodeBase64 } from "../src/base64.js";
+
+test("base64 uses browser globals when available", () => {
+  const bytes = Uint8Array.from([0, 1, 2, 127, 128, 255]);
+  assert.equal(encodeBase64(bytes), "AAECf4D/");
+  assert.deepEqual(decodeBase64("AAECf4D/"), bytes);
+});
+
+test("base64 falls back to the Node Buffer global", () => {
+  const atob = Object.getOwnPropertyDescriptor(globalThis, "atob");
+  const btoa = Object.getOwnPropertyDescriptor(globalThis, "btoa");
+  Object.defineProperty(globalThis, "atob", { configurable: true, value: undefined });
+  Object.defineProperty(globalThis, "btoa", { configurable: true, value: undefined });
+  try {
+    const bytes = Uint8Array.from([27, 91, 63, 108]);
+    assert.equal(encodeBase64(bytes), "G1s/bA==");
+    assert.deepEqual(decodeBase64("G1s/bA=="), bytes);
+  } finally {
+    if (atob) Object.defineProperty(globalThis, "atob", atob);
+    if (btoa) Object.defineProperty(globalThis, "btoa", btoa);
+  }
+});

--- a/cmux-tui/bindings/typescript/test/client.test.ts
+++ b/cmux-tui/bindings/typescript/test/client.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { CmuxClient } from "../src/client.js";
+import type { Transport, Unsubscribe } from "../src/transport.js";
+
+class ScriptedTransport implements Transport {
+  private readonly messageHandlers = new Set<(json: string) => void>();
+  private readonly closeHandlers = new Set<() => void>();
+  private readonly errorHandlers = new Set<(error: Error) => void>();
+  constructor(private readonly script: (request: Record<string, unknown>, transport: ScriptedTransport) => void) {}
+  send(json: string): void { this.script(JSON.parse(json) as Record<string, unknown>, this); }
+  onMessage(handler: (json: string) => void): Unsubscribe { this.messageHandlers.add(handler); return () => this.messageHandlers.delete(handler); }
+  onClose(handler: () => void): Unsubscribe { this.closeHandlers.add(handler); return () => this.closeHandlers.delete(handler); }
+  onError(handler: (error: Error) => void): Unsubscribe { this.errorHandlers.add(handler); return () => this.errorHandlers.delete(handler); }
+  close(): void { for (const handler of this.closeHandlers) handler(); }
+  emit(value: Record<string, unknown>): void {
+    const json = JSON.stringify(value);
+    for (const handler of this.messageHandlers) handler(json);
+  }
+}
+
+test("attachSurface decodes VT, output, and resized payloads", async () => {
+  const main = new ScriptedTransport((request, transport) => {
+    assert.equal(request.cmd, "identify");
+    transport.emit({ id: request.id, ok: true, data: { app: "cmux-tui", version: "0.1.2", protocol: 6, session: "main", pid: 1 } });
+  });
+  const attach = new ScriptedTransport((request, transport) => {
+    assert.equal(request.cmd, "attach-surface");
+    transport.emit({ event: "vt-state", surface: 7, cols: 80, rows: 24, data: "G1s/bA==" });
+    transport.emit({ id: request.id, ok: true, data: {} });
+    transport.emit({ event: "output", surface: 7, data: "aGk=" });
+    transport.emit({ event: "resized", surface: 7, cols: 100, rows: 30, replay: "AQID" });
+  });
+  const client = new CmuxClient({
+    transport: main,
+    streamTransportFactory: () => attach,
+    timeoutMs: 100,
+  });
+
+  const stream = await client.attachSurface(7);
+  const initial = await stream.next();
+  const output = await stream.next();
+  const resized = await stream.next();
+  assert.equal(initial.event, "vt-state");
+  if (initial.event === "vt-state") assert.deepEqual(initial.data, Uint8Array.from([27, 91, 63, 108]));
+  assert.equal(output.event, "output");
+  if (output.event === "output") assert.deepEqual(output.data, Uint8Array.from([104, 105]));
+  assert.equal(resized.event, "resized");
+  if (resized.event === "resized") assert.deepEqual(resized.replay, Uint8Array.from([1, 2, 3]));
+  stream.close();
+  await client.close();
+});
+
+test("generic request preserves exact wire command and typed result", async () => {
+  let sent: Record<string, unknown> | undefined;
+  const transport = new ScriptedTransport((request, connection) => {
+    sent = request;
+    connection.emit({ id: request.id, ok: true, data: { ok: true, version: "0.1.2", protocol: 6 } });
+  });
+  const client = new CmuxClient({ transport });
+  const result = await client.request({ cmd: "ping" });
+  assert.equal(result.protocol, 6);
+  assert.deepEqual(sent, { id: 1, cmd: "ping" });
+  await client.close();
+});

--- a/cmux-tui/bindings/typescript/test/protocol-types.ts
+++ b/cmux-tui/bindings/typescript/test/protocol-types.ts
@@ -1,0 +1,87 @@
+import type {
+  CmuxEvent,
+  CmuxRequest,
+  CmuxResponseData,
+  KnownCmuxEvent,
+} from "../src/browser.js";
+
+const requests = [
+  { cmd: "identify" },
+  { cmd: "ping" },
+  { cmd: "reload-config" },
+  { cmd: "set-window-title", title: "cmux" },
+  { cmd: "clear-window-title" },
+  { cmd: "list-workspaces" },
+  { cmd: "export-layout", screen: 1 },
+  { cmd: "apply-layout", layout: { type: "leaf" } },
+  { cmd: "send", surface: 1, text: "ls\r" },
+  { cmd: "read-screen", surface: 1 },
+  { cmd: "sidebar-plugin", cols: 20, rows: 40, relaunch: true },
+  { cmd: "vt-state", surface: 1 },
+  { cmd: "new-tab", pane: 1 },
+  { cmd: "new-browser-tab", url: "https://example.com" },
+  { cmd: "new-workspace", name: "sdk" },
+  { cmd: "new-screen", workspace: 1 },
+  { cmd: "split", pane: 1, dir: "right" },
+  { cmd: "set-ratio", pane: 1, dir: "down", ratio: 0.5 },
+  { cmd: "pane-neighbor", pane: 1, dir: "left" },
+  { cmd: "focus-direction", dir: "up" },
+  { cmd: "swap-pane", pane: 1, target: 2 },
+  { cmd: "zoom-pane", mode: "toggle" },
+  { cmd: "process-info", surface: 1 },
+  { cmd: "set-default-colors", fg: "#ffffff" },
+  { cmd: "close-surface", surface: 1 },
+  { cmd: "close-pane", pane: 1 },
+  { cmd: "close-screen", screen: 1 },
+  { cmd: "close-workspace", workspace: 1 },
+  { cmd: "rename-pane", pane: 1, name: "pane" },
+  { cmd: "rename-surface", surface: 1, name: "tab" },
+  { cmd: "rename-screen", screen: 1, name: "screen" },
+  { cmd: "rename-workspace", workspace: 1, name: "workspace" },
+  { cmd: "resize-surface", surface: 1, cols: 80, rows: 24 },
+  { cmd: "focus-pane", pane: 1 },
+  { cmd: "select-tab", pane: 1, index: 0 },
+  { cmd: "select-screen", delta: 1 },
+  { cmd: "select-workspace", index: 0 },
+  { cmd: "move-tab", surface: 1, pane: 2, index: 0 },
+  { cmd: "move-workspace", workspace: 1, index: 0 },
+  { cmd: "scroll-surface", surface: 1, delta: -10 },
+  { cmd: "subscribe", events: ["bell"] },
+  { cmd: "attach-surface", surface: 1 },
+  { cmd: "wait-for", surface: "a8f3k2", pattern: "ready", timeout_ms: 5000 },
+  { cmd: "run", argv: ["echo", "ok"] },
+  { cmd: "send-key", surface: 1, keys: ["ctrl+c"] },
+  { cmd: "copy", surface: 1, mode: "screen" },
+  { cmd: "ids", kind: "surface" },
+  { cmd: "notify", title: "Build", body: "done" },
+  { cmd: "list-agents", state: "working" },
+  { cmd: "report-agent", surface: 1, state: "working", source: "socket" },
+] satisfies CmuxRequest[];
+
+type IdentifyData = CmuxResponseData<(typeof requests)[0]>;
+const identify: IdentifyData = { app: "cmux-tui", version: "0.1.2", protocol: 6, session: "main", pid: 1 };
+void identify;
+
+function surfaceFromKnownEvent(event: KnownCmuxEvent): number | undefined {
+  switch (event.event) {
+    case "surface-output":
+    case "scroll-changed":
+    case "surface-resized":
+    case "surface-exited":
+    case "title-changed":
+    case "bell":
+    case "vt-state":
+    case "output":
+    case "resized":
+    case "detached": return event.surface;
+    default: return undefined;
+  }
+}
+
+const futureEvent: CmuxEvent = { event: "future-event", extension: true };
+void surfaceFromKnownEvent;
+void futureEvent;
+
+// @ts-expect-error `read-screen` requires a surface id.
+const invalidRequest: CmuxRequest = { cmd: "read-screen" };
+void invalidRequest;

--- a/cmux-tui/bindings/typescript/test/unix-transport.test.ts
+++ b/cmux-tui/bindings/typescript/test/unix-transport.test.ts
@@ -1,0 +1,41 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm } from "node:fs/promises";
+import { createServer } from "node:net";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { CmuxClient } from "../src/node-client.js";
+
+test("Unix transport preserves JSON-lines request and response framing", async () => {
+  const directory = await mkdtemp(join(tmpdir(), "cmux-typescript-"));
+  const socketPath = join(directory, "session.sock");
+  const server = createServer((socket) => {
+    socket.setEncoding("utf8");
+    let buffered = "";
+    socket.on("data", (chunk: string) => {
+      buffered += chunk;
+      const newline = buffered.indexOf("\n");
+      if (newline < 0) return;
+      const request = JSON.parse(buffered.slice(0, newline)) as Record<string, unknown>;
+      assert.deepEqual(request, { id: 1, cmd: "ping" });
+      socket.write(`${JSON.stringify({
+        id: request.id,
+        ok: true,
+        data: { ok: true, version: "0.1.2", protocol: 6 },
+      })}\n`);
+    });
+  });
+
+  try {
+    await new Promise<void>((resolve, reject) => {
+      server.once("error", reject);
+      server.listen(socketPath, resolve);
+    });
+    const client = new CmuxClient({ socketPath, timeoutMs: 1000 });
+    assert.deepEqual(await client.ping(), { ok: true, version: "0.1.2", protocol: 6 });
+    await client.close();
+  } finally {
+    await new Promise<void>((resolve, reject) => server.close((error) => error ? reject(error) : resolve()));
+    await rm(directory, { recursive: true, force: true });
+  }
+});

--- a/cmux-tui/bindings/typescript/test/websocket-transport.test.ts
+++ b/cmux-tui/bindings/typescript/test/websocket-transport.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  WebSocketTransport,
+  type WebSocketConstructor,
+  type WebSocketLike,
+} from "../src/websocket-transport.js";
+
+class FakeWebSocket implements WebSocketLike {
+  static readonly instances: FakeWebSocket[] = [];
+  readonly sent: string[] = [];
+  readonly url: string;
+  readonly protocols?: string | string[];
+  readyState = 0;
+  private readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  constructor(url: string | URL, protocols?: string | string[]) {
+    this.url = String(url);
+    this.protocols = protocols;
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data: string): void { this.sent.push(data); }
+  close(): void { this.readyState = 3; this.emit("close", {}); }
+  addEventListener(type: string, listener: (event: never) => void): void {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener as (event: unknown) => void);
+    this.listeners.set(type, listeners);
+  }
+  removeEventListener(type: string, listener: (event: never) => void): void {
+    this.listeners.get(type)?.delete(listener as (event: unknown) => void);
+  }
+  open(): void { this.readyState = 1; this.emit("open", {}); }
+  message(data: unknown): void { this.emit("message", { data }); }
+  error(error: Error): void { this.emit("error", { error }); }
+  private emit(type: string, event: unknown): void {
+    for (const listener of this.listeners.get(type) ?? []) listener(event);
+  }
+}
+
+const Constructor = FakeWebSocket as unknown as WebSocketConstructor;
+
+test("WebSocketTransport queues until open and sends one JSON text frame", () => {
+  const transport = new WebSocketTransport("ws://localhost/cmux", { WebSocket: Constructor, protocols: "cmux" });
+  const socket = FakeWebSocket.instances.at(-1)!;
+  transport.send('{"id":1,"cmd":"ping"}');
+  assert.deepEqual(socket.sent, []);
+  socket.open();
+  assert.deepEqual(socket.sent, ['{"id":1,"cmd":"ping"}']);
+  assert.equal(socket.url, "ws://localhost/cmux");
+  assert.equal(socket.protocols, "cmux");
+  transport.close();
+});
+
+test("WebSocketTransport forwards text, errors, and close", () => {
+  const transport = new WebSocketTransport("ws://localhost/cmux", Constructor);
+  const socket = FakeWebSocket.instances.at(-1)!;
+  const messages: string[] = [];
+  const errors: Error[] = [];
+  let closes = 0;
+  transport.onMessage((message) => messages.push(message));
+  transport.onError((error) => errors.push(error));
+  transport.onClose(() => closes += 1);
+  socket.open();
+  socket.message('{"event":"tree-changed"}');
+  socket.error(new Error("boom"));
+  socket.close();
+  assert.deepEqual(messages, ['{"event":"tree-changed"}']);
+  assert.equal(errors[0]?.message, "boom");
+  assert.equal(closes, 1);
+});
+
+test("WebSocketTransport rejects binary frames", () => {
+  const transport = new WebSocketTransport("ws://localhost/cmux", Constructor);
+  const socket = FakeWebSocket.instances.at(-1)!;
+  const errors: Error[] = [];
+  transport.onError((error) => errors.push(error));
+  socket.open();
+  socket.message(Uint8Array.from([1, 2, 3]));
+  assert.match(errors[0]?.message ?? "", /non-text frame/);
+  transport.close();
+});

--- a/cmux-tui/bindings/typescript/tsconfig.json
+++ b/cmux-tui/bindings/typescript/tsconfig.json
@@ -1,13 +1,14 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "Node",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "lib": ["ES2022", "DOM"],
     "strict": true,
     "declaration": true,
     "outDir": "dist",
     "rootDir": ".",
     "skipLibCheck": true
   },
-  "include": ["src/**/*.ts", "e2e/**/*.ts"]
+  "include": ["src/**/*.ts", "e2e/**/*.ts", "test/**/*.ts"]
 }

--- a/cmux-tui/spec/bindings.md
+++ b/cmux-tui/spec/bindings.md
@@ -40,7 +40,25 @@ The client should support context-manager usage to close sockets deterministical
 
 TypeScript bindings should expose promise-based command methods and discriminated unions for results and events. The `event` field is the event discriminator. Command errors should reject with a typed error carrying the server message and optional command id.
 
-The package should support Node.js first because the implemented transport is a Unix socket. Browser support is out of scope until HTTP is implemented.
+The `cmux` package is the frontend client library. Its package root conditionally exports a browser-safe ESM entry, while `cmux/node` explicitly exports the Node entry with the default Unix-socket behavior. Shared modules must not import Node builtins at module scope.
+
+All clients accept a `Transport` with this contract:
+
+```ts
+interface Transport {
+  send(json: string): void;
+  onMessage(handler: (json: string) => void): () => void;
+  onClose(handler: () => void): () => void;
+  onError(handler: (error: Error) => void): () => void;
+  close(): void;
+}
+```
+
+`UnixSocketTransport` frames each JSON message as one line. `WebSocketTransport` frames each JSON message as one text frame, uses the browser global by default, and accepts an injected WebSocket-compatible constructor in Node without requiring a runtime dependency.
+
+`CmuxRequest` is discriminated by exact wire `cmd`; `CmuxEvent` is discriminated by exact wire `event` and retains an unknown-event fallback. `request({cmd,...params})` infers successful response data from the request member. Typed command methods remain the preferred surface.
+
+`attachSurface()` yields an async iterable. Its `vt-state.data`, `output.data`, and `resized.replay` values are decoded to `Uint8Array` without relying on `Buffer` in shared browser code. Wire event types continue to expose their exact base64 string fields.
 
 Generated types must preserve exact field optionality. Unknown event names should be represented as `{ event: string; [key: string]: unknown }` rather than being dropped.
 


### PR DESCRIPTION
Turns the TypeScript binding into the client library for third-party cmux-tui frontends (the xterm.js React reference app and eventually the Swift app's web layer consume this): complete typed protocol (all 50 commands + events, discriminated unions mirroring spec/), a Transport abstraction with the wire-identical unix client and a browser+node WebSocketTransport (injected ctor, no hard ws dep), typed attach streaming with Uint8Array VT payloads, browser-safe package exports (cmux / cmux/node / cmux/browser). Conformance TS e2e unchanged and must stay green in CI (local server build blocked by the known host zig issue). 8/8 tests, npm pack clean.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7886"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786359508&installation_id=133855650&pr_number=7886&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7886&signature=e96e6dd31be0f290cba0316f002d0cc7c130007b918bc3125caae0a186707057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Large client refactor and expanded protocol surface; behavior changes mainly around streaming/multiplexing and attach decoding, though Node zero-arg usage is preserved via a thin wrapper.
> 
> **Overview**
> Refactors the **cmux** TypeScript binding from a Node-only Unix-socket client into a **frontend SDK**: injectable **`Transport`**, a shared **`MessageRouter`**, and **`CmuxStream`** for subscribe/attach instead of socket-specific JSON-line I/O.
> 
> Adds a **`protocol/`** module with discriminated **`CmuxRequest`** / event unions (full v6 command set), a generic **`request()`** that infers response types, and many new typed command helpers (layout, agents, `run`, `copy`, etc.). **`attachSurface()`** now decodes **`vt-state`**, **`output`**, and **`resized`** payloads to **`Uint8Array`** via portable base64 helpers (no **`Buffer`** in shared code).
> 
> Ships **`UnixSocketTransport`** and **`WebSocketTransport`** (browser global or injected ctor), conditional package exports (**`cmux`**, **`cmux/browser`**, **`cmux/node`**), ESM **`NodeNext`** build, **`npm test`**, and updated **`bindings.md`** TypeScript contract. Node **`new CmuxClient()`** / env socket defaults remain on the **`cmux/node`** (and root Node) entry via **`node-client`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 45c299f0c7e50d61cc5a74e5a592b79f73ad2914. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns the TypeScript bindings into a typed frontend SDK for `cmux` with a full protocol, pluggable transports, and browser-safe exports. Keeps the Node API compatible while adding typed streaming attach and a generic, type‑inferred request method that enforces required params.

- **New Features**
  - Full typed protocol: 50 commands + discriminated event unions.
  - Pluggable `Transport` with `UnixSocketTransport` (JSON-lines) and `WebSocketTransport` (browser + Node via injected `WebSocket`).
  - `CmuxClient.request(cmd, params)` enforces required params; `request({ cmd, ... })` infers result types. Existing command methods remain.
  - `attachSurface()` yields a stream; `vt-state`, `output`, and `resized` payloads decode to `Uint8Array`.
  - Browser-safe entries: `cmux` (browser condition), `cmux/browser`, and `cmux/node`; no runtime deps.

- **Migration**
  - No breaking changes for Node users; `import { CmuxClient } from "cmux"` still works. `cmux/node` is available explicitly. Requires Node 20+.
  - In browsers, use `cmux` or `cmux/browser` with `WebSocketTransport`.
  - In Node with WebSocket, inject a constructor (e.g., from `ws`) into `WebSocketTransport`.
  - For dedicated subscribe/attach connections, provide `streamTransportFactory` (default for Unix sockets).

<sup>Written for commit 45c299f0c7e50d61cc5a74e5a592b79f73ad2914. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a cross-platform TypeScript client supporting browser WebSockets and Node.js Unix sockets.
  * Added typed protocol commands, responses, events, streaming subscriptions, and surface attachment.
  * Added browser and Node package entry points with ESM support.
  * Added portable Base64 encoding and decoding helpers.
  * Added async streaming, typed raw requests, and forward-compatible event handling.

* **Documentation**
  * Expanded setup, runtime, frontend integration, transport, and verification guidance.

* **Tests**
  * Added coverage for transports, streaming, Base64 utilities, protocol typing, and Unix-socket communication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->