### PR TITLE
Fix command palette outside-click dismissal lifecycle

### DIFF
--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/AppKitCommandPaletteEventMonitorSource.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/AppKitCommandPaletteEventMonitorSource.swift
@@ -1,0 +1,27 @@
+import AppKit
+
+/// Adapts AppKit's process-local mouse monitor to palette pointer snapshots.
+@MainActor
+final class AppKitCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSource {
+    func addLocalMouseDownMonitor(
+        for window: AnyObject,
+        handler: @escaping (CommandPalettePointerEvent) -> Void
+    ) -> Any {
+        weak let observedWindow = window
+        return NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
+        ) { event in
+            let eventWindow = event.window
+                ?? (event.windowNumber > 0 ? NSApp.window(withWindowNumber: event.windowNumber) : nil)
+            handler(CommandPalettePointerEvent(
+                isInObservedWindow: eventWindow === observedWindow,
+                locationInWindow: event.locationInWindow
+            ))
+            return event
+        } as Any
+    }
+
+    func removeLocalMonitor(_ monitor: Any) {
+        NSEvent.removeMonitor(monitor)
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/AppKitCommandPaletteEventMonitorSource.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/AppKitCommandPaletteEventMonitorSource.swift
@@ -6,19 +6,23 @@ final class AppKitCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSo
     func addLocalMouseDownMonitor(
         for window: AnyObject,
         handler: @escaping (CommandPalettePointerEvent) -> Void
-    ) -> Any {
+    ) -> Any? {
         weak let observedWindow = window
-        return NSEvent.addLocalMonitorForEvents(
-            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown]
-        ) { event in
-            let eventWindow = event.window
-                ?? (event.windowNumber > 0 ? NSApp.window(withWindowNumber: event.windowNumber) : nil)
-            handler(CommandPalettePointerEvent(
-                isInObservedWindow: eventWindow === observedWindow,
-                locationInWindow: event.locationInWindow
-            ))
-            return event
-        } as Any
+        guard let monitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown, .otherMouseDown],
+            handler: { event in
+                let eventWindow = event.window
+                    ?? (event.windowNumber > 0 ? NSApp.window(withWindowNumber: event.windowNumber) : nil)
+                handler(CommandPalettePointerEvent(
+                    isInObservedWindow: eventWindow === observedWindow,
+                    locationInWindow: event.locationInWindow
+                ))
+                return event
+            }
+        ) else {
+            return nil
+        }
+        return monitor
     }
 
     func removeLocalMonitor(_ monitor: Any) {

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteEventMonitorSource.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteEventMonitorSource.swift
@@ -3,7 +3,7 @@ protocol CommandPaletteEventMonitorSource: AnyObject {
     func addLocalMouseDownMonitor(
         for window: AnyObject,
         handler: @escaping (CommandPalettePointerEvent) -> Void
-    ) -> Any
+    ) -> Any?
 
     @MainActor
     func removeLocalMonitor(_ monitor: Any)

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteEventMonitorSource.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteEventMonitorSource.swift
@@ -1,0 +1,10 @@
+protocol CommandPaletteEventMonitorSource: AnyObject {
+    @MainActor
+    func addLocalMouseDownMonitor(
+        for window: AnyObject,
+        handler: @escaping (CommandPalettePointerEvent) -> Void
+    ) -> Any
+
+    @MainActor
+    func removeLocalMonitor(_ monitor: Any)
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionDismissal.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionDismissal.swift
@@ -5,4 +5,7 @@ public enum CommandPaletteInteractionDismissal: Sendable, Equatable {
 
     /// The palette's host window stopped being the key window.
     case windowResignedKey
+
+    /// The application main menu entered its nested tracking loop.
+    case mainMenuBeganTracking
 }

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionDismissal.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionDismissal.swift
@@ -1,0 +1,8 @@
+/// The interaction that ended one visible command-palette lifecycle.
+public enum CommandPaletteInteractionDismissal: Sendable, Equatable {
+    /// A process-local pointer event occurred outside the palette panel.
+    case pointer(CommandPalettePointerEvent)
+
+    /// The palette's host window stopped being the key window.
+    case windowResignedKey
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
@@ -1,0 +1,115 @@
+import AppKit
+
+/// Owns every process-level observation used while one command palette is visible.
+///
+/// Activation is idempotent for a window: repeated render updates refresh the
+/// callbacks without installing duplicate monitors. Deactivation removes the
+/// local pointer monitor and both window-key observers as one lifecycle unit.
+@MainActor
+public final class CommandPaletteInteractionMonitor {
+    static let windowDidBecomeKeyNotification = NSWindow.didBecomeKeyNotification
+    static let windowDidResignKeyNotification = NSWindow.didResignKeyNotification
+    private let notificationCenter: NotificationCenter
+    private let eventSource: any CommandPaletteEventMonitorSource
+    private weak var window: AnyObject?
+    private var localMouseDownMonitor: Any?
+    private var windowObserverTokens: [any NSObjectProtocol] = []
+    private var shouldDismiss: ((CommandPalettePointerEvent) -> Bool)?
+    private var onWindowStateChange: (() -> Void)?
+    private var onDismiss: (() -> Void)?
+
+    /// Creates a monitor backed by the process event stream and default notification center.
+    public convenience init() {
+        self.init(
+            notificationCenter: .default,
+            eventSource: AppKitCommandPaletteEventMonitorSource()
+        )
+    }
+
+    init(
+        notificationCenter: NotificationCenter,
+        eventSource: any CommandPaletteEventMonitorSource
+    ) {
+        self.notificationCenter = notificationCenter
+        self.eventSource = eventSource
+    }
+
+    isolated deinit {
+        deactivate()
+    }
+
+    /// Starts observation for `window`, or refreshes the callbacks when already active.
+    ///
+    /// Callers should disable their overlay synchronously in `onDismiss`, allowing
+    /// the initiating mouse-down to reach the newly exposed underlying control.
+    ///
+    /// - Parameters:
+    ///   - window: The window object used to scope key-window notifications.
+    ///   - shouldDismiss: Returns whether a local mouse-down is outside the palette.
+    ///   - onWindowStateChange: Reconciles focus when the observed window changes key state.
+    ///   - onDismiss: Synchronously hides the overlay and updates presentation state.
+    public func activate(
+        for window: AnyObject,
+        shouldDismiss: @escaping (CommandPalettePointerEvent) -> Bool,
+        onWindowStateChange: @escaping () -> Void,
+        onDismiss: @escaping () -> Void
+    ) {
+        if self.window !== window {
+            deactivate()
+            self.window = window
+        }
+
+        self.shouldDismiss = shouldDismiss
+        self.onWindowStateChange = onWindowStateChange
+        self.onDismiss = onDismiss
+
+        if localMouseDownMonitor == nil {
+            localMouseDownMonitor = eventSource.addLocalMouseDownMonitor(for: window) { [weak self] event in
+                guard let self, self.shouldDismiss?(event) == true else { return }
+                self.onDismiss?()
+            }
+        }
+
+        guard windowObserverTokens.isEmpty else { return }
+        windowObserverTokens = [
+            observe(Self.windowDidBecomeKeyNotification, window: window, dismiss: false),
+            observe(Self.windowDidResignKeyNotification, window: window, dismiss: true),
+        ]
+    }
+
+    /// Removes all observation and releases the callbacks captured for presentation.
+    public func deactivate() {
+        if let localMouseDownMonitor {
+            eventSource.removeLocalMonitor(localMouseDownMonitor)
+            self.localMouseDownMonitor = nil
+        }
+        for token in windowObserverTokens {
+            notificationCenter.removeObserver(token)
+        }
+        windowObserverTokens.removeAll()
+        window = nil
+        shouldDismiss = nil
+        onWindowStateChange = nil
+        onDismiss = nil
+    }
+
+    private func observe(
+        _ name: Notification.Name,
+        window: AnyObject,
+        dismiss: Bool
+    ) -> any NSObjectProtocol {
+        notificationCenter.addObserver(
+            forName: name,
+            object: window,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                self.onWindowStateChange?()
+                if dismiss {
+                    self.onDismiss?()
+                }
+            }
+        }
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
@@ -1,5 +1,14 @@
 import AppKit
 
+/// The interaction that ended one visible command-palette lifecycle.
+public enum CommandPaletteInteractionDismissal: Sendable, Equatable {
+    /// A process-local pointer event occurred outside the palette panel.
+    case pointer(CommandPalettePointerEvent)
+
+    /// The palette's host window stopped being the key window.
+    case windowResignedKey
+}
+
 /// Owns every process-level observation used while one command palette is visible.
 ///
 /// Activation is idempotent for a window: repeated render updates refresh the
@@ -16,7 +25,7 @@ public final class CommandPaletteInteractionMonitor {
     private var windowObserverTokens: [any NSObjectProtocol] = []
     private var shouldDismiss: ((CommandPalettePointerEvent) -> Bool)?
     private var onWindowStateChange: (() -> Void)?
-    private var onDismiss: (() -> Void)?
+    private var onDismiss: ((CommandPaletteInteractionDismissal) -> Void)?
 
     /// Creates a monitor backed by the process event stream and default notification center.
     public convenience init() {
@@ -52,7 +61,7 @@ public final class CommandPaletteInteractionMonitor {
         for window: AnyObject,
         shouldDismiss: @escaping (CommandPalettePointerEvent) -> Bool,
         onWindowStateChange: @escaping () -> Void,
-        onDismiss: @escaping () -> Void
+        onDismiss: @escaping (CommandPaletteInteractionDismissal) -> Void
     ) {
         if self.window !== window {
             deactivate()
@@ -66,14 +75,14 @@ public final class CommandPaletteInteractionMonitor {
         if localMouseDownMonitor == nil {
             localMouseDownMonitor = eventSource.addLocalMouseDownMonitor(for: window) { [weak self] event in
                 guard let self, self.shouldDismiss?(event) == true else { return }
-                self.onDismiss?()
+                self.onDismiss?(.pointer(event))
             }
         }
 
         guard windowObserverTokens.isEmpty else { return }
         windowObserverTokens = [
-            observe(Self.windowDidBecomeKeyNotification, window: window, dismiss: false),
-            observe(Self.windowDidResignKeyNotification, window: window, dismiss: true),
+            observe(Self.windowDidBecomeKeyNotification, window: window, dismissal: nil),
+            observe(Self.windowDidResignKeyNotification, window: window, dismissal: .windowResignedKey),
         ]
     }
 
@@ -96,7 +105,7 @@ public final class CommandPaletteInteractionMonitor {
     private func observe(
         _ name: Notification.Name,
         window: AnyObject,
-        dismiss: Bool
+        dismissal: CommandPaletteInteractionDismissal?
     ) -> any NSObjectProtocol {
         notificationCenter.addObserver(
             forName: name,
@@ -106,8 +115,8 @@ public final class CommandPaletteInteractionMonitor {
             MainActor.assumeIsolated {
                 guard let self else { return }
                 self.onWindowStateChange?()
-                if dismiss {
-                    self.onDismiss?()
+                if let dismissal {
+                    self.onDismiss?(dismissal)
                 }
             }
         }

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
@@ -9,8 +9,10 @@ import AppKit
 public final class CommandPaletteInteractionMonitor {
     static let windowDidBecomeKeyNotification = NSWindow.didBecomeKeyNotification
     static let windowDidResignKeyNotification = NSWindow.didResignKeyNotification
+    static let menuDidBeginTrackingNotification = NSMenu.didBeginTrackingNotification
     private let notificationCenter: NotificationCenter
     private let eventSource: any CommandPaletteEventMonitorSource
+    private let mainMenuProvider: () -> NSMenu?
     private weak var window: AnyObject?
     private var localMouseDownMonitor: Any?
     private var windowObserverTokens: [any NSObjectProtocol] = []
@@ -22,16 +24,19 @@ public final class CommandPaletteInteractionMonitor {
     public convenience init() {
         self.init(
             notificationCenter: .default,
-            eventSource: AppKitCommandPaletteEventMonitorSource()
+            eventSource: AppKitCommandPaletteEventMonitorSource(),
+            mainMenuProvider: { NSApp.mainMenu }
         )
     }
 
     init(
         notificationCenter: NotificationCenter,
-        eventSource: any CommandPaletteEventMonitorSource
+        eventSource: any CommandPaletteEventMonitorSource,
+        mainMenuProvider: @escaping () -> NSMenu? = { NSApp.mainMenu }
     ) {
         self.notificationCenter = notificationCenter
         self.eventSource = eventSource
+        self.mainMenuProvider = mainMenuProvider
     }
 
     isolated deinit {
@@ -74,6 +79,7 @@ public final class CommandPaletteInteractionMonitor {
         windowObserverTokens = [
             observe(Self.windowDidBecomeKeyNotification, window: window, dismissal: nil),
             observe(Self.windowDidResignKeyNotification, window: window, dismissal: .windowResignedKey),
+            observeMainMenuTracking(),
         ]
     }
 
@@ -109,6 +115,27 @@ public final class CommandPaletteInteractionMonitor {
                 if let dismissal {
                     self.onDismiss?(dismissal)
                 }
+            }
+        }
+    }
+
+    private func observeMainMenuTracking() -> any NSObjectProtocol {
+        notificationCenter.addObserver(
+            forName: Self.menuDidBeginTrackingNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            guard let trackedMenu = notification.object as? NSMenu else { return }
+            var rootMenu = trackedMenu
+            while let supermenu = rootMenu.supermenu {
+                rootMenu = supermenu
+            }
+            let trackedRootIdentifier = ObjectIdentifier(rootMenu)
+            MainActor.assumeIsolated {
+                guard let self,
+                      let mainMenu = self.mainMenuProvider(),
+                      ObjectIdentifier(mainMenu) == trackedRootIdentifier else { return }
+                self.onDismiss?(.mainMenuBeganTracking)
             }
         }
     }

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
@@ -1,14 +1,5 @@
 import AppKit
 
-/// The interaction that ended one visible command-palette lifecycle.
-public enum CommandPaletteInteractionDismissal: Sendable, Equatable {
-    /// A process-local pointer event occurred outside the palette panel.
-    case pointer(CommandPalettePointerEvent)
-
-    /// The palette's host window stopped being the key window.
-    case windowResignedKey
-}
-
 /// Owns every process-level observation used while one command palette is visible.
 ///
 /// Activation is idempotent for a window: repeated render updates refresh the

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
@@ -37,8 +37,7 @@ public extension NSView {
     /// - Returns: Whether the point is inside the panel, or `nil` before marker mounting.
     func commandPalettePanelContains(windowPoint: NSPoint) -> Bool? {
         guard let marker = commandPalettePanelHitRegionDescendant() else { return nil }
-        let pointInMarker = marker.convert(windowPoint, from: nil)
-        return marker.bounds.contains(pointInMarker)
+        return marker.bounds.contains(marker.convert(windowPoint, from: nil))
     }
 
     private func commandPalettePanelHitRegionDescendant() -> NSView? {

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
@@ -1,0 +1,64 @@
+public import AppKit
+public import SwiftUI
+
+private let commandPalettePanelHitRegionIdentifier = NSUserInterfaceItemIdentifier(
+    "cmux.commandPalette.panelHitRegion"
+)
+
+private final class CommandPalettePanelHitRegionView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+/// Marks the command palette panel's bounds for AppKit-level outside-click routing.
+///
+/// The marker never participates in hit testing. The overlay controller queries its
+/// frame from the hosting view before deciding whether a mouse-down is outside.
+public struct CommandPalettePanelHitRegion: NSViewRepresentable {
+    /// Creates a passive panel-bounds marker.
+    public init() {}
+
+    /// Creates the passive AppKit marker view.
+    ///
+    /// - Parameter context: The representable context supplied by SwiftUI.
+    /// - Returns: A transparent, non-hit-testing marker view.
+    public func makeNSView(context: Context) -> NSView {
+        let view = CommandPalettePanelHitRegionView(frame: .zero)
+        view.identifier = commandPalettePanelHitRegionIdentifier
+        return view
+    }
+
+    /// Keeps the passive marker unchanged across SwiftUI updates.
+    ///
+    /// - Parameters:
+    ///   - nsView: The existing marker view.
+    ///   - context: The representable context supplied by SwiftUI.
+    public func updateNSView(_ nsView: NSView, context: Context) {}
+}
+
+public extension NSView {
+    /// Returns whether a window-coordinate point is inside the mounted palette panel.
+    ///
+    /// `nil` means the SwiftUI panel has not mounted its hit-region marker yet.
+    ///
+    /// - Parameter windowPoint: A point in the receiver's window coordinate space.
+    /// - Returns: Whether the point is inside the panel, or `nil` before marker mounting.
+    func commandPalettePanelContains(windowPoint: NSPoint) -> Bool? {
+        guard let marker = commandPalettePanelHitRegionDescendant() else { return nil }
+        let pointInMarker = marker.convert(windowPoint, from: nil)
+        return marker.bounds.contains(pointInMarker)
+    }
+
+    private func commandPalettePanelHitRegionDescendant() -> NSView? {
+        if identifier == commandPalettePanelHitRegionIdentifier {
+            return self
+        }
+        for subview in subviews {
+            if let match = subview.commandPalettePanelHitRegionDescendant() {
+                return match
+            }
+        }
+        return nil
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
@@ -36,7 +36,8 @@ public extension NSView {
     /// - Parameter windowPoint: A point in the receiver's window coordinate space.
     /// - Returns: Whether the point is inside the panel, or `nil` before marker mounting.
     func commandPalettePanelContains(windowPoint: NSPoint) -> Bool? {
-        guard let marker = commandPalettePanelHitRegionDescendant() else { return nil }
+        guard let marker = commandPalettePanelHitRegionDescendant(),
+              !marker.bounds.isEmpty else { return nil }
         return marker.bounds.contains(marker.convert(windowPoint, from: nil))
     }
 

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegion.swift
@@ -1,16 +1,6 @@
 public import AppKit
 public import SwiftUI
 
-private let commandPalettePanelHitRegionIdentifier = NSUserInterfaceItemIdentifier(
-    "cmux.commandPalette.panelHitRegion"
-)
-
-private final class CommandPalettePanelHitRegionView: NSView {
-    override func hitTest(_ point: NSPoint) -> NSView? {
-        nil
-    }
-}
-
 /// Marks the command palette panel's bounds for AppKit-level outside-click routing.
 ///
 /// The marker never participates in hit testing. The overlay controller queries its
@@ -25,7 +15,7 @@ public struct CommandPalettePanelHitRegion: NSViewRepresentable {
     /// - Returns: A transparent, non-hit-testing marker view.
     public func makeNSView(context: Context) -> NSView {
         let view = CommandPalettePanelHitRegionView(frame: .zero)
-        view.identifier = commandPalettePanelHitRegionIdentifier
+        view.identifier = CommandPalettePanelHitRegionView.interfaceIdentifier
         return view
     }
 
@@ -37,6 +27,7 @@ public struct CommandPalettePanelHitRegion: NSViewRepresentable {
     public func updateNSView(_ nsView: NSView, context: Context) {}
 }
 
+/// AppKit lookup support for a mounted command-palette panel marker.
 public extension NSView {
     /// Returns whether a window-coordinate point is inside the mounted palette panel.
     ///
@@ -51,7 +42,7 @@ public extension NSView {
     }
 
     private func commandPalettePanelHitRegionDescendant() -> NSView? {
-        if identifier == commandPalettePanelHitRegionIdentifier {
+        if identifier == CommandPalettePanelHitRegionView.interfaceIdentifier {
             return self
         }
         for subview in subviews {

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegionView.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePanelHitRegionView.swift
@@ -1,0 +1,12 @@
+import AppKit
+
+/// Passive AppKit marker backing ``CommandPalettePanelHitRegion``.
+final class CommandPalettePanelHitRegionView: NSView {
+    static let interfaceIdentifier = NSUserInterfaceItemIdentifier(
+        "cmux.commandPalette.panelHitRegion"
+    )
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePointerEvent.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePointerEvent.swift
@@ -1,0 +1,20 @@
+public import CoreGraphics
+
+/// A mouse-down snapshot used to decide whether a visible command palette should dismiss.
+public struct CommandPalettePointerEvent: Sendable, Equatable {
+    /// Whether the event belongs to the palette's observed window.
+    public let isInObservedWindow: Bool
+
+    /// The pointer location in the receiving window's coordinate space.
+    public let locationInWindow: CGPoint
+
+    /// Creates a pointer snapshot for palette interaction routing.
+    ///
+    /// - Parameters:
+    ///   - isInObservedWindow: Whether the event belongs to the observed window.
+    ///   - locationInWindow: The pointer location in window coordinates.
+    public init(isInObservedWindow: Bool, locationInWindow: CGPoint) {
+        self.isInObservedWindow = isInObservedWindow
+        self.locationInWindow = locationInWindow
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePointerEvent.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPalettePointerEvent.swift
@@ -17,4 +17,17 @@ public struct CommandPalettePointerEvent: Sendable, Equatable {
         self.isInObservedWindow = isInObservedWindow
         self.locationInWindow = locationInWindow
     }
+
+    /// Returns whether this event is known to be outside the visible palette.
+    ///
+    /// An unmounted panel marker produces `nil`. That transient geometry state is
+    /// not evidence of an outside click, so events in the observed window keep the
+    /// palette open until its panel bounds are available.
+    ///
+    /// - Parameter panelContainsPoint: Whether the mounted panel contains the event.
+    /// - Returns: `true` only for another window or a known-outside panel point.
+    public func shouldDismissPalette(panelContainsPoint: Bool?) -> Bool {
+        guard isInObservedWindow else { return true }
+        return panelContainsPoint == false
+    }
 }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -1,0 +1,174 @@
+import AppKit
+import Foundation
+import Testing
+@testable import CmuxCommandPalette
+
+@MainActor
+@Suite("CommandPaletteInteractionMonitor")
+struct CommandPaletteInteractionMonitorTests {
+    @Test("outside mouse-down dismisses and lifecycle cleanup removes every observer")
+    func outsideMouseDownDismissesAndCleansUp() throws {
+        let notificationCenter = RecordingCommandPaletteNotificationCenter()
+        let eventSource = RecordingCommandPaletteEventMonitorSource()
+        let monitor = CommandPaletteInteractionMonitor(
+            notificationCenter: notificationCenter,
+            eventSource: eventSource
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.close() }
+
+        var dismissCount = 0
+        var windowStateChangeCount = 0
+        monitor.activate(
+            for: window,
+            shouldDismiss: { _ in true },
+            onWindowStateChange: { windowStateChangeCount += 1 },
+            onDismiss: { dismissCount += 1 }
+        )
+
+        #expect(eventSource.addCount == 1)
+        #expect(notificationCenter.addedObservers.map(\.name) == [
+            NSWindow.didBecomeKeyNotification,
+            NSWindow.didResignKeyNotification,
+        ])
+
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: NSPoint(x: 20, y: 20),
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1
+        ))
+        #expect(eventSource.send(event) === event)
+        #expect(dismissCount == 1)
+
+        notificationCenter.post(name: NSWindow.didBecomeKeyNotification, object: window)
+        #expect(windowStateChangeCount == 1)
+        notificationCenter.post(name: NSWindow.didResignKeyNotification, object: window)
+        #expect(windowStateChangeCount == 2)
+        #expect(dismissCount == 2)
+
+        monitor.deactivate()
+        #expect(eventSource.removeCount == 1)
+        #expect(
+            notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map(\.token.id)
+        )
+    }
+
+    @Test("re-activation refreshes callbacks without duplicating monitors")
+    func reactivationRefreshesCallbacks() throws {
+        let eventSource = RecordingCommandPaletteEventMonitorSource()
+        let monitor = CommandPaletteInteractionMonitor(
+            notificationCenter: RecordingCommandPaletteNotificationCenter(),
+            eventSource: eventSource
+        )
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.close() }
+
+        var firstDismissCount = 0
+        var secondDismissCount = 0
+        monitor.activate(
+            for: window,
+            shouldDismiss: { _ in true },
+            onWindowStateChange: {},
+            onDismiss: { firstDismissCount += 1 }
+        )
+        monitor.activate(
+            for: window,
+            shouldDismiss: { _ in true },
+            onWindowStateChange: {},
+            onDismiss: { secondDismissCount += 1 }
+        )
+
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: .zero,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 2,
+            clickCount: 1,
+            pressure: 1
+        ))
+        _ = eventSource.send(event)
+
+        #expect(eventSource.addCount == 1)
+        #expect(firstDismissCount == 0)
+        #expect(secondDismissCount == 1)
+    }
+}
+
+@MainActor
+private final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSource {
+    private var handler: ((NSEvent) -> NSEvent?)?
+    private(set) var addCount = 0
+    private(set) var removeCount = 0
+
+    func addLocalMouseDownMonitor(
+        handler: @escaping (NSEvent) -> NSEvent?
+    ) -> Any {
+        addCount += 1
+        self.handler = handler
+        return NSObject()
+    }
+
+    func removeLocalMonitor(_ monitor: Any) {
+        removeCount += 1
+        handler = nil
+    }
+
+    func send(_ event: NSEvent) -> NSEvent? {
+        handler?(event)
+    }
+}
+
+private final class RecordingCommandPaletteObserverToken: NSObject {
+    let id: Int
+
+    init(id: Int) {
+        self.id = id
+        super.init()
+    }
+}
+
+private final class RecordingCommandPaletteNotificationCenter: NotificationCenter, @unchecked Sendable {
+    struct AddedObserver {
+        let name: Notification.Name?
+        weak var object: AnyObject?
+        let token: RecordingCommandPaletteObserverToken
+    }
+
+    private(set) var addedObservers: [AddedObserver] = []
+    private(set) var removedObserverIDs: [Int] = []
+
+    override func addObserver(
+        forName name: Notification.Name?,
+        object obj: Any?,
+        queue: OperationQueue?,
+        using block: @escaping @Sendable (Notification) -> Void
+    ) -> any NSObjectProtocol {
+        let token = RecordingCommandPaletteObserverToken(id: addedObservers.count + 1)
+        addedObservers.append(AddedObserver(name: name, object: obj as AnyObject?, token: token))
+        return token
+    }
+
+    override func removeObserver(_ observer: Any) {
+        guard let token = observer as? RecordingCommandPaletteObserverToken else { return }
+        removedObserverIDs.append(token.id)
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -64,7 +64,11 @@ struct CommandPaletteInteractionMonitorTests {
                 )
             },
             onWindowStateChange: {},
-            onDismiss: {
+            onDismiss: { dismissal in
+                #expect(dismissal == .pointer(CommandPalettePointerEvent(
+                    isInObservedWindow: true,
+                    locationInWindow: NSPoint(x: 20, y: 20)
+                )))
                 dismissCount += 1
                 overlayView.removeFromSuperview()
             }
@@ -105,13 +109,13 @@ struct CommandPaletteInteractionMonitorTests {
         )
         let window = NSObject()
 
-        var dismissCount = 0
+        var dismissals: [CommandPaletteInteractionDismissal] = []
         var windowStateChangeCount = 0
         monitor.activate(
             for: window,
             shouldDismiss: { _ in true },
             onWindowStateChange: { windowStateChangeCount += 1 },
-            onDismiss: { dismissCount += 1 }
+            onDismiss: { dismissals.append($0) }
         )
 
         #expect(eventSource.addCount == 1)
@@ -124,7 +128,10 @@ struct CommandPaletteInteractionMonitorTests {
             isInObservedWindow: true,
             locationInWindow: CGPoint(x: 20, y: 20)
         ))
-        #expect(dismissCount == 1)
+        #expect(dismissals == [.pointer(CommandPalettePointerEvent(
+            isInObservedWindow: true,
+            locationInWindow: CGPoint(x: 20, y: 20)
+        ))])
 
         notificationCenter.send(
             name: CommandPaletteInteractionMonitor.windowDidBecomeKeyNotification,
@@ -136,7 +143,13 @@ struct CommandPaletteInteractionMonitorTests {
             object: window
         )
         #expect(windowStateChangeCount == 2)
-        #expect(dismissCount == 2)
+        #expect(dismissals == [
+            .pointer(CommandPalettePointerEvent(
+                isInObservedWindow: true,
+                locationInWindow: CGPoint(x: 20, y: 20)
+            )),
+            .windowResignedKey,
+        ])
 
         monitor.deactivate()
         #expect(eventSource.removeCount == 1)
@@ -160,13 +173,13 @@ struct CommandPaletteInteractionMonitorTests {
             for: window,
             shouldDismiss: { _ in true },
             onWindowStateChange: {},
-            onDismiss: { firstDismissCount += 1 }
+            onDismiss: { _ in firstDismissCount += 1 }
         )
         monitor.activate(
             for: window,
             shouldDismiss: { _ in true },
             onWindowStateChange: {},
-            onDismiss: { secondDismissCount += 1 }
+            onDismiss: { _ in secondDismissCount += 1 }
         )
 
         eventSource.send(CommandPalettePointerEvent(isInObservedWindow: true, locationInWindow: .zero))
@@ -189,7 +202,7 @@ struct CommandPaletteInteractionMonitorTests {
             for: window,
             shouldDismiss: { _ in false },
             onWindowStateChange: {},
-            onDismiss: {}
+            onDismiss: { _ in }
         )
 
         weak let weakMonitor = monitor

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -1,10 +1,86 @@
-import Foundation
+import AppKit
+import SwiftUI
 import Testing
 @testable import CmuxCommandPalette
 
 @MainActor
 @Suite("CommandPaletteInteractionMonitor")
 struct CommandPaletteInteractionMonitorTests {
+    @Test("pointer dismissal requires known-outside panel geometry")
+    func pointerDismissalPolicy() {
+        let observedWindowEvent = CommandPalettePointerEvent(
+            isInObservedWindow: true,
+            locationInWindow: CGPoint(x: 20, y: 20)
+        )
+        let otherWindowEvent = CommandPalettePointerEvent(
+            isInObservedWindow: false,
+            locationInWindow: CGPoint(x: 20, y: 20)
+        )
+
+        #expect(!observedWindowEvent.shouldDismissPalette(panelContainsPoint: true))
+        #expect(!observedWindowEvent.shouldDismissPalette(panelContainsPoint: nil))
+        #expect(observedWindowEvent.shouldDismissPalette(panelContainsPoint: false))
+        #expect(otherWindowEvent.shouldDismissPalette(panelContainsPoint: true))
+        #expect(otherWindowEvent.shouldDismissPalette(panelContainsPoint: nil))
+    }
+
+    @Test("AppKit monitor keeps inside clicks and exposes the underlying view for outside clicks")
+    func appKitMonitorRoutesInsideAndOutsideClicks() throws {
+        _ = NSApplication.shared
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 400, height: 300),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        let underlyingView = RecordingMouseDownView(frame: window.contentView?.bounds ?? .zero)
+        window.contentView = underlyingView
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+
+        let overlayView = RecordingMouseDownView(frame: underlyingView.bounds)
+        overlayView.autoresizingMask = [.width, .height]
+        underlyingView.addSubview(overlayView)
+
+        let panelFrame = NSRect(x: 100, y: 100, width: 200, height: 100)
+        let panelMarker = NSHostingView(rootView: CommandPalettePanelHitRegion())
+        panelMarker.frame = panelFrame
+        overlayView.addSubview(panelMarker)
+        overlayView.layoutSubtreeIfNeeded()
+
+        #expect(overlayView.commandPalettePanelContains(windowPoint: panelFrame.center) == true)
+        #expect(overlayView.commandPalettePanelContains(windowPoint: NSPoint(x: 20, y: 20)) == false)
+        #expect(NSView().commandPalettePanelContains(windowPoint: .zero) == nil)
+
+        let monitor = CommandPaletteInteractionMonitor()
+        var dismissCount = 0
+        monitor.activate(
+            for: window,
+            shouldDismiss: { event in
+                event.shouldDismissPalette(
+                    panelContainsPoint: overlayView.commandPalettePanelContains(
+                        windowPoint: event.locationInWindow
+                    )
+                )
+            },
+            onWindowStateChange: {},
+            onDismiss: {
+                dismissCount += 1
+                overlayView.removeFromSuperview()
+            }
+        )
+        defer { monitor.deactivate() }
+
+        NSApp.sendEvent(try mouseDownEvent(at: panelFrame.center, in: window))
+        #expect(dismissCount == 0)
+        #expect(overlayView.mouseDownCount == 1)
+        #expect(underlyingView.mouseDownCount == 0)
+
+        NSApp.sendEvent(try mouseDownEvent(at: NSPoint(x: 20, y: 20), in: window))
+        #expect(dismissCount == 1)
+        #expect(underlyingView.mouseDownCount == 1)
+    }
+
     @Test("outside mouse-down dismisses and lifecycle cleanup removes every observer")
     func outsideMouseDownDismissesAndCleansUp() {
         let notificationCenter = RecordingCommandPaletteNotificationCenter()
@@ -110,6 +186,36 @@ struct CommandPaletteInteractionMonitorTests {
         #expect(
             notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map(\.token.id)
         )
+    }
+}
+
+private extension NSRect {
+    var center: NSPoint {
+        NSPoint(x: midX, y: midY)
+    }
+}
+
+@MainActor
+private func mouseDownEvent(at location: NSPoint, in window: NSWindow) throws -> NSEvent {
+    try #require(NSEvent.mouseEvent(
+        with: .leftMouseDown,
+        location: location,
+        modifierFlags: [],
+        timestamp: ProcessInfo.processInfo.systemUptime,
+        windowNumber: window.windowNumber,
+        context: nil,
+        eventNumber: 1,
+        clickCount: 1,
+        pressure: 1
+    ))
+}
+
+@MainActor
+private final class RecordingMouseDownView: NSView {
+    private(set) var mouseDownCount = 0
+
+    override func mouseDown(with event: NSEvent) {
+        mouseDownCount += 1
     }
 }
 

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -47,8 +47,9 @@ struct CommandPaletteInteractionMonitorTests {
         panelMarker.frame = panelFrame
         overlayView.addSubview(panelMarker)
         overlayView.layoutSubtreeIfNeeded()
+        let panelCenter = NSPoint(x: panelFrame.midX, y: panelFrame.midY)
 
-        #expect(overlayView.commandPalettePanelContains(windowPoint: panelFrame.center) == true)
+        #expect(overlayView.commandPalettePanelContains(windowPoint: panelCenter) == true)
         #expect(overlayView.commandPalettePanelContains(windowPoint: NSPoint(x: 20, y: 20)) == false)
         #expect(NSView().commandPalettePanelContains(windowPoint: .zero) == nil)
 
@@ -75,7 +76,7 @@ struct CommandPaletteInteractionMonitorTests {
         )
         defer { monitor.deactivate() }
 
-        NSApp.sendEvent(try mouseDownEvent(at: panelFrame.center, in: window))
+        NSApp.sendEvent(try mouseDownEvent(at: panelCenter, in: window))
         #expect(dismissCount == 0)
         #expect(overlayView.mouseDownCount == 1)
         #expect(underlyingView.mouseDownCount == 0)
@@ -232,94 +233,88 @@ struct CommandPaletteInteractionMonitorTests {
             notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map(\.token.id)
         )
     }
-}
 
-private extension NSRect {
-    var center: NSPoint {
-        NSPoint(x: midX, y: midY)
-    }
-}
+    @MainActor
+    private final class RecordingMouseDownView: NSView {
+        private(set) var mouseDownCount = 0
 
-@MainActor
-private final class RecordingMouseDownView: NSView {
-    private(set) var mouseDownCount = 0
-
-    override func mouseDown(with event: NSEvent) {
-        mouseDownCount += 1
-    }
-}
-
-@MainActor
-private final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSource {
-    private var handler: ((CommandPalettePointerEvent) -> Void)?
-    private(set) var addCount = 0
-    private(set) var removeCount = 0
-
-    func addLocalMouseDownMonitor(
-        for window: AnyObject,
-        handler: @escaping (CommandPalettePointerEvent) -> Void
-    ) -> Any? {
-        addCount += 1
-        self.handler = handler
-        return NSObject()
+        override func mouseDown(with event: NSEvent) {
+            mouseDownCount += 1
+        }
     }
 
-    func removeLocalMonitor(_ monitor: Any) {
-        removeCount += 1
-        handler = nil
+    @MainActor
+    private final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSource {
+        private var handler: ((CommandPalettePointerEvent) -> Void)?
+        private(set) var addCount = 0
+        private(set) var removeCount = 0
+
+        func addLocalMouseDownMonitor(
+            for window: AnyObject,
+            handler: @escaping (CommandPalettePointerEvent) -> Void
+        ) -> Any? {
+            addCount += 1
+            self.handler = handler
+            return NSObject()
+        }
+
+        func removeLocalMonitor(_ monitor: Any) {
+            removeCount += 1
+            handler = nil
+        }
+
+        func send(_ event: CommandPalettePointerEvent) {
+            handler?(event)
+        }
     }
 
-    func send(_ event: CommandPalettePointerEvent) {
-        handler?(event)
-    }
-}
+    private final class RecordingCommandPaletteObserverToken: NSObject {
+        let id: Int
 
-private final class RecordingCommandPaletteObserverToken: NSObject {
-    let id: Int
-
-    init(id: Int) {
-        self.id = id
-        super.init()
-    }
-}
-
-// Test callbacks are invoked synchronously on MainActor; no state crosses concurrency domains.
-private final class RecordingCommandPaletteNotificationCenter: NotificationCenter, @unchecked Sendable {
-    struct AddedObserver {
-        let name: Notification.Name?
-        weak var object: AnyObject?
-        let token: RecordingCommandPaletteObserverToken
-        let block: @Sendable (Notification) -> Void
+        init(id: Int) {
+            self.id = id
+            super.init()
+        }
     }
 
-    private(set) var addedObservers: [AddedObserver] = []
-    private(set) var removedObserverIDs: [Int] = []
+    // Test callbacks are invoked synchronously on MainActor; no state crosses concurrency domains.
+    private final class RecordingCommandPaletteNotificationCenter: NotificationCenter, @unchecked Sendable {
+        struct AddedObserver {
+            let name: Notification.Name?
+            weak var object: AnyObject?
+            let token: RecordingCommandPaletteObserverToken
+            let block: @Sendable (Notification) -> Void
+        }
 
-    override func addObserver(
-        forName name: Notification.Name?,
-        object obj: Any?,
-        queue: OperationQueue?,
-        using block: @escaping @Sendable (Notification) -> Void
-    ) -> any NSObjectProtocol {
-        let token = RecordingCommandPaletteObserverToken(id: addedObservers.count + 1)
-        addedObservers.append(AddedObserver(
-            name: name,
-            object: obj as AnyObject?,
-            token: token,
-            block: block
-        ))
-        return token
-    }
+        private(set) var addedObservers: [AddedObserver] = []
+        private(set) var removedObserverIDs: [Int] = []
 
-    override func removeObserver(_ observer: Any) {
-        guard let token = observer as? RecordingCommandPaletteObserverToken else { return }
-        removedObserverIDs.append(token.id)
-    }
+        override func addObserver(
+            forName name: Notification.Name?,
+            object obj: Any?,
+            queue: OperationQueue?,
+            using block: @escaping @Sendable (Notification) -> Void
+        ) -> any NSObjectProtocol {
+            let token = RecordingCommandPaletteObserverToken(id: addedObservers.count + 1)
+            addedObservers.append(AddedObserver(
+                name: name,
+                object: obj as AnyObject?,
+                token: token,
+                block: block
+            ))
+            return token
+        }
 
-    func send(name: Notification.Name, object: AnyObject) {
-        for observer in addedObservers where
-            observer.name == name && (observer.object == nil || observer.object === object) {
-            observer.block(Notification(name: name, object: object))
+        override func removeObserver(_ observer: Any) {
+            guard let token = observer as? RecordingCommandPaletteObserverToken else { return }
+            removedObserverIDs.append(token.id)
+        }
+
+        func send(name: Notification.Name, object: AnyObject) {
+            for observer in addedObservers where
+                observer.name == name && (observer.object == nil || observer.object === object) {
+                observer.block(Notification(name: name, object: object))
+            }
         }
     }
 }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -52,6 +52,11 @@ struct CommandPaletteInteractionMonitorTests {
         #expect(overlayView.commandPalettePanelContains(windowPoint: panelCenter) == true)
         #expect(overlayView.commandPalettePanelContains(windowPoint: NSPoint(x: 20, y: 20)) == false)
         #expect(NSView().commandPalettePanelContains(windowPoint: .zero) == nil)
+        let unlaidOutHost = NSView()
+        let unlaidOutMarker = CommandPalettePanelHitRegionView(frame: .zero)
+        unlaidOutMarker.identifier = CommandPalettePanelHitRegionView.interfaceIdentifier
+        unlaidOutHost.addSubview(unlaidOutMarker)
+        #expect(unlaidOutHost.commandPalettePanelContains(windowPoint: .zero) == nil)
 
         let monitor = CommandPaletteInteractionMonitor()
         var dismissCount = 0

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -1,4 +1,3 @@
-import AppKit
 import Foundation
 import Testing
 @testable import CmuxCommandPalette
@@ -7,20 +6,14 @@ import Testing
 @Suite("CommandPaletteInteractionMonitor")
 struct CommandPaletteInteractionMonitorTests {
     @Test("outside mouse-down dismisses and lifecycle cleanup removes every observer")
-    func outsideMouseDownDismissesAndCleansUp() throws {
+    func outsideMouseDownDismissesAndCleansUp() {
         let notificationCenter = RecordingCommandPaletteNotificationCenter()
         let eventSource = RecordingCommandPaletteEventMonitorSource()
         let monitor = CommandPaletteInteractionMonitor(
             notificationCenter: notificationCenter,
             eventSource: eventSource
         )
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
-        defer { window.close() }
+        let window = NSObject()
 
         var dismissCount = 0
         var windowStateChangeCount = 0
@@ -33,27 +26,25 @@ struct CommandPaletteInteractionMonitorTests {
 
         #expect(eventSource.addCount == 1)
         #expect(notificationCenter.addedObservers.map(\.name) == [
-            NSWindow.didBecomeKeyNotification,
-            NSWindow.didResignKeyNotification,
+            CommandPaletteInteractionMonitor.windowDidBecomeKeyNotification,
+            CommandPaletteInteractionMonitor.windowDidResignKeyNotification,
         ])
 
-        let event = try #require(NSEvent.mouseEvent(
-            with: .leftMouseDown,
-            location: NSPoint(x: 20, y: 20),
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: window.windowNumber,
-            context: nil,
-            eventNumber: 1,
-            clickCount: 1,
-            pressure: 1
+        eventSource.send(CommandPalettePointerEvent(
+            isInObservedWindow: true,
+            locationInWindow: CGPoint(x: 20, y: 20)
         ))
-        #expect(eventSource.send(event) === event)
         #expect(dismissCount == 1)
 
-        notificationCenter.post(name: NSWindow.didBecomeKeyNotification, object: window)
+        notificationCenter.send(
+            name: CommandPaletteInteractionMonitor.windowDidBecomeKeyNotification,
+            object: window
+        )
         #expect(windowStateChangeCount == 1)
-        notificationCenter.post(name: NSWindow.didResignKeyNotification, object: window)
+        notificationCenter.send(
+            name: CommandPaletteInteractionMonitor.windowDidResignKeyNotification,
+            object: window
+        )
         #expect(windowStateChangeCount == 2)
         #expect(dismissCount == 2)
 
@@ -65,19 +56,13 @@ struct CommandPaletteInteractionMonitorTests {
     }
 
     @Test("re-activation refreshes callbacks without duplicating monitors")
-    func reactivationRefreshesCallbacks() throws {
+    func reactivationRefreshesCallbacks() {
         let eventSource = RecordingCommandPaletteEventMonitorSource()
         let monitor = CommandPaletteInteractionMonitor(
             notificationCenter: RecordingCommandPaletteNotificationCenter(),
             eventSource: eventSource
         )
-        let window = NSWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 640, height: 420),
-            styleMask: [.titled],
-            backing: .buffered,
-            defer: false
-        )
-        defer { window.close() }
+        let window = NSObject()
 
         var firstDismissCount = 0
         var secondDismissCount = 0
@@ -94,33 +79,49 @@ struct CommandPaletteInteractionMonitorTests {
             onDismiss: { secondDismissCount += 1 }
         )
 
-        let event = try #require(NSEvent.mouseEvent(
-            with: .leftMouseDown,
-            location: .zero,
-            modifierFlags: [],
-            timestamp: 0,
-            windowNumber: window.windowNumber,
-            context: nil,
-            eventNumber: 2,
-            clickCount: 1,
-            pressure: 1
-        ))
-        _ = eventSource.send(event)
+        eventSource.send(CommandPalettePointerEvent(isInObservedWindow: true, locationInWindow: .zero))
 
         #expect(eventSource.addCount == 1)
         #expect(firstDismissCount == 0)
         #expect(secondDismissCount == 1)
     }
+
+    @Test("deinit removes pointer and key-window observation")
+    func deinitRemovesObservation() {
+        let notificationCenter = RecordingCommandPaletteNotificationCenter()
+        let eventSource = RecordingCommandPaletteEventMonitorSource()
+        var monitor: CommandPaletteInteractionMonitor? = CommandPaletteInteractionMonitor(
+            notificationCenter: notificationCenter,
+            eventSource: eventSource
+        )
+        let window = NSObject()
+        monitor?.activate(
+            for: window,
+            shouldDismiss: { _ in false },
+            onWindowStateChange: {},
+            onDismiss: {}
+        )
+
+        weak let weakMonitor = monitor
+        monitor = nil
+
+        #expect(weakMonitor == nil)
+        #expect(eventSource.removeCount == 1)
+        #expect(
+            notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map(\.token.id)
+        )
+    }
 }
 
 @MainActor
 private final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSource {
-    private var handler: ((NSEvent) -> NSEvent?)?
+    private var handler: ((CommandPalettePointerEvent) -> Void)?
     private(set) var addCount = 0
     private(set) var removeCount = 0
 
     func addLocalMouseDownMonitor(
-        handler: @escaping (NSEvent) -> NSEvent?
+        for window: AnyObject,
+        handler: @escaping (CommandPalettePointerEvent) -> Void
     ) -> Any {
         addCount += 1
         self.handler = handler
@@ -132,7 +133,7 @@ private final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEve
         handler = nil
     }
 
-    func send(_ event: NSEvent) -> NSEvent? {
+    func send(_ event: CommandPalettePointerEvent) {
         handler?(event)
     }
 }
@@ -146,11 +147,13 @@ private final class RecordingCommandPaletteObserverToken: NSObject {
     }
 }
 
+// Test callbacks are invoked synchronously on MainActor; no state crosses concurrency domains.
 private final class RecordingCommandPaletteNotificationCenter: NotificationCenter, @unchecked Sendable {
     struct AddedObserver {
         let name: Notification.Name?
         weak var object: AnyObject?
         let token: RecordingCommandPaletteObserverToken
+        let block: @Sendable (Notification) -> Void
     }
 
     private(set) var addedObservers: [AddedObserver] = []
@@ -163,12 +166,23 @@ private final class RecordingCommandPaletteNotificationCenter: NotificationCente
         using block: @escaping @Sendable (Notification) -> Void
     ) -> any NSObjectProtocol {
         let token = RecordingCommandPaletteObserverToken(id: addedObservers.count + 1)
-        addedObservers.append(AddedObserver(name: name, object: obj as AnyObject?, token: token))
+        addedObservers.append(AddedObserver(
+            name: name,
+            object: obj as AnyObject?,
+            token: token,
+            block: block
+        ))
         return token
     }
 
     override func removeObserver(_ observer: Any) {
         guard let token = observer as? RecordingCommandPaletteObserverToken else { return }
         removedObserverIDs.append(token.id)
+    }
+
+    func send(name: Notification.Name, object: AnyObject) {
+        for observer in addedObservers where observer.name == name && observer.object === object {
+            observer.block(Notification(name: name, object: object))
+        }
     }
 }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -103,9 +103,15 @@ struct CommandPaletteInteractionMonitorTests {
     func outsideMouseDownDismissesAndCleansUp() {
         let notificationCenter = RecordingCommandPaletteNotificationCenter()
         let eventSource = RecordingCommandPaletteEventMonitorSource()
+        let mainMenu = NSMenu()
+        let appMenu = NSMenu()
+        let appMenuItem = NSMenuItem()
+        appMenuItem.submenu = appMenu
+        mainMenu.addItem(appMenuItem)
         let monitor = CommandPaletteInteractionMonitor(
             notificationCenter: notificationCenter,
-            eventSource: eventSource
+            eventSource: eventSource,
+            mainMenuProvider: { mainMenu }
         )
         let window = NSObject()
 
@@ -122,6 +128,7 @@ struct CommandPaletteInteractionMonitorTests {
         #expect(notificationCenter.addedObservers.map(\.name) == [
             CommandPaletteInteractionMonitor.windowDidBecomeKeyNotification,
             CommandPaletteInteractionMonitor.windowDidResignKeyNotification,
+            CommandPaletteInteractionMonitor.menuDidBeginTrackingNotification,
         ])
 
         eventSource.send(CommandPalettePointerEvent(
@@ -150,6 +157,17 @@ struct CommandPaletteInteractionMonitorTests {
             )),
             .windowResignedKey,
         ])
+
+        notificationCenter.send(
+            name: CommandPaletteInteractionMonitor.menuDidBeginTrackingNotification,
+            object: NSMenu()
+        )
+        #expect(dismissals.count == 2)
+        notificationCenter.send(
+            name: CommandPaletteInteractionMonitor.menuDidBeginTrackingNotification,
+            object: appMenu
+        )
+        #expect(dismissals.last == .mainMenuBeganTracking)
 
         monitor.deactivate()
         #expect(eventSource.removeCount == 1)
@@ -299,7 +317,8 @@ private final class RecordingCommandPaletteNotificationCenter: NotificationCente
     }
 
     func send(name: Notification.Name, object: AnyObject) {
-        for observer in addedObservers where observer.name == name && observer.object === object {
+        for observer in addedObservers where
+            observer.name == name && (observer.object == nil || observer.object === object) {
             observer.block(Notification(name: name, object: object))
         }
     }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -126,7 +126,7 @@ struct CommandPaletteInteractionMonitorTests {
         )
 
         #expect(eventSource.addCount == 1)
-        #expect(notificationCenter.addedObservers.map(\.name) == [
+        #expect(notificationCenter.addedObservers.map { $0.name } == [
             CommandPaletteInteractionMonitor.windowDidBecomeKeyNotification,
             CommandPaletteInteractionMonitor.windowDidResignKeyNotification,
             CommandPaletteInteractionMonitor.menuDidBeginTrackingNotification,
@@ -173,7 +173,7 @@ struct CommandPaletteInteractionMonitorTests {
         monitor.deactivate()
         #expect(eventSource.removeCount == 1)
         #expect(
-            notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map(\.token.id)
+            notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map { $0.token.id }
         )
     }
 
@@ -230,91 +230,7 @@ struct CommandPaletteInteractionMonitorTests {
         #expect(weakMonitor == nil)
         #expect(eventSource.removeCount == 1)
         #expect(
-            notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map(\.token.id)
+            notificationCenter.removedObserverIDs == notificationCenter.addedObservers.map { $0.token.id }
         )
-    }
-
-    @MainActor
-    private final class RecordingMouseDownView: NSView {
-        private(set) var mouseDownCount = 0
-
-        override func mouseDown(with event: NSEvent) {
-            mouseDownCount += 1
-        }
-    }
-
-    @MainActor
-    private final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSource {
-        private var handler: ((CommandPalettePointerEvent) -> Void)?
-        private(set) var addCount = 0
-        private(set) var removeCount = 0
-
-        func addLocalMouseDownMonitor(
-            for window: AnyObject,
-            handler: @escaping (CommandPalettePointerEvent) -> Void
-        ) -> Any? {
-            addCount += 1
-            self.handler = handler
-            return NSObject()
-        }
-
-        func removeLocalMonitor(_ monitor: Any) {
-            removeCount += 1
-            handler = nil
-        }
-
-        func send(_ event: CommandPalettePointerEvent) {
-            handler?(event)
-        }
-    }
-
-    private final class RecordingCommandPaletteObserverToken: NSObject {
-        let id: Int
-
-        init(id: Int) {
-            self.id = id
-            super.init()
-        }
-    }
-
-    // Test callbacks are invoked synchronously on MainActor; no state crosses concurrency domains.
-    private final class RecordingCommandPaletteNotificationCenter: NotificationCenter, @unchecked Sendable {
-        struct AddedObserver {
-            let name: Notification.Name?
-            weak var object: AnyObject?
-            let token: RecordingCommandPaletteObserverToken
-            let block: @Sendable (Notification) -> Void
-        }
-
-        private(set) var addedObservers: [AddedObserver] = []
-        private(set) var removedObserverIDs: [Int] = []
-
-        override func addObserver(
-            forName name: Notification.Name?,
-            object obj: Any?,
-            queue: OperationQueue?,
-            using block: @escaping @Sendable (Notification) -> Void
-        ) -> any NSObjectProtocol {
-            let token = RecordingCommandPaletteObserverToken(id: addedObservers.count + 1)
-            addedObservers.append(AddedObserver(
-                name: name,
-                object: obj as AnyObject?,
-                token: token,
-                block: block
-            ))
-            return token
-        }
-
-        override func removeObserver(_ observer: Any) {
-            guard let token = observer as? RecordingCommandPaletteObserverToken else { return }
-            removedObserverIDs.append(token.id)
-        }
-
-        func send(name: Notification.Name, object: AnyObject) {
-            for observer in addedObservers where
-                observer.name == name && (observer.object == nil || observer.object === object) {
-                observer.block(Notification(name: name, object: object))
-            }
-        }
     }
 }

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/CommandPaletteInteractionMonitorTests.swift
@@ -81,6 +81,20 @@ struct CommandPaletteInteractionMonitorTests {
         #expect(underlyingView.mouseDownCount == 1)
     }
 
+    private func mouseDownEvent(at location: NSPoint, in window: NSWindow) throws -> NSEvent {
+        try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: location,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 1,
+            pressure: 1
+        ))
+    }
+
     @Test("outside mouse-down dismisses and lifecycle cleanup removes every observer")
     func outsideMouseDownDismissesAndCleansUp() {
         let notificationCenter = RecordingCommandPaletteNotificationCenter()
@@ -196,21 +210,6 @@ private extension NSRect {
 }
 
 @MainActor
-private func mouseDownEvent(at location: NSPoint, in window: NSWindow) throws -> NSEvent {
-    try #require(NSEvent.mouseEvent(
-        with: .leftMouseDown,
-        location: location,
-        modifierFlags: [],
-        timestamp: ProcessInfo.processInfo.systemUptime,
-        windowNumber: window.windowNumber,
-        context: nil,
-        eventNumber: 1,
-        clickCount: 1,
-        pressure: 1
-    ))
-}
-
-@MainActor
 private final class RecordingMouseDownView: NSView {
     private(set) var mouseDownCount = 0
 
@@ -228,7 +227,7 @@ private final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEve
     func addLocalMouseDownMonitor(
         for window: AnyObject,
         handler: @escaping (CommandPalettePointerEvent) -> Void
-    ) -> Any {
+    ) -> Any? {
         addCount += 1
         self.handler = handler
         return NSObject()

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingCommandPaletteEventMonitorSource.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingCommandPaletteEventMonitorSource.swift
@@ -1,0 +1,27 @@
+import Foundation
+@testable import CmuxCommandPalette
+
+@MainActor
+final class RecordingCommandPaletteEventMonitorSource: CommandPaletteEventMonitorSource {
+    private var handler: ((CommandPalettePointerEvent) -> Void)?
+    private(set) var addCount = 0
+    private(set) var removeCount = 0
+
+    func addLocalMouseDownMonitor(
+        for window: AnyObject,
+        handler: @escaping (CommandPalettePointerEvent) -> Void
+    ) -> Any? {
+        addCount += 1
+        self.handler = handler
+        return NSObject()
+    }
+
+    func removeLocalMonitor(_ monitor: Any) {
+        removeCount += 1
+        handler = nil
+    }
+
+    func send(_ event: CommandPalettePointerEvent) {
+        handler?(event)
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingCommandPaletteNotificationCenter.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingCommandPaletteNotificationCenter.swift
@@ -1,0 +1,43 @@
+import Foundation
+
+// Test callbacks are invoked synchronously on MainActor; no state crosses concurrency domains.
+final class RecordingCommandPaletteNotificationCenter: NotificationCenter, @unchecked Sendable {
+    typealias AddedObserver = (
+        name: Notification.Name?,
+        objectID: ObjectIdentifier?,
+        token: RecordingCommandPaletteObserverToken,
+        block: @Sendable (Notification) -> Void
+    )
+
+    private(set) var addedObservers: [AddedObserver] = []
+    private(set) var removedObserverIDs: [Int] = []
+
+    override func addObserver(
+        forName name: Notification.Name?,
+        object obj: Any?,
+        queue: OperationQueue?,
+        using block: @escaping @Sendable (Notification) -> Void
+    ) -> any NSObjectProtocol {
+        let token = RecordingCommandPaletteObserverToken(id: addedObservers.count + 1)
+        addedObservers.append((
+            name: name,
+            objectID: (obj as AnyObject?).map(ObjectIdentifier.init),
+            token: token,
+            block: block
+        ))
+        return token
+    }
+
+    override func removeObserver(_ observer: Any) {
+        guard let token = observer as? RecordingCommandPaletteObserverToken else { return }
+        removedObserverIDs.append(token.id)
+    }
+
+    func send(name: Notification.Name, object: AnyObject) {
+        let objectID = ObjectIdentifier(object)
+        for observer in addedObservers where
+            observer.name == name && (observer.objectID == nil || observer.objectID == objectID) {
+            observer.block(Notification(name: name, object: object))
+        }
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingCommandPaletteObserverToken.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingCommandPaletteObserverToken.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+final class RecordingCommandPaletteObserverToken: NSObject {
+    let id: Int
+
+    init(id: Int) {
+        self.id = id
+        super.init()
+    }
+}

--- a/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingMouseDownView.swift
+++ b/Packages/macOS/CmuxCommandPalette/Tests/CmuxCommandPaletteTests/RecordingMouseDownView.swift
@@ -1,0 +1,10 @@
+import AppKit
+
+@MainActor
+final class RecordingMouseDownView: NSView {
+    private(set) var mouseDownCount = 0
+
+    override func mouseDown(with event: NSEvent) {
+        mouseDownCount += 1
+    }
+}

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2925,6 +2925,8 @@ struct ContentView: View {
             let overlayController = commandPaletteWindowOverlayController(for: window)
             overlayController.update(
                 isVisible: isCommandPalettePresented,
+                // The monitored mouse-down is returned after synchronous teardown;
+                // that event, not the palette's saved responder, owns focus next.
                 onDismiss: { dismissCommandPalette(restoreFocus: false) }
             ) { AnyView(commandPaletteOverlay) }
         }))
@@ -3153,6 +3155,7 @@ struct ContentView: View {
             commandPaletteWindowOverlayController(for: window)
                 .update(
                     isVisible: isCommandPalettePresented,
+                    // Preserve focus chosen by the returned event or newly key window.
                     onDismiss: { dismissCommandPalette(restoreFocus: false) }
                 ) { commandPaletteOverlayView }
             TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8713,7 +8713,7 @@ struct ContentView: View {
             in: window
         )
         dismissCommandPalette(
-            restoreFocus: clickedFocusTarget != nil,
+            restoreFocus: true,
             preferredFocusTarget: clickedFocusTarget
         )
     }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8694,6 +8694,12 @@ struct ContentView: View {
         for dismissal: CommandPaletteInteractionDismissal,
         in window: NSWindow
     ) {
+        if dismissal == .mainMenuBeganTracking {
+            // Menu tracking keeps this window key. Restore the saved panel before
+            // entering the nested menu loop; a selected command can still replace it.
+            dismissCommandPalette(restoreFocus: true)
+            return
+        }
         guard case .pointer(let event) = dismissal, event.isInObservedWindow else {
             dismissCommandPalette(restoreFocus: false)
             return

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8747,7 +8747,7 @@ struct ContentView: View {
                 return CommandPaletteRestoreFocusTarget(
                     workspaceId: workspace.id,
                     panelId: panelId,
-                    intent: panel.captureFocusIntent(in: window) ?? .browser(.webView)
+                    intent: panel.captureFocusIntent(in: window)
                 )
             }
         }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -116,6 +116,7 @@ private final class WindowCommandPaletteOverlayController: NSObject {
     private let containerView = CommandPaletteOverlayContainerView(frame: .zero)
     private let hostingView = NSHostingView(rootView: AnyView(EmptyView()))
     private let chromeComposition = AppWindowChromeComposition()
+    private let interactionMonitor = CommandPaletteInteractionMonitor()
     private var installConstraints: [NSLayoutConstraint] = []
     private weak var installedContainerView: NSView?
     private weak var installedReferenceView: NSView?
@@ -123,8 +124,6 @@ private final class WindowCommandPaletteOverlayController: NSObject {
     private var scheduledFocusWorkItem: DispatchWorkItem?
     private var isPaletteVisible = false
     private var hasMountedPaletteRootView = false
-    private var windowDidBecomeKeyObserver: NSObjectProtocol?
-    private var windowDidResignKeyObserver: NSObjectProtocol?
 
     init(window: NSWindow) {
         self.window = window
@@ -147,7 +146,6 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             hostingView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor),
         ])
         _ = ensureInstalled()
-        installWindowKeyObservers()
     }
 
     @discardableResult
@@ -423,28 +421,6 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         }
     }
 
-    private func installWindowKeyObservers() {
-        guard let window else { return }
-        windowDidBecomeKeyObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didBecomeKeyNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.updateFocusLockForWindowState()
-            }
-        }
-        windowDidResignKeyObserver = NotificationCenter.default.addObserver(
-            forName: NSWindow.didResignKeyNotification,
-            object: window,
-            queue: .main
-        ) { [weak self] _ in
-            Task { @MainActor [weak self] in
-                self?.updateFocusLockForWindowState()
-            }
-        }
-    }
-
     private func updateFocusLockForWindowState() {
         guard let window else {
             stopFocusLockTimer()
@@ -532,6 +508,7 @@ private final class WindowCommandPaletteOverlayController: NSObject {
 
     func update(
         isVisible: Bool,
+        onDismiss: @MainActor @escaping () -> Void = {},
         makeRootView: @MainActor () -> AnyView = { AnyView(EmptyView()) }
     ) {
         let wasVisible = isPaletteVisible
@@ -565,36 +542,46 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             if shouldPromote {
                 promoteOverlayAboveSiblingsIfNeeded()
             }
+            if let window {
+                interactionMonitor.activate(
+                    for: window,
+                    shouldDismiss: { [weak self] event in
+                        self?.shouldDismissPalette(for: event) ?? false
+                    },
+                    onWindowStateChange: { [weak self] in
+                        self?.updateFocusLockForWindowState()
+                    },
+                    onDismiss: { [weak self] in
+                        guard let self, self.isPaletteVisible else { return }
+                        self.hideOverlay()
+                        onDismiss()
+                    }
+                )
+            }
             updateFocusLockForWindowState()
         } else {
-            stopFocusLockTimer()
-            if let window, isPaletteResponder(window.firstResponder) {
-                _ = window.makeFirstResponder(nil)
-            }
-            hostingView.rootView = AnyView(EmptyView())
-            hasMountedPaletteRootView = false
-            containerView.capturesMouseEvents = false
-            containerView.alphaValue = 0
-            containerView.isHidden = true
+            hideOverlay()
         }
     }
 
-    func underlyingResponder(atWindowPoint windowPoint: NSPoint) -> NSResponder? {
-        guard let window,
-              let target = chromeComposition
-                .contentOverlayTargetResolver
-                .installationTarget(for: window) else {
-            return nil
-        }
+    private func shouldDismissPalette(for event: CommandPalettePointerEvent) -> Bool {
+        guard window != nil else { return true }
+        guard event.isInObservedWindow else { return true }
+        return hostingView.commandPalettePanelContains(windowPoint: event.locationInWindow) != true
+    }
 
-        let previousCapturesMouseEvents = containerView.capturesMouseEvents
+    private func hideOverlay() {
+        interactionMonitor.deactivate()
+        stopFocusLockTimer()
+        if let window, isPaletteResponder(window.firstResponder) {
+            _ = window.makeFirstResponder(nil)
+        }
+        isPaletteVisible = false
+        hostingView.rootView = AnyView(EmptyView())
+        hasMountedPaletteRootView = false
         containerView.capturesMouseEvents = false
-        defer {
-            containerView.capturesMouseEvents = previousCapturesMouseEvents
-        }
-
-        let pointInContainer = target.container.convert(windowPoint, from: nil)
-        return target.container.hitTest(pointInContainer)
+        containerView.alphaValue = 0
+        containerView.isHidden = true
     }
 }
 
@@ -606,40 +593,6 @@ private func commandPaletteWindowOverlayController(for window: NSWindow) -> Wind
     let controller = WindowCommandPaletteOverlayController(window: window)
     objc_setAssociatedObject(window, &commandPaletteWindowOverlayKey, controller, .OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     return controller
-}
-
-private func commandPaletteOwningWebView(for responder: NSResponder?) -> WKWebView? {
-    guard let responder else { return nil }
-
-    if let webView = responder as? WKWebView {
-        return webView
-    }
-
-    if let view = responder as? NSView {
-        var current: NSView? = view
-        while let candidate = current {
-            if let webView = candidate as? WKWebView {
-                return webView
-            }
-            current = candidate.superview
-        }
-    }
-
-    if let textView = responder as? NSTextView,
-       let delegateView = textView.delegate as? NSView,
-       let webView = commandPaletteOwningWebView(for: delegateView) {
-        return webView
-    }
-
-    var currentResponder = responder.nextResponder
-    while let next = currentResponder {
-        if let webView = commandPaletteOwningWebView(for: next) {
-            return webView
-        }
-        currentResponder = next.nextResponder
-    }
-
-    return nil
 }
 
 // Lifted to `CmuxFoundation.WorkspaceMountPlan` / `MountedWorkspacePresentation`
@@ -2971,7 +2924,10 @@ struct ContentView: View {
         view = AnyView(view.background(WindowAccessor(dedupeByWindow: false) { window in
             refreshTmuxWorkspacePaneWindowOverlay(in: window)
             let overlayController = commandPaletteWindowOverlayController(for: window)
-            overlayController.update(isVisible: isCommandPalettePresented) { AnyView(commandPaletteOverlay) }
+            overlayController.update(
+                isVisible: isCommandPalettePresented,
+                onDismiss: { dismissCommandPalette(restoreFocus: false) }
+            ) { AnyView(commandPaletteOverlay) }
         }))
 
         view = AnyView(view.onChange(of: bgGlassTintHex) { _ in
@@ -3196,7 +3152,10 @@ struct ContentView: View {
         if backdropResult.didChangeGlassRoot {
             refreshTmuxWorkspacePaneWindowOverlay(in: window)
             commandPaletteWindowOverlayController(for: window)
-                .update(isVisible: isCommandPalettePresented) { commandPaletteOverlayView }
+                .update(
+                    isVisible: isCommandPalettePresented,
+                    onDismiss: { dismissCommandPalette(restoreFocus: false) }
+                ) { commandPaletteOverlayView }
             TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
             BrowserWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
         }
@@ -3399,13 +3358,6 @@ struct ContentView: View {
             ZStack(alignment: .top) {
                 Color.clear
                     .ignoresSafeArea()
-                    .contentShape(Rectangle())
-                    .gesture(
-                        DragGesture(minimumDistance: 0)
-                            .onEnded { value in
-                                handleCommandPaletteBackdropClick(atContentPoint: value.location)
-                            }
-                    )
 
                 Color.clear
                     .ignoresSafeArea()
@@ -3429,6 +3381,7 @@ struct ContentView: View {
                     }
                 }
                 .frame(width: targetWidth)
+                .background(CommandPalettePanelHitRegion())
                 .background(
                     RoundedRectangle(cornerRadius: 8, style: .continuous)
                         .fill(Color(nsColor: .windowBackgroundColor).opacity(0.98))
@@ -8803,138 +8756,6 @@ struct ContentView: View {
 
         guard restoreFocus, let focusTarget else { return }
         requestCommandPaletteFocusRestore(target: focusTarget)
-    }
-
-    private func handleCommandPaletteBackdropClick(atContentPoint contentPoint: CGPoint) {
-        let clickedFocusTarget = commandPaletteBackdropFocusTarget(atContentPoint: contentPoint)
-#if DEBUG
-        if let clickedFocusTarget {
-            cmuxDebugLog(
-                "palette.dismiss.backdrop focusTarget panel=\(clickedFocusTarget.panelId.uuidString.prefix(5)) " +
-                "workspace=\(clickedFocusTarget.workspaceId.uuidString.prefix(5)) intent=\(debugCommandPaletteFocusIntent(clickedFocusTarget.intent))"
-            )
-        } else {
-            cmuxDebugLog("palette.dismiss.backdrop focusTarget=nil")
-        }
-#endif
-        dismissCommandPalette(restoreFocus: true, preferredFocusTarget: clickedFocusTarget)
-    }
-
-    private func commandPaletteBackdropFocusTarget(atContentPoint contentPoint: CGPoint) -> CommandPaletteRestoreFocusTarget? {
-        guard let window = observedWindow,
-              let contentView = window.contentView else {
-            return nil
-        }
-
-        let nsContentPoint = NSPoint(x: contentPoint.x, y: contentPoint.y)
-        let windowPoint = contentView.convert(nsContentPoint, to: nil)
-        return commandPaletteBackdropFocusTarget(atWindowPoint: windowPoint, in: window)
-    }
-
-    private func commandPaletteBackdropFocusTarget(
-        atWindowPoint windowPoint: NSPoint,
-        in window: NSWindow
-    ) -> CommandPaletteRestoreFocusTarget? {
-        let overlayController = commandPaletteWindowOverlayController(for: window)
-        if let responder = overlayController.underlyingResponder(atWindowPoint: windowPoint),
-           let target = commandPaletteBackdropFocusTarget(for: responder) {
-            return target
-        }
-
-        if let webView = BrowserWindowPortalRegistry.webViewAtWindowPoint(windowPoint, in: window),
-           let target = commandPaletteBrowserFocusTarget(for: webView) {
-            return target
-        }
-
-        if let terminalView = TerminalWindowPortalRegistry.terminalViewAtWindowPoint(windowPoint, in: window),
-           let workspaceId = terminalView.tabId,
-           let panelId = terminalView.terminalSurface?.id,
-           tabManager.tabs.contains(where: { $0.id == workspaceId }) {
-            return commandPaletteRestoreFocusTarget(
-                workspaceId: workspaceId,
-                panelId: panelId,
-                fallbackIntent: .terminal(.surface),
-                in: window
-            )
-        }
-
-        return nil
-    }
-
-    private func commandPaletteBackdropFocusTarget(for responder: NSResponder) -> CommandPaletteRestoreFocusTarget? {
-        if let terminalView = cmuxOwningGhosttyView(for: responder),
-           let workspaceId = terminalView.tabId,
-           let panelId = terminalView.terminalSurface?.id,
-           tabManager.tabs.contains(where: { $0.id == workspaceId }) {
-            return commandPaletteRestoreFocusTarget(
-                workspaceId: workspaceId,
-                panelId: panelId,
-                fallbackIntent: .terminal(.surface),
-                in: observedWindow
-            )
-        }
-
-        if let webView = commandPaletteOwningWebView(for: responder),
-           let target = commandPaletteBrowserFocusTarget(for: webView) {
-            return target
-        }
-
-        return nil
-    }
-
-    private func commandPaletteBrowserFocusTarget(for webView: WKWebView) -> CommandPaletteRestoreFocusTarget? {
-        if let selectedWorkspace = tabManager.selectedWorkspace,
-           let target = commandPaletteBrowserFocusTarget(in: selectedWorkspace, for: webView) {
-            return target
-        }
-
-        let selectedWorkspaceId = tabManager.selectedTabId
-        for workspace in tabManager.tabs where workspace.id != selectedWorkspaceId {
-            if let target = commandPaletteBrowserFocusTarget(in: workspace, for: webView) {
-                return target
-            }
-        }
-
-        return nil
-    }
-
-    private func commandPaletteBrowserFocusTarget(
-        in workspace: Workspace,
-        for webView: WKWebView
-    ) -> CommandPaletteRestoreFocusTarget? {
-        for (panelId, panel) in workspace.panels {
-            guard let browserPanel = panel as? BrowserPanel,
-                  browserPanel.webView === webView else {
-                continue
-            }
-
-            return commandPaletteRestoreFocusTarget(
-                workspaceId: workspace.id,
-                panelId: panelId,
-                fallbackIntent: .browser(.webView),
-                in: observedWindow
-            )
-        }
-
-        return nil
-    }
-
-    private func commandPaletteRestoreFocusTarget(
-        workspaceId: UUID,
-        panelId: UUID,
-        fallbackIntent: PanelFocusIntent,
-        in window: NSWindow?
-    ) -> CommandPaletteRestoreFocusTarget {
-        let intent = tabManager.tabs
-            .first(where: { $0.id == workspaceId })?
-            .panels[panelId]?
-            .captureFocusIntent(in: window) ?? fallbackIntent
-
-        return CommandPaletteRestoreFocusTarget(
-            workspaceId: workspaceId,
-            panelId: panelId,
-            intent: intent
-        )
     }
 
     private func requestCommandPaletteFocusRestore(target: CommandPaletteRestoreFocusTarget) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -508,7 +508,7 @@ private final class WindowCommandPaletteOverlayController: NSObject {
 
     func update(
         isVisible: Bool,
-        onDismiss: @MainActor @escaping () -> Void = {},
+        onDismiss: @MainActor @escaping (CommandPaletteInteractionDismissal) -> Void = { _ in },
         makeRootView: @MainActor () -> AnyView = { AnyView(EmptyView()) }
     ) {
         let wasVisible = isPaletteVisible
@@ -552,10 +552,10 @@ private final class WindowCommandPaletteOverlayController: NSObject {
                 onWindowStateChange: { [weak self] in
                     self?.updateFocusLockForWindowState()
                 },
-                onDismiss: { [weak self] in
+                onDismiss: { [weak self] dismissal in
                     guard let self, self.isPaletteVisible else { return }
                     self.hideOverlay()
-                    onDismiss()
+                    onDismiss(dismissal)
                 }
             )
         }
@@ -2925,9 +2925,9 @@ struct ContentView: View {
             let overlayController = commandPaletteWindowOverlayController(for: window)
             overlayController.update(
                 isVisible: isCommandPalettePresented,
-                // The monitored mouse-down is returned after synchronous teardown;
-                // that event, not the palette's saved responder, owns focus next.
-                onDismiss: { dismissCommandPalette(restoreFocus: false) }
+                onDismiss: { dismissal in
+                    dismissCommandPalette(for: dismissal, in: window)
+                }
             ) { AnyView(commandPaletteOverlay) }
         }))
 
@@ -3155,8 +3155,9 @@ struct ContentView: View {
             commandPaletteWindowOverlayController(for: window)
                 .update(
                     isVisible: isCommandPalettePresented,
-                    // Preserve focus chosen by the returned event or newly key window.
-                    onDismiss: { dismissCommandPalette(restoreFocus: false) }
+                    onDismiss: { dismissal in
+                        dismissCommandPalette(for: dismissal, in: window)
+                    }
                 ) { commandPaletteOverlayView }
             TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
             BrowserWindowPortalRegistry.scheduleExternalGeometrySynchronize(for: window)
@@ -8687,6 +8688,64 @@ struct ContentView: View {
         syncCommandPaletteOverlayCommandListState()
         resetCommandPaletteSearchFocus()
         syncCommandPaletteDebugStateForObservedWindow()
+    }
+
+    private func dismissCommandPalette(
+        for dismissal: CommandPaletteInteractionDismissal,
+        in window: NSWindow
+    ) {
+        guard case .pointer(let event) = dismissal, event.isInObservedWindow else {
+            dismissCommandPalette(restoreFocus: false)
+            return
+        }
+
+        // Other local monitors have no ordering contract. Reconcile a clicked
+        // terminal/browser target directly after hiding the overlay; the returned
+        // mouse-down can still replace this provisional focus during dispatch.
+        let clickedFocusTarget = commandPalettePointerFocusTarget(
+            atWindowPoint: event.locationInWindow,
+            in: window
+        )
+        dismissCommandPalette(
+            restoreFocus: clickedFocusTarget != nil,
+            preferredFocusTarget: clickedFocusTarget
+        )
+    }
+
+    private func commandPalettePointerFocusTarget(
+        atWindowPoint windowPoint: NSPoint,
+        in window: NSWindow
+    ) -> CommandPaletteRestoreFocusTarget? {
+        if let terminalView = TerminalWindowPortalRegistry.terminalViewAtWindowPoint(windowPoint, in: window),
+           let workspaceId = terminalView.tabId,
+           let panelId = terminalView.terminalSurface?.id,
+           tabManager.tabs.contains(where: { $0.id == workspaceId }) {
+            return CommandPaletteRestoreFocusTarget(
+                workspaceId: workspaceId,
+                panelId: panelId,
+                intent: .terminal(.surface)
+            )
+        }
+
+        guard let webView = BrowserWindowPortalRegistry.webViewAtWindowPoint(windowPoint, in: window) else {
+            return nil
+        }
+        let selectedWorkspaceId = tabManager.selectedTabId
+        let orderedWorkspaces = tabManager.tabs.filter { $0.id == selectedWorkspaceId }
+            + tabManager.tabs.filter { $0.id != selectedWorkspaceId }
+        for workspace in orderedWorkspaces {
+            for (panelId, panel) in workspace.panels {
+                guard let browserPanel = panel as? BrowserPanel, browserPanel.webView === webView else {
+                    continue
+                }
+                return CommandPaletteRestoreFocusTarget(
+                    workspaceId: workspace.id,
+                    panelId: panelId,
+                    intent: .browser(.webView)
+                )
+            }
+        }
+        return nil
     }
 
     private func dismissCommandPalette(restoreFocus: Bool = true) {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -512,7 +512,9 @@ private final class WindowCommandPaletteOverlayController: NSObject {
         makeRootView: @MainActor () -> AnyView = { AnyView(EmptyView()) }
     ) {
         let wasVisible = isPaletteVisible
-        if !isVisible, !wasVisible, !hasMountedPaletteRootView, containerView.isHidden {
+        if !isVisible {
+            guard wasVisible || hasMountedPaletteRootView || !containerView.isHidden else { return }
+            hideOverlay()
             return
         }
 
@@ -532,42 +534,39 @@ private final class WindowCommandPaletteOverlayController: NSObject {
             cmuxDebugLog("palette.overlay.update visible=\(isVisible ? 1 : 0) promote=\(shouldPromote ? 1 : 0) window=nil")
         }
 #endif
-        isPaletteVisible = isVisible
-        if isVisible {
-            hostingView.rootView = makeRootView()
-            hasMountedPaletteRootView = true
-            containerView.capturesMouseEvents = true
-            containerView.isHidden = false
-            containerView.alphaValue = 1
-            if shouldPromote {
-                promoteOverlayAboveSiblingsIfNeeded()
-            }
-            if let window {
-                interactionMonitor.activate(
-                    for: window,
-                    shouldDismiss: { [weak self] event in
-                        self?.shouldDismissPalette(for: event) ?? false
-                    },
-                    onWindowStateChange: { [weak self] in
-                        self?.updateFocusLockForWindowState()
-                    },
-                    onDismiss: { [weak self] in
-                        guard let self, self.isPaletteVisible else { return }
-                        self.hideOverlay()
-                        onDismiss()
-                    }
-                )
-            }
-            updateFocusLockForWindowState()
-        } else {
-            hideOverlay()
+        isPaletteVisible = true
+        hostingView.rootView = makeRootView()
+        hasMountedPaletteRootView = true
+        containerView.capturesMouseEvents = true
+        containerView.isHidden = false
+        containerView.alphaValue = 1
+        if shouldPromote {
+            promoteOverlayAboveSiblingsIfNeeded()
         }
+        if let window {
+            interactionMonitor.activate(
+                for: window,
+                shouldDismiss: { [weak self] event in
+                    self?.shouldDismissPalette(for: event) ?? false
+                },
+                onWindowStateChange: { [weak self] in
+                    self?.updateFocusLockForWindowState()
+                },
+                onDismiss: { [weak self] in
+                    guard let self, self.isPaletteVisible else { return }
+                    self.hideOverlay()
+                    onDismiss()
+                }
+            )
+        }
+        updateFocusLockForWindowState()
     }
 
     private func shouldDismissPalette(for event: CommandPalettePointerEvent) -> Bool {
         guard window != nil else { return true }
-        guard event.isInObservedWindow else { return true }
-        return hostingView.commandPalettePanelContains(windowPoint: event.locationInWindow) != true
+        return event.shouldDismissPalette(
+            panelContainsPoint: hostingView.commandPalettePanelContains(windowPoint: event.locationInWindow)
+        )
     }
 
     private func hideOverlay() {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -8725,11 +8725,11 @@ struct ContentView: View {
         if let terminalView = TerminalWindowPortalRegistry.terminalViewAtWindowPoint(windowPoint, in: window),
            let workspaceId = terminalView.tabId,
            let panelId = terminalView.terminalSurface?.id,
-           tabManager.tabs.contains(where: { $0.id == workspaceId }) {
+           let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) {
             return CommandPaletteRestoreFocusTarget(
                 workspaceId: workspaceId,
                 panelId: panelId,
-                intent: .terminal(.surface)
+                intent: workspace.panels[panelId]?.captureFocusIntent(in: window) ?? .terminal(.surface)
             )
         }
 
@@ -8747,7 +8747,7 @@ struct ContentView: View {
                 return CommandPaletteRestoreFocusTarget(
                     workspaceId: workspace.id,
                     panelId: panelId,
-                    intent: .browser(.webView)
+                    intent: panel.captureFocusIntent(in: window) ?? .browser(.webView)
                 )
             }
         }


### PR DESCRIPTION
## Summary

- replace the transparent SwiftUI backdrop drag gesture with a process-local AppKit mouse-down monitor owned by the per-window palette overlay lifecycle
- synchronously disable overlay hit testing before returning the initiating event, so the same click reaches the sidebar, notification, browser navigation, terminal, or other underlying control
- dismiss when the host window resigns key status and remove the mouse monitor plus both key-window observers on hide and deinit
- mark the actual palette panel bounds with a passive AppKit hit region so clicks inside remain interactive while every outside mouse-down follows one dismissal path
- treat nil/unmounted/zero-sized panel geometry as non-dismissive, avoiding early inside-click dismissal before SwiftUI finishes laying out the marker
- carry an explicit pointer-vs-resign dismissal reason and reconcile the clicked terminal/browser portal directly, avoiding any dependency on ordering among AppKit local monitors
- observe application main-menu tracking while visible, because AppKit menu loops consume clicks before local event monitors without resigning the host window

Fixes #7906

## Root cause

The palette is not a separate window. It is a full-window AppKit overlay view mounted above the main content. Outside-click dismissal was delegated to a `DragGesture(minimumDistance: 0)` attached to a transparent SwiftUI backdrop. If SwiftUI never delivered the gesture end, the full-window overlay remained visible and hit-testable. It then intercepted the notification, sidebar, and browser back/forward clicks too, producing the reported app-wide dead-click state.

The fix moves pointer/key observation into one `@MainActor` lifecycle owner. It exists only while the palette is visible, refreshes callbacks without duplicating monitors, hides synchronously before AppKit dispatches the mouse-down, and removes every token as one teardown operation. Resign-key and other-window dismissal deliberately skip restoring the prior responder because the newly key window becomes the authoritative focus owner. A same-window click provisionally focuses the portal at the event point using that panel's captured focus intent, or the saved pre-palette panel when the click target is non-focusable. This avoids local-monitor ordering gaps and stranded nil responders; the returned mouse-down still runs afterward and can replace the provisional focus during normal dispatch.

## Stable-to-main audit and related issues

No palette-dismiss or click-routing fix landed between the current stable release `v0.64.17` and this branch point on `main`. Current `main` still uses the transparent backdrop gesture. PR #6962 / issue #5718 contains an unmerged observer-cleanup-only change; this PR subsumes that lifecycle hardening by removing the same key-window observer tokens on hide and deinit.

- #7503: the level-20 leaked-window mechanism is separate from this palette path. The palette creates no `NSWindow` or `NSPanel`; it is an `NSView` inside the main window. The reported long-session floating-window leak was audited but not cleanly reproduced or claimed fixed here. This change does prevent the palette overlay itself from remaining a click-intercepting layer and fixes its confirmed NotificationCenter token leak.
- #4303: keyboard focus uses the same overlay controller. The new owner reconciles key-window transitions and dismisses on resign, but this PR does not claim to solve every independent palette first-responder failure.
- #616: no window-creation path is changed. The outside event is returned to AppKit after the overlay is disabled; this PR does not claim to fix sporadic new-window creation.

## Regression coverage

Commit `3d21941d74` establishes the failing lifecycle contract before the fix. At current head `ddb8b36339`, `CommandPaletteInteractionMonitorTests` covers outside dismissal, nil/zero-sized/inside/outside panel-containment policy, idempotent reactivation, explicit cleanup, and deinit cleanup. A focused AppKit integration test creates a real `NSApplication`/`NSWindow`, sends the original mouse-down through the process-local monitor, and verifies that an inside click stays on the overlay while an outside click synchronously removes it and reaches the underlying view in the same dispatch. The long-running leaked-floating-window state from #7503 is not represented by this unit seam and is not faked.

## Validation

- `swift build --package-path Packages/macOS/CmuxCommandPalette --build-tests`
- `swift test --package-path Packages/macOS/CmuxCommandPalette --filter CommandPaletteInteractionMonitorTests` (5 tests passed)
- touched-file length check: `Sources/ContentView.swift` is 15,961 lines versus a 16,141-line budget; all new Swift files are under 500 lines
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- localization audit: no user-facing strings were added or changed

`python3 scripts/swift_file_length_budget.py` currently reports pre-existing overages in five unchanged `origin/main` files (`AutomationSocketUITests.swift`, `AgentLaunchSanitizerPrimaryPolicies.swift`, `TerminalController+ControlPaneContext.swift`, `TaskManagerTypes.swift`, and `TerminalSurface.swift`). This PR shrinks its only tracked budget file and does not modify either budget TSV.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7909"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786402814&installation_id=133855650&pr_number=7909&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7909&signature=48dbf71436edd2fe539973ba21de3651418345d27e467fcc12d28dd15d3fa717"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core window overlay, focus restore, and global event monitoring on macOS; behavior is well covered by new unit/integration tests but affects every palette dismiss path.
> 
> **Overview**
> Replaces the transparent SwiftUI backdrop **drag gesture** with a **`CommandPaletteInteractionMonitor`** in `CmuxCommandPalette` that owns process-local mouse-down monitoring, key-window notifications, and main-menu tracking only while the palette is visible.
> 
> Outside clicks dismiss via **`shouldDismissPalette`**, using a passive **`CommandPalettePanelHitRegion`** marker for panel bounds; **`nil`** geometry does not dismiss. The overlay **hides synchronously** in `onDismiss` so the same mouse-down reaches underlying controls. **`ContentView`** wires `onDismiss` to restore focus for same-window pointer hits (terminal/browser portals) and special-cases menu tracking; resign-key and other-window dismissals skip focus restore.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ddb8b36339a8894999fbe8a3c8d4224d3bd05e0e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the command palette’s transparent backdrop gesture with a per-window AppKit mouse-down monitor so outside clicks dismiss instantly and pass through. Also dismisses when the main menu starts tracking or the window resigns key; restores focus (and intent) for same-window clicks before the menu loop (fixes #7906).

- **Bug Fixes**
  - Disable overlay hit testing synchronously so the initiating click reaches underlying controls.
  - Use a passive `CommandPalettePanelHitRegion` to classify clicks; nil/unmounted geometry is non-dismissive and inside clicks stay interactive.
  - Dismiss on window resign-key and main-menu tracking; restore focus before the menu loop.
  - Restore focus only for same-window pointer dismissals; skip other-window and resign-key cases; preserve intent and handle non-focusable targets.

- **Refactors**
  - Added `CommandPaletteInteractionMonitor` in `CmuxCommandPalette` with pointer events, dismissal reasons, and a testable event source.
  - `WindowCommandPaletteOverlayController.update(isVisible:onDismiss:makeRootView:)` activates the monitor and hides via `hideOverlay()` before the event continues.
  - Replaced backdrop hit-testing with deterministic `commandPalettePointerFocusTarget(...)` for terminal/browser focus and removed unreachable browser fallback.
  - Added focused unit/integration tests and split interaction test fixtures.

<sup>Written for commit ddb8b36339a8894999fbe8a3c8d4224d3bd05e0e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Command palettes now dismiss via an added panel hit region that routes outside clicks more reliably.
  * Dismissal also occurs when the host window resigns key focus or when main menu tracking begins.
  * After dismissal, focus restoration targets the appropriate terminal first, otherwise a browser surface, with safer handling for transient panel geometry.

* **Bug Fixes**
  * Prevented duplicate interaction monitoring when the palette is refreshed.
  * Ensured event monitors and notification observers are consistently removed when the palette closes.

* **Tests**
  * Added coverage for pointer dismissal, window/menu-driven dismissal, and cleanup behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->