### PR TITLE
Fix cmux top topology for SSH-tmux mirrors

### DIFF
--- a/Sources/TerminalController+ControlSystemContext.swift
+++ b/Sources/TerminalController+ControlSystemContext.swift
@@ -51,7 +51,7 @@ extension TerminalController: ControlSystemContext {
                         continue
                     }
                     let workspace = manager.tabs[workspaceIndex]
-                    let workspaceNode = systemTreeWorkspaceNode(
+                    let workspaceNode = controlSystemTreeWorkspaceNode(
                         workspace: workspace,
                         index: workspaceIndex,
                         selected: workspace.id == manager.selectedTabId
@@ -72,7 +72,7 @@ extension TerminalController: ControlSystemContext {
                 }
 
                 let workspaceNodesForWindow = manager.tabs.enumerated().map { workspaceIndex, workspace in
-                    systemTreeWorkspaceNode(
+                    controlSystemTreeWorkspaceNode(
                         workspace: workspace,
                         index: workspaceIndex,
                         selected: workspace.id == manager.selectedTabId
@@ -106,9 +106,9 @@ extension TerminalController: ControlSystemContext {
         )
     }
 
-    /// The byte-faithful twin of the former `v2TreeWorkspaceNode`, producing
-    /// Sendable nodes instead of payload dictionaries.
-    private func systemTreeWorkspaceNode(
+    /// Projects the authoritative control-plane workspace topology shared by
+    /// `system.tree`, `system.top`, and the task-manager snapshot.
+    func controlSystemTreeWorkspaceNode(
         workspace: Workspace,
         index: Int,
         selected: Bool

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -3072,117 +3072,86 @@ class TerminalController {
         index: Int,
         selected: Bool
     ) -> [String: Any] {
-        var paneByPanelId: [UUID: UUID] = [:]
-        var indexInPaneByPanelId: [UUID: Int] = [:]
-        var selectedInPaneByPanelId: [UUID: Bool] = [:]
-
-        let paneIds = workspace.bonsplitController.allPaneIds
-        for paneId in paneIds {
-            let tabs = workspace.bonsplitController.tabs(inPane: paneId)
-            let selectedTab = workspace.bonsplitController.selectedTab(inPane: paneId)
-            for (tabIndex, tab) in tabs.enumerated() {
-                guard let panelId = workspace.panelIdFromSurfaceId(tab.id) else { continue }
-                paneByPanelId[panelId] = paneId.id
-                indexInPaneByPanelId[panelId] = tabIndex
-                selectedInPaneByPanelId[panelId] = (tab.id == selectedTab?.id)
-            }
-        }
-
-        var surfacesByPane: [UUID: [[String: Any]]] = [:]
-        let focusedSurfaceId = workspace.focusedPanelId
-        for (surfaceIndex, panel) in orderedPanels(in: workspace).enumerated() {
-            let paneUUID = paneByPanelId[panel.id]
-            let selectedInPane = selectedInPaneByPanelId[panel.id] ?? false
-
-            var item: [String: Any] = [
-                "kind": "surface",
-                "id": panel.id.uuidString,
-                "ref": v2Ref(kind: .surface, uuid: panel.id),
-                "index": surfaceIndex,
-                "type": panel.panelType.rawValue,
-                "title": workspace.panelTitle(panelId: panel.id) ?? panel.displayTitle,
-                "focused": panel.id == focusedSurfaceId,
-                "selected": selectedInPane,
-                "selected_in_pane": v2OrNull(selectedInPaneByPanelId[panel.id]),
-                "pane_id": v2OrNull(paneUUID?.uuidString),
-                "pane_ref": v2Ref(kind: .pane, uuid: paneUUID),
-                "index_in_pane": v2OrNull(indexInPaneByPanelId[panel.id]),
-                "tty": v2OrNull(workspace.surfaceTTYNames[panel.id]),
-                "webviews": []
-            ]
-
-            if panel.panelType == .browser, let browserPanel = panel as? BrowserPanel {
-                let webContentPID = CmuxWebContentProcessIdentifier.pid(for: browserPanel.webView)
-                let url = browserPanel.currentURL?.absoluteString ?? ""
-                let webViewLifecycle = browserPanel.webViewLifecycleTopPayload()
-                item["url"] = url
-                item["browser_web_content_pid"] = v2OrNull(webContentPID)
-                item["browser_webview_lifecycle_state"] = browserPanel.webViewLifecycleState.rawValue
-                item["webviews"] = [
-                    [
-                        "kind": "webview",
-                        "id": "\(panel.id.uuidString):webview",
-                        "ref": "\(v2Ref(kind: .surface, uuid: panel.id)):webview",
-                        "index": 0,
-                        "surface_id": panel.id.uuidString,
-                        "surface_ref": v2Ref(kind: .surface, uuid: panel.id),
-                        "title": browserPanel.displayTitle,
-                        "url": url,
-                        "pid": v2OrNull(webContentPID),
-                        "lifecycle": webViewLifecycle
-                    ] as [String: Any]
-                ]
-            } else {
-                item["url"] = NSNull()
-                item["browser_web_content_pid"] = NSNull()
-            }
-            if let paneUUID {
-                surfacesByPane[paneUUID, default: []].append(item)
-            }
-        }
-
-        for paneUUID in surfacesByPane.keys {
-            surfacesByPane[paneUUID]?.sort {
-                let lhs = ($0["index_in_pane"] as? Int) ?? ($0["index"] as? Int) ?? Int.max
-                let rhs = ($1["index_in_pane"] as? Int) ?? ($1["index"] as? Int) ?? Int.max
-                return lhs < rhs
-            }
-        }
-
-        let focusedPaneId = workspace.bonsplitController.focusedPaneId
-        let panes: [[String: Any]] = paneIds.enumerated().map { paneIndex, paneId in
-            let tabs = workspace.bonsplitController.tabs(inPane: paneId)
-            let surfaceUUIDs: [UUID] = tabs.compactMap { workspace.panelIdFromSurfaceId($0.id) }
-            let selectedTab = workspace.bonsplitController.selectedTab(inPane: paneId)
-            let selectedSurfaceUUID = selectedTab.flatMap { workspace.panelIdFromSurfaceId($0.id) }
-
+        let topology = controlSystemTreeWorkspaceNode(
+            workspace: workspace,
+            index: index,
+            selected: selected
+        )
+        let panes = topology.panes.map { pane in
             return [
                 "kind": "pane",
-                "id": paneId.id.uuidString,
-                "ref": v2Ref(kind: .pane, uuid: paneId.id),
-                "index": paneIndex,
-                "focused": paneId == focusedPaneId,
-                "surface_ids": surfaceUUIDs.map { $0.uuidString },
-                "surface_refs": surfaceUUIDs.map { v2Ref(kind: .surface, uuid: $0) },
-                "selected_surface_id": v2OrNull(selectedSurfaceUUID?.uuidString),
-                "selected_surface_ref": v2Ref(kind: .surface, uuid: selectedSurfaceUUID),
-                "surface_count": surfaceUUIDs.count,
-                "surfaces": surfacesByPane[paneId.id] ?? []
+                "id": pane.paneID.uuidString,
+                "ref": v2Ref(kind: .pane, uuid: pane.paneID),
+                "index": pane.index,
+                "focused": pane.isFocused,
+                "surface_ids": pane.surfaceIDs.map(\.uuidString),
+                "surface_refs": pane.surfaceIDs.map { v2Ref(kind: .surface, uuid: $0) },
+                "selected_surface_id": v2OrNull(pane.selectedSurfaceID?.uuidString),
+                "selected_surface_ref": v2Ref(kind: .surface, uuid: pane.selectedSurfaceID),
+                "surface_count": pane.surfaceIDs.count,
+                "surfaces": pane.surfaces.map { v2TopSurfaceNode($0, workspace: workspace) }
             ]
         }
 
         return [
             "kind": "workspace",
-            "id": workspace.id.uuidString,
-            "ref": v2Ref(kind: .workspace, uuid: workspace.id),
-            "index": index,
-            "title": workspace.title,
-            "description": v2OrNull(workspace.customDescription),
-            "selected": selected,
-            "pinned": workspace.isPinned,
+            "id": topology.workspaceID.uuidString,
+            "ref": v2Ref(kind: .workspace, uuid: topology.workspaceID),
+            "index": topology.index,
+            "title": topology.title,
+            "description": v2OrNull(topology.description),
+            "selected": topology.isSelected,
+            "pinned": topology.isPinned,
             "panes": panes,
             "tags": v2TopTagNodes(for: workspace)
         ]
+    }
+
+    private func v2TopSurfaceNode(
+        _ surface: ControlSystemTreeSurfaceNode,
+        workspace: Workspace
+    ) -> [String: Any] {
+        var item: [String: Any] = [
+            "kind": "surface",
+            "id": surface.surfaceID.uuidString,
+            "ref": v2Ref(kind: .surface, uuid: surface.surfaceID),
+            "index": surface.index,
+            "type": surface.typeRawValue,
+            "title": surface.title,
+            "focused": surface.isFocused,
+            "selected": surface.isSelected,
+            "selected_in_pane": v2OrNull(surface.selectedInPane),
+            "pane_id": v2OrNull(surface.paneID?.uuidString),
+            "pane_ref": v2Ref(kind: .pane, uuid: surface.paneID),
+            "index_in_pane": v2OrNull(surface.indexInPane),
+            "tty": v2OrNull(surface.tty),
+            "webviews": []
+        ]
+
+        guard let browserPanel = workspace.controlSurfaceTarget(for: surface.surfaceID)?.panel as? BrowserPanel else {
+            item["url"] = surface.isBrowser ? (surface.url ?? "") : NSNull()
+            item["browser_web_content_pid"] = NSNull()
+            return item
+        }
+
+        let webContentPID = CmuxWebContentProcessIdentifier.pid(for: browserPanel.webView)
+        let url = browserPanel.currentURL?.absoluteString ?? ""
+        item["url"] = url
+        item["browser_web_content_pid"] = v2OrNull(webContentPID)
+        item["browser_webview_lifecycle_state"] = browserPanel.webViewLifecycleState.rawValue
+        item["webviews"] = [[
+            "kind": "webview",
+            "id": "\(surface.surfaceID.uuidString):webview",
+            "ref": "\(v2Ref(kind: .surface, uuid: surface.surfaceID)):webview",
+            "index": 0,
+            "surface_id": surface.surfaceID.uuidString,
+            "surface_ref": v2Ref(kind: .surface, uuid: surface.surfaceID),
+            "title": browserPanel.displayTitle,
+            "url": url,
+            "pid": v2OrNull(webContentPID),
+            "lifecycle": browserPanel.webViewLifecycleTopPayload()
+        ] as [String: Any]]
+        return item
     }
 
     private func v2TopTagNodes(for workspace: Workspace) -> [[String: Any]] {

--- a/Sources/Workspace+RemoteTmuxControlTopology.swift
+++ b/Sources/Workspace+RemoteTmuxControlTopology.swift
@@ -1,4 +1,5 @@
 import Bonsplit
+import CmuxWorkspaces
 import Foundation
 
 @MainActor
@@ -90,6 +91,31 @@ extension Workspace {
         // Never alias it to the mutable active pane: callers may cache handles,
         // and a later focus publication would silently retarget that handle.
         return .unresolvedMirror
+    }
+
+    /// Intercepts focus requests the remote tmux layer owns. Focus activation
+    /// is dropped while mirror mutations suppress it, and a mirror-projected
+    /// pane surface — which is not a Bonsplit tab, so the ordinary focus path
+    /// cannot resolve it — routes through the pane's sole mutation owner
+    /// (select-pane on the remote) before focusing the mirror's container
+    /// panel, mirroring `focusRemoteTmuxControlPane`. Returns true when the
+    /// request was consumed.
+    func remoteTmuxMirrorInterceptsFocusPanel(
+        _ panelId: UUID,
+        previousHostedView: GhosttySurfaceScrollView?,
+        trigger: FocusPanelTrigger,
+        focusIntent: PanelFocusIntent?
+    ) -> Bool {
+        if remoteTmuxMirrorMutations.suppressesFocusActivation { return true }
+        guard let location = remoteTmuxControlPane(surfaceID: panelId) else { return false }
+        _ = location.controlFocus()
+        focusPanel(
+            location.containerPanelID,
+            previousHostedView: previousHostedView,
+            trigger: trigger,
+            focusIntent: focusIntent
+        )
+        return true
     }
 
     /// Canonicalizes an explicit control-plane terminal target. Hidden mirror

--- a/Sources/Workspace+RemoteTmuxControlTopology.swift
+++ b/Sources/Workspace+RemoteTmuxControlTopology.swift
@@ -98,8 +98,12 @@ extension Workspace {
     /// pane surface — which is not a Bonsplit tab, so the ordinary focus path
     /// cannot resolve it — routes through the pane's sole mutation owner
     /// (select-pane on the remote) before focusing the mirror's container
-    /// panel, mirroring `focusRemoteTmuxControlPane`. Returns true when the
-    /// request was consumed.
+    /// panel, mirroring `focusRemoteTmuxControlPane`. A single-pane session
+    /// window projects its display panel as both container and surface; that
+    /// identity stays on the ordinary focus path, both to terminate the
+    /// container recursion and because the container is a real Bonsplit tab
+    /// the ordinary path already handles. Returns true when the request was
+    /// consumed.
     func remoteTmuxMirrorInterceptsFocusPanel(
         _ panelId: UUID,
         previousHostedView: GhosttySurfaceScrollView?,
@@ -107,7 +111,8 @@ extension Workspace {
         focusIntent: PanelFocusIntent?
     ) -> Bool {
         if remoteTmuxMirrorMutations.suppressesFocusActivation { return true }
-        guard let location = remoteTmuxControlPane(surfaceID: panelId) else { return false }
+        guard let location = remoteTmuxControlPane(surfaceID: panelId),
+              location.containerPanelID != panelId else { return false }
         _ = location.controlFocus()
         focusPanel(
             location.containerPanelID,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9483,6 +9483,20 @@ final class Workspace: Identifiable, ObservableObject {
         focusIntent: PanelFocusIntent? = nil
     ) {
         guard !remoteTmuxMirrorMutations.suppressesFocusActivation else { return }
+        // A mirror-projected pane surface is not a Bonsplit tab, so the normal
+        // focus path below cannot resolve it. Route through the pane's sole
+        // mutation owner (select-pane on the remote) and focus the mirror's
+        // container panel, mirroring `focusRemoteTmuxControlPane`.
+        if let location = remoteTmuxControlPane(surfaceID: panelId) {
+            _ = location.controlFocus()
+            focusPanel(
+                location.containerPanelID,
+                previousHostedView: previousHostedView,
+                trigger: trigger,
+                focusIntent: focusIntent
+            )
+            return
+        }
         markExplicitFocusIntent(on: panelId)
 #if DEBUG
         let pane = bonsplitController.focusedPaneId?.id.uuidString.prefix(5) ?? "nil"

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -9482,21 +9482,7 @@ final class Workspace: Identifiable, ObservableObject {
         trigger: FocusPanelTrigger = .standard,
         focusIntent: PanelFocusIntent? = nil
     ) {
-        guard !remoteTmuxMirrorMutations.suppressesFocusActivation else { return }
-        // A mirror-projected pane surface is not a Bonsplit tab, so the normal
-        // focus path below cannot resolve it. Route through the pane's sole
-        // mutation owner (select-pane on the remote) and focus the mirror's
-        // container panel, mirroring `focusRemoteTmuxControlPane`.
-        if let location = remoteTmuxControlPane(surfaceID: panelId) {
-            _ = location.controlFocus()
-            focusPanel(
-                location.containerPanelID,
-                previousHostedView: previousHostedView,
-                trigger: trigger,
-                focusIntent: focusIntent
-            )
-            return
-        }
+        guard !remoteTmuxMirrorInterceptsFocusPanel(panelId, previousHostedView: previousHostedView, trigger: trigger, focusIntent: focusIntent) else { return }
         markExplicitFocusIntent(on: panelId)
 #if DEBUG
         let pane = bonsplitController.focusedPaneId?.id.uuidString.prefix(5) ?? "nil"

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1096,6 +1096,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */; };
 		F861B8D7C62A0BCB252A523A /* RemoteTmuxMirrorTabActivity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FC55CC7B42874062C64013A /* RemoteTmuxMirrorTabActivity.swift */; };
 		736200000000000000000008 /* RemoteTmuxMirrorTargetingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 736200000000000000000007 /* RemoteTmuxMirrorTargetingTests.swift */; };
+		7910A0017910A0017910A001 /* RemoteTmuxMirrorTopTopologyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7910B0017910B0017910B001 /* RemoteTmuxMirrorTopTopologyTests.swift */; };
 		7368BEEF7368BEEF7368B002 /* RemoteTmuxMissingTmuxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7368BEEF7368BEEF7368B001 /* RemoteTmuxMissingTmuxTests.swift */; };
 		740600000000000000000013 /* RemoteTmuxNativeLayoutMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 740600000000000000000012 /* RemoteTmuxNativeLayoutMetrics.swift */; };
 		74060000000000000000001F /* RemoteTmuxNativeMeasuredSplitTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74060000000000000000001E /* RemoteTmuxNativeMeasuredSplitTree.swift */; };
@@ -2815,6 +2816,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A7E1C4D2B3F09865E217D4C0 /* RemoteTmuxMirrorSplitRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorSplitRoutingTests.swift; sourceTree = "<group>"; };
 		6FC55CC7B42874062C64013A /* RemoteTmuxMirrorTabActivity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorTabActivity.swift; sourceTree = "<group>"; };
 		736200000000000000000007 /* RemoteTmuxMirrorTargetingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorTargetingTests.swift; sourceTree = "<group>"; };
+		7910B0017910B0017910B001 /* RemoteTmuxMirrorTopTopologyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorTopTopologyTests.swift; sourceTree = "<group>"; };
 		7368BEEF7368BEEF7368B001 /* RemoteTmuxMissingTmuxTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMissingTmuxTests.swift; sourceTree = "<group>"; };
 		740600000000000000000012 /* RemoteTmuxNativeLayoutMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNativeLayoutMetrics.swift; sourceTree = "<group>"; };
 		74060000000000000000001E /* RemoteTmuxNativeMeasuredSplitTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxNativeMeasuredSplitTree.swift; sourceTree = "<group>"; };
@@ -5121,6 +5123,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7738B0017738B0017738B001 /* RemoteTmuxMirrorCLIObservabilityTests.swift */,
 				7738B0027738B0027738B002 /* RemoteTmuxMirrorCLIFailClosedTests.swift */,
 				7837E0047837E0047837E004 /* RemoteTmuxMirrorResizeRoutingTests.swift */,
+				7910B0017910B0017910B001 /* RemoteTmuxMirrorTopTopologyTests.swift */,
 				A7E1C4D2B3F09865E217D4C1 /* RemoteTmuxMirrorFeedForwardTests.swift */,
 				740600000000000000000009 /* RemoteTmuxMirrorLayoutMathTests.swift */,
 				74060000000000000000000B /* RemoteTmuxMirrorPlacementTests.swift */,
@@ -7180,6 +7183,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				7837E0037837E0037837E003 /* RemoteTmuxMirrorResizeRoutingTests.swift in Sources */,
 				D4F8A2E61C5B39707A8E6F12 /* RemoteTmuxMirrorSplitRoutingTests.swift in Sources */,
 				736200000000000000000008 /* RemoteTmuxMirrorTargetingTests.swift in Sources */,
+				7910A0017910A0017910A001 /* RemoteTmuxMirrorTopTopologyTests.swift in Sources */,
 				7368BEEF7368BEEF7368B002 /* RemoteTmuxMissingTmuxTests.swift in Sources */,
 				0C7D0CDD0C7D0CDD0C7D0002 /* RemoteTmuxNewWindowCwdTests.swift in Sources */,
 				7020C0DE7020C0DE7020A002 /* RemoteTmuxProxyTransportRetryTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxMirrorLayoutIdentityTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorLayoutIdentityTests.swift
@@ -333,30 +333,12 @@ import Testing
         #expect(harness.controlPaneID(surfaceID: newSurfaceID) == stablePaneID)
         #expect(harness.sessionMirror.controlPaneID(forPane: 11)?.id == stablePaneID)
     }
-
-    /// A single-pane session window has no window mirror, so its control pane
-    /// projection reuses the display panel as both container and surface.
-    /// Focusing that panel must take the ordinary workspace focus path: the
-    /// mirror intercept re-entering itself with the same identity would
-    /// recurse without bound, and it must not mint a select-pane command that
-    /// the pre-projection focus path never sent.
-    @Test func singlePaneSessionWindowFocusUsesTheNormalPath() throws {
-        let harness = try Harness()
-        defer { harness.tearDown() }
-
-        let panel = try #require(harness.singlePanePanel(tmuxPaneID: 11))
-        let location = try #require(harness.workspace.remoteTmuxControlPane(surfaceID: panel.id))
-        #expect(location.containerPanelID == panel.id)
-
-        let baselinePendingCount = harness.connection.pendingCommandKindsForTesting.count
-        harness.workspace.focusPanel(panel.id)
-        #expect(harness.workspace.focusedPanelId == panel.id)
-        #expect(harness.connection.pendingCommandKindsForTesting.count == baselinePendingCount)
-    }
 }
 
+private typealias Harness = RemoteTmuxSessionMirrorLayoutHarness
+
 @MainActor
-private final class Harness {
+final class RemoteTmuxSessionMirrorLayoutHarness {
     struct LayoutUpdate {
         let windowID: Int
         let layout: String

--- a/cmuxTests/RemoteTmuxMirrorLayoutIdentityTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorLayoutIdentityTests.swift
@@ -333,6 +333,26 @@ import Testing
         #expect(harness.controlPaneID(surfaceID: newSurfaceID) == stablePaneID)
         #expect(harness.sessionMirror.controlPaneID(forPane: 11)?.id == stablePaneID)
     }
+
+    /// A single-pane session window has no window mirror, so its control pane
+    /// projection reuses the display panel as both container and surface.
+    /// Focusing that panel must take the ordinary workspace focus path: the
+    /// mirror intercept re-entering itself with the same identity would
+    /// recurse without bound, and it must not mint a select-pane command that
+    /// the pre-projection focus path never sent.
+    @Test func singlePaneSessionWindowFocusUsesTheNormalPath() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let panel = try #require(harness.singlePanePanel(tmuxPaneID: 11))
+        let location = try #require(harness.workspace.remoteTmuxControlPane(surfaceID: panel.id))
+        #expect(location.containerPanelID == panel.id)
+
+        let baselinePendingCount = harness.connection.pendingCommandKindsForTesting.count
+        harness.workspace.focusPanel(panel.id)
+        #expect(harness.workspace.focusedPanelId == panel.id)
+        #expect(harness.connection.pendingCommandKindsForTesting.count == baselinePendingCount)
+    }
 }
 
 @MainActor

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -1,0 +1,64 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+extension RemoteTmuxMirrorCLIObservabilityTests {
+    /// Regression for #7910: process enrichment must not mint a second view of
+    /// mirror topology. `system.top` and `system.tree` must expose the same
+    /// actionable pane and surface identities.
+    @Test func topUsesTreeTopologyForMirrorWorkspaces() async throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+
+        let tree = TerminalController.shared.controlSystemTreeWindows(
+            requestedWindowID: harness.windowID,
+            includeAllWindows: false,
+            focusedWindowID: nil,
+            workspaceFilter: harness.workspace.id
+        )
+        let treeWorkspace = try #require(tree.windows.first?.workspaces.first)
+        let expectedPaneIDs = treeWorkspace.panes.map(\.paneID)
+        let expectedSurfaceIDs = treeWorkspace.panes.flatMap(\.surfaceIDs)
+
+        let top = try await TerminalController.shared.taskManagerTopPayload(
+            includeProcesses: false
+        )
+        let windows = try #require(top["windows"] as? [[String: Any]])
+        let topWindow = try #require(windows.first {
+            $0["id"] as? String == harness.windowID.uuidString
+        })
+        let workspaces = try #require(topWindow["workspaces"] as? [[String: Any]])
+        let topWorkspace = try #require(workspaces.first {
+            $0["id"] as? String == harness.workspace.id.uuidString
+        })
+        let topPanes = try #require(topWorkspace["panes"] as? [[String: Any]])
+
+        let topPaneIDs = topPanes.compactMap {
+            ($0["id"] as? String).flatMap(UUID.init(uuidString:))
+        }
+        let topSurfaces = topPanes.flatMap {
+            $0["surfaces"] as? [[String: Any]] ?? []
+        }
+        let topSurfaceIDs = topSurfaces.compactMap {
+            ($0["id"] as? String).flatMap(UUID.init(uuidString:))
+        }
+
+        #expect(topPaneIDs == expectedPaneIDs)
+        #expect(topSurfaceIDs == expectedSurfaceIDs)
+        #expect(!topSurfaceIDs.contains(harness.outerPanelID))
+
+        for (pane, paneID) in zip(topPanes, topPaneIDs) {
+            let ref = try #require(pane["ref"] as? String)
+            #expect(TerminalController.shared.v2ResolveHandleRef(ref) == paneID)
+        }
+        for (surface, surfaceID) in zip(topSurfaces, topSurfaceIDs) {
+            let ref = try #require(surface["ref"] as? String)
+            #expect(TerminalController.shared.v2ResolveHandleRef(ref) == surfaceID)
+        }
+    }
+}

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -105,10 +105,8 @@ struct RemoteTmuxMirrorTopTopologyTests {
         )
         defer { harness.tearDown() }
 
-        let activeTmuxPaneID = try #require(harness.mirror.activePaneId)
-        let targetTmuxPaneID = try #require(harness.mirror.paneIDsInOrder.first {
-            $0 != activeTmuxPaneID
-        })
+        let targetTmuxPaneID = 22
+        #expect(harness.mirror.paneIDsInOrder.contains(targetTmuxPaneID))
         let targetSurfaceID = try #require(harness.mirror.panel(forPane: targetTmuxPaneID)?.id)
         let payload = try await TerminalController.shared.taskManagerTopPayload(
             includeProcesses: false
@@ -118,6 +116,8 @@ struct RemoteTmuxMirrorTopTopologyTests {
             $0.kind == .terminalSurface && $0.surfaceId == targetSurfaceID
         })
 
+        harness.mirror.noteRemoteActivePane(11)
+        #expect(harness.mirror.activePaneId == 11)
         let baselinePendingCount = harness.connection.pendingCommandKindsForTesting.count
         CmuxTaskManagerModel().viewTerminal(for: row)
         #expect(harness.connection.pendingCommandKindsForTesting.count == baselinePendingCount + 1)

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -102,7 +102,10 @@ struct RemoteTmuxMirrorTopTopologyTests {
         let harness = try RemoteTmuxMirrorCLIObservabilityTests.Harness(connectedTransport: true)
         defer { harness.tearDown() }
 
-        let targetTmuxPaneID = try #require(harness.mirror.paneIDsInOrder.first)
+        let activeTmuxPaneID = try #require(harness.mirror.activePaneId)
+        let targetTmuxPaneID = try #require(harness.mirror.paneIDsInOrder.first {
+            $0 != activeTmuxPaneID
+        })
         let targetSurfaceID = try #require(harness.mirror.panel(forPane: targetTmuxPaneID)?.id)
         let payload = try await TerminalController.shared.taskManagerTopPayload(
             includeProcesses: false
@@ -112,7 +115,9 @@ struct RemoteTmuxMirrorTopTopologyTests {
             $0.kind == .terminalSurface && $0.surfaceId == targetSurfaceID
         })
 
+        let baselinePendingCount = harness.connection.pendingCommandKindsForTesting.count
         CmuxTaskManagerModel().viewTerminal(for: row)
+        #expect(harness.connection.pendingCommandKindsForTesting.count == baselinePendingCount + 1)
 
         let writer = try #require(harness.controlWriter)
         let pipe = try #require(harness.controlPipe)
@@ -121,6 +126,7 @@ struct RemoteTmuxMirrorTopTopologyTests {
             bytes: try pipe.fileHandleForReading.readToEnd() ?? Data(),
             encoding: .utf8
         ))
-        #expect(commands == "select-pane -t @3.%\(targetTmuxPaneID)\n")
+        let commandLines = commands.split(separator: "\n").map(String.init)
+        #expect(commandLines.last == "select-pane -t @3.%\(targetTmuxPaneID)")
     }
 }

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -99,7 +99,10 @@ struct RemoteTmuxMirrorTopTopologyTests {
     /// Task Manager navigation must consume the same projected surface IDs
     /// that its top snapshot displays.
     @Test func taskManagerViewsProjectedMirrorSurface() async throws {
-        let harness = try RemoteTmuxMirrorCLIObservabilityTests.Harness(connectedTransport: true)
+        let harness = try RemoteTmuxMirrorCLIObservabilityTests.Harness(
+            activeTmuxPaneID: 11,
+            connectedTransport: true
+        )
         defer { harness.tearDown() }
 
         let activeTmuxPaneID = try #require(harness.mirror.activePaneId)

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -93,4 +93,32 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
             }
         }
     }
+
+    /// Task Manager navigation must consume the same projected surface IDs
+    /// that its top snapshot displays.
+    @Test func taskManagerViewsProjectedMirrorSurface() async throws {
+        let harness = try Harness(connectedTransport: true)
+        defer { harness.tearDown() }
+
+        let targetTmuxPaneID = try #require(harness.mirror.paneIDsInOrder.first)
+        let targetSurfaceID = try #require(harness.mirror.panel(forPane: targetTmuxPaneID)?.id)
+        let payload = try await TerminalController.shared.taskManagerTopPayload(
+            includeProcesses: false
+        )
+        let snapshot = CmuxTaskManagerSnapshot(payload: payload)
+        let row = try #require(snapshot.rows.first {
+            $0.kind == .terminalSurface && $0.surfaceId == targetSurfaceID
+        })
+
+        CmuxTaskManagerModel().viewTerminal(for: row)
+
+        let writer = try #require(harness.controlWriter)
+        let pipe = try #require(harness.controlPipe)
+        writer.close()
+        let commands = try #require(String(
+            bytes: try pipe.fileHandleForReading.readToEnd() ?? Data(),
+            encoding: .utf8
+        ))
+        #expect(commands == "select-pane -t @3.%\(targetTmuxPaneID)\n")
+    }
 }

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -7,12 +7,14 @@ import Testing
 @testable import cmux
 #endif
 
-extension RemoteTmuxMirrorCLIObservabilityTests {
+@MainActor
+@Suite(.serialized)
+struct RemoteTmuxMirrorTopTopologyTests {
     /// Regression for #7910: process enrichment must not mint a second view of
     /// mirror topology. `system.top` and `system.tree` must expose the same
     /// actionable pane and surface identities.
     @Test func topUsesTreeTopologyForMirrorWorkspaces() async throws {
-        let harness = try Harness()
+        let harness = try RemoteTmuxMirrorCLIObservabilityTests.Harness()
         defer { harness.tearDown() }
 
         let tree = TerminalController.shared.controlSystemTreeWindows(
@@ -97,7 +99,7 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
     /// Task Manager navigation must consume the same projected surface IDs
     /// that its top snapshot displays.
     @Test func taskManagerViewsProjectedMirrorSurface() async throws {
-        let harness = try Harness(connectedTransport: true)
+        let harness = try RemoteTmuxMirrorCLIObservabilityTests.Harness(connectedTransport: true)
         defer { harness.tearDown() }
 
         let targetTmuxPaneID = try #require(harness.mirror.paneIDsInOrder.first)

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -38,27 +38,59 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
         })
         let topPanes = try #require(topWorkspace["panes"] as? [[String: Any]])
 
-        let topPaneIDs = topPanes.compactMap {
-            ($0["id"] as? String).flatMap(UUID.init(uuidString:))
+        let workspaceRef = try #require(topWorkspace["ref"] as? String)
+        #expect(TerminalController.shared.v2ResolveHandleRef(workspaceRef) == harness.workspace.id)
+
+        let topPaneIDs = try topPanes.map { pane in
+            let id = try #require(pane["id"] as? String)
+            return try #require(UUID(uuidString: id))
         }
-        let topSurfaces = topPanes.flatMap {
-            $0["surfaces"] as? [[String: Any]] ?? []
+        let topSurfacesByPane = try topPanes.map { pane in
+            try #require(pane["surfaces"] as? [[String: Any]])
         }
-        let topSurfaceIDs = topSurfaces.compactMap {
-            ($0["id"] as? String).flatMap(UUID.init(uuidString:))
+        let topSurfaceIDsByPane = try topSurfacesByPane.map { surfaces in
+            try surfaces.map { surface in
+                let id = try #require(surface["id"] as? String)
+                return try #require(UUID(uuidString: id))
+            }
         }
+        let topSurfaceIDs = topSurfaceIDsByPane.flatMap { $0 }
 
         #expect(topPaneIDs == expectedPaneIDs)
         #expect(topSurfaceIDs == expectedSurfaceIDs)
         #expect(!topSurfaceIDs.contains(harness.outerPanelID))
 
-        for (pane, paneID) in zip(topPanes, topPaneIDs) {
+        let expectedPanesByID = Dictionary(uniqueKeysWithValues: treeWorkspace.panes.map {
+            ($0.paneID, $0)
+        })
+        for (index, pane) in topPanes.enumerated() {
+            let paneID = topPaneIDs[index]
+            let surfaces = topSurfacesByPane[index]
+            let surfaceIDs = topSurfaceIDsByPane[index]
+            let expectedPane = try #require(expectedPanesByID[paneID])
+
             let ref = try #require(pane["ref"] as? String)
             #expect(TerminalController.shared.v2ResolveHandleRef(ref) == paneID)
-        }
-        for (surface, surfaceID) in zip(topSurfaces, topSurfaceIDs) {
-            let ref = try #require(surface["ref"] as? String)
-            #expect(TerminalController.shared.v2ResolveHandleRef(ref) == surfaceID)
+
+            #expect(surfaceIDs == expectedPane.surfaceIDs)
+            let surfaceRefs = try #require(pane["surface_refs"] as? [String])
+            let resolvedSurfaceRefs = surfaceRefs.map {
+                TerminalController.shared.v2ResolveHandleRef($0)
+            }
+            #expect(resolvedSurfaceRefs == expectedPane.surfaceIDs.map { Optional($0) })
+
+            let selectedSurfaceID = try #require(expectedPane.selectedSurfaceID)
+            let selectedSurfaceRef = try #require(pane["selected_surface_ref"] as? String)
+            #expect(TerminalController.shared.v2ResolveHandleRef(selectedSurfaceRef) == selectedSurfaceID)
+
+            for (surfaceIndex, surface) in surfaces.enumerated() {
+                let surfaceID = surfaceIDs[surfaceIndex]
+                let surfaceRef = try #require(surface["ref"] as? String)
+                #expect(TerminalController.shared.v2ResolveHandleRef(surfaceRef) == surfaceID)
+
+                let paneRef = try #require(surface["pane_ref"] as? String)
+                #expect(TerminalController.shared.v2ResolveHandleRef(paneRef) == paneID)
+            }
         }
     }
 }

--- a/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorTopTopologyTests.swift
@@ -132,4 +132,24 @@ struct RemoteTmuxMirrorTopTopologyTests {
         let commandLines = commands.split(separator: "\n").map(String.init)
         #expect(commandLines.last == "select-pane -t @3.%\(targetTmuxPaneID)")
     }
+
+    /// A single-pane session window has no window mirror, so its control pane
+    /// projection reuses the display panel as both container and surface.
+    /// Focusing that panel must take the ordinary workspace focus path: the
+    /// mirror intercept re-entering itself with the same identity would
+    /// recurse without bound, and it must not mint a select-pane command that
+    /// the pre-projection focus path never sent.
+    @Test func singlePaneSessionWindowFocusUsesTheNormalPath() throws {
+        let harness = try RemoteTmuxSessionMirrorLayoutHarness()
+        defer { harness.tearDown() }
+
+        let panel = try #require(harness.singlePanePanel(tmuxPaneID: 11))
+        let location = try #require(harness.workspace.remoteTmuxControlPane(surfaceID: panel.id))
+        #expect(location.containerPanelID == panel.id)
+
+        let baselinePendingCount = harness.connection.pendingCommandKindsForTesting.count
+        harness.workspace.focusPanel(panel.id)
+        #expect(harness.workspace.focusedPanelId == panel.id)
+        #expect(harness.connection.pendingCommandKindsForTesting.count == baselinePendingCount)
+    }
 }


### PR DESCRIPTION
Closes #7910\n\n## Root cause\n\nThe public control tree already projects SSH-tmux mirror containers into stable remote pane and surface identities through ControlSystemTreeWorkspaceNode. The top snapshot maintained a second topology walk over local Bonsplit panes and raw ordered panels. That duplicate walk exposed the hidden mirror container as a real pane/surface, so top emitted identities that disagreed with tree and could not be resolved by other commands.\n\n## Fix\n\n- Make system.top and the task-manager snapshot render pane/surface topology from the same typed workspace projection used by system.tree.\n- Keep top-only process, resource, and browser lifecycle enrichment layered on those projected nodes.\n- Delete the duplicate Bonsplit/raw-panel identity walk, so mirror container IDs cannot leak into top by construction.\n\nThis applies the same authoritative projection principle as #7837: control-plane identities are resolved once by the workspace topology owner, then consumers dispatch or enrich those identities without recreating them.\n\n## Regression coverage\n\nThe PR preserves red/green provenance in two commits:\n\n1. ba25efc776 adds a failing Swift Testing regression that creates a two-pane SSH-tmux mirror, compares tree and top pane/surface IDs, rejects the hidden container surface, and verifies every top ref resolves.\n2. dc6b6543e5 switches top to the shared typed projection.\n\nNo local Xcode tests were run, per issue instructions. CI owns test execution.\n\n## Local verification\n\n- ./scripts/setup.sh\n- ./scripts/reload.sh --tag issue-7910-top-topology (build succeeded; app not launched)\n- swiftc frontend parse of both changed source files and the regression test\n- ./scripts/lint-pbxproj-test-wiring.sh\n- ./scripts/check-pbxproj.sh\n- python3 scripts/swift_file_length_budget.py --base-ref origin/main\n- python3 scripts/check-package-resolved-policy.py\n- python3 scripts/check-workspace-package-groups.py --check\n- git diff --check\n\nThe repository-wide no-base-ref Swift budget command still reports five pre-existing overages on origin/main; this branch touches none of those files and shrinks TerminalController.swift by 31 lines. Neither Swift budget TSV was modified.\n\n## Localization audit\n\nNo user-facing strings or localized surfaces changed. Added strings are test labels/comments and protocol dictionary keys only, so Resources/Localizable.xcstrings requires no update.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7915"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786404489&installation_id=133855650&pr_number=7915&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7915&signature=66946ffd5c9567d9ad3bd45c3171c7562f0d65189ffabb2f9b7f6e184e95ddb7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes control-plane identity emission and focus routing for remote tmux mirrors; regressions could break Task Manager refs or focus recursion, but behavior is heavily regression-tested.
> 
> **Overview**
> Fixes **#7910** by making **`system.top`** and the Task Manager snapshot build pane/surface topology from **`controlSystemTreeWorkspaceNode`**—the same typed projection as **`system.tree`**—instead of a second walk over Bonsplit panes and raw ordered panels that could expose hidden mirror container IDs.
> 
> **`v2TopWorkspaceNode`** now maps that projection into top JSON via **`v2TopSurfaceNode`**, which keeps browser URL/PID/webview enrichment on projected surfaces only.
> 
> **`remoteTmuxMirrorInterceptsFocusPanel`** replaces the blunt “drop all focus when suppressed” guard in **`focusPanel`**: mirror-projected surfaces (not Bonsplit tabs) run remote **`select-pane`** then focus the container; single-pane windows where container equals surface stay on the normal path to avoid recursion and stray commands.
> 
> Adds **`RemoteTmuxMirrorTopTopologyTests`** (tree/top ID parity, Task Manager navigation, single-pane focus) and promotes the layout test harness to **`RemoteTmuxSessionMirrorLayoutHarness`** for reuse.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d42ebf52213524e54c88a362740d23fa23c0662. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `system.top` topology for SSH‑tmux mirrors by using the `system.tree` workspace projection, preventing hidden mirror container IDs. Task Manager now snapshots and navigates using projected IDs; mirror focus is routed via `remoteTmuxMirrorInterceptsFocusPanel`, and single‑pane sessions use the normal focus path. Closes #7910.

- **Bug Fixes**
  - Render `system.top` and Task Manager snapshot from `controlSystemTreeWorkspaceNode` (shared with `system.tree`); remove the duplicate Bonsplit/raw‑panel walk.
  - Intercept mirror‑projected surface focus via `remoteTmuxMirrorInterceptsFocusPanel` to run `select-pane`, then focus the mirror container; only intercept when the projected surface differs from its container so single‑pane session windows stay on the normal path, avoiding recursion and stray `select-pane`.
  - Keep top‑only process/resource/browser enrichment on projected nodes via `v2TopSurfaceNode`.
  - Add `RemoteTmuxMirrorTopTopologyTests` covering tree/top ID parity, handle‑ref resolution, exclusion of the mirror container, Task Manager navigation to a non‑default mirror pane, and single‑pane session window focus; expose `RemoteTmuxSessionMirrorLayoutHarness` and move the single‑pane regression into this suite; scheduled in CI.

<sup>Written for commit 9d42ebf52213524e54c88a362740d23fa23c0662. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7915?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consistency between control-system “tree” topology and mirrored “top” workspace topology, including pane/surface identity and selection mapping.
  * Updated mirrored “top” payload construction to derive pane/surface structure directly from the control-system topology.
  * Browser-specific details (URL/PID/webviews) are now emitted only for browser-backed surfaces.
* **Tests**
  * Added regression tests covering mirrored “top” mapping from control-system “tree” and projected mirror surface selection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->