### PR TITLE
Promote permission panes without stealing focus

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamStoreTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/Workstream/WorkstreamStoreTests.swift
@@ -14,6 +14,16 @@ struct WorkstreamStoreTests {
         #expect(store.items[0].kind == .permissionRequest)
     }
 
+    @Test("observe-only permission is telemetry, not a reply-capable pending card")
+    func ingestObserveOnlyPermission() {
+        let store = WorkstreamStore(ringCapacity: 10)
+        store.ingestObserveOnly(.permission("s1", requestId: "r1"))
+        #expect(store.items.count == 1)
+        #expect(store.pending.isEmpty)
+        #expect(store.items[0].status == .telemetry)
+        #expect(store.items[0].kind == .permissionRequest)
+    }
+
     @Test("send(.approvePermission) marks the item resolved")
     func resolvePermission() async throws {
         let store = WorkstreamStore(ringCapacity: 10)

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -988,6 +988,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		6313B6A0 /* PaneMemoryWarning.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6313B6A1 /* PaneMemoryWarning.swift */; };
 		E30760090000000000000002 /* PassthroughWindowOverlayContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30760090000000000000001 /* PassthroughWindowOverlayContainerView.swift */; };
 		A5001425 /* PDFPreviewChromeDebugWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001424 /* PDFPreviewChromeDebugWindowController.swift */; };
+		A1A0711A1A0711A1A1000001 /* PermissionPanePromotionPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1A0711A1A0711A1A1000002 /* PermissionPanePromotionPolicyTests.swift */; };
 		D1F0A00400000000000000D1 /* PhoneForwardingMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */; };
 		D1F0A00100000000000000A1 /* PhonePushClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A2 /* PhonePushClient.swift */; };
 		D1F0A00100000000000000A3 /* PhonePushPayload.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00100000000000000A4 /* PhonePushPayload.swift */; };
@@ -2699,6 +2700,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		6313B6A1 /* PaneMemoryWarning.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PaneMemoryWarning.swift; sourceTree = "<group>"; };
 		E30760090000000000000001 /* PassthroughWindowOverlayContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PassthroughWindowOverlayContainerView.swift; sourceTree = "<group>"; };
 		A5001424 /* PDFPreviewChromeDebugWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/PDFPreviewChromeDebugWindowController.swift; sourceTree = "<group>"; };
+		A1A0711A1A0711A1A1000002 /* PermissionPanePromotionPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PermissionPanePromotionPolicyTests.swift; sourceTree = "<group>"; };
 		D1F0A00400000000000000D2 /* PhoneForwardingMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PhoneForwardingMode.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A2 /* PhonePushClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushClient.swift; sourceTree = "<group>"; };
 		D1F0A00100000000000000A4 /* PhonePushPayload.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = PhonePushPayload.swift; sourceTree = "<group>"; };
@@ -5130,6 +5132,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5659A0045659A0045659A004 /* WorkspaceSidebarObservationTests.swift */,
 				14D09524E94048DBB6773437 /* WorkspaceSidebarProcessTitleObservationTests.swift */,
 				FEEDC0DEC0DEC0DEC0DE0002 /* FeedCoordinatorTests.swift */,
+				A1A0711A1A0711A1A1000002 /* PermissionPanePromotionPolicyTests.swift */,
 				1D301919B10F22B8708E8883 /* WorkspaceManualUnreadTests.swift */,
 				EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */,
 				C9A57304C9A57304C9A57304 /* SidebarWorkspaceGroupHeaderMetricsTests.swift */,
@@ -7106,6 +7109,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */,
 					C44550000000000000000001 /* PanelOwnedNativeViewSessionTests.swift in Sources */,
 					6313FACE0000000000000000 /* PaneMemoryGuardrailTests.swift in Sources */,
+				A1A0711A1A0711A1A1000001 /* PermissionPanePromotionPolicyTests.swift in Sources */,
 					D1F0A00300000000000000C1 /* PhonePushPresenceGateTests.swift in Sources */,
 					B3575000000000000000000A /* PiVaultAgentPersistenceTests.swift in Sources */,
 				5B0C00010000000000000005 /* PortalDividerCursorOcclusionTests.swift in Sources */,

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -10,6 +10,55 @@ import CMUXAgentLaunch
 
 @Suite("Feed coordinator", .serialized)
 struct FeedCoordinatorTests {
+    @Test @MainActor
+    func closingPanelConcludesObservedPermissionAttentionLease() throws {
+        let manager = TabManager()
+        let workspace = try #require(manager.selectedWorkspace)
+        let panelID = try #require(workspace.focusedPanelId)
+        let key = FeedCoordinator.ObservedAttentionKey(
+            source: "claude",
+            sessionID: "panel-close-lease",
+            workspaceID: workspace.id,
+            panelID: panelID
+        )
+        let target = FeedCoordinator.AttentionTarget(
+            workspaceId: workspace.id,
+            panelId: panelID,
+            statusKey: "claude_code"
+        )
+        FeedCoordinator.shared.recordObservedAttentionLease(key: key, target: target, ppid: nil)
+        defer { FeedCoordinator.shared.concludeObservedAttentionLeases(workspaceID: workspace.id) }
+
+        #expect(FeedCoordinator.shared.hasObservedAttentionLease(key: key))
+        #expect(workspace.closePanel(panelID, force: true))
+        drainMainQueue()
+        drainMainQueue()
+        #expect(!FeedCoordinator.shared.hasObservedAttentionLease(key: key))
+    }
+
+    @Test @MainActor
+    func closingWorkspaceConcludesObservedPermissionAttentionLeaseWithoutPanel() throws {
+        let manager = TabManager()
+        let workspace = manager.addWorkspace()
+        let key = FeedCoordinator.ObservedAttentionKey(
+            source: "claude",
+            sessionID: "workspace-close-lease",
+            workspaceID: workspace.id,
+            panelID: nil
+        )
+        let target = FeedCoordinator.AttentionTarget(
+            workspaceId: workspace.id,
+            panelId: nil,
+            statusKey: "claude_code"
+        )
+        FeedCoordinator.shared.recordObservedAttentionLease(key: key, target: target, ppid: nil)
+        defer { FeedCoordinator.shared.concludeObservedAttentionLeases(workspaceID: workspace.id) }
+
+        #expect(FeedCoordinator.shared.hasObservedAttentionLease(key: key))
+        manager.closeWorkspace(workspace)
+        #expect(!FeedCoordinator.shared.hasObservedAttentionLease(key: key))
+    }
+
     @Test func codexTeamsResolvesExplicitWorkingDirectoryFlags() {
         let base = "/tmp/cmux-base"
 

--- a/cmuxTests/PermissionPanePromotionPolicyTests.swift
+++ b/cmuxTests/PermissionPanePromotionPolicyTests.swift
@@ -1,0 +1,92 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Permission pane promotion policy")
+struct PermissionPanePromotionPolicyTests {
+    private let top = UUID()
+    private let middle = UUID()
+    private let bottom = UUID()
+
+    private func input(
+        enabled: Bool = true,
+        kind: FeedDecisionAttentionKind = .permission,
+        source: UUID?,
+        panes: [UUID],
+        layout: PermissionPanePromotionPolicy.LayoutClass = .verticalStack,
+        selected: Bool = true,
+        remote: Bool = false
+    ) -> PermissionPanePromotionPolicy.Input {
+        .init(
+            enabled: enabled,
+            eventKind: kind,
+            sourcePaneID: source,
+            orderedPaneIDs: panes,
+            layout: layout,
+            sourceSurfaceIsSelected: selected,
+            isRemoteTmuxMirror: remote
+        )
+    }
+
+    @Test func disabledIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(enabled: false, source: bottom, panes: [top, bottom])) == .noOp(.disabled))
+    }
+
+    @Test func nonPermissionIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(kind: .question, source: bottom, panes: [top, bottom])) == .noOp(.notPermission))
+    }
+
+    @Test func singlePaneIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: top, panes: [top], layout: .singlePane)) == .noOp(.singlePane))
+    }
+
+    @Test func alreadyTopIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: top, panes: [top, middle])) == .noOp(.alreadyTop))
+    }
+
+    @Test func middlePlansSwapWithTop() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: middle, panes: [top, middle, bottom])) == .swap(sourcePaneID: middle, targetPaneID: top))
+    }
+
+    @Test func bottomPlansSwapWithTop() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: bottom, panes: [top, middle, bottom])) == .swap(sourcePaneID: bottom, targetPaneID: top))
+    }
+
+    @Test func horizontalIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: bottom, panes: [top, bottom], layout: .horizontalRow)) == .noOp(.unsupportedLayout))
+    }
+
+    @Test func mixedLayoutIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: bottom, panes: [top, bottom], layout: .mixed2D)) == .noOp(.unsupportedLayout))
+    }
+
+    @Test func remoteTmuxIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: bottom, panes: [top, bottom], remote: true)) == .noOp(.remoteTmux))
+    }
+
+    @Test func nonSelectedSurfaceIsNoOp() {
+        #expect(PermissionPanePromotionPolicy().plan(input(source: bottom, panes: [top, bottom], selected: false)) == .noOp(.surfaceNotSelected))
+    }
+}
+
+@Suite("Pane surface swap rollback")
+struct PaneSurfaceSwapRollbackTests {
+    @Test func successfulRollbackCleansUpPlaceholders() {
+        #expect(
+            PaneSurfaceSwapRollbackPlan.afterSourceRollback(succeeded: true)
+                == .cleanupPlaceholders
+        )
+    }
+
+    @Test func failedRollbackPreservesPlaceholders() {
+        #expect(
+            PaneSurfaceSwapRollbackPlan.afterSourceRollback(succeeded: false)
+                == .preservePlaceholders
+        )
+    }
+}


### PR DESCRIPTION
## Purpose

Automatically move the pane associated with an observe-only agent permission request to the top of a vertical stack while preserving keyboard focus.

## Red regression commit

The current Draft PR intentionally contains tests only. Commit dbde25b adds behavioral coverage for:

- observe-only permission events remaining telemetry rather than reply-capable pending cards
- permission-pane promotion policy and rollback decisions
- attention lease cleanup when a panel or workspace closes

This commit is expected to fail because ingestObserveOnly, PermissionPanePromotionPolicy, PaneSurfaceSwapRollbackPlan, and the attention-lease lifecycle APIs are not implemented yet. Local evidence: the focused WorkstreamStore test fails to compile with WorkstreamStore has no member ingestObserveOnly.

## Planned fix

The second commit will add the shared promotion/swap path, focus preservation and rollback, lease lifecycle cleanup, settings and localization, project source wiring, and Xcode 26 Swift/Sparkle compatibility updates.

## Validation plan

- confirm a relevant GitHub check is red on this tests-only commit
- push the production implementation as Commit 2
- rerun focused unit/package tests and project audits
- retain the completed tagged-app dogfood results

---
🤖 Posted via Codex

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7927"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786436062&installation_id=133855650&pr_number=7927&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7927&signature=e31b8f8a24a8b859d12ac3bde7696ffcc5ee6431688a2f91aa85edd8e37ad4bb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add regression tests that cover promoting observe‑only permission panes to the top of a vertical stack without stealing focus. Tests also ensure observe‑only permissions are recorded as telemetry (not reply‑capable pending cards), validate pane swap planning and rollback, and verify attention‑lease cleanup when a panel or workspace closes.

<sup>Written for commit dbde25bcbe98d8ad300a1f9091b006295acee483. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

