### PR TITLE
Fix localized SEO metadata from Ahrefs audit

### DIFF
--- a/web/app/[locale]/(landing)/assets/page.tsx
+++ b/web/app/[locale]/(landing)/assets/page.tsx
@@ -1,7 +1,7 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
-import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 
 const brandAssets = [
@@ -36,7 +36,7 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "brandAssets" });
   const alternates = buildAlternates(locale, "/assets");
-  const title = t("metaTitle");
+  const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
   return {
     title,

--- a/web/app/[locale]/(landing)/assets/page.tsx
+++ b/web/app/[locale]/(landing)/assets/page.tsx
@@ -37,7 +37,9 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "brandAssets" });
   const alternates = buildAlternates(locale, "/assets");
   const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"));
+  const description = seoDescription(locale, t("metaDescription"), {
+    minLength: 110,
+  });
   return {
     title,
     description,

--- a/web/app/[locale]/(landing)/assets/page.tsx
+++ b/web/app/[locale]/(landing)/assets/page.tsx
@@ -1,7 +1,8 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import Image from "next/image";
-import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+import { assetsSeoCopy } from "@/i18n/audited-seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 
 const brandAssets = [
@@ -35,11 +36,9 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "brandAssets" });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "/assets");
-  const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"), {
-    minLength: 110,
-  });
+  const { title, description } = assetsSeoCopy(locale, t, siteMeta);
   return {
     title,
     description,

--- a/web/app/[locale]/(landing)/best-terminal-for-mac/page.tsx
+++ b/web/app/[locale]/(landing)/best-terminal-for-mac/page.tsx
@@ -1,15 +1,16 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+import { bestTerminalSeoCopy } from "@/i18n/audited-seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 import { CompareTable, LandingCTA } from "../landing-ui";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "landing.bestTerminal" });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "/best-terminal-for-mac");
-  const title = t("metaTitle");
-  const description = seoDescription(locale, t("metaDescription"));
+  const { title, description } = bestTerminalSeoCopy(locale, t, siteMeta);
   return {
     title,
     description,

--- a/web/app/[locale]/(landing)/blog/blog-schema.tsx
+++ b/web/app/[locale]/(landing)/blog/blog-schema.tsx
@@ -6,18 +6,22 @@ import {
 } from "@/app/[locale]/components/json-ld";
 
 /**
- * Article + BreadcrumbList JSON-LD for a blog post. Reads the post title from
- * the post's `blog.posts.<key>` namespace and the description from the post's
- * `blog.<key>.metaDescription`. Breadcrumb is Home > Blog > <post>.
+ * Article + BreadcrumbList JSON-LD for a blog post. Defaults to the post's
+ * localized title and metadata description; callers with audited SEO copy can
+ * pass the exact headline and description shared by page metadata.
  */
 export function BlogSchema({
   postKey,
   path,
   datePublished,
+  headline: headlineOverride,
+  description: descriptionOverride,
 }: {
   postKey: string;
   path: string;
   datePublished: string;
+  headline?: string;
+  description?: string;
 }) {
   const tp = useTranslations(`blog.posts.${postKey}`);
   const tm = useTranslations(`blog.${postKey}`);
@@ -25,8 +29,8 @@ export function BlogSchema({
   const tn = useTranslations("nav");
   const locale = useLocale();
 
-  const headline = tp("title");
-  const description = tm("metaDescription");
+  const headline = headlineOverride ?? tp("title");
+  const description = descriptionOverride ?? tm("metaDescription");
 
   return (
     <>

--- a/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
+++ b/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
@@ -1,6 +1,7 @@
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+import { cmuxHistorySeoCopy } from "@/i18n/audited-seo";
 import { BlogSchema } from "../blog-schema";
 import { Link } from "@/i18n/navigation";
 import { CodeBlock } from "@/app/[locale]/components/code-block";
@@ -12,11 +13,18 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog.cmuxHistory" });
-  const alternates = buildAlternates(locale, "/blog/cmux-history");
-  const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"), {
-    minLength: 110,
+  const post = await getTranslations({
+    locale,
+    namespace: "blog.posts.cmuxHistory",
   });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
+  const alternates = buildAlternates(locale, "/blog/cmux-history");
+  const { title, description } = cmuxHistorySeoCopy(
+    locale,
+    t,
+    post,
+    siteMeta,
+  );
   return {
     title: { absolute: title },
     description,
@@ -34,11 +42,21 @@ export async function generateMetadata({
 
 export default function CmuxHistoryBlogPage() {
   const t = useTranslations("blog.posts.cmuxHistory");
+  const tm = useTranslations("blog.cmuxHistory");
+  const siteMeta = useTranslations("meta");
   const tc = useTranslations("common");
+  const locale = useLocale();
+  const seoCopy = cmuxHistorySeoCopy(locale, tm, t, siteMeta);
 
   return (
     <>
-      <BlogSchema postKey="cmuxHistory" path="/blog/cmux-history" datePublished="2026-06-02T00:00:00Z" />
+      <BlogSchema
+        postKey="cmuxHistory"
+        path="/blog/cmux-history"
+        datePublished="2026-06-02T00:00:00Z"
+        headline={seoCopy.title}
+        description={seoCopy.description}
+      />
       <div className="mb-8">
         <Link
           href="/blog"

--- a/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
+++ b/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
 import { BlogSchema } from "../blog-schema";
 import { Link } from "@/i18n/navigation";
 import { CodeBlock } from "@/app/[locale]/components/code-block";
@@ -13,7 +13,8 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog.cmuxHistory" });
   const alternates = buildAlternates(locale, "/blog/cmux-history");
-  const title = t("metaTitle");
+  // Leave room for the blog layout's localized title suffix.
+  const title = seoTitle(locale, t("metaTitle"), { maxLength: 48 });
   const description = seoDescription(locale, t("metaDescription"));
   return {
     title,

--- a/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
+++ b/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
@@ -13,11 +13,10 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog.cmuxHistory" });
   const alternates = buildAlternates(locale, "/blog/cmux-history");
-  // Leave room for the blog layout's localized title suffix.
-  const title = seoTitle(locale, t("metaTitle"), { maxLength: 48 });
+  const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
   return {
-    title,
+    title: { absolute: title },
     description,
     openGraph: {
       ...openGraphDefaults(locale, "article"),

--- a/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
+++ b/web/app/[locale]/(landing)/blog/cmux-history/page.tsx
@@ -14,7 +14,9 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "blog.cmuxHistory" });
   const alternates = buildAlternates(locale, "/blog/cmux-history");
   const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"));
+  const description = seoDescription(locale, t("metaDescription"), {
+    minLength: 110,
+  });
   return {
     title: { absolute: title },
     description,

--- a/web/app/[locale]/(landing)/blog/page.tsx
+++ b/web/app/[locale]/(landing)/blog/page.tsx
@@ -13,7 +13,9 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "blog" });
   const alternates = buildAlternates(locale, "/blog");
   const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"));
+  const description = seoDescription(locale, t("metaDescription"), {
+    minLength: 110,
+  });
   return {
     title: { absolute: title },
     description,

--- a/web/app/[locale]/(landing)/blog/page.tsx
+++ b/web/app/[locale]/(landing)/blog/page.tsx
@@ -1,6 +1,6 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
 import { Link } from "@/i18n/navigation";
 import { blogPosts } from "@/app/[locale]/components/blog-posts";
 
@@ -12,7 +12,7 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog" });
   const alternates = buildAlternates(locale, "/blog");
-  const title = t("metaTitle");
+  const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
   return {
     title,

--- a/web/app/[locale]/(landing)/blog/page.tsx
+++ b/web/app/[locale]/(landing)/blog/page.tsx
@@ -15,7 +15,7 @@ export async function generateMetadata({
   const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
   return {
-    title,
+    title: { absolute: title },
     description,
     alternates,
     openGraph: {

--- a/web/app/[locale]/(landing)/blog/page.tsx
+++ b/web/app/[locale]/(landing)/blog/page.tsx
@@ -1,6 +1,7 @@
 import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+import { blogIndexSeoCopy } from "@/i18n/audited-seo";
 import { Link } from "@/i18n/navigation";
 import { blogPosts } from "@/app/[locale]/components/blog-posts";
 
@@ -11,11 +12,9 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "blog" });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "/blog");
-  const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"), {
-    minLength: 110,
-  });
+  const { title, description } = blogIndexSeoCopy(locale, t, siteMeta);
   return {
     title: { absolute: title },
     description,

--- a/web/app/[locale]/(landing)/community/page.tsx
+++ b/web/app/[locale]/(landing)/community/page.tsx
@@ -1,6 +1,6 @@
 import { useLocale, useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 import { OfficialLinks } from "@/app/[locale]/components/official-links";
 import {
@@ -15,7 +15,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "community" });
   const alternates = buildAlternates(locale, "/community");
-  const title = t("metaTitle");
+  const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
   return {
     title,

--- a/web/app/[locale]/(landing)/community/page.tsx
+++ b/web/app/[locale]/(landing)/community/page.tsx
@@ -1,6 +1,7 @@
 import { useLocale, useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, seoTitle, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+import { communitySeoCopy } from "@/i18n/audited-seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 import { OfficialLinks } from "@/app/[locale]/components/official-links";
 import {
@@ -14,11 +15,9 @@ import { CommunityProjectBrowser } from "./project-browser";
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "community" });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "/community");
-  const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"), {
-    minLength: 110,
-  });
+  const { title, description } = communitySeoCopy(locale, t, siteMeta);
   return {
     title,
     description,

--- a/web/app/[locale]/(landing)/community/page.tsx
+++ b/web/app/[locale]/(landing)/community/page.tsx
@@ -16,7 +16,9 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const t = await getTranslations({ locale, namespace: "community" });
   const alternates = buildAlternates(locale, "/community");
   const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"));
+  const description = seoDescription(locale, t("metaDescription"), {
+    minLength: 110,
+  });
   return {
     title,
     description,

--- a/web/app/[locale]/(landing)/compare/[slug]/page.tsx
+++ b/web/app/[locale]/(landing)/compare/[slug]/page.tsx
@@ -4,10 +4,9 @@ import { notFound } from "next/navigation";
 import {
   buildAlternates,
   openGraphDefaults,
-  seoDescription,
-  seoTitle,
   twitterSummary,
 } from "@/i18n/seo";
+import { comparePageSeoCopy } from "@/i18n/audited-seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 import {
   comparePageForSlug,
@@ -41,12 +40,20 @@ export async function generateMetadata({
 
   const namespace = `landing.compare.pages.${page.key}`;
   const t = await getTranslations({ locale, namespace });
+  const landingLinks = await getTranslations({
+    locale,
+    namespace: "landing.links",
+  });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const path = comparePath(page.slug);
   const alternates = buildAlternates(locale, path);
-  const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"), {
-    minLength: 110,
-  });
+  const { title, description } = comparePageSeoCopy(
+    locale,
+    page.key,
+    t,
+    landingLinks,
+    siteMeta,
+  );
 
   return {
     title,
@@ -99,8 +106,10 @@ function ComparePageContent({
   const t = useTranslations(namespace);
   const tl = useTranslations("landing.links");
   const tc = useTranslations("landing.compare");
+  const siteMeta = useTranslations("meta");
   const locale = useLocale();
   const path = comparePath(slug);
+  const seoCopy = comparePageSeoCopy(locale, pageKey, t, tl, siteMeta);
   const sections = t.raw("sections") as Section[];
   const table = t.raw("table") as Table;
   const qas = [1, 2, 3].map((n) => ({
@@ -115,10 +124,8 @@ function ComparePageContent({
         data={articleSchema({
           locale,
           path,
-          headline: t("title"),
-          description: seoDescription(locale, t("metaDescription"), {
-            minLength: 110,
-          }),
+          headline: seoCopy.title,
+          description: seoCopy.description,
           datePublished: lastModified,
           dateModified: lastModified,
         })}

--- a/web/app/[locale]/(landing)/compare/[slug]/page.tsx
+++ b/web/app/[locale]/(landing)/compare/[slug]/page.tsx
@@ -5,6 +5,7 @@ import {
   buildAlternates,
   openGraphDefaults,
   seoDescription,
+  seoTitle,
   twitterSummary,
 } from "@/i18n/seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
@@ -42,7 +43,7 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace });
   const path = comparePath(page.slug);
   const alternates = buildAlternates(locale, path);
-  const title = t("metaTitle");
+  const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
 
   return {

--- a/web/app/[locale]/(landing)/compare/[slug]/page.tsx
+++ b/web/app/[locale]/(landing)/compare/[slug]/page.tsx
@@ -44,7 +44,9 @@ export async function generateMetadata({
   const path = comparePath(page.slug);
   const alternates = buildAlternates(locale, path);
   const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"));
+  const description = seoDescription(locale, t("metaDescription"), {
+    minLength: 110,
+  });
 
   return {
     title,
@@ -114,7 +116,9 @@ function ComparePageContent({
           locale,
           path,
           headline: t("title"),
-          description: seoDescription(locale, t("metaDescription")),
+          description: seoDescription(locale, t("metaDescription"), {
+            minLength: 110,
+          }),
           datePublished: lastModified,
           dateModified: lastModified,
         })}

--- a/web/app/[locale]/(landing)/compare/page.tsx
+++ b/web/app/[locale]/(landing)/compare/page.tsx
@@ -20,7 +20,9 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "landing.compare" });
   const alternates = buildAlternates(locale, "/compare");
   const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"));
+  const description = seoDescription(locale, t("metaDescription"), {
+    minLength: 110,
+  });
   return {
     title,
     description,

--- a/web/app/[locale]/(landing)/compare/page.tsx
+++ b/web/app/[locale]/(landing)/compare/page.tsx
@@ -4,6 +4,7 @@ import {
   buildAlternates,
   openGraphDefaults,
   seoDescription,
+  seoTitle,
   twitterSummary,
 } from "@/i18n/seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
@@ -18,7 +19,7 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "landing.compare" });
   const alternates = buildAlternates(locale, "/compare");
-  const title = t("metaTitle");
+  const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
   return {
     title,

--- a/web/app/[locale]/(landing)/compare/page.tsx
+++ b/web/app/[locale]/(landing)/compare/page.tsx
@@ -3,10 +3,9 @@ import { getTranslations } from "next-intl/server";
 import {
   buildAlternates,
   openGraphDefaults,
-  seoDescription,
-  seoTitle,
   twitterSummary,
 } from "@/i18n/seo";
+import { compareIndexSeoCopy } from "@/i18n/audited-seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 import { comparePages, comparePath } from "../../../lib/compare-pages";
 import { TrackedLink } from "../tracked-link";
@@ -18,11 +17,9 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "landing.compare" });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "/compare");
-  const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"), {
-    minLength: 110,
-  });
+  const { title, description } = compareIndexSeoCopy(locale, t, siteMeta);
   return {
     title,
     description,

--- a/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
+++ b/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
@@ -2,16 +2,31 @@ import { useTranslations } from "next-intl";
 import { getTranslations } from "next-intl/server";
 import { CodeBlock } from "@/app/[locale]/components/code-block";
 import { DocsHeading } from "@/app/[locale]/components/docs-heading";
-import { buildAlternates } from "@/i18n/seo";
+import {
+  buildAlternates,
+  openGraphDefaults,
+  seoDescription,
+  twitterSummary,
+} from "@/i18n/seo";
 import { DocsSchema } from "../../docs-schema";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.ohMyPi" });
+  const alternates = buildAlternates(locale, "/docs/agent-integrations/oh-my-pi");
+  const title = t("metaTitle");
+  const description = seoDescription(locale, t("metaDescription"));
   return {
-    title: t("metaTitle"),
-    description: t("metaDescription"),
-    alternates: buildAlternates(locale, "/docs/agent-integrations/oh-my-pi"),
+    title,
+    description,
+    alternates,
+    openGraph: {
+      ...openGraphDefaults(locale, "article"),
+      title,
+      description,
+      url: alternates.canonical,
+    },
+    twitter: twitterSummary(locale, title, description),
   };
 }
 

--- a/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
+++ b/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
@@ -5,10 +5,9 @@ import { DocsHeading } from "@/app/[locale]/components/docs-heading";
 import {
   buildAlternates,
   openGraphDefaults,
-  seoDescription,
-  seoTitle,
   twitterSummary,
 } from "@/i18n/seo";
+import { ohMyPiSeoCopy } from "@/i18n/audited-seo";
 import {
   fallbackContentLocales,
   hasFallbackContent,
@@ -18,16 +17,18 @@ import { DocsSchema } from "../../docs-schema";
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.ohMyPi" });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const contentLocale = hasFallbackContent(locale) ? locale : "en";
   const alternates = buildAlternates(
     contentLocale,
     "/docs/agent-integrations/oh-my-pi",
     fallbackContentLocales,
   );
-  const title = seoTitle(contentLocale, t("metaTitle"));
-  const description = seoDescription(contentLocale, t("metaDescription"), {
-    minLength: 110,
-  });
+  const { title, description } = ohMyPiSeoCopy(
+    contentLocale,
+    t,
+    siteMeta,
+  );
   return {
     title: { absolute: title },
     description,

--- a/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
+++ b/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
@@ -6,6 +6,7 @@ import {
   buildAlternates,
   openGraphDefaults,
   seoDescription,
+  seoTitle,
   twitterSummary,
 } from "@/i18n/seo";
 import { DocsSchema } from "../../docs-schema";
@@ -14,10 +15,10 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.ohMyPi" });
   const alternates = buildAlternates(locale, "/docs/agent-integrations/oh-my-pi");
-  const title = t("metaTitle");
+  const title = seoTitle(locale, t("metaTitle"));
   const description = seoDescription(locale, t("metaDescription"));
   return {
-    title,
+    title: { absolute: title },
     description,
     alternates,
     openGraph: {

--- a/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
+++ b/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
@@ -9,13 +9,21 @@ import {
   seoTitle,
   twitterSummary,
 } from "@/i18n/seo";
+import {
+  fallbackContentLocales,
+  hasFallbackContent,
+} from "@/i18n/locale-availability";
 import { DocsSchema } from "../../docs-schema";
 
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.ohMyPi" });
-  const contentLocale = locale === "ja" ? "ja" : "en";
-  const alternates = buildAlternates(locale, "/docs/agent-integrations/oh-my-pi");
+  const contentLocale = hasFallbackContent(locale) ? locale : "en";
+  const alternates = buildAlternates(
+    contentLocale,
+    "/docs/agent-integrations/oh-my-pi",
+    fallbackContentLocales,
+  );
   const title = seoTitle(contentLocale, t("metaTitle"));
   const description = seoDescription(contentLocale, t("metaDescription"), {
     minLength: 110,

--- a/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
+++ b/web/app/[locale]/(landing)/docs/agent-integrations/oh-my-pi/page.tsx
@@ -14,20 +14,23 @@ import { DocsSchema } from "../../docs-schema";
 export async function generateMetadata({ params }: { params: Promise<{ locale: string }> }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "docs.ohMyPi" });
+  const contentLocale = locale === "ja" ? "ja" : "en";
   const alternates = buildAlternates(locale, "/docs/agent-integrations/oh-my-pi");
-  const title = seoTitle(locale, t("metaTitle"));
-  const description = seoDescription(locale, t("metaDescription"));
+  const title = seoTitle(contentLocale, t("metaTitle"));
+  const description = seoDescription(contentLocale, t("metaDescription"), {
+    minLength: 110,
+  });
   return {
     title: { absolute: title },
     description,
     alternates,
     openGraph: {
-      ...openGraphDefaults(locale, "article"),
+      ...openGraphDefaults(contentLocale, "article"),
       title,
       description,
       url: alternates.canonical,
     },
-    twitter: twitterSummary(locale, title, description),
+    twitter: twitterSummary(contentLocale, title, description),
   };
 }
 

--- a/web/app/[locale]/(legal)/eula/page.tsx
+++ b/web/app/[locale]/(legal)/eula/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
+import { legalMetadata } from "../legal-metadata";
 
-export const metadata: Metadata = {
-  title: "EULA — cmux",
-  description: "End-User License Agreement for cmux",
-  alternates: { canonical: "https://cmux.com/eula" },
-};
+export const metadata: Metadata = legalMetadata(
+  "/eula",
+  "EULA — cmux",
+  "End-User License Agreement for the cmux macOS application",
+);
 
 export default function EulaPage() {
   return (

--- a/web/app/[locale]/(legal)/legal-metadata.ts
+++ b/web/app/[locale]/(legal)/legal-metadata.ts
@@ -11,7 +11,7 @@ export function legalMetadata(
   title: string,
   summary: string,
 ): Metadata {
-  const description = seoDescription("en", summary);
+  const description = seoDescription("en", summary, { minLength: 0 });
   const alternates = buildAlternates("en", path, ["en"]);
 
   return {

--- a/web/app/[locale]/(legal)/legal-metadata.ts
+++ b/web/app/[locale]/(legal)/legal-metadata.ts
@@ -1,0 +1,29 @@
+import type { Metadata } from "next";
+import {
+  buildAlternates,
+  openGraphDefaults,
+  seoDescription,
+  twitterSummary,
+} from "@/i18n/seo";
+
+export function legalMetadata(
+  path: string,
+  title: string,
+  summary: string,
+): Metadata {
+  const description = seoDescription("en", summary);
+  const alternates = buildAlternates("en", path, ["en"]);
+
+  return {
+    title,
+    description,
+    alternates,
+    openGraph: {
+      ...openGraphDefaults("en", "website"),
+      title,
+      description,
+      url: alternates.canonical,
+    },
+    twitter: twitterSummary("en", title, description),
+  };
+}

--- a/web/app/[locale]/(legal)/privacy-policy/page.tsx
+++ b/web/app/[locale]/(legal)/privacy-policy/page.tsx
@@ -1,11 +1,12 @@
 import type { Metadata } from "next";
 import { Link } from "../../../../i18n/navigation";
+import { legalMetadata } from "../legal-metadata";
 
-export const metadata: Metadata = {
-  title: "Privacy Policy — cmux",
-  description: "Privacy policy for cmux",
-  alternates: { canonical: "https://cmux.com/privacy-policy" },
-};
+export const metadata: Metadata = legalMetadata(
+  "/privacy-policy",
+  "Privacy Policy — cmux",
+  "Privacy policy for the cmux website and macOS application",
+);
 
 export default function PrivacyPolicyPage() {
   return (

--- a/web/app/[locale]/(legal)/terms-of-service/page.tsx
+++ b/web/app/[locale]/(legal)/terms-of-service/page.tsx
@@ -1,10 +1,11 @@
 import type { Metadata } from "next";
+import { legalMetadata } from "../legal-metadata";
 
-export const metadata: Metadata = {
-  title: "Terms of Service — cmux",
-  description: "Terms of service for cmux",
-  alternates: { canonical: "https://cmux.com/terms-of-service" },
-};
+export const metadata: Metadata = legalMetadata(
+  "/terms-of-service",
+  "Terms of Service — cmux",
+  "Terms of service for the cmux website and macOS application",
+);
 
 export default function TermsOfServicePage() {
   return (

--- a/web/app/[locale]/components/content-locale-link.tsx
+++ b/web/app/[locale]/components/content-locale-link.tsx
@@ -1,0 +1,29 @@
+import type { ComponentProps } from "react";
+import NextLink from "next/link";
+import { Link } from "../../../i18n/navigation";
+import type { Locale } from "../../../i18n/routing";
+
+type ContentLocaleLinkProps = Omit<ComponentProps<typeof NextLink>, "locale"> & {
+  currentLocale: string;
+  contentLocales?: readonly Locale[];
+};
+
+export function ContentLocaleLink({
+  currentLocale,
+  contentLocales,
+  ...props
+}: ContentLocaleLinkProps) {
+  if (!contentLocales) {
+    return <Link {...props} />;
+  }
+
+  const requestedLocale = currentLocale as Locale;
+  const contentLocale = contentLocales.includes(requestedLocale)
+    ? requestedLocale
+    : contentLocales[0];
+
+  if (contentLocale === "en") {
+    return <NextLink {...props} />;
+  }
+  return <Link {...props} locale={contentLocale} />;
+}

--- a/web/app/[locale]/components/content-locale-link.tsx
+++ b/web/app/[locale]/components/content-locale-link.tsx
@@ -3,27 +3,50 @@ import NextLink from "next/link";
 import { Link } from "../../../i18n/navigation";
 import type { Locale } from "../../../i18n/routing";
 
-type ContentLocaleLinkProps = Omit<ComponentProps<typeof NextLink>, "locale"> & {
+type SharedLinkProps = Omit<
+  ComponentProps<typeof NextLink>,
+  "href" | "locale"
+> & {
   currentLocale: string;
-  contentLocales?: readonly Locale[];
 };
 
-export function ContentLocaleLink({
-  currentLocale,
-  contentLocales,
-  ...props
-}: ContentLocaleLinkProps) {
-  if (!contentLocales) {
-    return <Link {...props} />;
+type ContentLocaleLinkProps = SharedLinkProps &
+  (
+    | {
+        contentLocales: readonly Locale[];
+        href: string;
+      }
+    | {
+        contentLocales?: undefined;
+        href: ComponentProps<typeof NextLink>["href"];
+      }
+  );
+
+export function ContentLocaleLink(props: ContentLocaleLinkProps) {
+  if (!props.contentLocales) {
+    const {
+      currentLocale: omittedCurrentLocale,
+      contentLocales: omittedContentLocales,
+      ...linkProps
+    } = props;
+    void omittedCurrentLocale;
+    void omittedContentLocales;
+    return <Link {...linkProps} />;
   }
 
+  const { currentLocale, contentLocales, href, ...linkProps } = props;
   const requestedLocale = currentLocale as Locale;
   const contentLocale = contentLocales.includes(requestedLocale)
     ? requestedLocale
     : contentLocales[0];
+  const localizedHref = localizeContentHref(href, contentLocale);
 
-  if (contentLocale === "en") {
-    return <NextLink {...props} />;
+  return <NextLink {...linkProps} href={localizedHref} />;
+}
+
+function localizeContentHref(href: string, locale: Locale): string {
+  if (locale === "en" || !href.startsWith("/")) {
+    return href;
   }
-  return <Link {...props} locale={contentLocale} />;
+  return `/${locale}${href === "/" ? "" : href}`;
 }

--- a/web/app/[locale]/components/docs-nav-items.ts
+++ b/web/app/[locale]/components/docs-nav-items.ts
@@ -1,5 +1,6 @@
 import type { Locale } from "../../../i18n/routing";
 import {
+  fallbackContentLocales,
   featureWorkflowContentLocales,
   remoteTmuxDocsLocales,
 } from "../../../i18n/locale-availability";
@@ -8,6 +9,7 @@ export type NavLink = {
   titleKey: string;
   href: string;
   locales?: readonly Locale[];
+  contentLocales?: readonly Locale[];
 };
 export type NavSection = { sectionKey: string; children: NavLink[] };
 export type NavEntry = NavLink | NavSection;
@@ -42,6 +44,18 @@ export function navItemsForLocale(locale: string): NavEntry[] {
   return entries;
 }
 
+export function navItemContentLocale(item: NavLink, locale: string): Locale {
+  const requestedLocale = locale as Locale;
+  if (!item.contentLocales || item.contentLocales.includes(requestedLocale)) {
+    return requestedLocale;
+  }
+  return item.contentLocales[0];
+}
+
+export function hasNavItemContent(item: NavLink, locale: string): boolean {
+  return navItemContentLocale(item, locale) === locale;
+}
+
 export const navItems: NavEntry[] = [
   { titleKey: "gettingStarted", href: "/docs/getting-started" },
   { titleKey: "concepts", href: "/docs/concepts" },
@@ -68,7 +82,11 @@ export const navItems: NavEntry[] = [
       { titleKey: "claudeCodeTeams", href: "/docs/agent-integrations/claude-code-teams" },
       { titleKey: "ohMyOpenCode", href: "/docs/agent-integrations/oh-my-opencode" },
       { titleKey: "ohMyCodex", href: "/docs/agent-integrations/oh-my-codex" },
-      { titleKey: "ohMyPi", href: "/docs/agent-integrations/oh-my-pi" },
+      {
+        titleKey: "ohMyPi",
+        href: "/docs/agent-integrations/oh-my-pi",
+        contentLocales: fallbackContentLocales,
+      },
       { titleKey: "ohMyClaudeCode", href: "/docs/agent-integrations/oh-my-claudecode" },
     ],
   },

--- a/web/app/[locale]/components/docs-pager.tsx
+++ b/web/app/[locale]/components/docs-pager.tsx
@@ -2,7 +2,11 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { Link, usePathname } from "../../../i18n/navigation";
-import { navItemsForLocale, flatNavItems } from "./docs-nav-items";
+import {
+  navItemContentLocale,
+  navItemsForLocale,
+  flatNavItems,
+} from "./docs-nav-items";
 
 export function DocsPager() {
   const pathname = usePathname();
@@ -20,6 +24,7 @@ export function DocsPager() {
       {prev ? (
         <Link
           href={prev.href}
+          locale={navItemContentLocale(prev, locale)}
           className="flex items-center gap-1.5 text-muted hover:text-foreground transition-colors"
         >
           <span aria-hidden>&larr;</span>
@@ -31,6 +36,7 @@ export function DocsPager() {
       {next ? (
         <Link
           href={next.href}
+          locale={navItemContentLocale(next, locale)}
           className="flex items-center gap-1.5 text-muted hover:text-foreground transition-colors"
         >
           {t(next.titleKey)}

--- a/web/app/[locale]/components/docs-pager.tsx
+++ b/web/app/[locale]/components/docs-pager.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useLocale, useTranslations } from "next-intl";
-import { Link, usePathname } from "../../../i18n/navigation";
+import { usePathname } from "../../../i18n/navigation";
 import {
-  navItemContentLocale,
   navItemsForLocale,
   flatNavItems,
 } from "./docs-nav-items";
+import { ContentLocaleLink } from "./content-locale-link";
 
 export function DocsPager() {
   const pathname = usePathname();
@@ -22,26 +22,28 @@ export function DocsPager() {
   return (
     <nav className="flex items-center justify-between mt-12 pt-6 border-t border-border text-[14px]">
       {prev ? (
-        <Link
+        <ContentLocaleLink
           href={prev.href}
-          locale={navItemContentLocale(prev, locale)}
+          currentLocale={locale}
+          contentLocales={prev.contentLocales}
           className="flex items-center gap-1.5 text-muted hover:text-foreground transition-colors"
         >
           <span aria-hidden>&larr;</span>
           {t(prev.titleKey)}
-        </Link>
+        </ContentLocaleLink>
       ) : (
         <span />
       )}
       {next ? (
-        <Link
+        <ContentLocaleLink
           href={next.href}
-          locale={navItemContentLocale(next, locale)}
+          currentLocale={locale}
+          contentLocales={next.contentLocales}
           className="flex items-center gap-1.5 text-muted hover:text-foreground transition-colors"
         >
           {t(next.titleKey)}
           <span aria-hidden>&rarr;</span>
-        </Link>
+        </ContentLocaleLink>
       ) : (
         <span />
       )}

--- a/web/app/[locale]/components/docs-sidebar.tsx
+++ b/web/app/[locale]/components/docs-sidebar.tsx
@@ -1,14 +1,14 @@
 "use client";
 
 import { useLocale, useTranslations } from "next-intl";
-import { Link, usePathname } from "../../../i18n/navigation";
+import { usePathname } from "../../../i18n/navigation";
 import {
-  navItemContentLocale,
   navItemsForLocale,
   isSection,
   type NavLink,
 } from "./docs-nav-items";
 import { DocsSearch } from "./docs-search";
+import { ContentLocaleLink } from "./content-locale-link";
 
 function SidebarLink({
   item,
@@ -27,9 +27,10 @@ function SidebarLink({
 }) {
   const active = pathname === item.href;
   return (
-    <Link
+    <ContentLocaleLink
       href={item.href}
-      locale={navItemContentLocale(item, locale)}
+      currentLocale={locale}
+      contentLocales={item.contentLocales}
       onClick={onNavigate}
       className={`block py-1.5 text-[14px] rounded-md transition-colors ${
         indent ? "px-5" : "px-3"
@@ -40,7 +41,7 @@ function SidebarLink({
       }`}
     >
       {t(item.titleKey)}
-    </Link>
+    </ContentLocaleLink>
   );
 }
 

--- a/web/app/[locale]/components/docs-sidebar.tsx
+++ b/web/app/[locale]/components/docs-sidebar.tsx
@@ -2,17 +2,24 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { Link, usePathname } from "../../../i18n/navigation";
-import { navItemsForLocale, isSection, type NavLink } from "./docs-nav-items";
+import {
+  navItemContentLocale,
+  navItemsForLocale,
+  isSection,
+  type NavLink,
+} from "./docs-nav-items";
 import { DocsSearch } from "./docs-search";
 
 function SidebarLink({
   item,
+  locale,
   pathname,
   onNavigate,
   indent,
   t,
 }: {
   item: NavLink;
+  locale: string;
   pathname: string;
   onNavigate?: () => void;
   indent?: boolean;
@@ -22,6 +29,7 @@ function SidebarLink({
   return (
     <Link
       href={item.href}
+      locale={navItemContentLocale(item, locale)}
       onClick={onNavigate}
       className={`block py-1.5 text-[14px] rounded-md transition-colors ${
         indent ? "px-5" : "px-3"
@@ -57,6 +65,7 @@ export function DocsSidebar({ onNavigate }: { onNavigate?: () => void }) {
                   <SidebarLink
                     key={child.href}
                     item={child}
+                    locale={locale}
                     pathname={pathname}
                     onNavigate={onNavigate}
                     indent
@@ -70,6 +79,7 @@ export function DocsSidebar({ onNavigate }: { onNavigate?: () => void }) {
             <SidebarLink
               key={entry.href}
               item={entry}
+              locale={locale}
               pathname={pathname}
               onNavigate={onNavigate}
               t={t}

--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -2,14 +2,14 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { Link } from "../../../i18n/navigation";
-import { hasFallbackContent } from "../../../i18n/locale-availability";
+import { fallbackContentLocales } from "../../../i18n/locale-availability";
 import posthog from "posthog-js";
 import { ProUpgradeVisibility } from "./pro-upgrade-visibility";
+import { ContentLocaleLink } from "./content-locale-link";
 
 export function NavLinks() {
   const t = useTranslations("nav");
   const locale = useLocale();
-  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   return (
     <>
       <Link
@@ -37,16 +37,17 @@ export function NavLinks() {
         {t("community")}
       </Link>
       <ProUpgradeVisibility>
-        <Link
+        <ContentLocaleLink
           href="/pricing"
-          locale={pricingLocale}
+          currentLocale={locale}
+          contentLocales={fallbackContentLocales}
           onClick={() =>
             posthog.capture("cmuxterm_pricing_nav_clicked", { location: "nav" })
           }
           className="hover:text-foreground transition-colors"
         >
           {t("pricing")}
-        </Link>
+        </ContentLocaleLink>
       </ProUpgradeVisibility>
       <a
         href="https://github.com/manaflow-ai/cmux"

--- a/web/app/[locale]/components/nav-links.tsx
+++ b/web/app/[locale]/components/nav-links.tsx
@@ -1,12 +1,15 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Link } from "../../../i18n/navigation";
+import { hasFallbackContent } from "../../../i18n/locale-availability";
 import posthog from "posthog-js";
 import { ProUpgradeVisibility } from "./pro-upgrade-visibility";
 
 export function NavLinks() {
   const t = useTranslations("nav");
+  const locale = useLocale();
+  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   return (
     <>
       <Link
@@ -36,6 +39,7 @@ export function NavLinks() {
       <ProUpgradeVisibility>
         <Link
           href="/pricing"
+          locale={pricingLocale}
           onClick={() =>
             posthog.capture("cmuxterm_pricing_nav_clicked", { location: "nav" })
           }

--- a/web/app/[locale]/components/pro-welcome-banner.tsx
+++ b/web/app/[locale]/components/pro-welcome-banner.tsx
@@ -1,13 +1,17 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
+import { Link } from "../../../i18n/navigation";
+import { hasFallbackContent } from "../../../i18n/locale-availability";
 
 // Reads the ?welcome= / ?billing= states set by /api/billing/checkout so the
 // /pro page itself can stay static.
 // Render inside <Suspense> (useSearchParams requirement).
 export function ProWelcomeBanner() {
   const t = useTranslations("pricing");
+  const locale = useLocale();
+  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   const params = useSearchParams();
   const welcome = params.get("welcome");
   const billing = params.get("billing");
@@ -41,12 +45,13 @@ export function ProWelcomeBanner() {
       {welcome === "pending" && (
         <>
           {" "}
-          <a
+          <Link
             href="/pricing"
+            locale={pricingLocale}
             className="underline underline-offset-2 decoration-link-underline hover:decoration-foreground transition-colors"
           >
             {t("welcomePendingAction")}
-          </a>
+          </Link>
         </>
       )}
     </div>

--- a/web/app/[locale]/components/pro-welcome-banner.tsx
+++ b/web/app/[locale]/components/pro-welcome-banner.tsx
@@ -2,8 +2,8 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { useSearchParams } from "next/navigation";
-import { Link } from "../../../i18n/navigation";
-import { hasFallbackContent } from "../../../i18n/locale-availability";
+import { fallbackContentLocales } from "../../../i18n/locale-availability";
+import { ContentLocaleLink } from "./content-locale-link";
 
 // Reads the ?welcome= / ?billing= states set by /api/billing/checkout so the
 // /pro page itself can stay static.
@@ -11,7 +11,6 @@ import { hasFallbackContent } from "../../../i18n/locale-availability";
 export function ProWelcomeBanner() {
   const t = useTranslations("pricing");
   const locale = useLocale();
-  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   const params = useSearchParams();
   const welcome = params.get("welcome");
   const billing = params.get("billing");
@@ -45,13 +44,14 @@ export function ProWelcomeBanner() {
       {welcome === "pending" && (
         <>
           {" "}
-          <Link
+          <ContentLocaleLink
             href="/pricing"
-            locale={pricingLocale}
+            currentLocale={locale}
+            contentLocales={fallbackContentLocales}
             className="underline underline-offset-2 decoration-link-underline hover:decoration-foreground transition-colors"
           >
             {t("welcomePendingAction")}
-          </Link>
+          </ContentLocaleLink>
         </>
       )}
     </div>

--- a/web/app/[locale]/components/site-footer.tsx
+++ b/web/app/[locale]/components/site-footer.tsx
@@ -1,5 +1,7 @@
-import { getTranslations } from "next-intl/server";
+import { getLocale, getTranslations } from "next-intl/server";
 import { Link } from "../../../i18n/navigation";
+import { hasFallbackContent } from "../../../i18n/locale-availability";
+import type { Locale } from "../../../i18n/routing";
 import { LanguageSwitcher } from "./language-switcher";
 import { ProUpgradeVisibility } from "./pro-upgrade-visibility";
 
@@ -12,6 +14,7 @@ type FooterLink = {
   href: string;
   proUpgrade?: boolean;
   unlocalized?: boolean;
+  locale?: Locale;
 };
 
 type FooterColumn = {
@@ -21,13 +24,20 @@ type FooterColumn = {
 
 export async function SiteFooter() {
   const t = await getTranslations("footer");
+  const locale = await getLocale();
+  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   const year = new Date().getFullYear();
 
   const columns: FooterColumn[] = [
     {
       heading: t("product"),
       links: [
-        { label: t("pricing"), href: "/pricing", proUpgrade: true },
+        {
+          label: t("pricing"),
+          href: "/pricing",
+          proUpgrade: true,
+          locale: pricingLocale,
+        },
         { label: t("blog"), href: "/blog" },
         { label: t("community"), href: "/community" },
         { label: t("nightly"), href: "/nightly" },
@@ -91,6 +101,7 @@ export async function SiteFooter() {
                       ) : (
                         <Link
                           href={link.href}
+                          locale={link.locale}
                           className="text-sm text-muted hover:text-foreground transition-colors"
                         >
                           {link.label}

--- a/web/app/[locale]/components/site-footer.tsx
+++ b/web/app/[locale]/components/site-footer.tsx
@@ -1,9 +1,10 @@
 import { getLocale, getTranslations } from "next-intl/server";
 import { Link } from "../../../i18n/navigation";
-import { hasFallbackContent } from "../../../i18n/locale-availability";
+import { fallbackContentLocales } from "../../../i18n/locale-availability";
 import type { Locale } from "../../../i18n/routing";
 import { LanguageSwitcher } from "./language-switcher";
 import { ProUpgradeVisibility } from "./pro-upgrade-visibility";
+import { ContentLocaleLink } from "./content-locale-link";
 
 function isExternal(href: string) {
   return href.startsWith("http") || href.startsWith("mailto:");
@@ -14,7 +15,7 @@ type FooterLink = {
   href: string;
   proUpgrade?: boolean;
   unlocalized?: boolean;
-  locale?: Locale;
+  contentLocales?: readonly Locale[];
 };
 
 type FooterColumn = {
@@ -25,7 +26,6 @@ type FooterColumn = {
 export async function SiteFooter() {
   const t = await getTranslations("footer");
   const locale = await getLocale();
-  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   const year = new Date().getFullYear();
 
   const columns: FooterColumn[] = [
@@ -36,7 +36,7 @@ export async function SiteFooter() {
           label: t("pricing"),
           href: "/pricing",
           proUpgrade: true,
-          locale: pricingLocale,
+          contentLocales: fallbackContentLocales,
         },
         { label: t("blog"), href: "/blog" },
         { label: t("community"), href: "/community" },
@@ -98,10 +98,18 @@ export async function SiteFooter() {
                         >
                           {link.label}
                         </a>
+                      ) : link.contentLocales ? (
+                        <ContentLocaleLink
+                          href={link.href}
+                          currentLocale={locale}
+                          contentLocales={link.contentLocales}
+                          className="text-sm text-muted hover:text-foreground transition-colors"
+                        >
+                          {link.label}
+                        </ContentLocaleLink>
                       ) : (
                         <Link
                           href={link.href}
-                          locale={link.locale}
                           className="text-sm text-muted hover:text-foreground transition-colors"
                         >
                           {link.label}

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useTranslations } from "next-intl";
+import { useLocale, useTranslations } from "next-intl";
 import { Link } from "../../../i18n/navigation";
+import { hasFallbackContent } from "../../../i18n/locale-availability";
 import { NavLinks } from "./nav-links";
 import { DownloadButton } from "./download-button";
 import { ThemeToggle } from "../theme";
@@ -23,6 +24,8 @@ export function SiteHeader({
 }) {
   const t = useTranslations("nav");
   const tc = useTranslations("common");
+  const locale = useLocale();
+  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   const { open, toggle, close, drawerRef, buttonRef } = useMobileDrawer();
 
   return (
@@ -141,6 +144,7 @@ export function SiteHeader({
           <ProUpgradeVisibility>
             <Link
               href="/pricing"
+              locale={pricingLocale}
               onClick={close}
               className="hover:text-foreground transition-colors py-1"
             >

--- a/web/app/[locale]/components/site-header.tsx
+++ b/web/app/[locale]/components/site-header.tsx
@@ -2,7 +2,7 @@
 
 import { useLocale, useTranslations } from "next-intl";
 import { Link } from "../../../i18n/navigation";
-import { hasFallbackContent } from "../../../i18n/locale-availability";
+import { fallbackContentLocales } from "../../../i18n/locale-availability";
 import { NavLinks } from "./nav-links";
 import { DownloadButton } from "./download-button";
 import { ThemeToggle } from "../theme";
@@ -14,6 +14,7 @@ import {
 } from "./mobile-drawer";
 import { BrandLogoLink } from "./brand-logo-link";
 import { ProUpgradeVisibility } from "./pro-upgrade-visibility";
+import { ContentLocaleLink } from "./content-locale-link";
 
 export function SiteHeader({
   section,
@@ -25,7 +26,6 @@ export function SiteHeader({
   const t = useTranslations("nav");
   const tc = useTranslations("common");
   const locale = useLocale();
-  const pricingLocale = hasFallbackContent(locale) ? locale : "en";
   const { open, toggle, close, drawerRef, buttonRef } = useMobileDrawer();
 
   return (
@@ -142,14 +142,15 @@ export function SiteHeader({
             {t("community")}
           </Link>
           <ProUpgradeVisibility>
-            <Link
+            <ContentLocaleLink
               href="/pricing"
-              locale={pricingLocale}
+              currentLocale={locale}
+              contentLocales={fallbackContentLocales}
               onClick={close}
               className="hover:text-foreground transition-colors py-1"
             >
               {t("pricing")}
-            </Link>
+            </ContentLocaleLink>
           </ProUpgradeVisibility>
           <GitHubStarsBadge location="mobile_drawer" />
           <div className="pt-2">

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -65,7 +65,7 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "");
-  const title = seoTitle(locale, t("title"));
+  const title = seoTitle(locale, t("title"), { minLength: 0 });
   const description = seoDescription(locale, t("description"));
   const ogDescription = seoDescription(locale, t("ogDescription"));
   return {

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -66,8 +66,12 @@ export async function generateMetadata({
   const t = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "");
   const title = seoTitle(locale, t("title"), { minLength: 0 });
-  const description = seoDescription(locale, t("description"));
-  const ogDescription = seoDescription(locale, t("ogDescription"));
+  const description = seoDescription(locale, t("description"), {
+    minLength: 110,
+  });
+  const ogDescription = seoDescription(locale, t("ogDescription"), {
+    minLength: 110,
+  });
   return {
     title,
     description,
@@ -104,7 +108,9 @@ export default async function LocaleLayout({
 
   const messages = pruneClientMessages(await getMessages());
   const t = await getTranslations({ locale, namespace: "meta" });
-  const webSiteDescription = seoDescription(locale, t("description"));
+  const webSiteDescription = seoDescription(locale, t("description"), {
+    minLength: 110,
+  });
 
   const organizationJsonLd = {
     "@context": "https://schema.org",

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -11,10 +11,9 @@ import {
   buildAlternates,
   defaultOpenGraphImage,
   openGraphDefaults,
-  seoDescription,
-  seoTitle,
   twitterSummary,
 } from "../../i18n/seo";
+import { homeSeoCopy } from "../../i18n/audited-seo";
 import { Providers } from "./providers";
 import { DevPanel } from "./components/spacing-control";
 import { ThemeBootstrapScript } from "./theme-bootstrap-script";
@@ -65,23 +64,17 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "");
-  const title = seoTitle(locale, t("title"), { minLength: 0 });
-  const description = seoDescription(locale, t("description"), {
-    minLength: 110,
-  });
-  const ogDescription = seoDescription(locale, t("ogDescription"), {
-    minLength: 110,
-  });
+  const { title, description } = homeSeoCopy(locale, t);
   return {
     title,
     description,
     openGraph: {
       ...openGraphDefaults(locale, "website"),
       title,
-      description: ogDescription,
+      description,
       url: alternates.canonical,
     },
-    twitter: twitterSummary(locale, title, ogDescription),
+    twitter: twitterSummary(locale, title, description),
     alternates,
     metadataBase: new URL("https://cmux.com"),
   };
@@ -108,9 +101,7 @@ export default async function LocaleLayout({
 
   const messages = pruneClientMessages(await getMessages());
   const t = await getTranslations({ locale, namespace: "meta" });
-  const webSiteDescription = seoDescription(locale, t("description"), {
-    minLength: 110,
-  });
+  const { description: webSiteDescription } = homeSeoCopy(locale, t);
 
   const organizationJsonLd = {
     "@context": "https://schema.org",

--- a/web/app/[locale]/layout.tsx
+++ b/web/app/[locale]/layout.tsx
@@ -12,6 +12,7 @@ import {
   defaultOpenGraphImage,
   openGraphDefaults,
   seoDescription,
+  seoTitle,
   twitterSummary,
 } from "../../i18n/seo";
 import { Providers } from "./providers";
@@ -64,7 +65,7 @@ export async function generateMetadata({
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "meta" });
   const alternates = buildAlternates(locale, "");
-  const title = t("title");
+  const title = seoTitle(locale, t("title"));
   const description = seoDescription(locale, t("description"));
   const ogDescription = seoDescription(locale, t("ogDescription"));
   return {

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -48,23 +48,25 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "pricing" });
+  const contentLocale = locale === "ja" ? "ja" : "en";
   const description = seoDescription(
-    locale,
+    contentLocale,
     SHOW_VAULT ? t("metaDescription") : t("metaDescriptionNoVault"),
+    { minLength: 110 },
   );
   const alternates = buildAlternates(locale, "/pricing");
-  const title = seoTitle(locale, t("metaTitle"));
+  const title = seoTitle(contentLocale, t("metaTitle"));
   return {
     title,
     description,
     alternates,
     openGraph: {
-      ...openGraphDefaults(locale, "website"),
+      ...openGraphDefaults(contentLocale, "website"),
       title,
       description,
       url: alternates.canonical,
     },
-    twitter: twitterSummary(locale, title, description),
+    twitter: twitterSummary(contentLocale, title, description),
   };
 }
 

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -7,7 +7,13 @@ import { PRO_CHECKOUT_URL, TEAM_CHECKOUT_URL } from "../../lib/billing";
 import { DOWNLOAD_CONFIRMATION_HREF } from "../../lib/download";
 import { getStackServerApp, isStackConfigured } from "../../lib/stack";
 import { resolveProPlanStatus } from "../../../services/billing/pro";
-import { buildAlternates, seoDescription } from "../../../i18n/seo";
+import {
+  buildAlternates,
+  openGraphDefaults,
+  seoDescription,
+  seoTitle,
+  twitterSummary,
+} from "../../../i18n/seo";
 import {
   CurrentPlanBadge,
   DisabledButton,
@@ -46,10 +52,19 @@ export async function generateMetadata({
     locale,
     SHOW_VAULT ? t("metaDescription") : t("metaDescriptionNoVault"),
   );
+  const alternates = buildAlternates(locale, "/pricing");
+  const title = seoTitle(locale, t("metaTitle"));
   return {
-    title: t("metaTitle"),
+    title,
     description,
-    alternates: buildAlternates(locale, "/pricing"),
+    alternates,
+    openGraph: {
+      ...openGraphDefaults(locale, "website"),
+      title,
+      description,
+      url: alternates.canonical,
+    },
+    twitter: twitterSummary(locale, title, description),
   };
 }
 

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -10,10 +10,9 @@ import { resolveProPlanStatus } from "../../../services/billing/pro";
 import {
   buildAlternates,
   openGraphDefaults,
-  seoDescription,
-  seoTitle,
   twitterSummary,
 } from "../../../i18n/seo";
+import { pricingSeoCopy } from "../../../i18n/audited-seo";
 import {
   fallbackContentLocales,
   hasFallbackContent,
@@ -52,18 +51,19 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "pricing" });
+  const siteMeta = await getTranslations({ locale, namespace: "meta" });
   const contentLocale = hasFallbackContent(locale) ? locale : "en";
-  const description = seoDescription(
+  const { title, description } = pricingSeoCopy(
     contentLocale,
-    SHOW_VAULT ? t("metaDescription") : t("metaDescriptionNoVault"),
-    { minLength: 110 },
+    t,
+    siteMeta,
+    SHOW_VAULT ? "metaDescription" : "metaDescriptionNoVault",
   );
   const alternates = buildAlternates(
     contentLocale,
     "/pricing",
     fallbackContentLocales,
   );
-  const title = seoTitle(contentLocale, t("metaTitle"));
   return {
     title,
     description,

--- a/web/app/[locale]/pricing/page.tsx
+++ b/web/app/[locale]/pricing/page.tsx
@@ -15,6 +15,10 @@ import {
   twitterSummary,
 } from "../../../i18n/seo";
 import {
+  fallbackContentLocales,
+  hasFallbackContent,
+} from "../../../i18n/locale-availability";
+import {
   CurrentPlanBadge,
   DisabledButton,
   FeatureList,
@@ -48,13 +52,17 @@ export async function generateMetadata({
 }) {
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "pricing" });
-  const contentLocale = locale === "ja" ? "ja" : "en";
+  const contentLocale = hasFallbackContent(locale) ? locale : "en";
   const description = seoDescription(
     contentLocale,
     SHOW_VAULT ? t("metaDescription") : t("metaDescriptionNoVault"),
     { minLength: 110 },
   );
-  const alternates = buildAlternates(locale, "/pricing");
+  const alternates = buildAlternates(
+    contentLocale,
+    "/pricing",
+    fallbackContentLocales,
+  );
   const title = seoTitle(contentLocale, t("metaTitle"));
   return {
     title,

--- a/web/app/lib/agent-page-paths.ts
+++ b/web/app/lib/agent-page-paths.ts
@@ -2,6 +2,7 @@ import { locales } from "../../i18n/routing";
 import { comparePages, comparePath } from "./compare-pages";
 import type { ComparePageKey } from "./compare-pages";
 import {
+  fallbackContentLocales,
   featureWorkflowContentLocales,
   remoteTmuxDocsLocales,
 } from "../../i18n/locale-availability";
@@ -109,7 +110,7 @@ const agentReadableComparePages = comparePages.map((page) => ({
 export const agentReadablePages = [
   { path: "/", title: "Home" },
   { path: "/ios", title: "cmux iOS" },
-  { path: "/pricing", title: "Pricing" },
+  { path: "/pricing", title: "Pricing", locales: fallbackContentLocales },
   { path: "/enterprise", title: "Enterprise" },
   { path: "/blog", title: "Blog" },
   {
@@ -174,6 +175,7 @@ export const agentReadablePages = [
   {
     path: "/docs/agent-integrations/oh-my-pi",
     title: "oh-my-pi",
+    locales: fallbackContentLocales,
   },
   {
     path: "/docs/agent-integrations/oh-my-claudecode",

--- a/web/app/sitemap.ts
+++ b/web/app/sitemap.ts
@@ -1,5 +1,6 @@
 import type { MetadataRoute } from "next";
 import {
+  fallbackContentLocales,
   featureWorkflowContentLocales,
   remoteTmuxDocsLocales,
 } from "../i18n/locale-availability";
@@ -18,7 +19,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
   }> = [
     { path: "", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 1 },
     { path: "/ios", lastModified: "2026-06-22", changeFrequency: "monthly" as const, priority: 0.8 },
-    { path: "/pricing", lastModified: "2026-07-01", changeFrequency: "monthly" as const, priority: 0.9 },
+    { path: "/pricing", lastModified: "2026-07-01", changeFrequency: "monthly" as const, priority: 0.9, locales: fallbackContentLocales },
     { path: "/enterprise", lastModified: "2026-07-04", changeFrequency: "monthly" as const, priority: 0.8 },
     { path: "/blog", lastModified: "2026-07-04", changeFrequency: "weekly" as const, priority: 0.8 },
     { path: "/blog/claude-code-best-worktree-manager", lastModified: "2026-07-04", changeFrequency: "monthly" as const, priority: 0.7 },
@@ -61,7 +62,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: "/docs/agent-integrations/claude-code-teams", lastModified: "2026-03-30", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/docs/agent-integrations/oh-my-opencode", lastModified: "2026-03-30", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/docs/agent-integrations/oh-my-codex", lastModified: "2026-03-30", changeFrequency: "monthly" as const, priority: 0.7 },
-    { path: "/docs/agent-integrations/oh-my-pi", lastModified: "2026-07-07", changeFrequency: "monthly" as const, priority: 0.7 },
+    { path: "/docs/agent-integrations/oh-my-pi", lastModified: "2026-07-07", changeFrequency: "monthly" as const, priority: 0.7, locales: fallbackContentLocales },
     { path: "/docs/agent-integrations/oh-my-claudecode", lastModified: "2026-03-30", changeFrequency: "monthly" as const, priority: 0.7 },
     { path: "/docs/changelog", lastModified: "2026-03-18", changeFrequency: "weekly" as const, priority: 0.5 },
     { path: "/community", lastModified: "2026-03-18", changeFrequency: "monthly" as const, priority: 0.5 },

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -73,10 +73,12 @@ function selectDescription(
     locale,
     openGraphImageTagline(locale),
   );
-  const completeCandidates = (options.completeCandidates ?? []).map(
-    (candidate) => completeMetadataSentence(locale, candidate),
+  const completeCandidates = (options.completeCandidates ?? [])
+    .filter((candidate) => !/[:：]\s*$/u.test(candidate))
+    .map((candidate) => completeMetadataSentence(locale, candidate));
+  const contextFragments = (options.contextFragments ?? []).filter(
+    (candidate) => !/[:：]\s*$/u.test(candidate),
   );
-  const contextFragments = options.contextFragments ?? [];
   const contextualCandidates = [
     ...completeCandidates,
     ...completeCandidates.map((candidate) =>

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -2,6 +2,7 @@ import {
   openGraphImageAlt,
   openGraphImageTagline,
   detailedSeoDescriptionCandidate,
+  joinMetadataSentences,
   seoDescription,
   seoTitle,
   shortSeoDescriptionCandidate,
@@ -67,21 +68,14 @@ function selectDescription(
   const tagline = openGraphImageTagline(locale);
   const contextualCandidates = authoredCandidates.flatMap((candidate) => [
     candidate,
-    joinSentences(candidate, short),
-    joinSentences(candidate, detailed),
-    joinSentences(joinSentences(candidate, short), tagline),
+    joinMetadataSentences(candidate, short),
+    joinMetadataSentences(candidate, detailed),
+    joinMetadataSentences(joinMetadataSentences(candidate, short), tagline),
   ]);
   return seoDescription(locale, original, {
     minLength: 110,
     fallbackCandidates: contextualCandidates,
   });
-}
-
-function joinSentences(first: string, second: string) {
-  const leading = first.trim();
-  const trailing = second.trim();
-  const separator = /[.!?。！？؟។៕]$/u.test(leading) ? " " : ". ";
-  return `${leading}${separator}${trailing}`;
 }
 
 export function homeSeoCopy(locale: string, meta: SeoMessageLookup) {
@@ -106,7 +100,7 @@ export function assetsSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      joinSentences(t("title"), t("metaDescription")),
+      joinMetadataSentences(t("title"), t("metaDescription")),
       t("description"),
     ]),
   };
@@ -121,7 +115,7 @@ export function blogIndexSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      joinSentences(t("title"), t("metaDescription")),
+      joinMetadataSentences(t("title"), t("metaDescription")),
     ]),
   };
 }
@@ -138,7 +132,7 @@ export function communitySeoCopy(
     ]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      joinSentences(t("title"), t("metaDescription")),
+      joinMetadataSentences(t("title"), t("metaDescription")),
       t("description"),
     ]),
   };
@@ -154,7 +148,7 @@ export function bestTerminalSeoCopy(
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
       t("cmuxBuiltFor"),
-      joinSentences(t("title"), t("cmuxBuiltFor")),
+      joinMetadataSentences(t("title"), t("cmuxBuiltFor")),
     ]),
   };
 }
@@ -194,7 +188,7 @@ export function compareIndexSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      joinSentences(t("title"), openGraphImageAlt(locale)),
+      joinMetadataSentences(t("title"), openGraphImageAlt(locale)),
       t("intro"),
     ]),
   };
@@ -222,9 +216,9 @@ export function comparePageSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, titleCandidates),
     description: selectDescription(locale, t("metaDescription"), [
       ...descriptionCandidates,
-      joinSentences(t("faqQ1"), t("faqA1")),
-      joinSentences(t("faqQ2"), t("faqA2")),
-      joinSentences(t("faqQ3"), t("faqA3")),
+      joinMetadataSentences(t("faqQ1"), t("faqA1")),
+      joinMetadataSentences(t("faqQ2"), t("faqA2")),
+      joinMetadataSentences(t("faqQ3"), t("faqA3")),
     ]),
   };
 }

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -1,0 +1,255 @@
+import {
+  openGraphImageAlt,
+  openGraphImageTagline,
+  detailedSeoDescriptionCandidate,
+  seoDescription,
+  seoTitle,
+  shortSeoDescriptionCandidate,
+} from "./seo";
+
+export type SeoMessageLookup = (key: string) => string;
+
+const conciseTitleLocales = new Set(["ja", "zh-CN", "zh-TW", "ko"]);
+
+const shortTitleContexts: Record<string, string> = {
+  en: "AI coding on macOS",
+  ja: "macOS の AI コーディング",
+  "zh-CN": "macOS AI 编码",
+  "zh-TW": "macOS AI 編碼",
+  ko: "macOS AI 코딩",
+  de: "KI-Coding auf macOS",
+  es: "Código IA en macOS",
+  fr: "Codage IA sur macOS",
+  it: "Codifica IA su macOS",
+  da: "AI-kodning på macOS",
+  pl: "Kodowanie AI na macOS",
+  ru: "AI-кодинг на macOS",
+  bs: "AI kodiranje na macOS-u",
+  ar: "برمجة الذكاء الاصطناعي على macOS",
+  no: "AI-koding på macOS",
+  "pt-BR": "Código com IA no macOS",
+  th: "AI coding บน macOS",
+  tr: "macOS'ta AI kodlama",
+  km: "AI coding លើ macOS",
+  uk: "AI-кодування на macOS",
+};
+
+const compareIdentityTitles: Partial<Record<string, string>> = {
+  multipleClaudeAgents: "cmux · Claude Code",
+};
+
+function selectTitle(
+  locale: string,
+  original: string,
+  siteMeta: SeoMessageLookup,
+  authoredCandidates: readonly string[],
+) {
+  const tagline = openGraphImageTagline(locale);
+  const shortContext = shortTitleContexts[locale] ?? shortTitleContexts.en;
+  const contextualCandidates = authoredCandidates.flatMap((candidate) => [
+    candidate,
+    `${candidate} — cmux`,
+    `${candidate} — ${shortContext}`,
+    `${candidate} — ${tagline}`,
+    `${candidate} — ${siteMeta("title")}`,
+  ]);
+  return seoTitle(locale, original, {
+    minLength: conciseTitleLocales.has(locale) ? 0 : undefined,
+    fallbackCandidates: [
+      ...contextualCandidates,
+    ],
+  });
+}
+
+function selectDescription(
+  locale: string,
+  original: string,
+  authoredCandidates: readonly string[] = [],
+) {
+  const short = shortSeoDescriptionCandidate(locale);
+  const detailed = detailedSeoDescriptionCandidate(locale);
+  const contextualCandidates = authoredCandidates.flatMap((candidate) => [
+    candidate,
+    `${candidate}. ${short}`,
+    `${candidate}. ${detailed}`,
+  ]);
+  return seoDescription(locale, original, {
+    minLength: 110,
+    fallbackCandidates: contextualCandidates,
+  });
+}
+
+export function homeSeoCopy(locale: string, meta: SeoMessageLookup) {
+  const title = selectTitle(locale, meta("title"), meta, [
+    openGraphImageAlt(locale),
+    openGraphImageTagline(locale),
+  ]);
+  const description = selectDescription(locale, meta("description"), [
+    "cmux",
+    meta("ogDescription"),
+    openGraphImageAlt(locale),
+  ]);
+  return { title, description };
+}
+
+export function assetsSeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
+    description: selectDescription(locale, t("metaDescription"), [
+      t("title"),
+      `${t("title")}. ${t("metaDescription")}`,
+      t("description"),
+    ]),
+  };
+}
+
+export function blogIndexSeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
+    description: selectDescription(locale, t("metaDescription"), [
+      t("title"),
+      `${t("title")}. ${t("metaDescription")}`,
+    ]),
+  };
+}
+
+export function communitySeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, [
+      t("title"),
+      t("section"),
+    ]),
+    description: selectDescription(locale, t("metaDescription"), [
+      t("title"),
+      `${t("title")}. ${t("metaDescription")}`,
+      t("description"),
+    ]),
+  };
+}
+
+export function bestTerminalSeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
+    description: selectDescription(locale, t("metaDescription"), [
+      t("title"),
+      t("cmuxBuiltFor"),
+      `${t("title")}. ${t("cmuxBuiltFor")}`,
+    ]),
+  };
+}
+
+export function cmuxHistorySeoCopy(
+  locale: string,
+  metadata: SeoMessageLookup,
+  post: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  const metaTitle = metadata("metaTitle");
+  return {
+    title: selectTitle(locale, metaTitle, siteMeta, [
+      post("title"),
+      post("reopenTitle"),
+      post("agentTitle"),
+      post("focusTitle"),
+    ]),
+    description: selectDescription(locale, metadata("metaDescription"), [
+      post("summary"),
+      post("p1"),
+      post("agentP2"),
+      post("focusP"),
+      post("fullHistoryP"),
+      post("docsCta"),
+      `${metaTitle} — ${post("agentTitle")}`,
+    ]),
+  };
+}
+
+export function compareIndexSeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
+    description: selectDescription(locale, t("metaDescription"), [
+      t("title"),
+      `${t("title")}. ${openGraphImageAlt(locale)}`,
+      t("intro"),
+    ]),
+  };
+}
+
+export function comparePageSeoCopy(
+  locale: string,
+  pageKey: string,
+  t: SeoMessageLookup,
+  landingLinks: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  const titleCandidates = [t("title")];
+  if (pageKey === "bestTerminalForAgents") {
+    titleCandidates.push(landingLinks("bestTerminal"));
+  } else {
+    const identityTitle = compareIdentityTitles[pageKey];
+    if (identityTitle) titleCandidates.push(identityTitle);
+    titleCandidates.push(t("faqQ1"), t("faqQ2"), t("faqQ3"));
+  }
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, titleCandidates),
+    description: selectDescription(locale, t("metaDescription"), [
+      t("title"),
+      t("summaryBody"),
+      t("intro"),
+      t("faqA1"),
+      t("faqA2"),
+      t("faqA3"),
+      `${t("title")}. ${t("faqQ1")}`,
+      `${t("title")}. ${t("faqQ2")}`,
+      `${t("faqQ1")} ${t("faqQ2")}`,
+      `${t("title")}. ${t("faqA1")}`,
+      `${t("faqQ1")} ${t("faqA1")}`,
+    ]),
+  };
+}
+
+export function pricingSeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+  descriptionKey: "metaDescription" | "metaDescriptionNoVault",
+) {
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
+    description: selectDescription(locale, t(descriptionKey), [t("title")]),
+  };
+}
+
+export function ohMyPiSeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+  siteMeta: SeoMessageLookup,
+) {
+  return {
+    title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
+    description: selectDescription(locale, t("metaDescription"), [
+      t("title"),
+      t("intro"),
+    ]),
+  };
+}

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -1,4 +1,5 @@
 import {
+  completeMetadataSentence,
   openGraphImageAlt,
   openGraphImageTagline,
   detailedSeoDescriptionCandidate,
@@ -61,18 +62,44 @@ function selectTitle(
 function selectDescription(
   locale: string,
   original: string,
-  authoredCandidates: readonly string[] = [],
+  options: {
+    completeCandidates?: readonly string[];
+    contextFragments?: readonly string[];
+  } = {},
 ) {
   const short = shortSeoDescriptionCandidate(locale);
   const detailed = detailedSeoDescriptionCandidate(locale);
-  const tagline = openGraphImageTagline(locale);
-  const contextualCandidates = authoredCandidates.flatMap((candidate) => [
-    candidate,
-    joinMetadataSentences(candidate, short),
-    joinMetadataSentences(candidate, detailed),
-    joinMetadataSentences(joinMetadataSentences(candidate, short), tagline),
-  ]);
-  return seoDescription(locale, original, {
+  const tagline = completeMetadataSentence(
+    locale,
+    openGraphImageTagline(locale),
+  );
+  const completeCandidates = (options.completeCandidates ?? []).map(
+    (candidate) => completeMetadataSentence(locale, candidate),
+  );
+  const contextFragments = options.contextFragments ?? [];
+  const contextualCandidates = [
+    ...completeCandidates,
+    ...completeCandidates.map((candidate) =>
+      joinMetadataSentences(locale, candidate, short),
+    ),
+    ...completeCandidates.map((candidate) =>
+      joinMetadataSentences(locale, candidate, detailed),
+    ),
+    ...contextFragments.map((candidate) =>
+      joinMetadataSentences(locale, candidate, short),
+    ),
+    ...contextFragments.map((candidate) =>
+      joinMetadataSentences(locale, candidate, detailed),
+    ),
+    ...contextFragments.map((candidate) =>
+      joinMetadataSentences(
+        locale,
+        joinMetadataSentences(locale, candidate, short),
+        tagline,
+      ),
+    ),
+  ];
+  return seoDescription(locale, completeMetadataSentence(locale, original), {
     minLength: 110,
     fallbackCandidates: contextualCandidates,
   });
@@ -83,11 +110,14 @@ export function homeSeoCopy(locale: string, meta: SeoMessageLookup) {
     openGraphImageAlt(locale),
     openGraphImageTagline(locale),
   ]);
-  const description = selectDescription(locale, meta("description"), [
-    "cmux",
-    meta("ogDescription"),
-    openGraphImageAlt(locale),
-  ]);
+  const description = selectDescription(locale, meta("description"), {
+    completeCandidates: [meta("ogDescription")],
+    contextFragments: [
+      `cmux — ${shortTitleContexts[locale] ?? shortTitleContexts.en}`,
+      "cmux",
+      openGraphImageAlt(locale),
+    ],
+  });
   return { title, description };
 }
 
@@ -98,11 +128,10 @@ export function assetsSeoCopy(
 ) {
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
-    description: selectDescription(locale, t("metaDescription"), [
-      t("title"),
-      joinMetadataSentences(t("title"), t("metaDescription")),
-      t("description"),
-    ]),
+    description: selectDescription(locale, t("metaDescription"), {
+      completeCandidates: [t("description")],
+      contextFragments: [t("title")],
+    }),
   };
 }
 
@@ -113,10 +142,10 @@ export function blogIndexSeoCopy(
 ) {
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
-    description: selectDescription(locale, t("metaDescription"), [
-      t("title"),
-      joinMetadataSentences(t("title"), t("metaDescription")),
-    ]),
+    description: selectDescription(locale, t("metaDescription"), {
+      completeCandidates: [t("description")],
+      contextFragments: [t("title")],
+    }),
   };
 }
 
@@ -130,11 +159,14 @@ export function communitySeoCopy(
       t("title"),
       t("section"),
     ]),
-    description: selectDescription(locale, t("metaDescription"), [
-      t("title"),
-      joinMetadataSentences(t("title"), t("metaDescription")),
-      t("description"),
-    ]),
+    description: selectDescription(locale, t("metaDescription"), {
+      completeCandidates: [t("description")],
+      contextFragments: [
+        `${t("title")} — ${t("sourceAction")}`,
+        t("title"),
+        t("section"),
+      ],
+    }),
   };
 }
 
@@ -145,11 +177,10 @@ export function bestTerminalSeoCopy(
 ) {
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
-    description: selectDescription(locale, t("metaDescription"), [
-      t("title"),
-      t("cmuxBuiltFor"),
-      joinMetadataSentences(t("title"), t("cmuxBuiltFor")),
-    ]),
+    description: selectDescription(locale, t("metaDescription"), {
+      completeCandidates: [t("intro")],
+      contextFragments: [t("title"), t("cmuxBuiltFor")],
+    }),
   };
 }
 
@@ -167,15 +198,23 @@ export function cmuxHistorySeoCopy(
       post("agentTitle"),
       post("focusTitle"),
     ]),
-    description: selectDescription(locale, metadata("metaDescription"), [
-      post("summary"),
-      post("p1"),
-      post("agentP2"),
-      post("focusP"),
-      post("fullHistoryP"),
-      post("docsCta"),
-      `${metaTitle} — ${post("agentTitle")}`,
-    ]),
+    description: selectDescription(locale, metadata("metaDescription"), {
+      completeCandidates: [
+        post("summary"),
+        post("p1"),
+        post("agentP2"),
+        post("focusP"),
+        post("fullHistoryP"),
+        post("docsCta"),
+      ],
+      contextFragments: [
+        post("title"),
+        post("reopenTitle"),
+        post("agentTitle"),
+        post("focusTitle"),
+        `${metaTitle} — ${post("agentTitle")}`,
+      ],
+    }),
   };
 }
 
@@ -186,11 +225,10 @@ export function compareIndexSeoCopy(
 ) {
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
-    description: selectDescription(locale, t("metaDescription"), [
-      t("title"),
-      joinMetadataSentences(t("title"), openGraphImageAlt(locale)),
-      t("intro"),
-    ]),
+    description: selectDescription(locale, t("metaDescription"), {
+      completeCandidates: [t("intro")],
+      contextFragments: [t("title")],
+    }),
   };
 }
 
@@ -202,24 +240,29 @@ export function comparePageSeoCopy(
   siteMeta: SeoMessageLookup,
 ) {
   const titleCandidates = [t("title")];
-  const descriptionCandidates = [t("title"), t("summaryBody"), t("intro")];
+  const completeDescriptionCandidates = [t("summaryBody"), t("intro")];
+  const descriptionFragments = [t("title")];
   if (pageKey === "bestTerminalForAgents") {
     titleCandidates.push(landingLinks("bestTerminal"));
-    descriptionCandidates.push(landingLinks("agents"));
+    descriptionFragments.push(landingLinks("agents"));
   } else if (pageKey === "multipleClaudeAgents") {
     titleCandidates.push(landingLinks("claudeTeams"));
+    descriptionFragments.push(landingLinks("claudeTeams"));
     titleCandidates.push(t("faqQ1"), t("faqQ2"), t("faqQ3"));
   } else {
     titleCandidates.push(t("faqQ1"), t("faqQ2"), t("faqQ3"));
   }
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, titleCandidates),
-    description: selectDescription(locale, t("metaDescription"), [
-      ...descriptionCandidates,
-      joinMetadataSentences(t("faqQ1"), t("faqA1")),
-      joinMetadataSentences(t("faqQ2"), t("faqA2")),
-      joinMetadataSentences(t("faqQ3"), t("faqA3")),
-    ]),
+    description: selectDescription(locale, t("metaDescription"), {
+      completeCandidates: [
+        ...completeDescriptionCandidates,
+        joinMetadataSentences(locale, t("faqQ1"), t("faqA1")),
+        joinMetadataSentences(locale, t("faqQ2"), t("faqA2")),
+        joinMetadataSentences(locale, t("faqQ3"), t("faqA3")),
+      ],
+      contextFragments: descriptionFragments,
+    }),
   };
 }
 
@@ -231,7 +274,16 @@ export function pricingSeoCopy(
 ) {
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
-    description: selectDescription(locale, t(descriptionKey), [t("title")]),
+    description: selectDescription(locale, t(descriptionKey), {
+      completeCandidates: [
+        t(
+          descriptionKey === "metaDescription"
+            ? "metaDescriptionShort"
+            : "metaDescriptionNoVaultShort",
+        ),
+      ],
+      contextFragments: [t("title")],
+    }),
   };
 }
 
@@ -242,9 +294,9 @@ export function ohMyPiSeoCopy(
 ) {
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
-    description: selectDescription(locale, t("metaDescription"), [
-      t("title"),
-      t("intro"),
-    ]),
+    description: selectDescription(locale, t("metaDescription"), {
+      completeCandidates: [t("intro")],
+      contextFragments: [t("title")],
+    }),
   };
 }

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -58,13 +58,18 @@ function selectTitle(
 ) {
   const tagline = openGraphImageTagline(locale);
   const shortContext = shortTitleContexts[locale] ?? shortTitleContexts.en;
-  const contextualCandidates = authoredCandidates.flatMap((candidate) => [
-    candidate,
-    `${candidate} — cmux`,
-    `${candidate} — ${shortContext}`,
-    `${candidate} — ${tagline}`,
-    `${candidate} — ${siteMeta("title")}`,
-  ]);
+  const contextualCandidates = authoredCandidates.flatMap((candidate) => {
+    const brandCandidate = /cmux/iu.test(candidate)
+      ? []
+      : [`${candidate} — cmux`];
+    return [
+      candidate,
+      ...brandCandidate,
+      `${candidate} — ${shortContext}`,
+      `${candidate} — ${tagline}`,
+      `${candidate} — ${siteMeta("title")}`,
+    ];
+  });
   return seoTitle(locale, original, {
     minLength: conciseTitleLocales.has(locale) ? 0 : undefined,
     fallbackCandidates: [
@@ -212,10 +217,7 @@ export function cmuxHistorySeoCopy(
         ...(shortDescription ? [shortDescription] : []),
         post("summary"),
         post("p1"),
-        post("agentP2"),
-        post("focusP"),
         post("fullHistoryP"),
-        post("docsCta"),
       ],
       contextFragments: [
         post("title"),

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -34,10 +34,6 @@ const shortTitleContexts: Record<string, string> = {
   uk: "AI-кодування на macOS",
 };
 
-const compareIdentityTitles: Partial<Record<string, string>> = {
-  multipleClaudeAgents: "cmux · Claude Code",
-};
-
 function selectTitle(
   locale: string,
   original: string,
@@ -71,14 +67,21 @@ function selectDescription(
   const tagline = openGraphImageTagline(locale);
   const contextualCandidates = authoredCandidates.flatMap((candidate) => [
     candidate,
-    `${candidate}. ${short}`,
-    `${candidate}. ${detailed}`,
-    `${candidate}. ${short} ${tagline}`,
+    joinSentences(candidate, short),
+    joinSentences(candidate, detailed),
+    joinSentences(joinSentences(candidate, short), tagline),
   ]);
   return seoDescription(locale, original, {
     minLength: 110,
     fallbackCandidates: contextualCandidates,
   });
+}
+
+function joinSentences(first: string, second: string) {
+  const leading = first.trim();
+  const trailing = second.trim();
+  const separator = /[.!?。！？؟។៕]$/u.test(leading) ? " " : ". ";
+  return `${leading}${separator}${trailing}`;
 }
 
 export function homeSeoCopy(locale: string, meta: SeoMessageLookup) {
@@ -103,7 +106,7 @@ export function assetsSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      `${t("title")}. ${t("metaDescription")}`,
+      joinSentences(t("title"), t("metaDescription")),
       t("description"),
     ]),
   };
@@ -118,7 +121,7 @@ export function blogIndexSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      `${t("title")}. ${t("metaDescription")}`,
+      joinSentences(t("title"), t("metaDescription")),
     ]),
   };
 }
@@ -135,7 +138,7 @@ export function communitySeoCopy(
     ]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      `${t("title")}. ${t("metaDescription")}`,
+      joinSentences(t("title"), t("metaDescription")),
       t("description"),
     ]),
   };
@@ -151,7 +154,7 @@ export function bestTerminalSeoCopy(
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
       t("cmuxBuiltFor"),
-      `${t("title")}. ${t("cmuxBuiltFor")}`,
+      joinSentences(t("title"), t("cmuxBuiltFor")),
     ]),
   };
 }
@@ -191,7 +194,7 @@ export function compareIndexSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), [
       t("title"),
-      `${t("title")}. ${openGraphImageAlt(locale)}`,
+      joinSentences(t("title"), openGraphImageAlt(locale)),
       t("intro"),
     ]),
   };
@@ -205,27 +208,23 @@ export function comparePageSeoCopy(
   siteMeta: SeoMessageLookup,
 ) {
   const titleCandidates = [t("title")];
+  const descriptionCandidates = [t("title"), t("summaryBody"), t("intro")];
   if (pageKey === "bestTerminalForAgents") {
     titleCandidates.push(landingLinks("bestTerminal"));
+    descriptionCandidates.push(landingLinks("agents"));
+  } else if (pageKey === "multipleClaudeAgents") {
+    titleCandidates.push(landingLinks("claudeTeams"));
+    titleCandidates.push(t("faqQ1"), t("faqQ2"), t("faqQ3"));
   } else {
-    const identityTitle = compareIdentityTitles[pageKey];
-    if (identityTitle) titleCandidates.push(identityTitle);
     titleCandidates.push(t("faqQ1"), t("faqQ2"), t("faqQ3"));
   }
   return {
     title: selectTitle(locale, t("metaTitle"), siteMeta, titleCandidates),
     description: selectDescription(locale, t("metaDescription"), [
-      t("title"),
-      t("summaryBody"),
-      t("intro"),
-      t("faqA1"),
-      t("faqA2"),
-      t("faqA3"),
-      `${t("title")}. ${t("faqQ1")}`,
-      `${t("title")}. ${t("faqQ2")}`,
-      `${t("faqQ1")} ${t("faqQ2")}`,
-      `${t("title")}. ${t("faqA1")}`,
-      `${t("faqQ1")} ${t("faqA1")}`,
+      ...descriptionCandidates,
+      joinSentences(t("faqQ1"), t("faqA1")),
+      joinSentences(t("faqQ2"), t("faqA2")),
+      joinSentences(t("faqQ3"), t("faqA3")),
     ]),
   };
 }

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -70,10 +70,6 @@ function selectDescription(
 ) {
   const short = shortSeoDescriptionCandidate(locale);
   const detailed = detailedSeoDescriptionCandidate(locale);
-  const tagline = completeMetadataSentence(
-    locale,
-    openGraphImageTagline(locale),
-  );
   const completeCandidates = (options.completeCandidates ?? [])
     .filter((candidate) => !/[:：]\s*$/u.test(candidate))
     .map((candidate) => completeMetadataSentence(locale, candidate));
@@ -88,25 +84,11 @@ function selectDescription(
     ...completeCandidates.map((candidate) =>
       joinMetadataSentences(locale, candidate, detailed),
     ),
-    ...completeCandidates.map((candidate) =>
-      joinMetadataSentences(
-        locale,
-        joinMetadataSentences(locale, candidate, short),
-        tagline,
-      ),
-    ),
     ...contextFragments.map((candidate) =>
       joinMetadataSentences(locale, candidate, short),
     ),
     ...contextFragments.map((candidate) =>
       joinMetadataSentences(locale, candidate, detailed),
-    ),
-    ...contextFragments.map((candidate) =>
-      joinMetadataSentences(
-        locale,
-        joinMetadataSentences(locale, candidate, short),
-        tagline,
-      ),
     ),
   ];
   return seoDescription(locale, completeMetadataSentence(locale, original), {
@@ -140,7 +122,10 @@ export function assetsSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), {
       completeCandidates: [t("description")],
-      contextFragments: [t("title")],
+      contextFragments: [
+        `${t("title")} — ${t("iconSection")}`,
+        t("title"),
+      ],
     }),
   };
 }
@@ -237,7 +222,10 @@ export function compareIndexSeoCopy(
     title: selectTitle(locale, t("metaTitle"), siteMeta, [t("title")]),
     description: selectDescription(locale, t("metaDescription"), {
       completeCandidates: [t("intro")],
-      contextFragments: [t("title")],
+      contextFragments: [
+        `${t("title")} — ${shortTitleContexts[locale] ?? shortTitleContexts.en}`,
+        t("title"),
+      ],
     }),
   };
 }
@@ -270,6 +258,21 @@ export function comparePageSeoCopy(
         joinMetadataQuestionAndAnswer(locale, t("faqQ1"), t("faqA1")),
         joinMetadataQuestionAndAnswer(locale, t("faqQ2"), t("faqA2")),
         joinMetadataQuestionAndAnswer(locale, t("faqQ3"), t("faqA3")),
+        joinMetadataQuestionAndAnswer(
+          locale,
+          t("faqQ1"),
+          shortSeoDescriptionCandidate(locale),
+        ),
+        joinMetadataQuestionAndAnswer(
+          locale,
+          t("faqQ2"),
+          shortSeoDescriptionCandidate(locale),
+        ),
+        joinMetadataQuestionAndAnswer(
+          locale,
+          t("faqQ3"),
+          shortSeoDescriptionCandidate(locale),
+        ),
       ],
       contextFragments: descriptionFragments,
     }),

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -4,6 +4,7 @@ import {
   openGraphImageTagline,
   detailedSeoDescriptionCandidate,
   joinMetadataSentences,
+  joinMetadataQuestionAndAnswer,
   seoDescription,
   seoTitle,
   shortSeoDescriptionCandidate,
@@ -86,6 +87,13 @@ function selectDescription(
     ),
     ...completeCandidates.map((candidate) =>
       joinMetadataSentences(locale, candidate, detailed),
+    ),
+    ...completeCandidates.map((candidate) =>
+      joinMetadataSentences(
+        locale,
+        joinMetadataSentences(locale, candidate, short),
+        tagline,
+      ),
     ),
     ...contextFragments.map((candidate) =>
       joinMetadataSentences(locale, candidate, short),
@@ -259,9 +267,9 @@ export function comparePageSeoCopy(
     description: selectDescription(locale, t("metaDescription"), {
       completeCandidates: [
         ...completeDescriptionCandidates,
-        joinMetadataSentences(locale, t("faqQ1"), t("faqA1")),
-        joinMetadataSentences(locale, t("faqQ2"), t("faqA2")),
-        joinMetadataSentences(locale, t("faqQ3"), t("faqA3")),
+        joinMetadataQuestionAndAnswer(locale, t("faqQ1"), t("faqA1")),
+        joinMetadataQuestionAndAnswer(locale, t("faqQ2"), t("faqA2")),
+        joinMetadataQuestionAndAnswer(locale, t("faqQ3"), t("faqA3")),
       ],
       contextFragments: descriptionFragments,
     }),

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -68,10 +68,12 @@ function selectDescription(
 ) {
   const short = shortSeoDescriptionCandidate(locale);
   const detailed = detailedSeoDescriptionCandidate(locale);
+  const tagline = openGraphImageTagline(locale);
   const contextualCandidates = authoredCandidates.flatMap((candidate) => [
     candidate,
     `${candidate}. ${short}`,
     `${candidate}. ${detailed}`,
+    `${candidate}. ${short} ${tagline}`,
   ]);
   return seoDescription(locale, original, {
     minLength: 110,

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -37,6 +37,19 @@ const shortTitleContexts: Record<string, string> = {
   uk: "AI-кодування на macOS",
 };
 
+const historyShortDescriptions: Partial<Record<string, string>> = {
+  th: "cmux history ช่วยเปิดเทอร์มินัล เบราว์เซอร์ และเซสชัน AI ที่ปิดไป พร้อมเลื่อนโฟกัสบน macOS.",
+};
+
+const khmerComparePageFallbacks = new Set([
+  "cmuxVsDevin",
+  "cmuxVsIterm2",
+  "cmuxVsKitty",
+  "cmuxVsTmux",
+  "cmuxVsVscode",
+  "cmuxVsWezterm",
+]);
+
 function selectTitle(
   locale: string,
   original: string,
@@ -186,6 +199,7 @@ export function cmuxHistorySeoCopy(
   siteMeta: SeoMessageLookup,
 ) {
   const metaTitle = metadata("metaTitle");
+  const shortDescription = historyShortDescriptions[locale];
   return {
     title: selectTitle(locale, metaTitle, siteMeta, [
       post("title"),
@@ -195,6 +209,7 @@ export function cmuxHistorySeoCopy(
     ]),
     description: selectDescription(locale, metadata("metaDescription"), {
       completeCandidates: [
+        ...(shortDescription ? [shortDescription] : []),
         post("summary"),
         post("p1"),
         post("agentP2"),
@@ -239,6 +254,11 @@ export function comparePageSeoCopy(
 ) {
   const titleCandidates = [t("title")];
   const completeDescriptionCandidates = [t("summaryBody"), t("intro")];
+  if (locale === "km" && khmerComparePageFallbacks.has(pageKey)) {
+    completeDescriptionCandidates.push(
+      `${t("title")} ប្រៀបធៀបភ្នាក់ងារសរសេរកូដ AI ការជូនដំណឹង កន្លែងធ្វើការ និងស្វ័យប្រវត្តិកម្មលើ macOS។`,
+    );
+  }
   const descriptionFragments = [t("title")];
   if (pageKey === "bestTerminalForAgents") {
     titleCandidates.push(landingLinks("bestTerminal"));
@@ -258,21 +278,6 @@ export function comparePageSeoCopy(
         joinMetadataQuestionAndAnswer(locale, t("faqQ1"), t("faqA1")),
         joinMetadataQuestionAndAnswer(locale, t("faqQ2"), t("faqA2")),
         joinMetadataQuestionAndAnswer(locale, t("faqQ3"), t("faqA3")),
-        joinMetadataQuestionAndAnswer(
-          locale,
-          t("faqQ1"),
-          shortSeoDescriptionCandidate(locale),
-        ),
-        joinMetadataQuestionAndAnswer(
-          locale,
-          t("faqQ2"),
-          shortSeoDescriptionCandidate(locale),
-        ),
-        joinMetadataQuestionAndAnswer(
-          locale,
-          t("faqQ3"),
-          shortSeoDescriptionCandidate(locale),
-        ),
       ],
       contextFragments: descriptionFragments,
     }),

--- a/web/i18n/locale-availability.ts
+++ b/web/i18n/locale-availability.ts
@@ -15,6 +15,17 @@ export const remoteTmuxDocsLocales = [
   "ja",
 ] as const satisfies readonly Locale[];
 
+// These routes currently ship page copy and metadata only in English and Japanese.
+export const fallbackContentLocales = [
+  "en",
+  "ja",
+] as const satisfies readonly Locale[];
+
+export const fallbackContentPaths = [
+  "/pricing",
+  "/docs/agent-integrations/oh-my-pi",
+] as const;
+
 export function hasFeatureWorkflowContent(
   locale: string,
 ): locale is (typeof featureWorkflowContentLocales)[number] {
@@ -43,6 +54,34 @@ export function featureWorkflowDocRequestForPathname(
   ) {
     return {
       path: path as (typeof featureWorkflowDocPaths)[number],
+      locale,
+    };
+  }
+  return null;
+}
+
+export function hasFallbackContent(
+  locale: string,
+): locale is (typeof fallbackContentLocales)[number] {
+  return fallbackContentLocales.includes(
+    locale as (typeof fallbackContentLocales)[number],
+  );
+}
+
+export function fallbackContentRequestForPathname(
+  pathname: string,
+): {
+  path: (typeof fallbackContentPaths)[number];
+  locale: Locale | null;
+} | null {
+  const { locale, path } = unprefixLocale(pathname);
+  if (
+    fallbackContentPaths.includes(
+      path as (typeof fallbackContentPaths)[number],
+    )
+  ) {
+    return {
+      path: path as (typeof fallbackContentPaths)[number],
       locale,
     };
   }

--- a/web/i18n/locale-availability.ts
+++ b/web/i18n/locale-availability.ts
@@ -89,10 +89,19 @@ export function fallbackContentRequestForPathname(
 }
 
 function unprefixLocale(pathname: string): { locale: Locale | null; path: string } {
+  let decoded: string;
+  try {
+    decoded = decodeURI(pathname)
+      .replace(/\\/gu, "%5C")
+      .replace(/[\t\n\r]/gu, "")
+      .replace(/\/+/gu, "/");
+  } catch {
+    return { locale: null, path: pathname };
+  }
   const normalized =
-    pathname.length > 1 && pathname.endsWith("/")
-      ? pathname.slice(0, -1)
-      : pathname;
+    decoded.length > 1 && decoded.endsWith("/")
+      ? decoded.slice(0, -1)
+      : decoded;
   for (const locale of locales) {
     if (normalized === `/${locale}`) {
       return { locale, path: "/" };

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -26,6 +26,17 @@ const shortDescriptionSuffixes: Record<string, string> = {
   uk: "Створено для AI-агентів програмування на macOS.",
 };
 
+const conciseDescriptionSuffixes: Record<string, string> = {
+  ...shortDescriptionSuffixes,
+  en: "Built for AI coding agents on macOS.",
+  es: "Creado para agentes de codificación con IA en macOS.",
+  fr: "Conçu pour les agents de codage IA sur macOS.",
+  pl: "Stworzone dla agentów kodowania AI na macOS.",
+  bs: "Napravljeno za AI agente za kodiranje na macOS-u.",
+  th: "สร้างมาเพื่อเอเจนต์เขียนโค้ด AI บน macOS.",
+  km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដលើ macOS។",
+};
+
 const detailedDescriptionSuffixes: Record<string, string> = {
   en: "Built for AI coding agents on macOS, with vertical tabs, notifications, split panes, and browser automation.",
   ja: "macOS の AI コーディングエージェント向け。縦型タブ、通知、分割ペイン、ブラウザ自動化、セッション復元を備えています。",
@@ -215,7 +226,11 @@ export function seoDescription(
     const suffixes =
       minLength >= AUDIT_MIN_DESCRIPTION_LENGTH
         ? [detailedDescriptionSuffixes]
-        : [shortDescriptionSuffixes, detailedDescriptionSuffixes];
+        : [
+            shortDescriptionSuffixes,
+            conciseDescriptionSuffixes,
+            detailedDescriptionSuffixes,
+          ];
     for (const localizedSuffixes of suffixes) {
       const suffix = localizedSuffixes[locale] ?? localizedSuffixes.en;
       if (!trimmed.includes(suffix)) {

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -28,10 +28,10 @@ const shortDescriptionSuffixes: Record<string, string> = {
 
 const detailedDescriptionSuffixes: Record<string, string> = {
   en: "Built for AI coding agents on macOS, with vertical tabs, notifications, split panes, and browser automation.",
-  ja: "macOS の AI コーディングエージェント向け。縦型タブ、通知、分割ペイン、ブラウザ自動化を備えています。",
-  "zh-CN": "面向 macOS 上的 AI 编码代理，提供垂直标签页、通知、分屏窗格和浏览器自动化。",
-  "zh-TW": "面向 macOS 上的 AI 程式碼代理，提供垂直分頁、通知、分割窗格與瀏覽器自動化。",
-  ko: "macOS의 AI 코딩 에이전트를 위해 수직 탭, 알림, 분할 패널, 브라우저 자동화를 제공합니다.",
+  ja: "macOS の AI コーディングエージェント向け。縦型タブ、通知、分割ペイン、ブラウザ自動化、セッション復元を備えています。",
+  "zh-CN": "面向 macOS 上的 AI 编码代理，提供垂直标签页、通知、分屏窗格、浏览器自动化、多代理工作区、会话恢复和快捷命令。",
+  "zh-TW": "面向 macOS 上的 AI 程式碼代理，提供垂直分頁、通知、分割窗格、瀏覽器自動化、多代理工作區、工作階段復原與快捷指令。",
+  ko: "macOS의 AI 코딩 에이전트를 위해 수직 탭, 알림, 분할 패널, 브라우저 자동화와 세션 복원을 제공합니다.",
   de: "Für KI-Coding-Agenten auf macOS, mit vertikalen Tabs, Benachrichtigungen, geteilten Bereichen und Browser-Automatisierung.",
   es: "Creado para agentes de código con IA en macOS, con pestañas verticales, notificaciones, paneles divididos y automatización del navegador.",
   fr: "Conçu pour les agents de codage IA sur macOS, avec onglets verticaux, notifications, panneaux divisés et automatisation du navigateur.",
@@ -57,6 +57,8 @@ const MAX_TITLE_LENGTH = 60;
 const metadataSegmenter = new Intl.Segmenter("en", {
   granularity: "grapheme",
 });
+const wideMetadataGrapheme =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Khmer}\p{Extended_Pictographic}]/u;
 
 const openGraphImageAlts: Record<string, string> = {
   en: "cmux - The terminal built for multitasking",
@@ -143,7 +145,7 @@ export function seoDescription(
 ) {
   const minLength = options.minLength ?? DEFAULT_MIN_DESCRIPTION_LENGTH;
   const trimmed = description.trim();
-  if (metadataLength(trimmed) >= minLength) {
+  if (metadataSearchLength(trimmed) >= minLength) {
     return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH, minLength);
   }
 
@@ -218,7 +220,7 @@ function truncateMetadataText(
     .join("")
     .replace(/[-,:;–—]+$/u, "")
     .trimEnd();
-  if (metadataLength(truncated) + 1 < minLength) {
+  if (metadataSearchLength(truncated) + 1 < minLength) {
     truncated = candidate.join("").trimEnd();
   }
   return `${truncated}…`;
@@ -230,6 +232,14 @@ function metadataCharacters(value: string) {
 
 function metadataLength(value: string) {
   return metadataCharacters(value).length;
+}
+
+function metadataSearchLength(value: string) {
+  return metadataCharacters(value).reduce(
+    (length, grapheme) =>
+      length + (wideMetadataGrapheme.test(grapheme) ? 2 : 1),
+    0,
+  );
 }
 
 export function openGraphDefaults(

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -214,11 +214,13 @@ export function seoDescription(
   ) {
     const suffixes =
       minLength >= AUDIT_MIN_DESCRIPTION_LENGTH
-        ? detailedDescriptionSuffixes
-        : shortDescriptionSuffixes;
-    const suffix = suffixes[locale] ?? suffixes.en;
-    if (!trimmed.includes(suffix)) {
-      candidates.push(joinMetadataSentences(locale, trimmed, suffix));
+        ? [detailedDescriptionSuffixes]
+        : [shortDescriptionSuffixes, detailedDescriptionSuffixes];
+    for (const localizedSuffixes of suffixes) {
+      const suffix = localizedSuffixes[locale] ?? localizedSuffixes.en;
+      if (!trimmed.includes(suffix)) {
+        candidates.push(joinMetadataSentences(locale, trimmed, suffix));
+      }
     }
   }
 
@@ -272,6 +274,13 @@ function selectCompleteMetadataCandidate(
     const length = metadataSearchLength(candidate);
     return length >= minLength && length <= maxLength;
   });
+  const bestUnderMaximum = normalizedCandidates
+    .map((candidate) => ({
+      candidate,
+      length: metadataSearchLength(candidate),
+    }))
+    .filter(({ length }) => length <= maxLength)
+    .sort((left, right) => right.length - left.length)[0];
   const originalLength = metadataSearchLength(original);
   const originalIsSafe = isSafeMetadataText(original);
   if (
@@ -282,8 +291,16 @@ function selectCompleteMetadataCandidate(
     return original;
   }
   if (withinAllBounds) return withinAllBounds;
+  if (
+    originalIsSafe &&
+    originalLength < minLength &&
+    bestUnderMaximum &&
+    bestUnderMaximum.length > originalLength
+  ) {
+    return bestUnderMaximum.candidate;
+  }
   if (originalIsSafe) return original;
-  return normalizedCandidates[0] ?? "";
+  return bestUnderMaximum?.candidate ?? normalizedCandidates[0] ?? "";
 }
 
 function isSafeMetadataText(value: string) {

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -10,19 +10,19 @@ const shortDescriptionSuffixes: Record<string, string> = {
   "zh-TW": "面向 macOS 上的 AI 程式碼代理。",
   ko: "macOS의 AI 코딩 에이전트를 위해 설계되었습니다.",
   de: "Für KI-Coding-Agenten auf macOS entwickelt.",
-  es: "Creado para agentes de codificación con IA en macOS.",
-  fr: "Conçu pour les agents de codage IA sur macOS.",
+  es: "Creado para agentes de codificación con IA y flujos de trabajo paralelos y multitarea en macOS.",
+  fr: "Conçu pour les agents de codage IA et les workflows multitâches sur macOS.",
   it: "Creato per agenti di codifica IA su macOS.",
   da: "Bygget til AI-kodeagenter på macOS.",
-  pl: "Stworzone dla agentów kodowania AI na macOS.",
+  pl: "Stworzone dla agentów kodowania AI i wielozadaniowych przepływów pracy na macOS.",
   ru: "Создано для AI-агентов программирования на macOS.",
-  bs: "Napravljeno za AI agente za kodiranje na macOS-u.",
+  bs: "Napravljeno za AI agente za kodiranje i višezadaćne radne tokove na macOS-u.",
   ar: "مصمم لوكلاء البرمجة بالذكاء الاصطناعي على macOS.",
   no: "Laget for AI-kodeagenter på macOS.",
   "pt-BR": "Criado para agentes de código com IA no macOS.",
   th: "สร้างมาเพื่อเอเจนต์เขียนโค้ด AI และการทำงานหลายอย่างบน macOS.",
   tr: "macOS'taki AI kodlama ajanları için tasarlandı.",
-  km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដលើ macOS។",
+  km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដ និងលំហូរការងារពហុកិច្ចការលើ macOS។",
   uk: "Створено для AI-агентів програмування на macOS.",
 };
 
@@ -284,7 +284,11 @@ function selectCompleteMetadataCandidate(
 }
 
 function isSafeMetadataText(value: string) {
-  return !/<\/?[a-z][^>]*>/iu.test(value) && !/[{}]/u.test(value);
+  return (
+    !/<\/?[a-z][^>]*>/iu.test(value) &&
+    !/[{}]/u.test(value) &&
+    !/__CMUXPH/iu.test(value)
+  );
 }
 
 function metadataSearchLength(value: string) {

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -54,11 +54,10 @@ const AUDIT_MIN_DESCRIPTION_LENGTH = 110;
 const MAX_DESCRIPTION_LENGTH = 160;
 const MIN_TITLE_LENGTH = 30;
 const MAX_TITLE_LENGTH = 60;
-const metadataSegmenter = new Intl.Segmenter("en", {
-  granularity: "grapheme",
-});
-const wideMetadataGrapheme =
+const wideMetadataBaseCodePoint =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Khmer}\p{Extended_Pictographic}]/u;
+const zeroWidthMetadataCodePoint =
+  /[\p{Mark}\u200D\uFE0E\uFE0F\u{E0100}-\u{E01EF}\u{1F3FB}-\u{1F3FF}]/u;
 
 const openGraphImageAlts: Record<string, string> = {
   en: "cmux - The terminal built for multitasking",
@@ -229,19 +228,16 @@ function selectCompleteMetadataCandidate(
   return original;
 }
 
-function metadataCharacters(value: string) {
-  return Array.from(metadataSegmenter.segment(value), ({ segment }) => segment);
-}
-
 function metadataSearchLength(value: string) {
-  return metadataCharacters(value).reduce(
-    (length, grapheme) => length + metadataGraphemeWidth(grapheme),
+  return Array.from(value).reduce(
+    (length, codePoint) => length + metadataCodePointWidth(codePoint),
     0,
   );
 }
 
-function metadataGraphemeWidth(grapheme: string) {
-  return wideMetadataGrapheme.test(grapheme) ? 2 : 1;
+function metadataCodePointWidth(codePoint: string) {
+  if (zeroWidthMetadataCodePoint.test(codePoint)) return 0;
+  return wideMetadataBaseCodePoint.test(codePoint) ? 2 : 1;
 }
 
 export function openGraphDefaults(

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -176,7 +176,7 @@ export function seoTitle(
   const maxLength = options.maxLength ?? MAX_TITLE_LENGTH;
   let normalized = title.trim();
 
-  if (metadataLength(normalized) < minLength) {
+  if (metadataSearchLength(normalized) < minLength) {
     const context = openGraphImageTagline(locale);
     if (!normalized.includes(context)) {
       normalized = `${normalized} — ${context}`;
@@ -192,27 +192,38 @@ function truncateMetadataText(
   minLength = 0,
 ) {
   const characters = metadataCharacters(value);
-  if (characters.length <= maxLength) return value;
+  if (metadataSearchLength(value) <= maxLength) return value;
 
-  const candidate = characters.slice(0, maxLength - 1);
+  const candidate: string[] = [];
+  const candidateWidths: number[] = [];
+  let candidateWidth = 0;
+  for (const character of characters) {
+    const characterWidth = metadataGraphemeWidth(character);
+    if (candidateWidth + characterWidth > maxLength - 1) break;
+    candidate.push(character);
+    candidateWidth += characterWidth;
+    candidateWidths.push(candidateWidth);
+  }
   while (/\s/u.test(candidate.at(-1) ?? "")) candidate.pop();
 
-  const minimumBoundary = Math.max(
+  const minimumBoundaryWidth = Math.max(
     minLength,
     Math.floor(maxLength * 0.6),
   );
   const sentenceTerminators = new Set([".", "!", "?", "。", "！", "？"]);
   const sentenceBoundary = candidate.findLastIndex(
     (character, index) =>
-      index >= minimumBoundary && sentenceTerminators.has(character),
+      candidateWidths[index] >= minimumBoundaryWidth &&
+      sentenceTerminators.has(character),
   );
   const wordBoundary = candidate.findLastIndex(
-    (character, index) => index >= minimumBoundary && character === " ",
+    (character, index) =>
+      candidateWidths[index] >= minimumBoundaryWidth && character === " ",
   );
   const boundary =
-    sentenceBoundary >= minimumBoundary
+    sentenceBoundary >= 0
       ? sentenceBoundary + 1
-      : wordBoundary >= minimumBoundary
+      : wordBoundary >= 0
         ? wordBoundary
         : candidate.length;
   let truncated = candidate
@@ -230,16 +241,15 @@ function metadataCharacters(value: string) {
   return Array.from(metadataSegmenter.segment(value), ({ segment }) => segment);
 }
 
-function metadataLength(value: string) {
-  return metadataCharacters(value).length;
-}
-
 function metadataSearchLength(value: string) {
   return metadataCharacters(value).reduce(
-    (length, grapheme) =>
-      length + (wideMetadataGrapheme.test(grapheme) ? 2 : 1),
+    (length, grapheme) => length + metadataGraphemeWidth(grapheme),
     0,
   );
+}
+
+function metadataGraphemeWidth(grapheme: string) {
+  return wideMetadataGrapheme.test(grapheme) ? 2 : 1;
 }
 
 export function openGraphDefaults(

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -155,7 +155,7 @@ export function joinMetadataSentences(
   const compact = usesCompactSentenceSpacing(locale);
   const terminator = localizedSentenceTerminator(locale);
   const spacing = compact ? "" : " ";
-  const separator = /[.!?。！？؟។៕]$/u.test(leading)
+  const separator = /[.!?。！？؟។៕:：]$/u.test(leading)
     ? spacing
     : `${terminator}${spacing}`;
   return `${leading}${separator}${trailing}`;
@@ -163,7 +163,7 @@ export function joinMetadataSentences(
 
 export function completeMetadataSentence(locale: string, value: string) {
   const trimmed = value.trim();
-  return /[.!?。！？؟។៕]$/u.test(trimmed)
+  return /[.!?。！？؟។៕:：]$/u.test(trimmed)
     ? trimmed
     : `${trimmed}${localizedSentenceTerminator(locale)}`;
 }

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -4,7 +4,7 @@ const BASE = "https://cmux.com";
 const DEFAULT_OG_IMAGE_PATH = "/opengraph-image";
 
 const shortDescriptionSuffixes: Record<string, string> = {
-  en: "Built for AI coding agents on macOS.",
+  en: "Built for AI coding agents and multitasking on macOS.",
   ja: "macOS の AI コーディングエージェント向けです。",
   "zh-CN": "面向 macOS 上的 AI 编码代理。",
   "zh-TW": "面向 macOS 上的 AI 程式碼代理。",
@@ -208,7 +208,10 @@ export function seoDescription(
   const trimmed = description.trim();
   const candidates = [...(options.fallbackCandidates ?? [])];
 
-  if (metadataSearchLength(trimmed) < minLength) {
+  if (
+    isSafeMetadataText(trimmed) &&
+    metadataSearchLength(trimmed) < minLength
+  ) {
     const suffixes =
       minLength >= AUDIT_MIN_DESCRIPTION_LENGTH
         ? detailedDescriptionSuffixes
@@ -287,7 +290,8 @@ function isSafeMetadataText(value: string) {
   return (
     !/<\/?[a-z][^>]*>/iu.test(value) &&
     !/[{}]/u.test(value) &&
-    !/__CMUXPH/iu.test(value)
+    !/__CMUXPH/iu.test(value) &&
+    !/[:：]\s*$/u.test(value)
   );
 }
 

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -145,6 +145,13 @@ export function shortSeoDescriptionCandidate(locale: string) {
   return shortDescriptionSuffixes[locale] ?? shortDescriptionSuffixes.en;
 }
 
+export function joinMetadataSentences(first: string, second: string) {
+  const leading = first.trim();
+  const trailing = second.trim();
+  const separator = /[.!?。！？؟។៕]$/u.test(leading) ? " " : ". ";
+  return `${leading}${separator}${trailing}`;
+}
+
 export function seoDescription(
   locale: string,
   description: string,
@@ -164,9 +171,7 @@ export function seoDescription(
         : shortDescriptionSuffixes;
     const suffix = suffixes[locale] ?? suffixes.en;
     if (!trimmed.includes(suffix)) {
-      const separator =
-        /[。！？.!?]$/.test(trimmed) || trimmed.endsWith("؟") ? " " : ". ";
-      candidates.push(`${trimmed}${separator}${suffix}`);
+      candidates.push(joinMetadataSentences(trimmed, suffix));
     }
   }
 

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -168,6 +168,25 @@ export function completeMetadataSentence(locale: string, value: string) {
     : `${trimmed}${localizedSentenceTerminator(locale)}`;
 }
 
+export function joinMetadataQuestionAndAnswer(
+  locale: string,
+  question: string,
+  answer: string,
+) {
+  const trimmedQuestion = question.trim();
+  const questionTerminator =
+    locale === "ja" || locale === "zh-CN" || locale === "zh-TW"
+      ? "？"
+      : locale === "ar"
+        ? "؟"
+        : "?";
+  const completedQuestion = /[?？؟]$/u.test(trimmedQuestion)
+    ? trimmedQuestion
+    : `${trimmedQuestion.replace(/[.!。！។៕]+$/u, "")}${questionTerminator}`;
+  const spacing = usesCompactSentenceSpacing(locale) ? "" : " ";
+  return `${completedQuestion}${spacing}${completeMetadataSentence(locale, answer)}`;
+}
+
 function localizedSentenceTerminator(locale: string) {
   if (usesCompactSentenceSpacing(locale)) return "。";
   return locale === "km" ? "។" : ".";
@@ -245,21 +264,27 @@ function selectCompleteMetadataCandidate(
 ) {
   const normalizedCandidates = candidates
     .map((candidate) => candidate.trim())
-    .filter(
-      (candidate) =>
-        !/<\/?[a-z][^>]*>/iu.test(candidate) &&
-        !/\{[a-z][a-z0-9_]*\}/iu.test(candidate),
-    );
+    .filter(isSafeMetadataText);
   const withinAllBounds = normalizedCandidates.find((candidate) => {
     const length = metadataSearchLength(candidate);
     return length >= minLength && length <= maxLength;
   });
   const originalLength = metadataSearchLength(original);
-  if (originalLength >= minLength && originalLength <= maxLength) {
+  const originalIsSafe = isSafeMetadataText(original);
+  if (
+    originalIsSafe &&
+    originalLength >= minLength &&
+    originalLength <= maxLength
+  ) {
     return original;
   }
   if (withinAllBounds) return withinAllBounds;
-  return original;
+  if (originalIsSafe) return original;
+  return normalizedCandidates[0] ?? "";
+}
+
+function isSafeMetadataText(value: string) {
+  return !/<\/?[a-z][^>]*>/iu.test(value) && !/[{}]/u.test(value);
 }
 
 function metadataSearchLength(value: string) {

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -245,7 +245,11 @@ function selectCompleteMetadataCandidate(
 ) {
   const normalizedCandidates = candidates
     .map((candidate) => candidate.trim())
-    .filter((candidate) => !/<\/?[a-z][^>]*>/iu.test(candidate));
+    .filter(
+      (candidate) =>
+        !/<\/?[a-z][^>]*>/iu.test(candidate) &&
+        !/\{[a-z][a-z0-9_]*\}/iu.test(candidate),
+    );
   const withinAllBounds = normalizedCandidates.find((candidate) => {
     const length = metadataSearchLength(candidate);
     return length >= minLength && length <= maxLength;

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -138,157 +138,95 @@ export function hasLocalizedSeoCopy(locale: string) {
   );
 }
 
+export function detailedSeoDescriptionCandidate(locale: string) {
+  return detailedDescriptionSuffixes[locale] ?? detailedDescriptionSuffixes.en;
+}
+
+export function shortSeoDescriptionCandidate(locale: string) {
+  return shortDescriptionSuffixes[locale] ?? shortDescriptionSuffixes.en;
+}
+
 export function seoDescription(
   locale: string,
   description: string,
-  options: { minLength?: number } = {},
+  options: {
+    minLength?: number;
+    fallbackCandidates?: readonly string[];
+  } = {},
 ) {
   const minLength = options.minLength ?? DEFAULT_MIN_DESCRIPTION_LENGTH;
   const trimmed = description.trim();
-  if (metadataSearchLength(trimmed) >= minLength) {
-    return truncateMetadataText(
-      locale,
-      trimmed,
-      MAX_DESCRIPTION_LENGTH,
-      minLength,
-    );
+  const candidates = [...(options.fallbackCandidates ?? [])];
+
+  if (metadataSearchLength(trimmed) < minLength) {
+    const suffixes =
+      minLength >= AUDIT_MIN_DESCRIPTION_LENGTH
+        ? detailedDescriptionSuffixes
+        : shortDescriptionSuffixes;
+    const suffix = suffixes[locale] ?? suffixes.en;
+    if (!trimmed.includes(suffix)) {
+      const separator =
+        /[。！？.!?]$/.test(trimmed) || trimmed.endsWith("؟") ? " " : ". ";
+      candidates.push(`${trimmed}${separator}${suffix}`);
+    }
   }
 
-  const suffixes =
-    minLength >= AUDIT_MIN_DESCRIPTION_LENGTH
-      ? detailedDescriptionSuffixes
-      : shortDescriptionSuffixes;
-  const suffix = suffixes[locale] ?? suffixes.en;
-  if (trimmed.includes(suffix)) {
-    return truncateMetadataText(
-      locale,
-      trimmed,
-      MAX_DESCRIPTION_LENGTH,
-      minLength,
-    );
-  }
-
-  const separator =
-    /[。！？.!?]$/.test(trimmed) || trimmed.endsWith("؟") ? " " : ". ";
-  return truncateMetadataText(
-    locale,
-    `${trimmed}${separator}${suffix}`,
-    MAX_DESCRIPTION_LENGTH,
+  return selectCompleteMetadataCandidate(
+    trimmed,
+    candidates,
     minLength,
+    MAX_DESCRIPTION_LENGTH,
   );
 }
 
 export function seoTitle(
   locale: string,
   title: string,
-  options: { minLength?: number; maxLength?: number } = {},
+  options: {
+    minLength?: number;
+    maxLength?: number;
+    fallbackCandidates?: readonly string[];
+  } = {},
 ) {
   const minLength = options.minLength ?? MIN_TITLE_LENGTH;
   const maxLength = options.maxLength ?? MAX_TITLE_LENGTH;
-  let normalized = title.trim();
+  const normalized = title.trim();
+  const candidates = [...(options.fallbackCandidates ?? [])];
 
   if (metadataSearchLength(normalized) < minLength) {
     const context = openGraphImageTagline(locale);
     if (!normalized.includes(context)) {
-      normalized = `${normalized} — ${context}`;
+      candidates.push(`${normalized} — ${context}`);
     }
   }
 
-  return truncateMetadataText(locale, normalized, maxLength);
-}
-
-function truncateMetadataText(
-  locale: string,
-  value: string,
-  maxLength: number,
-  minLength = 0,
-) {
-  const characters = metadataCharacters(value);
-  if (metadataSearchLength(value) <= maxLength) return value;
-
-  const candidate: string[] = [];
-  let candidateWidth = 0;
-  for (const character of characters) {
-    const characterWidth = metadataGraphemeWidth(character);
-    if (candidateWidth + characterWidth > maxLength - 1) break;
-    candidate.push(character);
-    candidateWidth += characterWidth;
-  }
-  while (/\s/u.test(candidate.at(-1) ?? "")) candidate.pop();
-
-  const minimumBoundaryWidth = Math.max(
+  return selectCompleteMetadataCandidate(
+    normalized,
+    candidates,
     minLength,
-    Math.floor(maxLength * 0.6),
+    maxLength,
   );
-  const maximumBoundaryWidth = maxLength - 1;
-  const sentenceBoundary = lastSentenceBoundary(
-    value,
-    locale,
-    minimumBoundaryWidth,
-    maximumBoundaryWidth,
-  );
-  const wordBoundary = lastWordBoundary(
-    value,
-    locale,
-    minimumBoundaryWidth,
-    maximumBoundaryWidth,
-  );
-  const boundary =
-    sentenceBoundary >= 0
-      ? sentenceBoundary
-      : wordBoundary >= 0
-        ? wordBoundary
-        : -1;
-  let truncated = (boundary >= 0 ? value.slice(0, boundary) : candidate.join(""))
-    .replace(/[-,:;–—]+$/u, "")
-    .trimEnd();
-  if (metadataSearchLength(truncated) + 1 < minLength) {
-    truncated = candidate.join("").trimEnd();
-  }
-  return `${truncated}…`;
 }
 
-const terminalSentencePunctuation = /[.!?。！？؟][”’"')\]}»›]*$/u;
-
-function lastSentenceBoundary(
-  value: string,
-  locale: string,
-  minWidth: number,
-  maxWidth: number,
+function selectCompleteMetadataCandidate(
+  original: string,
+  candidates: readonly string[],
+  minLength: number,
+  maxLength: number,
 ) {
-  const segments = new Intl.Segmenter(locale, {
-    granularity: "sentence",
-  }).segment(value);
-  let boundary = -1;
-  for (const { index, segment } of segments) {
-    const sentence = segment.trimEnd();
-    if (!terminalSentencePunctuation.test(sentence)) continue;
-    const end = index + sentence.length;
-    const width = metadataSearchLength(value.slice(0, end));
-    if (width > maxWidth) break;
-    if (width >= minWidth) boundary = end;
+  const normalizedCandidates = candidates
+    .map((candidate) => candidate.trim())
+    .filter((candidate) => !/<\/?[a-z][^>]*>/iu.test(candidate));
+  const withinAllBounds = normalizedCandidates.find((candidate) => {
+    const length = metadataSearchLength(candidate);
+    return length >= minLength && length <= maxLength;
+  });
+  const originalLength = metadataSearchLength(original);
+  if (originalLength >= minLength && originalLength <= maxLength) {
+    return original;
   }
-  return boundary;
-}
-
-function lastWordBoundary(
-  value: string,
-  locale: string,
-  minWidth: number,
-  maxWidth: number,
-) {
-  const segments = new Intl.Segmenter(locale, {
-    granularity: "word",
-  }).segment(value);
-  let boundary = -1;
-  for (const { index, isWordLike, segment } of segments) {
-    if (!isWordLike && !wideMetadataGrapheme.test(segment)) continue;
-    const end = index + segment.length;
-    const width = metadataSearchLength(value.slice(0, end));
-    if (width > maxWidth) break;
-    if (width >= minWidth) boundary = end;
-  }
-  return boundary;
+  if (withinAllBounds) return withinAllBounds;
+  return original;
 }
 
 function metadataCharacters(value: string) {

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -20,7 +20,7 @@ const shortDescriptionSuffixes: Record<string, string> = {
   ar: "مصمم لوكلاء البرمجة بالذكاء الاصطناعي على macOS.",
   no: "Laget for AI-kodeagenter på macOS.",
   "pt-BR": "Criado para agentes de código com IA no macOS.",
-  th: "สร้างมาเพื่อเอเจนต์เขียนโค้ด AI บน macOS.",
+  th: "สร้างมาเพื่อเอเจนต์เขียนโค้ด AI และการทำงานหลายอย่างบน macOS.",
   tr: "macOS'taki AI kodlama ajanları için tasarlandı.",
   km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដលើ macOS។",
   uk: "Створено для AI-агентів програмування на macOS.",
@@ -43,7 +43,7 @@ const detailedDescriptionSuffixes: Record<string, string> = {
   ar: "مصمم لوكلاء البرمجة بالذكاء الاصطناعي على macOS، مع علامات تبويب عمودية وإشعارات وأجزاء مقسمة وأتمتة للمتصفح.",
   no: "Laget for AI-kodeagenter på macOS med vertikale faner, varsler, delte paneler og nettleserautomatisering.",
   "pt-BR": "Criado para agentes de código com IA no macOS, com abas verticais, notificações, painéis divididos e automação do navegador.",
-  th: "สร้างมาสำหรับเอเจนต์เขียนโค้ด AI บน macOS พร้อมแท็บแนวตั้ง การแจ้งเตือน แผงแยก และระบบเบราว์เซอร์อัตโนมัติ",
+  th: "สร้างมาสำหรับเอเจนต์เขียนโค้ด AI บน macOS พร้อมแท็บแนวตั้ง การแจ้งเตือน แผงแยก และระบบเบราว์เซอร์อัตโนมัติ.",
   tr: "macOS'taki AI kodlama ajanları için dikey sekmeler, bildirimler, bölünmüş paneller ve tarayıcı otomasyonuyla tasarlandı.",
   km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដលើ macOS ជាមួយផ្ទាំងបញ្ឈរ ការជូនដំណឹង ផ្ទាំងបំបែក និងស្វ័យប្រវត្តិកម្មកម្មវិធីរុករក។",
   uk: "Створено для AI-агентів програмування на macOS: вертикальні вкладки, сповіщення, розділені панелі й автоматизація браузера.",
@@ -145,11 +145,36 @@ export function shortSeoDescriptionCandidate(locale: string) {
   return shortDescriptionSuffixes[locale] ?? shortDescriptionSuffixes.en;
 }
 
-export function joinMetadataSentences(first: string, second: string) {
+export function joinMetadataSentences(
+  locale: string,
+  first: string,
+  second: string,
+) {
   const leading = first.trim();
   const trailing = second.trim();
-  const separator = /[.!?。！？؟។៕]$/u.test(leading) ? " " : ". ";
+  const compact = usesCompactSentenceSpacing(locale);
+  const terminator = localizedSentenceTerminator(locale);
+  const spacing = compact ? "" : " ";
+  const separator = /[.!?。！？؟។៕]$/u.test(leading)
+    ? spacing
+    : `${terminator}${spacing}`;
   return `${leading}${separator}${trailing}`;
+}
+
+export function completeMetadataSentence(locale: string, value: string) {
+  const trimmed = value.trim();
+  return /[.!?。！？؟។៕]$/u.test(trimmed)
+    ? trimmed
+    : `${trimmed}${localizedSentenceTerminator(locale)}`;
+}
+
+function localizedSentenceTerminator(locale: string) {
+  if (usesCompactSentenceSpacing(locale)) return "。";
+  return locale === "km" ? "។" : ".";
+}
+
+function usesCompactSentenceSpacing(locale: string) {
+  return locale === "ja" || locale === "zh-CN" || locale === "zh-TW";
 }
 
 export function seoDescription(
@@ -171,7 +196,7 @@ export function seoDescription(
         : shortDescriptionSuffixes;
     const suffix = suffixes[locale] ?? suffixes.en;
     if (!trimmed.includes(suffix)) {
-      candidates.push(joinMetadataSentences(trimmed, suffix));
+      candidates.push(joinMetadataSentences(locale, trimmed, suffix));
     }
   }
 

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -4,27 +4,32 @@ const BASE = "https://cmux.com";
 const DEFAULT_OG_IMAGE_PATH = "/opengraph-image";
 
 const shortDescriptionSuffixes: Record<string, string> = {
-  en: "Built for AI coding agents on macOS.",
-  ja: "macOS の AI コーディングエージェント向けです。",
-  "zh-CN": "面向 macOS 上的 AI 编码代理。",
-  "zh-TW": "面向 macOS 上的 AI 程式碼代理。",
-  ko: "macOS의 AI 코딩 에이전트를 위해 설계되었습니다.",
-  de: "Für KI-Coding-Agenten auf macOS entwickelt.",
-  es: "Creado para agentes de codificación con IA en macOS.",
-  fr: "Conçu pour les agents de codage IA sur macOS.",
-  it: "Creato per agenti di codifica IA su macOS.",
-  da: "Bygget til AI-kodeagenter på macOS.",
-  pl: "Stworzone dla agentów kodowania AI na macOS.",
-  ru: "Создано для AI-агентов программирования на macOS.",
-  bs: "Napravljeno za AI agente za kodiranje na macOS-u.",
-  ar: "مصمم لوكلاء البرمجة بالذكاء الاصطناعي على macOS.",
-  no: "Laget for AI-kodeagenter på macOS.",
-  "pt-BR": "Criado para agentes de código com IA no macOS.",
-  th: "สร้างมาเพื่อเอเจนต์เขียนโค้ด AI บน macOS.",
-  tr: "macOS'taki AI kodlama ajanları için tasarlandı.",
-  km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដលើ macOS។",
-  uk: "Створено для AI-агентів програмування на macOS.",
+  en: "Built for AI coding agents on macOS, with vertical tabs, notifications, split panes, and browser automation.",
+  ja: "macOS の AI コーディングエージェント向け。縦型タブ、通知、分割ペイン、ブラウザ自動化を備えています。",
+  "zh-CN": "面向 macOS 上的 AI 编码代理，提供垂直标签页、通知、分屏窗格和浏览器自动化。",
+  "zh-TW": "面向 macOS 上的 AI 程式碼代理，提供垂直分頁、通知、分割窗格與瀏覽器自動化。",
+  ko: "macOS의 AI 코딩 에이전트를 위해 수직 탭, 알림, 분할 패널, 브라우저 자동화를 제공합니다.",
+  de: "Für KI-Coding-Agenten auf macOS, mit vertikalen Tabs, Benachrichtigungen, geteilten Bereichen und Browser-Automatisierung.",
+  es: "Creado para agentes de código con IA en macOS, con pestañas verticales, notificaciones, paneles divididos y automatización del navegador.",
+  fr: "Conçu pour les agents de codage IA sur macOS, avec onglets verticaux, notifications, panneaux divisés et automatisation du navigateur.",
+  it: "Creato per agenti di codifica IA su macOS, con schede verticali, notifiche, pannelli divisi e automazione del browser.",
+  da: "Bygget til AI-kodeagenter på macOS med lodrette faner, notifikationer, opdelte ruder og browserautomatisering.",
+  pl: "Stworzone dla agentów kodowania AI na macOS, z pionowymi kartami, powiadomieniami, dzielonymi panelami i automatyzacją przeglądarki.",
+  ru: "Создано для AI-агентов программирования на macOS: вертикальные вкладки, уведомления, разделённые панели и автоматизация браузера.",
+  bs: "Napravljeno za AI agente za kodiranje na macOS-u, s vertikalnim tabovima, obavijestima, podijeljenim panelima i automatizacijom preglednika.",
+  ar: "مصمم لوكلاء البرمجة بالذكاء الاصطناعي على macOS، مع علامات تبويب عمودية وإشعارات وأجزاء مقسمة وأتمتة للمتصفح.",
+  no: "Laget for AI-kodeagenter på macOS med vertikale faner, varsler, delte paneler og nettleserautomatisering.",
+  "pt-BR": "Criado para agentes de código com IA no macOS, com abas verticais, notificações, painéis divididos e automação do navegador.",
+  th: "สร้างมาสำหรับเอเจนต์เขียนโค้ด AI บน macOS พร้อมแท็บแนวตั้ง การแจ้งเตือน แผงแยก และระบบเบราว์เซอร์อัตโนมัติ",
+  tr: "macOS'taki AI kodlama ajanları için dikey sekmeler, bildirimler, bölünmüş paneller ve tarayıcı otomasyonuyla tasarlandı.",
+  km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដលើ macOS ជាមួយផ្ទាំងបញ្ឈរ ការជូនដំណឹង ផ្ទាំងបំបែក និងស្វ័យប្រវត្តិកម្មកម្មវិធីរុករក។",
+  uk: "Створено для AI-агентів програмування на macOS: вертикальні вкладки, сповіщення, розділені панелі й автоматизація браузера.",
 };
+
+const MIN_DESCRIPTION_LENGTH = 110;
+const MAX_DESCRIPTION_LENGTH = 160;
+const MIN_TITLE_LENGTH = 30;
+const MAX_TITLE_LENGTH = 60;
 
 const openGraphImageAlts: Record<string, string> = {
   en: "cmux - The terminal built for multitasking",
@@ -105,15 +110,68 @@ export function hasLocalizedSeoCopy(locale: string) {
 
 export function seoDescription(locale: string, description: string) {
   const trimmed = description.trim();
-  if (trimmed.length >= 90) return trimmed;
+  if (trimmed.length >= MIN_DESCRIPTION_LENGTH) {
+    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH);
+  }
 
   const suffix =
     shortDescriptionSuffixes[locale] ?? shortDescriptionSuffixes.en;
-  if (trimmed.includes(suffix)) return trimmed;
+  if (trimmed.includes(suffix)) {
+    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH);
+  }
 
   const separator =
     /[。！？.!?]$/.test(trimmed) || trimmed.endsWith("؟") ? " " : ". ";
-  return `${trimmed}${separator}${suffix}`;
+  return truncateMetadataText(
+    `${trimmed}${separator}${suffix}`,
+    MAX_DESCRIPTION_LENGTH,
+  );
+}
+
+export function seoTitle(
+  locale: string,
+  title: string,
+  options: { minLength?: number; maxLength?: number } = {},
+) {
+  const minLength = options.minLength ?? MIN_TITLE_LENGTH;
+  const maxLength = options.maxLength ?? MAX_TITLE_LENGTH;
+  let normalized = title.trim();
+
+  if (normalized.length < minLength) {
+    const context = openGraphImageTagline(locale);
+    if (!normalized.includes(context)) {
+      normalized = `${normalized} — ${context}`;
+    }
+  }
+
+  return truncateMetadataText(normalized, maxLength);
+}
+
+function truncateMetadataText(value: string, maxLength: number) {
+  if (value.length <= maxLength) return value;
+
+  const candidate = value.slice(0, maxLength - 1).trimEnd();
+  const minimumBoundary = Math.floor(maxLength * 0.6);
+  const sentenceBoundary = Math.max(
+    candidate.lastIndexOf("."),
+    candidate.lastIndexOf("!"),
+    candidate.lastIndexOf("?"),
+    candidate.lastIndexOf("。"),
+    candidate.lastIndexOf("！"),
+    candidate.lastIndexOf("？"),
+  );
+  const wordBoundary = candidate.lastIndexOf(" ");
+  const boundary =
+    sentenceBoundary >= minimumBoundary
+      ? sentenceBoundary + 1
+      : wordBoundary >= minimumBoundary
+        ? wordBoundary
+        : candidate.length;
+  const truncated = candidate
+    .slice(0, boundary)
+    .replace(/[-,:;–—]+$/u, "")
+    .trimEnd();
+  return `${truncated}…`;
 }
 
 export function openGraphDefaults(

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -30,6 +30,9 @@ const MIN_DESCRIPTION_LENGTH = 110;
 const MAX_DESCRIPTION_LENGTH = 160;
 const MIN_TITLE_LENGTH = 30;
 const MAX_TITLE_LENGTH = 60;
+const metadataSegmenter = new Intl.Segmenter("en", {
+  granularity: "grapheme",
+});
 
 const openGraphImageAlts: Record<string, string> = {
   en: "cmux - The terminal built for multitasking",
@@ -110,7 +113,7 @@ export function hasLocalizedSeoCopy(locale: string) {
 
 export function seoDescription(locale: string, description: string) {
   const trimmed = description.trim();
-  if (trimmed.length >= MIN_DESCRIPTION_LENGTH) {
+  if (metadataLength(trimmed) >= MIN_DESCRIPTION_LENGTH) {
     return truncateMetadataText(
       trimmed,
       MAX_DESCRIPTION_LENGTH,
@@ -146,7 +149,7 @@ export function seoTitle(
   const maxLength = options.maxLength ?? MAX_TITLE_LENGTH;
   let normalized = title.trim();
 
-  if (normalized.length < minLength) {
+  if (metadataLength(normalized) < minLength) {
     const context = openGraphImageTagline(locale);
     if (!normalized.includes(context)) {
       normalized = `${normalized} — ${context}`;
@@ -161,7 +164,7 @@ function truncateMetadataText(
   maxLength: number,
   minLength = 0,
 ) {
-  const characters = Array.from(value);
+  const characters = metadataCharacters(value);
   if (characters.length <= maxLength) return value;
 
   const candidate = characters.slice(0, maxLength - 1);
@@ -190,10 +193,18 @@ function truncateMetadataText(
     .join("")
     .replace(/[-,:;–—]+$/u, "")
     .trimEnd();
-  if (Array.from(truncated).length + 1 < minLength) {
+  if (metadataLength(truncated) + 1 < minLength) {
     truncated = candidate.join("").trimEnd();
   }
   return `${truncated}…`;
+}
+
+function metadataCharacters(value: string) {
+  return Array.from(metadataSegmenter.segment(value), ({ segment }) => segment);
+}
+
+function metadataLength(value: string) {
+  return metadataCharacters(value).length;
 }
 
 export function openGraphDefaults(

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -146,7 +146,12 @@ export function seoDescription(
   const minLength = options.minLength ?? DEFAULT_MIN_DESCRIPTION_LENGTH;
   const trimmed = description.trim();
   if (metadataSearchLength(trimmed) >= minLength) {
-    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH, minLength);
+    return truncateMetadataText(
+      locale,
+      trimmed,
+      MAX_DESCRIPTION_LENGTH,
+      minLength,
+    );
   }
 
   const suffixes =
@@ -155,12 +160,18 @@ export function seoDescription(
       : shortDescriptionSuffixes;
   const suffix = suffixes[locale] ?? suffixes.en;
   if (trimmed.includes(suffix)) {
-    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH, minLength);
+    return truncateMetadataText(
+      locale,
+      trimmed,
+      MAX_DESCRIPTION_LENGTH,
+      minLength,
+    );
   }
 
   const separator =
     /[。！？.!?]$/.test(trimmed) || trimmed.endsWith("؟") ? " " : ". ";
   return truncateMetadataText(
+    locale,
     `${trimmed}${separator}${suffix}`,
     MAX_DESCRIPTION_LENGTH,
     minLength,
@@ -183,10 +194,11 @@ export function seoTitle(
     }
   }
 
-  return truncateMetadataText(normalized, maxLength);
+  return truncateMetadataText(locale, normalized, maxLength);
 }
 
 function truncateMetadataText(
+  locale: string,
   value: string,
   maxLength: number,
   minLength = 0,
@@ -195,14 +207,12 @@ function truncateMetadataText(
   if (metadataSearchLength(value) <= maxLength) return value;
 
   const candidate: string[] = [];
-  const candidateWidths: number[] = [];
   let candidateWidth = 0;
   for (const character of characters) {
     const characterWidth = metadataGraphemeWidth(character);
     if (candidateWidth + characterWidth > maxLength - 1) break;
     candidate.push(character);
     candidateWidth += characterWidth;
-    candidateWidths.push(candidateWidth);
   }
   while (/\s/u.test(candidate.at(-1) ?? "")) candidate.pop();
 
@@ -210,31 +220,75 @@ function truncateMetadataText(
     minLength,
     Math.floor(maxLength * 0.6),
   );
-  const sentenceTerminators = new Set([".", "!", "?", "。", "！", "？"]);
-  const sentenceBoundary = candidate.findLastIndex(
-    (character, index) =>
-      candidateWidths[index] >= minimumBoundaryWidth &&
-      sentenceTerminators.has(character),
+  const maximumBoundaryWidth = maxLength - 1;
+  const sentenceBoundary = lastSentenceBoundary(
+    value,
+    locale,
+    minimumBoundaryWidth,
+    maximumBoundaryWidth,
   );
-  const wordBoundary = candidate.findLastIndex(
-    (character, index) =>
-      candidateWidths[index] >= minimumBoundaryWidth && character === " ",
+  const wordBoundary = lastWordBoundary(
+    value,
+    locale,
+    minimumBoundaryWidth,
+    maximumBoundaryWidth,
   );
   const boundary =
     sentenceBoundary >= 0
-      ? sentenceBoundary + 1
+      ? sentenceBoundary
       : wordBoundary >= 0
         ? wordBoundary
-        : candidate.length;
-  let truncated = candidate
-    .slice(0, boundary)
-    .join("")
+        : -1;
+  let truncated = (boundary >= 0 ? value.slice(0, boundary) : candidate.join(""))
     .replace(/[-,:;–—]+$/u, "")
     .trimEnd();
   if (metadataSearchLength(truncated) + 1 < minLength) {
     truncated = candidate.join("").trimEnd();
   }
   return `${truncated}…`;
+}
+
+const terminalSentencePunctuation = /[.!?。！？؟][”’"')\]}»›]*$/u;
+
+function lastSentenceBoundary(
+  value: string,
+  locale: string,
+  minWidth: number,
+  maxWidth: number,
+) {
+  const segments = new Intl.Segmenter(locale, {
+    granularity: "sentence",
+  }).segment(value);
+  let boundary = -1;
+  for (const { index, segment } of segments) {
+    const sentence = segment.trimEnd();
+    if (!terminalSentencePunctuation.test(sentence)) continue;
+    const end = index + sentence.length;
+    const width = metadataSearchLength(value.slice(0, end));
+    if (width > maxWidth) break;
+    if (width >= minWidth) boundary = end;
+  }
+  return boundary;
+}
+
+function lastWordBoundary(
+  value: string,
+  locale: string,
+  minWidth: number,
+  maxWidth: number,
+) {
+  const segments = new Intl.Segmenter(locale, {
+    granularity: "word",
+  }).segment(value);
+  let boundary = -1;
+  for (const { index, isWordLike, segment } of segments) {
+    if (!isWordLike && !wideMetadataGrapheme.test(segment)) continue;
+    const end = index + segment.length;
+    const width = metadataSearchLength(value.slice(0, end));
+    if (width > maxWidth) break;
+    if (width >= minWidth) boundary = end;
+  }
+  return boundary;
 }
 
 function metadataCharacters(value: string) {

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -4,6 +4,29 @@ const BASE = "https://cmux.com";
 const DEFAULT_OG_IMAGE_PATH = "/opengraph-image";
 
 const shortDescriptionSuffixes: Record<string, string> = {
+  en: "Built for AI coding agents on macOS.",
+  ja: "macOS の AI コーディングエージェント向けです。",
+  "zh-CN": "面向 macOS 上的 AI 编码代理。",
+  "zh-TW": "面向 macOS 上的 AI 程式碼代理。",
+  ko: "macOS의 AI 코딩 에이전트를 위해 설계되었습니다.",
+  de: "Für KI-Coding-Agenten auf macOS entwickelt.",
+  es: "Creado para agentes de codificación con IA en macOS.",
+  fr: "Conçu pour les agents de codage IA sur macOS.",
+  it: "Creato per agenti di codifica IA su macOS.",
+  da: "Bygget til AI-kodeagenter på macOS.",
+  pl: "Stworzone dla agentów kodowania AI na macOS.",
+  ru: "Создано для AI-агентов программирования на macOS.",
+  bs: "Napravljeno za AI agente za kodiranje na macOS-u.",
+  ar: "مصمم لوكلاء البرمجة بالذكاء الاصطناعي على macOS.",
+  no: "Laget for AI-kodeagenter på macOS.",
+  "pt-BR": "Criado para agentes de código com IA no macOS.",
+  th: "สร้างมาเพื่อเอเจนต์เขียนโค้ด AI บน macOS.",
+  tr: "macOS'taki AI kodlama ajanları için tasarlandı.",
+  km: "បង្កើតសម្រាប់ភ្នាក់ងារ AI សរសេរកូដលើ macOS។",
+  uk: "Створено для AI-агентів програмування на macOS.",
+};
+
+const detailedDescriptionSuffixes: Record<string, string> = {
   en: "Built for AI coding agents on macOS, with vertical tabs, notifications, split panes, and browser automation.",
   ja: "macOS の AI コーディングエージェント向け。縦型タブ、通知、分割ペイン、ブラウザ自動化を備えています。",
   "zh-CN": "面向 macOS 上的 AI 编码代理，提供垂直标签页、通知、分屏窗格和浏览器自动化。",
@@ -26,7 +49,8 @@ const shortDescriptionSuffixes: Record<string, string> = {
   uk: "Створено для AI-агентів програмування на macOS: вертикальні вкладки, сповіщення, розділені панелі й автоматизація браузера.",
 };
 
-const MIN_DESCRIPTION_LENGTH = 110;
+const DEFAULT_MIN_DESCRIPTION_LENGTH = 90;
+const AUDIT_MIN_DESCRIPTION_LENGTH = 110;
 const MAX_DESCRIPTION_LENGTH = 160;
 const MIN_TITLE_LENGTH = 30;
 const MAX_TITLE_LENGTH = 60;
@@ -106,29 +130,30 @@ export const defaultOpenGraphImage = openGraphImage("en");
 export function hasLocalizedSeoCopy(locale: string) {
   return (
     Object.hasOwn(shortDescriptionSuffixes, locale) &&
+    Object.hasOwn(detailedDescriptionSuffixes, locale) &&
     Object.hasOwn(openGraphImageAlts, locale) &&
     Object.hasOwn(openGraphImageTaglines, locale)
   );
 }
 
-export function seoDescription(locale: string, description: string) {
+export function seoDescription(
+  locale: string,
+  description: string,
+  options: { minLength?: number } = {},
+) {
+  const minLength = options.minLength ?? DEFAULT_MIN_DESCRIPTION_LENGTH;
   const trimmed = description.trim();
-  if (metadataLength(trimmed) >= MIN_DESCRIPTION_LENGTH) {
-    return truncateMetadataText(
-      trimmed,
-      MAX_DESCRIPTION_LENGTH,
-      MIN_DESCRIPTION_LENGTH,
-    );
+  if (metadataLength(trimmed) >= minLength) {
+    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH, minLength);
   }
 
-  const suffix =
-    shortDescriptionSuffixes[locale] ?? shortDescriptionSuffixes.en;
+  const suffixes =
+    minLength >= AUDIT_MIN_DESCRIPTION_LENGTH
+      ? detailedDescriptionSuffixes
+      : shortDescriptionSuffixes;
+  const suffix = suffixes[locale] ?? suffixes.en;
   if (trimmed.includes(suffix)) {
-    return truncateMetadataText(
-      trimmed,
-      MAX_DESCRIPTION_LENGTH,
-      MIN_DESCRIPTION_LENGTH,
-    );
+    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH, minLength);
   }
 
   const separator =
@@ -136,7 +161,7 @@ export function seoDescription(locale: string, description: string) {
   return truncateMetadataText(
     `${trimmed}${separator}${suffix}`,
     MAX_DESCRIPTION_LENGTH,
-    MIN_DESCRIPTION_LENGTH,
+    minLength,
   );
 }
 

--- a/web/i18n/seo.ts
+++ b/web/i18n/seo.ts
@@ -111,13 +111,21 @@ export function hasLocalizedSeoCopy(locale: string) {
 export function seoDescription(locale: string, description: string) {
   const trimmed = description.trim();
   if (trimmed.length >= MIN_DESCRIPTION_LENGTH) {
-    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH);
+    return truncateMetadataText(
+      trimmed,
+      MAX_DESCRIPTION_LENGTH,
+      MIN_DESCRIPTION_LENGTH,
+    );
   }
 
   const suffix =
     shortDescriptionSuffixes[locale] ?? shortDescriptionSuffixes.en;
   if (trimmed.includes(suffix)) {
-    return truncateMetadataText(trimmed, MAX_DESCRIPTION_LENGTH);
+    return truncateMetadataText(
+      trimmed,
+      MAX_DESCRIPTION_LENGTH,
+      MIN_DESCRIPTION_LENGTH,
+    );
   }
 
   const separator =
@@ -125,6 +133,7 @@ export function seoDescription(locale: string, description: string) {
   return truncateMetadataText(
     `${trimmed}${separator}${suffix}`,
     MAX_DESCRIPTION_LENGTH,
+    MIN_DESCRIPTION_LENGTH,
   );
 }
 
@@ -147,30 +156,43 @@ export function seoTitle(
   return truncateMetadataText(normalized, maxLength);
 }
 
-function truncateMetadataText(value: string, maxLength: number) {
-  if (value.length <= maxLength) return value;
+function truncateMetadataText(
+  value: string,
+  maxLength: number,
+  minLength = 0,
+) {
+  const characters = Array.from(value);
+  if (characters.length <= maxLength) return value;
 
-  const candidate = value.slice(0, maxLength - 1).trimEnd();
-  const minimumBoundary = Math.floor(maxLength * 0.6);
-  const sentenceBoundary = Math.max(
-    candidate.lastIndexOf("."),
-    candidate.lastIndexOf("!"),
-    candidate.lastIndexOf("?"),
-    candidate.lastIndexOf("。"),
-    candidate.lastIndexOf("！"),
-    candidate.lastIndexOf("？"),
+  const candidate = characters.slice(0, maxLength - 1);
+  while (/\s/u.test(candidate.at(-1) ?? "")) candidate.pop();
+
+  const minimumBoundary = Math.max(
+    minLength,
+    Math.floor(maxLength * 0.6),
   );
-  const wordBoundary = candidate.lastIndexOf(" ");
+  const sentenceTerminators = new Set([".", "!", "?", "。", "！", "？"]);
+  const sentenceBoundary = candidate.findLastIndex(
+    (character, index) =>
+      index >= minimumBoundary && sentenceTerminators.has(character),
+  );
+  const wordBoundary = candidate.findLastIndex(
+    (character, index) => index >= minimumBoundary && character === " ",
+  );
   const boundary =
     sentenceBoundary >= minimumBoundary
       ? sentenceBoundary + 1
       : wordBoundary >= minimumBoundary
         ? wordBoundary
         : candidate.length;
-  const truncated = candidate
+  let truncated = candidate
     .slice(0, boundary)
+    .join("")
     .replace(/[-,:;–—]+$/u, "")
     .trimEnd();
+  if (Array.from(truncated).length + 1 < minLength) {
+    truncated = candidate.join("").trimEnd();
+  }
   return `${truncated}…`;
 }
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -341,7 +341,9 @@
   "pricing": {
     "metaTitle": "Pricing — cmux",
     "metaDescription": "cmux is a free, open source macOS terminal for AI coding agents. Upgrade to Pro for Cloud VMs, cmux Vault session backup, and a model gateway. Enterprise adds SSO and self-hosting.",
+    "metaDescriptionShort": "cmux is a free, open source macOS terminal. Pro adds Cloud VMs, Vault session backup, and a model gateway; Enterprise adds SSO and self-hosting.",
     "metaDescriptionNoVault": "cmux is a free, open source macOS terminal for AI coding agents. Upgrade to Pro for Cloud VMs and a model gateway. Enterprise adds SSO and self-hosting.",
+    "metaDescriptionNoVaultShort": "cmux is a free, open source macOS terminal. Pro adds Cloud VMs and a model gateway; Enterprise adds SSO and self-hosting.",
     "title": "Pricing",
     "perMonth": "/month",
     "perUserMonth": "/user/month",

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -696,7 +696,7 @@
   },
   "community": {
     "title": "Community",
-    "description": "Browse projects built by the cmux community, from agent hooks to multi-agent orchestration and remote access.",
+    "description": "Browse projects built by the cmux community, from agent hooks to multi-agent orchestration and remote access tools.",
     "metaTitle": "Community — cmux",
     "metaDescription": "Browse every project from awesome-cmux on the cmux community page",
     "sourceAction": "View awesome-cmux",

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -341,7 +341,9 @@
   "pricing": {
     "metaTitle": "料金 — cmux",
     "metaDescription": "cmux はAIコーディングエージェント向けの無料・オープンソースの macOS ターミナルです。Pro では Cloud VM、cmux Vault によるセッションバックアップ、モデルゲートウェイが使えます。Enterprise は SSO とセルフホストに対応します。",
+    "metaDescriptionShort": "cmux は無料・オープンソースの macOS ターミナルです。Pro では Cloud VM、Vault、モデルゲートウェイを利用でき、Enterprise では SSO とセルフホストに対応します。",
     "metaDescriptionNoVault": "cmux はAIコーディングエージェント向けの無料・オープンソースの macOS ターミナルです。Pro では Cloud VM とモデルゲートウェイが使えます。Enterprise は SSO とセルフホストに対応します。",
+    "metaDescriptionNoVaultShort": "cmux は無料・オープンソースの macOS ターミナルです。Pro では Cloud VM とモデルゲートウェイを利用でき、Enterprise では SSO とセルフホストに対応します。",
     "title": "料金",
     "perMonth": "/月",
     "perUserMonth": "/ユーザー/月",

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -79,6 +79,11 @@ export default function middleware(request: NextRequest) {
   }
 
   const fallbackContentRequest = fallbackContentRequestForPathname(pathname);
+  if (fallbackContentRequest && !fallbackContentRequest.locale) {
+    const url = request.nextUrl.clone();
+    url.pathname = `/en${fallbackContentRequest.path}`;
+    return NextResponse.rewrite(url);
+  }
   if (
     fallbackContentRequest?.locale &&
     !hasFallbackContent(fallbackContentRequest.locale)

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -184,6 +184,9 @@ function preferredFallbackContentLocale(request: NextRequest): "en" | "ja" {
   if (cookieLocale && hasFallbackContent(cookieLocale)) {
     return cookieLocale;
   }
+  if (cookieLocale && routing.locales.some((locale) => locale === cookieLocale)) {
+    return "en";
+  }
 
   const preferences = (request.headers.get("accept-language") ?? "")
     .split(",")

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -3,8 +3,10 @@ import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 import { isAgentPageVariantPath } from "./app/lib/agent-page-paths";
 import {
+  fallbackContentRequestForPathname,
   featureWorkflowContentLocales,
   featureWorkflowDocRequestForPathname,
+  hasFallbackContent,
   remoteTmuxDocsLocales,
 } from "./i18n/locale-availability";
 import { buildAlternateLinkHeader } from "./i18n/seo";
@@ -74,6 +76,16 @@ export default function middleware(request: NextRequest) {
       featureWorkflowDocRequest.path,
     );
     return response;
+  }
+
+  const fallbackContentRequest = fallbackContentRequestForPathname(pathname);
+  if (
+    fallbackContentRequest?.locale &&
+    !hasFallbackContent(fallbackContentRequest.locale)
+  ) {
+    const url = request.nextUrl.clone();
+    url.pathname = fallbackContentRequest.path;
+    return NextResponse.redirect(url, 301);
   }
 
   // Legal pages are English-only. Redirect /<locale>/legal-page to /legal-page,

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -190,24 +190,58 @@ function preferredFallbackContentLocale(request: NextRequest): "en" | "ja" {
     .map((preference, index) => {
       const [tag, ...parameters] = preference.trim().split(";");
       const qualityParameter = parameters.find((parameter) =>
-        parameter.trim().startsWith("q="),
+        /^q\s*=/iu.test(parameter.trim()),
       );
-      const quality = qualityParameter
-        ? Number.parseFloat(qualityParameter.trim().slice(2))
-        : 1;
-      return { tag: tag.toLowerCase(), quality, index };
+      const qualityValue = qualityParameter?.split("=")[1].trim();
+      const quality =
+        qualityValue === undefined
+          ? 1
+          : /^(?:0(?:\.\d{0,3})?|1(?:\.0{0,3})?)$/u.test(qualityValue)
+            ? Number(qualityValue)
+            : Number.NaN;
+      return { tag: tag.trim().toLowerCase(), quality, index };
     })
-    .filter(({ quality }) => Number.isFinite(quality) && quality > 0)
-    .sort(
-      (left, right) =>
-        right.quality - left.quality || left.index - right.index,
+    .filter(
+      ({ tag, quality }) =>
+        tag.length > 0 &&
+        Number.isFinite(quality) &&
+        quality >= 0 &&
+        quality <= 1,
     );
 
-  for (const { tag } of preferences) {
-    if (tag === "ja" || tag.startsWith("ja-")) return "ja";
-    if (tag === "en" || tag.startsWith("en-")) return "en";
+  const english = effectiveLanguageQuality("en", preferences);
+  const japanese = effectiveLanguageQuality("ja", preferences);
+  if (japanese.quality > english.quality) return "ja";
+  if (
+    japanese.quality === english.quality &&
+    japanese.quality > 0 &&
+    japanese.index < english.index
+  ) {
+    return "ja";
   }
   return "en";
+}
+
+function effectiveLanguageQuality(
+  locale: "en" | "ja",
+  preferences: Array<{ tag: string; quality: number; index: number }>,
+) {
+  const explicitMatches = preferences.filter(({ tag }) => {
+    if (tag === "*") return false;
+    return tag.split("-")[0] === locale;
+  });
+  const matches =
+    explicitMatches.length > 0
+      ? explicitMatches
+      : preferences.filter(({ tag }) => tag === "*");
+  return matches.reduce(
+    (best, preference) =>
+      preference.quality > best.quality ||
+      (preference.quality === best.quality && preference.index < best.index)
+        ? preference
+        : best,
+    { quality: 0, index: Number.POSITIVE_INFINITY },
+  );
 }
 
 function setFeatureWorkflowDocLinkHeader(

--- a/web/proxy.ts
+++ b/web/proxy.ts
@@ -3,6 +3,7 @@ import createMiddleware from "next-intl/middleware";
 import { routing } from "./i18n/routing";
 import { isAgentPageVariantPath } from "./app/lib/agent-page-paths";
 import {
+  fallbackContentLocales,
   fallbackContentRequestForPathname,
   featureWorkflowContentLocales,
   featureWorkflowDocRequestForPathname,
@@ -80,9 +81,19 @@ export default function middleware(request: NextRequest) {
 
   const fallbackContentRequest = fallbackContentRequestForPathname(pathname);
   if (fallbackContentRequest && !fallbackContentRequest.locale) {
+    const preferredLocale = preferredFallbackContentLocale(request);
     const url = request.nextUrl.clone();
-    url.pathname = `/en${fallbackContentRequest.path}`;
-    return NextResponse.rewrite(url);
+    url.pathname = `/${preferredLocale}${fallbackContentRequest.path}`;
+    const response =
+      preferredLocale === "en"
+        ? NextResponse.rewrite(url)
+        : NextResponse.redirect(url, 307);
+    setFallbackContentLinkHeader(
+      response,
+      request,
+      fallbackContentRequest.path,
+    );
+    return response;
   }
   if (
     fallbackContentRequest?.locale &&
@@ -142,8 +153,61 @@ export default function middleware(request: NextRequest) {
       featureWorkflowDocRequest.path,
     );
   }
+  if (fallbackContentRequest) {
+    setFallbackContentLinkHeader(
+      response,
+      request,
+      fallbackContentRequest.path,
+    );
+  }
 
   return response;
+}
+
+function setFallbackContentLinkHeader(
+  response: NextResponse,
+  request: NextRequest,
+  path: string,
+) {
+  response.headers.set(
+    "Link",
+    buildAlternateLinkHeader(
+      requestOrigin(request),
+      path,
+      fallbackContentLocales,
+    ),
+  );
+}
+
+function preferredFallbackContentLocale(request: NextRequest): "en" | "ja" {
+  const cookieLocale = request.cookies.get("NEXT_LOCALE")?.value;
+  if (cookieLocale && hasFallbackContent(cookieLocale)) {
+    return cookieLocale;
+  }
+
+  const preferences = (request.headers.get("accept-language") ?? "")
+    .split(",")
+    .map((preference, index) => {
+      const [tag, ...parameters] = preference.trim().split(";");
+      const qualityParameter = parameters.find((parameter) =>
+        parameter.trim().startsWith("q="),
+      );
+      const quality = qualityParameter
+        ? Number.parseFloat(qualityParameter.trim().slice(2))
+        : 1;
+      return { tag: tag.toLowerCase(), quality, index };
+    })
+    .filter(({ quality }) => Number.isFinite(quality) && quality > 0)
+    .sort(
+      (left, right) =>
+        right.quality - left.quality || left.index - right.index,
+    );
+
+  for (const { tag } of preferences) {
+    if (tag === "ja" || tag.startsWith("ja-")) return "ja";
+    if (tag === "en" || tag.startsWith("en-")) return "en";
+  }
+  return "en";
 }
 
 function setFeatureWorkflowDocLinkHeader(

--- a/web/tests/app-pricing-page.test.tsx
+++ b/web/tests/app-pricing-page.test.tsx
@@ -15,6 +15,7 @@ const redirect = mock((href: unknown) => {
 // carry every export another test in the suite might import.
 mock.module("next/navigation", () => ({
   redirect,
+  usePathname: () => "/",
   notFound: () => {
     throw new Error("notFound");
   },

--- a/web/tests/app-pro-welcome-page.test.tsx
+++ b/web/tests/app-pro-welcome-page.test.tsx
@@ -9,6 +9,7 @@ const redirect = mock((href: unknown) => {
 // carry every export another test in the suite might import.
 mock.module("next/navigation", () => ({
   redirect,
+  usePathname: () => "/",
   notFound: () => {
     throw new Error("notFound");
   },

--- a/web/tests/billing-success-page.test.tsx
+++ b/web/tests/billing-success-page.test.tsx
@@ -15,6 +15,7 @@ const retrieveSession = mock(async () => ({
 
 mock.module("next/navigation", () => ({
   redirect,
+  usePathname: () => "/",
   notFound: () => {
     throw new Error("notFound");
   },

--- a/web/tests/content-locale-link.test.tsx
+++ b/web/tests/content-locale-link.test.tsx
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { NextIntlClientProvider } from "next-intl";
+import { ContentLocaleLink } from "../app/[locale]/components/content-locale-link";
+import { fallbackContentLocales } from "../i18n/locale-availability";
+
+describe("fallback-content links", () => {
+  test("renders direct canonical hrefs for English fallback content", () => {
+    for (const href of [
+      "/pricing",
+      "/docs/agent-integrations/oh-my-pi",
+    ]) {
+      const markup = renderLink("de", href);
+      expect(markup).toContain(`href="${href}"`);
+      expect(markup).not.toContain("/en/");
+      expect(markup).not.toContain("/de/");
+    }
+  });
+
+  test("renders the localized Japanese href when translated content exists", () => {
+    expect(renderLink("ja", "/pricing")).toContain('href="/ja/pricing"');
+  });
+});
+
+function renderLink(locale: string, href: string) {
+  return renderToStaticMarkup(
+    <NextIntlClientProvider locale={locale} messages={{}}>
+      <ContentLocaleLink
+        href={href}
+        currentLocale={locale}
+        contentLocales={fallbackContentLocales}
+      >
+        Link
+      </ContentLocaleLink>
+    </NextIntlClientProvider>,
+  );
+}

--- a/web/tests/content-locale-link.test.tsx
+++ b/web/tests/content-locale-link.test.tsx
@@ -1,6 +1,5 @@
 import { describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import { NextIntlClientProvider } from "next-intl";
 import { ContentLocaleLink } from "../app/[locale]/components/content-locale-link";
 import { fallbackContentLocales } from "../i18n/locale-availability";
 
@@ -24,14 +23,12 @@ describe("fallback-content links", () => {
 
 function renderLink(locale: string, href: string) {
   return renderToStaticMarkup(
-    <NextIntlClientProvider locale={locale} messages={{}}>
-      <ContentLocaleLink
-        href={href}
-        currentLocale={locale}
-        contentLocales={fallbackContentLocales}
-      >
-        Link
-      </ContentLocaleLink>
-    </NextIntlClientProvider>,
+    <ContentLocaleLink
+      href={href}
+      currentLocale={locale}
+      contentLocales={fallbackContentLocales}
+    >
+      Link
+    </ContentLocaleLink>,
   );
 }

--- a/web/tests/docs-search-index.test.ts
+++ b/web/tests/docs-search-index.test.ts
@@ -54,6 +54,20 @@ describe("docs search index", () => {
     expect(
       pages.some((page) => page.locale === "ja" && page.href === "/docs/task-manager"),
     ).toBe(true);
+    expect(
+      pages.some(
+        (page) =>
+          page.locale === "de" &&
+          page.href === "/docs/agent-integrations/oh-my-pi",
+      ),
+    ).toBe(false);
+    expect(
+      pages.some(
+        (page) =>
+          page.locale === "ja" &&
+          page.href === "/docs/agent-integrations/oh-my-pi",
+      ),
+    ).toBe(true);
   });
 
   test("uses the API page message namespace in every locale", async () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -78,6 +78,7 @@ describe("SEO metadata helpers", () => {
     expect(
       completeMetadataSentence("en", "The terminal built for multitasking"),
     ).toBe("The terminal built for multitasking.");
+    expect(completeMetadataSentence("en", "Examples:")).toBe("Examples:");
   });
 
   test("preserves overbound authored copy when no complete candidate fits", () => {
@@ -359,6 +360,7 @@ describe("SEO metadata helpers", () => {
           /…|<\/?(?:link|code)>/u,
         );
         expect(row.copy.description).not.toMatch(/[!?។៕。！？؟]\./u);
+        expect(row.copy.description).not.toMatch(/[:：][.。]/u);
         expect(row.copy.description).toMatch(/[.!?。！？؟។៕]$/u);
         const hasRouteContext = row.contexts.some(
           (context) =>

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -63,10 +63,16 @@ describe("SEO metadata helpers", () => {
   test("does not split Unicode characters at the metadata cutoff", () => {
     const description = seoDescription(
       "en",
-      `${"A".repeat(158)}😀${"B".repeat(20)}`,
+      `${"A".repeat(158)}👩🏽‍💻${"B".repeat(20)}`,
     );
-    expect(description).toContain("😀");
-    expect(Array.from(description).length).toBeLessThanOrEqual(160);
+    expect(description).toContain("👩🏽‍💻");
+    expect(
+      Array.from(
+        new Intl.Segmenter("en", { granularity: "grapheme" }).segment(
+          description,
+        ),
+      ).length,
+    ).toBeLessThanOrEqual(160);
   });
 
   test("adds useful context to short titles and trims long titles", () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -8,6 +8,7 @@ import {
   openGraphDefaults,
   openGraphImageTagline,
   seoDescription,
+  seoTitle,
   twitterSummary,
 } from "../i18n/seo";
 import { locales } from "../i18n/routing";
@@ -22,18 +23,44 @@ describe("SEO metadata helpers", () => {
   });
 
   test("extends short descriptions with localized product context", () => {
-    expect(seoDescription("en", "CLI reference")).toBe(
-      "CLI reference. Built for AI coding agents on macOS.",
+    expect(seoDescription("en", "CLI reference")).toContain(
+      "vertical tabs, notifications, split panes, and browser automation",
     );
     expect(seoDescription("ja", "CLI リファレンス。")).toContain(
-      "macOS の AI コーディングエージェント向けです。",
+      "macOS の AI コーディングエージェント向け。",
     );
     expect(
       seoDescription(
         "en",
         "A detailed page about running multiple coding agents in cmux on macOS.",
       ),
-    ).toContain("Built for AI coding agents on macOS.");
+    ).toContain("Built for AI coding agents on macOS,");
+  });
+
+  test("keeps descriptions within search snippet bounds", () => {
+    const short = seoDescription("en", "News from the cmux team");
+    expect(short.length).toBeGreaterThanOrEqual(110);
+    expect(short.length).toBeLessThanOrEqual(160);
+
+    const long = seoDescription(
+      "en",
+      "A very long metadata description ".repeat(12),
+    );
+    expect(long.length).toBeLessThanOrEqual(160);
+    expect(long.endsWith("…")).toBe(true);
+    expect(long).not.toMatch(/\s…$/);
+  });
+
+  test("adds useful context to short titles and trims long titles", () => {
+    expect(seoTitle("en", "Blog")).toBe(
+      "Blog — The terminal built for multitasking",
+    );
+    const long = seoTitle(
+      "en",
+      "The best terminal and agent workspace for every AI coding workflow in 2026",
+    );
+    expect(long.length).toBeLessThanOrEqual(60);
+    expect(long.endsWith("…")).toBe(true);
   });
 
   test("adds complete shared social metadata", () => {
@@ -68,6 +95,9 @@ describe("SEO metadata helpers", () => {
       );
       expect(openGraphDefaults(locale, "website").images[0].alt).not.toBe("");
       expect(openGraphImageTagline(locale)).not.toBe("");
+      expect(seoDescription(locale, "CLI reference").length).toBeLessThanOrEqual(
+        160,
+      );
     }
   });
 });

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -227,6 +227,9 @@ describe("SEO metadata helpers", () => {
             messages.blog.posts.cmuxHistory.p1,
             messages.blog.posts.cmuxHistory.focusP,
             messages.blog.posts.cmuxHistory.fullHistoryP,
+            messages.blog.posts.cmuxHistory.reopenTitle,
+            messages.blog.posts.cmuxHistory.agentTitle,
+            messages.blog.posts.cmuxHistory.focusTitle,
           ],
           [
             messages.blog.cmuxHistory.metaTitle,
@@ -384,7 +387,7 @@ describe("SEO metadata helpers", () => {
           /…|<\/?(?:link|code)>/u,
         );
         expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
-          /[{}]/u,
+          /[{}]|__CMUXPH/iu,
         );
         expect(row.copy.description).not.toMatch(/[!?។៕。！？؟]\./u);
         expect(row.copy.description).not.toMatch(/[:：][.。]/u);

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
+import { comparePages } from "../app/lib/compare-pages";
 import sitemap from "../app/sitemap";
 import { legalMetadata } from "../app/[locale]/(legal)/legal-metadata";
 import middleware from "../proxy";
@@ -13,8 +14,19 @@ import {
   seoTitle,
   twitterSummary,
 } from "../i18n/seo";
+import {
+  assetsSeoCopy,
+  bestTerminalSeoCopy,
+  blogIndexSeoCopy,
+  cmuxHistorySeoCopy,
+  communitySeoCopy,
+  compareIndexSeoCopy,
+  comparePageSeoCopy,
+  homeSeoCopy,
+  ohMyPiSeoCopy,
+  pricingSeoCopy,
+} from "../i18n/audited-seo";
 import { locales } from "../i18n/routing";
-import thMessages from "../messages/th.json";
 
 describe("SEO metadata helpers", () => {
   test("keeps canonical URLs locale-aware", () => {
@@ -36,78 +48,46 @@ describe("SEO metadata helpers", () => {
     ).toContain(
       "macOS の AI コーディングエージェント向け。",
     );
+    const overboundWithSuffix =
+      "A detailed page about running multiple coding agents in cmux on macOS.";
     expect(
-      seoDescription(
-        "en",
-        "A detailed page about running multiple coding agents in cmux on macOS.",
-        { minLength: 110 },
-      ),
-    ).toContain("Built for AI coding agents on macOS,");
+      seoDescription("en", overboundWithSuffix, { minLength: 110 }),
+    ).toBe(overboundWithSuffix);
   });
 
-  test("keeps descriptions within search snippet bounds", () => {
+  test("appends complete localized context only when the result fits", () => {
     const short = seoDescription("en", "News from the cmux team", {
       minLength: 110,
     });
     expect(short.length).toBeGreaterThanOrEqual(110);
     expect(short.length).toBeLessThanOrEqual(160);
 
-    const long = seoDescription(
-      "en",
-      "A very long metadata description ".repeat(12),
-    );
-    expect(long.length).toBeLessThanOrEqual(160);
-    expect(long.endsWith("…")).toBe(true);
-    expect(long).not.toMatch(/\s…$/);
+    const original = "A very long metadata description ".repeat(12).trim();
+    expect(seoDescription("en", original)).toBe(original);
   });
 
-  test("keeps truncated descriptions above the minimum boundary", () => {
-    const description = seoDescription(
-      "en",
-      `${"A".repeat(100)}. ${"B".repeat(100)}`,
-      { minLength: 110 },
-    );
-    expect(Array.from(description).length).toBeGreaterThanOrEqual(110);
-    expect(Array.from(description).length).toBeLessThanOrEqual(160);
+  test("preserves overbound authored copy when no complete candidate fits", () => {
+    const description = `${"A".repeat(157)}👩🏽‍💻${"B".repeat(20)}`;
+    expect(seoDescription("en", description)).toBe(description);
+
+    const title =
+      "The best terminal and agent workspace for every AI coding workflow in 2026";
+    expect(
+      seoTitle("en", title, { fallbackCandidates: ["Short fallback"] }),
+    ).toBe(title);
   });
 
-  test("does not split Unicode characters at the metadata cutoff", () => {
-    const description = seoDescription(
-      "en",
-      `${"A".repeat(157)}👩🏽‍💻${"B".repeat(20)}`,
-    );
-    expect(description).toContain("👩🏽‍💻");
-    expect(searchSnippetLength(description)).toBeLessThanOrEqual(160);
-  });
-
-  test("keeps dotted product names intact in localized descriptions", () => {
-    const description = seoDescription(
-      "th",
-      thMessages.landing.bestTerminal.metaDescription,
-    );
-    expect(description).toContain("Terminal.app");
-    expect(description).not.toContain("Terminal.…");
-    expect(searchSnippetLength(description)).toBeLessThanOrEqual(160);
-  });
-
-  test("truncates Thai titles at a word boundary", () => {
-    const title = seoTitle("th", thMessages.blog.cmuxHistory.metaTitle);
-    expect(title).toBe(
-      "cmux history: เปิดเทอร์มินัลและเซสชันที่ปิด…",
-    );
-    expect(searchSnippetLength(title)).toBeLessThanOrEqual(60);
-  });
-
-  test("adds useful context to short titles and trims long titles", () => {
+  test("adds useful context to short titles and selects complete fallbacks", () => {
     expect(seoTitle("en", "Blog")).toBe(
       "Blog — The terminal built for multitasking",
     );
-    const long = seoTitle(
-      "en",
-      "The best terminal and agent workspace for every AI coding workflow in 2026",
-    );
-    expect(long.length).toBeLessThanOrEqual(60);
-    expect(long.endsWith("…")).toBe(true);
+    expect(
+      seoTitle(
+        "en",
+        "The best terminal and agent workspace for every AI coding workflow in 2026",
+        { fallbackCandidates: ["A complete authored fallback title"] },
+      ),
+    ).toBe("A complete authored fallback title");
   });
 
   test("can preserve a complete localized title below the generic minimum", () => {
@@ -154,21 +134,220 @@ describe("SEO metadata helpers", () => {
 
   test("has localized SEO fallback copy for every configured locale", () => {
     for (const locale of locales) {
+      const standardDescription = seoDescription(locale, "CLI reference");
       const detailedDescription = seoDescription(locale, "CLI reference", {
         minLength: 110,
       });
       const detailedLength = searchSnippetLength(detailedDescription);
       expect(hasLocalizedSeoCopy(locale)).toBe(true);
-      expect(seoDescription(locale, "CLI reference").length).toBeGreaterThan(
-        "CLI reference".length,
-      );
       expect(openGraphDefaults(locale, "website").images[0].alt).not.toBe("");
       expect(openGraphImageTagline(locale)).not.toBe("");
-      expect(seoDescription(locale, "CLI reference").length).toBeLessThanOrEqual(
-        160,
-      );
-      expect(detailedLength).toBeGreaterThanOrEqual(110);
+      expect(standardDescription).not.toContain("…");
+      expect(detailedDescription).not.toContain("…");
+      expect(searchSnippetLength(standardDescription)).toBeLessThanOrEqual(160);
       expect(detailedLength).toBeLessThanOrEqual(160);
+    }
+  });
+
+  test("selects bounded, route-specific copy for the audited matrix", async () => {
+    for (const locale of locales) {
+      const messages = await messagesFor(locale);
+      const siteMeta = messageLookup(messages.meta);
+      const rows = [
+        auditedRow("/", homeSeoCopy(locale, siteMeta), [
+          "cmux",
+          messages.meta.description,
+          messages.meta.ogDescription,
+        ]),
+        auditedRow(
+          "/assets",
+          assetsSeoCopy(locale, messageLookup(messages.brandAssets), siteMeta),
+          [
+            messages.brandAssets.title,
+            messages.brandAssets.metaDescription,
+            messages.brandAssets.description,
+          ],
+        ),
+        auditedRow(
+          "/blog",
+          blogIndexSeoCopy(locale, messageLookup(messages.blog), siteMeta),
+          [messages.blog.title, messages.blog.metaDescription],
+        ),
+        auditedRow(
+          "/blog/cmux-history",
+          cmuxHistorySeoCopy(
+            locale,
+            messageLookup(messages.blog.cmuxHistory),
+            messageLookup(messages.blog.posts.cmuxHistory),
+            siteMeta,
+          ),
+          [
+            messages.blog.cmuxHistory.metaDescription,
+            messages.blog.posts.cmuxHistory.title,
+            messages.blog.posts.cmuxHistory.summary,
+            messages.blog.posts.cmuxHistory.p1,
+            messages.blog.posts.cmuxHistory.focusP,
+            messages.blog.posts.cmuxHistory.fullHistoryP,
+          ],
+          [
+            messages.blog.cmuxHistory.metaTitle,
+            messages.blog.posts.cmuxHistory.title,
+            messages.blog.posts.cmuxHistory.reopenTitle,
+            messages.blog.posts.cmuxHistory.agentTitle,
+            messages.blog.posts.cmuxHistory.focusTitle,
+          ],
+        ),
+        auditedRow(
+          "/community",
+          communitySeoCopy(
+            locale,
+            messageLookup(messages.community),
+            siteMeta,
+          ),
+          [
+            messages.community.title,
+            messages.community.metaDescription,
+            messages.community.description,
+          ],
+        ),
+        auditedRow(
+          "/best-terminal-for-mac",
+          bestTerminalSeoCopy(
+            locale,
+            messageLookup(messages.landing.bestTerminal),
+            siteMeta,
+          ),
+          [
+            messages.landing.bestTerminal.title,
+            messages.landing.bestTerminal.metaDescription,
+            messages.landing.bestTerminal.cmuxBuiltFor,
+          ],
+        ),
+        auditedRow(
+          "/compare",
+          compareIndexSeoCopy(
+            locale,
+            messageLookup(messages.landing.compare),
+            siteMeta,
+          ),
+          [
+            messages.landing.compare.title,
+            messages.landing.compare.metaDescription,
+            messages.landing.compare.intro,
+          ],
+          [
+            messages.landing.compare.metaTitle,
+            messages.landing.compare.title,
+          ],
+        ),
+      ];
+
+      const compareTitles: string[] = [];
+      for (const page of comparePages) {
+        const pageMessages = messages.landing.compare.pages[page.key];
+        const copy = comparePageSeoCopy(
+          locale,
+          page.key,
+          messageLookup(pageMessages),
+          messageLookup(messages.landing.links),
+          siteMeta,
+        );
+        compareTitles.push(copy.title);
+        rows.push(
+          auditedRow(`/compare/${page.slug}`, copy, [
+            pageMessages.title,
+            pageMessages.metaDescription,
+            pageMessages.faqQ1,
+            pageMessages.summaryBody,
+            pageMessages.intro,
+            pageMessages.faqA1,
+            pageMessages.faqA2,
+            pageMessages.faqA3,
+          ],
+          page.key === "bestTerminalForAgents"
+            ? [
+                pageMessages.metaTitle,
+                pageMessages.title,
+                messages.landing.links.bestTerminal,
+              ]
+            : [
+                pageMessages.metaTitle,
+                pageMessages.title,
+                ...(page.key === "multipleClaudeAgents"
+                  ? ["cmux · Claude Code"]
+                  : []),
+              ],
+          ),
+        );
+      }
+      expect(new Set(compareTitles).size).toBe(comparePages.length);
+
+      if (locale === "en" || locale === "ja") {
+        const pricing = messageLookup(messages.pricing);
+        rows.push(
+          auditedRow(
+            "/pricing",
+            pricingSeoCopy(locale, pricing, siteMeta, "metaDescription"),
+            [messages.pricing.title, messages.pricing.metaDescription],
+          ),
+          auditedRow(
+            "/pricing?without-vault",
+            pricingSeoCopy(
+              locale,
+              pricing,
+              siteMeta,
+              "metaDescriptionNoVault",
+            ),
+            [messages.pricing.title, messages.pricing.metaDescriptionNoVault],
+          ),
+          auditedRow(
+            "/docs/agent-integrations/oh-my-pi",
+            ohMyPiSeoCopy(
+              locale,
+              messageLookup(messages.docs.ohMyPi),
+              siteMeta,
+            ),
+            [
+              messages.docs.ohMyPi.title,
+              messages.docs.ohMyPi.metaDescription,
+              messages.docs.ohMyPi.intro,
+            ],
+          ),
+        );
+      }
+
+      for (const row of rows) {
+        const titleLength = searchSnippetLength(row.copy.title);
+        const descriptionLength = searchSnippetLength(row.copy.description);
+        if (!conciseTitleLocales.has(locale)) {
+          expect(titleLength).toBeGreaterThanOrEqual(30);
+        }
+        expect(titleLength).toBeLessThanOrEqual(60);
+        expect(descriptionLength).toBeGreaterThanOrEqual(110);
+        expect(descriptionLength).toBeLessThanOrEqual(160);
+        expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
+          /…|<\/?(?:link|code)>/u,
+        );
+        const hasRouteContext = row.contexts.some(
+          (context) =>
+            context.length > 0 && row.copy.description.includes(context),
+        );
+        if (!hasRouteContext) {
+          throw new Error(
+            `${locale}${row.route} lost route context: ${row.copy.description}`,
+          );
+        }
+        if (
+          !row.titleContexts.some(
+            (context) =>
+              context.length > 0 && row.copy.title.includes(context),
+          )
+        ) {
+          throw new Error(
+            `${locale}${row.route} lost title identity: ${row.copy.title}`,
+          );
+        }
+      }
     }
   });
 });
@@ -271,11 +450,37 @@ const searchWidthSegmenter = new Intl.Segmenter("en", {
 });
 const wideSearchGrapheme =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Khmer}\p{Extended_Pictographic}]/u;
+const conciseTitleLocales = new Set(["ja", "zh-CN", "zh-TW", "ko"]);
+type Messages = typeof import("../messages/en.json");
+type SeoCopy = { title: string; description: string };
 
 function searchSnippetLength(value: string) {
   return Array.from(searchWidthSegmenter.segment(value), ({ segment }) =>
     wideSearchGrapheme.test(segment) ? 2 : 1,
   ).reduce((sum, length) => sum + length, 0);
+}
+
+function messageLookup(messages: object) {
+  return (key: string) => {
+    const value = (messages as Record<string, unknown>)[key];
+    if (typeof value !== "string") {
+      throw new Error(`Expected a string message for ${key}`);
+    }
+    return value;
+  };
+}
+
+async function messagesFor(locale: string) {
+  return (await import(`../messages/${locale}.json`)).default as Messages;
+}
+
+function auditedRow(
+  route: string,
+  copy: SeoCopy,
+  contexts: string[],
+  titleContexts: string[] = [contexts[0]],
+) {
+  return { route, copy, contexts, titleContexts };
 }
 
 function requestFor(pathname: string, headers: Record<string, string> = {}) {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -90,6 +90,17 @@ describe("SEO metadata helpers", () => {
     expect(
       seoTitle("en", title, { fallbackCandidates: ["Short fallback"] }),
     ).toBe(title);
+
+    const safeCandidate = `Complete localized route description ${"B".repeat(75)}`;
+    expect(
+      seoDescription("en", "X".repeat(200), {
+        minLength: 110,
+        fallbackCandidates: [
+          `Literal {new} placeholder ${"A".repeat(85)}`,
+          safeCandidate,
+        ],
+      }),
+    ).toBe(safeCandidate);
   });
 
   test("adds useful context to short titles and selects complete fallbacks", () => {
@@ -358,6 +369,9 @@ describe("SEO metadata helpers", () => {
         expect(titleLength).toBeLessThanOrEqual(60);
         expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
           /…|<\/?(?:link|code)>/u,
+        );
+        expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
+          /\{[a-z][a-z0-9_]*\}/iu,
         );
         expect(row.copy.description).not.toMatch(/[!?។៕。！？؟]\./u);
         expect(row.copy.description).not.toMatch(/[:：][.。]/u);

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -172,24 +172,34 @@ describe("SEO middleware", () => {
   });
 
   test("redirects fallback-only locale routes to translated content", () => {
-    for (const path of [
-      "/de/pricing",
-      "/de/docs/agent-integrations/oh-my-pi",
+    for (const canonicalPath of [
+      "/pricing",
+      "/docs/agent-integrations/oh-my-pi",
     ]) {
+      const path = `/de${canonicalPath}`;
       const response = middleware(
         requestFor(path, { "accept-language": "de" }),
       );
       expect(response.status).toBe(301);
       expect(response.headers.get("location")).toBe(
-        `https://cmux.com${path.replace("/de", "")}`,
+        `https://cmux.com${canonicalPath}`,
+      );
+
+      const canonical = middleware(
+        requestFor(canonicalPath, { "accept-language": "de" }),
+      );
+      expect(canonical.status).toBe(200);
+      expect(canonical.headers.get("location")).toBeNull();
+      expect(canonical.headers.get("x-middleware-rewrite")).toBe(
+        `https://cmux.com/en${canonicalPath}`,
       );
     }
 
-    expect(
-      middleware(
-        requestFor("/ja/pricing", { "accept-language": "ja" }),
-      ).status,
-    ).toBe(200);
+    const japanese = middleware(
+      requestFor("/ja/pricing", { "accept-language": "ja" }),
+    );
+    expect(japanese.status).toBe(200);
+    expect(japanese.headers.get("location")).toBeNull();
   });
 
   test("lists only translated fallback-content locales in the sitemap", () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -319,12 +319,15 @@ describe("SEO metadata helpers", () => {
       for (const row of rows) {
         const titleLength = searchSnippetLength(row.copy.title);
         const descriptionLength = searchSnippetLength(row.copy.description);
+        if (descriptionLength < 110 || descriptionLength > 160) {
+          throw new Error(
+            `${locale}${row.route} description length ${descriptionLength}: ${row.copy.description}`,
+          );
+        }
         if (!conciseTitleLocales.has(locale)) {
           expect(titleLength).toBeGreaterThanOrEqual(30);
         }
         expect(titleLength).toBeLessThanOrEqual(60);
-        expect(descriptionLength).toBeGreaterThanOrEqual(110);
-        expect(descriptionLength).toBeLessThanOrEqual(160);
         expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
           /…|<\/?(?:link|code)>/u,
         );
@@ -349,6 +352,24 @@ describe("SEO metadata helpers", () => {
         }
       }
     }
+  });
+
+  test("uses deterministic code-point widths for Khmer metadata", async () => {
+    const messages = await messagesFor("km");
+    const page = messages.landing.compare.pages.cmuxVsZed;
+    const copy = comparePageSeoCopy(
+      "km",
+      "cmuxVsZed",
+      messageLookup(page),
+      messageLookup(messages.landing.links),
+      messageLookup(messages.meta),
+    );
+
+    expect(searchSnippetLength("ក\u17D2ម")).toBe(4);
+    expect(copy.description).not.toBe(page.metaDescription);
+    expect(copy.description).toContain(page.title);
+    expect(searchSnippetLength(copy.description)).toBeGreaterThanOrEqual(110);
+    expect(searchSnippetLength(copy.description)).toBeLessThanOrEqual(160);
   });
 });
 
@@ -445,19 +466,19 @@ describe("SEO middleware", () => {
   });
 });
 
-const searchWidthSegmenter = new Intl.Segmenter("en", {
-  granularity: "grapheme",
-});
-const wideSearchGrapheme =
+const wideSearchBaseCodePoint =
   /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Khmer}\p{Extended_Pictographic}]/u;
+const zeroWidthSearchCodePoint =
+  /[\p{Mark}\u200D\uFE0E\uFE0F\u{E0100}-\u{E01EF}\u{1F3FB}-\u{1F3FF}]/u;
 const conciseTitleLocales = new Set(["ja", "zh-CN", "zh-TW", "ko"]);
 type Messages = typeof import("../messages/en.json");
 type SeoCopy = { title: string; description: string };
 
 function searchSnippetLength(value: string) {
-  return Array.from(searchWidthSegmenter.segment(value), ({ segment }) =>
-    wideSearchGrapheme.test(segment) ? 2 : 1,
-  ).reduce((sum, length) => sum + length, 0);
+  return Array.from(value).reduce((sum, codePoint) => {
+    if (zeroWidthSearchCodePoint.test(codePoint)) return sum;
+    return sum + (wideSearchBaseCodePoint.test(codePoint) ? 2 : 1);
+  }, 0);
 }
 
 function messageLookup(messages: object) {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -23,22 +23,29 @@ describe("SEO metadata helpers", () => {
   });
 
   test("extends short descriptions with localized product context", () => {
-    expect(seoDescription("en", "CLI reference")).toContain(
+    expect(
+      seoDescription("en", "CLI reference", { minLength: 110 }),
+    ).toContain(
       "vertical tabs, notifications, split panes, and browser automation",
     );
-    expect(seoDescription("ja", "CLI リファレンス。")).toContain(
+    expect(
+      seoDescription("ja", "CLI リファレンス。", { minLength: 110 }),
+    ).toContain(
       "macOS の AI コーディングエージェント向け。",
     );
     expect(
       seoDescription(
         "en",
         "A detailed page about running multiple coding agents in cmux on macOS.",
+        { minLength: 110 },
       ),
     ).toContain("Built for AI coding agents on macOS,");
   });
 
   test("keeps descriptions within search snippet bounds", () => {
-    const short = seoDescription("en", "News from the cmux team");
+    const short = seoDescription("en", "News from the cmux team", {
+      minLength: 110,
+    });
     expect(short.length).toBeGreaterThanOrEqual(110);
     expect(short.length).toBeLessThanOrEqual(160);
 
@@ -55,6 +62,7 @@ describe("SEO metadata helpers", () => {
     const description = seoDescription(
       "en",
       `${"A".repeat(100)}. ${"B".repeat(100)}`,
+      { minLength: 110 },
     );
     expect(Array.from(description).length).toBeGreaterThanOrEqual(110);
     expect(Array.from(description).length).toBeLessThanOrEqual(160);
@@ -90,6 +98,12 @@ describe("SEO metadata helpers", () => {
   test("can preserve a complete localized title below the generic minimum", () => {
     const title = "cmux — 专为多任务打造的终端";
     expect(seoTitle("zh-CN", title, { minLength: 0 })).toBe(title);
+  });
+
+  test("does not add localized copy to an English fallback description", () => {
+    const fallback =
+      "Talk with cmux about Enterprise deployment, SSO, self-hosted Cloud VMs, audit logs, and committed usage.";
+    expect(seoDescription("de", fallback)).toBe(fallback);
   });
 
   test("adds complete shared social metadata", () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -193,13 +193,38 @@ describe("SEO middleware", () => {
       expect(canonical.headers.get("x-middleware-rewrite")).toBe(
         `https://cmux.com/en${canonicalPath}`,
       );
+      expect(canonical.headers.get("Link")).toContain('hreflang="ja"');
+      expect(canonical.headers.get("Link")).not.toContain('hreflang="de"');
     }
+
+    const negotiatedJapanese = middleware(
+      requestFor("/pricing", { "accept-language": "ja,en;q=0.9" }),
+    );
+    expect(negotiatedJapanese.status).toBe(307);
+    expect(negotiatedJapanese.headers.get("location")).toBe(
+      "https://cmux.com/ja/pricing",
+    );
+    expect(negotiatedJapanese.headers.get("location")).not.toContain("/en/");
+
+    const cookieJapanese = middleware(
+      requestFor("/pricing", {
+        cookie: "NEXT_LOCALE=ja",
+        "accept-language": "en",
+      }),
+    );
+    expect(cookieJapanese.status).toBe(307);
+    expect(cookieJapanese.headers.get("location")).toBe(
+      "https://cmux.com/ja/pricing",
+    );
 
     const japanese = middleware(
       requestFor("/ja/pricing", { "accept-language": "ja" }),
     );
     expect(japanese.status).toBe(200);
     expect(japanese.headers.get("location")).toBeNull();
+    expect(japanese.headers.get("Link")).toContain('hreflang="en"');
+    expect(japanese.headers.get("Link")).toContain('hreflang="ja"');
+    expect(japanese.headers.get("Link")).not.toContain('hreflang="de"');
   });
 
   test("lists only translated fallback-content locales in the sitemap", () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
+import sitemap from "../app/sitemap";
 import middleware from "../proxy";
 import {
   buildAlternates,
@@ -141,6 +142,11 @@ describe("SEO metadata helpers", () => {
       expect(seoDescription(locale, "CLI reference").length).toBeLessThanOrEqual(
         160,
       );
+      expect(
+        searchSnippetLength(
+          seoDescription(locale, "CLI reference", { minLength: 110 }),
+        ),
+      ).toBeGreaterThanOrEqual(110);
     }
   });
 });
@@ -164,7 +170,56 @@ describe("SEO middleware", () => {
     );
     expect(canonicalEnglish.headers.get("location")).toBeNull();
   });
+
+  test("redirects fallback-only locale routes to translated content", () => {
+    for (const path of [
+      "/de/pricing",
+      "/de/docs/agent-integrations/oh-my-pi",
+    ]) {
+      const response = middleware(
+        requestFor(path, { "accept-language": "de" }),
+      );
+      expect(response.status).toBe(301);
+      expect(response.headers.get("location")).toBe(
+        `https://cmux.com${path.replace("/de", "")}`,
+      );
+    }
+
+    expect(
+      middleware(
+        requestFor("/ja/pricing", { "accept-language": "ja" }),
+      ).status,
+    ).toBe(200);
+  });
+
+  test("lists only translated fallback-content locales in the sitemap", () => {
+    const urls = sitemap()
+      .map((entry) => entry.url)
+      .filter(
+        (url) =>
+          url.endsWith("/pricing") ||
+          url.endsWith("/docs/agent-integrations/oh-my-pi"),
+      );
+    expect(urls).toEqual([
+      "https://cmux.com/pricing",
+      "https://cmux.com/ja/pricing",
+      "https://cmux.com/docs/agent-integrations/oh-my-pi",
+      "https://cmux.com/ja/docs/agent-integrations/oh-my-pi",
+    ]);
+  });
 });
+
+const searchWidthSegmenter = new Intl.Segmenter("en", {
+  granularity: "grapheme",
+});
+const wideSearchGrapheme =
+  /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}\p{Script=Thai}\p{Script=Khmer}\p{Extended_Pictographic}]/u;
+
+function searchSnippetLength(value: string) {
+  return Array.from(searchWidthSegmenter.segment(value), ({ segment }) =>
+    wideSearchGrapheme.test(segment) ? 2 : 1,
+  ).reduce((sum, length) => sum + length, 0);
+}
 
 function requestFor(pathname: string, headers: Record<string, string> = {}) {
   return new NextRequest(`https://cmux.com${pathname}`, {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -10,6 +10,7 @@ import {
   completeMetadataSentence,
   hasLocalizedSeoCopy,
   joinMetadataSentences,
+  joinMetadataQuestionAndAnswer,
   openGraphDefaults,
   openGraphImageTagline,
   seoDescription,
@@ -79,6 +80,9 @@ describe("SEO metadata helpers", () => {
       completeMetadataSentence("en", "The terminal built for multitasking"),
     ).toBe("The terminal built for multitasking.");
     expect(completeMetadataSentence("en", "Examples:")).toBe("Examples:");
+    expect(joinMetadataQuestionAndAnswer("th", "ทำไมต้อง cmux", "เพราะเร็ว")).toBe(
+      "ทำไมต้อง cmux? เพราะเร็ว.",
+    );
   });
 
   test("preserves overbound authored copy when no complete candidate fits", () => {
@@ -96,11 +100,16 @@ describe("SEO metadata helpers", () => {
       seoDescription("en", "X".repeat(200), {
         minLength: 110,
         fallbackCandidates: [
-          `Literal {new} placeholder ${"A".repeat(85)}`,
+          `Literal {count, plural, one {item} other {items}} ${"A".repeat(60)}`,
           safeCandidate,
         ],
       }),
     ).toBe(safeCandidate);
+    expect(
+      seoTitle("en", "Compare {product} for AI coding agents", {
+        fallbackCandidates: ["Complete safe metadata title for cmux"],
+      }),
+    ).toBe("Complete safe metadata title for cmux");
   });
 
   test("adds useful context to short titles and selects complete fallbacks", () => {
@@ -197,7 +206,11 @@ describe("SEO metadata helpers", () => {
         auditedRow(
           "/blog",
           blogIndexSeoCopy(locale, messageLookup(messages.blog), siteMeta),
-          [messages.blog.title, messages.blog.metaDescription],
+          [
+            messages.blog.title,
+            messages.blog.metaDescription,
+            messages.blog.description,
+          ],
         ),
         auditedRow(
           "/blog/cmux-history",
@@ -371,7 +384,7 @@ describe("SEO metadata helpers", () => {
           /…|<\/?(?:link|code)>/u,
         );
         expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
-          /\{[a-z][a-z0-9_]*\}/iu,
+          /[{}]/u,
         );
         expect(row.copy.description).not.toMatch(/[!?។៕。！？؟]\./u);
         expect(row.copy.description).not.toMatch(/[:：][.。]/u);
@@ -440,6 +453,7 @@ describe("SEO metadata helpers", () => {
     );
 
     expect(bestTerminalCopy.description).toContain(bestTerminal.faqQ2);
+    expect(bestTerminalCopy.description).toContain(`${bestTerminal.faqQ2}?`);
     expect(bestTerminalCopy.description).toContain(bestTerminal.faqA2);
     expect(bestTerminalCopy.description).not.toBe(bestTerminal.faqA1);
     expect(multipleAgentsCopy.title).toContain(
@@ -484,6 +498,16 @@ describe("SEO metadata helpers", () => {
         messages.pricing.title,
         "Built for AI coding agents on macOS.",
       ),
+    );
+
+    const khmerMessages = await messagesFor("km");
+    const khmerBlogCopy = blogIndexSeoCopy(
+      "km",
+      messageLookup(khmerMessages.blog),
+      messageLookup(khmerMessages.meta),
+    );
+    expect(khmerBlogCopy.description).toContain(
+      khmerMessages.blog.description,
     );
   });
 });

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -51,6 +51,24 @@ describe("SEO metadata helpers", () => {
     expect(long).not.toMatch(/\s…$/);
   });
 
+  test("keeps truncated descriptions above the minimum boundary", () => {
+    const description = seoDescription(
+      "en",
+      `${"A".repeat(100)}. ${"B".repeat(100)}`,
+    );
+    expect(Array.from(description).length).toBeGreaterThanOrEqual(110);
+    expect(Array.from(description).length).toBeLessThanOrEqual(160);
+  });
+
+  test("does not split Unicode characters at the metadata cutoff", () => {
+    const description = seoDescription(
+      "en",
+      `${"A".repeat(158)}😀${"B".repeat(20)}`,
+    );
+    expect(description).toContain("😀");
+    expect(Array.from(description).length).toBeLessThanOrEqual(160);
+  });
+
   test("adds useful context to short titles and trims long titles", () => {
     expect(seoTitle("en", "Blog")).toBe(
       "Blog — The terminal built for multitasking",

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -87,6 +87,11 @@ describe("SEO metadata helpers", () => {
     expect(long.endsWith("…")).toBe(true);
   });
 
+  test("can preserve a complete localized title below the generic minimum", () => {
+    const title = "cmux — 专为多任务打造的终端";
+    expect(seoTitle("zh-CN", title, { minLength: 0 })).toBe(title);
+  });
+
   test("adds complete shared social metadata", () => {
     expect(openGraphDefaults("en", "article")).toEqual({
       siteName: "cmux",

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -14,6 +14,7 @@ import {
   twitterSummary,
 } from "../i18n/seo";
 import { locales } from "../i18n/routing";
+import thMessages from "../messages/th.json";
 
 describe("SEO metadata helpers", () => {
   test("keeps canonical URLs locale-aware", () => {
@@ -77,6 +78,24 @@ describe("SEO metadata helpers", () => {
     );
     expect(description).toContain("👩🏽‍💻");
     expect(searchSnippetLength(description)).toBeLessThanOrEqual(160);
+  });
+
+  test("keeps dotted product names intact in localized descriptions", () => {
+    const description = seoDescription(
+      "th",
+      thMessages.landing.bestTerminal.metaDescription,
+    );
+    expect(description).toContain("Terminal.app");
+    expect(description).not.toContain("Terminal.…");
+    expect(searchSnippetLength(description)).toBeLessThanOrEqual(160);
+  });
+
+  test("truncates Thai titles at a word boundary", () => {
+    const title = seoTitle("th", thMessages.blog.cmuxHistory.metaTitle);
+    expect(title).toBe(
+      "cmux history: เปิดเทอร์มินัลและเซสชันที่ปิด…",
+    );
+    expect(searchSnippetLength(title)).toBeLessThanOrEqual(60);
   });
 
   test("adds useful context to short titles and trims long titles", () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { NextRequest } from "next/server";
 import sitemap from "../app/sitemap";
+import { legalMetadata } from "../app/[locale]/(legal)/legal-metadata";
 import middleware from "../proxy";
 import {
   buildAlternates,
@@ -105,6 +106,13 @@ describe("SEO metadata helpers", () => {
     const fallback =
       "Talk with cmux about Enterprise deployment, SSO, self-hosted Cloud VMs, audit logs, and committed usage.";
     expect(seoDescription("de", fallback)).toBe(fallback);
+  });
+
+  test("keeps legal descriptions limited to their legal summary", () => {
+    const summary = "The terms that govern use of cmux.";
+    expect(legalMetadata("/terms-of-service", "Terms", summary).description).toBe(
+      summary,
+    );
   });
 
   test("adds complete shared social metadata", () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -385,6 +385,7 @@ describe("SEO metadata helpers", () => {
           expect(titleLength).toBeGreaterThanOrEqual(30);
         }
         expect(titleLength).toBeLessThanOrEqual(60);
+        expect(row.copy.title).not.toMatch(/cmux\s*—\s*cmux/iu);
         expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
           /…|<\/?(?:link|code)>/u,
         );

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -53,6 +53,15 @@ describe("SEO metadata helpers", () => {
     );
     expect(seoDescription("ja", "Hacker Newsでcmuxをローンチした話。"))
       .toContain("縦型タブ、通知、分割ペイン、ブラウザ自動化、セッション復元");
+    const thaiDescription = seoDescription(
+      "th",
+      "ทำไมเราถึงสร้าง cmux เทอร์มินัลใหม่สำหรับ macOS",
+    );
+    expect(thaiDescription).toContain(
+      "สร้างมาเพื่อเอเจนต์เขียนโค้ด AI บน macOS.",
+    );
+    expect(searchSnippetLength(thaiDescription)).toBeGreaterThanOrEqual(90);
+    expect(searchSnippetLength(thaiDescription)).toBeLessThanOrEqual(160);
     const overboundWithSuffix =
       "A detailed page about running multiple coding agents in cmux on macOS.";
     expect(
@@ -637,6 +646,24 @@ describe("SEO middleware", () => {
       "https://cmux.com/en/pricing",
     );
     expect(unavailableCookieLocale.headers.get("set-cookie")).toBeNull();
+
+    const encodedUnavailableLocale = middleware(
+      requestFor("/de/pr%69cing", { "accept-language": "de" }),
+    );
+    expect(encodedUnavailableLocale.status).toBe(301);
+    expect(encodedUnavailableLocale.headers.get("location")).toBe(
+      "https://cmux.com/pricing",
+    );
+
+    const encodedDocsLocale = middleware(
+      requestFor("/de/docs/agent-integrations/oh-my-p%69", {
+        "accept-language": "de",
+      }),
+    );
+    expect(encodedDocsLocale.status).toBe(301);
+    expect(encodedDocsLocale.headers.get("location")).toBe(
+      "https://cmux.com/docs/agent-integrations/oh-my-pi",
+    );
 
     const japanese = middleware(
       requestFor("/ja/pricing", { "accept-language": "ja" }),

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -73,16 +73,10 @@ describe("SEO metadata helpers", () => {
   test("does not split Unicode characters at the metadata cutoff", () => {
     const description = seoDescription(
       "en",
-      `${"A".repeat(158)}👩🏽‍💻${"B".repeat(20)}`,
+      `${"A".repeat(157)}👩🏽‍💻${"B".repeat(20)}`,
     );
     expect(description).toContain("👩🏽‍💻");
-    expect(
-      Array.from(
-        new Intl.Segmenter("en", { granularity: "grapheme" }).segment(
-          description,
-        ),
-      ).length,
-    ).toBeLessThanOrEqual(160);
+    expect(searchSnippetLength(description)).toBeLessThanOrEqual(160);
   });
 
   test("adds useful context to short titles and trims long titles", () => {
@@ -141,6 +135,10 @@ describe("SEO metadata helpers", () => {
 
   test("has localized SEO fallback copy for every configured locale", () => {
     for (const locale of locales) {
+      const detailedDescription = seoDescription(locale, "CLI reference", {
+        minLength: 110,
+      });
+      const detailedLength = searchSnippetLength(detailedDescription);
       expect(hasLocalizedSeoCopy(locale)).toBe(true);
       expect(seoDescription(locale, "CLI reference").length).toBeGreaterThan(
         "CLI reference".length,
@@ -150,11 +148,8 @@ describe("SEO metadata helpers", () => {
       expect(seoDescription(locale, "CLI reference").length).toBeLessThanOrEqual(
         160,
       );
-      expect(
-        searchSnippetLength(
-          seoDescription(locale, "CLI reference", { minLength: 110 }),
-        ),
-      ).toBeGreaterThanOrEqual(110);
+      expect(detailedLength).toBeGreaterThanOrEqual(110);
+      expect(detailedLength).toBeLessThanOrEqual(160);
     }
   });
 });

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -8,6 +8,7 @@ import {
   buildAlternates,
   canonicalUrl,
   hasLocalizedSeoCopy,
+  joinMetadataSentences,
   openGraphDefaults,
   openGraphImageTagline,
   seoDescription,
@@ -64,6 +65,12 @@ describe("SEO metadata helpers", () => {
 
     const original = "A very long metadata description ".repeat(12).trim();
     expect(seoDescription("en", original)).toBe(original);
+  });
+
+  test("joins metadata sentences without duplicating localized punctuation", () => {
+    expect(joinMetadataSentences("សាកល្បង។", "បន្ទាប់")).toBe(
+      "សាកល្បង។ បន្ទាប់",
+    );
   });
 
   test("preserves overbound authored copy when no complete candidate fits", () => {

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -625,6 +625,19 @@ describe("SEO middleware", () => {
       "https://cmux.com/en/pricing",
     );
 
+    const unavailableCookieLocale = middleware(
+      requestFor("/pricing", {
+        cookie: "NEXT_LOCALE=de",
+        "accept-language": "ja,en;q=0.9",
+      }),
+    );
+    expect(unavailableCookieLocale.status).toBe(200);
+    expect(unavailableCookieLocale.headers.get("location")).toBeNull();
+    expect(unavailableCookieLocale.headers.get("x-middleware-rewrite")).toBe(
+      "https://cmux.com/en/pricing",
+    );
+    expect(unavailableCookieLocale.headers.get("set-cookie")).toBeNull();
+
     const japanese = middleware(
       requestFor("/ja/pricing", { "accept-language": "ja" }),
     );

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -51,6 +51,8 @@ describe("SEO metadata helpers", () => {
     ).toContain(
       "macOS の AI コーディングエージェント向け。",
     );
+    expect(seoDescription("ja", "Hacker Newsでcmuxをローンチした話。"))
+      .toContain("縦型タブ、通知、分割ペイン、ブラウザ自動化、セッション復元");
     const overboundWithSuffix =
       "A detailed page about running multiple coding agents in cmux on macOS.";
     expect(

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -258,11 +258,13 @@ describe("SEO metadata helpers", () => {
             pageMessages.title,
             pageMessages.metaDescription,
             pageMessages.faqQ1,
+            pageMessages.faqQ2,
+            pageMessages.faqQ3,
             pageMessages.summaryBody,
             pageMessages.intro,
-            pageMessages.faqA1,
-            pageMessages.faqA2,
-            pageMessages.faqA3,
+            ...(page.key === "bestTerminalForAgents"
+              ? [messages.landing.links.agents]
+              : []),
           ],
           page.key === "bestTerminalForAgents"
             ? [
@@ -274,7 +276,7 @@ describe("SEO metadata helpers", () => {
                 pageMessages.metaTitle,
                 pageMessages.title,
                 ...(page.key === "multipleClaudeAgents"
-                  ? ["cmux · Claude Code"]
+                  ? [messages.landing.links.claudeTeams]
                   : []),
               ],
           ),
@@ -331,6 +333,7 @@ describe("SEO metadata helpers", () => {
         expect(`${row.copy.title}${row.copy.description}`).not.toMatch(
           /…|<\/?(?:link|code)>/u,
         );
+        expect(row.copy.description).not.toMatch(/[!?។៕。！？؟]\./u);
         const hasRouteContext = row.contexts.some(
           (context) =>
             context.length > 0 && row.copy.description.includes(context),
@@ -370,6 +373,47 @@ describe("SEO metadata helpers", () => {
     expect(copy.description).toContain(page.title);
     expect(searchSnippetLength(copy.description)).toBeGreaterThanOrEqual(110);
     expect(searchSnippetLength(copy.description)).toBeLessThanOrEqual(160);
+  });
+
+  test("keeps synthesized compare metadata tied to its localized route", async () => {
+    const messages = await messagesFor("th");
+    const lookup = messageLookup(messages.landing.links);
+    const siteMeta = messageLookup(messages.meta);
+    const bestTerminal = messages.landing.compare.pages.bestTerminalForAgents;
+    const bestTerminalCopy = comparePageSeoCopy(
+      "th",
+      "bestTerminalForAgents",
+      messageLookup(bestTerminal),
+      lookup,
+      siteMeta,
+    );
+    const multipleAgents = messages.landing.compare.pages.multipleClaudeAgents;
+    const multipleAgentsCopy = comparePageSeoCopy(
+      "th",
+      "multipleClaudeAgents",
+      messageLookup(multipleAgents),
+      lookup,
+      siteMeta,
+    );
+
+    expect(bestTerminalCopy.description).toContain(messages.landing.links.agents);
+    expect(bestTerminalCopy.description).not.toBe(bestTerminal.faqA1);
+    expect(multipleAgentsCopy.title).toContain(
+      messages.landing.links.claudeTeams,
+    );
+    expect(multipleAgentsCopy.title).not.toContain("cmux · Claude Code");
+
+    const khmerMessages = await messagesFor("km");
+    const khmerMultipleAgents =
+      khmerMessages.landing.compare.pages.multipleClaudeAgents;
+    const khmerCopy = comparePageSeoCopy(
+      "km",
+      "multipleClaudeAgents",
+      messageLookup(khmerMultipleAgents),
+      messageLookup(khmerMessages.landing.links),
+      messageLookup(khmerMessages.meta),
+    );
+    expect(khmerCopy.description).not.toContain("។.");
   });
 });
 
@@ -428,6 +472,35 @@ describe("SEO middleware", () => {
     );
     expect(negotiatedJapanese.headers.get("location")).not.toContain("/en/");
 
+    const wildcardPrefersEnglish = middleware(
+      requestFor("/pricing", {
+        "accept-language": "ja;q=0.5,*;q=0.9",
+      }),
+    );
+    expect(wildcardPrefersEnglish.status).toBe(200);
+    expect(wildcardPrefersEnglish.headers.get("location")).toBeNull();
+    expect(wildcardPrefersEnglish.headers.get("x-middleware-rewrite")).toBe(
+      "https://cmux.com/en/pricing",
+    );
+
+    const wildcardExcludesEnglish = middleware(
+      requestFor("/pricing", {
+        "accept-language": "en;q=0,*;q=1",
+      }),
+    );
+    expect(wildcardExcludesEnglish.status).toBe(307);
+    expect(wildcardExcludesEnglish.headers.get("location")).toBe(
+      "https://cmux.com/ja/pricing",
+    );
+
+    const invalidJapaneseQuality = middleware(
+      requestFor("/pricing", {
+        "accept-language": "ja;q=0.8oops,en;q=0.4",
+      }),
+    );
+    expect(invalidJapaneseQuality.status).toBe(200);
+    expect(invalidJapaneseQuality.headers.get("location")).toBeNull();
+
     const cookieJapanese = middleware(
       requestFor("/pricing", {
         cookie: "NEXT_LOCALE=ja",
@@ -437,6 +510,18 @@ describe("SEO middleware", () => {
     expect(cookieJapanese.status).toBe(307);
     expect(cookieJapanese.headers.get("location")).toBe(
       "https://cmux.com/ja/pricing",
+    );
+
+    const cookieEnglish = middleware(
+      requestFor("/pricing", {
+        cookie: "NEXT_LOCALE=en",
+        "accept-language": "en;q=0,*;q=1",
+      }),
+    );
+    expect(cookieEnglish.status).toBe(200);
+    expect(cookieEnglish.headers.get("location")).toBeNull();
+    expect(cookieEnglish.headers.get("x-middleware-rewrite")).toBe(
+      "https://cmux.com/en/pricing",
     );
 
     const japanese = middleware(

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -7,6 +7,7 @@ import middleware from "../proxy";
 import {
   buildAlternates,
   canonicalUrl,
+  completeMetadataSentence,
   hasLocalizedSeoCopy,
   joinMetadataSentences,
   openGraphDefaults,
@@ -68,9 +69,15 @@ describe("SEO metadata helpers", () => {
   });
 
   test("joins metadata sentences without duplicating localized punctuation", () => {
-    expect(joinMetadataSentences("សាកល្បង។", "បន្ទាប់")).toBe(
+    expect(joinMetadataSentences("km", "សាកល្បង។", "បន្ទាប់")).toBe(
       "សាកល្បង។ បន្ទាប់",
     );
+    expect(joinMetadataSentences("ja", "ブランドアセット", "次の文です。")).toBe(
+      "ブランドアセット。次の文です。",
+    );
+    expect(
+      completeMetadataSentence("en", "The terminal built for multitasking"),
+    ).toBe("The terminal built for multitasking.");
   });
 
   test("preserves overbound authored copy when no complete candidate fits", () => {
@@ -272,6 +279,9 @@ describe("SEO metadata helpers", () => {
             ...(page.key === "bestTerminalForAgents"
               ? [messages.landing.links.agents]
               : []),
+            ...(page.key === "multipleClaudeAgents"
+              ? [messages.landing.links.claudeTeams]
+              : []),
           ],
           page.key === "bestTerminalForAgents"
             ? [
@@ -297,7 +307,11 @@ describe("SEO metadata helpers", () => {
           auditedRow(
             "/pricing",
             pricingSeoCopy(locale, pricing, siteMeta, "metaDescription"),
-            [messages.pricing.title, messages.pricing.metaDescription],
+            [
+              messages.pricing.title,
+              messages.pricing.metaDescription,
+              messages.pricing.metaDescriptionShort,
+            ],
           ),
           auditedRow(
             "/pricing?without-vault",
@@ -307,7 +321,11 @@ describe("SEO metadata helpers", () => {
               siteMeta,
               "metaDescriptionNoVault",
             ),
-            [messages.pricing.title, messages.pricing.metaDescriptionNoVault],
+            [
+              messages.pricing.title,
+              messages.pricing.metaDescriptionNoVault,
+              messages.pricing.metaDescriptionNoVaultShort,
+            ],
           ),
           auditedRow(
             "/docs/agent-integrations/oh-my-pi",
@@ -341,6 +359,7 @@ describe("SEO metadata helpers", () => {
           /…|<\/?(?:link|code)>/u,
         );
         expect(row.copy.description).not.toMatch(/[!?។៕。！？؟]\./u);
+        expect(row.copy.description).toMatch(/[.!?。！？؟។៕]$/u);
         const hasRouteContext = row.contexts.some(
           (context) =>
             context.length > 0 && row.copy.description.includes(context),
@@ -377,7 +396,8 @@ describe("SEO metadata helpers", () => {
 
     expect(searchSnippetLength("ក\u17D2ម")).toBe(4);
     expect(copy.description).not.toBe(page.metaDescription);
-    expect(copy.description).toContain(page.title);
+    expect(copy.description).toContain(page.faqQ2);
+    expect(copy.description).toContain(page.faqA2);
     expect(searchSnippetLength(copy.description)).toBeGreaterThanOrEqual(110);
     expect(searchSnippetLength(copy.description)).toBeLessThanOrEqual(160);
   });
@@ -403,7 +423,8 @@ describe("SEO metadata helpers", () => {
       siteMeta,
     );
 
-    expect(bestTerminalCopy.description).toContain(messages.landing.links.agents);
+    expect(bestTerminalCopy.description).toContain(bestTerminal.faqQ2);
+    expect(bestTerminalCopy.description).toContain(bestTerminal.faqA2);
     expect(bestTerminalCopy.description).not.toBe(bestTerminal.faqA1);
     expect(multipleAgentsCopy.title).toContain(
       messages.landing.links.claudeTeams,
@@ -421,6 +442,33 @@ describe("SEO metadata helpers", () => {
       messageLookup(khmerMessages.meta),
     );
     expect(khmerCopy.description).not.toContain("។.");
+  });
+
+  test("prefers complete route prose over generic metadata context", async () => {
+    const messages = await messagesFor("en");
+    const siteMeta = messageLookup(messages.meta);
+    const communityCopy = communitySeoCopy(
+      "en",
+      messageLookup(messages.community),
+      siteMeta,
+    );
+    const pricingCopy = pricingSeoCopy(
+      "en",
+      messageLookup(messages.pricing),
+      siteMeta,
+      "metaDescription",
+    );
+
+    expect(communityCopy.description).toContain(messages.community.description);
+    expect(pricingCopy.description).toContain("Pro");
+    expect(pricingCopy.description).toContain("Enterprise");
+    expect(pricingCopy.description).not.toBe(
+      joinMetadataSentences(
+        "en",
+        messages.pricing.title,
+        "Built for AI coding agents on macOS.",
+      ),
+    );
   });
 });
 

--- a/web/tools/build-docs-search.mjs
+++ b/web/tools/build-docs-search.mjs
@@ -5,6 +5,7 @@ import { fileURLToPath } from "node:url";
 import * as ts from "typescript";
 import {
   flatNavItems,
+  hasNavItemContent,
   navItems,
   navItemsForLocale,
 } from "../app/[locale]/components/docs-nav-items";
@@ -55,12 +56,14 @@ const docsPageMessageKeys = {
 
 export function docsSearchRoutes() {
   return routing.locales.flatMap((locale) =>
-    flatNavItems(navItemsForLocale(locale)).map((navItem) => ({
-      locale,
-      navItem,
-      href: navItem.href,
-      path: localizedDocsPath(locale, navItem.href),
-    })),
+    flatNavItems(navItemsForLocale(locale))
+      .filter((navItem) => hasNavItemContent(navItem, locale))
+      .map((navItem) => ({
+        locale,
+        navItem,
+        href: navItem.href,
+        path: localizedDocsPath(locale, navItem.href),
+      })),
   );
 }
 


### PR DESCRIPTION
Fixes the actionable metadata findings in the [cmux Ahrefs crawl](https://app.ahrefs.com/site-audit/9589643/issues).

- bounds descriptions to 110–160 characters where language structure supports it, with localized product context for short copy
- bounds flagged page titles and adds localized context to short standalone titles
- adds canonical Open Graph URLs and complete social cards to pricing, legal, and oh-my-pi pages
- preserves concise CJK metadata where raw character-count thresholds are not meaningful

Validation:
- `bun test tests/seo.test.ts`
- `bun run typecheck`
- focused `bun run lint`
- `bun run build`
- rendered representative English and localized routes locally and verified title, description, and `og:url` output

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7888"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786361131&installation_id=133855650&pr_number=7888&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7888&signature=43b988eeb005907022db76ddf88eecf59e9ac7243a0ef24b3d03151068fca491"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide touch on middleware redirects, canonical/hreflang behavior, and metadata synthesis across all locales; mistakes could affect SEO indexing or send users to wrong locale URLs, but changes are heavily covered by expanded `seo.test.ts`.
> 
> **Overview**
> Addresses Ahrefs audit findings by centralizing **route-specific SEO** in `i18n/audited-seo.ts` and upgrading `seoTitle` / `seoDescription` to pick localized titles and descriptions within search-width bounds (Unicode-aware), using authored fallbacks instead of bare `metaTitle` + `seoDescription` on key landing, blog, compare, home, pricing, and docs pages.
> 
> **Metadata & social:** Blog/compare JSON-LD and `BlogSchema` can reuse the same headline/description as `<meta>`. Legal pages share `legalMetadata` with full OG/Twitter and English-only canonicals. Pricing and oh-my-pi gain complete social cards and canonical `og:url`; some blog routes use `title: { absolute: ... }`.
> 
> **en/ja-only content:** Pricing and oh-my-pi are limited to `fallbackContentLocales`; middleware negotiates locale, rewrites/redirects unsupported prefixes, and sets `hreflang` `Link` headers. `ContentLocaleLink` routes nav/footer/docs links to canonical English or `/ja/...` when translated; sitemap, agent-readable pages, and docs search index respect the same rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a261994a1fd1499b3505fa7e1b4043d9aabe9a0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes localized SEO metadata from the Ahrefs audit and finalizes en/ja-only fallback-content routing for Pricing and Oh My Pi. Centralizes route‑specific SEO copy with deterministic, Unicode‑safe widths and normalizes encoded paths so canonicals, social cards, and redirects stay stable.

- **Bug Fixes**
  - Titles/descriptions: enforce 30–60/110–160 search-width bounds with Unicode‑ and grapheme‑safe counts (incl. Khmer/emoji); preserve over‑bound authored copy; keep source language when best; join sentences/Q&A with localized punctuation; avoid ellipses; reject HTML/placeholders/lead‑ins; skip trailing-colon/duplicate‑punctuation fragments. Home allows short CJK titles and aligns OG/Twitter with the page description.
  - Route identity: new helpers in `i18n/audited-seo.ts` plus `seoTitle`/`seoDescription` select contextual authored fallbacks; blog/compare JSON‑LD can reuse the exact `<meta>` headline/description via schema overrides; compare page titles are unique.
  - Canonicals/social: set `openGraph.url` from the canonical and emit full Open Graph/Twitter cards in the content locale. Legal pages share `legalMetadata` for English‑only canonicals without marketing padding.
  - Audited pages: home, assets, community, best‑terminal, blog index/history, compare index/pages, pricing, and Oh My Pi now read bounded, localized copy via `i18n/audited-seo.ts`.
  - Tests: expand coverage for middleware locale negotiation (q‑values, wildcards, cookies), path decoding/normalization, docs search indexing, and content‑locale links; stabilize `next/navigation` pathname mocks.

- **Fallback Content & Links**
  - Middleware for en/ja‑only routes (Pricing, Oh My Pi): decodes/normalizes paths, negotiates locale from `NEXT_LOCALE` and `Accept-Language`, rewrites bare paths to canonical English, 307s to `/ja/...` when preferred, 301s unsupported locale prefixes, and sets `Link` `hreflang` for `en`/`ja` only.
  - Linking/indexing: sitemap and agent‑readable pages list only those locales; docs search indexes only locales with content. `ContentLocaleLink` emits direct English hrefs (no `/en`) or `/ja/...` when translated and is used in the header, nav, footer, docs sidebar/pager, and the Pro banner.

<sup>Written for commit a261994a1fd1499b3505fa7e1b4043d9aabe9a0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **SEO Improvements**
  * Updated page metadata titles/descriptions across landing, blog, docs, community, compare, pricing, and the locale layout to use shared, locale-aware SEO helpers.
  * Improved snippet length handling (configurable min/max), Unicode-safe truncation, and consistent Open Graph/Twitter title/description output.
  * Applied `minLength: 110` for descriptions where applicable.
* **Legal Pages**
  * Standardized EULA, privacy policy, and Terms of Service metadata via a shared legal-page helper.
* **Localization & Fallback Content**
  * Added fallback-content support for selected routes, including sitemap localization and middleware rewrite/redirect behavior.
* **Tests**
  * Expanded SEO helper coverage for localized formatting, length bounds, ellipsis behavior, and grapheme cluster safety.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->