### PR TITLE
Fix initial cmux ssh connection state output

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2295,7 +2295,12 @@ final class Workspace: Identifiable, ObservableObject {
         set { surfaceRegistry.surfaceTTYNames = newValue }
     }
     private var remoteSessionController: RemoteSessionCoordinator?
-    private var pendingRemoteForegroundAuthToken: String?
+    private enum RemoteForegroundAuthenticationPhase {
+        case readyBeforeConfiguration(token: String)
+        case authenticating(token: String)
+    }
+
+    private var remoteForegroundAuthenticationPhase: RemoteForegroundAuthenticationPhase?
     var activeRemoteSessionControllerID: UUID?
     private var remoteLastErrorFingerprint: String?
     private var remoteLastDaemonErrorFingerprint: String?
@@ -5299,10 +5304,20 @@ final class Workspace: Identifiable, ObservableObject {
         applyBrowserRemoteWorkspaceStatusToPanels()
 
         let foregroundAuthToken = Self.normalizedForegroundAuthToken(configuration.foregroundAuthToken)
+        let foregroundAuthenticationWasReady: Bool
+        if case .readyBeforeConfiguration(let readyToken) = remoteForegroundAuthenticationPhase {
+            foregroundAuthenticationWasReady = foregroundAuthToken == readyToken
+        } else {
+            foregroundAuthenticationWasReady = false
+        }
         let shouldAutoConnect =
             autoConnect
-            || (foregroundAuthToken != nil && foregroundAuthToken == pendingRemoteForegroundAuthToken)
-        pendingRemoteForegroundAuthToken = nil
+            || foregroundAuthenticationWasReady
+        remoteForegroundAuthenticationPhase = if !shouldAutoConnect, let foregroundAuthToken {
+            .authenticating(token: foregroundAuthToken)
+        } else {
+            nil
+        }
         if configuration.transport == .websocket,
            configuration.daemonWebSocketEndpoint == nil {
             remoteConnectionState = .connected
@@ -5311,7 +5326,7 @@ final class Workspace: Identifiable, ObservableObject {
             return
         }
         guard shouldAutoConnect else {
-            remoteConnectionState = .disconnected
+            remoteConnectionState = foregroundAuthToken == nil ? .disconnected : .connecting
             applyBrowserRemoteWorkspaceStatusToPanels()
             postRemoteConnectionPresentationDidChange()
             return
@@ -5425,7 +5440,7 @@ final class Workspace: Identifiable, ObservableObject {
         }
 
         guard let remoteConfiguration else {
-            pendingRemoteForegroundAuthToken = foregroundAuthToken
+            remoteForegroundAuthenticationPhase = .readyBeforeConfiguration(token: foregroundAuthToken)
             return
         }
 
@@ -5433,9 +5448,10 @@ final class Workspace: Identifiable, ObservableObject {
             return
         }
 
-        pendingRemoteForegroundAuthToken = nil
-        guard remoteConnectionState == .disconnected else { return }
-        reconnectRemoteConnection()
+        guard case .authenticating(let expectedToken) = remoteForegroundAuthenticationPhase,
+              expectedToken == foregroundAuthToken else { return }
+        remoteForegroundAuthenticationPhase = nil
+        configureRemoteConnection(remoteConfiguration, autoConnect: true)
     }
 
     func disconnectRemoteConnection(clearConfiguration: Bool = false, disconnectedDetail: String? = nil) {
@@ -5451,7 +5467,7 @@ final class Workspace: Identifiable, ObservableObject {
         activeRemoteSessionControllerID = nil
         remoteSessionController = nil
         previousController?.stop()
-        pendingRemoteForegroundAuthToken = nil
+        remoteForegroundAuthenticationPhase = nil
         remoteDisconnectPlaceholderPanelIds.formUnion(activeRemoteTerminalSurfaceIds)
         activeRemoteTerminalSurfaceIds.removeAll()
         let remoteDirectoryPanelIdsToClear = clearConfiguration ? remoteDirectoryTrustRequiredPanelIds.union(remoteDirectoryReportPanelIds) : []

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2295,11 +2295,9 @@ final class Workspace: Identifiable, ObservableObject {
         set { surfaceRegistry.surfaceTTYNames = newValue }
     }
     private var remoteSessionController: RemoteSessionCoordinator?
-    private enum RemoteForegroundAuthenticationPhase {
-        case readyBeforeConfiguration(token: String)
-        case authenticating(token: String)
+    private enum RemoteForegroundAuthenticationPhase: Equatable {
+        case readyBeforeConfiguration(token: String), authenticating(token: String)
     }
-
     private var remoteForegroundAuthenticationPhase: RemoteForegroundAuthenticationPhase?
     var activeRemoteSessionControllerID: UUID?
     private var remoteLastErrorFingerprint: String?
@@ -5302,22 +5300,12 @@ final class Workspace: Identifiable, ObservableObject {
         previousController?.stop()
         applyRemoteProxyEndpointUpdate(nil)
         applyBrowserRemoteWorkspaceStatusToPanels()
-
         let foregroundAuthToken = Self.normalizedForegroundAuthToken(configuration.foregroundAuthToken)
-        let foregroundAuthenticationWasReady: Bool
-        if case .readyBeforeConfiguration(let readyToken) = remoteForegroundAuthenticationPhase {
-            foregroundAuthenticationWasReady = foregroundAuthToken == readyToken
-        } else {
-            foregroundAuthenticationWasReady = false
-        }
-        let shouldAutoConnect =
-            autoConnect
-            || foregroundAuthenticationWasReady
-        remoteForegroundAuthenticationPhase = if !shouldAutoConnect, let foregroundAuthToken {
-            .authenticating(token: foregroundAuthToken)
-        } else {
-            nil
-        }
+        let foregroundAuthenticationWasReady = foregroundAuthToken.map {
+            remoteForegroundAuthenticationPhase == .readyBeforeConfiguration(token: $0)
+        } ?? false
+        let shouldAutoConnect = autoConnect || foregroundAuthenticationWasReady
+        remoteForegroundAuthenticationPhase = nil
         if configuration.transport == .websocket,
            configuration.daemonWebSocketEndpoint == nil {
             remoteConnectionState = .connected
@@ -5326,12 +5314,12 @@ final class Workspace: Identifiable, ObservableObject {
             return
         }
         guard shouldAutoConnect else {
+            remoteForegroundAuthenticationPhase = foregroundAuthToken.map { .authenticating(token: $0) }
             remoteConnectionState = foregroundAuthToken == nil ? .disconnected : .connecting
             applyBrowserRemoteWorkspaceStatusToPanels()
             postRemoteConnectionPresentationDidChange()
             return
         }
-
         remoteConnectionState = .connecting
         applyBrowserRemoteWorkspaceStatusToPanels()
         postRemoteConnectionPresentationDidChange()
@@ -5438,18 +5426,14 @@ final class Workspace: Identifiable, ObservableObject {
         guard let foregroundAuthToken = Self.normalizedForegroundAuthToken(token) else {
             return
         }
-
         guard let remoteConfiguration else {
             remoteForegroundAuthenticationPhase = .readyBeforeConfiguration(token: foregroundAuthToken)
             return
         }
-
         guard Self.normalizedForegroundAuthToken(remoteConfiguration.foregroundAuthToken) == foregroundAuthToken else {
             return
         }
-
-        guard case .authenticating(let expectedToken) = remoteForegroundAuthenticationPhase,
-              expectedToken == foregroundAuthToken else { return }
+        guard remoteForegroundAuthenticationPhase == .authenticating(token: foregroundAuthToken) else { return }
         remoteForegroundAuthenticationPhase = nil
         configureRemoteConnection(remoteConfiguration, autoConnect: true)
     }

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1306,7 +1306,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
     }
 
     @MainActor
-    func testForegroundSSHAuthReadyReconnectsConfiguredDisconnectedRemoteWorkspace() {
+    func testForegroundSSHAuthReadyReconnectsConfiguredConnectingRemoteWorkspace() {
         let workspace = Workspace()
         let config = WorkspaceRemoteConfiguration(
             destination: "cmux-macmini",
@@ -1323,7 +1323,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         )
 
         workspace.configureRemoteConnection(config, autoConnect: false)
-        XCTAssertEqual(workspace.remoteConnectionState, .disconnected)
+        XCTAssertEqual(workspace.remoteConnectionState, .connecting)
 
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-a")
 
@@ -6712,7 +6712,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
 
         XCTAssertFalse(result.timedOut, result.stderr)
         XCTAssertEqual(result.status, 0, result.stderr)
-        XCTAssertEqual(result.stdout, "OK workspace=\(workspaceRef) target=cmux-macmini state=disconnected\n")
+        XCTAssertEqual(result.stdout, "OK workspace=\(workspaceRef) target=cmux-macmini state=connecting\n")
         XCTAssertTrue(result.stderr.isEmpty, result.stderr)
 
         let requests = try state.commands.map { line -> [String: Any] in

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1297,11 +1297,12 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             terminalStartupCommand: "ssh cmux-macmini",
             foregroundAuthToken: "token-a"
         )
-
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-a")
+        XCTAssertEqual(workspace.remoteConnectionState, .disconnected)
+        XCTAssertNil(workspace.activeRemoteSessionControllerID)
         workspace.configureRemoteConnection(config, autoConnect: false)
-
         XCTAssertEqual(workspace.remoteConnectionState, .connecting)
+        XCTAssertNotNil(workspace.activeRemoteSessionControllerID)
         workspace.disconnectRemoteConnection(clearConfiguration: true)
     }
 
@@ -1321,13 +1322,12 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             terminalStartupCommand: "ssh cmux-macmini",
             foregroundAuthToken: "token-a"
         )
-
         workspace.configureRemoteConnection(config, autoConnect: false)
         XCTAssertEqual(workspace.remoteConnectionState, .connecting)
-
+        XCTAssertNil(workspace.activeRemoteSessionControllerID)
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-a")
-
         XCTAssertEqual(workspace.remoteConnectionState, .connecting)
+        XCTAssertNotNil(workspace.activeRemoteSessionControllerID)
         workspace.disconnectRemoteConnection(clearConfiguration: true)
     }
 
@@ -1347,11 +1347,10 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             terminalStartupCommand: "ssh cmux-macmini",
             foregroundAuthToken: "token-b"
         )
-
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-a")
         workspace.configureRemoteConnection(config, autoConnect: false)
-
         XCTAssertEqual(workspace.remoteConnectionState, .connecting)
+        XCTAssertNil(workspace.activeRemoteSessionControllerID)
     }
 
     @MainActor
@@ -1397,11 +1396,10 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
             terminalStartupCommand: "ssh cmux-macmini",
             foregroundAuthToken: "token-a"
         )
-
         workspace.configureRemoteConnection(config, autoConnect: false)
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-b")
-
         XCTAssertEqual(workspace.remoteConnectionState, .connecting)
+        XCTAssertNil(workspace.activeRemoteSessionControllerID)
     }
 
     @MainActor

--- a/cmuxTests/WorkspaceRemoteConnectionTests.swift
+++ b/cmuxTests/WorkspaceRemoteConnectionTests.swift
@@ -1351,7 +1351,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-a")
         workspace.configureRemoteConnection(config, autoConnect: false)
 
-        XCTAssertEqual(workspace.remoteConnectionState, .disconnected)
+        XCTAssertEqual(workspace.remoteConnectionState, .connecting)
     }
 
     @MainActor
@@ -1401,7 +1401,7 @@ final class WorkspaceRemoteConnectionTests: XCTestCase {
         workspace.configureRemoteConnection(config, autoConnect: false)
         workspace.notifyRemoteForegroundAuthenticationReady(token: "token-b")
 
-        XCTAssertEqual(workspace.remoteConnectionState, .disconnected)
+        XCTAssertEqual(workspace.remoteConnectionState, .connecting)
     }
 
     @MainActor
@@ -6672,7 +6672,7 @@ final class CLINotifyProcessIntegrationTests: XCTestCase {
                         "workspace_ref": workspaceRef,
                         "remote": [
                             "enabled": true,
-                            "state": autoConnect ? "connecting" : "disconnected",
+                            "state": autoConnect || params["foreground_auth_token"] != nil ? "connecting" : "disconnected",
                         ],
                     ]
                 )


### PR DESCRIPTION
## Summary

- model deferred foreground SSH authentication as an in-progress connection lifecycle
- return `state=connecting` from `workspace.remote.configure` while that authentication is pending
- consume the matching foreground-auth phase before starting the remote session coordinator
- keep `state=disconnected` for configurations with no active connection attempt

## Root cause

`cmux ssh` intentionally sets `auto_connect=false` when OpenSSH foreground authentication must finish before the background remote-session coordinator starts. `Workspace.configureRemoteConnection` treated every `auto_connect=false` configuration as disconnected, even when the configuration carried the one-time foreground-auth token proving that a launch was already in progress. The socket response serialized that state immediately and the CLI faithfully printed the misleading `state=disconnected`.

The fix makes the workspace the single lifecycle owner. It tracks whether the auth callback arrived before configuration or whether foreground authentication is currently in progress. The public state is `connecting` throughout that launch phase; the matching token is consumed before coordinator startup, while explicit disconnect clears the phase so stale callbacks cannot reconnect it.

## Verification

- regression coverage is split into a test-only commit followed by the fix commit
- workspace behavior test covers the pending foreground-auth lifecycle state
- CLI process integration test covers the exact `cmux ssh` launch output
- `git diff --check`
- touched Swift files remain within their existing checked-in length budgets
- no local Xcode tests or build run, per task instructions; CI is the compile/test gate
- no user-facing strings changed, so no localization catalog changes are required

Note: the repository-wide Swift file budget script currently reports pre-existing overages in five untouched files. This PR does not modify either budget TSV and both touched files remain at or below their checked-in limits.

Closes #7912

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7913"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786403859&installation_id=133855650&pr_number=7913&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7913&signature=3010c198a80b5b349f779377abb1ae171e4398aaec618e3d622507717c4b205f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes remote connection state machine and when the session coordinator starts; wrong phase handling could block connects or accept stale auth callbacks, though token matching and disconnect cleanup mitigate that.
> 
> **Overview**
> Fixes misleading **`state=disconnected`** from `cmux ssh` when a remote workspace is configured with **`auto_connect=false`** but foreground SSH authentication is already in progress.
> 
> **`Workspace`** replaces the single pending token with **`RemoteForegroundAuthenticationPhase`** (`readyBeforeConfiguration` vs **`authenticating`**). With a foreground auth token and no auto-connect yet, **`remoteConnectionState`** is **`connecting`** and the session coordinator stays idle until **`notifyRemoteForegroundAuthenticationReady`** matches the token and re-runs configuration with auto-connect. Disconnect clears the phase so stale callbacks cannot reconnect.
> 
> Tests and the CLI integration mock now expect **`connecting`** (including when a **`foreground_auth_token`** is present on **`workspace.remote.configure`**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5d4bc7b4b1f3aa349d4767d6fec0f4c9e08b7093. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect SSH launch status: `workspace.remote.configure` now reports `state=connecting` during foreground SSH authentication so `cmux ssh` prints the correct pending state. The session starts automatically once auth completes.

- **Bug Fixes**
  - Added `RemoteForegroundAuthenticationPhase` to track foreground SSH auth and block stale callbacks.
  - When a `foreground_auth_token` is present, return `connecting` and defer coordinator start until the matching ready event; remain `disconnected` only when there’s no active attempt.
  - Expanded lifecycle tests (pre/post configuration) and CLI integration to assert deferred start and `state=connecting` output.

<sup>Written for commit 5d4bc7b4b1f3aa349d4767d6fec0f4c9e08b7093. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

