### PR TITLE
fix: taller-than-pane webviews open un-scrollable until a real resize (#7895)

### DIFF
--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -9,15 +9,28 @@ import WebKit
 /// hidden or alpha-0 window. When such a webview becomes visible again (a
 /// portal reveal, or adoption out of the prewarm pool's offscreen host), the
 /// refresh pass must fire WebKit's re-enter selectors or the first paint
-/// keeps the stale layer tree from the hidden host.
+/// keeps the stale layer tree from the hidden host. A first-sized reveal also
+/// delivers a real geometry delta so WebKit recomputes scrollable content.
 
 private var cmuxBrowserPortalNeedsRenderingStateReattachKey: UInt8 = 0
+private var cmuxBrowserPortalNeedsFirstSizedRevealNudgeKey: UInt8 = 0
+private var cmuxBrowserPortalFirstSizedRevealNudgeGenerationKey: UInt8 = 0
 
 #if DEBUG
 private func browserPortalRenderingStateDebugToken(_ view: NSView?) -> String {
     guard let view else { return "nil" }
     let ptr = Unmanaged.passUnretained(view).toOpaque()
     return String(describing: ptr)
+}
+
+private func browserPortalRenderingStateDebugFrame(_ frame: NSRect) -> String {
+    String(
+        format: "%.1f,%.1f %.1fx%.1f",
+        frame.origin.x,
+        frame.origin.y,
+        frame.size.width,
+        frame.size.height
+    )
 }
 #endif
 
@@ -34,6 +47,17 @@ private extension NSObject {
 }
 
 extension WKWebView {
+    private static func browserPortalRectApproximatelyEqual(
+        _ lhs: NSRect,
+        _ rhs: NSRect,
+        epsilon: CGFloat = 0.5
+    ) -> Bool {
+        abs(lhs.origin.x - rhs.origin.x) <= epsilon &&
+            abs(lhs.origin.y - rhs.origin.y) <= epsilon &&
+            abs(lhs.size.width - rhs.size.width) <= epsilon &&
+            abs(lhs.size.height - rhs.size.height) <= epsilon
+    }
+
     fileprivate var browserPortalNeedsRenderingStateReattach: Bool {
         get {
             (objc_getAssociatedObject(self, &cmuxBrowserPortalNeedsRenderingStateReattachKey) as? NSNumber)?
@@ -49,8 +73,69 @@ extension WKWebView {
         }
     }
 
+    fileprivate var browserPortalNeedsFirstSizedRevealNudge: Bool {
+        get {
+            (objc_getAssociatedObject(self, &cmuxBrowserPortalNeedsFirstSizedRevealNudgeKey) as? NSNumber)?
+                .boolValue ?? false
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &cmuxBrowserPortalNeedsFirstSizedRevealNudgeKey,
+                NSNumber(value: newValue),
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
+    fileprivate var browserPortalFirstSizedRevealNudgeGeneration: UInt64 {
+        get {
+            (objc_getAssociatedObject(self, &cmuxBrowserPortalFirstSizedRevealNudgeGenerationKey) as? NSNumber)?
+                .uint64Value ?? 0
+        }
+        set {
+            objc_setAssociatedObject(
+                self,
+                &cmuxBrowserPortalFirstSizedRevealNudgeGenerationKey,
+                NSNumber(value: newValue),
+                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
+            )
+        }
+    }
+
     var browserPortalRequiresRenderingStateReattach: Bool {
         browserPortalNeedsRenderingStateReattach
+    }
+
+    var browserPortalRequiresFirstSizedRevealNudge: Bool {
+        browserPortalNeedsFirstSizedRevealNudge
+    }
+
+#if DEBUG
+    var browserPortalHasPendingFirstSizedRevealNudgeForTesting: Bool {
+        browserPortalNeedsFirstSizedRevealNudge
+    }
+#endif
+
+    func browserPortalMarkNeedsFirstSizedRevealNudge(reason: String) {
+        browserPortalNeedsFirstSizedRevealNudge = true
+#if DEBUG
+        cmuxDebugLog(
+            "browser.portal.webview.firstSizedReveal.flag web=\(browserPortalRenderingStateDebugToken(self)) " +
+            "reason=\(reason) window=\(window == nil ? 0 : 1) frame=\(browserPortalRenderingStateDebugFrame(frame))"
+        )
+#endif
+    }
+
+    func browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsUnsized(reason: String) {
+        guard window == nil ||
+            !frame.size.width.isFinite ||
+            !frame.size.height.isFinite ||
+            frame.width <= 1 ||
+            frame.height <= 1 else {
+            return
+        }
+        browserPortalMarkNeedsFirstSizedRevealNudge(reason: reason)
     }
 
     /// A pool-prewarmed webview loads inside an alpha-0 offscreen window, so
@@ -75,6 +160,125 @@ extension WKWebView {
             )
         }
 #endif
+    }
+
+    @discardableResult
+    func browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+        reason: String,
+        hasCompanionWKSubviews: Bool,
+        managedByExternalFullscreenWindow: Bool
+    ) -> Bool {
+        guard browserPortalNeedsFirstSizedRevealNudge else { return false }
+        guard window != nil else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=noWindow frame=\(browserPortalRenderingStateDebugFrame(frame))"
+            )
+#endif
+            return false
+        }
+        guard frame.size.width.isFinite,
+              frame.size.height.isFinite,
+              frame.width > 1,
+              frame.height > 1 else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=tinyFrame frame=\(browserPortalRenderingStateDebugFrame(frame))"
+            )
+#endif
+            return false
+        }
+        guard !hasCompanionWKSubviews else {
+            browserPortalNeedsFirstSizedRevealNudge = false
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=companionWKSubviews frame=\(browserPortalRenderingStateDebugFrame(frame))"
+            )
+#endif
+            return false
+        }
+        guard !managedByExternalFullscreenWindow else {
+            browserPortalNeedsFirstSizedRevealNudge = false
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=externalFullscreen frame=\(browserPortalRenderingStateDebugFrame(frame))"
+            )
+#endif
+            return false
+        }
+
+        let originalFrame = frame
+        let originalSize = originalFrame.size
+        let nudgedSize = NSSize(width: originalSize.width, height: max(1, originalSize.height - 1))
+        let nudgedFrame = NSRect(origin: originalFrame.origin, size: nudgedSize)
+        guard !Self.browserPortalRectApproximatelyEqual(originalFrame, nudgedFrame) else {
+            browserPortalNeedsFirstSizedRevealNudge = false
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=noDelta frame=\(browserPortalRenderingStateDebugFrame(frame))"
+            )
+#endif
+            return false
+        }
+
+        browserPortalNeedsFirstSizedRevealNudge = false
+        browserPortalFirstSizedRevealNudgeGeneration &+= 1
+        let generation = browserPortalFirstSizedRevealNudgeGeneration
+
+#if DEBUG
+        cmuxDebugLog(
+            "browser.portal.webview.firstSizedReveal.nudge web=\(browserPortalRenderingStateDebugToken(self)) " +
+            "reason=\(reason) old=\(browserPortalRenderingStateDebugFrame(originalFrame)) " +
+            "nudge=\(browserPortalRenderingStateDebugFrame(nudgedFrame))"
+        )
+#endif
+
+        setFrameSize(nudgedSize)
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        enclosingScrollView?.layoutSubtreeIfNeeded()
+        displayIfNeeded()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+            guard self.browserPortalFirstSizedRevealNudgeGeneration == generation else { return }
+            guard self.window != nil else {
+#if DEBUG
+                cmuxDebugLog(
+                    "browser.portal.webview.firstSizedReveal.restore.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                    "reason=\(reason) skip=noWindow"
+                )
+#endif
+                return
+            }
+            guard Self.browserPortalRectApproximatelyEqual(self.frame, nudgedFrame) else {
+#if DEBUG
+                cmuxDebugLog(
+                    "browser.portal.webview.firstSizedReveal.restore.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                    "reason=\(reason) skip=frameChanged current=\(browserPortalRenderingStateDebugFrame(self.frame)) " +
+                    "expected=\(browserPortalRenderingStateDebugFrame(nudgedFrame))"
+                )
+#endif
+                return
+            }
+            self.setFrameSize(originalSize)
+            self.needsLayout = true
+            self.layoutSubtreeIfNeeded()
+            self.enclosingScrollView?.layoutSubtreeIfNeeded()
+            self.displayIfNeeded()
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.restore web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) frame=\(browserPortalRenderingStateDebugFrame(self.frame))"
+            )
+#endif
+        }
+        return true
     }
 
     func browserPortalReattachRenderingState(reason: String) {

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -149,6 +149,7 @@ extension WKWebView {
 
     func browserPortalNotifyHidden(reason: String) {
         browserPortalNeedsRenderingStateReattach = true
+        browserPortalMarkNeedsFirstSizedRevealNudge(reason: reason)
         let firedSelectors = ["viewDidHide", "_exitInWindow"].filter {
             browserPortalCallVoidIfAvailable($0)
         }

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -159,6 +159,19 @@ extension WKWebView {
     @discardableResult
     func browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
         reason: String,
+        companionSearchRoot: NSView,
+        relativeTo expectedWindow: NSWindow?
+    ) -> Bool {
+        browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: reason,
+            hasCompanionWKSubviews: companionSearchRoot.browserPortalHasVisibleWebKitCompanionSubview(for: self),
+            managedByExternalFullscreenWindow: cmuxIsManagedByExternalFullscreenWindow(relativeTo: expectedWindow)
+        )
+    }
+
+    @discardableResult
+    func browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+        reason: String,
         hasCompanionWKSubviews: Bool,
         managedByExternalFullscreenWindow: Bool
     ) -> Bool {
@@ -311,11 +324,11 @@ extension WKWebView {
     }
 }
 
-extension WindowBrowserSlotView {
-    func hasVisibleWebKitCompanionSubview(for primaryWebView: WKWebView) -> Bool {
+extension NSView {
+    func browserPortalHasVisibleWebKitCompanionSubview(for primaryWebView: WKWebView) -> Bool {
         var stack = subviews.filter { $0 !== primaryWebView }
         while let current = stack.popLast() {
-            if current.isDescendant(of: primaryWebView) {
+            if current === primaryWebView || current.isDescendant(of: primaryWebView) {
                 continue
             }
             if current.isHidden || current.alphaValue <= 0 {

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -121,6 +121,7 @@ extension WKWebView {
         let startsInHiddenWindow = window.map { $0.alphaValue <= 0.01 } ?? false
         guard window == nil ||
             startsInHiddenWindow ||
+            isHiddenOrHasHiddenAncestor ||
             !frame.size.width.isFinite ||
             !frame.size.height.isFinite ||
             frame.width <= 1 ||

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -127,8 +127,10 @@ extension WKWebView {
 #endif
     }
 
-    func browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsUnsized(reason: String) {
+    func browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsWithoutPresentation(reason: String) {
+        let startsInHiddenWindow = window.map { $0.alphaValue <= 0.01 } ?? false
         guard window == nil ||
+            startsInHiddenWindow ||
             !frame.size.width.isFinite ||
             !frame.size.height.isFinite ||
             frame.width <= 1 ||

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -47,15 +47,13 @@ private extension NSObject {
 }
 
 extension WKWebView {
-    private static func browserPortalRectApproximatelyEqual(
-        _ lhs: NSRect,
-        _ rhs: NSRect,
+    private static func browserPortalSizeApproximatelyEqual(
+        _ lhs: NSSize,
+        _ rhs: NSSize,
         epsilon: CGFloat = 0.5
     ) -> Bool {
-        abs(lhs.origin.x - rhs.origin.x) <= epsilon &&
-            abs(lhs.origin.y - rhs.origin.y) <= epsilon &&
-            abs(lhs.size.width - rhs.size.width) <= epsilon &&
-            abs(lhs.size.height - rhs.size.height) <= epsilon
+        abs(lhs.width - rhs.width) <= epsilon &&
+            abs(lhs.height - rhs.height) <= epsilon
     }
 
     fileprivate var browserPortalNeedsRenderingStateReattach: Bool {
@@ -162,7 +160,8 @@ extension WKWebView {
         companionSearchRoot: NSView,
         relativeTo expectedWindow: NSWindow?
     ) -> Bool {
-        browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+        guard browserPortalNeedsFirstSizedRevealNudge else { return false }
+        return browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
             reason: reason,
             hasCompanionWKSubviews: companionSearchRoot.browserPortalHasVisibleWebKitCompanionSubview(for: self),
             managedByExternalFullscreenWindow: cmuxIsManagedByExternalFullscreenWindow(relativeTo: expectedWindow)
@@ -176,11 +175,29 @@ extension WKWebView {
         managedByExternalFullscreenWindow: Bool
     ) -> Bool {
         guard browserPortalNeedsFirstSizedRevealNudge else { return false }
-        guard window != nil else {
+        guard let window else {
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
                 "reason=\(reason) skip=noWindow frame=\(browserPortalRenderingStateDebugFrame(frame))"
+            )
+#endif
+            return false
+        }
+        guard window.alphaValue > 0.01 else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=hiddenWindow frame=\(browserPortalRenderingStateDebugFrame(frame))"
+            )
+#endif
+            return false
+        }
+        guard !isHiddenOrHasHiddenAncestor else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=hiddenView frame=\(browserPortalRenderingStateDebugFrame(frame))"
             )
 #endif
             return false
@@ -222,7 +239,7 @@ extension WKWebView {
         let originalSize = originalFrame.size
         let nudgedSize = NSSize(width: originalSize.width, height: max(1, originalSize.height - 1))
         let nudgedFrame = NSRect(origin: originalFrame.origin, size: nudgedSize)
-        guard !Self.browserPortalRectApproximatelyEqual(originalFrame, nudgedFrame) else {
+        guard !Self.browserPortalSizeApproximatelyEqual(originalSize, nudgedSize) else {
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
@@ -250,24 +267,15 @@ extension WKWebView {
         enclosingScrollView?.layoutSubtreeIfNeeded()
         displayIfNeeded()
 
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else { return }
             guard self.browserPortalFirstSizedRevealNudgeGeneration == generation else { return }
-            guard self.window != nil else {
+            guard Self.browserPortalSizeApproximatelyEqual(self.frame.size, nudgedSize) else {
 #if DEBUG
                 cmuxDebugLog(
                     "browser.portal.webview.firstSizedReveal.restore.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
-                    "reason=\(reason) skip=noWindow"
-                )
-#endif
-                return
-            }
-            guard Self.browserPortalRectApproximatelyEqual(self.frame, nudgedFrame) else {
-#if DEBUG
-                cmuxDebugLog(
-                    "browser.portal.webview.firstSizedReveal.restore.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
-                    "reason=\(reason) skip=frameChanged current=\(browserPortalRenderingStateDebugFrame(self.frame)) " +
-                    "expected=\(browserPortalRenderingStateDebugFrame(nudgedFrame))"
+                    "reason=\(reason) skip=sizeChanged current=\(browserPortalRenderingStateDebugFrame(self.frame)) " +
+                    "expectedSize=\(String(format: "%.1fx%.1f", nudgedSize.width, nudgedSize.height))"
                 )
 #endif
                 return

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -73,7 +73,7 @@ extension WKWebView {
         }
     }
 
-    fileprivate var browserPortalNeedsFirstSizedRevealNudge: Bool {
+    private(set) var browserPortalNeedsFirstSizedRevealNudge: Bool {
         get {
             (objc_getAssociatedObject(self, &cmuxBrowserPortalNeedsFirstSizedRevealNudgeKey) as? NSNumber)?
                 .boolValue ?? false
@@ -106,16 +106,6 @@ extension WKWebView {
     var browserPortalRequiresRenderingStateReattach: Bool {
         browserPortalNeedsRenderingStateReattach
     }
-
-    var browserPortalRequiresFirstSizedRevealNudge: Bool {
-        browserPortalNeedsFirstSizedRevealNudge
-    }
-
-#if DEBUG
-    var browserPortalHasPendingFirstSizedRevealNudgeForTesting: Bool {
-        browserPortalNeedsFirstSizedRevealNudge
-    }
-#endif
 
     func browserPortalMarkNeedsFirstSizedRevealNudge(reason: String) {
         browserPortalNeedsFirstSizedRevealNudge = true
@@ -219,7 +209,6 @@ extension WKWebView {
         let nudgedSize = NSSize(width: originalSize.width, height: max(1, originalSize.height - 1))
         let nudgedFrame = NSRect(origin: originalFrame.origin, size: nudgedSize)
         guard !Self.browserPortalRectApproximatelyEqual(originalFrame, nudgedFrame) else {
-            browserPortalNeedsFirstSizedRevealNudge = false
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
@@ -318,5 +307,29 @@ extension WKWebView {
             )
         }
 #endif
+    }
+}
+
+extension WindowBrowserSlotView {
+    func hasVisibleWebKitCompanionSubview(for primaryWebView: WKWebView) -> Bool {
+        var stack = subviews.filter { $0 !== primaryWebView }
+        while let current = stack.popLast() {
+            if current.isDescendant(of: primaryWebView) {
+                continue
+            }
+            if current.isHidden || current.alphaValue <= 0 {
+                continue
+            }
+            if String(describing: type(of: current)).contains("WK") {
+                let width = max(current.frame.width, current.bounds.width)
+                let height = max(current.frame.height, current.bounds.height)
+                if width > 1, height > 1 {
+                    return true
+                }
+                continue
+            }
+            stack.append(contentsOf: current.subviews)
+        }
+        return false
     }
 }

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -116,7 +116,9 @@ extension WKWebView {
     }
 
     func browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsWithoutPresentation(reason: String) {
-        let startsInHiddenWindow = window.map { $0.alphaValue <= 0.01 } ?? false
+        let startsInHiddenWindow = window.map {
+            !$0.isVisible || $0.isMiniaturized || $0.alphaValue <= 0.01
+        } ?? false
         guard window == nil ||
             startsInHiddenWindow ||
             isHiddenOrHasHiddenAncestor ||
@@ -193,7 +195,7 @@ extension WKWebView {
 #endif
             return false
         }
-        guard window.alphaValue > 0.01 else {
+        guard window.isVisible, !window.isMiniaturized, window.alphaValue > 0.01 else {
 #if DEBUG
             cmuxDebugLog(
                 "browser.portal.webview.firstSizedReveal.skip web=\(browserPortalRenderingStateDebugToken(self)) " +

--- a/Sources/BrowserPortalWebViewRenderingState.swift
+++ b/Sources/BrowserPortalWebViewRenderingState.swift
@@ -139,6 +139,15 @@ extension WKWebView {
     }
 
     func browserPortalNotifyHidden(reason: String) {
+        guard !cmuxIsWebInspectorObject(self) else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.hidden.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=inspectorFrontend"
+            )
+#endif
+            return
+        }
         browserPortalNeedsRenderingStateReattach = true
         browserPortalMarkNeedsFirstSizedRevealNudge(reason: reason)
         let firedSelectors = ["viewDidHide", "_exitInWindow"].filter {
@@ -295,8 +304,17 @@ extension WKWebView {
         return true
     }
 
-    func browserPortalReattachRenderingState(reason: String) {
-        guard browserPortalNeedsRenderingStateReattach else { return }
+    private func browserPortalApplyRenderingStateRefresh(reason: String, force: Bool) {
+        guard !cmuxIsWebInspectorObject(self) else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.webview.reattach.skip web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "reason=\(reason) skip=inspectorFrontend"
+            )
+#endif
+            return
+        }
+        guard force || browserPortalNeedsRenderingStateReattach else { return }
         guard window != nil else { return }
         browserPortalNeedsRenderingStateReattach = false
 
@@ -323,12 +341,21 @@ extension WKWebView {
 #if DEBUG
         if !firedSelectors.isEmpty {
             cmuxDebugLog(
-                "browser.portal.webview.reattach web=\(browserPortalRenderingStateDebugToken(self)) " +
+                "\(force ? "browser.portal.webview.forceRefresh" : "browser.portal.webview.reattach") " +
+                "web=\(browserPortalRenderingStateDebugToken(self)) " +
                 "reason=\(reason) selectors=\(firedSelectors.joined(separator: ",")) " +
                 "frame=\(String(format: "%.1f,%.1f %.1fx%.1f", frame.origin.x, frame.origin.y, frame.size.width, frame.size.height))"
             )
         }
 #endif
+    }
+
+    func browserPortalReattachRenderingState(reason: String) {
+        browserPortalApplyRenderingStateRefresh(reason: reason, force: false)
+    }
+
+    func browserPortalForceRenderingStateRefresh(reason: String) {
+        browserPortalApplyRenderingStateRefresh(reason: reason, force: true)
     }
 }
 

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1513,7 +1513,7 @@ final class WindowBrowserSlotView: NSView {
     func pinHostedWebView(_ webView: WKWebView) {
         guard webView.superview === self else { return }
 
-        let hasCompanionWKSubviews = Self.hasWebKitCompanionSubview(in: self, primaryWebView: webView)
+        let hasCompanionWKSubviews = hasVisibleWebKitCompanionSubview(for: webView)
         let needsPlainWebViewFrameReset =
             !hasCompanionWKSubviews &&
             Self.frameDiffersFromBounds(webView.frame, bounds: bounds)
@@ -1571,6 +1571,10 @@ final class WindowBrowserSlotView: NSView {
             stack.append(contentsOf: current.subviews)
         }
         return false
+    }
+
+    func hasVisibleWebKitCompanionSubview(for primaryWebView: WKWebView) -> Bool {
+        Self.hasWebKitCompanionSubview(in: self, primaryWebView: primaryWebView)
     }
 
     func effectivePaneTopChromeHeight() -> CGFloat {

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -2403,6 +2403,13 @@ final class WindowBrowserPortal: NSObject {
             if reattachRenderingState {
                 webKitSubview.browserPortalReattachRenderingState(reason: "\(reason):\(phase)")
             }
+            if webKitSubview === webView {
+                webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+                    reason: "\(reason):\(phase)",
+                    hasCompanionWKSubviews: containerView.hasVisibleWebKitCompanionSubview(for: webView),
+                    managedByExternalFullscreenWindow: webView.cmuxIsManagedByExternalFullscreenWindow(relativeTo: window)
+                )
+            }
             webKitSubview.displayIfNeeded()
         }
         containerView.displayIfNeeded()
@@ -2530,6 +2537,7 @@ final class WindowBrowserPortal: NSObject {
             "reveal",
             "transientRecovery",
             "anchor",
+            "firstSizedReveal",
         ]
 
         static func resolve(reasons: [String]) -> Self {
@@ -3536,6 +3544,9 @@ final class WindowBrowserPortal: NSObject {
         }
         if forcePresentationRefresh {
             refreshReasons.append("anchor")
+        }
+        if webView.browserPortalRequiresFirstSizedRevealNudge {
+            refreshReasons.append("firstSizedReveal")
         }
         if transientRecoveryReason == nil {
             resetTransientRecoveryRetryIfNeeded(forWebViewId: webViewId, entry: &entry)

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1513,7 +1513,7 @@ final class WindowBrowserSlotView: NSView {
     func pinHostedWebView(_ webView: WKWebView) {
         guard webView.superview === self else { return }
 
-        let hasCompanionWKSubviews = hasVisibleWebKitCompanionSubview(for: webView)
+        let hasCompanionWKSubviews = browserPortalHasVisibleWebKitCompanionSubview(for: webView)
         let needsPlainWebViewFrameReset =
             !hasCompanionWKSubviews &&
             Self.frameDiffersFromBounds(webView.frame, bounds: bounds)
@@ -2380,8 +2380,8 @@ final class WindowBrowserPortal: NSObject {
             if webKitSubview === webView {
                 webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
                     reason: "\(reason):\(phase)",
-                    hasCompanionWKSubviews: containerView.hasVisibleWebKitCompanionSubview(for: webView),
-                    managedByExternalFullscreenWindow: webView.cmuxIsManagedByExternalFullscreenWindow(relativeTo: window)
+                    companionSearchRoot: containerView,
+                    relativeTo: window
                 )
             }
             webKitSubview.displayIfNeeded()

--- a/Sources/BrowserWindowPortal.swift
+++ b/Sources/BrowserWindowPortal.swift
@@ -1551,32 +1551,6 @@ final class WindowBrowserSlotView: NSView {
             abs(frame.height - bounds.height) > epsilon
     }
 
-    private static func hasWebKitCompanionSubview(in host: NSView, primaryWebView: WKWebView) -> Bool {
-        var stack = host.subviews.filter { $0 !== primaryWebView }
-        while let current = stack.popLast() {
-            if current.isDescendant(of: primaryWebView) {
-                continue
-            }
-            if current.isHidden || current.alphaValue <= 0 {
-                continue
-            }
-            if String(describing: type(of: current)).contains("WK") {
-                let width = max(current.frame.width, current.bounds.width)
-                let height = max(current.frame.height, current.bounds.height)
-                if width > 1, height > 1 {
-                    return true
-                }
-                continue
-            }
-            stack.append(contentsOf: current.subviews)
-        }
-        return false
-    }
-
-    func hasVisibleWebKitCompanionSubview(for primaryWebView: WKWebView) -> Bool {
-        Self.hasWebKitCompanionSubview(in: self, primaryWebView: primaryWebView)
-    }
-
     func effectivePaneTopChromeHeight() -> CGFloat {
         paneTopChromeHeight
     }
@@ -3545,7 +3519,7 @@ final class WindowBrowserPortal: NSObject {
         if forcePresentationRefresh {
             refreshReasons.append("anchor")
         }
-        if webView.browserPortalRequiresFirstSizedRevealNudge {
+        if webView.browserPortalNeedsFirstSizedRevealNudge {
             refreshReasons.append("firstSizedReveal")
         }
         if transientRecoveryReason == nil {

--- a/Sources/Panels/BrowserAddressBarFocusSelectionIntent.swift
+++ b/Sources/Panels/BrowserAddressBarFocusSelectionIntent.swift
@@ -1,0 +1,8 @@
+enum BrowserAddressBarFocusSelectionIntent: Equatable {
+    case preserveFieldEditorSelection
+    case selectAll
+
+    var shouldSelectAll: Bool {
+        self == .selectAll
+    }
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -22,15 +22,6 @@ import CommonCrypto
 import Security
 #endif
 
-enum BrowserAddressBarFocusSelectionIntent: Equatable {
-    case preserveFieldEditorSelection
-    case selectAll
-
-    var shouldSelectAll: Bool {
-        self == .selectAll
-    }
-}
-
 fileprivate func dedupedCanonicalURLs(_ urls: [URL]) -> [URL] {
     var seen = Set<String>()
     var result: [URL] = []

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -976,10 +976,13 @@ func browserReadAccessURL(forLocalFileURL fileURL: URL, fileManager: FileManager
 @discardableResult
 func browserLoadRequest(_ request: URLRequest, in webView: WKWebView) -> WKNavigation? {
     guard let url = request.url else { return nil }
+    let nudgeReason = "navigationStart:\(url.scheme?.lowercased() ?? "none")"
     if url.isFileURL {
         guard let readAccessURL = browserReadAccessURL(forLocalFileURL: url) else { return nil }
+        webView.browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsUnsized(reason: nudgeReason)
         return webView.loadFileURL(url, allowingReadAccessTo: readAccessURL)
     }
+    webView.browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsUnsized(reason: nudgeReason)
     return webView.load(browserPreparedNavigationRequest(request))
 }
 

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -979,10 +979,10 @@ func browserLoadRequest(_ request: URLRequest, in webView: WKWebView) -> WKNavig
     let nudgeReason = "navigationStart:\(url.scheme?.lowercased() ?? "none")"
     if url.isFileURL {
         guard let readAccessURL = browserReadAccessURL(forLocalFileURL: url) else { return nil }
-        webView.browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsUnsized(reason: nudgeReason)
+        webView.browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsWithoutPresentation(reason: nudgeReason)
         return webView.loadFileURL(url, allowingReadAccessTo: readAccessURL)
     }
-    webView.browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsUnsized(reason: nudgeReason)
+    webView.browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsWithoutPresentation(reason: nudgeReason)
     return webView.load(browserPreparedNavigationRequest(request))
 }
 
@@ -4232,6 +4232,7 @@ final class BrowserPanel: Panel, ObservableObject {
             webView.frame = contentView.bounds
             webView.autoresizingMask = [.width, .height]
             contentView.addSubview(webView)
+            webView.browserPortalNotifyHidden(reason: "backgroundPreload:\(reason)")
             return true
         }
 
@@ -4260,6 +4261,7 @@ final class BrowserPanel: Panel, ObservableObject {
         window.contentView = contentView
         backgroundPreloadWindow = window
         window.orderFrontRegardless()
+        webView.browserPortalNotifyHidden(reason: "backgroundPreload:\(reason)")
 
 #if DEBUG
         cmuxDebugLog(

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -5917,6 +5917,13 @@ struct WebViewRepresentable: NSViewRepresentable {
                 }
                 webView.displayIfNeeded()
             }
+            if let hostedWebView {
+                hostedWebView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+                    reason: reason,
+                    companionSearchRoot: self,
+                    relativeTo: window
+                )
+            }
 
             localInlineSlotView.displayIfNeeded()
             displayIfNeeded()
@@ -5950,10 +5957,7 @@ struct WebViewRepresentable: NSViewRepresentable {
         func pinHostedWebView(_ webView: WKWebView, in container: NSView) {
             guard webView.superview === container || webView.isDescendant(of: container) else { return }
 
-            let hasCompanionWKSubviews = Self.hasWebKitCompanionSubview(
-                in: container,
-                primaryWebView: webView
-            )
+            let hasCompanionWKSubviews = container.browserPortalHasVisibleWebKitCompanionSubview(for: webView)
             let needsPlainWebViewFrameReset =
                 webView.superview === container &&
                 !hasCompanionWKSubviews &&
@@ -5991,28 +5995,6 @@ struct WebViewRepresentable: NSViewRepresentable {
                 abs(frame.minY - bounds.minY) > epsilon ||
                 abs(frame.width - bounds.width) > epsilon ||
                 abs(frame.height - bounds.height) > epsilon
-        }
-
-        private static func hasWebKitCompanionSubview(in host: NSView, primaryWebView: WKWebView) -> Bool {
-            var stack = host.subviews.filter { $0 !== primaryWebView }
-            while let current = stack.popLast() {
-                if current.isDescendant(of: primaryWebView) {
-                    continue
-                }
-                if current.isHidden || current.alphaValue <= 0 {
-                    continue
-                }
-                if String(describing: type(of: current)).contains("WK") {
-                    let width = max(current.frame.width, current.bounds.width)
-                    let height = max(current.frame.height, current.bounds.height)
-                    if width > 1, height > 1 {
-                        return true
-                    }
-                    continue
-                }
-                stack.append(contentsOf: current.subviews)
-            }
-            return false
         }
 
         private func ensureHostedInspectorSideDockContainerView() -> HostedInspectorSideDockContainerView {

--- a/Sources/Panels/BrowserPanelView.swift
+++ b/Sources/Panels/BrowserPanelView.swift
@@ -6,137 +6,8 @@ import CmuxSettingsUI
 import SwiftUI
 import WebKit
 import AppKit
-import ObjectiveC
 
-private var cmuxBrowserPanelNeedsRenderingStateReattachKey: UInt8 = 0
 let browserOmnibarTextFieldIdentifier = NSUserInterfaceItemIdentifier("cmux.browserOmnibarTextField")
-
-private func browserPanelViewObjectID(_ object: AnyObject?) -> String {
-    guard let object else { return "nil" }
-    return String(describing: Unmanaged.passUnretained(object).toOpaque())
-}
-
-private func browserPanelViewRectDescription(_ rect: NSRect) -> String {
-    String(format: "%.1f,%.1f %.1fx%.1f", rect.origin.x, rect.origin.y, rect.width, rect.height)
-}
-
-private extension NSObject {
-    @discardableResult
-    func browserPanelCallVoidIfAvailable(_ rawSelector: String) -> Bool {
-        let selector = NSSelectorFromString(rawSelector)
-        guard responds(to: selector) else { return false }
-        typealias Fn = @convention(c) (AnyObject, Selector) -> Void
-        let fn = unsafeBitCast(method(for: selector), to: Fn.self)
-        fn(self, selector)
-        return true
-    }
-}
-
-private extension WKWebView {
-    private var cmuxBrowserPanelNeedsRenderingStateReattach: Bool {
-        get {
-            (objc_getAssociatedObject(self, &cmuxBrowserPanelNeedsRenderingStateReattachKey) as? NSNumber)?
-                .boolValue ?? false
-        }
-        set {
-            objc_setAssociatedObject(
-                self,
-                &cmuxBrowserPanelNeedsRenderingStateReattachKey,
-                NSNumber(value: newValue),
-                .OBJC_ASSOCIATION_RETAIN_NONATOMIC
-            )
-        }
-    }
-
-    var cmuxBrowserPanelRequiresRenderingStateReattach: Bool {
-        cmuxBrowserPanelNeedsRenderingStateReattach
-    }
-
-    var cmuxBrowserPanelIsInspectorFrontend: Bool {
-        cmuxIsWebInspectorObject(self)
-    }
-
-    private func cmuxBrowserPanelApplyRenderingStateRefresh(
-        reason: String,
-        force: Bool
-    ) {
-        guard !cmuxBrowserPanelIsInspectorFrontend else {
-#if DEBUG
-            cmuxDebugLog(
-                "browser.localHost.webview.skipInspectorLifecycle " +
-                "web=\(browserPanelViewObjectID(self)) reason=\(reason)"
-            )
-#endif
-            return
-        }
-        guard force || cmuxBrowserPanelNeedsRenderingStateReattach else { return }
-        guard window != nil else { return }
-        cmuxBrowserPanelNeedsRenderingStateReattach = false
-
-        let firedSelectors = [
-            "viewDidUnhide",
-            "_enterInWindow",
-            "_endDeferringViewInWindowChangesSync",
-        ].filter {
-            browserPanelCallVoidIfAvailable($0)
-        }
-
-        if let scrollView = enclosingScrollView {
-            scrollView.needsLayout = true
-            scrollView.needsDisplay = true
-            scrollView.setNeedsDisplay(scrollView.bounds)
-            scrollView.contentView.needsLayout = true
-            scrollView.contentView.needsDisplay = true
-        }
-
-        needsLayout = true
-        needsDisplay = true
-        setNeedsDisplay(bounds)
-
-#if DEBUG
-        if !firedSelectors.isEmpty {
-            cmuxDebugLog(
-                "\(force ? "browser.localHost.webview.forceRefresh" : "browser.localHost.webview.reattach") " +
-                "web=\(browserPanelViewObjectID(self)) " +
-                "reason=\(reason) selectors=\(firedSelectors.joined(separator: ",")) " +
-                "frame=\(browserPanelViewRectDescription(frame))"
-            )
-        }
-#endif
-    }
-
-    func cmuxBrowserPanelNotifyHidden(reason: String) {
-        guard !cmuxBrowserPanelIsInspectorFrontend else {
-#if DEBUG
-            cmuxDebugLog(
-                "browser.localHost.webview.skipInspectorHidden " +
-                "web=\(browserPanelViewObjectID(self)) reason=\(reason)"
-            )
-#endif
-            return
-        }
-        cmuxBrowserPanelNeedsRenderingStateReattach = true
-        let firedSelectors = ["viewDidHide", "_exitInWindow"].filter {
-            browserPanelCallVoidIfAvailable($0)
-        }
-#if DEBUG
-        if !firedSelectors.isEmpty {
-            cmuxDebugLog(
-                "browser.localHost.webview.hidden web=\(browserPanelViewObjectID(self)) " +
-                "reason=\(reason) selectors=\(firedSelectors.joined(separator: ","))"
-            )
-        }
-#endif
-    }
-
-    func cmuxBrowserPanelReattachRenderingState(reason: String) {
-        cmuxBrowserPanelApplyRenderingStateRefresh(reason: reason, force: false)
-    }
-
-    func cmuxBrowserPanelForceRenderingStateRefresh(reason: String) {
-        cmuxBrowserPanelApplyRenderingStateRefresh(reason: reason, force: true)
-    }
-}
 
 enum BrowserDevToolsIconOption: String, CaseIterable, Identifiable {
     case wrenchAndScrewdriver = "wrench.and.screwdriver"
@@ -5836,7 +5707,7 @@ struct WebViewRepresentable: NSViewRepresentable {
             seen: inout Set<ObjectIdentifier>
         ) {
             if let webView = root as? WKWebView {
-                guard !webView.cmuxBrowserPanelIsInspectorFrontend else { return }
+                guard !cmuxIsWebInspectorObject(webView) else { return }
                 let id = ObjectIdentifier(webView)
                 if seen.insert(id).inserted {
                     result.append(webView)
@@ -5853,7 +5724,7 @@ struct WebViewRepresentable: NSViewRepresentable {
 
             func append(_ webView: WKWebView?) {
                 guard let webView else { return }
-                guard !webView.cmuxBrowserPanelIsInspectorFrontend else { return }
+                guard !cmuxIsWebInspectorObject(webView) else { return }
                 let id = ObjectIdentifier(webView)
                 guard seen.insert(id).inserted else { return }
                 result.append(webView)
@@ -5866,7 +5737,7 @@ struct WebViewRepresentable: NSViewRepresentable {
 
         private func notifyHostedWebKitHidden(reason: String) {
             for webView in hostedWebKitSubviews {
-                webView.cmuxBrowserPanelNotifyHidden(reason: reason)
+                webView.browserPortalNotifyHidden(reason: reason)
             }
         }
 
@@ -5911,9 +5782,9 @@ struct WebViewRepresentable: NSViewRepresentable {
                 }
                 webView.layoutSubtreeIfNeeded()
                 if forceLifecycleRefresh {
-                    webView.cmuxBrowserPanelForceRenderingStateRefresh(reason: reason)
+                    webView.browserPortalForceRenderingStateRefresh(reason: reason)
                 } else {
-                    webView.cmuxBrowserPanelReattachRenderingState(reason: reason)
+                    webView.browserPortalReattachRenderingState(reason: reason)
                 }
                 webView.displayIfNeeded()
             }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -265,6 +265,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C2035A090000000000000001 /* BrowserPendingSSLTrustBypass.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2035A090000000000000002 /* BrowserPendingSSLTrustBypass.swift */; };
 		C67540040000000000000001 /* BrowserPopupPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67540040000000000000002 /* BrowserPopupPanel.swift */; };
 		A5007420 /* BrowserPopupWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5007421 /* BrowserPopupWindowController.swift */; };
+		C0DE78950000000000000001 /* BrowserPortalFirstRevealScrollTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE78950000000000000002 /* BrowserPortalFirstRevealScrollTests.swift */; };
 		B7380102B7380102B7380102 /* BrowserPortalOmnibarSuggestionsConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7380101B7380101B7380101 /* BrowserPortalOmnibarSuggestionsConfiguration.swift */; };
 		B7380104B7380104B7380104 /* BrowserPortalOmnibarSuggestionsHostingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7380103B7380103B7380103 /* BrowserPortalOmnibarSuggestionsHostingView.swift */; };
 		B7380004B7380004B7380004 /* BrowserPortalOmnibarSuggestionsOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7380003B7380003B7380003 /* BrowserPortalOmnibarSuggestionsOverlay.swift */; };
@@ -2044,6 +2045,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C2035A090000000000000002 /* BrowserPendingSSLTrustBypass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPendingSSLTrustBypass.swift; sourceTree = "<group>"; };
 		C67540040000000000000002 /* BrowserPopupPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPopupPanel.swift; sourceTree = "<group>"; };
 		A5007421 /* BrowserPopupWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserPopupWindowController.swift; sourceTree = "<group>"; };
+		C0DE78950000000000000002 /* BrowserPortalFirstRevealScrollTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPortalFirstRevealScrollTests.swift; sourceTree = "<group>"; };
 		B7380101B7380101B7380101 /* BrowserPortalOmnibarSuggestionsConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPortalOmnibarSuggestionsConfiguration.swift; sourceTree = "<group>"; };
 		B7380103B7380103B7380103 /* BrowserPortalOmnibarSuggestionsHostingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPortalOmnibarSuggestionsHostingView.swift; sourceTree = "<group>"; };
 		B7380003B7380003B7380003 /* BrowserPortalOmnibarSuggestionsOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserPortalOmnibarSuggestionsOverlay.swift; sourceTree = "<group>"; };
@@ -4970,6 +4972,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				58C7B1B978620BE162CC057E /* BrowserPanelTests.swift */,
 				C42660040000000000000002 /* BrowserPDFPreviewActionRegressionTests.swift */,
 					C42660050000000000000002 /* BrowserPDFPreviewActionUnitTests.swift */,
+					C0DE78950000000000000002 /* BrowserPortalFirstRevealScrollTests.swift */,
 					C0DE62600000000000000002 /* BrowserWindowPortalRegistryNotificationTests.swift */,
 					19D536229C6194FD62B44503 /* BrowserHistorySuggestionCacheTests.swift */,
 					48D6AE11906A4DF3BEB8CDFE /* OmnibarSubmitDecisionTests.swift */,
@@ -6954,6 +6957,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				1F14445B9627DE9D3AF4FD2E /* BrowserPanelTests.swift in Sources */,
 				C42660040000000000000001 /* BrowserPDFPreviewActionRegressionTests.swift in Sources */,
 				C42660050000000000000001 /* BrowserPDFPreviewActionUnitTests.swift in Sources */,
+				C0DE78950000000000000001 /* BrowserPortalFirstRevealScrollTests.swift in Sources */,
 				B6585001B6585001B658PW01 /* BrowserPrewarmedWebViewPoolTests.swift in Sources */,
 				C2035A060000000000000001 /* BrowserSSLTrustBypassStateTests.swift in Sources */,
 				C7B800062D4202A13C962D2D /* BrowserSystemProxyMirrorTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -176,6 +176,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */; };
 		D0B10002A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10003A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift */; };
 		AA1B2C3D4E5F60718 /* BonsplitTabDragUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */; };
+		B424PNRQ0000000000000001 /* BrowserAddressBarFocusSelectionIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = B424PNRQ0000000000000002 /* BrowserAddressBarFocusSelectionIntent.swift */; };
 		D3622000A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */; };
 		D7032A070000000000000001 /* BrowserAuthPromptTextFormatter.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A070000000000000002 /* BrowserAuthPromptTextFormatter.swift */; };
 		B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3770BA00000000000000002 /* BrowserAutomation.swift */; };
@@ -1956,6 +1957,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D0B10011A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabBarDebug.swift; sourceTree = "<group>"; };
 		D0B10003A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabBarPassThrough.swift; sourceTree = "<group>"; };
 		AA1B2C3D4E5F60719 /* BonsplitTabDragUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BonsplitTabDragUITests.swift; sourceTree = "<group>"; };
+		B424PNRQ0000000000000002 /* BrowserAddressBarFocusSelectionIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAddressBarFocusSelectionIntent.swift; sourceTree = "<group>"; };
 		D3622001A1B2C3D4E5F60718 /* BrowserArrowKeyForwardingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserArrowKeyForwardingTests.swift; sourceTree = "<group>"; };
 		D7032A070000000000000002 /* BrowserAuthPromptTextFormatter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAuthPromptTextFormatter.swift; sourceTree = "<group>"; };
 		B3770BA00000000000000002 /* BrowserAutomation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserAutomation.swift; sourceTree = "<group>"; };
@@ -4314,6 +4316,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B4245004000000000000PW01 /* BrowserPrewarmedWebViewPool.swift */,
 				B424PWAD000000000000PW02 /* BrowserPanel+PrewarmedWebViewAdoption.swift */,
 				B424PWNP000000000000PW02 /* BrowserNavigationPolicy.swift */,
+				B424PNRQ0000000000000002 /* BrowserAddressBarFocusSelectionIntent.swift */,
 				B424PWRS000000000000PW02 /* BrowserPortalWebViewRenderingState.swift */,
 				D7032A070000000000000002 /* BrowserAuthPromptTextFormatter.swift */,
 				D7032A020000000000000002 /* BrowserClientCertificateAuthenticationController.swift */,
@@ -5804,6 +5807,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				74060000000000000000001B /* BonsplitConfiguration+RemoteTmuxEmbedded.swift in Sources */,
 					D0B10010A1B2C3D4E5F60001 /* BonsplitTabBarDebug.swift in Sources */,
 				D0B10002A1B2C3D4E5F60001 /* BonsplitTabBarPassThrough.swift in Sources */,
+				B424PNRQ0000000000000001 /* BrowserAddressBarFocusSelectionIntent.swift in Sources */,
 				D7032A070000000000000001 /* BrowserAuthPromptTextFormatter.swift in Sources */,
 				B3770BA00000000000000001 /* BrowserAutomation.swift in Sources */,
 				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -216,6 +216,45 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(!webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
     }
 
+    @Test func localInlineHostDefersNudgeUntilViewAndWindowAreVisible() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let host = WebViewRepresentable.HostContainerView(frame: fixture.anchor.frame)
+        fixture.window.contentView?.addSubview(host)
+        let slot = host.ensureLocalInlineSlotView()
+        host.layoutSubtreeIfNeeded()
+
+        let webView = RecordingWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        webView.browserPortalPrepareForHiddenHostAdoption()
+        slot.addSubview(webView)
+        host.pinHostedWebView(webView, in: slot)
+        webView.frameSizeCalls.removeAll()
+        let revealedSize = slot.bounds.size
+        let nudgedSize = NSSize(width: revealedSize.width, height: max(1, revealedSize.height - 1))
+
+        host.isHidden = true
+        host.refreshHostedWebKitPresentation(reason: "unitTestLocalInlineHiddenAncestor")
+
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+        #expect(!webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
+
+        host.isHidden = false
+        fixture.window.alphaValue = 0
+        host.refreshHostedWebKitPresentation(reason: "unitTestLocalInlineAlphaZeroWindow")
+
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+        #expect(!webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
+
+        fixture.window.alphaValue = 1
+        host.refreshHostedWebKitPresentation(reason: "unitTestLocalInlineVisibleReveal")
+        await waitForNextMainTurn()
+
+        #expect(webView.frameSizeCalls.filter { size($0, approximatelyEquals: nudgedSize) }.count == 1)
+        #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: revealedSize) })
+        #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
+    }
+
     @Test func localInlineHostCompanionSkipsAndClearsPendingNudge() async {
         let fixture = makeWindowFixture()
         defer { fixture.window.orderOut(nil) }
@@ -335,5 +374,77 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
         #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
         #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
+    }
+
+    @Test func nextTurnRestoreSurvivesOriginChange() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let originalFrame = NSRect(x: 0, y: 0, width: 300, height: 180)
+        let webView = RecordingWebView(
+            frame: originalFrame,
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        webView.browserPortalNotifyHidden(reason: "unitTestOriginChangeRestore")
+
+        let fired = webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestOriginChangeRestore",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: false
+        )
+        let movedOrigin = NSPoint(x: 25, y: 30)
+        webView.setFrameOrigin(movedOrigin)
+        await waitForNextMainTurn()
+
+        #expect(fired)
+        #expect(webView.frame.origin == movedOrigin)
+        #expect(size(webView.frame.size, approximatelyEquals: originalFrame.size))
+    }
+
+    @Test func nextTurnRestoreSurvivesDetachment() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let originalSize = NSSize(width: 300, height: 180)
+        let webView = RecordingWebView(
+            frame: NSRect(origin: .zero, size: originalSize),
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        webView.browserPortalNotifyHidden(reason: "unitTestDetachmentRestore")
+
+        let fired = webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestDetachmentRestore",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: false
+        )
+        webView.removeFromSuperview()
+        await waitForNextMainTurn()
+
+        #expect(fired)
+        #expect(webView.window == nil)
+        #expect(size(webView.frame.size, approximatelyEquals: originalSize))
+    }
+
+    @Test func nextTurnRestoreDoesNotOverwriteRealSizeChange() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let webView = RecordingWebView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 180),
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        webView.browserPortalNotifyHidden(reason: "unitTestRealSizeChange")
+
+        let fired = webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestRealSizeChange",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: false
+        )
+        let resizedSize = NSSize(width: 320, height: 200)
+        webView.setFrameSize(resizedSize)
+        await waitForNextMainTurn()
+
+        #expect(fired)
+        #expect(size(webView.frame.size, approximatelyEquals: resizedSize))
     }
 }

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -123,6 +123,33 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
     }
 
+    @Test func navigationStartedInHiddenFullSizedSlotSetsPendingFirstRevealNudge() throws {
+        let fixture = makeWindowFixture()
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 300, height: 180))
+        let webView = RecordingWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
+        slot.addSubview(webView)
+        fixture.window.contentView?.addSubview(slot)
+        slot.isHidden = true
+        fixture.window.orderFrontRegardless()
+        defer {
+            webView.stopLoading()
+            fixture.window.orderOut(nil)
+            fixture.window.close()
+        }
+
+        #expect(webView.window === fixture.window)
+        #expect(fixture.window.alphaValue > 0.01)
+        #expect(webView.frame.width == 300)
+        #expect(webView.frame.height == 180)
+        #expect(webView.isHiddenOrHasHiddenAncestor)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
+
+        let navigationURL = try #require(URL(string: "about:blank"))
+        _ = browserLoadRequest(URLRequest(url: navigationURL), in: webView)
+
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+    }
+
     @Test func hiddenHostRevealThroughPortalNudgesFrameOnceAndClearsFlag() async throws {
         let fixture = makeWindowFixture()
         defer { fixture.window.orderOut(nil) }

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -39,6 +39,7 @@ struct BrowserPortalFirstRevealScrollTests {
         let anchor = NSView(frame: anchorFrame)
         contentView.addSubview(anchor)
         contentView.layoutSubtreeIfNeeded()
+        window.orderFrontRegardless()
         window.displayIfNeeded()
         return WindowFixture(window: window, anchor: anchor)
     }
@@ -148,6 +149,42 @@ struct BrowserPortalFirstRevealScrollTests {
         _ = browserLoadRequest(URLRequest(url: navigationURL), in: webView)
 
         #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+    }
+
+    @Test func orderedOutWindowMarksAndDefersPendingNudgeUntilVisible() async {
+        let fixture = makeWindowFixture()
+        defer {
+            fixture.window.orderOut(nil)
+            fixture.window.close()
+        }
+        let webView = RecordingWebView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 180),
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        fixture.window.orderOut(nil)
+
+        #expect(!fixture.window.isVisible)
+        webView.browserPortalMarkFirstSizedRevealNudgeIfNavigationStartsWithoutPresentation(
+            reason: "unitTestOrderedOutNavigation"
+        )
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+        #expect(!webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestOrderedOutReveal",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: false
+        ))
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+
+        fixture.window.orderFrontRegardless()
+        #expect(fixture.window.isVisible)
+        #expect(webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestOrderedInReveal",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: false
+        ))
+        await waitForNextMainTurn()
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
     }
 
     @Test func hiddenHostRevealThroughPortalNudgesFrameOnceAndClearsFlag() async throws {

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -195,6 +195,7 @@ struct BrowserPortalFirstRevealScrollTests {
 
         let webView = RecordingWebView(frame: .zero, configuration: WKWebViewConfiguration())
         webView.browserPortalPrepareForHiddenHostAdoption()
+        #expect(webView.browserPortalRequiresRenderingStateReattach)
         slot.addSubview(webView)
         host.pinHostedWebView(webView, in: slot)
         webView.frameSizeCalls.removeAll()
@@ -207,6 +208,7 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(webView.frameSizeCalls.filter { size($0, approximatelyEquals: nudgedSize) }.count == 1)
         #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: revealedSize) })
         #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
+        #expect(!webView.browserPortalRequiresRenderingStateReattach)
         #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
 
         webView.frameSizeCalls.removeAll()

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -60,11 +60,11 @@ struct BrowserPortalFirstRevealScrollTests {
         let webView = RecordingWebView(frame: .zero, configuration: WKWebViewConfiguration())
         defer { webView.stopLoading() }
 
-        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
 
         _ = browserLoadRequest(URLRequest(url: URL(fileURLWithPath: #filePath)), in: webView)
 
-        #expect(webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
     }
 
     @Test func navigationStartedInAlphaZeroBackgroundHostSetsPendingFirstRevealNudge() throws {
@@ -91,12 +91,12 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(webView.window === window)
         #expect(webView.frame.width == 800)
         #expect(webView.frame.height == 600)
-        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
 
         let navigationURL = try #require(URL(string: "about:blank"))
         _ = browserLoadRequest(URLRequest(url: navigationURL), in: webView)
 
-        #expect(webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
     }
 
     @Test func navigationStartedInVisibleSizedWindowDoesNotSetPendingFirstRevealNudge() throws {
@@ -115,12 +115,12 @@ struct BrowserPortalFirstRevealScrollTests {
 
         #expect(webView.window === fixture.window)
         #expect(fixture.window.alphaValue > 0.01)
-        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
 
         let navigationURL = try #require(URL(string: "about:blank"))
         _ = browserLoadRequest(URLRequest(url: navigationURL), in: webView)
 
-        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
     }
 
     @Test func hiddenHostRevealThroughPortalNudgesFrameOnceAndClearsFlag() async throws {
@@ -134,7 +134,7 @@ struct BrowserPortalFirstRevealScrollTests {
         defer { BrowserWindowPortalRegistry.detach(webView: webView) }
 
         webView.browserPortalPrepareForHiddenHostAdoption()
-        #expect(webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
 
         BrowserWindowPortalRegistry.bind(webView: webView, to: fixture.anchor, visibleInUI: true)
         BrowserWindowPortalRegistry.synchronizeForAnchor(fixture.anchor)
@@ -147,7 +147,7 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(webView.frameSizeCalls.filter { size($0, approximatelyEquals: nudgedSize) }.count == 1)
         #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: revealedSize) })
         #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
-        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
         #expect(fixture.window.firstResponder === firstResponder)
 
         webView.frameSizeCalls.removeAll()
@@ -178,7 +178,7 @@ struct BrowserPortalFirstRevealScrollTests {
 
         #expect(!fired)
         #expect(webView.frameSizeCalls.isEmpty)
-        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
     }
 
     @Test func slotCompanionDetectionMatchesDockedWebKitSubviewCondition() throws {
@@ -214,6 +214,44 @@ struct BrowserPortalFirstRevealScrollTests {
 
         #expect(!fired)
         #expect(webView.frameSizeCalls.isEmpty)
-        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
+    }
+
+    @Test func noDeltaAtMinimumHeightKeepsPendingNudgeForLaterSizedReveal() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let webView = RecordingWebView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 1.25),
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        webView.browserPortalNotifyHidden(reason: "unitTestNoDelta")
+        webView.frameSizeCalls.removeAll()
+
+        let firedAtMinimumHeight = webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestNoDelta",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: false
+        )
+
+        #expect(!firedAtMinimumHeight)
+        #expect(webView.browserPortalNeedsFirstSizedRevealNudge)
+        #expect(webView.frameSizeCalls.isEmpty)
+
+        let revealedSize = NSSize(width: 300, height: 180)
+        webView.setFrameSize(revealedSize)
+        webView.frameSizeCalls.removeAll()
+        let firedAfterSizing = webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestNoDeltaRetry",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: false
+        )
+        await waitForNextMainTurn()
+
+        let nudgedSize = NSSize(width: revealedSize.width, height: revealedSize.height - 1)
+        #expect(firedAfterSizing)
+        #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
+        #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
     }
 }

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -67,6 +67,62 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
     }
 
+    @Test func navigationStartedInAlphaZeroBackgroundHostSetsPendingFirstRevealNudge() throws {
+        let hostFrame = NSRect(x: -10_000, y: -10_000, width: 800, height: 600)
+        let window = NSWindow(
+            contentRect: hostFrame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.alphaValue = 0
+        let contentView = NSView(frame: hostFrame)
+        let webView = RecordingWebView(frame: contentView.bounds, configuration: WKWebViewConfiguration())
+        contentView.addSubview(webView)
+        window.contentView = contentView
+        window.orderFrontRegardless()
+        defer {
+            webView.stopLoading()
+            window.orderOut(nil)
+            window.close()
+        }
+
+        #expect(webView.window === window)
+        #expect(webView.frame.width == 800)
+        #expect(webView.frame.height == 600)
+        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+
+        let navigationURL = try #require(URL(string: "about:blank"))
+        _ = browserLoadRequest(URLRequest(url: navigationURL), in: webView)
+
+        #expect(webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+    }
+
+    @Test func navigationStartedInVisibleSizedWindowDoesNotSetPendingFirstRevealNudge() throws {
+        let fixture = makeWindowFixture()
+        let webView = RecordingWebView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 180),
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        fixture.window.orderFrontRegardless()
+        defer {
+            webView.stopLoading()
+            fixture.window.orderOut(nil)
+            fixture.window.close()
+        }
+
+        #expect(webView.window === fixture.window)
+        #expect(fixture.window.alphaValue > 0.01)
+        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+
+        let navigationURL = try #require(URL(string: "about:blank"))
+        _ = browserLoadRequest(URLRequest(url: navigationURL), in: webView)
+
+        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+    }
+
     @Test func hiddenHostRevealThroughPortalNudgesFrameOnceAndClearsFlag() async throws {
         let fixture = makeWindowFixture()
         defer { fixture.window.orderOut(nil) }

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -1,0 +1,163 @@
+import AppKit
+import Testing
+import WebKit
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite(.serialized)
+struct BrowserPortalFirstRevealScrollTests {
+    private final class RecordingWebView: WKWebView {
+        var frameSizeCalls: [NSSize] = []
+
+        override func setFrameSize(_ newSize: NSSize) {
+            frameSizeCalls.append(newSize)
+            super.setFrameSize(newSize)
+        }
+    }
+
+    private final class WKCompanionTestView: NSView {}
+
+    private struct WindowFixture {
+        let window: NSWindow
+        let anchor: NSView
+    }
+
+    private func makeWindowFixture(anchorFrame: NSRect = NSRect(x: 20, y: 20, width: 300, height: 180)) -> WindowFixture {
+        let contentView = NSView(frame: NSRect(x: 0, y: 0, width: 420, height: 280))
+        let window = NSWindow(
+            contentRect: contentView.frame,
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = contentView
+        let anchor = NSView(frame: anchorFrame)
+        contentView.addSubview(anchor)
+        contentView.layoutSubtreeIfNeeded()
+        window.displayIfNeeded()
+        return WindowFixture(window: window, anchor: anchor)
+    }
+
+    private func waitForNextMainTurn() async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.main.async {
+                continuation.resume()
+            }
+        }
+    }
+
+    private func size(_ size: NSSize, approximatelyEquals expected: NSSize, epsilon: CGFloat = 0.5) -> Bool {
+        abs(size.width - expected.width) <= epsilon &&
+            abs(size.height - expected.height) <= epsilon
+    }
+
+    @Test func coldFileNavigationStartedWithoutWindowSetsPendingFirstRevealNudge() {
+        let webView = RecordingWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        defer { webView.stopLoading() }
+
+        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+
+        _ = browserLoadRequest(URLRequest(url: URL(fileURLWithPath: #filePath)), in: webView)
+
+        #expect(webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+    }
+
+    @Test func hiddenHostRevealThroughPortalNudgesFrameOnceAndClearsFlag() async throws {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let focusView = NSTextField(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        fixture.window.contentView?.addSubview(focusView)
+        #expect(fixture.window.makeFirstResponder(focusView))
+        let firstResponder = fixture.window.firstResponder
+        let webView = RecordingWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        defer { BrowserWindowPortalRegistry.detach(webView: webView) }
+
+        webView.browserPortalPrepareForHiddenHostAdoption()
+        #expect(webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+
+        BrowserWindowPortalRegistry.bind(webView: webView, to: fixture.anchor, visibleInUI: true)
+        BrowserWindowPortalRegistry.synchronizeForAnchor(fixture.anchor)
+        await waitForNextMainTurn()
+
+        let slot = try #require(webView.superview as? WindowBrowserSlotView)
+        let revealedSize = slot.bounds.size
+        let nudgedSize = NSSize(width: revealedSize.width, height: max(1, revealedSize.height - 1))
+
+        #expect(webView.frameSizeCalls.filter { size($0, approximatelyEquals: nudgedSize) }.count == 1)
+        #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: revealedSize) })
+        #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
+        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+        #expect(fixture.window.firstResponder === firstResponder)
+
+        webView.frameSizeCalls.removeAll()
+        BrowserWindowPortalRegistry.synchronizeForAnchor(fixture.anchor)
+        await waitForNextMainTurn()
+
+        #expect(!webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
+        #expect(fixture.window.firstResponder === firstResponder)
+    }
+
+    @Test func companionWebKitSubviewSkipsAndClearsPendingNudge() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let webView = RecordingWebView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 180),
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        webView.browserPortalNotifyHidden(reason: "unitTestCompanion")
+        webView.frameSizeCalls.removeAll()
+
+        let fired = webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestCompanion",
+            hasCompanionWKSubviews: true,
+            managedByExternalFullscreenWindow: false
+        )
+        await waitForNextMainTurn()
+
+        #expect(!fired)
+        #expect(webView.frameSizeCalls.isEmpty)
+        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+    }
+
+    @Test func slotCompanionDetectionMatchesDockedWebKitSubviewCondition() throws {
+        let slot = WindowBrowserSlotView(frame: NSRect(x: 0, y: 0, width: 300, height: 180))
+        let webView = RecordingWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
+        slot.addSubview(webView)
+
+        #expect(!slot.hasVisibleWebKitCompanionSubview(for: webView))
+
+        let companion = WKCompanionTestView(frame: NSRect(x: 0, y: 0, width: 60, height: 180))
+        slot.addSubview(companion)
+
+        #expect(slot.hasVisibleWebKitCompanionSubview(for: webView))
+    }
+
+    @Test func externalFullscreenWindowSkipsAndClearsPendingNudge() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let webView = RecordingWebView(
+            frame: NSRect(x: 0, y: 0, width: 300, height: 180),
+            configuration: WKWebViewConfiguration()
+        )
+        fixture.window.contentView?.addSubview(webView)
+        webView.browserPortalNotifyHidden(reason: "unitTestExternalFullscreen")
+        webView.frameSizeCalls.removeAll()
+
+        let fired = webView.browserPortalApplyFirstSizedRevealGeometryNudgeIfNeeded(
+            reason: "unitTestExternalFullscreen",
+            hasCompanionWKSubviews: false,
+            managedByExternalFullscreenWindow: true
+        )
+        await waitForNextMainTurn()
+
+        #expect(!fired)
+        #expect(webView.frameSizeCalls.isEmpty)
+        #expect(!webView.browserPortalHasPendingFirstSizedRevealNudgeForTesting)
+    }
+}

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -185,6 +185,61 @@ struct BrowserPortalFirstRevealScrollTests {
         #expect(fixture.window.firstResponder === firstResponder)
     }
 
+    @Test func hiddenHostRevealThroughLocalInlineHostNudgesFrameOnceAndClearsFlag() async throws {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let host = WebViewRepresentable.HostContainerView(frame: fixture.anchor.frame)
+        fixture.window.contentView?.addSubview(host)
+        let slot = host.ensureLocalInlineSlotView()
+        host.layoutSubtreeIfNeeded()
+
+        let webView = RecordingWebView(frame: .zero, configuration: WKWebViewConfiguration())
+        webView.browserPortalPrepareForHiddenHostAdoption()
+        slot.addSubview(webView)
+        host.pinHostedWebView(webView, in: slot)
+        webView.frameSizeCalls.removeAll()
+
+        host.refreshHostedWebKitPresentation(reason: "unitTestLocalInlineReveal")
+        await waitForNextMainTurn()
+
+        let revealedSize = slot.bounds.size
+        let nudgedSize = NSSize(width: revealedSize.width, height: max(1, revealedSize.height - 1))
+        #expect(webView.frameSizeCalls.filter { size($0, approximatelyEquals: nudgedSize) }.count == 1)
+        #expect(webView.frameSizeCalls.contains { size($0, approximatelyEquals: revealedSize) })
+        #expect(size(webView.frame.size, approximatelyEquals: revealedSize))
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
+
+        webView.frameSizeCalls.removeAll()
+        host.refreshHostedWebKitPresentation(reason: "unitTestLocalInlineRevealAgain")
+        await waitForNextMainTurn()
+
+        #expect(!webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
+    }
+
+    @Test func localInlineHostCompanionSkipsAndClearsPendingNudge() async {
+        let fixture = makeWindowFixture()
+        defer { fixture.window.orderOut(nil) }
+        let host = WebViewRepresentable.HostContainerView(frame: fixture.anchor.frame)
+        fixture.window.contentView?.addSubview(host)
+        let slot = host.ensureLocalInlineSlotView()
+        host.layoutSubtreeIfNeeded()
+
+        let webView = RecordingWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
+        slot.addSubview(webView)
+        host.pinHostedWebView(webView, in: slot)
+        let companion = WKCompanionTestView(frame: NSRect(x: 0, y: 0, width: 60, height: slot.bounds.height))
+        slot.addSubview(companion)
+        webView.browserPortalNotifyHidden(reason: "unitTestLocalInlineCompanion")
+        webView.frameSizeCalls.removeAll()
+
+        host.refreshHostedWebKitPresentation(reason: "unitTestLocalInlineCompanion")
+        await waitForNextMainTurn()
+
+        let nudgedSize = NSSize(width: slot.bounds.width, height: max(1, slot.bounds.height - 1))
+        #expect(!webView.frameSizeCalls.contains { size($0, approximatelyEquals: nudgedSize) })
+        #expect(!webView.browserPortalNeedsFirstSizedRevealNudge)
+    }
+
     @Test func companionWebKitSubviewSkipsAndClearsPendingNudge() async {
         let fixture = makeWindowFixture()
         defer { fixture.window.orderOut(nil) }

--- a/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
+++ b/cmuxTests/BrowserPortalFirstRevealScrollTests.swift
@@ -268,12 +268,12 @@ struct BrowserPortalFirstRevealScrollTests {
         let webView = RecordingWebView(frame: slot.bounds, configuration: WKWebViewConfiguration())
         slot.addSubview(webView)
 
-        #expect(!slot.hasVisibleWebKitCompanionSubview(for: webView))
+        #expect(!slot.browserPortalHasVisibleWebKitCompanionSubview(for: webView))
 
         let companion = WKCompanionTestView(frame: NSRect(x: 0, y: 0, width: 60, height: 180))
         slot.addSubview(companion)
 
-        #expect(slot.hasVisibleWebKitCompanionSubview(for: webView))
+        #expect(slot.browserPortalHasVisibleWebKitCompanionSubview(for: webView))
     }
 
     @Test func externalFullscreenWindowSkipsAndClearsPendingNudge() async {


### PR DESCRIPTION
Fixes #7895.

## Problem

A browser/artifact WKWebView pane whose page is taller than the pane opens un-scrollable; only a real geometry change (fullscreen toggle or pane resize) unfreezes it. Root cause: navigations start before the webview has real on-screen geometry — cold loads start at `frame: .zero` inside `BrowserPanel.init`, prewarmed loads lay out inside the pool's alpha-0 offscreen window, and automation-created panes (`BrowserPanelCreationPolicy.automationPreload`, i.e. how agent/Artifact panes open) attach to an 800×600 alpha-0 background-preload window before `browserLoadRequest` runs. The existing reveal path (`browserPortalReattachRenderingState`) re-enters WebKit lifecycle selectors but never delivers a genuine bounds delta, so WebKit keeps the stale scrollable content size.

## Fix

First-sized-reveal geometry nudge:

- Mark a webview at the shared `browserLoadRequest` chokepoint when navigation starts without presentation (no window, ≤1pt frame, or an effectively hidden window with `alphaValue <= 0.01`), and on `browserPortalNotifyHidden` (prewarm adoption / portal hides). Both branches of `ensureBackgroundPreloadHostIfNeeded` now fire `browserPortalNotifyHidden`, so the background-preload host follows the prewarm pool's hidden-host contract (rendering-state reattach included).
- On the first sized portal presentation, apply a genuine 1pt frame nudge and restore it on the next runloop turn (generation- and frame-guarded so real user resizes win; at most one nudge per pending flag). DevTools-docked and external-fullscreen webviews are exempt.

## Commit structure (two red/green pairs)

1. `test:` mechanism tests + inert scaffolding — fails at assertions (verified locally: 3 assertion failures, compiles fine)
2. `fix:` round-1 nudge — suite green
3. `test:` alpha-0 background-preload host coverage — fails against round-1 code (verified locally: 1 assertion failure)
4. `fix:` hidden-window marking + preload-host hidden contract — suite green (7/7)

## Verification

- Focused suite `cmuxTests/BrowserPortalFirstRevealScrollTests` via the `cmux-unit` scheme: 7/7 green (and both red states demonstrated before their fix commits).
- `./scripts/reload.sh --tag fix-webview-scroll-on-open` builds; `./scripts/lint-pbxproj-test-wiring.sh` passes (447 files); determinism checker: 0 findings.
- **Live in the tagged app** with the issue's repro HTML: `cmux browser open` of the tall page logs `firstSizedReveal.flag → webview.reattach → firstSizedReveal.nudge` and the page scrolls to the absolute bottom (`scrollY == scrollHeight - innerHeight`) on first load with no manual resize, for both the cold `file://` path and the automation/background-preload path; `http://` content also scrolls on open. No repeat nudges on subsequent syncs; visible-pane navigations don't set the flag.
- The WebKit freeze itself did not reproduce headlessly on this machine (macOS 26.4.1; reporter is on 26.5), so the regression tests assert the nudge mechanism (flag set on hidden/unsized load, exactly one genuine frame delta on first sized reveal, flag cleared, exemptions honored) rather than in-page scroll state.

Localization audit: no user-facing strings were added or changed (DEBUG-only `cmuxDebugLog` lines); no localization files needed updating.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7917"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786407464&installation_id=133855650&pr_number=7917&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7917&signature=0b0b682fc073b700bb10982ee2b807fbdffe4a1d238d2c14d6dba86903f91ada"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core WKWebView presentation paths (portal sync, navigation chokepoint, frame manipulation) with private WebKit selectors; behavior is heavily tested but layout flicker or interaction with docked DevTools/fullscreen is possible.
> 
> **Overview**
> Fixes **taller-than-pane pages opening without scroll** when `WKWebView` loads before it has real on-screen geometry (zero frame, alpha-0 prewarm/background-preload hosts, hidden portal slots). Lifecycle reattach alone never gave WebKit a real bounds change, so scrollable content stayed stale until a manual resize.
> 
> **First-sized-reveal nudge:** At `browserLoadRequest`, webviews are flagged when navigation starts without presentation; `browserPortalNotifyHidden` (including background-preload hosts) sets the same flag plus existing reattach behavior. On the first **visible, sized** portal or local-inline refresh, the code applies a **1pt height frame delta**, then **restores** size on the next main turn with generation guards so real resizes win. Nudge is skipped for inspector frontends, visible WK companion subviews (e.g. docked DevTools), and external fullscreen.
> 
> **Consolidation:** Duplicate `WKWebView` hidden/reattach logic is removed from `BrowserPanelView` in favor of shared `browserPortal*` APIs in `BrowserPortalWebViewRenderingState`; companion detection moves to `NSView.browserPortalHasVisibleWebKitCompanionSubview`. `BrowserAddressBarFocusSelectionIntent` is split into its own file. **`BrowserPortalFirstRevealScrollTests`** covers flagging, one-shot nudge, visibility gating, exemptions, and restore edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57d660c37f08f0409b12b3a1fb2dae65c764ad28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes taller-than-pane webviews opening unscrollable when loaded hidden, unsized, or in an ordered-out window. We now apply a one-time 1pt frame nudge on the first truly visible, sized reveal (portal and local-inline) and restore it next runloop.

- **Bug Fixes**
  - Mark webviews for a first-sized-reveal nudge at navigation start when not truly presented (no window, alpha-0/hidden/ordered-out window, hidden portal slot, tiny/invalid frame) and on `browserPortalNotifyHidden`; background-preload hosts always notify hidden.
  - On the first visible, sized reveal, apply a 1pt frame delta and restore next runloop; defers while view/window are hidden or ordered out, retries after tiny/no-delta reveals, skips when a visible WK companion subview exists or in external fullscreen; restoration is generation-guarded and survives origin changes and detachment; triggered via `firstSizedReveal` in window portals and in local-inline hosts.
  - Expanded tests (`BrowserPortalFirstRevealScrollTests`) cover visibility gating (including ordered-out windows), one-shot nudge, safe restoration, retries, exemptions, and the local-inline path.

- **Refactors**
  - Unified portal and local-inline WebKit lifecycle into shared `browserPortal*` APIs in `BrowserPortalWebViewRenderingState` (reattach/force refresh, hidden notify, first-reveal nudge).
  - Replaced duplicate companion-subview checks with `NSView.browserPortalHasVisibleWebKitCompanionSubview`; moved `BrowserAddressBarFocusSelectionIntent` to its own file.

<sup>Written for commit 57d660c37f08f0409b12b3a1fb2dae65c764ad28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved “first reveal” rendering for portal-embedded `WKWebView`, including navigations that begin before the view is visibly presented (e.g., background preload scenarios).
  * Added a dedicated address-bar focus/selection intent with a “select all” option.

* **Bug Fixes**
  * Prevented redundant or conflicting first-reveal geometry adjustments when WebKit companion views are present or when an external fullscreen window manages layout.
  * Added safer deferred retry behavior when the initial geometry change is effectively zero.

* **Tests**
  * Added a comprehensive first-reveal nudge test suite covering portal/inline hosting, companion conditions, and deferred-restore edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->