### PR TITLE
Make TextBox Git ignore probes fail soft

### DIFF
--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ProcessPipe/FileHandle+ProcessPipeWriting.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/ProcessPipe/FileHandle+ProcessPipeWriting.swift
@@ -1,0 +1,41 @@
+import Darwin
+public import Foundation
+
+extension FileHandle {
+    /// Writes every byte to a child-process pipe without allowing `SIGPIPE` to terminate the process.
+    ///
+    /// Unlike Foundation's legacy nonthrowing write APIs, a closed reader is
+    /// reported as a ``POSIXError``. Partial writes and interrupted system
+    /// calls are completed before this method returns.
+    ///
+    /// - Parameter data: The bytes to write to the pipe.
+    /// - Throws: A ``POSIXError`` when configuring or writing the descriptor fails.
+    public func writeProcessPipeInput(_ data: Data) throws {
+        let descriptor = fileDescriptor
+        guard fcntl(descriptor, F_SETNOSIGPIPE, 1) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+
+        try data.withUnsafeBytes { bytes in
+            guard let baseAddress = bytes.baseAddress else { return }
+            var offset = 0
+            while offset < bytes.count {
+                let written = Darwin.write(
+                    descriptor,
+                    baseAddress.advanced(by: offset),
+                    bytes.count - offset
+                )
+                if written > 0 {
+                    offset += written
+                    continue
+                }
+
+                let code = written == 0 ? EIO : errno
+                if code == EINTR {
+                    continue
+                }
+                throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/FileHandleProcessPipeWritingTests.swift
+++ b/Packages/macOS/CmuxFoundation/Tests/CmuxFoundationTests/FileHandleProcessPipeWritingTests.swift
@@ -1,0 +1,44 @@
+import Darwin
+import Foundation
+import Testing
+@testable import CmuxFoundation
+
+@Suite("FileHandle process-pipe writing")
+struct FileHandleProcessPipeWritingTests {
+    @Test("writeProcessPipeInput writes every byte")
+    func writesEveryByte() async throws {
+        let pipe = Pipe()
+        defer {
+            try? pipe.fileHandleForWriting.close()
+            try? pipe.fileHandleForReading.close()
+        }
+        let payload = Data(repeating: 0x41, count: 128 * 1024)
+
+        let readDescriptor = pipe.fileHandleForReading.fileDescriptor
+        let readTask = Task.detached {
+            ProcessPipeEndRead.reading(fileDescriptor: readDescriptor)
+        }
+        try pipe.fileHandleForWriting.writeProcessPipeInput(payload)
+        try pipe.fileHandleForWriting.close()
+
+        let result = await readTask.value
+        #expect(result.readError == nil)
+        #expect(result.data == payload)
+    }
+
+    @Test("writeProcessPipeInput reports EPIPE when the reader closes")
+    func reportsClosedReader() throws {
+        let pipe = Pipe()
+        try pipe.fileHandleForReading.close()
+        defer { try? pipe.fileHandleForWriting.close() }
+
+        do {
+            try pipe.fileHandleForWriting.writeProcessPipeInput(Data("payload".utf8))
+            Issue.record("Expected the closed process pipe to reject input")
+        } catch let error as POSIXError {
+            #expect(error.code == .EPIPE)
+        } catch {
+            Issue.record("Expected POSIXError, received \(error)")
+        }
+    }
+}

--- a/Sources/TextBoxGitIgnoreProbe.swift
+++ b/Sources/TextBoxGitIgnoreProbe.swift
@@ -1,0 +1,114 @@
+import CmuxFoundation
+import Foundation
+
+/// Owns the complete Git subprocess boundary used by TextBox file mentions.
+struct TextBoxGitIgnoreProbe: Sendable {
+    private let rootURL: URL
+
+    init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    func isWorkTree() async -> Bool {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [
+            "git",
+            "-C", rootURL.path,
+            "rev-parse",
+            "--is-inside-work-tree"
+        ]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        let terminationStatus = observeTermination(of: process)
+
+        do {
+            try process.run()
+        } catch {
+            return false
+        }
+        return await terminationStatus.wait() == 0
+    }
+
+    func ignoredRelativePaths(_ relativePaths: [String]) async -> Set<String> {
+        guard !relativePaths.isEmpty else { return [] }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [
+            "git",
+            "-C", rootURL.path,
+            "check-ignore",
+            "--stdin"
+        ]
+
+        let stdin = Pipe()
+        let stdout = Pipe()
+        process.standardInput = stdin
+        process.standardOutput = stdout
+        process.standardError = FileHandle.nullDevice
+        let terminationStatus = observeTermination(of: process)
+
+        do {
+            try process.run()
+        } catch {
+            return []
+        }
+
+        // The child owns duplicated copies after run() returns. Closing the
+        // parent's child-side handles makes EOF and resource ownership explicit.
+        try? stdin.fileHandleForReading.close()
+        try? stdout.fileHandleForWriting.close()
+
+        let inputHandle = stdin.fileHandleForWriting
+        let outputHandle = stdout.fileHandleForReading
+        let outputDescriptor = outputHandle.fileDescriptor
+        defer {
+            try? inputHandle.close()
+            try? outputHandle.close()
+        }
+
+        // Capture only the Sendable descriptor in detached work. The local
+        // Pipe keeps its FileHandle alive until this task has been awaited.
+        let outputTask = Task.detached(priority: .utility) {
+            ProcessPipeEndRead.reading(fileDescriptor: outputDescriptor)
+        }
+
+        let probePaths = relativePaths + relativePaths.map { "\($0)/" }
+        let input = Data((probePaths.joined(separator: "\n") + "\n").utf8)
+        let inputSucceeded: Bool
+        do {
+            try inputHandle.writeProcessPipeInput(input)
+            try inputHandle.close()
+            inputSucceeded = true
+        } catch {
+            try? inputHandle.close()
+            inputSucceeded = false
+        }
+
+        let output = await outputTask.value
+        let status = await terminationStatus.wait()
+        guard inputSucceeded,
+              output.readError == nil,
+              status == 0 || status == 1,
+              let outputText = String(data: output.data, encoding: .utf8) else {
+            return []
+        }
+
+        return Set(outputText
+            .split(separator: "\n", omittingEmptySubsequences: true)
+            .map(String.init))
+    }
+
+    private func observeTermination(of process: Process) -> TextBoxProcessTerminationStatus {
+        let terminationStatus = TextBoxProcessTerminationStatus()
+        process.terminationHandler = { process in
+            let status = process.terminationStatus
+            Task {
+                await terminationStatus.finish(status: status)
+            }
+        }
+        return terminationStatus
+    }
+}

--- a/Sources/TextBoxMentionIndexStore.swift
+++ b/Sources/TextBoxMentionIndexStore.swift
@@ -391,8 +391,9 @@ actor TextBoxMentionIndexStore {
         let relativePaths = candidateURLs.map {
             Self.relativePath(for: $0.path, rootPath: rootPath)
         }
-        let ignoredRelativePaths = await isGitWorkTree(rootURL: rootURL)
-            ? await gitIgnoredRelativePaths(rootURL: rootURL, relativePaths: relativePaths)
+        let gitIgnoreProbe = TextBoxGitIgnoreProbe(rootURL: rootURL)
+        let ignoredRelativePaths = await gitIgnoreProbe.isWorkTree()
+            ? await gitIgnoreProbe.ignoredRelativePaths(relativePaths)
             : []
 
         var candidates: [TextBoxMentionCandidate] = []
@@ -447,6 +448,7 @@ actor TextBoxMentionIndexStore {
         process.currentDirectoryURL = rootURL
 
         let stdout = Pipe()
+        let outputHandle = stdout.fileHandleForReading
         process.standardOutput = stdout
         process.standardError = FileHandle.nullDevice
         let terminationStatus = TextBoxProcessTerminationStatus()
@@ -460,8 +462,12 @@ actor TextBoxMentionIndexStore {
         do {
             try process.run()
         } catch {
+            try? stdout.fileHandleForWriting.close()
+            try? outputHandle.close()
             return nil
         }
+        try? stdout.fileHandleForWriting.close()
+        defer { try? outputHandle.close() }
 
         let directorySeed = await scanDirectoryCandidateSeed(rootURL: rootURL)
         var directoryCandidates = directorySeed.candidates
@@ -512,7 +518,7 @@ actor TextBoxMentionIndexStore {
         var buffer = Data()
         let newline: UInt8 = 10
         do {
-            for try await byte in stdout.fileHandleForReading.bytes {
+            for try await byte in outputHandle.bytes {
                 buffer.append(byte)
                 guard byte == newline else { continue }
 
@@ -554,7 +560,8 @@ actor TextBoxMentionIndexStore {
     ) async -> (candidates: [TextBoxMentionCandidate], seenRelativePaths: Set<String>) {
         let fileManager = FileManager.default
         let rootPath = rootURL.standardizedFileURL.path
-        let checksGitIgnore = await isGitWorkTree(rootURL: rootURL)
+        let gitIgnoreProbe = TextBoxGitIgnoreProbe(rootURL: rootURL)
+        let checksGitIgnore = await gitIgnoreProbe.isWorkTree()
         var candidates: [TextBoxMentionCandidate] = []
         var seenRelativePaths = Set<String>()
         candidates.reserveCapacity(min(maxIndexedDirectories, 256))
@@ -571,7 +578,7 @@ actor TextBoxMentionIndexStore {
                 Self.relativePath(for: $0.path, rootPath: rootPath)
             }
             let ignoredRelativePaths = checksGitIgnore
-                ? await gitIgnoredRelativePaths(rootURL: rootURL, relativePaths: relativePaths)
+                ? await gitIgnoreProbe.ignoredRelativePaths(relativePaths)
                 : []
 
             for standardizedURL in directoryBatch {
@@ -617,94 +624,6 @@ actor TextBoxMentionIndexStore {
                 (try? $0.resourceValues(forKeys: [.isDirectoryKey]).isDirectory) == true &&
                     !shouldSkipIndexedDirectoryName($0.lastPathComponent)
             }
-    }
-
-    private static func isGitWorkTree(rootURL: URL) async -> Bool {
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [
-            "git",
-            "-C", rootURL.path,
-            "rev-parse",
-            "--is-inside-work-tree"
-        ]
-        process.standardOutput = FileHandle.nullDevice
-        process.standardError = FileHandle.nullDevice
-        let terminationStatus = TextBoxProcessTerminationStatus()
-        process.terminationHandler = { process in
-            let status = process.terminationStatus
-            Task {
-                await terminationStatus.finish(status: status)
-            }
-        }
-
-        do {
-            try process.run()
-        } catch {
-            return false
-        }
-        return await terminationStatus.wait() == 0
-    }
-
-    private static func gitIgnoredRelativePaths(rootURL: URL, relativePaths: [String]) async -> Set<String> {
-        guard !relativePaths.isEmpty else { return [] }
-
-        let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
-        process.arguments = [
-            "git",
-            "-C", rootURL.path,
-            "check-ignore",
-            "--stdin"
-        ]
-
-        let stdin = Pipe()
-        let stdout = Pipe()
-        process.standardInput = stdin
-        process.standardOutput = stdout
-        process.standardError = FileHandle.nullDevice
-        let terminationStatus = TextBoxProcessTerminationStatus()
-        process.terminationHandler = { process in
-            let status = process.terminationStatus
-            Task {
-                await terminationStatus.finish(status: status)
-            }
-        }
-
-        do {
-            try process.run()
-        } catch {
-            return []
-        }
-        let outputTask = Task<Data, Never> {
-            var output = Data()
-            do {
-                for try await byte in stdout.fileHandleForReading.bytes {
-                    output.append(byte)
-                }
-            } catch {
-                return Data()
-            }
-            return output
-        }
-
-        let probePaths = relativePaths + relativePaths.map { "\($0)/" }
-        let input = probePaths.joined(separator: "\n") + "\n"
-        if let data = input.data(using: .utf8) {
-            stdin.fileHandleForWriting.write(data)
-        }
-        stdin.fileHandleForWriting.closeFile()
-
-        let output = await outputTask.value
-        let status = await terminationStatus.wait()
-        guard status == 0 || status == 1,
-              let outputText = String(data: output, encoding: .utf8) else {
-            return []
-        }
-
-        return Set(outputText
-            .split(separator: "\n", omittingEmptySubsequences: true)
-            .map(String.init))
     }
 
     private static func directoryCandidate(relativePath: String, directoryURL: URL) -> TextBoxMentionCandidate {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1539,6 +1539,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE7B230000000000000001 /* TextBoxMentionCompletionDetector.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B230000000000000002 /* TextBoxMentionCompletionDetector.swift */; };
 		C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */; };
 		C0DE7B320000000000000001 /* TextBoxMentionFileIndexRefreshTask.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B320000000000000002 /* TextBoxMentionFileIndexRefreshTask.swift */; };
+		7898A0010000000000000001 /* TextBoxMentionGitIgnoreProbeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7898A0010000000000000002 /* TextBoxMentionGitIgnoreProbeTests.swift */; };
 		C0DE7B270000000000000001 /* TextBoxMentionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B270000000000000002 /* TextBoxMentionIndexStore.swift */; };
 		C0DE7B200000000000000001 /* TextBoxMentionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B200000000000000002 /* TextBoxMentionKind.swift */; };
 		C0DE7B240000000000000001 /* TextBoxMentionMarkdown.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B240000000000000002 /* TextBoxMentionMarkdown.swift */; };
@@ -3244,6 +3245,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE7B230000000000000002 /* TextBoxMentionCompletionDetector.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCompletionDetector.swift; sourceTree = "<group>"; };
 		C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCompletionTests.swift; sourceTree = "<group>"; };
 		C0DE7B320000000000000002 /* TextBoxMentionFileIndexRefreshTask.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionFileIndexRefreshTask.swift; sourceTree = "<group>"; };
+		7898A0010000000000000002 /* TextBoxMentionGitIgnoreProbeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionGitIgnoreProbeTests.swift; sourceTree = "<group>"; };
 		C0DE7B270000000000000002 /* TextBoxMentionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionIndexStore.swift; sourceTree = "<group>"; };
 		C0DE7B200000000000000002 /* TextBoxMentionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionKind.swift; sourceTree = "<group>"; };
 		C0DE7B240000000000000002 /* TextBoxMentionMarkdown.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionMarkdown.swift; sourceTree = "<group>"; };
@@ -4891,6 +4893,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6512F0C06512F0C06512F001 /* MainWindowFocusRestoreTests.swift */,
 				C3467AB10000000000000002 /* ShortcutWhenClauseTests.swift */,
 				C0DE7B300000000000000002 /* TextBoxMentionCompletionTests.swift */,
+				7898A0010000000000000002 /* TextBoxMentionGitIgnoreProbeTests.swift */,
 				C1713005C1713005C1713005 /* CommandPaletteShortcutCustomizationTests.swift */,
 				17FCD4CC61D54A2F8F2F463D /* AppDelegateBareSpaceShortcutRoutingTests.swift */,
 				C34670010000000000000002 /* AppDelegateRenameShortcutContextTests.swift */,
@@ -7287,6 +7290,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C95BAC3D37A6111B487582DC /* TerminalWindowPortalLifecycleHiddenRefreshTests.swift in Sources */,
 				B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */,
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,
+				7898A0010000000000000001 /* TextBoxMentionGitIgnoreProbeTests.swift in Sources */,
 				C0DE7B3C0000000000000001 /* TextBoxSubmitActionSettingsFileTests.swift in Sources */,
 				C0DE7B360000000000000001 /* TextBoxSubmitActionTests.swift in Sources */,
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1530,6 +1530,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B7758A030000000000000001 /* TerminationWatchdogAtomic.c in Sources */ = {isa = PBXBuildFile; fileRef = B7758A030000000000000002 /* TerminationWatchdogAtomic.c */; };
 		B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7758A020000000000000002 /* TerminationWatchdogTests.swift */; };
 		C0DE7B330000000000000001 /* TextBoxAgentDetection.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B330000000000000002 /* TextBoxAgentDetection.swift */; };
+		7898A0020000000000000001 /* TextBoxGitIgnoreProbe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7898A0020000000000000002 /* TextBoxGitIgnoreProbe.swift */; };
 		C0DE7B100000000000000001 /* TextBoxInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B100000000000000002 /* TextBoxInput.swift */; };
 		C0DE7B3B0000000000000001 /* TextBoxInputTextViewDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B3B0000000000000002 /* TextBoxInputTextViewDebug.swift */; };
 		C0DE7B310000000000000001 /* TextBoxMentionCachedIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B310000000000000002 /* TextBoxMentionCachedIndex.swift */; };
@@ -3236,6 +3237,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B7758A040000000000000002 /* TerminationWatchdogAtomic.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = TerminationWatchdogAtomic.h; sourceTree = "<group>"; };
 		B7758A020000000000000002 /* TerminationWatchdogTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminationWatchdogTests.swift; sourceTree = "<group>"; };
 		C0DE7B330000000000000002 /* TextBoxAgentDetection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxAgentDetection.swift; sourceTree = "<group>"; };
+		7898A0020000000000000002 /* TextBoxGitIgnoreProbe.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxGitIgnoreProbe.swift; sourceTree = "<group>"; };
 		C0DE7B100000000000000002 /* TextBoxInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxInput.swift; sourceTree = "<group>"; };
 		C0DE7B3B0000000000000002 /* TextBoxInputTextViewDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Debug/TextBoxInputTextViewDebug.swift; sourceTree = "<group>"; };
 		C0DE7B310000000000000002 /* TextBoxMentionCachedIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxMentionCachedIndex.swift; sourceTree = "<group>"; };
@@ -3939,6 +3941,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A50012F2 /* KeyboardShortcutSettings.swift */,
 				63F0CD0E /* KeyboardShortcutSettings+SystemWideHotkeyConflicts.swift */,
 				C0DE7B330000000000000002 /* TextBoxAgentDetection.swift */,
+				7898A0020000000000000002 /* TextBoxGitIgnoreProbe.swift */,
 				C0DE7B310000000000000002 /* TextBoxMentionCachedIndex.swift */,
 				C0DE7B250000000000000002 /* TextBoxMentionCandidate.swift */,
 				C0DE7B260000000000000002 /* TextBoxMentionCandidateIndex.swift */,
@@ -6598,6 +6601,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B7758A010000000000000001 /* TerminationWatchdog.swift in Sources */,
 				B7758A030000000000000001 /* TerminationWatchdogAtomic.c in Sources */,
 				C0DE7B330000000000000001 /* TextBoxAgentDetection.swift in Sources */,
+				7898A0020000000000000001 /* TextBoxGitIgnoreProbe.swift in Sources */,
 				C0DE7B100000000000000001 /* TextBoxInput.swift in Sources */,
 				C0DE7B3B0000000000000001 /* TextBoxInputTextViewDebug.swift in Sources */,
 				C0DE7B310000000000000001 /* TextBoxMentionCachedIndex.swift in Sources */,

--- a/cmuxTests/TextBoxMentionGitIgnoreProbeTests.swift
+++ b/cmuxTests/TextBoxMentionGitIgnoreProbeTests.swift
@@ -1,0 +1,67 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Text box mention Git ignore probe")
+struct TextBoxMentionGitIgnoreProbeTests {
+    @Test
+    func fileSuggestionsSurviveGitIgnoreClosingItsInputPipe() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory.appendingPathComponent(
+            "cmux-textbox-git-ignore-broken-pipe-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? fileManager.removeItem(at: root) }
+
+        let sourceDirectory = root.appendingPathComponent("Sources", isDirectory: true)
+        try fileManager.createDirectory(at: sourceDirectory, withIntermediateDirectories: true)
+        try "struct VisibleNeedle {}".write(
+            to: sourceDirectory.appendingPathComponent("VisibleNeedle.swift"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        // Fill each probe batch beyond a normal pipe buffer. This makes the
+        // parent observe the child closing stdin instead of winning the race
+        // by buffering its entire write before Git exits.
+        for index in 0..<256 {
+            let prefix = String(format: "probe-%03d-", index)
+            let directoryName = prefix + String(repeating: "x", count: 255 - prefix.utf8.count)
+            try fileManager.createDirectory(
+                at: root.appendingPathComponent(directoryName, isDirectory: true),
+                withIntermediateDirectories: false
+            )
+        }
+
+        let gitInit = Process()
+        gitInit.executableURL = URL(fileURLWithPath: "/usr/bin/git")
+        gitInit.arguments = ["-C", root.path, "init", "--quiet"]
+        gitInit.standardInput = FileHandle.nullDevice
+        gitInit.standardOutput = FileHandle.nullDevice
+        gitInit.standardError = FileHandle.nullDevice
+        try gitInit.run()
+        gitInit.waitUntilExit()
+        #expect(gitInit.terminationStatus == 0)
+
+        // rev-parse still recognizes the worktree, but check-ignore exits 128
+        // before consuming stdin because it must parse the corrupt index.
+        try Data("corrupt index".utf8).write(to: root.appendingPathComponent(".git/index"))
+
+        let suggestions = await TextBoxMentionIndexStore.shared.suggestions(
+            for: TextBoxMentionQuery(
+                kind: .file,
+                range: NSRange(location: 0, length: 14),
+                query: "VisibleNeedle",
+                trigger: "@"
+            ),
+            rootDirectory: root.path
+        )
+
+        #expect(suggestions.contains { $0.title == "@Sources/VisibleNeedle.swift" })
+    }
+}


### PR DESCRIPTION
## Summary
- extract `TextBoxGitIgnoreProbe` as the sole owner of TextBox Git subprocess lifecycle and soft-fail every launch, input, output, close, and exit-status failure
- add a reusable CmuxFoundation process-pipe writer using `F_SETNOSIGPIPE` plus descriptor-level partial-write and `EINTR` handling, so `EPIPE` is a Swift error rather than an app-terminating `NSFileHandleOperationException`
- explicitly close and recover the remaining ripgrep output handles in mention indexing
- add a real corrupt-index regression with enough stdin to deterministically exercise the dead-reader path

## Regression commit structure
1. `33350f98db` adds the failing corrupt-index regression only.
2. `5a200e65ef` adds the fix and lower-level pipe writer coverage.

## Prior art overlap
This overlaps PR #7887 in suppressing `SIGPIPE`, recovering a closed `git check-ignore --stdin` pipe, returning an empty ignore set, and covering a corrupt Git index. This PR is deliberately broader: it removes the Foundation write operation entirely, centralizes both Git child processes behind one TextBox probe boundary, handles partial writes and `EINTR`, explicitly owns parent/child pipe-end closure, treats stdout read and close failures as soft failures, and hardens the neighboring ripgrep handle lifecycle. It does not duplicate the IME replacement-range work in PR #5346.

## Testing
- `arch -arm64 swift test --package-path Packages/macOS/CmuxFoundation` — 93 tests passed
- direct `swiftc -typecheck -warnings-as-errors` for `TextBoxGitIgnoreProbe` and `TextBoxProcessTerminationStatus`
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `git diff --check`

The mandatory Swift file-length audit was run. It reports five files already over budget on `origin/main`; none is changed here. `TextBoxMentionIndexStore.swift` shrinks from 937 to 856 lines, all new Swift files are below 500 lines, and neither budget TSV is touched.

No user-facing strings changed; no localization catalog changes are required.

Per task instruction, no local app build or app-host `xcodebuild test` was run; PR CI owns the app-host regression.

Fixes #7898

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7903"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786397756&installation_id=133855650&pr_number=7903&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7903&signature=63d3c6f59663971a21b6031abfa3d4eb6ab14c2cd8e073d33d6a98c8b96af4dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches subprocess and pipe I/O on the TextBox mention indexing path; behavior change is intentional fail-soft (empty ignore set) rather than crash, with regression tests for the corrupt-index case.
> 
> **Overview**
> Prevents TextBox `@` file mentions from crashing or emptying suggestions when `git check-ignore` dies early (e.g. corrupt index) and the parent still writes a large stdin batch to a closed pipe.
> 
> Adds **`FileHandle.writeProcessPipeInput`** in CmuxFoundation: **`F_SETNOSIGPIPE`**, looped **`write(2)`** for partial writes and **`EINTR`**, and **`EPIPE`** surfaced as **`POSIXError`** instead of a terminating Foundation write exception.
> 
> Moves all TextBox Git subprocess work into **`TextBoxGitIgnoreProbe`**, which **soft-fails** launch, stdin, stdout read, and exit-status problems by returning **`false`** / an **empty ignore set**, so indexing keeps going. **`TextBoxMentionIndexStore`** drops the inlined helpers and wires the probe in; ripgrep scanning gets **explicit child-side pipe closes** and **`defer`** cleanup on the read handle.
> 
> Regression coverage: CmuxFoundation pipe writer tests plus an app test that corrupts **`.git/index`** and forces a pipe-buffer-sized probe batch so file suggestions still include the visible file.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a200e65ef636022ab22ed4011e9e7e524e25560. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent crashes when probing Git ignores by making subprocess IO fail-soft and centralizing Git process ownership in `TextBoxGitIgnoreProbe`. Fixes #7898.

- **Bug Fixes**
  - Use `F_SETNOSIGPIPE` and a new pipe writer to turn closed-reader `EPIPE` into a Swift `POSIXError`, preventing `NSFileHandleOperationException` crashes.
  - Soft-fail on all launch, IO, close, and exit-status errors; return an empty ignore set if `git check-ignore --stdin` fails (e.g., corrupt index).
  - Explicitly close parent/child pipe ends and recover ripgrep stdout handles; add a corrupt-index regression to verify suggestions still work.

- **Refactors**
  - Added `TextBoxGitIgnoreProbe` as the single owner of TextBox Git subprocesses; removed ad-hoc logic from `TextBoxMentionIndexStore`.
  - Introduced `FileHandle.writeProcessPipeInput` in `CmuxFoundation` with partial-write and `EINTR` handling, plus tests.

<sup>Written for commit 5a200e65ef636022ab22ed4011e9e7e524e25560. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved text-box file suggestions by respecting Git-ignored paths.
  * Added reliable Git repository detection for file scanning.
  * Added robust process-pipe writing with clear errors when the reader closes.

* **Bug Fixes**
  * File scanning now remains functional when Git closes its input early or encounters repository errors.
  * Improved cleanup of process resources after scanning failures.

* **Tests**
  * Added coverage for large pipe writes, closed readers, ignored files, and unusual Git failure scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->