### PR TITLE
fix(cli): run workspace --command as process, not send_text

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7494,6 +7494,17 @@ struct CMUXCLI {
             params["layout"] = layoutObj
         }
         try applyFocusOption(focusOpt, defaultValue: false, to: &params)
+        // Process-as-command: pass initial_command into workspace.create so Ghostty
+        // runs the command as the terminal process. Do NOT surface.send_text after
+        // create — that races interactive shell startup (.zshrc/neofetch/shell-init)
+        // and is not portable across shells. /bin/sh -c is shell-agnostic and does
+        // not source the user's interactive login rc.
+        if layoutOpt == nil, let commandText = commandOpt {
+            let trimmed = commandText.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmed.isEmpty {
+                params["initial_command"] = Self.workspaceCreateProcessCommand(trimmed)
+            }
+        }
         let response = try client.sendV2(method: "workspace.create", params: params)
         let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
         if jsonOutput && honorJSONOutput {
@@ -7501,14 +7512,28 @@ struct CMUXCLI {
         } else {
             print("OK \(wsId)")
         }
-        if layoutOpt == nil, let commandText = commandOpt, !wsId.isEmpty {
-            let text = unescapeSendText(commandText + "\\n")
-            let sendParams: [String: Any] = [
-                "text": text,
-                "workspace_id": wsId
-            ]
-            _ = try client.sendV2(method: "surface.send_text", params: sendParams)
+    }
+
+    /// Wrap a user `--command` string so Ghostty runs it as the surface process via
+    /// `/bin/sh -c`, without an interactive login shell (no zshrc/neofetch race).
+    /// Multi-word commands and shell metacharacters are handled portably.
+    ///
+    /// A minimal PATH is injected so tools like `kpm` / Homebrew CLIs resolve without
+    /// sourcing the user's interactive rc. This does **not** run shell-init or neofetch.
+    private static func workspaceCreateProcessCommand(_ command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        // Already a posix process wrapper — leave intact (resume scripts, dock scripts, etc.).
+        if trimmed.hasPrefix("/bin/sh -c ")
+            || trimmed.hasPrefix("/bin/bash -c ")
+            || trimmed.hasPrefix("/usr/bin/env ")
+            || (trimmed.hasPrefix("/") && !trimmed.contains(" ") && !trimmed.contains("'")) {
+            return trimmed
         }
+        // Portable bootstrap: common user/Homebrew paths first, then existing PATH.
+        let bootstrap = #"""
+        export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"; \
+        """#
+        return "/bin/sh -c " + shellSingleQuote(bootstrap + trimmed)
     }
 
     /// Parses repeatable `--env KEY=VALUE` / `--env=KEY=VALUE` and
@@ -15744,7 +15769,9 @@ struct CMUXCLI {
               --name <title>       Set a custom name for the new workspace
               --description <text> Set a custom description for the new workspace
               --cwd <path>         Set the working directory for the new workspace
-              --command <text>     Send text+Enter to the new workspace after creation
+              --command <text>     Run as the initial terminal process (process-as-command
+                                   via /bin/sh -c; not typed into an interactive shell).
+                                   Pane stays open after the command exits (wait-after-command).
               --env KEY=VALUE      Set a workspace environment variable. Repeatable.
                                    Reserved CMUX_* variables cannot be overridden.
               --env-file <path>    Load KEY=VALUE lines from a file. Repeatable.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7496,9 +7496,10 @@ struct CMUXCLI {
         try applyFocusOption(focusOpt, defaultValue: false, to: &params)
         // Process-as-command: pass initial_command into workspace.create so Ghostty
         // runs the command as the terminal process. Do NOT surface.send_text after
-        // create — that races interactive shell startup (.zshrc/neofetch/shell-init)
-        // and is not portable across shells. /bin/sh -c is shell-agnostic and does
-        // not source the user's interactive login rc.
+        // create — that races interactive shell startup (.zshrc, neofetch, and any
+        // other login/rc work) and is not portable across shells. /bin/sh -c is
+        // shell-agnostic and does not source the user's interactive login rc.
+        // Keep in lockstep with Sources/TerminalProcessCommand.asInitialProcess.
         if layoutOpt == nil, let commandText = commandOpt {
             let trimmed = commandText.trimmingCharacters(in: .whitespacesAndNewlines)
             if !trimmed.isEmpty {
@@ -7518,8 +7519,9 @@ struct CMUXCLI {
     /// `/bin/sh -c`, without an interactive login shell (no zshrc/neofetch race).
     /// Multi-word commands and shell metacharacters are handled portably.
     ///
-    /// A minimal PATH is injected so tools like `kpm` / Homebrew CLIs resolve without
-    /// sourcing the user's interactive rc. This does **not** run shell-init or neofetch.
+    /// A minimal PATH is injected so user bins and common package-manager locations
+    /// (`~/bin`, Homebrew, `/usr/local`) resolve without sourcing the user's
+    /// interactive rc. Must match `TerminalProcessCommand.asInitialProcess` in Sources.
     private static func workspaceCreateProcessCommand(_ command: String) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         // Already a posix process wrapper — leave intact (resume scripts, dock scripts, etc.).
@@ -7529,10 +7531,10 @@ struct CMUXCLI {
             || (trimmed.hasPrefix("/") && !trimmed.contains(" ") && !trimmed.contains("'")) {
             return trimmed
         }
-        // Portable bootstrap: common user/Homebrew paths first, then existing PATH.
-        let bootstrap = #"""
-        export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"; \
-        """#
+        // Single-line prefix (no line-continuation backslash): inside shellSingleQuote
+        // a trailing `\` would be literal and break the following command.
+        let bootstrap =
+            #"export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"; "#
         return "/bin/sh -c " + shellSingleQuote(bootstrap + trimmed)
     }
 
@@ -15760,7 +15762,7 @@ struct CMUXCLI {
               cmux rename-tab --workspace workspace:2 --surface surface:5 --title "agent run"
             """
         case "new-workspace":
-            return """
+            return String(localized: "cli.new-workspace.usage", defaultValue: """
             Usage: cmux new-workspace [--name <title>] [--description <text>] [--cwd <path>] [--command <text>] [--env KEY=VALUE]... [--env-file <path>]... [--layout <json>] [--window <id|ref|index>] [--focus <true|false>] [--group <id|ref>] [--group-placement afterCurrent|top|end] [--group-reference <workspace>]
 
             Create a new workspace in the caller's window.
@@ -15790,7 +15792,7 @@ struct CMUXCLI {
               cmux new-workspace --cwd ~/projects/myapp
               cmux new-workspace --cwd . --command "npm test"
               cmux new-workspace --name "Dev" --layout '{"direction":"horizontal","split":0.5,"children":[{"pane":{"surfaces":[{"type":"terminal","command":"vim"}]}},{"pane":{"surfaces":[{"type":"terminal","command":"npm run start"}]}}]}'
-            """
+            """)
         case "list-workspaces":
             return """
             Usage: cmux list-workspaces [--window <id|ref|index>]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7499,12 +7499,22 @@ struct CMUXCLI {
         // create — that races interactive shell startup (.zshrc, neofetch, and any
         // other login/rc work) and is not portable across shells. /bin/sh -c is
         // shell-agnostic and does not source the user's interactive login rc.
-        // Keep in lockstep with Sources/TerminalProcessCommand.asInitialProcess.
-        if layoutOpt == nil, let commandText = commandOpt {
-            let trimmed = commandText.trimmingCharacters(in: .whitespacesAndNewlines)
-            if !trimmed.isEmpty {
-                params["initial_command"] = Self.workspaceCreateProcessCommand(trimmed)
-            }
+        // Keep in lockstep with Sources/TerminalProcessCommand.initialCommand.
+        // Layout surfaces define their own commands; combining --layout with
+        // --command is ambiguous and must not silently drop the flag.
+        let trimmedCommand = commandOpt?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        if layoutOpt != nil, !trimmedCommand.isEmpty {
+            throw CLIError(message: String(
+                format: String(
+                    localized: "cli.workspace.create.error.commandWithLayout",
+                    defaultValue: "%@: --command cannot be combined with --layout (layout surfaces define their own commands)"
+                ),
+                locale: .current,
+                commandName
+            ))
+        }
+        if layoutOpt == nil, !trimmedCommand.isEmpty {
+            params["initial_command"] = Self.workspaceCreateProcessCommand(trimmedCommand)
         }
         let response = try client.sendV2(method: "workspace.create", params: params)
         let wsId = (response["workspace_ref"] as? String) ?? (response["workspace_id"] as? String) ?? ""
@@ -7521,7 +7531,7 @@ struct CMUXCLI {
     ///
     /// A minimal PATH is injected so user bins and common package-manager locations
     /// (`~/bin`, Homebrew, `/usr/local`) resolve without sourcing the user's
-    /// interactive rc. Must match `TerminalProcessCommand.asInitialProcess` in Sources.
+    /// interactive rc. Must match `TerminalProcessCommand(...).initialCommand` in Sources.
     private static func workspaceCreateProcessCommand(_ command: String) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         // Already a posix process wrapper — leave intact (resume scripts, dock scripts, etc.).
@@ -15774,6 +15784,7 @@ struct CMUXCLI {
               --command <text>     Run as the initial terminal process (process-as-command
                                    via /bin/sh -c; not typed into an interactive shell).
                                    Pane stays open after the command exits (wait-after-command).
+                                   Cannot be combined with --layout.
               --env KEY=VALUE      Set a workspace environment variable. Repeatable.
                                    Reserved CMUX_* variables cannot be overridden.
               --env-file <path>    Load KEY=VALUE lines from a file. Repeatable.

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -7531,7 +7531,8 @@ struct CMUXCLI {
     ///
     /// A minimal PATH is injected so user bins and common package-manager locations
     /// (`~/bin`, Homebrew, `/usr/local`) resolve without sourcing the user's
-    /// interactive rc. Must match `TerminalProcessCommand(...).initialCommand` in Sources.
+    /// interactive rc. Must match `TerminalProcessCommand(...).initialCommand` in Sources
+    /// (same PATH bootstrap and `TerminalStartupShellQuoting.singleQuoted` semantics).
     private static func workspaceCreateProcessCommand(_ command: String) -> String {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         // Already a posix process wrapper — leave intact (resume scripts, dock scripts, etc.).
@@ -7541,11 +7542,24 @@ struct CMUXCLI {
             || (trimmed.hasPrefix("/") && !trimmed.contains(" ") && !trimmed.contains("'")) {
             return trimmed
         }
-        // Single-line prefix (no line-continuation backslash): inside shellSingleQuote
-        // a trailing `\` would be literal and break the following command.
+        // Single-line prefix (no line-continuation backslash): inside a single-quoted
+        // payload a trailing `\` would be literal and break the following command.
         let bootstrap =
             #"export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"; "#
-        return "/bin/sh -c " + shellSingleQuote(bootstrap + trimmed)
+        return "/bin/sh -c " + processCommandSingleQuoted(bootstrap + trimmed)
+    }
+
+    /// Shell single-quote matching `TerminalStartupShellQuoting.singleQuoted` in Sources
+    /// (printf-octal for non-ASCII UTF-8; `'\''` for ASCII apostrophes). Kept separate from
+    /// `shellSingleQuote` so freestyle cloud exports keep their existing quoting style.
+    private static func processCommandSingleQuoted(_ value: String) -> String {
+        if value.utf8.contains(where: { $0 >= 0x80 }) {
+            let octalBytes = value.utf8
+                .map { String(format: #"\%03o"#, Int($0)) }
+                .joined()
+            return #""$(printf '"# + octalBytes + #"')""#
+        }
+        return "'" + value.replacingOccurrences(of: "'", with: "'\\''") + "'"
     }
 
     /// Parses repeatable `--env KEY=VALUE` / `--env=KEY=VALUE` and

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -31,6 +31,43 @@ enum TerminalStartupShellQuoting {
     }
 }
 
+/// Builds portable process-as-command strings for terminal surfaces.
+///
+/// Prefer this over typing into an interactive shell (`send_text` / `sendInputWhenReady`)
+/// when a command should be the surface's initial process: that path is shell-agnostic,
+/// does not race interactive login rc (neofetch, zshrc, etc.), and keeps the pane
+/// observable via wait-after-command.
+///
+/// Keep the CLI (`CMUXCLI.workspaceCreateProcessCommand`) in lockstep — the CLI target
+/// cannot share this type, but both must produce the same `/bin/sh -c` + PATH shape.
+nonisolated enum TerminalProcessCommand {
+    /// Minimal PATH so common user and package-manager bins resolve without sourcing
+    /// the user's interactive login rc. Order: `~/bin`, Homebrew, `/usr/local`, system.
+    static let pathBootstrapPrefix =
+        #"export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"; "#
+
+    /// Wrap `command` as a Ghostty `initial_command` process via `/bin/sh -c`.
+    /// Already-wrapped process forms (`/bin/sh -c …`, absolute single tokens, etc.)
+    /// are returned unchanged so resume/dock scripts are not double-wrapped.
+    static func asInitialProcess(_ command: String) -> String {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return trimmed }
+        if isAlreadyProcessWrapper(trimmed) {
+            return trimmed
+        }
+        return "/bin/sh -c " + TerminalStartupShellQuoting.singleQuoted(pathBootstrapPrefix + trimmed)
+    }
+
+    /// True when `command` is already a process launch form that should not be re-wrapped.
+    static func isAlreadyProcessWrapper(_ command: String) -> Bool {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.hasPrefix("/bin/sh -c ")
+            || trimmed.hasPrefix("/bin/bash -c ")
+            || trimmed.hasPrefix("/usr/bin/env ")
+            || (trimmed.hasPrefix("/") && !trimmed.contains(" ") && !trimmed.contains("'"))
+    }
+}
+
 fileprivate func shellSingleQuoted(_ value: String) -> String {
     TerminalStartupShellQuoting.singleQuoted(value)
 }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -31,7 +31,8 @@ enum TerminalStartupShellQuoting {
     }
 }
 
-/// Builds portable process-as-command strings for terminal surfaces.
+/// Value type that owns a user/config command and exposes its Ghostty
+/// `initial_command` form for process-as-command launches.
 ///
 /// Prefer this over typing into an interactive shell (`send_text` / `sendInputWhenReady`)
 /// when a command should be the surface's initial process: that path is shell-agnostic,
@@ -40,31 +41,38 @@ enum TerminalStartupShellQuoting {
 ///
 /// Keep the CLI (`CMUXCLI.workspaceCreateProcessCommand`) in lockstep — the CLI target
 /// cannot share this type, but both must produce the same `/bin/sh -c` + PATH shape.
-nonisolated enum TerminalProcessCommand {
+nonisolated struct TerminalProcessCommand: Sendable, Equatable {
+    /// Ghostty `initial_command` string (already-wrapped process forms are unchanged).
+    let initialCommand: String
+
     /// Minimal PATH so common user and package-manager bins resolve without sourcing
     /// the user's interactive login rc. Order: `~/bin`, Homebrew, `/usr/local`, system.
-    static let pathBootstrapPrefix =
+    private static let pathBootstrapPrefix =
         #"export PATH="${HOME}/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin${PATH:+:$PATH}"; "#
 
-    /// Wrap `command` as a Ghostty `initial_command` process via `/bin/sh -c`.
+    /// Wraps `command` as a portable process-as-command. Empty input stays empty.
     /// Already-wrapped process forms (`/bin/sh -c …`, absolute single tokens, etc.)
-    /// are returned unchanged so resume/dock scripts are not double-wrapped.
-    static func asInitialProcess(_ command: String) -> String {
+    /// are left intact so resume/dock scripts are not double-wrapped.
+    init(_ command: String) {
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return trimmed }
-        if isAlreadyProcessWrapper(trimmed) {
-            return trimmed
+        guard !trimmed.isEmpty else {
+            initialCommand = trimmed
+            return
         }
-        return "/bin/sh -c " + TerminalStartupShellQuoting.singleQuoted(pathBootstrapPrefix + trimmed)
+        if Self.isAlreadyProcessWrapper(trimmed) {
+            initialCommand = trimmed
+            return
+        }
+        initialCommand =
+            "/bin/sh -c " + TerminalStartupShellQuoting.singleQuoted(Self.pathBootstrapPrefix + trimmed)
     }
 
     /// True when `command` is already a process launch form that should not be re-wrapped.
-    static func isAlreadyProcessWrapper(_ command: String) -> Bool {
-        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
-        return trimmed.hasPrefix("/bin/sh -c ")
-            || trimmed.hasPrefix("/bin/bash -c ")
-            || trimmed.hasPrefix("/usr/bin/env ")
-            || (trimmed.hasPrefix("/") && !trimmed.contains(" ") && !trimmed.contains("'"))
+    private static func isAlreadyProcessWrapper(_ command: String) -> Bool {
+        command.hasPrefix("/bin/sh -c ")
+            || command.hasPrefix("/bin/bash -c ")
+            || command.hasPrefix("/usr/bin/env ")
+            || (command.hasPrefix("/") && !command.contains(" ") && !command.contains("'"))
     }
 }
 

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -186,6 +186,10 @@ extension Workspace {
     /// surface creation so a failed create can retry setup on a later surface.
     /// Setup and surface commands are joined with newlines (legacy semantics) so a
     /// trailing `#` comment on setup cannot swallow the surface command.
+    ///
+    /// Whitespace-only setup/command strings are intentionally dropped (treated as
+    /// empty): process-as-command has no useful no-op for spaces alone, and the
+    /// legacy typed path's space-only enqueue was not a meaningful setup.
     private static func buildInitialProcessCommand(
         setup: String?,
         command: String?

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -241,6 +241,16 @@ extension Workspace {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
+            } else {
+                // Replace failed: keep placeholder and type setup/command so work is not lost.
+                if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
+                if surface.focus == true { focusPanelId = panelId }
+                if let input = Self.dequeueInitialTerminalInput(
+                    pendingSetup: &pendingSetup,
+                    command: surface.command
+                ), let terminal = terminalPanel(for: panelId) {
+                    sendInputWhenReady(input, to: terminal)
+                }
             }
 
         case .terminal:
@@ -263,6 +273,17 @@ extension Workspace {
                     _ = closePanel(panelId, force: true)
                     if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                     if surface.focus == true { focusPanelId = panel.id }
+                } else {
+                    // Process replace failed: fall back to typed input on the placeholder
+                    // so single-pane layouts do not silently drop setup/command.
+                    if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
+                    if surface.focus == true { focusPanelId = panelId }
+                    if let input = Self.dequeueInitialTerminalInput(
+                        pendingSetup: &pendingSetup,
+                        command: surface.command
+                    ), let terminal = terminalPanel(for: panelId) {
+                        sendInputWhenReady(input, to: terminal)
+                    }
                 }
             } else {
                 if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -54,16 +54,24 @@ extension Workspace {
         }()
         guard let firstTerminal else { return }
         // Prefer process-as-command when the initial terminal has no command yet.
+        // Create the replacement in the pane that actually hosts firstTerminal
+        // (not focusedPaneId — focus may be on a browser/project in another pane).
         if firstTerminal.surface.initialCommand == nil {
-            let processCommand = "/bin/sh -c " + TerminalStartupShellQuoting.singleQuoted(trimmed)
+            let processCommand = TerminalProcessCommand.asInitialProcess(trimmed)
             let cwd = firstTerminal.requestedWorkingDirectory
-            if let paneId = bonsplitController.focusedPaneId
-                ?? bonsplitController.allPaneIds.first,
+            let targetPaneId = paneId(forPanelId: firstTerminal.id)
+                ?? bonsplitController.focusedPaneId
+                ?? bonsplitController.allPaneIds.first
+            // Preserve the workspace env the original panel was seeded with.
+            // newTerminalSurface also merges current workspaceEnvironment; this
+            // keeps any values that were present on the original seed path.
+            if let targetPaneId,
                let panel = newTerminalSurface(
-                    inPane: paneId,
+                    inPane: targetPaneId,
                     focus: false,
                     workingDirectory: cwd,
-                    initialCommand: processCommand
+                    initialCommand: processCommand,
+                    startupEnvironment: firstTerminal.seededWorkspaceEnvironment
                ) {
                 _ = closePanel(firstTerminal.id, force: true)
                 focusPanel(panel.id)
@@ -155,7 +163,7 @@ extension Workspace {
 
     /// Consumes the workspace-level setup command on the first terminal surface it
     /// reaches, sequencing it ahead of that surface's own `command`.
-    /// Returns keystroke-oriented input (legacy); prefer ``dequeueInitialProcessCommand``
+    /// Returns keystroke-oriented input (legacy); prefer ``buildInitialProcessCommand``
     /// for process-as-command launches.
     private static func dequeueInitialTerminalInput(
         pendingSetup: inout String?,
@@ -174,23 +182,36 @@ extension Workspace {
     }
 
     /// Builds a portable process-as-command for layout terminal surfaces.
-    /// Runs via `/bin/sh -c` so setup + surface commands execute as the PTY process
-    /// without racing an interactive login shell (.zshrc / neofetch / shell-init).
-    private static func dequeueInitialProcessCommand(
-        pendingSetup: inout String?,
+    /// Does **not** mutate `pendingSetup` — callers clear it only after a successful
+    /// surface creation so a failed create can retry setup on a later surface.
+    /// Setup and surface commands are joined with newlines (legacy semantics) so a
+    /// trailing `#` comment on setup cannot swallow the surface command.
+    private static func buildInitialProcessCommand(
+        setup: String?,
         command: String?
     ) -> String? {
         var parts: [String] = []
-        if let setup = pendingSetup?.trimmingCharacters(in: .whitespacesAndNewlines), !setup.isEmpty {
+        if let setup = setup?.trimmingCharacters(in: .whitespacesAndNewlines), !setup.isEmpty {
             parts.append(setup)
-            pendingSetup = nil
         }
         if let command = command?.trimmingCharacters(in: .whitespacesAndNewlines), !command.isEmpty {
             parts.append(command)
         }
         guard !parts.isEmpty else { return nil }
-        let script = parts.joined(separator: "; ")
-        return "/bin/sh -c " + TerminalStartupShellQuoting.singleQuoted(script)
+        let script = parts.joined(separator: "\n")
+        return TerminalProcessCommand.asInitialProcess(script)
+    }
+
+    /// Clears `pendingSetup` after a successful process-as-command launch that
+    /// incorporated it. No-op when setup was empty or was not part of the launch.
+    private static func consumePendingSetupIfUsed(
+        _ pendingSetup: inout String?,
+        processCommand: String?
+    ) {
+        guard processCommand != nil else { return }
+        guard let setup = pendingSetup?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !setup.isEmpty else { return }
+        pendingSetup = nil
     }
 
     private func configureExistingSurface(
@@ -205,8 +226,8 @@ extension Workspace {
         case .terminal where surface.cwd != nil || surface.env != nil:
             // Placeholder can't change cwd/env — replace it
             let resolvedCwd = CmuxConfigStore.resolveCwd(surface.cwd, relativeTo: baseCwd)
-            let processCommand = Self.dequeueInitialProcessCommand(
-                pendingSetup: &pendingSetup,
+            let processCommand = Self.buildInitialProcessCommand(
+                setup: pendingSetup,
                 command: surface.command
             )
             if let panel = newTerminalSurface(
@@ -216,14 +237,15 @@ extension Workspace {
                 initialCommand: processCommand,
                 startupEnvironment: surface.env ?? [:]
             ) {
+                Self.consumePendingSetupIfUsed(&pendingSetup, processCommand: processCommand)
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
             }
 
         case .terminal:
-            let processCommand = Self.dequeueInitialProcessCommand(
-                pendingSetup: &pendingSetup,
+            let processCommand = Self.buildInitialProcessCommand(
+                setup: pendingSetup,
                 command: surface.command
             )
             if let processCommand {
@@ -237,6 +259,7 @@ extension Workspace {
                     initialCommand: processCommand,
                     startupEnvironment: surface.env ?? [:]
                 ) {
+                    Self.consumePendingSetupIfUsed(&pendingSetup, processCommand: processCommand)
                     _ = closePanel(panelId, force: true)
                     if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                     if surface.focus == true { focusPanelId = panel.id }
@@ -282,8 +305,8 @@ extension Workspace {
         switch surface.type {
         case .terminal:
             let resolvedCwd = CmuxConfigStore.resolveCwd(surface.cwd, relativeTo: baseCwd)
-            let processCommand = Self.dequeueInitialProcessCommand(
-                pendingSetup: &pendingSetup,
+            let processCommand = Self.buildInitialProcessCommand(
+                setup: pendingSetup,
                 command: surface.command
             )
             if let panel = newTerminalSurface(
@@ -293,6 +316,7 @@ extension Workspace {
                 initialCommand: processCommand,
                 startupEnvironment: surface.env ?? [:]
             ) {
+                Self.consumePendingSetupIfUsed(&pendingSetup, processCommand: processCommand)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
             }

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -35,9 +35,12 @@ extension Workspace {
         }
     }
 
-    /// Sends a config-defined workspace `setup` command to the first terminal
-    /// panel. Used by workspace actions/commands that define no custom layout.
+    /// Runs a config-defined workspace `setup` command as the first terminal's
+    /// process when possible; falls back to typed input only if the panel already
+    /// has a startup command of its own.
     func sendConfigSetupCommand(_ command: String) {
+        let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
         let firstTerminal: TerminalPanel? = focusedTerminalPanel ?? {
             for paneId in bonsplitController.allPaneIds {
                 for tab in bonsplitController.tabs(inPane: paneId) {
@@ -50,7 +53,24 @@ extension Workspace {
             return nil
         }()
         guard let firstTerminal else { return }
-        sendInputWhenReady(command + "\n", to: firstTerminal)
+        // Prefer process-as-command when the initial terminal has no command yet.
+        if firstTerminal.surface.initialCommand == nil {
+            let processCommand = "/bin/sh -c " + TerminalStartupShellQuoting.singleQuoted(trimmed)
+            let cwd = firstTerminal.requestedWorkingDirectory
+            if let paneId = bonsplitController.focusedPaneId
+                ?? bonsplitController.allPaneIds.first,
+               let panel = newTerminalSurface(
+                    inPane: paneId,
+                    focus: false,
+                    workingDirectory: cwd,
+                    initialCommand: processCommand
+               ) {
+                _ = closePanel(firstTerminal.id, force: true)
+                focusPanel(panel.id)
+                return
+            }
+        }
+        sendInputWhenReady(trimmed + "\n", to: firstTerminal)
     }
 
     private func buildCustomLayoutTree(
@@ -135,6 +155,8 @@ extension Workspace {
 
     /// Consumes the workspace-level setup command on the first terminal surface it
     /// reaches, sequencing it ahead of that surface's own `command`.
+    /// Returns keystroke-oriented input (legacy); prefer ``dequeueInitialProcessCommand``
+    /// for process-as-command launches.
     private static func dequeueInitialTerminalInput(
         pendingSetup: inout String?,
         command: String?
@@ -151,6 +173,26 @@ extension Workspace {
         return lines.map { $0 + "\n" }.joined()
     }
 
+    /// Builds a portable process-as-command for layout terminal surfaces.
+    /// Runs via `/bin/sh -c` so setup + surface commands execute as the PTY process
+    /// without racing an interactive login shell (.zshrc / neofetch / shell-init).
+    private static func dequeueInitialProcessCommand(
+        pendingSetup: inout String?,
+        command: String?
+    ) -> String? {
+        var parts: [String] = []
+        if let setup = pendingSetup?.trimmingCharacters(in: .whitespacesAndNewlines), !setup.isEmpty {
+            parts.append(setup)
+            pendingSetup = nil
+        }
+        if let command = command?.trimmingCharacters(in: .whitespacesAndNewlines), !command.isEmpty {
+            parts.append(command)
+        }
+        guard !parts.isEmpty else { return nil }
+        let script = parts.joined(separator: "; ")
+        return "/bin/sh -c " + TerminalStartupShellQuoting.singleQuoted(script)
+    }
+
     private func configureExistingSurface(
         panelId: UUID,
         inPane paneId: PaneID,
@@ -163,26 +205,45 @@ extension Workspace {
         case .terminal where surface.cwd != nil || surface.env != nil:
             // Placeholder can't change cwd/env — replace it
             let resolvedCwd = CmuxConfigStore.resolveCwd(surface.cwd, relativeTo: baseCwd)
+            let processCommand = Self.dequeueInitialProcessCommand(
+                pendingSetup: &pendingSetup,
+                command: surface.command
+            )
             if let panel = newTerminalSurface(
                 inPane: paneId,
                 focus: false,
                 workingDirectory: resolvedCwd,
+                initialCommand: processCommand,
                 startupEnvironment: surface.env ?? [:]
             ) {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
-                    sendInputWhenReady(input, to: panel)
-                }
             }
 
         case .terminal:
-            if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
-            if surface.focus == true { focusPanelId = panelId }
-            if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command),
-               let terminal = terminalPanel(for: panelId) {
-                sendInputWhenReady(input, to: terminal)
+            let processCommand = Self.dequeueInitialProcessCommand(
+                pendingSetup: &pendingSetup,
+                command: surface.command
+            )
+            if let processCommand {
+                // Replace placeholder with a process-as-command terminal so layout
+                // `command` does not race interactive shell startup.
+                let resolvedCwd = CmuxConfigStore.resolveCwd(surface.cwd, relativeTo: baseCwd)
+                if let panel = newTerminalSurface(
+                    inPane: paneId,
+                    focus: false,
+                    workingDirectory: resolvedCwd,
+                    initialCommand: processCommand,
+                    startupEnvironment: surface.env ?? [:]
+                ) {
+                    _ = closePanel(panelId, force: true)
+                    if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
+                    if surface.focus == true { focusPanelId = panel.id }
+                }
+            } else {
+                if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
+                if surface.focus == true { focusPanelId = panelId }
             }
 
         case .browser:
@@ -221,17 +282,19 @@ extension Workspace {
         switch surface.type {
         case .terminal:
             let resolvedCwd = CmuxConfigStore.resolveCwd(surface.cwd, relativeTo: baseCwd)
+            let processCommand = Self.dequeueInitialProcessCommand(
+                pendingSetup: &pendingSetup,
+                command: surface.command
+            )
             if let panel = newTerminalSurface(
                 inPane: paneId,
                 focus: false,
                 workingDirectory: resolvedCwd,
+                initialCommand: processCommand,
                 startupEnvironment: surface.env ?? [:]
             ) {
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
-                    sendInputWhenReady(input, to: panel)
-                }
             }
 
         case .browser:

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -57,7 +57,7 @@ extension Workspace {
         // Create the replacement in the pane that actually hosts firstTerminal
         // (not focusedPaneId — focus may be on a browser/project in another pane).
         if firstTerminal.surface.initialCommand == nil {
-            let processCommand = TerminalProcessCommand.asInitialProcess(trimmed)
+            let processCommand = TerminalProcessCommand(trimmed).initialCommand
             let cwd = firstTerminal.requestedWorkingDirectory
             let targetPaneId = paneId(forPanelId: firstTerminal.id)
                 ?? bonsplitController.focusedPaneId
@@ -199,7 +199,7 @@ extension Workspace {
         }
         guard !parts.isEmpty else { return nil }
         let script = parts.joined(separator: "\n")
-        return TerminalProcessCommand.asInitialProcess(script)
+        return TerminalProcessCommand(script).initialCommand
     }
 
     /// Clears `pendingSetup` after a successful process-as-command launch that
@@ -212,6 +212,25 @@ extension Workspace {
         guard let setup = pendingSetup?.trimmingCharacters(in: .whitespacesAndNewlines),
               !setup.isEmpty else { return }
         pendingSetup = nil
+    }
+
+    /// Typed-input fallback when process-as-command surface replace fails.
+    /// Confirms a terminal panel exists **before** consuming `pendingSetup`.
+    private func applyFallbackTypedInput(
+        panelId: UUID,
+        surface: CmuxSurfaceDefinition,
+        focusPanelId: inout UUID?,
+        pendingSetup: inout String?
+    ) {
+        if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
+        if surface.focus == true { focusPanelId = panelId }
+        guard let terminal = terminalPanel(for: panelId) else { return }
+        if let input = Self.dequeueInitialTerminalInput(
+            pendingSetup: &pendingSetup,
+            command: surface.command
+        ) {
+            sendInputWhenReady(input, to: terminal)
+        }
     }
 
     private func configureExistingSurface(
@@ -243,14 +262,12 @@ extension Workspace {
                 if surface.focus == true { focusPanelId = panel.id }
             } else {
                 // Replace failed: keep placeholder and type setup/command so work is not lost.
-                if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
-                if surface.focus == true { focusPanelId = panelId }
-                if let input = Self.dequeueInitialTerminalInput(
-                    pendingSetup: &pendingSetup,
-                    command: surface.command
-                ), let terminal = terminalPanel(for: panelId) {
-                    sendInputWhenReady(input, to: terminal)
-                }
+                applyFallbackTypedInput(
+                    panelId: panelId,
+                    surface: surface,
+                    focusPanelId: &focusPanelId,
+                    pendingSetup: &pendingSetup
+                )
             }
 
         case .terminal:
@@ -276,14 +293,12 @@ extension Workspace {
                 } else {
                     // Process replace failed: fall back to typed input on the placeholder
                     // so single-pane layouts do not silently drop setup/command.
-                    if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
-                    if surface.focus == true { focusPanelId = panelId }
-                    if let input = Self.dequeueInitialTerminalInput(
-                        pendingSetup: &pendingSetup,
-                        command: surface.command
-                    ), let terminal = terminalPanel(for: panelId) {
-                        sendInputWhenReady(input, to: terminal)
-                    }
+                    applyFallbackTypedInput(
+                        panelId: panelId,
+                        surface: surface,
+                        focusPanelId: &focusPanelId,
+                        pendingSetup: &pendingSetup
+                    )
                 }
             } else {
                 if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }


### PR DESCRIPTION
## Summary

- **`cmux new-workspace` / `workspace create --command`** no longer types into the interactive shell after create (`surface.send_text`), which raced shell startup (neofetch, `.zshrc`, and any other interactive login/rc work) and was shell-specific.
- The command is passed as **`initial_command`** on `workspace.create` so Ghostty runs it as the **surface process**.
- Wrapped with portable **`/bin/sh -c`** plus a minimal PATH bootstrap (`~/bin`, Homebrew, `/usr/local`, system bins) so user-installed tools resolve without sourcing the interactive login rc.
- **Layout surface `command` / setup** uses the same process-as-command path instead of `sendInputWhenReady`.
- Pane remains visible after exit via existing `waitAfterCommand` behavior for initial commands.
- On process-surface **replace failure**, fall back to typed input so setup/command are not silently dropped.

## Design constraint

This is a **core cmux** fix, not a special case for any particular tool. Process-as-command is the right model for `--command` regardless of what the user runs (`npm test`, coding agents, env wrappers, etc.).

## Factory quality (contributor-owned)

| Gate | Result |
|------|--------|
| Independent quality lead | PASS |
| PATH bootstrap / layout harden / localization | PASS |
| Tool-agnostic (no kpm coupling) | PASS |
| `cmux-cli` Debug build | PASS |
| Shell PATH/quoting simulation | PASS |
| **`cmux-unit` Debug build** | **PASS** (zig 0.15.2 + Metal toolchain) |
| Replace-failure fallback | PASS (`3ac0981`) |

**SHIP GATE: PASS**

## Test plan

- [x] Independent code review of full PR diff vs main
- [x] PATH bootstrap + quoting shell tests
- [x] `xcodebuild -scheme cmux-cli` BUILD SUCCEEDED
- [x] `xcodebuild -scheme cmux-unit` BUILD SUCCEEDED (with zig 0.15.2 pin)
- [x] Review harden + replace-failure fallback
- [ ] Reviewer dogfood without contributor zshrc

## Notes for reviewers

- Help text: process-as-command; localized `cli.new-workspace.usage`.
- Cold process-as-command does not run interactive login/rc.
- Pre-existing `/bin/sh -c` / absolute wrappers left unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default CLI and layout startup behavior (process vs keystrokes), though fallbacks exist; incorrect quoting/PATH wrapping could break some command strings.
> 
> **Overview**
> **`cmux new-workspace --command`** now sets Ghostty **`initial_command`** on `workspace.create` instead of typing into the shell via **`surface.send_text`**, avoiding races with interactive login/rc and making startup shell-agnostic. Commands are wrapped as **`/bin/sh -c`** with a minimal **PATH** bootstrap; existing **`/bin/sh -c`**, **`/usr/bin/env`**, and bare absolute executables are left unchanged. **`--command` with `--layout`** is rejected with a localized error.
> 
> The app adds **`TerminalProcessCommand`** (shared quoting/PATH semantics with the CLI) and routes **custom layout** terminal **`command`** values and **workspace setup** through **`initialCommand`** on **`newTerminalSurface`**, with **typed-input fallback** if process replacement fails. Help and **`cli.new-workspace.usage`** / **`cli.workspace.create.error.commandWithLayout`** strings are updated across locales.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93db1f9dd63bfcbd96e8e8bc54ffd526e34884bb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * `cmux new-workspace --command` now starts the specified process directly as the initial terminal process (pane stays open after exit).
  * Added safer command preparation for common shell-wrapper formats.
  * Workspace setup commands now prefer process-based startup when available.
* **Bug Fixes**
  * `--command` can no longer be combined with `--layout`; a validation error is shown.
  * Setup commands are preserved when direct process startup isn’t possible.
* **Documentation**
  * Updated localized CLI usage and error messages to reflect the new `--command`/`--layout` behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->