### PR TITLE
cmux-tui: WebSocket transport for third-party frontends

### DIFF
--- a/cmux-tui/crates/cmux-tui-core/Cargo.toml
+++ b/cmux-tui/crates/cmux-tui-core/Cargo.toml
@@ -20,9 +20,7 @@ anyhow.workspace = true
 base64.workspace = true
 libc.workspace = true
 regex.workspace = true
+tungstenite.workspace = true
 
 [target.'cfg(windows)'.dependencies]
 uds_windows.workspace = true
-
-[dev-dependencies]
-tungstenite.workspace = true

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -1,9 +1,9 @@
-//! Control socket: a JSON-lines protocol over the platform transport.
+//! Control protocol server over Unix JSON-lines and WebSocket text frames.
 //!
 //! This is the attach surface for external frontends (the cmux app, the
-//! bundled `cmux-tui attach` client, scripts). One JSON request per line;
-//! every request gets one JSON response line. Two commands additionally
-//! turn the connection full-duplex:
+//! bundled `cmux-tui attach` client, scripts). Unix uses one JSON message
+//! per line and WebSocket uses one JSON message per text frame. Two commands
+//! additionally turn the connection full-duplex:
 //!
 //! - `subscribe` — the server pushes `{"event":...}` lines (tree-changed,
 //!   surface-output, surface-exited, title-changed, bell) interleaved
@@ -20,15 +20,21 @@
 
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
+use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::{Arc, Mutex};
-use std::time::Instant;
+use std::thread::JoinHandle;
+use std::time::{Duration, Instant};
 
 use base64::Engine;
 use ghostty_vt::{KeyEncoder, key_input_from_chord};
 use regex::Regex;
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use tungstenite::protocol::CloseFrame;
+use tungstenite::protocol::frame::coding::CloseCode;
+use tungstenite::{Error as WebSocketError, Message, WebSocket, accept};
 
 use crate::model::{Screen, State};
 use crate::platform::{self, transport};
@@ -408,17 +414,81 @@ struct Response {
     error: Option<String>,
 }
 
-/// Line-oriented shared writer: responses and event streams interleave
-/// whole lines.
-#[derive(Clone)]
-struct LineWriter(Arc<Mutex<Box<dyn transport::Stream>>>);
+const STREAM_DISCONNECT_POLL: Duration = Duration::from_millis(100);
 
-impl LineWriter {
+trait MessageSink: Send + Sync {
+    fn send(&self, value: &Value) -> std::io::Result<()>;
+    fn close(&self);
+}
+
+/// Transport-independent writer shared by command responses and event streams.
+#[derive(Clone)]
+struct MessageWriter {
+    sink: Arc<dyn MessageSink>,
+    open: Arc<AtomicBool>,
+}
+
+impl MessageWriter {
+    fn new(sink: impl MessageSink + 'static) -> Self {
+        Self { sink: Arc::new(sink), open: Arc::new(AtomicBool::new(true)) }
+    }
+
+    fn send(&self, value: &Value) -> std::io::Result<()> {
+        if !self.is_open() {
+            return Err(std::io::Error::new(std::io::ErrorKind::BrokenPipe, "connection closed"));
+        }
+        self.sink.send(value)
+    }
+
+    fn is_open(&self) -> bool {
+        self.open.load(Ordering::Acquire)
+    }
+
+    fn close(&self) {
+        if self.open.swap(false, Ordering::AcqRel) {
+            self.sink.close();
+        }
+    }
+}
+
+struct LineSink(Arc<Mutex<Box<dyn transport::Stream>>>);
+
+impl MessageSink for LineSink {
     fn send(&self, value: &Value) -> std::io::Result<()> {
         let mut bytes = serde_json::to_vec(value)?;
         bytes.push(b'\n');
         let mut stream = self.0.lock().unwrap();
         stream.write_all(&bytes)
+    }
+
+    fn close(&self) {}
+}
+
+struct WebSocketSink(Mutex<WebSocket<TcpStream>>);
+
+impl WebSocketSink {
+    fn read(&self) -> Result<Message, WebSocketError> {
+        self.0.lock().unwrap().read()
+    }
+
+    fn flush(&self) -> Result<(), WebSocketError> {
+        self.0.lock().unwrap().flush()
+    }
+
+    fn reject_auth(&self) {
+        let frame = CloseFrame { code: CloseCode::Policy, reason: "authentication failed".into() };
+        let _ = self.0.lock().unwrap().close(Some(frame));
+    }
+}
+
+impl MessageSink for Arc<WebSocketSink> {
+    fn send(&self, value: &Value) -> std::io::Result<()> {
+        let text = serde_json::to_string(value)?;
+        self.0.lock().unwrap().send(Message::Text(text.into())).map_err(websocket_io_error)
+    }
+
+    fn close(&self) {
+        let _ = self.0.lock().unwrap().close(None);
     }
 }
 
@@ -454,6 +524,74 @@ pub fn serve(mux: Arc<Mux>, path: Option<PathBuf>) -> anyhow::Result<PathBuf> {
     Ok(path)
 }
 
+/// A running opt-in WebSocket listener. Dropping it stops accepts and closes clients.
+pub struct WebSocketServer {
+    local_addr: SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    connections: Arc<Mutex<HashMap<u64, TcpStream>>>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl WebSocketServer {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+}
+
+impl Drop for WebSocketServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Release);
+        for stream in self.connections.lock().unwrap().values() {
+            let _ = stream.shutdown(Shutdown::Both);
+        }
+        let _ = TcpStream::connect(self.local_addr);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+/// Bind an opt-in WebSocket listener using one JSON message per text frame.
+pub fn serve_websocket(
+    mux: Arc<Mux>,
+    addr: SocketAddr,
+    token: Option<String>,
+    allow_insecure_bind: bool,
+) -> anyhow::Result<WebSocketServer> {
+    // WebSocket has no TLS here. Remote deployments must explicitly opt in and
+    // should put cmux-tui behind a TLS-terminating reverse proxy.
+    if !addr.ip().is_loopback() && !allow_insecure_bind {
+        anyhow::bail!("refusing non-loopback WebSocket bind {addr} without --ws-insecure-bind");
+    }
+    let listener = TcpListener::bind(addr)?;
+    let local_addr = listener.local_addr()?;
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let connections = Arc::new(Mutex::new(HashMap::new()));
+    let next_connection = Arc::new(AtomicU64::new(1));
+    let thread_shutdown = shutdown.clone();
+    let thread_connections = connections.clone();
+    let thread = std::thread::Builder::new().name("mux-ws-server".into()).spawn(move || {
+        while !thread_shutdown.load(Ordering::Acquire) {
+            let Ok((stream, _)) = listener.accept() else { continue };
+            if thread_shutdown.load(Ordering::Acquire) {
+                break;
+            }
+            let id = next_connection.fetch_add(1, Ordering::Relaxed);
+            if let Ok(tracked) = stream.try_clone() {
+                thread_connections.lock().unwrap().insert(id, tracked);
+            }
+            let mux = mux.clone();
+            let token = token.clone();
+            let connections = thread_connections.clone();
+            let _ = std::thread::Builder::new().name("mux-ws-conn".into()).spawn(move || {
+                handle_websocket_connection(mux, stream, token.as_deref());
+                connections.lock().unwrap().remove(&id);
+            });
+        }
+    })?;
+    Ok(WebSocketServer { local_addr, shutdown, connections, thread: Some(thread) })
+}
+
 pub fn window_title_osc(title: &str) -> Vec<u8> {
     let title = sanitize_window_title(title);
     format!("\x1b]0;{title}\x07\x1b]2;{title}\x07").into_bytes()
@@ -471,33 +609,103 @@ fn sanitize_window_title(title: &str) -> String {
 
 fn handle_connection(mux: Arc<Mux>, stream: Box<dyn transport::Stream>) {
     let Ok(write_half) = stream.try_clone_box() else { return };
-    let writer = LineWriter(Arc::new(Mutex::new(write_half)));
+    let writer = MessageWriter::new(LineSink(Arc::new(Mutex::new(write_half))));
     let reader = BufReader::new(stream);
     for line in reader.lines() {
         let Ok(line) = line else { break };
         if line.trim().is_empty() {
             continue;
         }
-        let response = match serde_json::from_str::<Request>(&line) {
-            Ok(req) => {
-                let id = req.id.clone();
-                match handle_command(&mux, req.cmd, &writer) {
-                    Ok(data) => Response { id, ok: true, data: Some(data), error: None },
-                    Err(e) => Response { id, ok: false, data: None, error: Some(e.to_string()) },
-                }
-            }
-            Err(e) => Response {
-                id: None,
-                ok: false,
-                data: None,
-                error: Some(format!("bad request: {e}")),
-            },
-        };
-        let Ok(value) = serde_json::to_value(&response) else { break };
-        if writer.send(&value).is_err() {
+        if !handle_message(&mux, &line, &writer) {
             break;
         }
     }
+    writer.close();
+}
+
+fn handle_websocket_connection(mux: Arc<Mux>, stream: TcpStream, token: Option<&str>) {
+    let Ok(websocket) = accept(stream) else { return };
+    let sink = Arc::new(WebSocketSink(Mutex::new(websocket)));
+    let writer = MessageWriter::new(sink.clone());
+
+    if let Some(expected) = token {
+        let authenticated = match sink.read() {
+            Ok(Message::Text(text)) => auth_token(&text)
+                .is_some_and(|provided| constant_time_eq(provided.as_bytes(), expected.as_bytes())),
+            _ => false,
+        };
+        if !authenticated {
+            sink.reject_auth();
+            writer.close();
+            return;
+        }
+    }
+    let _ = sink.0.lock().unwrap().get_mut().set_read_timeout(Some(STREAM_DISCONNECT_POLL));
+
+    while writer.is_open() {
+        match sink.read() {
+            Ok(Message::Text(text)) => {
+                if !handle_message(&mux, &text, &writer) {
+                    break;
+                }
+            }
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
+                let _ = sink.flush();
+            }
+            Ok(Message::Close(_)) => break,
+            Ok(_) => break,
+            Err(WebSocketError::Io(error))
+                if matches!(
+                    error.kind(),
+                    std::io::ErrorKind::WouldBlock | std::io::ErrorKind::TimedOut
+                ) => {}
+            Err(_) => break,
+        }
+    }
+    writer.close();
+}
+
+fn handle_message(mux: &Arc<Mux>, message: &str, writer: &MessageWriter) -> bool {
+    let response = match serde_json::from_str::<Request>(message) {
+        Ok(req) => {
+            let id = req.id.clone();
+            match handle_command(mux, req.cmd, writer) {
+                Ok(data) => Response { id, ok: true, data: Some(data), error: None },
+                Err(e) => Response { id, ok: false, data: None, error: Some(e.to_string()) },
+            }
+        }
+        Err(e) => {
+            Response { id: None, ok: false, data: None, error: Some(format!("bad request: {e}")) }
+        }
+    };
+    serde_json::to_value(&response).is_ok_and(|value| writer.send(&value).is_ok())
+}
+
+fn auth_token(message: &str) -> Option<String> {
+    let value: Value = serde_json::from_str(message).ok()?;
+    let object = value.as_object()?;
+    if object.len() != 1 {
+        return None;
+    }
+    let auth = object.get("auth")?.as_object()?;
+    if auth.len() != 1 {
+        return None;
+    }
+    auth.get("token")?.as_str().map(str::to_string)
+}
+
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    let mut difference = a.len() ^ b.len();
+    let length = a.len().max(b.len());
+    for index in 0..length {
+        difference |=
+            usize::from(a.get(index).copied().unwrap_or(0) ^ b.get(index).copied().unwrap_or(0));
+    }
+    difference == 0
+}
+
+fn websocket_io_error(error: WebSocketError) -> std::io::Error {
+    std::io::Error::other(error)
 }
 
 fn node_json(node: &Node) -> Value {
@@ -832,13 +1040,18 @@ fn browser_state_json(
 fn spawn_attach_notification_stream(
     mux: Arc<Mux>,
     surface_id: SurfaceId,
-    writer: LineWriter,
+    writer: MessageWriter,
 ) -> std::io::Result<()> {
     let events = mux.subscribe();
     std::thread::Builder::new()
         .name("mux-attach-notifications".into())
         .spawn(move || {
-            while let Ok(event) = events.recv() {
+            while writer.is_open() {
+                let event = match events.recv_timeout(STREAM_DISCONNECT_POLL) {
+                    Ok(event) => event,
+                    Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                    Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                };
                 let value = match event {
                     MuxEvent::Notification(notification)
                         if notification.surface == Some(surface_id) =>
@@ -872,7 +1085,7 @@ fn spawn_attach_notification_stream(
         .map(|_| ())
 }
 
-fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::Result<Value> {
+fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &MessageWriter) -> anyhow::Result<Value> {
     match cmd {
         Command::Identify => Ok(json!({
             "app": "cmux-tui",
@@ -958,7 +1171,7 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                 }
                 anyhow::bail!("timeout waiting for pattern");
             }
-            let deadline = start + std::time::Duration::from_millis(timeout_ms);
+            let deadline = start + Duration::from_millis(timeout_ms);
             let attach = surface.attach_stream()?;
             if let Some(text) = check()? {
                 return Ok(json!({
@@ -1367,7 +1580,12 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             let events = mux.subscribe();
             let writer = writer.clone();
             std::thread::Builder::new().name("mux-events-out".into()).spawn(move || {
-                while let Ok(event) = events.recv() {
+                while writer.is_open() {
+                    let event = match events.recv_timeout(STREAM_DISCONNECT_POLL) {
+                        Ok(event) => event,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    };
                     let value = match &event {
                         MuxEvent::SurfaceOutput(id) => {
                             json!({"event": "surface-output", "surface": id})
@@ -1431,7 +1649,12 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
                 writer.send(&browser_state_json(surface_id, &state, true))?;
                 let writer = writer.clone();
                 std::thread::Builder::new().name("mux-attach-out".into()).spawn(move || {
-                    while frames.notify.recv().is_ok() {
+                    while writer.is_open() {
+                        match frames.notify.recv_timeout(STREAM_DISCONNECT_POLL) {
+                            Ok(()) => {}
+                            Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                            Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                        }
                         let update = std::mem::take(&mut *frames.slot.lock().unwrap());
                         if let Some(state) = update.state
                             && writer.send(&browser_state_json(surface_id, &state, false)).is_err()
@@ -1466,7 +1689,12 @@ fn handle_command(mux: &Arc<Mux>, cmd: Command, writer: &LineWriter) -> anyhow::
             }))?;
             let writer = writer.clone();
             std::thread::Builder::new().name("mux-attach-out".into()).spawn(move || {
-                while let Ok(frame) = attach.stream.recv() {
+                while writer.is_open() {
+                    let frame = match attach.stream.recv_timeout(STREAM_DISCONNECT_POLL) {
+                        Ok(frame) => frame,
+                        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => continue,
+                        Err(std::sync::mpsc::RecvTimeoutError::Disconnected) => break,
+                    };
                     let value = match frame {
                         AttachFrame::Output(chunk) => json!({
                             "event": "output",
@@ -1538,8 +1766,10 @@ mod tests {
         Mux::new_for_test("test", SurfaceOptions::default())
     }
 
-    fn test_writer() -> LineWriter {
-        LineWriter(Arc::new(Mutex::new(Box::new(NullStream) as Box<dyn transport::Stream>)))
+    fn test_writer() -> MessageWriter {
+        MessageWriter::new(LineSink(Arc::new(Mutex::new(
+            Box::new(NullStream) as Box<dyn transport::Stream>
+        ))))
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui-core/src/server.rs
+++ b/cmux-tui/crates/cmux-tui-core/src/server.rs
@@ -23,6 +23,7 @@ use std::io::{BufRead, BufReader, Write};
 use std::net::{Shutdown, SocketAddr, TcpListener, TcpStream};
 use std::path::{Path, PathBuf};
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::mpsc::{Sender, TryRecvError, channel};
 use std::sync::{Arc, Mutex};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant};
@@ -34,7 +35,7 @@ use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
 use tungstenite::protocol::CloseFrame;
 use tungstenite::protocol::frame::coding::CloseCode;
-use tungstenite::{Error as WebSocketError, Message, WebSocket, accept};
+use tungstenite::{Error as WebSocketError, Message, accept};
 
 use crate::model::{Screen, State};
 use crate::platform::{self, transport};
@@ -464,32 +465,17 @@ impl MessageSink for LineSink {
     fn close(&self) {}
 }
 
-struct WebSocketSink(Mutex<WebSocket<TcpStream>>);
+struct WebSocketSink(Sender<String>);
 
-impl WebSocketSink {
-    fn read(&self) -> Result<Message, WebSocketError> {
-        self.0.lock().unwrap().read()
-    }
-
-    fn flush(&self) -> Result<(), WebSocketError> {
-        self.0.lock().unwrap().flush()
-    }
-
-    fn reject_auth(&self) {
-        let frame = CloseFrame { code: CloseCode::Policy, reason: "authentication failed".into() };
-        let _ = self.0.lock().unwrap().close(Some(frame));
-    }
-}
-
-impl MessageSink for Arc<WebSocketSink> {
+impl MessageSink for WebSocketSink {
     fn send(&self, value: &Value) -> std::io::Result<()> {
         let text = serde_json::to_string(value)?;
-        self.0.lock().unwrap().send(Message::Text(text.into())).map_err(websocket_io_error)
+        self.0.send(text).map_err(|_| {
+            std::io::Error::new(std::io::ErrorKind::BrokenPipe, "WebSocket connection closed")
+        })
     }
 
-    fn close(&self) {
-        let _ = self.0.lock().unwrap().close(None);
-    }
+    fn close(&self) {}
 }
 
 /// Bind the socket and serve connections on background threads.
@@ -572,7 +558,18 @@ pub fn serve_websocket(
     let thread_connections = connections.clone();
     let thread = std::thread::Builder::new().name("mux-ws-server".into()).spawn(move || {
         while !thread_shutdown.load(Ordering::Acquire) {
-            let Ok((stream, _)) = listener.accept() else { continue };
+            let stream = match listener.accept() {
+                Ok((stream, _)) => stream,
+                Err(_) => {
+                    if thread_shutdown.load(Ordering::Acquire) {
+                        break;
+                    }
+                    // Accept errors can persist (for example, after resource exhaustion).
+                    // A short backoff prevents a hot retry loop while still recovering promptly.
+                    std::thread::sleep(STREAM_DISCONNECT_POLL);
+                    continue;
+                }
+            };
             if thread_shutdown.load(Ordering::Acquire) {
                 break;
             }
@@ -624,33 +621,46 @@ fn handle_connection(mux: Arc<Mux>, stream: Box<dyn transport::Stream>) {
 }
 
 fn handle_websocket_connection(mux: Arc<Mux>, stream: TcpStream, token: Option<&str>) {
-    let Ok(websocket) = accept(stream) else { return };
-    let sink = Arc::new(WebSocketSink(Mutex::new(websocket)));
-    let writer = MessageWriter::new(sink.clone());
+    let Ok(mut websocket) = accept(stream) else { return };
 
     if let Some(expected) = token {
-        let authenticated = match sink.read() {
+        let authenticated = match websocket.read() {
             Ok(Message::Text(text)) => auth_token(&text)
                 .is_some_and(|provided| constant_time_eq(provided.as_bytes(), expected.as_bytes())),
             _ => false,
         };
         if !authenticated {
-            sink.reject_auth();
-            writer.close();
+            let frame =
+                CloseFrame { code: CloseCode::Policy, reason: "authentication failed".into() };
+            let _ = websocket.close(Some(frame));
             return;
         }
     }
-    let _ = sink.0.lock().unwrap().get_mut().set_read_timeout(Some(STREAM_DISCONNECT_POLL));
+    let _ = websocket.get_mut().set_read_timeout(Some(STREAM_DISCONNECT_POLL));
+    let (outbound_tx, outbound_rx) = channel();
+    let writer = MessageWriter::new(WebSocketSink(outbound_tx));
 
-    while writer.is_open() {
-        match sink.read() {
+    'connection: while writer.is_open() {
+        loop {
+            match outbound_rx.try_recv() {
+                Ok(text) => {
+                    if websocket.send(Message::Text(text.into())).is_err() {
+                        break 'connection;
+                    }
+                }
+                Err(TryRecvError::Empty) => break,
+                Err(TryRecvError::Disconnected) => break 'connection,
+            }
+        }
+
+        match websocket.read() {
             Ok(Message::Text(text)) => {
                 if !handle_message(&mux, &text, &writer) {
                     break;
                 }
             }
             Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
-                let _ = sink.flush();
+                let _ = websocket.flush();
             }
             Ok(Message::Close(_)) => break,
             Ok(_) => break,
@@ -663,6 +673,7 @@ fn handle_websocket_connection(mux: Arc<Mux>, stream: TcpStream, token: Option<&
         }
     }
     writer.close();
+    let _ = websocket.close(None);
 }
 
 fn handle_message(mux: &Arc<Mux>, message: &str, writer: &MessageWriter) -> bool {
@@ -702,10 +713,6 @@ fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
             usize::from(a.get(index).copied().unwrap_or(0) ^ b.get(index).copied().unwrap_or(0));
     }
     difference == 0
-}
-
-fn websocket_io_error(error: WebSocketError) -> std::io::Error {
-    std::io::Error::other(error)
 }
 
 fn node_json(node: &Node) -> Value {

--- a/cmux-tui/crates/cmux-tui-core/tests/websocket_transport.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/websocket_transport.rs
@@ -127,10 +127,21 @@ fn websocket_streams_subscribe_and_attach_and_survives_unclean_disconnect() {
 }
 
 #[test]
-fn websocket_refuses_non_loopback_without_explicit_insecure_opt_in() {
+fn websocket_non_loopback_bind_requires_and_accepts_explicit_insecure_opt_in() {
     let mux = Mux::new("ws-bind", SurfaceOptions::default());
-    let error = server::serve_websocket(mux, "0.0.0.0:0".parse().unwrap(), None, false)
+    let error = server::serve_websocket(mux.clone(), "0.0.0.0:0".parse().unwrap(), None, false)
         .err()
         .expect("non-loopback bind should fail");
     assert!(error.to_string().contains("--ws-insecure-bind"));
+
+    let server =
+        server::serve_websocket(mux.clone(), "0.0.0.0:0".parse().unwrap(), None, true).unwrap();
+    let addr = SocketAddr::from(([127, 0, 0, 1], server.local_addr().port()));
+    let mut websocket = connect(addr);
+    send_json(&mut websocket, json!({"id": 1, "cmd": "identify"}));
+    let identify = read_json(&mut websocket);
+    assert_eq!(identify["ok"], true);
+    assert_eq!(identify["data"]["protocol"], server::PROTOCOL_VERSION);
+
+    mux.shutdown();
 }

--- a/cmux-tui/crates/cmux-tui-core/tests/websocket_transport.rs
+++ b/cmux-tui/crates/cmux-tui-core/tests/websocket_transport.rs
@@ -1,0 +1,136 @@
+use std::net::{Shutdown, SocketAddr, TcpStream};
+use std::time::Duration;
+
+use base64::Engine;
+use cmux_tui_core::{Mux, MuxEvent, SurfaceOptions, server};
+use serde_json::{Value, json};
+use tungstenite::{Message, WebSocket, client};
+
+fn connect(addr: SocketAddr) -> WebSocket<TcpStream> {
+    let stream = TcpStream::connect(addr).unwrap();
+    stream.set_read_timeout(Some(Duration::from_secs(10))).unwrap();
+    client(format!("ws://{addr}/"), stream).unwrap().0
+}
+
+fn send_json(websocket: &mut WebSocket<TcpStream>, value: Value) {
+    websocket.send(Message::Text(value.to_string().into())).unwrap();
+}
+
+fn read_json(websocket: &mut WebSocket<TcpStream>) -> Value {
+    loop {
+        match websocket.read().unwrap() {
+            Message::Text(text) => return serde_json::from_str(&text).unwrap(),
+            Message::Ping(data) => websocket.send(Message::Pong(data)).unwrap(),
+            message => panic!("expected a JSON text frame, got {message:?}"),
+        }
+    }
+}
+
+fn read_until(websocket: &mut WebSocket<TcpStream>, predicate: impl Fn(&Value) -> bool) -> Value {
+    loop {
+        let value = read_json(websocket);
+        if predicate(&value) {
+            return value;
+        }
+    }
+}
+
+#[test]
+fn websocket_auth_accepts_exact_preamble_and_rejects_missing_or_wrong_tokens() {
+    let mux = Mux::new("ws-auth", SurfaceOptions::default());
+    let server = server::serve_websocket(
+        mux.clone(),
+        "127.0.0.1:0".parse().unwrap(),
+        Some("correct horse".to_string()),
+        false,
+    )
+    .unwrap();
+
+    for first_frame in
+        [json!({"id": 1, "cmd": "identify"}), json!({"auth": {"token": "wrong battery"}})]
+    {
+        let mut websocket = connect(server.local_addr());
+        send_json(&mut websocket, first_frame);
+        assert!(matches!(
+            websocket.read(),
+            Ok(Message::Close(_))
+                | Err(tungstenite::Error::ConnectionClosed)
+                | Err(tungstenite::Error::AlreadyClosed)
+        ));
+    }
+
+    let mut websocket = connect(server.local_addr());
+    send_json(&mut websocket, json!({"auth": {"token": "correct horse"}}));
+    send_json(&mut websocket, json!({"id": 7, "cmd": "identify"}));
+    let identify = read_json(&mut websocket);
+    assert_eq!(identify["id"], 7);
+    assert_eq!(identify["ok"], true);
+    assert_eq!(identify["data"]["protocol"], server::PROTOCOL_VERSION);
+    assert_eq!(identify["data"]["session"], "ws-auth");
+
+    mux.shutdown();
+}
+
+#[test]
+fn websocket_streams_subscribe_and_attach_and_survives_unclean_disconnect() {
+    let mux = Mux::new("ws-streams", SurfaceOptions::default());
+    let surface = mux
+        .run_command_surface(vec!["/bin/cat".to_string()], None, true, None, None, Some((80, 24)))
+        .unwrap()
+        .surface;
+    let server =
+        server::serve_websocket(mux.clone(), "127.0.0.1:0".parse().unwrap(), None, false).unwrap();
+
+    let mut websocket = connect(server.local_addr());
+    send_json(&mut websocket, json!({"id": 1, "cmd": "subscribe"}));
+    let subscribe = read_until(&mut websocket, |value| value["id"] == 1);
+    assert_eq!(subscribe["ok"], true);
+    mux.emit(MuxEvent::TreeChanged);
+    let tree_changed = read_until(&mut websocket, |value| value["event"] == "tree-changed");
+    assert_eq!(tree_changed, json!({"event": "tree-changed"}));
+
+    send_json(&mut websocket, json!({"id": 2, "cmd": "attach-surface", "surface": surface}));
+    let vt_state = read_until(&mut websocket, |value| value["event"] == "vt-state");
+    assert_eq!(vt_state["surface"], surface);
+    assert!(
+        base64::engine::general_purpose::STANDARD
+            .decode(vt_state["data"].as_str().unwrap())
+            .is_ok()
+    );
+    let attach = read_until(&mut websocket, |value| value["id"] == 2);
+    assert_eq!(attach["ok"], true);
+
+    let marker = "cmux-websocket-roundtrip";
+    send_json(
+        &mut websocket,
+        json!({"id": 3, "cmd": "send", "surface": surface, "text": format!("{marker}\n")}),
+    );
+    let output = read_until(&mut websocket, |value| {
+        value["event"] == "output"
+            && value["data"]
+                .as_str()
+                .and_then(|data| base64::engine::general_purpose::STANDARD.decode(data).ok())
+                .is_some_and(|bytes| String::from_utf8_lossy(&bytes).contains(marker))
+    });
+    assert_eq!(output["surface"], surface);
+
+    websocket.get_mut().shutdown(Shutdown::Both).unwrap();
+    drop(websocket);
+
+    let mut second = connect(server.local_addr());
+    send_json(&mut second, json!({"id": 4, "cmd": "identify"}));
+    let identify = read_json(&mut second);
+    assert_eq!(identify["ok"], true);
+    assert_eq!(identify["data"]["protocol"], server::PROTOCOL_VERSION);
+
+    mux.shutdown();
+}
+
+#[test]
+fn websocket_refuses_non_loopback_without_explicit_insecure_opt_in() {
+    let mux = Mux::new("ws-bind", SurfaceOptions::default());
+    let error = server::serve_websocket(mux, "0.0.0.0:0".parse().unwrap(), None, false)
+        .err()
+        .expect("non-loopback bind should fail");
+    assert!(error.to_string().contains("--ws-insecure-bind"));
+}

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -47,6 +47,10 @@
 //!   "scrollbar": {
 //!     "position": "column"
 //!   },
+//!   "server": {
+//!     "ws": "127.0.0.1:7681",
+//!     "ws_token": "replace-with-a-secret"
+//!   },
 //!   "keys": {
 //!     "prefix": "ctrl+b",
 //!     "alt_shortcuts": true,
@@ -128,11 +132,20 @@ struct RawConfig {
     browser: RawBrowser,
     #[serde(default)]
     scrollbar: RawScrollbar,
+    #[serde(default)]
+    server: RawServer,
     /// Key bindings: `"prefix"` plus one entry per action. Values may be
     /// a chord string, an array of chord strings, `"none"`, or
     /// `"alt_shortcuts": false`.
     #[serde(default)]
     keys: HashMap<String, Value>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawServer {
+    ws: Option<String>,
+    ws_token: Option<String>,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -924,7 +937,14 @@ pub struct Config {
     pub sidebar: Sidebar,
     pub browser: Browser,
     pub scrollbar: Scrollbar,
+    pub server: Server,
     pub keys: Keys,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Server {
+    pub ws: Option<String>,
+    pub ws_token: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, Default)]
@@ -1090,6 +1110,8 @@ pub fn load() -> Config {
     if let Some(position) = raw.scrollbar.position {
         config.scrollbar.position = position;
     }
+    config.server.ws = raw.server.ws.filter(|value| !value.trim().is_empty());
+    config.server.ws_token = raw.server.ws_token;
     config.keys.apply(&raw.keys);
     config
 }
@@ -1413,6 +1435,15 @@ mod tests {
         assert!(err.contains("light"), "{err}");
         assert!(err.contains("dark"), "{err}");
         assert!(err.contains("auto"), "{err}");
+    }
+
+    #[test]
+    fn parses_websocket_server_config() {
+        let raw: RawConfig =
+            serde_json::from_str(r#"{"server":{"ws":"127.0.0.1:7681","ws_token":"secret"}}"#)
+                .unwrap();
+        assert_eq!(raw.server.ws.as_deref(), Some("127.0.0.1:7681"));
+        assert_eq!(raw.server.ws_token.as_deref(), Some("secret"));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -1111,7 +1111,7 @@ pub fn load() -> Config {
         config.scrollbar.position = position;
     }
     config.server.ws = raw.server.ws.filter(|value| !value.trim().is_empty());
-    config.server.ws_token = raw.server.ws_token;
+    config.server.ws_token = raw.server.ws_token.filter(|value| !value.trim().is_empty());
     config.keys.apply(&raw.keys);
     config
 }
@@ -1444,6 +1444,26 @@ mod tests {
                 .unwrap();
         assert_eq!(raw.server.ws.as_deref(), Some("127.0.0.1:7681"));
         assert_eq!(raw.server.ws_token.as_deref(), Some("secret"));
+    }
+
+    #[test]
+    fn ignores_empty_websocket_server_config_values() {
+        let _guard = CONFIG_ENV_LOCK.lock().unwrap();
+        let old_mux_config = std::env::var_os("CMUX_MUX_CONFIG");
+        let dir = std::env::temp_dir()
+            .join(format!("mux-config-test-empty-websocket-values-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).unwrap();
+        let path = dir.join("mux.json");
+        std::fs::write(&path, r#"{"server":{"ws":"","ws_token":"   "}}"#).unwrap();
+        // SAFETY: env mutation in tests is serialized by CONFIG_ENV_LOCK.
+        unsafe { std::env::set_var("CMUX_MUX_CONFIG", &path) };
+
+        let config = load();
+
+        restore_env_var("CMUX_MUX_CONFIG", old_mux_config);
+        let _ = std::fs::remove_dir_all(&dir);
+        assert_eq!(config.server.ws, None);
+        assert_eq!(config.server.ws_token, None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/main.rs
+++ b/cmux-tui/crates/cmux-tui/src/main.rs
@@ -61,6 +61,9 @@ OPTIONS:
   --session <name>   Session name (default: main). Determines the socket path.
   --socket <path>    Explicit control socket path.
   --headless         Run only the control socket, no TUI.
+  --ws <addr>        Also listen for WebSocket clients (default: off).
+  --ws-token <token> Require an auth preamble on WebSocket connections.
+  --ws-insecure-bind Allow a non-loopback WebSocket bind (no TLS; use a proxy).
   --term <value>     TERM for child shells (default: xterm-256color).
   -h, --help         Show this help.
   -V, --version      Print the cmux-tui version.
@@ -110,6 +113,9 @@ struct Args {
     session: String,
     socket: Option<PathBuf>,
     headless: bool,
+    ws: Option<String>,
+    ws_token: Option<String>,
+    ws_insecure_bind: bool,
     term: Option<String>,
 }
 
@@ -119,6 +125,9 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
         session: "main".to_string(),
         socket: None,
         headless: false,
+        ws: None,
+        ws_token: None,
+        ws_insecure_bind: false,
         term: None,
     };
     let mut args = args.into_iter().peekable();
@@ -137,6 +146,14 @@ fn parse_args(args: impl IntoIterator<Item = String>) -> Args {
                 );
             }
             "--headless" => out.headless = true,
+            "--ws" => {
+                out.ws = Some(args.next().unwrap_or_else(|| usage_exit("--ws needs a value")));
+            }
+            "--ws-token" => {
+                out.ws_token =
+                    Some(args.next().unwrap_or_else(|| usage_exit("--ws-token needs a value")));
+            }
+            "--ws-insecure-bind" => out.ws_insecure_bind = true,
             "--term" => {
                 out.term = Some(args.next().unwrap_or_else(|| usage_exit("--term needs a value")));
             }
@@ -191,6 +208,8 @@ fn run_attach(args: Args) -> anyhow::Result<()> {
 fn run_server(args: Args) -> anyhow::Result<()> {
     let mut surface_options = SurfaceOptions::default();
     let config = config::load();
+    let ws_addr = args.ws.or(config.server.ws.clone());
+    let ws_token = args.ws_token.or(config.server.ws_token.clone());
     config::apply_browser_to_surface_options(&config, &mut surface_options);
     if let Some(term) = args.term {
         surface_options.term = term;
@@ -203,6 +222,23 @@ fn run_server(args: Args) -> anyhow::Result<()> {
 
     let mux = Mux::new(args.session.clone(), surface_options);
     mux.configure_sidebar_plugin(config.sidebar.plugin.clone());
+    let websocket_server = match ws_addr {
+        Some(addr) => {
+            let addr = addr
+                .parse()
+                .map_err(|error| anyhow::anyhow!("invalid WebSocket address {addr:?}: {error}"))?;
+            Some(cmux_tui_core::server::serve_websocket(
+                mux.clone(),
+                addr,
+                ws_token,
+                args.ws_insecure_bind,
+            )?)
+        }
+        None => None,
+    };
+    if let Some(server) = &websocket_server {
+        eprintln!("cmux-tui: WebSocket control at ws://{}", server.local_addr());
+    }
     cmux_tui_core::server::serve(mux.clone(), Some(socket_path.clone()))?;
 
     let result = if args.headless {
@@ -210,6 +246,7 @@ fn run_server(args: Args) -> anyhow::Result<()> {
     } else {
         run_tui(Session::Local(mux.clone()), args.session)
     };
+    drop(websocket_server);
     mux.shutdown();
     cmux_tui_core::server::cleanup(&socket_path);
     result

--- a/cmux-tui/crates/cmux-tui/tests/cli.rs
+++ b/cmux-tui/crates/cmux-tui/tests/cli.rs
@@ -281,6 +281,9 @@ fn help_lists_plugin_verbs() {
     assert!(stdout.contains("plugin install <git-url>"));
     assert!(stdout.contains("plugin use --builtin"));
     assert!(stdout.contains("Manage installed sidebar plugins locally."));
+    assert!(stdout.contains("--ws <addr>"));
+    assert!(stdout.contains("--ws-token <token>"));
+    assert!(stdout.contains("--ws-insecure-bind"));
 }
 
 #[cfg(unix)]

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -90,6 +90,15 @@ The default launched profile is `~/Library/Application Support/cmux-tui/chrome-p
 | --- | --- | --- | --- |
 | `scrollbar.position` | `"column"` or `"border"` | `"column"` | Dedicated scrollbar column or right-border overlay |
 
+## Server
+
+| Key | Type | Default | Effect |
+| --- | --- | --- | --- |
+| `server.ws` | socket address string | unset | Enables the WebSocket control listener, for example `127.0.0.1:7681` |
+| `server.ws_token` | string | unset | Requires the first WebSocket text frame to be `{"auth":{"token":"..."}}` |
+
+WebSocket binds must be loopback unless cmux-tui is started with `--ws-insecure-bind`. The listener has no TLS; use an authenticated TLS reverse proxy for remote access. See the [transport contract](../spec/transports.md#websocket).
+
 ## Keys
 
 | Key | Type | Default | Effect |
@@ -184,6 +193,10 @@ Chord strings can be single characters or a key name with optional `ctrl`, `cont
   },
   "scrollbar": {
     "position": "column"
+  },
+  "server": {
+    "ws": "127.0.0.1:7681",
+    "ws_token": "replace-with-a-secret"
   },
   "keys": {
     "prefix": "ctrl+a",

--- a/cmux-tui/spec/README.md
+++ b/cmux-tui/spec/README.md
@@ -32,7 +32,8 @@ The generator must preserve the wire command names, parameter names, result shap
 | --- | --- |
 | `commands.md` | Command contract, CLI mapping for each command, examples, and compatibility notes |
 | `events.md` | Subscribe and attach event payloads, ordering guarantees, and proposed filters |
-| `transports.md` | Implemented Unix socket transport and proposed HTTP, SSE, and WebSocket transports |
+| `transports.md` | Implemented Unix socket and WebSocket transports plus proposed HTTP and SSE transports |
+| `frontends.md` | Canonical connection, synchronization, terminal streaming, and agent/notification guide for frontend authors |
 | `cli.md` | Generated `cmux-tui <verb>` conventions, exit codes, stdin rules, verb table, and examples |
 | `bindings.md` | Language binding style sheets and conformance suite contract |
 | `plugins.md` | Sidebar plugin PTY, manifest, lifecycle, focus, and config contract |

--- a/cmux-tui/spec/events.md
+++ b/cmux-tui/spec/events.md
@@ -10,11 +10,11 @@ Implemented event lines can appear on two stream types:
 | Attach stream v5 | `attach-surface` command | `vt-state`, `output`, `detached` |
 | Attach stream v6 | `attach-surface` command | `vt-state`, `resized`, `output`, `scroll-changed`, `detached` |
 
-Events and command responses share one JSON-lines connection. Clients must route lines by checking for `event`. If `event` is absent, the line is a command response and should be matched by `id`.
+Events and command responses share one full-duplex connection. Each event or response is a complete transport message: a JSON line on Unix or a text frame on WebSocket. Clients must route messages by checking for `event`. If `event` is absent, the message is a command response and should be matched by `id`.
 
 ## Ordering Guarantees
 
-The socket writes each response or event as one complete JSON line. Lines are not interleaved at the byte level.
+The server writes each response or event as one complete transport message. JSON lines and WebSocket text frames are not interleaved at the byte level.
 
 For a single subscription, events are delivered in the order the mux broadcasts them. The server does not create a total order across unrelated producer threads beyond the order in which events enter the mux broadcaster.
 

--- a/cmux-tui/spec/frontends.md
+++ b/cmux-tui/spec/frontends.md
@@ -1,0 +1,85 @@
+# Build a cmux-tui Frontend
+
+This is the canonical integration path for an external cmux-tui frontend. A frontend is a protocol client: it connects over Unix JSON-lines or WebSocket text frames, builds UI from the authoritative tree, subscribes to invalidation events, and attaches to terminal surfaces for byte-exact VT streaming. The complete request and result schemas are in [`commands.md`](commands.md); event schemas and ordering are in [`events.md`](events.md).
+
+## 1. Connect
+
+For a local native frontend, connect to the Unix socket described in [`transports.md`](transports.md#unix-socket). Send each JSON request followed by `\n`, and split incoming bytes on `\n`. Ignore blank lines.
+
+For a browser or remote-capable frontend, the server must be started with `--ws <addr>` or `server.ws`. Send one complete JSON request per WebSocket text frame and treat every received text frame as one complete JSON response or event. Do not add newline framing. The TypeScript SDK exposes `WebSocketTransport` for browsers and compatible Node WebSocket implementations.
+
+If the WebSocket listener has a token, its first frame must be the transport preamble below. It is not a command and the server sends no acknowledgement:
+
+```json
+{"auth":{"token":"replace-with-a-secret"}}
+```
+
+Only after that preamble should the client send protocol requests. See [`transports.md`](transports.md#authentication-preamble) for rejection and bind rules.
+
+## 2. Identify the Server
+
+Send [`identify`](commands.md#identify) immediately after connecting. Verify `data.app == "cmux-tui"` and `data.protocol == 6` before enabling protocol-v6 behavior. Preserve request `id` values and route every non-event response back to the pending request with that id.
+
+```json
+{"id":1,"cmd":"identify"}
+{"id":1,"ok":true,"data":{"app":"cmux-tui","version":"0.1.0","protocol":6,"session":"main","pid":12345}}
+```
+
+## 3. Load and Track the Workspace Tree
+
+Call [`list-workspaces`](commands.md#list-workspaces) to load the authoritative workspace, screen, pane, tab, surface, active-selection, notification, and short-id state. Then call [`subscribe`](commands.md#subscribe) on the same connection or on a dedicated connection.
+
+`subscribe` does not send an initial snapshot. It registers its receiver before its success response is written, so an event can race with the response. A robust frontend should:
+
+1. Start `subscribe` and buffer events.
+2. Fetch `list-workspaces`.
+3. Apply the snapshot.
+4. Process buffered invalidations and re-fetch the affected state.
+
+Treat `tree-changed` as an instruction to call `list-workspaces`, `layout-changed` as an instruction to refresh layout/tree data, and surface/title/notification events as invalidations according to [`events.md`](events.md). Responses and events can be interleaved; route a message with `event` as an event and a message without it as a response.
+
+## 4. Attach and Render a Terminal Surface
+
+For a PTY tab, send [`attach-surface`](commands.md#attach-surface) with its numeric surface id. The stream begins with a `vt-state` event containing `cols`, `rows`, and a standard-base64 `data` field. Decode `data` to bytes and feed the VT replay into a fresh terminal emulator, such as xterm.js.
+
+After the replay, apply each base64-decoded `output.data` byte chunk in arrival order. On `resized`, resize the emulator, discard its old parser state, and replace it from the event's fresh base64 replay before applying later output. `scroll-changed` updates viewport state. `detached` ends the surface stream. Protocol v6 guarantees this order:
+
+```text
+vt-state -> (resized | output | scroll-changed)* -> detached
+```
+
+To send user input, call [`send`](commands.md#send) with `text` for UTF-8 text or `bytes` for standard-base64 raw bytes. For named keys and terminal mode-aware encoding, use [`send-key`](commands.md#send-key). When the frontend's terminal geometry changes, call [`resize-surface`](commands.md#resize-surface) with the final cell `cols` and `rows`; do not resize from pixel dimensions until the frontend has converted them to cells.
+
+Browser surfaces use the browser attach events documented in [`events.md`](events.md) rather than VT replay/output.
+
+## 5. Notifications and Agents
+
+The workspace tree carries per-surface notification state for initial rendering. A subscribed frontend also receives `notification` events with title, body, level, and optional surface. Show the notification and mark the referenced surface as needing attention until the user views it; then use the relevant selection/read path described in [`commands.md`](commands.md).
+
+Call [`list-agents`](commands.md#list-agents) to read current agent records, optionally filtered by surface or state. Agent producers report state through [`report-agent`](commands.md#report-agent); a presentation-only frontend normally reads and displays these records rather than inventing its own agent state. There is no dedicated agent-change event in protocol v6, so re-fetch after a frontend reports state and when tree or surface lifecycle events make the presentation stale.
+
+## End-to-End WebSocket Transcript
+
+Each line below is one WebSocket text frame. `C>` is client-to-server and `S>` is server-to-client. The auth line is present only when `--ws-token` or `server.ws_token` is configured.
+
+```text
+C> {"auth":{"token":"secret"}}
+C> {"id":1,"cmd":"identify"}
+S> {"id":1,"ok":true,"data":{"app":"cmux-tui","version":"0.1.0","protocol":6,"session":"main","pid":12345}}
+C> {"id":2,"cmd":"subscribe"}
+S> {"id":2,"ok":true,"data":{}}
+C> {"id":3,"cmd":"list-workspaces"}
+S> {"id":3,"ok":true,"data":{"workspaces":[...]}}
+C> {"id":4,"cmd":"attach-surface","surface":1}
+S> {"event":"vt-state","surface":1,"cols":80,"rows":24,"data":"G1s/..."}
+S> {"id":4,"ok":true,"data":{}}
+C> {"id":5,"cmd":"send","surface":1,"text":"echo ready\n"}
+S> {"id":5,"ok":true,"data":{}}
+S> {"event":"output","surface":1,"data":"ZWNobyByZWFkeQ0K"}
+C> {"id":6,"cmd":"resize-surface","surface":1,"cols":120,"rows":36}
+S> {"event":"resized","surface":1,"cols":120,"rows":36,"data":"G1s/..."}
+S> {"id":6,"ok":true,"data":{}}
+S> {"event":"tree-changed"}
+```
+
+The event/response ordering shown around streaming commands is intentional: attach events can precede the command response, and subscribe events can race with its response. Never assume request-response alternation once streaming begins.

--- a/cmux-tui/spec/transports.md
+++ b/cmux-tui/spec/transports.md
@@ -1,6 +1,6 @@
 # Transport Contract
 
-The command schema is transport-independent. Protocol v5 implements a Unix domain socket JSON-lines transport. Protocol v6 proposes HTTP, SSE, and WebSocket transports that preserve the same command and event payloads.
+The command schema is transport-independent. Protocol v5 introduced the Unix domain socket JSON-lines transport. Protocol v6 also implements an opt-in WebSocket transport with the same command and event payloads. HTTP and SSE remain proposals.
 
 ## Unix Socket
 
@@ -67,18 +67,57 @@ When binding, the server creates the runtime directory if needed, refuses to clo
 
 Access to the Unix socket is equivalent to access to the mux session. A client can type into PTYs, read screens, close surfaces, and change focus. Hosts must keep the runtime directory private.
 
-### Optional Socket Token
+The Unix socket does not use the WebSocket auth preamble. Its filesystem permissions remain the access boundary.
 
-Protocol v6 may add an optional token to the socket transport for parity with HTTP. Filesystem permissions remain the primary protection. The exact framing is deferred until the v6 implementation.
+## WebSocket
 
-A compatible deferred design is an initial auth line before any command:
+| Field | Value |
+| --- | --- |
+| status | implemented |
+| since | protocol 6 |
+
+WebSocket is opt-in and can run alongside either the local TUI or `--headless`:
 
 ```text
-{"auth":"<token>"}
-{"ok":true}
+cmux-tui --ws 127.0.0.1:7681
+cmux-tui --headless --ws 127.0.0.1:7681
 ```
 
-If auth fails, the server responds with `{"ok":false,"error":"invalid token"}` and closes the connection. The Unix socket transport must not use the HTTP `Authorization` header because its framing is JSON-lines, not HTTP.
+The equivalent config is:
+
+```json
+{"server":{"ws":"127.0.0.1:7681"}}
+```
+
+`server.ws` and the `--ws` value are socket addresses (`IP:port`, with brackets around IPv6). The command-line flag takes precedence over config. WebSocket is disabled when neither is set.
+
+### Framing
+
+Each client request is one UTF-8 JSON object in one WebSocket text frame. Each response or event is one complete JSON object in one WebSocket text frame. Do not append a newline. Responses and events may be interleaved after `subscribe` or `attach-surface`, exactly as on the Unix socket. The request/response envelopes, command names, event payloads, protocol version, attach ordering, and base64 encoding are unchanged.
+
+Binary frames are not protocol messages and cause the connection to close. The server accepts a normal WebSocket upgrade on any request path and does not require a WebSocket subprotocol.
+
+This framing exactly matches the TypeScript SDK's `WebSocketTransport`: `send(json)` sends that string as one text frame, and every received text frame is delivered as one complete JSON message.
+
+### Authentication Preamble
+
+Authentication is optional. Set it with `--ws-token <token>` or `server.ws_token`; the command-line flag takes precedence over config:
+
+```json
+{"server":{"ws":"127.0.0.1:7681","ws_token":"replace-with-a-secret"}}
+```
+
+When a token is configured, the first WebSocket frame must be this transport-level preamble:
+
+```json
+{"auth":{"token":"replace-with-a-secret"}}
+```
+
+The preamble is not a protocol command, has no `id`, and receives no success response. After sending it, the client may immediately send normal protocol requests. A missing, malformed, or incorrect preamble closes the connection with WebSocket policy code `1008` before dispatch. When no token is configured, the first text frame is a normal protocol request.
+
+### Bind Security
+
+By default the listener accepts only an IP loopback address such as `127.0.0.1` or `[::1]`. cmux-tui refuses a non-loopback address unless `--ws-insecure-bind` is also present. This listener provides no TLS; for remote access, bind deliberately and place it behind a TLS-terminating, authenticated reverse proxy. A WebSocket client has the same authority as a Unix socket client: it can read terminal contents, type into PTYs, and mutate or close the session.
 
 ## HTTP
 


### PR DESCRIPTION
Browsers and remote frontends can now drive cmux-tui: `--ws 127.0.0.1:7681` (config server.ws) serves the exact existing JSON protocol over WebSocket (one message per text frame — matching the merged TS SDK's WebSocketTransport), with a single shared per-connection handler behind both framings so unix and WS cannot drift. Security defaults: loopback-only binds unless --ws-insecure-bind, optional --ws-token auth preamble. Protocol stays v6; unix behavior byte-identical (bindings-e2e is the proof). spec/frontends.md is the new canonical guide for building a frontend (the xterm.js React reference app consumes this next; the Swift app eventually rides the same API). Integration tests cover auth, identify, subscribe, attach/send roundtrip, unclean-close cleanup, and bind rejection. Local test execution blocked by the known host zig issue — CI gates.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786363891&installation_id=133855650&pr_number=7890&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7890&signature=e9a2f07e38c8dc3542e72bcce33889bf123870eda7213408ecea490c6e996f2f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> WebSocket clients get the same session authority as the Unix socket (PTY I/O and session mutation); token and loopback defaults mitigate exposure but non-loopback binds and missing TLS still need careful deployment.
> 
> **Overview**
> Adds an **opt-in WebSocket listener** so browsers and remote clients can use the same v6 JSON control protocol as the Unix socket, with **one JSON object per WebSocket text frame** (no newline framing).
> 
> The control server is refactored around a shared **`MessageWriter` / `MessageSink`** path so Unix lines and WebSocket frames both go through **`handle_message`** and **`handle_command`**, keeping subscribe/attach streaming behavior aligned. Event/stream threads now poll with timeouts so they stop cleanly when the connection closes.
> 
> **Security defaults:** binds are **loopback-only** unless **`--ws-insecure-bind`**; optional **`--ws-token`** / **`server.ws_token`** requires a first-frame **`{"auth":{"token":"..."}}`** preamble (constant-time compare; bad auth closes with policy **1008**). No TLS on the listener—remote use expects a proxy.
> 
> **Wiring:** **`--ws`**, **`--ws-token`**, **`--ws-insecure-bind`** plus config **`server.ws`** / **`server.ws_token`** (CLI overrides config); **`tungstenite`** is a runtime dependency. New integration tests cover auth, subscribe/attach/send, reconnect after unclean close, and bind rules. Spec/docs add **`frontends.md`** and document WebSocket in **`transports.md`** / **`configuration.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b79f31768919b9b616a47ef08eb7a1512e3b852e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in WebSocket transport so browsers and remote frontends can use the existing JSON protocol. Also fixes WS streaming starvation with a single-owner read/write pump (≈100ms bounded latency); protocol stays v6 and Unix socket behavior is unchanged.

- **New Features**
  - WebSocket listener via `--ws <addr>` or `server.ws`; one JSON message per WS text frame; shared per-connection handler with Unix.
  - Optional token auth via `--ws-token` or `server.ws_token`; first frame must be `{"auth":{"token":"..."}}` (empty token treated as unset); bad/missing token closes with policy code 1008.
  - Bind safety: loopback-only by default; non-loopback requires `--ws-insecure-bind` (no TLS; put behind an authenticated TLS reverse proxy).
  - Single-owner WS pump drains an outbound mpsc between 100ms reads to prevent event starvation; clean shutdown on close; accept-loop backoff added.
  - CLI/help/config updated; new `spec/frontends.md`; expanded `spec/transports.md`/`spec/events.md`; integration tests cover auth accept/reject, identify, subscribe/attach/send roundtrip, unclean-close cleanup, and bind rejection/explicit opt-in; `tungstenite` is now a runtime dependency.

- **Migration**
  - No breaking changes; existing Unix clients are unaffected.
  - To enable: run `cmux-tui --ws 127.0.0.1:7681` or config `{"server":{"ws":"127.0.0.1:7681","ws_token":"secret"}}`. For remote access, bind deliberately with `--ws-insecure-bind` and place behind a TLS-authenticated reverse proxy.

<sup>Written for commit b79f31768919b9b616a47ef08eb7a1512e3b852e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7890?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional WebSocket control for external frontends, including command responses, events, subscriptions, and terminal attachment.
  * Added WebSocket server support with token-based authentication and a configurable WebSocket bind address.
  * Added `--ws`, `--ws-token`, and `--ws-insecure-bind` options plus a matching `server` configuration section.

* **Bug Fixes**
  * Improved WebSocket session shutdown and streaming responsiveness to disconnect/reconnect.

* **Documentation**
  * Updated configuration and transport/spec docs to describe the WebSocket protocol, auth preamble, and bind security rules.

* **Tests**
  * Added integration tests for authentication, streaming/attach behavior, reconnects, and secure bind restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->