### PR TITLE
cmux-tui: default sidebar back to the workspace list

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/config.rs
+++ b/cmux-tui/crates/cmux-tui/src/config.rs
@@ -509,7 +509,7 @@ pub struct Sidebar {
 
 impl Default for Sidebar {
     fn default() -> Self {
-        Sidebar { view: SidebarView::Files, width: 22, max_width: 0, plugin: None }
+        Sidebar { view: SidebarView::Workspaces, width: 22, max_width: 0, plugin: None }
     }
 }
 
@@ -1683,7 +1683,7 @@ mod tests {
 
     #[test]
     fn sidebar_view_defaults_parses_and_unknown_values_fall_back_with_warning() {
-        assert_eq!(Sidebar::default().view, SidebarView::Files);
+        assert_eq!(Sidebar::default().view, SidebarView::Workspaces);
         assert_eq!(parse_sidebar_view("files"), Ok(SidebarView::Files));
         assert_eq!(parse_sidebar_view("workspaces"), Ok(SidebarView::Workspaces));
 
@@ -1693,7 +1693,7 @@ mod tests {
         if let Ok(view) = parse_sidebar_view("tree") {
             sidebar.view = view;
         }
-        assert_eq!(sidebar.view, SidebarView::Files);
+        assert_eq!(sidebar.view, SidebarView::Workspaces);
     }
 
     #[test]

--- a/cmux-tui/docs/configuration.md
+++ b/cmux-tui/docs/configuration.md
@@ -36,11 +36,11 @@ Tabs are numbered by default. A recognized agent program can appear after the nu
 
 ## Sidebar
 
-The built-in sidebar now defaults to the file browser. To preserve the previous workspace-list default, set `"sidebar": {"view": "workspaces"}`. `Tab` toggles the built-in view while the sidebar is focused, and the configurable `toggle-sidebar-view` action toggles it from anywhere. A configured `sidebar.plugin` still replaces either built-in view.
+The built-in sidebar defaults to the workspace list. Set `"sidebar": {"view": "files"}` for the yazi-style file browser. `Tab` toggles the built-in view while the sidebar is focused, and the configurable `toggle-sidebar-view` action toggles it from anywhere. A configured `sidebar.plugin` still replaces either built-in view.
 
 | Key | Type | Default | Effect |
 | --- | --- | --- | --- |
-| `sidebar.view` | `"files"` or `"workspaces"` | `"files"` | Built-in sidebar view when `sidebar.plugin` is unset |
+| `sidebar.view` | `"files"` or `"workspaces"` | `"workspaces"` | Built-in sidebar view when `sidebar.plugin` is unset |
 | `sidebar.width` | integer | `22` | Sidebar width, clamped to 10 through 60 on load |
 | `sidebar.max_width` | integer | `0` | Maximum live drag width; `0` means no configured maximum |
 | `sidebar.plugin.command` | array of strings | unset | External sidebar plugin argv; when set, the sidebar hosts this program in a PTY instead of the built-in list |

--- a/cmux-tui/docs/mouse.md
+++ b/cmux-tui/docs/mouse.md
@@ -2,7 +2,7 @@
 
 ## Click Targets
 
-The default files sidebar shows the focused pane's cwd, one row per directory/file, and a count or filter footer. A single click selects a file row. Crossterm's mouse events do not expose an existing double-click concept here, so clicks do not open or descend; use Enter or Right while the sidebar is focused. Toggle to the workspaces view with focused-sidebar `Tab` or the `toggle-sidebar-view` action.
+The files sidebar view (`sidebar.view = "files"`) shows the focused pane's cwd, one row per directory/file, and a count or filter footer. A single click selects a file row. Crossterm's mouse events do not expose an existing double-click concept here, so clicks do not open or descend; use Enter or Right while the sidebar is focused. Toggle to the workspaces view with focused-sidebar `Tab` or the `toggle-sidebar-view` action.
 
 The workspaces view shows a `workspaces` header, two rows per workspace, and `+ new workspace`. Click either row of a workspace to select it. Click `+ new workspace` to create one. Drag the sidebar's right border in either built-in view to set a session-local width override. Configured `sidebar.max_width` limits the drag width when it is greater than zero, and the TUI still leaves at least 40 columns for panes.
 

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -404,15 +404,20 @@ print("prefix-S returns focus to the pane ok")
 with open(config_path, "w", encoding="utf-8") as f:
     json.dump({"sidebar": {"width": 22}}, f)
 assert rpc({"id": 31, "cmd": "reload-config"})["ok"]
-# The cwd follow runs on a 2s cadence; wait event-driven rather than a fixed drain.
-wait_render_contains(sidebar_marker)
-print("sidebar plugin config reload falls back to default files sidebar ok")
+wait_render_contains("workspaces")
+print("sidebar plugin config reload falls back to default workspaces sidebar ok")
 os.write(fd, b"\x02S")
 drain(0.4)
 os.write(fd, b"\t")
+# The files view roots at the pane spawn cwd (HOME=tmpdir); the cwd follow
+# runs on a 2s cadence, so wait event-driven for the seeded marker.
+wait_render_contains(sidebar_marker)
+print("focused sidebar Tab toggles workspaces to files ok")
+os.write(fd, b"\t")
 drain(0.5)
 assert "workspaces" in render_text_snapshot(output), output[-1200:]
-print("focused sidebar Tab toggles files to workspaces ok")
+os.write(fd, b"\x02S")
+drain(0.4)
 
 # Prefix-B creates a browser tab immediately and focuses its in-pane
 # omnibar. The dead CDP endpoint keeps this Chrome-free and fast.


### PR DESCRIPTION
Reverts the default sidebar.view to workspaces per dogfood: the files view is great one keypress away (Tab in a focused sidebar, prefix-e anywhere, sidebar.view=files) but as a silent default it costs more than it gives until sidebar switching is first-class UX. The files view, its keys, and the plugin system are unchanged; smoke still exercises both views + the plugin fallback path. Follow-up idea tracked: an easy switcher between built-in views and installed plugins.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7918"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786408988&installation_id=133855650&pr_number=7918&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7918&signature=12013b942971b52bbfba83fc1bcc732761dee6fb79c6813737ac4431d4b9ece0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Config default and documentation only; files view, keys, and plugins are unchanged.
> 
> **Overview**
> **Restores the workspace list as the default built-in sidebar** when no `sidebar.plugin` is configured, instead of the files browser.
> 
> `Sidebar::default()` and related tests now expect `sidebar.view` **`workspaces`**. Docs (`configuration.md`, `mouse.md`) describe workspaces as the default and note **`"sidebar": {"view": "files"}`** for the file browser. The smoke script reloads config to assert the **workspaces** fallback after removing a plugin, then **`Tab`** in a focused sidebar toggles to files and back.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b159f2cb650f9d73b8b228086e0e72f4700411a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the default sidebar view back to workspaces to reduce friction; the files view is still one keypress away and plugins continue to replace the built-in view when configured. Docs, tests, and smoke flow updated to reflect the new default while still exercising both views.

- **Migration**
  - To keep the files view as your default, set `"sidebar": {"view": "files"}` in your config.

<sup>Written for commit 3b159f2cb650f9d73b8b228086e0e72f4700411a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The sidebar now opens to the workspace list by default instead of the file browser.
  * Users can still select the files view through the sidebar configuration.

* **Documentation**
  * Updated configuration and mouse interaction documentation to reflect the new default sidebar view.

* **Tests**
  * Updated automated checks to validate workspace and file view switching, including configuration reload behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->