### PR TITLE
Add OpenCode sidebar status integration

### DIFF
--- a/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
+++ b/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
@@ -43,6 +43,8 @@ function sessionState(sessionId) {
       lastUserMessage: null,
       assistantPreamble: null,
       cwd: null,
+      started: false,
+      activeTurn: false,
       updatedAt: Date.now(),
     });
   }
@@ -95,8 +97,7 @@ function sessionIdFor(event) {
     props.session_id,
     props.session && props.session.id,
     event && event.sessionID,
-    event && event.sessionId,
-    event && event.id
+    event && event.sessionId
   );
 }
 
@@ -264,6 +265,33 @@ function sendHook(subcommand, ctx, event, extra = {}) {
   } catch (_) {}
 }
 
+function sendStartOnce(ctx, event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+  const state = sessionState(sessionId);
+  if (state.started) return;
+  state.started = true;
+  sendHook("session-start", ctx, event);
+}
+
+function sendPromptSubmitOnce(ctx, event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+  const state = sessionState(sessionId);
+  if (state.activeTurn) return;
+  state.activeTurn = true;
+  sendHook("prompt-submit", ctx, event);
+}
+
+function sendStopIfActive(ctx, event) {
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+  const state = sessionState(sessionId);
+  if (!state.activeTurn) return;
+  state.activeTurn = false;
+  sendHook("stop", ctx, event);
+}
+
 function trackMessage(event) {
   const props = eventProperties(event);
   if (event && event.type === "message.updated") {
@@ -304,30 +332,31 @@ const CMUXSessionRestore = async (ctx) => {
       const props = eventProperties(event);
       switch (event && event.type) {
         case "session.created":
-          sendHook("session-start", ctx, event);
+          sendStartOnce(ctx, event);
           break;
         case "session.updated":
           if (props.info && props.info.time && props.info.time.archived) {
+            sendStopIfActive(ctx, event);
             sendHook("session-end", ctx, event);
             dropSession(sessionIdFor(event));
           } else {
-            sendHook("session-start", ctx, event);
+            sendStartOnce(ctx, event);
           }
           break;
         case "session.status":
           if (isIdleStatus(openCodeStatusType(event))) {
-            sendHook("stop", ctx, event);
+            sendStopIfActive(ctx, event);
           } else if (isRetryingStatus(openCodeStatusType(event))) {
             sendHook("notification", ctx, event, {
               cmux_status: "retrying",
               reason: "retrying",
             });
           } else if (isRunningStatus(openCodeStatusType(event))) {
-            sendHook("prompt-submit", ctx, event);
+            sendPromptSubmitOnce(ctx, event);
           }
           break;
         case "session.idle":
-          sendHook("stop", ctx, event);
+          sendStopIfActive(ctx, event);
           break;
         case "permission.asked":
           sendHook("notification", ctx, event, {
@@ -346,8 +375,10 @@ const CMUXSessionRestore = async (ctx) => {
             message: openCodeEventMessage(event),
             reason: "error",
           });
+          sendStopIfActive(ctx, event);
           break;
         case "session.deleted":
+          sendStopIfActive(ctx, event);
           sendHook("session-end", ctx, event);
           dropSession(sessionIdFor(event));
           break;

--- a/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
+++ b/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
@@ -45,6 +45,7 @@ function sessionState(sessionId) {
       cwd: null,
       started: false,
       activeTurn: false,
+      retrying: false,
       updatedAt: Date.now(),
     });
   }
@@ -280,6 +281,7 @@ function sendPromptSubmitOnce(ctx, event) {
   const state = sessionState(sessionId);
   if (state.activeTurn) return;
   state.activeTurn = true;
+  state.retrying = false;
   sendHook("prompt-submit", ctx, event);
 }
 
@@ -287,8 +289,9 @@ function sendStopIfActive(ctx, event) {
   const sessionId = sessionIdFor(event);
   if (!sessionId) return;
   const state = sessionState(sessionId);
-  if (!state.activeTurn) return;
+  if (!state.activeTurn && !state.retrying) return;
   state.activeTurn = false;
+  state.retrying = false;
   sendHook("stop", ctx, event);
 }
 
@@ -347,6 +350,8 @@ const CMUXSessionRestore = async (ctx) => {
           if (isIdleStatus(openCodeStatusType(event))) {
             sendStopIfActive(ctx, event);
           } else if (isRetryingStatus(openCodeStatusType(event))) {
+            const sessionId = sessionIdFor(event);
+            if (sessionId) sessionState(sessionId).retrying = true;
             sendHook("notification", ctx, event, {
               cmux_status: "retrying",
               reason: "retrying",

--- a/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
+++ b/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
@@ -372,7 +372,7 @@ const CMUXSessionRestore = async (ctx) => {
           break;
         case "session.error":
           sendHook("notification", ctx, event, {
-            message: openCodeEventMessage(event),
+            message: "OpenCode reported an error",
             reason: "error",
           });
           sendStopIfActive(ctx, event);

--- a/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
+++ b/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
@@ -1,0 +1,365 @@
+import Foundation
+
+extension CMUXCLI {
+    static let openCodeSessionPluginMarker = "cmux-opencode-session-plugin-marker"
+    static let openCodeSessionPluginFilename = "cmux-session.js"
+    static let openCodeSessionPluginSource = #"""
+// cmux-opencode-session-plugin-marker v1
+// Bridges OpenCode session lifecycle events into cmux's restorable session store.
+// Installed by `cmux hooks opencode install` or `cmux hooks setup`.
+// DO NOT EDIT MANUALLY. cmux upgrades this file in place.
+
+import { spawnSync } from "node:child_process";
+import * as fs from "node:fs";
+import * as path from "node:path";
+
+const CMUX_PLUGIN_INSTALLED_KEY = Symbol.for("cmux.session.restore.plugin.installed");
+const MAX_TRACKED_SESSIONS = 100;
+const messageRoles = new Map();
+const sessions = new Map();
+
+function firstString(...values) {
+  for (const value of values) {
+    if (typeof value === "string" && value.trim().length > 0) return value.trim();
+  }
+  return null;
+}
+
+function eventProperties(event) {
+  return (event && typeof event === "object" && event.properties) || {};
+}
+
+function normalizeText(value, max = 1000) {
+  if (typeof value !== "string") return null;
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return null;
+  return normalized.length > max ? `${normalized.slice(0, max - 3)}...` : normalized;
+}
+
+function sessionState(sessionId) {
+  const key = sessionId || "unknown";
+  if (!sessions.has(key)) {
+    sessions.set(key, {
+      lastUserMessage: null,
+      assistantPreamble: null,
+      cwd: null,
+      updatedAt: Date.now(),
+    });
+  }
+  const state = sessions.get(key);
+  state.updatedAt = Date.now();
+  pruneSessions();
+  return state;
+}
+
+function pruneSessions() {
+  while (sessions.size > MAX_TRACKED_SESSIONS) {
+    let oldestKey = null;
+    let oldestUpdatedAt = Infinity;
+    for (const [key, state] of sessions.entries()) {
+      const updatedAt = Number(state && state.updatedAt) || 0;
+      if (updatedAt < oldestUpdatedAt) {
+        oldestUpdatedAt = updatedAt;
+        oldestKey = key;
+      }
+    }
+    if (!oldestKey) break;
+    dropSession(oldestKey);
+  }
+}
+
+function dropSession(sessionId) {
+  const key = sessionId || "unknown";
+  sessions.delete(key);
+  for (const [messageId, meta] of messageRoles.entries()) {
+    if (meta && meta.sessionId === key) {
+      messageRoles.delete(messageId);
+    }
+  }
+}
+
+function contextForSession(sessionId) {
+  const state = sessionState(sessionId);
+  const context = {};
+  if (state.lastUserMessage) context.lastUserMessage = state.lastUserMessage;
+  if (state.assistantPreamble) context.assistantPreamble = state.assistantPreamble;
+  return Object.keys(context).length > 0 ? context : undefined;
+}
+
+function sessionIdFor(event) {
+  const props = eventProperties(event);
+  return firstString(
+    props.info && props.info.id,
+    props.sessionID,
+    props.sessionId,
+    props.session_id,
+    props.session && props.session.id,
+    event && event.sessionID,
+    event && event.sessionId,
+    event && event.id
+  );
+}
+
+function cwdFor(ctx, event) {
+  const props = eventProperties(event);
+  return firstString(
+    props.info && props.info.directory,
+    props.cwd,
+    props.directory,
+    ctx && ctx.directory,
+    process.cwd()
+  );
+}
+
+function openCodeStatusType(event) {
+  const props = eventProperties(event);
+  const status = props.status || (props.info && props.info.status) || (event && event.status);
+  return firstString(
+    status && status.type,
+    status && status.status,
+    status && status.state,
+    props.status,
+    props.type,
+    props.state
+  );
+}
+
+function isRetryingStatus(value) {
+  return String(value || "").toLowerCase().includes("retry");
+}
+
+function isIdleStatus(value) {
+  const normalized = String(value || "").toLowerCase();
+  return normalized === "idle" || normalized === "done" || normalized === "stopped";
+}
+
+function isRunningStatus(value) {
+  const normalized = String(value || "").toLowerCase();
+  return [
+    "active",
+    "busy",
+    "running",
+    "streaming",
+    "thinking",
+    "working",
+  ].includes(normalized);
+}
+
+function openCodeEventMessage(event) {
+  const props = eventProperties(event);
+  const candidates = [
+    props.message,
+    props.body,
+    props.text,
+    props.error && props.error.message,
+    props.error,
+    props.question && props.question.question,
+    props.question && props.question.prompt,
+    props.permission && props.permission.message,
+    props.permission && props.permission.description,
+    props.title,
+  ];
+  return firstString(...candidates);
+}
+
+function resolveExecutable(name) {
+  const pathEnv = process.env.PATH || "";
+  for (const dir of pathEnv.split(path.delimiter)) {
+    if (!dir) continue;
+    const candidate = path.join(dir, name);
+    try {
+      fs.accessSync(candidate, fs.constants.X_OK);
+      return candidate;
+    } catch (_) {}
+  }
+  return name;
+}
+
+function looksLikeOpenCodeScript(value) {
+  if (!value) return false;
+  const lower = String(value).toLowerCase();
+  return lower.includes("opencode") || lower.includes("open-code");
+}
+
+function isOpenCodeInternalWorkerArg(value) {
+  if (!value) return false;
+  const normalized = String(value).replaceAll("\\", "/");
+  return normalized.includes("/$bunfs/") && normalized.endsWith("/tui/worker.js");
+}
+
+function withoutOpenCodeInternalWorkerArgs(argv) {
+  const result = [];
+  for (let i = 0; i < argv.length; i += 1) {
+    const value = argv[i];
+    if (i > 0 && isOpenCodeInternalWorkerArg(value)) continue;
+    result.push(value);
+  }
+  return result.length > 0 ? result : [resolveExecutable("opencode")];
+}
+
+function normalizedLaunchArgv() {
+  const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
+  if (raw.length === 0) return [resolveExecutable("opencode")];
+
+  const firstBase = path.basename(raw[0]).toLowerCase();
+  if (looksLikeOpenCodeScript(firstBase)) return withoutOpenCodeInternalWorkerArgs(raw);
+
+  let tail = raw.slice(1);
+  if (tail.length > 0 && looksLikeOpenCodeScript(tail[0])) {
+    tail = tail.slice(1);
+  }
+  return withoutOpenCodeInternalWorkerArgs([resolveExecutable("opencode"), ...tail]);
+}
+
+function base64NulSeparated(values) {
+  const bytes = [];
+  for (const value of values) {
+    bytes.push(Buffer.from(String(value), "utf8"));
+    bytes.push(Buffer.from([0]));
+  }
+  return Buffer.concat(bytes).toString("base64");
+}
+
+function hookEnvironment(cwd) {
+  const env = { ...process.env };
+  delete env.AMP_API_KEY;
+  if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
+    const argv = normalizedLaunchArgv();
+    env.CMUX_AGENT_LAUNCH_KIND = "opencode";
+    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolveExecutable("opencode");
+    env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
+    env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
+  }
+  return env;
+}
+
+function sendHook(subcommand, ctx, event, extra = {}) {
+  if (process.env.CMUX_OPENCODE_HOOKS_DISABLED === "1") return;
+  if (!process.env.CMUX_SURFACE_ID) return;
+
+  const sessionId = sessionIdFor(event);
+  if (!sessionId) return;
+
+  const cwd = cwdFor(ctx, event);
+  const state = sessionState(sessionId);
+  state.cwd = cwd || state.cwd;
+  const payload = {
+    session_id: sessionId,
+    cwd,
+    event: event && event.type,
+    hook_event_name: event && event.type,
+    ...extra,
+  };
+  const context = extra.context || contextForSession(sessionId);
+  if (context) payload.context = context;
+  const cmux = process.env.CMUX_OPENCODE_CMUX_BIN || "cmux";
+  try {
+    spawnSync(cmux, ["hooks", "opencode", subcommand], {
+      input: JSON.stringify(payload),
+      encoding: "utf8",
+      env: hookEnvironment(cwd),
+      stdio: ["pipe", "ignore", "ignore"],
+      timeout: 5000,
+    });
+  } catch (_) {}
+}
+
+function trackMessage(event) {
+  const props = eventProperties(event);
+  if (event && event.type === "message.updated") {
+    const info = props.info || props.message || {};
+    const messageId = info.id || props.messageID;
+    const sessionId = info.sessionID || props.sessionID;
+    const role = info.role || props.role;
+    if (messageId && sessionId && role) {
+      messageRoles.set(messageId, { sessionId, role });
+      if (messageRoles.size > 300) {
+        messageRoles.delete(messageRoles.keys().next().value);
+      }
+    }
+    return;
+  }
+
+  if (!event || event.type !== "message.part.updated") return;
+  const part = props.part || {};
+  if (part.type !== "text" || !part.messageID) return;
+  const meta = messageRoles.get(part.messageID);
+  if (!meta) return;
+  const text = normalizeText(part.text || part.textDelta || part.content);
+  if (!text) return;
+  const state = sessionState(meta.sessionId);
+  if (meta.role === "user") {
+    state.lastUserMessage = text;
+  } else if (meta.role === "assistant") {
+    state.assistantPreamble = text;
+  }
+}
+
+const CMUXSessionRestore = async (ctx) => {
+  if (globalThis[CMUX_PLUGIN_INSTALLED_KEY]) return {};
+  globalThis[CMUX_PLUGIN_INSTALLED_KEY] = true;
+  return {
+    event: async ({ event }) => {
+      trackMessage(event);
+      const props = eventProperties(event);
+      switch (event && event.type) {
+        case "session.created":
+          sendHook("session-start", ctx, event);
+          break;
+        case "session.updated":
+          if (props.info && props.info.time && props.info.time.archived) {
+            sendHook("session-end", ctx, event);
+            dropSession(sessionIdFor(event));
+          } else {
+            sendHook("session-start", ctx, event);
+          }
+          break;
+        case "session.status":
+          if (isIdleStatus(openCodeStatusType(event))) {
+            sendHook("stop", ctx, event);
+          } else if (isRetryingStatus(openCodeStatusType(event))) {
+            sendHook("notification", ctx, event, {
+              cmux_status: "retrying",
+              reason: "retrying",
+            });
+          } else if (isRunningStatus(openCodeStatusType(event))) {
+            sendHook("prompt-submit", ctx, event);
+          }
+          break;
+        case "session.idle":
+          sendHook("stop", ctx, event);
+          break;
+        case "permission.asked":
+          sendHook("notification", ctx, event, {
+            message: openCodeEventMessage(event),
+            reason: "permission_prompt",
+          });
+          break;
+        case "question.asked":
+          sendHook("notification", ctx, event, {
+            message: openCodeEventMessage(event),
+            reason: "question answer",
+          });
+          break;
+        case "session.error":
+          sendHook("notification", ctx, event, {
+            message: openCodeEventMessage(event),
+            reason: "error",
+          });
+          break;
+        case "session.deleted":
+          sendHook("session-end", ctx, event);
+          dropSession(sessionIdFor(event));
+          break;
+        default:
+          break;
+      }
+    },
+  };
+};
+
+export { CMUXSessionRestore };
+export default CMUXSessionRestore;
+"""#
+
+}

--- a/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
+++ b/CLI/CMUXCLI+OpenCodeSessionPluginSource.swift
@@ -236,11 +236,11 @@ function hookEnvironment(cwd) {
 }
 
 function sendHook(subcommand, ctx, event, extra = {}) {
-  if (process.env.CMUX_OPENCODE_HOOKS_DISABLED === "1") return;
-  if (!process.env.CMUX_SURFACE_ID) return;
+  if (process.env.CMUX_OPENCODE_HOOKS_DISABLED === "1") return false;
+  if (!process.env.CMUX_SURFACE_ID) return false;
 
   const sessionId = sessionIdFor(event);
-  if (!sessionId) return;
+  if (!sessionId) return false;
 
   const cwd = cwdFor(ctx, event);
   const state = sessionState(sessionId);
@@ -256,14 +256,16 @@ function sendHook(subcommand, ctx, event, extra = {}) {
   if (context) payload.context = context;
   const cmux = process.env.CMUX_OPENCODE_CMUX_BIN || "cmux";
   try {
-    spawnSync(cmux, ["hooks", "opencode", subcommand], {
+    const result = spawnSync(cmux, ["hooks", "opencode", subcommand], {
       input: JSON.stringify(payload),
       encoding: "utf8",
       env: hookEnvironment(cwd),
       stdio: ["pipe", "ignore", "ignore"],
       timeout: 5000,
     });
+    return !result.error && result.status === 0 && !result.signal;
   } catch (_) {}
+  return false;
 }
 
 function sendStartOnce(ctx, event) {
@@ -271,8 +273,9 @@ function sendStartOnce(ctx, event) {
   if (!sessionId) return;
   const state = sessionState(sessionId);
   if (state.started) return;
-  state.started = true;
-  sendHook("session-start", ctx, event);
+  if (sendHook("session-start", ctx, event)) {
+    state.started = true;
+  }
 }
 
 function sendPromptSubmitOnce(ctx, event) {
@@ -280,9 +283,10 @@ function sendPromptSubmitOnce(ctx, event) {
   if (!sessionId) return;
   const state = sessionState(sessionId);
   if (state.activeTurn) return;
-  state.activeTurn = true;
-  state.retrying = false;
-  sendHook("prompt-submit", ctx, event);
+  if (sendHook("prompt-submit", ctx, event)) {
+    state.activeTurn = true;
+    state.retrying = false;
+  }
 }
 
 function sendStopIfActive(ctx, event) {
@@ -290,9 +294,10 @@ function sendStopIfActive(ctx, event) {
   if (!sessionId) return;
   const state = sessionState(sessionId);
   if (!state.activeTurn && !state.retrying) return;
-  state.activeTurn = false;
-  state.retrying = false;
-  sendHook("stop", ctx, event);
+  if (sendHook("stop", ctx, event)) {
+    state.activeTurn = false;
+    state.retrying = false;
+  }
 }
 
 function trackMessage(event) {
@@ -377,7 +382,7 @@ const CMUXSessionRestore = async (ctx) => {
           break;
         case "session.error":
           sendHook("notification", ctx, event, {
-            message: "OpenCode reported an error",
+            message: "Agent reported an error",
             reason: "error",
           });
           sendStopIfActive(ctx, event);

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -28151,291 +28151,6 @@ struct CMUXCLI {
         }
     }
 
-    private static let openCodeSessionPluginMarker = "cmux-opencode-session-plugin-marker"
-    private static let openCodeSessionPluginFilename = "cmux-session.js"
-    private static let openCodeSessionPluginSource = #"""
-// cmux-opencode-session-plugin-marker v1
-// Bridges OpenCode session lifecycle events into cmux's restorable session store.
-// Installed by `cmux hooks opencode install` or `cmux hooks setup`.
-// DO NOT EDIT MANUALLY. cmux upgrades this file in place.
-
-import { spawnSync } from "node:child_process";
-import * as fs from "node:fs";
-import * as path from "node:path";
-
-const CMUX_PLUGIN_INSTALLED_KEY = Symbol.for("cmux.session.restore.plugin.installed");
-const MAX_TRACKED_SESSIONS = 100;
-const messageRoles = new Map();
-const sessions = new Map();
-
-function firstString(...values) {
-  for (const value of values) {
-    if (typeof value === "string" && value.trim().length > 0) return value.trim();
-  }
-  return null;
-}
-
-function eventProperties(event) {
-  return (event && typeof event === "object" && event.properties) || {};
-}
-
-function normalizeText(value, max = 1000) {
-  if (typeof value !== "string") return null;
-  const normalized = value.replace(/\s+/g, " ").trim();
-  if (!normalized) return null;
-  return normalized.length > max ? `${normalized.slice(0, max - 3)}...` : normalized;
-}
-
-function sessionState(sessionId) {
-  const key = sessionId || "unknown";
-  if (!sessions.has(key)) {
-    sessions.set(key, {
-      lastUserMessage: null,
-      assistantPreamble: null,
-      cwd: null,
-      updatedAt: Date.now(),
-    });
-  }
-  const state = sessions.get(key);
-  state.updatedAt = Date.now();
-  pruneSessions();
-  return state;
-}
-
-function pruneSessions() {
-  while (sessions.size > MAX_TRACKED_SESSIONS) {
-    let oldestKey = null;
-    let oldestUpdatedAt = Infinity;
-    for (const [key, state] of sessions.entries()) {
-      const updatedAt = Number(state && state.updatedAt) || 0;
-      if (updatedAt < oldestUpdatedAt) {
-        oldestUpdatedAt = updatedAt;
-        oldestKey = key;
-      }
-    }
-    if (!oldestKey) break;
-    dropSession(oldestKey);
-  }
-}
-
-function dropSession(sessionId) {
-  const key = sessionId || "unknown";
-  sessions.delete(key);
-  for (const [messageId, meta] of messageRoles.entries()) {
-    if (meta && meta.sessionId === key) {
-      messageRoles.delete(messageId);
-    }
-  }
-}
-
-function contextForSession(sessionId) {
-  const state = sessionState(sessionId);
-  const context = {};
-  if (state.lastUserMessage) context.lastUserMessage = state.lastUserMessage;
-  if (state.assistantPreamble) context.assistantPreamble = state.assistantPreamble;
-  return Object.keys(context).length > 0 ? context : undefined;
-}
-
-function sessionIdFor(event) {
-  const props = eventProperties(event);
-  return firstString(
-    props.info && props.info.id,
-    props.sessionID,
-    props.sessionId,
-    props.session_id,
-    props.session && props.session.id,
-    event && event.sessionID,
-    event && event.sessionId,
-    event && event.id
-  );
-}
-
-function cwdFor(ctx, event) {
-  const props = eventProperties(event);
-  return firstString(
-    props.info && props.info.directory,
-    props.cwd,
-    props.directory,
-    ctx && ctx.directory,
-    process.cwd()
-  );
-}
-
-function resolveExecutable(name) {
-  const pathEnv = process.env.PATH || "";
-  for (const dir of pathEnv.split(path.delimiter)) {
-    if (!dir) continue;
-    const candidate = path.join(dir, name);
-    try {
-      fs.accessSync(candidate, fs.constants.X_OK);
-      return candidate;
-    } catch (_) {}
-  }
-  return name;
-}
-
-function looksLikeOpenCodeScript(value) {
-  if (!value) return false;
-  const lower = String(value).toLowerCase();
-  return lower.includes("opencode") || lower.includes("open-code");
-}
-
-function isOpenCodeInternalWorkerArg(value) {
-  if (!value) return false;
-  const normalized = String(value).replaceAll("\\", "/");
-  return normalized.includes("/$bunfs/") && normalized.endsWith("/tui/worker.js");
-}
-
-function withoutOpenCodeInternalWorkerArgs(argv) {
-  const result = [];
-  for (let i = 0; i < argv.length; i += 1) {
-    const value = argv[i];
-    if (i > 0 && isOpenCodeInternalWorkerArg(value)) continue;
-    result.push(value);
-  }
-  return result.length > 0 ? result : [resolveExecutable("opencode")];
-}
-
-function normalizedLaunchArgv() {
-  const raw = Array.isArray(process.argv) ? process.argv.map((value) => String(value)) : [];
-  if (raw.length === 0) return [resolveExecutable("opencode")];
-
-  const firstBase = path.basename(raw[0]).toLowerCase();
-  if (looksLikeOpenCodeScript(firstBase)) return withoutOpenCodeInternalWorkerArgs(raw);
-
-  let tail = raw.slice(1);
-  if (tail.length > 0 && looksLikeOpenCodeScript(tail[0])) {
-    tail = tail.slice(1);
-  }
-  return withoutOpenCodeInternalWorkerArgs([resolveExecutable("opencode"), ...tail]);
-}
-
-function base64NulSeparated(values) {
-  const bytes = [];
-  for (const value of values) {
-    bytes.push(Buffer.from(String(value), "utf8"));
-    bytes.push(Buffer.from([0]));
-  }
-  return Buffer.concat(bytes).toString("base64");
-}
-
-function hookEnvironment(cwd) {
-  const env = { ...process.env };
-  delete env.AMP_API_KEY;
-  if (!env.CMUX_AGENT_LAUNCH_ARGV_B64) {
-    const argv = normalizedLaunchArgv();
-    env.CMUX_AGENT_LAUNCH_KIND = "opencode";
-    env.CMUX_AGENT_LAUNCH_EXECUTABLE = argv[0] || resolveExecutable("opencode");
-    env.CMUX_AGENT_LAUNCH_ARGV_B64 = base64NulSeparated(argv);
-    env.CMUX_AGENT_LAUNCH_CWD = cwd || process.cwd();
-  }
-  return env;
-}
-
-function sendHook(subcommand, ctx, event, extra = {}) {
-  if (process.env.CMUX_OPENCODE_HOOKS_DISABLED === "1") return;
-  if (!process.env.CMUX_SURFACE_ID) return;
-
-  const sessionId = sessionIdFor(event);
-  if (!sessionId) return;
-
-  const cwd = cwdFor(ctx, event);
-  const state = sessionState(sessionId);
-  state.cwd = cwd || state.cwd;
-  const payload = {
-    session_id: sessionId,
-    cwd,
-    event: event && event.type,
-    hook_event_name: event && event.type,
-    ...extra,
-  };
-  const context = extra.context || contextForSession(sessionId);
-  if (context) payload.context = context;
-  const cmux = process.env.CMUX_OPENCODE_CMUX_BIN || "cmux";
-  try {
-    spawnSync(cmux, ["hooks", "opencode", subcommand], {
-      input: JSON.stringify(payload),
-      encoding: "utf8",
-      env: hookEnvironment(cwd),
-      stdio: ["pipe", "ignore", "ignore"],
-      timeout: 5000,
-    });
-  } catch (_) {}
-}
-
-function trackMessage(event) {
-  const props = eventProperties(event);
-  if (event && event.type === "message.updated") {
-    const info = props.info || props.message || {};
-    const messageId = info.id || props.messageID;
-    const sessionId = info.sessionID || props.sessionID;
-    const role = info.role || props.role;
-    if (messageId && sessionId && role) {
-      messageRoles.set(messageId, { sessionId, role });
-      if (messageRoles.size > 300) {
-        messageRoles.delete(messageRoles.keys().next().value);
-      }
-    }
-    return;
-  }
-
-  if (!event || event.type !== "message.part.updated") return;
-  const part = props.part || {};
-  if (part.type !== "text" || !part.messageID) return;
-  const meta = messageRoles.get(part.messageID);
-  if (!meta) return;
-  const text = normalizeText(part.text || part.textDelta || part.content);
-  if (!text) return;
-  const state = sessionState(meta.sessionId);
-  if (meta.role === "user") {
-    state.lastUserMessage = text;
-  } else if (meta.role === "assistant") {
-    state.assistantPreamble = text;
-  }
-}
-
-const CMUXSessionRestore = async (ctx) => {
-  if (globalThis[CMUX_PLUGIN_INSTALLED_KEY]) return {};
-  globalThis[CMUX_PLUGIN_INSTALLED_KEY] = true;
-  return {
-    event: async ({ event }) => {
-      trackMessage(event);
-      const props = eventProperties(event);
-      switch (event && event.type) {
-        case "session.created":
-          sendHook("session-start", ctx, event);
-          break;
-        case "session.updated":
-          if (props.info && props.info.time && props.info.time.archived) {
-            sendHook("session-end", ctx, event);
-            dropSession(sessionIdFor(event));
-          } else {
-            sendHook("session-start", ctx, event);
-          }
-          break;
-        case "session.status":
-          if (props.status && props.status.type === "idle") {
-            sendHook("stop", ctx, event);
-          }
-          break;
-        case "session.idle":
-          sendHook("stop", ctx, event);
-          break;
-        case "session.deleted":
-          sendHook("session-end", ctx, event);
-          dropSession(sessionIdFor(event));
-          break;
-        default:
-          break;
-      }
-    },
-  };
-};
-
-export { CMUXSessionRestore };
-export default CMUXSessionRestore;
-"""#
-
     private func openCodeSessionPluginURL(for def: AgentHookDef) -> URL {
         URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
             .appendingPathComponent("plugins", isDirectory: true)
@@ -31389,6 +31104,61 @@ export default CMUXSessionRestore;
             let surfaceId = target.surfaceId
 
             let notificationCwd = hookCwd ?? mapped?.cwd
+            if def.name == "opencode",
+               (input.rawObject?["cmux_status"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "retrying" {
+                let pid = mapped?.pid ?? inferredPID
+                let launchCommand = agentLaunchCommandFromEnvironment(
+                    env,
+                    fallbackPID: pid,
+                    fallbackKind: def.name,
+                    cwd: notificationCwd
+                )
+                if !sessionId.isEmpty {
+                    try? store.upsert(
+                        sessionId: sessionId,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        cwd: notificationCwd,
+                        transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
+                        pid: pid,
+                        launchCommand: launchCommand,
+                        agentLifecycle: .running,
+                        runtimeStatus: .running,
+                        updateRuntimeStatus: true
+                    )
+                    publishAgentSurfaceResumeBinding(
+                        client: client,
+                        workspaceId: workspaceId,
+                        surfaceId: surfaceId,
+                        kind: def.name,
+                        displayName: def.displayName,
+                        sessionId: sessionId,
+                        cwd: notificationCwd,
+                        launchCommand: launchCommand ?? mapped?.launchCommand
+                    )
+                }
+                if let pid {
+                    _ = try? sendV1Command(
+                        "set_agent_pid \(pidKey) \(pid) --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
+                        client: client
+                    )
+                }
+                setAgentLifecycle(
+                    client: client,
+                    key: def.statusKey,
+                    lifecycle: .running,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId
+                )
+                let retryingStatus = String(localized: "agent.generic.status.retrying", defaultValue: "Retrying")
+                _ = try? sendV1Command(
+                    "set_status \(def.statusKey) \(retryingStatus) --icon=arrow.triangle.2.circlepath --color=#FF9500 --tab=\(workspaceId)\(socketPanelOption(surfaceId))",
+                    client: client
+                )
+                sendAgentFeedTelemetryUnlessSuppressed(workspaceId: workspaceId, surfaceId: surfaceId)
+                print("{}")
+                return
+            }
 #if DEBUG
             agentHookDebugLog(
                 "agentHook.notification.target agent=\(def.name) session=\(agentHookDebugShort(sessionId)) workspace=\(agentHookDebugShort(workspaceId)) surface=\(agentHookDebugShort(surfaceId)) mapped=\(mapped == nil ? 0 : 1) hasCwd=\(notificationCwd == nil ? 0 : 1)",

--- a/Resources/bin/cmux-opencode-wrapper
+++ b/Resources/bin/cmux-opencode-wrapper
@@ -82,6 +82,78 @@ cmux_socket_available() {
         "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
 }
 
+# opencode subcommands that never start a session (and thus never load
+# ~/.config/opencode plugins). Sourced from `opencode --help`. When the first
+# non-option token is one of these, the plugin install is pure latency.
+# Conservative: bare `opencode`, a project path, and any UNKNOWN leading token
+# default to "needs plugin" so a new opencode subcommand can never be silently
+# skipped.
+opencode_known_non_session_subcommand() {
+    case "$1" in
+        completion|mcp|debug|providers|auth|agent|upgrade|uninstall|\
+        models|stats|export|import|github|session|plugin|plug|db)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+opencode_passthrough_option_flag() {
+    case "$1" in
+        --help|-h|--version|-v|-V)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+opencode_option_consumes_value() {
+    case "$1" in
+        -m|--model|-s|--session|--prompt|--agent|\
+        --port|--hostname|--mdns-domain|--cors|--replay-limit|--log-level)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+# Whether this invocation could load opencode plugins (i.e. starts or continues
+# a session). Mirrors should_inject_codex_hooks in cmux-codex-wrapper: a leading
+# --help/--version or a known non-session subcommand means skip; everything else
+# (bare opencode, a project path, `run`, `pr`, an unknown future subcommand) is
+# treated as a session and receives the install.
+opencode_invocation_needs_plugin() {
+    (( $# == 0 )) && return 0
+
+    local arg skip_next=false
+    for arg in "$@"; do
+        if [[ "$skip_next" == true ]]; then
+            skip_next=false
+            continue
+        fi
+        case "$arg" in
+            --)
+                return 0
+                ;;
+            -*)
+                if opencode_passthrough_option_flag "$arg"; then
+                    return 1
+                fi
+                if [[ "$arg" != *=* ]] && opencode_option_consumes_value "$arg"; then
+                    skip_next=true
+                fi
+                continue
+                ;;
+            *)
+                opencode_known_non_session_subcommand "$arg" && return 1
+                return 0
+                ;;
+        esac
+    done
+
+    return 0
+}
+
 REAL_OPENCODE="$(find_real_opencode || true)"
 if [[ -z "$REAL_OPENCODE" ]]; then
     exec opencode "$@"
@@ -89,7 +161,9 @@ fi
 
 if [[ "${CMUX_OPENCODE_HOOKS_DISABLED:-}" != "1" &&
       -n "${CMUX_SURFACE_ID:-}" &&
-      -n "${CMUX_SOCKET_PATH:-}" ]] && cmux_socket_available; then
+      -n "${CMUX_SOCKET_PATH:-}" ]] &&
+   opencode_invocation_needs_plugin "$@" &&
+   cmux_socket_available; then
     CMUX_BIN="$(resolve_hook_cmux_bin)"
     export CMUX_OPENCODE_CMUX_BIN="$CMUX_BIN"
     "$CMUX_BIN" hooks opencode install --yes >/dev/null 2>&1 || true

--- a/Resources/bin/cmux-opencode-wrapper
+++ b/Resources/bin/cmux-opencode-wrapper
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# cmux opencode wrapper - installs cmux's OpenCode plugin when inside cmux.
+#
+# Outside cmux, or when hooks are disabled, this wrapper passes through to the
+# real opencode binary unchanged. Inside a live cmux terminal it best-effort
+# installs the bundled OpenCode plugin so OpenCode lifecycle events can update
+# cmux sidebar status.
+
+cmux_opencode_wrapper_is_self_or_shim() {
+    local candidate="$1"
+    [[ -n "$candidate" ]] || return 1
+    if [[ -e "$candidate" && "$candidate" -ef "$0" ]]; then
+        return 0
+    fi
+    case "$candidate" in
+        */cmux-cli-shims/*/opencode|*/cmux-cli-shims/opencode)
+            return 0
+            ;;
+        */Contents/Resources/bin/opencode|*/Resources/bin/opencode|*/cmux-opencode-wrapper)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+find_real_opencode() {
+    local custom="${CMUX_CUSTOM_OPENCODE_PATH:-}"
+    custom="${custom#"${custom%%[![:space:]]*}"}"
+    custom="${custom%"${custom##*[![:space:]]}"}"
+    if [[ -n "$custom" && -f "$custom" && -x "$custom" ]]; then
+        if ! cmux_opencode_wrapper_is_self_or_shim "$custom"; then
+            printf '%s' "$custom"
+            return 0
+        fi
+    fi
+
+    local self_dir
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    local IFS=:
+    for d in $PATH; do
+        [[ "$d" == "$self_dir" ]] && continue
+        local candidate="$d/opencode"
+        cmux_opencode_wrapper_is_self_or_shim "$candidate" && continue
+        [[ -x "$candidate" ]] && printf '%s' "$candidate" && return 0
+    done
+    return 1
+}
+
+resolve_hook_cmux_bin() {
+    local self_dir bundled_cli
+    bundled_cli="${CMUX_BUNDLED_CLI_PATH:-}"
+    if [[ -n "$bundled_cli" && -x "$bundled_cli" ]]; then
+        printf '%s' "$bundled_cli"
+        return 0
+    fi
+
+    self_dir="$(cd "$(dirname "$0")" && pwd)"
+    bundled_cli="$self_dir/cmux"
+    if [[ -x "$bundled_cli" ]]; then
+        printf '%s' "$bundled_cli"
+        return 0
+    fi
+
+    bundled_cli="$(command -v cmux 2>/dev/null || true)"
+    if [[ -n "$bundled_cli" ]]; then
+        printf '%s' "$bundled_cli"
+        return 0
+    fi
+
+    printf '%s' "cmux"
+}
+
+cmux_socket_available() {
+    local socket="${CMUX_SOCKET_PATH:-}"
+    [[ -n "$socket" && -S "$socket" ]] || return 1
+
+    local cmux_bin
+    cmux_bin="$(resolve_hook_cmux_bin)"
+    [[ -n "$cmux_bin" ]] || return 1
+
+    CMUXTERM_CLI_RESPONSE_TIMEOUT_SEC=0.75 \
+        "$cmux_bin" --socket "$socket" ping >/dev/null 2>&1
+}
+
+REAL_OPENCODE="$(find_real_opencode || true)"
+if [[ -z "$REAL_OPENCODE" ]]; then
+    exec opencode "$@"
+fi
+
+if [[ "${CMUX_OPENCODE_HOOKS_DISABLED:-}" != "1" &&
+      -n "${CMUX_SURFACE_ID:-}" &&
+      -n "${CMUX_SOCKET_PATH:-}" ]] && cmux_socket_available; then
+    CMUX_BIN="$(resolve_hook_cmux_bin)"
+    export CMUX_OPENCODE_CMUX_BIN="$CMUX_BIN"
+    "$CMUX_BIN" hooks opencode install --yes >/dev/null 2>&1 || true
+fi
+
+exec "$REAL_OPENCODE" "$@"

--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -340,6 +340,7 @@ _cmux_install_cli_wrapper() {
 }
 _cmux_install_cli_wrapper claude _CMUX_CLAUDE_WRAPPER cmux-claude-wrapper
 _cmux_install_cli_wrapper grok _CMUX_GROK_WRAPPER
+_cmux_install_cli_wrapper opencode _CMUX_OPENCODE_WRAPPER cmux-opencode-wrapper
 _cmux_now() {
     printf '%s\n' "${EPOCHSECONDS:-$SECONDS}"
 }

--- a/Resources/shell-integration/cmux-zsh-integration.zsh
+++ b/Resources/shell-integration/cmux-zsh-integration.zsh
@@ -365,6 +365,7 @@ _cmux_install_cli_wrapper() {
 }
 _cmux_install_cli_wrapper claude _CMUX_CLAUDE_WRAPPER cmux-claude-wrapper
 _cmux_install_cli_wrapper grok _CMUX_GROK_WRAPPER
+_cmux_install_cli_wrapper opencode _CMUX_OPENCODE_WRAPPER cmux-opencode-wrapper
 
 _cmux_normalize_claude_config_dir() {
     [[ -n "${CLAUDE_CONFIG_DIR:-}" && -n "${HOME:-}" ]] || return 0
@@ -1906,6 +1907,7 @@ _cmux_fix_path() {
     fi
     _cmux_install_cli_wrapper claude _CMUX_CLAUDE_WRAPPER cmux-claude-wrapper
     _cmux_install_cli_wrapper grok _CMUX_GROK_WRAPPER
+    _cmux_install_cli_wrapper opencode _CMUX_OPENCODE_WRAPPER cmux-opencode-wrapper
     add-zsh-hook -d precmd _cmux_fix_path
 }
 

--- a/Resources/shell-integration/fish/config.fish
+++ b/Resources/shell-integration/fish/config.fish
@@ -233,11 +233,16 @@ if test "$_cmux_integration_enabled" != 0
                 function grok --wraps "$wrapper_path" --inherit-variable wrapper_path
                     "$wrapper_path" $argv
                 end
+            case opencode
+                function opencode --wraps "$wrapper_path" --inherit-variable wrapper_path
+                    "$wrapper_path" $argv
+                end
         end
     end
 
     _cmux_install_cli_wrapper claude cmux-claude-wrapper
     _cmux_install_cli_wrapper grok grok
+    _cmux_install_cli_wrapper opencode cmux-opencode-wrapper
 
     function _cmux_report_tty_once
         test "$_CMUX_TTY_REPORTED" = 1; and return 0

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -379,6 +379,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */ = {isa = PBXBuildFile; fileRef = B9000004A1B2C3D4E5F60719 /* cmux */; };
 		C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */; };
 		C1ADE30002A1B2C3D4E5F719 /* cmux-codex-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE30001A1B2C3D4E5F719 /* cmux-codex-wrapper */; };
+		C1ADE40002A1B2C3D4E5F719 /* cmux-opencode-wrapper in Copy CLI */ = {isa = PBXBuildFile; fileRef = C1ADE40001A1B2C3D4E5F719 /* cmux-opencode-wrapper */; };
 		A5001623 /* cmux.sdef in Resources */ = {isa = PBXBuildFile; fileRef = A5001622 /* cmux.sdef */; };
 		B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000001A1B2C3D4E5F60719 /* cmux.swift */; };
 		C0DE1A060000000000000001 /* cmux_layout.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE1A060000000000000002 /* cmux_layout.swift */; };
@@ -1770,6 +1771,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 				B900000BA1B2C3D4E5F60719 /* cmux in Copy CLI */,
 				C1ADE20002A1B2C3D4E5F719 /* cmux-claude-wrapper in Copy CLI */,
 				C1ADE30002A1B2C3D4E5F719 /* cmux-codex-wrapper in Copy CLI */,
+				C1ADE40002A1B2C3D4E5F719 /* cmux-opencode-wrapper in Copy CLI */,
 				C1ADE10002A1B2C3D4E5F719 /* grok in Copy CLI */,
 					D1BEF00002A1B2C3D4E5F719 /* open in Copy CLI */,
 					C0DE70500000000000000002 /* start-cmux-profiling in Copy CLI */,
@@ -2162,6 +2164,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001018 /* cmux-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "cmux-Bridging-Header.h"; sourceTree = "<group>"; };
 		C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-claude-wrapper"; sourceTree = SOURCE_ROOT; };
 		C1ADE30001A1B2C3D4E5F719 /* cmux-codex-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-codex-wrapper"; sourceTree = SOURCE_ROOT; };
+		C1ADE40001A1B2C3D4E5F719 /* cmux-opencode-wrapper */ = {isa = PBXFileReference; lastKnownFileType = text.script.sh; path = "Resources/bin/cmux-opencode-wrapper"; sourceTree = SOURCE_ROOT; };
 		A5001000 /* cmux.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = cmux.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		A5001622 /* cmux.sdef */ = {isa = PBXFileReference; lastKnownFileType = text.sdef; path = cmux.sdef; sourceTree = "<group>"; };
 		B9000001A1B2C3D4E5F60719 /* cmux.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = cmux.swift; sourceTree = "<group>"; };
@@ -3539,6 +3542,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
 					C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */,
 					C1ADE30001A1B2C3D4E5F719 /* cmux-codex-wrapper */,
+					C1ADE40001A1B2C3D4E5F719 /* cmux-opencode-wrapper */,
 					C1ADE10001A1B2C3D4E5F719 /* grok */,
 					C0DE70500000000000000001 /* start-cmux-profiling */,
 					C0DE70530000000000000001 /* submit-cmux-profile */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -431,6 +431,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B9000071A1B2C3D4E5F60719 /* CMUXCLI+Memory.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000070A1B2C3D4E5F60719 /* CMUXCLI+Memory.swift */; };
 		D7AB0000000000000000000D /* CMUXCLI+MoveTabToNewWorkspace.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB0000000000000000000E /* CMUXCLI+MoveTabToNewWorkspace.swift */; };
 		B9000072A1B2C3D4E5F60719 /* CMUXCLI+OmpExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000073A1B2C3D4E5F60719 /* CMUXCLI+OmpExtension.swift */; };
+		C14250020000000000000002 /* CMUXCLI+OpenCodeSessionPluginSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C14250010000000000000002 /* CMUXCLI+OpenCodeSessionPluginSource.swift */; };
 		C05555010000000000000001 /* CMUXCLI+PiExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05555010000000000000002 /* CMUXCLI+PiExtension.swift */; };
 		C05555010000000000000003 /* CMUXCLI+PiExtensionSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05555010000000000000004 /* CMUXCLI+PiExtensionSource.swift */; };
 		C05555010000000000000005 /* CMUXCLI+PiExtensionSourcePart1.swift in Sources */ = {isa = PBXBuildFile; fileRef = C05555010000000000000006 /* CMUXCLI+PiExtensionSourcePart1.swift */; };
@@ -2200,6 +2201,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B9000070A1B2C3D4E5F60719 /* CMUXCLI+Memory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+Memory.swift"; sourceTree = "<group>"; };
 		D7AB0000000000000000000E /* CMUXCLI+MoveTabToNewWorkspace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+MoveTabToNewWorkspace.swift"; sourceTree = "<group>"; };
 		B9000073A1B2C3D4E5F60719 /* CMUXCLI+OmpExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+OmpExtension.swift"; sourceTree = "<group>"; };
+		C14250010000000000000002 /* CMUXCLI+OpenCodeSessionPluginSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+OpenCodeSessionPluginSource.swift"; sourceTree = "<group>"; };
 		C05555010000000000000002 /* CMUXCLI+PiExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+PiExtension.swift"; sourceTree = "<group>"; };
 		C05555010000000000000004 /* CMUXCLI+PiExtensionSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+PiExtensionSource.swift"; sourceTree = "<group>"; };
 		C05555010000000000000006 /* CMUXCLI+PiExtensionSourcePart1.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+PiExtensionSourcePart1.swift"; sourceTree = "<group>"; };
@@ -4778,6 +4780,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B9000069A1B2C3D4E5F60719 /* CMUXCLI+AmpExtension.swift */,
 				C0D3F1F00000000000000102 /* CMUXCLI+CodexFireAndForgetHooks.swift */,
 				B9000073A1B2C3D4E5F60719 /* CMUXCLI+OmpExtension.swift */,
+				C14250010000000000000002 /* CMUXCLI+OpenCodeSessionPluginSource.swift */,
 				B9000075A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtension.swift */,
 				B9000079A1B2C3D4E5F60719 /* CMUXCLI+CampfireExtensionInstall.swift */,
 				B9000077A1B2C3D4E5F60719 /* CMUXCLI+CampfireNotifications.swift */,
@@ -6781,6 +6784,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B9000071A1B2C3D4E5F60719 /* CMUXCLI+Memory.swift in Sources */,
 				D7AB0000000000000000000D /* CMUXCLI+MoveTabToNewWorkspace.swift in Sources */,
 				B9000072A1B2C3D4E5F60719 /* CMUXCLI+OmpExtension.swift in Sources */,
+				C14250020000000000000002 /* CMUXCLI+OpenCodeSessionPluginSource.swift in Sources */,
 				C05555010000000000000001 /* CMUXCLI+PiExtension.swift in Sources */,
 				C05555010000000000000003 /* CMUXCLI+PiExtensionSource.swift in Sources */,
 						C05555010000000000000005 /* CMUXCLI+PiExtensionSourcePart1.swift in Sources */,

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -2,7 +2,7 @@
 
 cmux uses agent hooks to show running state, Feed approvals, notifications, and to restore agent sessions after a normal app relaunch.
 
-Claude Code is handled by the cmux Claude wrapper when Claude Code integration is enabled in Settings. OpenCode is also wrapped: the cmux OpenCode wrapper auto-installs its session plugin the first time you run `opencode` inside a cmux terminal, so no separate setup step is required. Other agents are installed with:
+Claude Code is handled by the cmux Claude wrapper when Claude Code integration is enabled in Settings. OpenCode is also wrapped: the cmux OpenCode wrapper auto-installs the cmux OpenCode plugins (session and Feed) the first time you run `opencode` inside a cmux terminal, so no separate setup step is required. Other agents are installed with:
 
 ```bash
 cmux hooks setup

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -2,7 +2,7 @@
 
 cmux uses agent hooks to show running state, Feed approvals, notifications, and to restore agent sessions after a normal app relaunch.
 
-Claude Code is handled by the cmux Claude wrapper when Claude Code integration is enabled in Settings. Other agents are installed with:
+Claude Code is handled by the cmux Claude wrapper when Claude Code integration is enabled in Settings. OpenCode is also wrapped: the cmux OpenCode wrapper auto-installs its session plugin the first time you run `opencode` inside a cmux terminal, so no separate setup step is required. Other agents are installed with:
 
 ```bash
 cmux hooks setup
@@ -20,7 +20,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, 
 | Claude Code | `claude` through wrapper | wrapper-injected settings | `claude --resume <id>` | PermissionRequest |
 | Codex | `codex` | `~/.codex/hooks.json`, `~/.codex/config.toml` | `codex resume <id>` | PreToolUse, PermissionRequest telemetry |
 | Grok | `grok` | `~/.grok/hooks/cmux-session.json` | `grok -r <id>` | PreToolUse |
-| OpenCode | `opencode` | `~/.config/opencode/plugins/cmux-session.js`, `~/.config/opencode/plugins/cmux-feed.js` | `opencode --session <id>` | plugin event bus |
+| OpenCode | `opencode` through wrapper | `~/.config/opencode/plugins/cmux-session.js`, `~/.config/opencode/plugins/cmux-feed.js` | `opencode --session <id>` | plugin event bus |
 | Pi | `pi` | `~/.pi/agent/extensions/cmux-session.ts` | `pi --session <id>` | tool_execution_start / tool_execution_end telemetry |
 | OMP | `omp` | `~/.omp/agent/extensions/cmux-omp-session.ts` or `$PI_CODING_AGENT_DIR/extensions/cmux-omp-session.ts` | `omp --session <id>` | none |
 | Campfire | `campfire` | `~/.campfire/agent/extensions/cmux-campfire-session.ts` or `$CAMPFIRE_CODING_AGENT_DIR/extensions/cmux-campfire-session.ts` | `campfire --session <id>` | none |
@@ -52,6 +52,8 @@ The sanitizer preserves model, sandbox, config, and cwd-related flags. It drops 
 Claude Code's `PushNotification` tool (model-initiated "notify the user now" pushes) is bridged through a `PostToolUse` hook into cmux notifications. The tool normally delivers via a raw OSC desktop notification, which cmux suppresses on surfaces running a hook-integrated agent, so the bridge is what makes those pushes visible inside cmux. It mirrors the tool's own outcome: a push the tool reports as skipped (user active, channel disabled) is not duplicated.
 
 Grok uses its `Notification` hook for user-facing completion messages. cmux records `Stop` as idle state, but leaves the visible notification text to the `Notification` payload so repeated turns keep Grok's own message instead of a generic completion fallback.
+
+OpenCode's session plugin surfaces actionable moments as cmux notifications: permission prompts (`permission.asked`), questions (`question.asked`), and errors (`session.error`). A `session.status` event with a retrying type flips the sidebar status pill to a localized "Retrying" indicator (and marks the session running) so a stalled retry is visible without watching the terminal; a running status drives `prompt-submit` and an idle status drives `stop`, matching the other agents' turn lifecycle.
 
 ## Workspace auto-naming
 

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -170,4 +170,4 @@ Double-click a Feed row and cmux focuses the cmux workspace + surface where the 
 
 **Notifications aren't showing inline buttons.** The three Feed categories (`CMUXFeedPermission`, `CMUXFeedExitPlan`, `CMUXFeedQuestion`) are registered at app launch. On first Feed use, macOS may prompt for notification authorization; if authorization is denied, Feed rows still appear in the sidebar but no native banner is delivered.
 
-**OpenCode plugin doesn't fire.** Plugin is only installed if `opencode` is on `PATH` at `cmux hooks setup` time. Check `~/.config/opencode/plugins/cmux-feed.js` contains `// cmux-feed-plugin-marker v1`. If you added project-local plugins (`.opencode/plugins/…`), re-run `cmux hooks opencode install --project`.
+**OpenCode plugin doesn't fire.** The plugin is installed by `cmux hooks setup`, or automatically by the cmux OpenCode wrapper the first time you run `opencode` inside a cmux terminal. Check `~/.config/opencode/plugins/cmux-feed.js` contains `// cmux-feed-plugin-marker v1`. If you added project-local plugins (`.opencode/plugins/…`), re-run `cmux hooks opencode install --project`.

--- a/tests/test_opencode_plugin_install.py
+++ b/tests/test_opencode_plugin_install.py
@@ -108,12 +108,31 @@ def main() -> int:
 
         opencode = shutil.which("opencode")
         if opencode is not None:
+            debug_config_dir = root / "opencode-debug"
+            debug_config_dir.mkdir(parents=True, exist_ok=True)
+            debug_env = env.copy()
+            debug_env["OPENCODE_CONFIG_DIR"] = str(debug_config_dir)
+            debug_install = subprocess.run(
+                [cli_path, "hooks", "opencode", "install", "--yes"],
+                capture_output=True,
+                text=True,
+                check=False,
+                env=debug_env,
+                timeout=20,
+            )
+            if debug_install.returncode != 0:
+                print("FAIL: opencode plugin debug install failed")
+                print(f"exit={debug_install.returncode}")
+                print(f"stdout={debug_install.stdout.strip()}")
+                print(f"stderr={debug_install.stderr.strip()}")
+                return 1
+            debug_plugin_path = debug_config_dir / "plugins" / "cmux-session.js"
             debug = subprocess.run(
                 [opencode, "--print-logs", "--log-level", "DEBUG", "debug", "config"],
                 capture_output=True,
                 text=True,
                 check=False,
-                env=env,
+                env=debug_env,
                 timeout=30,
             )
             debug_output = debug.stdout + "\n" + debug.stderr
@@ -126,7 +145,11 @@ def main() -> int:
                 print("FAIL: opencode tried to resolve cmux-session as a package")
                 print(debug_output[-4000:])
                 return 1
-            if f"file://{plugin_path}" not in debug_output:
+            plugin_urls = {
+                f"file://{debug_plugin_path}",
+                f"file://{debug_plugin_path.resolve()}",
+            }
+            if not any(url in debug_output for url in plugin_urls):
                 print("FAIL: opencode did not auto-load cmux session plugin file")
                 print(debug_output[-4000:])
                 return 1
@@ -198,6 +221,59 @@ await hooks.event({
     }
   }
 });
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
+      status: { type: "running" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
+      status: { type: "retrying" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "permission.asked",
+    properties: {
+      sessionID: "opencode-session-test",
+      message: "Allow shell command?"
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "question.asked",
+    properties: {
+      sessionID: "opencode-session-test",
+      question: { question: "Which model?" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.error",
+    properties: {
+      sessionID: "opencode-session-test",
+      error: { message: "provider failed" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.idle",
+    properties: {
+      sessionID: "opencode-session-test"
+    }
+  }
+});
 """
         check = subprocess.run(
             [bun, "--eval", check_source],
@@ -224,9 +300,29 @@ await hooks.event({
         if args_log.count("hooks opencode session-start") != 1:
             print(f"FAIL: plugin invoked duplicate session-start hooks, got {args_log!r}")
             return 1
+        for expected in [
+            "hooks opencode prompt-submit",
+            "hooks opencode notification",
+            "hooks opencode stop",
+        ]:
+            if expected not in args_log:
+                print(f"FAIL: plugin did not invoke {expected}, got {args_log!r}")
+                return 1
+        if args_log.count("hooks opencode notification") != 4:
+            print(f"FAIL: plugin should notify for retry, permission, question, and error events; got {args_log!r}")
+            return 1
         if '"session_id":"opencode-session-test"' not in stdin_log or '"/tmp/opencode-project"' not in stdin_log:
             print(f"FAIL: plugin did not pass expected session payload, got {stdin_log!r}")
             return 1
+        for expected in [
+            '"cmux_status":"retrying"',
+            '"reason":"permission_prompt"',
+            '"reason":"question answer"',
+            '"reason":"error"',
+        ]:
+            if expected not in stdin_log:
+                print(f"FAIL: plugin did not pass expected status payload {expected}, got {stdin_log!r}")
+                return 1
         if "kind=opencode" not in env_log or "cwd=/tmp/opencode-project" not in env_log or "argv=" not in env_log:
             print(f"FAIL: plugin did not pass launch metadata environment, got {env_log!r}")
             return 1

--- a/tests/test_opencode_plugin_install.py
+++ b/tests/test_opencode_plugin_install.py
@@ -172,12 +172,17 @@ printf '\\n---\\n' >> "$FAKE_CMUX_STDIN_LOG"
   printf 'cwd=%s\\n' "${CMUX_AGENT_LAUNCH_CWD-}"
   printf 'argv=%s\\n' "${CMUX_AGENT_LAUNCH_ARGV_B64-}"
 } >> "$FAKE_CMUX_ENV_LOG"
+if [[ -n "${FAKE_CMUX_FAIL_ONCE_MATCH-}" && -n "${FAKE_CMUX_FAIL_ONCE_MARKER-}" && "$*" == *"$FAKE_CMUX_FAIL_ONCE_MATCH"* && ! -e "$FAKE_CMUX_FAIL_ONCE_MARKER" ]]; then
+  : > "$FAKE_CMUX_FAIL_ONCE_MARKER"
+  exit 42
+fi
 """,
         )
 
         check_env = env.copy()
         check_env["CMUX_TEST_OPENCODE_PLUGIN_PATH"] = str(plugin_path)
         check_env["CMUX_TEST_OPENCODE_PLUGIN_COPY_PATH"] = str(plugin_copy_path)
+        check_env["CMUX_TEST_OPENCODE_FAILURE_MARKER_DIR"] = str(root)
         check_env["CMUX_SURFACE_ID"] = "surface-opencode-test"
         check_env["CMUX_OPENCODE_CMUX_BIN"] = str(fake_cmux)
         check_env["FAKE_CMUX_ARGS_LOG"] = str(fake_args_log)
@@ -311,6 +316,106 @@ await hooks.event({
     }
   }
 });
+process.env.FAKE_CMUX_FAIL_ONCE_MATCH = "hooks opencode session-start";
+process.env.FAKE_CMUX_FAIL_ONCE_MARKER = `${process.env.CMUX_TEST_OPENCODE_FAILURE_MARKER_DIR}/start-failed-once`;
+await hooks.event({
+  event: {
+    type: "session.created",
+    properties: {
+      info: {
+        id: "opencode-start-failure-test",
+        directory: "/tmp/opencode-project"
+      }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.updated",
+    properties: {
+      info: {
+        id: "opencode-start-failure-test",
+        title: "retry start"
+      }
+    }
+  }
+});
+delete process.env.FAKE_CMUX_FAIL_ONCE_MATCH;
+delete process.env.FAKE_CMUX_FAIL_ONCE_MARKER;
+await hooks.event({
+  event: {
+    type: "session.created",
+    properties: {
+      info: {
+        id: "opencode-prompt-failure-test",
+        directory: "/tmp/opencode-project"
+      }
+    }
+  }
+});
+process.env.FAKE_CMUX_FAIL_ONCE_MATCH = "hooks opencode prompt-submit";
+process.env.FAKE_CMUX_FAIL_ONCE_MARKER = `${process.env.CMUX_TEST_OPENCODE_FAILURE_MARKER_DIR}/prompt-failed-once`;
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-prompt-failure-test",
+      status: { type: "running" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-prompt-failure-test",
+      status: { type: "streaming" }
+    }
+  }
+});
+delete process.env.FAKE_CMUX_FAIL_ONCE_MATCH;
+delete process.env.FAKE_CMUX_FAIL_ONCE_MARKER;
+await hooks.event({
+  event: {
+    type: "session.created",
+    properties: {
+      info: {
+        id: "opencode-stop-failure-test",
+        directory: "/tmp/opencode-project"
+      }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-stop-failure-test",
+      status: { type: "running" }
+    }
+  }
+});
+process.env.FAKE_CMUX_FAIL_ONCE_MATCH = "hooks opencode stop";
+process.env.FAKE_CMUX_FAIL_ONCE_MARKER = `${process.env.CMUX_TEST_OPENCODE_FAILURE_MARKER_DIR}/stop-failed-once`;
+await hooks.event({
+  event: {
+    type: "session.idle",
+    properties: {
+      sessionID: "opencode-stop-failure-test"
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-stop-failure-test",
+      status: { type: "done" }
+    }
+  }
+});
+delete process.env.FAKE_CMUX_FAIL_ONCE_MATCH;
+delete process.env.FAKE_CMUX_FAIL_ONCE_MARKER;
 """
         check = subprocess.run(
             [bun, "--eval", check_source],
@@ -334,14 +439,14 @@ await hooks.event({
         if "hooks opencode session-start" not in args_log:
             print(f"FAIL: plugin did not invoke hooks opencode session-start, got {args_log!r}")
             return 1
-        if args_log.count("hooks opencode session-start") != 1:
-            print(f"FAIL: plugin invoked duplicate session-start hooks, got {args_log!r}")
+        if args_log.count("hooks opencode session-start") != 5:
+            print(f"FAIL: plugin did not retry failed session-start hooks correctly, got {args_log!r}")
             return 1
-        if args_log.count("hooks opencode prompt-submit") != 1:
-            print(f"FAIL: plugin invoked duplicate prompt-submit hooks, got {args_log!r}")
+        if args_log.count("hooks opencode prompt-submit") != 4:
+            print(f"FAIL: plugin did not retry failed prompt-submit hooks correctly, got {args_log!r}")
             return 1
-        if args_log.count("hooks opencode stop") != 2:
-            print(f"FAIL: plugin should stop after the error and retrying-only idle, got {args_log!r}")
+        if args_log.count("hooks opencode stop") != 4:
+            print(f"FAIL: plugin should stop after the error, retrying-only idle, and failed stop retry, got {args_log!r}")
             return 1
         for expected in [
             "hooks opencode prompt-submit",
@@ -362,10 +467,14 @@ await hooks.event({
             '"reason":"permission_prompt"',
             '"reason":"question answer"',
             '"reason":"error"',
+            '"message":"Agent reported an error"',
         ]:
             if expected not in stdin_log:
                 print(f"FAIL: plugin did not pass expected status payload {expected}, got {stdin_log!r}")
                 return 1
+        if "provider failed" in stdin_log:
+            print(f"FAIL: plugin leaked provider error text into notification payload, got {stdin_log!r}")
+            return 1
         if "kind=opencode" not in env_log or "cwd=/tmp/opencode-project" not in env_log or "argv=" not in env_log:
             print(f"FAIL: plugin did not pass launch metadata environment, got {env_log!r}")
             return 1

--- a/tests/test_opencode_plugin_install.py
+++ b/tests/test_opencode_plugin_install.py
@@ -235,6 +235,26 @@ await hooks.event({
     type: "session.status",
     properties: {
       sessionID: "opencode-session-test",
+      status: { type: "streaming" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.updated",
+    properties: {
+      info: {
+        id: "opencode-session-test",
+        title: "Updated title"
+      }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
       status: { type: "retrying" }
     }
   }
@@ -299,6 +319,12 @@ await hooks.event({
             return 1
         if args_log.count("hooks opencode session-start") != 1:
             print(f"FAIL: plugin invoked duplicate session-start hooks, got {args_log!r}")
+            return 1
+        if args_log.count("hooks opencode prompt-submit") != 1:
+            print(f"FAIL: plugin invoked duplicate prompt-submit hooks, got {args_log!r}")
+            return 1
+        if args_log.count("hooks opencode stop") != 1:
+            print(f"FAIL: plugin should stop once after the error closes the active turn, got {args_log!r}")
             return 1
         for expected in [
             "hooks opencode prompt-submit",

--- a/tests/test_opencode_plugin_install.py
+++ b/tests/test_opencode_plugin_install.py
@@ -294,6 +294,23 @@ await hooks.event({
     }
   }
 });
+await hooks.event({
+  event: {
+    type: "session.status",
+    properties: {
+      sessionID: "opencode-session-test",
+      status: { type: "retrying" }
+    }
+  }
+});
+await hooks.event({
+  event: {
+    type: "session.idle",
+    properties: {
+      sessionID: "opencode-session-test"
+    }
+  }
+});
 """
         check = subprocess.run(
             [bun, "--eval", check_source],
@@ -323,8 +340,8 @@ await hooks.event({
         if args_log.count("hooks opencode prompt-submit") != 1:
             print(f"FAIL: plugin invoked duplicate prompt-submit hooks, got {args_log!r}")
             return 1
-        if args_log.count("hooks opencode stop") != 1:
-            print(f"FAIL: plugin should stop once after the error closes the active turn, got {args_log!r}")
+        if args_log.count("hooks opencode stop") != 2:
+            print(f"FAIL: plugin should stop after the error and retrying-only idle, got {args_log!r}")
             return 1
         for expected in [
             "hooks opencode prompt-submit",
@@ -334,8 +351,8 @@ await hooks.event({
             if expected not in args_log:
                 print(f"FAIL: plugin did not invoke {expected}, got {args_log!r}")
                 return 1
-        if args_log.count("hooks opencode notification") != 4:
-            print(f"FAIL: plugin should notify for retry, permission, question, and error events; got {args_log!r}")
+        if args_log.count("hooks opencode notification") != 5:
+            print(f"FAIL: plugin should notify for retry, permission, question, error, and retry-only events; got {args_log!r}")
             return 1
         if '"session_id":"opencode-session-test"' not in stdin_log or '"/tmp/opencode-project"' not in stdin_log:
             print(f"FAIL: plugin did not pass expected session payload, got {stdin_log!r}")

--- a/tests/test_opencode_wrapper.py
+++ b/tests/test_opencode_wrapper.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""
+Regression tests for Resources/bin/cmux-opencode-wrapper.
+"""
+
+from __future__ import annotations
+
+import os
+import socket
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SOURCE_WRAPPER = ROOT / "Resources" / "bin" / "cmux-opencode-wrapper"
+
+
+def make_executable(path: Path, content: str) -> None:
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8") if path.exists() else ""
+
+
+def run_wrapper(*, inside_cmux: bool, hooks_disabled: bool = False) -> tuple[int, str, str, str]:
+    with tempfile.TemporaryDirectory(prefix="cmux-opencode-wrapper-test-") as td:
+        tmp = Path(td)
+        wrapper_dir = tmp / "wrapper-bin"
+        real_dir = tmp / "real-bin"
+        wrapper_dir.mkdir(parents=True, exist_ok=True)
+        real_dir.mkdir(parents=True, exist_ok=True)
+
+        wrapper = wrapper_dir / "cmux-opencode-wrapper"
+        shutil.copy2(SOURCE_WRAPPER, wrapper)
+        wrapper.chmod(0o755)
+
+        real_log = tmp / "real.log"
+        cmux_log = tmp / "cmux.log"
+        env_log = tmp / "env.log"
+        socket_path = tmp / "cmux.sock"
+
+        make_executable(
+            real_dir / "opencode",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$REAL_LOG"
+printf 'cmux_bin=%s\\n' "${CMUX_OPENCODE_CMUX_BIN-}" >> "$ENV_LOG"
+""",
+        )
+        make_executable(
+            wrapper_dir / "cmux",
+            """#!/usr/bin/env bash
+set -euo pipefail
+printf '%s\\n' "$*" >> "$CMUX_LOG"
+if [[ "${1:-}" == "--socket" ]]; then
+  shift 2
+fi
+if [[ "${1:-}" == "ping" ]]; then
+  exit 0
+fi
+exit 0
+""",
+        )
+
+        unix_socket: socket.socket | None = None
+        if inside_cmux:
+            unix_socket = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+            unix_socket.bind(str(socket_path))
+
+        env = os.environ.copy()
+        env["PATH"] = f"{wrapper_dir}:{real_dir}:{env.get('PATH', '/usr/bin:/bin')}"
+        env["REAL_LOG"] = str(real_log)
+        env["CMUX_LOG"] = str(cmux_log)
+        env["ENV_LOG"] = str(env_log)
+        if inside_cmux:
+            env["CMUX_SURFACE_ID"] = "surface:opencode"
+            env["CMUX_SOCKET_PATH"] = str(socket_path)
+        else:
+            env.pop("CMUX_SURFACE_ID", None)
+            env.pop("CMUX_SOCKET_PATH", None)
+        if hooks_disabled:
+            env["CMUX_OPENCODE_HOOKS_DISABLED"] = "1"
+        else:
+            env.pop("CMUX_OPENCODE_HOOKS_DISABLED", None)
+
+        try:
+            result = subprocess.run(
+                [str(wrapper), "run", "task"],
+                env=env,
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=10,
+            )
+        finally:
+            if unix_socket is not None:
+                unix_socket.close()
+
+        return result.returncode, read_text(cmux_log), read_text(real_log), read_text(env_log)
+
+
+def main() -> int:
+    if not SOURCE_WRAPPER.exists():
+        print(f"FAIL: missing wrapper at {SOURCE_WRAPPER}")
+        return 1
+
+    rc, cmux_log, real_log, env_log = run_wrapper(inside_cmux=True)
+    if rc != 0:
+        print(f"FAIL: wrapper exited {rc}")
+        return 1
+    if "--socket" not in cmux_log or "ping" not in cmux_log:
+        print(f"FAIL: wrapper did not ping cmux socket, got {cmux_log!r}")
+        return 1
+    if "hooks opencode install --yes" not in cmux_log:
+        print(f"FAIL: wrapper did not install OpenCode hooks, got {cmux_log!r}")
+        return 1
+    if real_log.strip() != "run task":
+        print(f"FAIL: wrapper did not exec real opencode, got {real_log!r}")
+        return 1
+    if "cmux_bin=" not in env_log:
+        print(f"FAIL: wrapper did not export plugin cmux binary path, got {env_log!r}")
+        return 1
+
+    rc, cmux_log, real_log, _ = run_wrapper(inside_cmux=False)
+    if rc != 0 or cmux_log:
+        print(f"FAIL: wrapper should pass through outside cmux, rc={rc}, cmux_log={cmux_log!r}")
+        return 1
+    if real_log.strip() != "run task":
+        print(f"FAIL: outside-cmux wrapper did not exec real opencode, got {real_log!r}")
+        return 1
+
+    rc, cmux_log, real_log, _ = run_wrapper(inside_cmux=True, hooks_disabled=True)
+    if rc != 0 or cmux_log:
+        print(f"FAIL: disabled wrapper should skip cmux calls, rc={rc}, cmux_log={cmux_log!r}")
+        return 1
+    if real_log.strip() != "run task":
+        print(f"FAIL: disabled wrapper did not exec real opencode, got {real_log!r}")
+        return 1
+
+    print("PASS: cmux OpenCode wrapper installs hooks only inside live cmux terminals")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_opencode_wrapper.py
+++ b/tests/test_opencode_wrapper.py
@@ -26,7 +26,7 @@ def read_text(path: Path) -> str:
     return path.read_text(encoding="utf-8") if path.exists() else ""
 
 
-def run_wrapper(*, inside_cmux: bool, hooks_disabled: bool = False) -> tuple[int, str, str, str]:
+def run_wrapper(*, inside_cmux: bool, hooks_disabled: bool = False, args: list[str] | None = None) -> tuple[int, str, str, str]:
     with tempfile.TemporaryDirectory(prefix="cmux-opencode-wrapper-test-") as td:
         tmp = Path(td)
         wrapper_dir = tmp / "wrapper-bin"
@@ -89,7 +89,7 @@ exit 0
 
         try:
             result = subprocess.run(
-                [str(wrapper), "run", "task"],
+                [str(wrapper), *(args or ["run", "task"])],
                 env=env,
                 capture_output=True,
                 text=True,
@@ -140,6 +140,30 @@ def main() -> int:
     if real_log.strip() != "run task":
         print(f"FAIL: disabled wrapper did not exec real opencode, got {real_log!r}")
         return 1
+
+    # Non-session entrypoints (--help/--version/admin subcommands) must skip the
+    # install AND the socket ping entirely, even inside a live cmux terminal.
+    for non_session_args in (["--help"], ["--version"], ["completion"], ["models"], ["mcp", "list"]):
+        rc, cmux_log, real_log, _ = run_wrapper(inside_cmux=True, args=non_session_args)
+        if rc != 0 or cmux_log:
+            print(f"FAIL: non-session {non_session_args} should skip cmux calls, rc={rc}, cmux_log={cmux_log!r}")
+            return 1
+        if real_log.strip() != " ".join(non_session_args):
+            print(f"FAIL: non-session {non_session_args} did not exec real opencode, got {real_log!r}")
+            return 1
+
+    # Session entrypoints still trigger the install path inside cmux.
+    for session_args in (["run", "task"], ["pr", "42"], ["serve"], ["myproject"]):
+        rc, cmux_log, real_log, _ = run_wrapper(inside_cmux=True, args=session_args)
+        if rc != 0:
+            print(f"FAIL: session {session_args} exited {rc}")
+            return 1
+        if "hooks opencode install --yes" not in cmux_log:
+            print(f"FAIL: session {session_args} did not install OpenCode hooks, got {cmux_log!r}")
+            return 1
+        if real_log.strip() != " ".join(session_args):
+            print(f"FAIL: session {session_args} did not exec real opencode, got {real_log!r}")
+            return 1
 
     print("PASS: cmux OpenCode wrapper installs hooks only inside live cmux terminals")
     return 0


### PR DESCRIPTION
## Summary

- Add a built-in OpenCode session plugin path that maps OpenCode lifecycle/status events into cmux sidebar activity/status updates.
- Add `cmux-opencode-wrapper` and shell integration wiring so OpenCode sessions launched inside cmux can auto-install the cmux OpenCode plugins.
- Add localized `Retrying` sidebar status, focused wrapper/plugin tests, Xcode project wiring, and authoritative docs for the OpenCode wrapper/status behavior.

## Validation

No-mistakes gate on `fm/cmux-1425-rebuild`:
- Review: passed after no-mistakes-applied focused fixes for Copy CLI bundling and wrapper session-entrypoint gating.
- Tests: passed Linux-runnable focused checks, including `tests/test_opencode_wrapper.py` and direct Bun validation of the embedded OpenCode plugin event-to-hook mapping.
- Docs: passed after approving the focused-docs decision: authoritative docs are updated in `docs/agent-hooks.md` and `docs/feed.md`; README and 20 localized README copies intentionally left unchanged because the README statement is true but non-exhaustive.
- Lint/static: passed configured Linux-runnable checks (`check-pbxproj.sh`, Python compile, JSON validation, wrapper shellcheck/bash syntax, Swift file-length budget for this change).

Additional M1 Air validation before publish:
- Tagged cmux build passed with `./scripts/reload.sh --tag cmux-1425-rebuild` using the repo's `CMUX_SKIP_ZIG_BUILD=1` helper-stub mode.
- Built tagged CLI passed `CMUX_CLI_BIN=... python3 tests/test_opencode_plugin_install.py`.
- `python3 tests/test_opencode_wrapper.py` passed.
- `zsh -n` passed on the zsh shell integration.

Known limitations documented, not fixed here:
- A full Ghostty CLI helper build on the M1 Air failed independently with Zig 0.15.2 due undefined macOS linker symbols; the tagged app build was validated with the repo-supported `CMUX_SKIP_ZIG_BUILD=1` stub path.
- `fish` was not installed on the M1 Air host, so `fish -n` could not be run there.
- Existing unrelated baseline issues were not changed: pre-existing shellcheck warnings in large shell-integration files and unrelated Swift file-budget drift noted during earlier local assessment.

Preserved work:
- Preserved the older `2f54f7b109` commit/branch unchanged; this PR is rebuilt from current `origin/main`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7940"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786476408&installation_id=133855650&pr_number=7940&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7940&signature=2a74d483344d1bcf1527c01310340e517562877f0b1e9f90d17dcd993edfe60a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes agent hook bridging, session store updates, and shell `opencode` interception; mistakes could mis-report running/idle state or add latency on every session launch inside cmux.
> 
> **Overview**
> Adds **OpenCode sidebar integration** by moving the embedded session plugin into `CMUXCLI+OpenCodeSessionPluginSource.swift` and **expanding** what it reports: turn lifecycle (`prompt-submit` / `stop` with once-per-turn guards and retries), notifications for permissions, questions, and errors, and a **retrying** status path into cmux.
> 
> Introduces **`cmux-opencode-wrapper`**, wired through bash/zsh/fish and the app **Copy CLI** bundle. Inside a live cmux terminal (socket ping + `CMUX_SURFACE_ID`), session-like `opencode` invocations best-effort run `cmux hooks opencode install --yes` before exec’ing the real binary; `--help`, admin subcommands, and outside-cmux paths pass through without install latency.
> 
> **CLI handling** for OpenCode `notification` hooks with `cmux_status: retrying` updates the session store, resume binding, PID, lifecycle, and a localized **Retrying** status pill (`agent.generic.status.retrying`).
> 
> Docs (`agent-hooks.md`, `feed.md`) describe wrapper-based setup and the new behaviors; tests cover the wrapper gating and extended plugin event→hook mapping.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9a8f0354f3ad07e272b80ee5ed63ac910c8134. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds OpenCode sidebar status with a localized “Retrying” pill and a new `opencode` wrapper that auto-installs cmux OpenCode plugins only inside cmux terminals. Moves the session plugin to `CMUXCLI+OpenCodeSessionPluginSource.swift`, wires the wrapper into bash/zsh/fish and the Copy CLI, and updates docs/tests; supports Linear CMUX-1425.

- **New Features**
  - Session plugin maps lifecycle to cmux hooks: running/streaming/thinking -> `prompt-submit`, idle/done/stopped -> `stop`, archived/deleted -> `session-end`; forwards permission prompts, questions, errors; includes launch metadata and recent message context.
  - “Retrying” status emits a notification, marks the session running, and shows a localized pill; `cmux-opencode-wrapper` resolves the real binary, pings the socket, and installs session + Feed plugins only for session-like invocations inside a live cmux terminal (skips `--help`/admin).

- **Bug Fixes**
  - Debounced duplicate start/turn events; stopped active turns on errors; broadened running/idle parsing; stopped retry-only sessions on idle to avoid a stuck “running” state.
  - Handled failed hook delivery: the plugin retries and only flips start/turn/stop state after a successful hook call.

<sup>Written for commit 6e9a8f0354f3ad07e272b80ee5ed63ac910c8134. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Automatic OpenCode integration inside cmux, including one-time plugin installation on the first `opencode` run.
  * Added `opencode` command wrappers for bash, zsh, and fish.
  * OpenCode session lifecycle now bridges into cmux notifications, including permission/question prompts and errors.
* **Bug Fixes**
  * Improved handling of OpenCode “retrying” so agent status and lifecycle correctly resume.
* **Documentation**
  * Updated OpenCode setup/troubleshooting to reflect wrapper-based installation.
* **Localization**
  * Added translated support for the “Retrying” agent status.
* **Tests**
  * Expanded regression coverage for wrapper behavior and session event handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->