### PR TITLE
Prevent deep process trees from crashing system.top

### DIFF
--- a/Sources/CmuxTopSnapshot.swift
+++ b/Sources/CmuxTopSnapshot.swift
@@ -130,6 +130,9 @@ struct CmuxTopProcessScope: Sendable, Equatable {
 }
 
 final class CmuxTopProcessSnapshot: @unchecked Sendable {
+    // Leaves headroom for the recursive JSON bridge, Foundation encoder, and clients.
+    private static let maximumProcessTreeDepth = 128
+
     let sampledAt: Date
     private let includesProcessDetails: Bool
     private let includesCMUXScope: Bool
@@ -559,6 +562,15 @@ final class CmuxTopProcessSnapshot: @unchecked Sendable {
         }
     }
 
+    private struct ProcessTreeFrame {
+        let process: CmuxTopProcessInfo
+        let childPIDs: [Int]
+        let depth: Int
+        var nextChildIndex = 0
+        var childNodes: [[String: Any]] = []
+        var truncatedDescendantPIDs: [Int] = []
+    }
+
     private func processTreeNode(
         pid: Int,
         allowedPIDs: Set<Int>,
@@ -570,18 +582,101 @@ final class CmuxTopProcessSnapshot: @unchecked Sendable {
             return nil
         }
 
-        let childNodes = (childrenByParentPID[pid] ?? [])
-            .filter { allowedPIDs.contains($0) }
-            .sorted { processSortKey($0) < processSortKey($1) }
-            .compactMap {
-                processTreeNode(
-                    pid: $0,
+        var stack = [
+            ProcessTreeFrame(
+                process: process,
+                childPIDs: processTreeChildPIDs(for: pid, allowedPIDs: allowedPIDs),
+                depth: 1
+            )
+        ]
+
+        while !stack.isEmpty {
+            let frameIndex = stack.index(before: stack.endIndex)
+
+            if stack[frameIndex].depth >= Self.maximumProcessTreeDepth,
+               stack[frameIndex].nextChildIndex < stack[frameIndex].childPIDs.count {
+                let childPIDs = stack[frameIndex].childPIDs
+                stack[frameIndex].truncatedDescendantPIDs = visitTruncatedProcessTreeDescendants(
+                    startingWith: childPIDs,
                     allowedPIDs: allowedPIDs,
-                    rootPIDs: rootPIDs,
                     visited: &visited
                 )
+                stack[frameIndex].nextChildIndex = childPIDs.count
+                continue
             }
 
+            if stack[frameIndex].nextChildIndex < stack[frameIndex].childPIDs.count {
+                let childPID = stack[frameIndex].childPIDs[stack[frameIndex].nextChildIndex]
+                stack[frameIndex].nextChildIndex += 1
+                guard visited.insert(childPID).inserted,
+                      let childProcess = processesByPID[childPID] else {
+                    continue
+                }
+                let childDepth = stack[frameIndex].depth + 1
+                stack.append(
+                    ProcessTreeFrame(
+                        process: childProcess,
+                        childPIDs: processTreeChildPIDs(for: childPID, allowedPIDs: allowedPIDs),
+                        depth: childDepth
+                    )
+                )
+                continue
+            }
+
+            let completed = stack.removeLast()
+            let payload = processTreeNodePayload(
+                for: completed.process,
+                allowedPIDs: allowedPIDs,
+                rootPIDs: rootPIDs,
+                childNodes: completed.childNodes,
+                truncatedDescendantPIDs: completed.truncatedDescendantPIDs
+            )
+            guard !stack.isEmpty else { return payload }
+            let parentIndex = stack.index(before: stack.endIndex)
+            stack[parentIndex].childNodes.append(payload)
+        }
+
+        return nil
+    }
+
+    private func processTreeChildPIDs(for pid: Int, allowedPIDs: Set<Int>) -> [Int] {
+        (childrenByParentPID[pid] ?? [])
+            .filter { allowedPIDs.contains($0) }
+            .sorted { processSortKey($0) < processSortKey($1) }
+    }
+
+    private func visitTruncatedProcessTreeDescendants(
+        startingWith childPIDs: [Int],
+        allowedPIDs: Set<Int>,
+        visited: inout Set<Int>
+    ) -> [Int] {
+        var truncatedPIDs: [Int] = []
+        var pending = Array(childPIDs.reversed())
+
+        while let pid = pending.popLast() {
+            guard visited.insert(pid).inserted,
+                  processesByPID[pid] != nil else {
+                continue
+            }
+            truncatedPIDs.append(pid)
+            pending.append(
+                contentsOf: processTreeChildPIDs(for: pid, allowedPIDs: allowedPIDs).reversed()
+            )
+        }
+
+        return truncatedPIDs
+    }
+
+    private func processTreeNodePayload(
+        for process: CmuxTopProcessInfo,
+        allowedPIDs: Set<Int>,
+        rootPIDs: Set<Int>,
+        childNodes: [[String: Any]],
+        truncatedDescendantPIDs: [Int]
+    ) -> [String: Any] {
+        // Keep resource accounting and PID lookup complete even when the nested
+        // representation stops here. Only per-descendant node metadata is omitted.
+        let summarizedPIDs = Set(truncatedDescendantPIDs).union([process.pid])
         var payload: [String: Any] = [
             "kind": "process",
             "pid": process.pid,
@@ -592,9 +687,13 @@ final class CmuxTopProcessSnapshot: @unchecked Sendable {
             "thread_count": process.threadCount,
             "memory_source": process.memorySource.rawValue,
             "resident_memory_source": process.residentMemorySource.rawValue,
-            "resources": summary(for: [pid]).payload(),
+            "resources": summary(for: summarizedPIDs).payload(),
             "children": childNodes
         ]
+        if !truncatedDescendantPIDs.isEmpty {
+            payload["children_truncated"] = true
+            payload["truncated_descendant_count"] = truncatedDescendantPIDs.count
+        }
         if let ttyDevice = process.ttyDevice {
             payload["tty_device"] = ttyDevice
         } else {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -668,6 +668,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C7A511000000000000000002 /* CmuxTopProcessEnumeration.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A511000000000000000001 /* CmuxTopProcessEnumeration.swift */; };
 		0A1107110000000000000018 /* CmuxTopProcessSnapshot+PromptAgentDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1107110000000000000019 /* CmuxTopProcessSnapshot+PromptAgentDetection.swift */; };
 		C7A512000000000000000002 /* CmuxTopProcessSnapshotCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A512000000000000000001 /* CmuxTopProcessSnapshotCache.swift */; };
+		A7848A000000000000000002 /* CmuxTopProcessTreeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7848A000000000000000001 /* CmuxTopProcessTreeTests.swift */; };
 		C7A501000000000000000002 /* CmuxTopSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A501000000000000000001 /* CmuxTopSnapshot.swift */; };
 		C7A508000000000000000002 /* CmuxTopSnapshotScopeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */; };
 		C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */; };
@@ -2714,6 +2715,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C7A511000000000000000001 /* CmuxTopProcessEnumeration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessEnumeration.swift; sourceTree = "<group>"; };
 		0A1107110000000000000019 /* CmuxTopProcessSnapshot+PromptAgentDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CmuxTopProcessSnapshot+PromptAgentDetection.swift"; sourceTree = "<group>"; };
 		C7A512000000000000000001 /* CmuxTopProcessSnapshotCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessSnapshotCache.swift; sourceTree = "<group>"; };
+		A7848A000000000000000001 /* CmuxTopProcessTreeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopProcessTreeTests.swift; sourceTree = "<group>"; };
 		C7A501000000000000000001 /* CmuxTopSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshot.swift; sourceTree = "<group>"; };
 		C7A508000000000000000001 /* CmuxTopSnapshotScopeCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCache.swift; sourceTree = "<group>"; };
 		C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxTopSnapshotScopeCacheTests.swift; sourceTree = "<group>"; };
@@ -6112,6 +6114,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A509000000000000000001 /* CmuxTopSnapshotScopeTests.swift */,
 				C7A5090000000000000005A1 /* CmuxTopSnapshotScopeCacheTests.swift */,
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
+				A7848A000000000000000001 /* CmuxTopProcessTreeTests.swift */,
 				C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
 				B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */,
@@ -8296,6 +8299,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C3677001000000000000001 /* CmuxSSHURLRequestTests.swift in Sources */,
 				C7A50C000000000000000003 /* CmuxTopProcessArgumentsTests.swift in Sources */,
 				C7A50C000000000000000002 /* CmuxTopProcessCPUTests.swift in Sources */,
+				A7848A000000000000000002 /* CmuxTopProcessTreeTests.swift in Sources */,
 				C7A5090000000000000005A2 /* CmuxTopSnapshotScopeCacheTests.swift in Sources */,
 				C7A509000000000000000002 /* CmuxTopSnapshotScopeTests.swift in Sources */,
 				D7C0DE00000000000000A103 /* CmuxWebViewContextMenuLinkCaptureTests.swift in Sources */,

--- a/cmuxTests/CmuxTopProcessTreeTests.swift
+++ b/cmuxTests/CmuxTopProcessTreeTests.swift
@@ -1,0 +1,258 @@
+import CmuxControlSocket
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct CmuxTopProcessTreeTests {
+    @Test
+    func boundsDeepProcessTreesBeforeWireEncoding() async {
+        let processCount = 700
+        let processes = (1...processCount).map { pid in
+            Self.process(
+                pid: pid,
+                parentPID: pid == 1 ? 0 : pid - 1,
+                name: "process"
+            )
+        }
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: processes,
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: false
+        )
+        let allowedPIDs = Set(1...processCount)
+
+        let result = await Self.onSocketWorkerStack {
+            let roots = snapshot.processTreePayload(for: allowedPIDs, rootPIDs: [1])
+            var emittedPIDs: [Int] = []
+            var current = roots.first
+            var childrenTruncated = false
+            var truncatedDescendantCount = 0
+
+            while let node = current {
+                guard let pid = node["pid"] as? Int else { break }
+                emittedPIDs.append(pid)
+                if node["children_truncated"] as? Bool == true {
+                    childrenTruncated = true
+                    truncatedDescendantCount = node["truncated_descendant_count"] as? Int ?? 0
+                }
+                current = (node["children"] as? [[String: Any]])?.first
+            }
+
+            let envelope: [String: Any] = [
+                "windows": [[
+                    "workspaces": [[
+                        "panes": [[
+                            "surfaces": [[
+                                "processes": roots
+                            ] as [String: Any]]
+                        ] as [String: Any]]
+                    ] as [String: Any]]
+                ] as [String: Any]]
+            ]
+            let wireEncoded: Bool
+            if let value = JSONValue(foundationObject: envelope) {
+                wireEncoded = ControlResponseEncoder().ok(id: nil, result: value)
+                    != ControlResponseEncoder.encodeFailureResponse
+            } else {
+                wireEncoded = false
+            }
+
+            return DeepTreeResult(
+                emittedPIDs: emittedPIDs,
+                childrenTruncated: childrenTruncated,
+                truncatedDescendantCount: truncatedDescendantCount,
+                wireEncoded: wireEncoded
+            )
+        }
+
+        #expect(result.emittedPIDs == Array(1...128))
+        #expect(result.childrenTruncated)
+        #expect(result.truncatedDescendantCount == processCount - result.emittedPIDs.count)
+        #expect(result.wireEncoded)
+    }
+
+    @Test
+    func shallowPayloadPreservesExactContract() throws {
+        let workspaceID = try #require(UUID(uuidString: "11111111-2222-3333-4444-555555555555"))
+        let surfaceID = try #require(UUID(uuidString: "AAAAAAAA-BBBB-CCCC-DDDD-EEEEEEEEEEEE"))
+        let process = Self.process(
+            pid: 42,
+            parentPID: 1,
+            name: "codex",
+            path: "/usr/local/bin/codex",
+            ttyDevice: 7,
+            workspaceID: workspaceID,
+            surfaceID: surfaceID,
+            attributionReason: "test-fixture",
+            processGroupID: 42,
+            terminalProcessGroupID: 42,
+            cpuPercent: 12.5,
+            memoryBytes: 4_096,
+            residentBytes: 2_048,
+            virtualBytes: 8_192,
+            threadCount: 3
+        )
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [process],
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: false
+        )
+
+        let actual = snapshot.processTreePayload(for: [42], rootPIDs: [42])
+        let expected: [[String: Any]] = [[
+            "kind": "process",
+            "pid": 42,
+            "ppid": 1,
+            "name": "codex",
+            "path": "/usr/local/bin/codex",
+            "attribution_reason": "test-fixture",
+            "thread_count": 3,
+            "memory_source": CmuxTopProcessMemorySource.physicalFootprint.rawValue,
+            "resident_memory_source": CmuxTopProcessMemorySource.residentSize.rawValue,
+            "resources": [
+                "cpu_percent": 12.5,
+                "memory_bytes": 4_096,
+                "resident_bytes": 2_048,
+                "virtual_bytes": 8_192,
+                "process_count": 1,
+                "pids": [42],
+                "missing_pids": [],
+                "memory_source_fallback_pids": [],
+                "memory_source_fallback_count": 0,
+                "resident_memory_source_fallback_pids": [],
+                "resident_memory_source_fallback_count": 0,
+                "unavailable_memory_pids": [],
+                "unavailable_memory_count": 0,
+                "unavailable_resident_memory_pids": [],
+                "unavailable_resident_memory_count": 0
+            ] as [String: Any],
+            "children": [],
+            "tty_device": 7,
+            "cmux_workspace_id": workspaceID.uuidString,
+            "cmux_surface_id": surfaceID.uuidString,
+            "pgid": 42,
+            "tpgid": 42
+        ]]
+
+        #expect(try Self.canonicalJSON(actual) == Self.canonicalJSON(expected))
+    }
+
+    @Test
+    func sortsChildrenAndFiltersDisallowedPIDsWhileKeepingOrphanedRoots() throws {
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [
+                Self.process(pid: 100, parentPID: 1, name: "alpha-root"),
+                Self.process(pid: 200, parentPID: 100, name: "zeta-child"),
+                Self.process(pid: 300, parentPID: 100, name: "alpha-child"),
+                Self.process(pid: 400, parentPID: 300, name: "excluded-grandchild"),
+                Self.process(pid: 500, parentPID: 999, name: "zeta-orphan")
+            ],
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: false
+        )
+
+        let roots = snapshot.processTreePayload(
+            for: [100, 200, 300, 500, 9_999],
+            rootPIDs: [100, 9_999]
+        )
+        #expect(roots.compactMap { $0["pid"] as? Int } == [100, 500])
+
+        let root = try #require(roots.first)
+        let children = try #require(root["children"] as? [[String: Any]])
+        #expect(children.compactMap { $0["pid"] as? Int } == [300, 200])
+        #expect(root["attribution_reason"] as? String == "explicit-root-pid")
+        #expect(children.allSatisfy { $0["attribution_reason"] as? String == "child-process" })
+        #expect(roots[1]["attribution_reason"] as? String == "included-process")
+        #expect(children.allSatisfy { ($0["children"] as? [[String: Any]])?.isEmpty == true })
+    }
+
+    @Test
+    func explicitRootsBreakCyclesWithoutDuplicatingVisitedProcesses() throws {
+        let snapshot = CmuxTopProcessSnapshot(
+            processes: [
+                Self.process(pid: 1, parentPID: 2, name: "alpha"),
+                Self.process(pid: 2, parentPID: 1, name: "beta")
+            ],
+            sampledAt: Date(timeIntervalSince1970: 0),
+            includesProcessDetails: false
+        )
+
+        #expect(snapshot.processTreePayload(for: [1, 2]).isEmpty)
+
+        let roots = snapshot.processTreePayload(for: [1, 2], rootPIDs: [1, 2])
+        let root = try #require(roots.first)
+        let children = try #require(root["children"] as? [[String: Any]])
+        let child = try #require(children.first)
+
+        #expect(roots.count == 1)
+        #expect(root["pid"] as? Int == 1)
+        #expect(children.count == 1)
+        #expect(child["pid"] as? Int == 2)
+        #expect((child["children"] as? [[String: Any]])?.isEmpty == true)
+    }
+
+    private struct DeepTreeResult: Sendable {
+        let emittedPIDs: [Int]
+        let childrenTruncated: Bool
+        let truncatedDescendantCount: Int
+        let wireEncoded: Bool
+    }
+
+    private static func onSocketWorkerStack<Result: Sendable>(
+        _ operation: @escaping @Sendable () -> Result
+    ) async -> Result {
+        await withCheckedContinuation { continuation in
+            let thread = Thread {
+                continuation.resume(returning: operation())
+            }
+            thread.stackSize = 512 * 1_024
+            thread.start()
+        }
+    }
+
+    private static func canonicalJSON(_ object: Any) throws -> Data {
+        try JSONSerialization.data(withJSONObject: object, options: [.sortedKeys])
+    }
+
+    private static func process(
+        pid: Int,
+        parentPID: Int,
+        name: String,
+        path: String? = nil,
+        ttyDevice: Int64? = nil,
+        workspaceID: UUID? = nil,
+        surfaceID: UUID? = nil,
+        attributionReason: String? = nil,
+        processGroupID: Int? = nil,
+        terminalProcessGroupID: Int? = nil,
+        cpuPercent: Double = 0,
+        memoryBytes: Int64? = nil,
+        residentBytes: Int64 = 0,
+        virtualBytes: Int64 = 0,
+        threadCount: Int = 1
+    ) -> CmuxTopProcessInfo {
+        CmuxTopProcessInfo(
+            pid: pid,
+            parentPID: parentPID,
+            name: name,
+            path: path,
+            ttyDevice: ttyDevice,
+            cmuxWorkspaceID: workspaceID,
+            cmuxSurfaceID: surfaceID,
+            cmuxAttributionReason: attributionReason,
+            processGroupID: processGroupID,
+            terminalProcessGroupID: terminalProcessGroupID,
+            cpuPercent: cpuPercent,
+            memoryBytes: memoryBytes,
+            residentBytes: residentBytes,
+            virtualBytes: virtualBytes,
+            threadCount: threadCount
+        )
+    }
+}

--- a/cmuxTests/CmuxTopProcessTreeTests.swift
+++ b/cmuxTests/CmuxTopProcessTreeTests.swift
@@ -17,7 +17,10 @@ struct CmuxTopProcessTreeTests {
             Self.process(
                 pid: pid,
                 parentPID: pid == 1 ? 0 : pid - 1,
-                name: "process"
+                name: "process",
+                cpuPercent: 1,
+                memoryBytes: 1,
+                residentBytes: 1
             )
         }
         let snapshot = CmuxTopProcessSnapshot(
@@ -33,13 +36,22 @@ struct CmuxTopProcessTreeTests {
             var current = roots.first
             var childrenTruncated = false
             var truncatedDescendantCount = 0
+            var summarizedPIDs: [Int] = []
+            var summarizedProcessCount = 0
+            var visibleCPUPercent = 0.0
+            var visibleProcessCount = 0
 
             while let node = current {
                 guard let pid = node["pid"] as? Int else { break }
                 emittedPIDs.append(pid)
+                let resources = node["resources"] as? [String: Any] ?? [:]
+                visibleCPUPercent += resources["cpu_percent"] as? Double ?? 0
+                visibleProcessCount += resources["process_count"] as? Int ?? 0
                 if node["children_truncated"] as? Bool == true {
                     childrenTruncated = true
                     truncatedDescendantCount = node["truncated_descendant_count"] as? Int ?? 0
+                    summarizedPIDs = resources["pids"] as? [Int] ?? []
+                    summarizedProcessCount = resources["process_count"] as? Int ?? 0
                 }
                 current = (node["children"] as? [[String: Any]])?.first
             }
@@ -67,6 +79,10 @@ struct CmuxTopProcessTreeTests {
                 emittedPIDs: emittedPIDs,
                 childrenTruncated: childrenTruncated,
                 truncatedDescendantCount: truncatedDescendantCount,
+                summarizedPIDs: summarizedPIDs,
+                summarizedProcessCount: summarizedProcessCount,
+                visibleCPUPercent: visibleCPUPercent,
+                visibleProcessCount: visibleProcessCount,
                 wireEncoded: wireEncoded
             )
         }
@@ -74,6 +90,10 @@ struct CmuxTopProcessTreeTests {
         #expect(result.emittedPIDs == Array(1...128))
         #expect(result.childrenTruncated)
         #expect(result.truncatedDescendantCount == processCount - result.emittedPIDs.count)
+        #expect(result.summarizedPIDs == Array(128...processCount))
+        #expect(result.summarizedProcessCount == processCount - 127)
+        #expect(result.visibleCPUPercent == Double(processCount))
+        #expect(result.visibleProcessCount == processCount)
         #expect(result.wireEncoded)
     }
 
@@ -201,6 +221,10 @@ struct CmuxTopProcessTreeTests {
         let emittedPIDs: [Int]
         let childrenTruncated: Bool
         let truncatedDescendantCount: Int
+        let summarizedPIDs: [Int]
+        let summarizedProcessCount: Int
+        let visibleCPUPercent: Double
+        let visibleProcessCount: Int
         let wireEncoded: Bool
     }
 


### PR DESCRIPTION
## Summary

- replace recursive process-tree construction with an explicit heap-backed DFS stack
- cap the nested wire representation at 128 process levels and mark the boundary with `children_truncated` and `truncated_descendant_count`
- aggregate the boundary node resources over omitted descendants so CPU, memory, process count, and `resources.pids` lookup remain complete
- add deep-tree wire regression coverage plus exact shallow-contract, ordering/filtering, and cycle tests

## Root cause

`CmuxTopProcessSnapshot.processTreeNode` recursively emitted one nested dictionary per process generation. A sufficiently deep agent process chain could exhaust the socket worker stack. Changing only that walk to a loop was not sufficient: the same deeply nested payload then crossed recursive `JSONValue` bridging, Foundation encoding, CLI formatting, and Task Manager consumers.

The fix therefore bounds both the producer call stack and the resulting wire-data depth. Only per-descendant node metadata beyond the boundary is omitted; aggregate accounting and PID-to-surface fallback lookup remain available through the boundary node resources.

## Compatibility

- shallow payloads are byte-for-byte equivalent when canonicalized as JSON
- root and child sorting, allowed-PID filtering, attribution reasons, global visited semantics, and cycle handling are preserved
- no user-facing strings or localization files change

Fixes #7848

## Testing

- `CmuxTopProcessTreeTests` (4 tests): passed
  - 700-deep tree on a 512 KiB worker stack
  - Foundation-to-`JSONValue` bridge and `ControlResponseEncoder`
  - cap-node PID/resource conservation and visible aggregate totals
  - shallow contract, ordering/filtering/orphans, and cycles
- existing `CmuxTopSnapshotScopeTests/testApplicationProcessTreeIsExposedAtWindowLevel`: passed
- `scripts/lint-pbxproj-test-wiring.sh`: passed (446 test files)
- `scripts/check-pbxproj.sh`: passed
- `git diff --check`: passed
- isolated tagged build on `007c93a062`: passed with `./scripts/reload.sh --tag 7848-process-tree --no-global-cli-links`

## CI status

This is an external-fork draft. GitHub Actions still require maintainer approval to run. The two visible Vercel failures are deployment-authorization links, not code-test failures. The commits retain the test-only Red step followed by the Green implementation step for review.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control-socket process-tree JSON shape for deep trees (new truncation fields) while preserving shallow payloads; affects Task Manager / `system.top` consumers but is well-tested.
> 
> **Overview**
> Fixes crashes from **very deep process chains** in `system.top` by changing how `CmuxTopProcessSnapshot` builds nested process JSON.
> 
> **Process tree construction** no longer uses unbounded recursion. It walks the tree with an explicit stack and stops emitting nested child nodes at **128 levels** (`maximumProcessTreeDepth`). At that boundary, nodes gain `children_truncated` and `truncated_descendant_count`, while **`resources` still rolls up** CPU, memory, process counts, and `pids` for omitted descendants so totals and PID lookup stay complete.
> 
> Shallow trees should match the prior wire shape; ordering, allowed-PID filtering, attribution, visit semantics, and cycle handling are covered by new **`CmuxTopProcessTreeTests`** (including a 700-deep tree on a small stack and control-socket encoding).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 007c93a062a9f1539d0ee7598a46fa6084b1ab7b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Process tree views now limit deeply nested branches for improved readability and performance.
  - Truncated branches are clearly identified, including the number of hidden descendants.
  - Resource summaries now include processes hidden by tree-depth limits, providing more accurate aggregate information.

- **Bug Fixes**
  - Improved process ordering, filtering, root handling, and cycle detection for more reliable process tree displays.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->