### PR TITLE
iroh broker: use the 7 self-hosted relay.cmux.dev relays

### DIFF
--- a/web/services/iroh/publicationPolicy.ts
+++ b/web/services/iroh/publicationPolicy.ts
@@ -8,10 +8,13 @@
  */
 
 export const MANAGED_RELAY_URLS = [
-  "https://euc1-1.relay.lawrence.cmux.iroh.link/",
-  "https://use1-1.relay.lawrence.cmux.iroh.link/",
-  "https://usw1-1.relay.lawrence.cmux.iroh.link/",
-  "https://aps1-1.relay.lawrence.cmux.iroh.link/",
+  "https://usc1.relay.cmux.dev/",
+  "https://usw1.relay.cmux.dev/",
+  "https://use4.relay.cmux.dev/",
+  "https://euw4.relay.cmux.dev/",
+  "https://apne1.relay.cmux.dev/",
+  "https://apse1.relay.cmux.dev/",
+  "https://ape1.relay.cmux.dev/",
 ] as const;
 
 const MANAGED_RELAY_URL_SET: ReadonlySet<string> = new Set(MANAGED_RELAY_URLS);

--- a/web/tests/devices-route.test.ts
+++ b/web/tests/devices-route.test.ts
@@ -35,7 +35,7 @@ let sql: Sql | null = null;
 const DEVICE_A = "11111111-1111-4111-8111-111111111111";
 const DEVICE_B = "22222222-2222-4222-8222-222222222222";
 const IROH_ENDPOINT_ID = "a".repeat(64);
-const APPROVED_IROH_RELAY = "https://use1-1.relay.lawrence.cmux.iroh.link/";
+const APPROVED_IROH_RELAY = "https://use4.relay.cmux.dev/";
 
 const legacyTailscaleRoute = {
   id: "legacy",

--- a/workers/presence/src/routePrivacy.ts
+++ b/workers/presence/src/routePrivacy.ts
@@ -2,10 +2,13 @@
 // The Worker cannot import from `web/` because each deployment has its own
 // build root. Exact URLs are intentional: arbitrary relay URLs are path hints.
 export const APPROVED_IROH_RELAY_URLS = [
-  "https://euc1-1.relay.lawrence.cmux.iroh.link/",
-  "https://use1-1.relay.lawrence.cmux.iroh.link/",
-  "https://usw1-1.relay.lawrence.cmux.iroh.link/",
-  "https://aps1-1.relay.lawrence.cmux.iroh.link/",
+  "https://usc1.relay.cmux.dev/",
+  "https://usw1.relay.cmux.dev/",
+  "https://use4.relay.cmux.dev/",
+  "https://euw4.relay.cmux.dev/",
+  "https://apne1.relay.cmux.dev/",
+  "https://apse1.relay.cmux.dev/",
+  "https://ape1.relay.cmux.dev/",
 ] as const;
 
 const APPROVED_IROH_RELAY_URL_SET: ReadonlySet<string> = new Set(APPROVED_IROH_RELAY_URLS);

--- a/workers/presence/test/core.test.ts
+++ b/workers/presence/test/core.test.ts
@@ -332,7 +332,7 @@ describe("heartbeat routes", () => {
     endpoint: {
       type: "peer",
       id: "a".repeat(64),
-      relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+      relay_url: "https://use4.relay.cmux.dev/",
       relay_hint: "legacy-private-relay-hint",
       direct_addrs: ["192.168.1.20:49152"],
     },
@@ -344,7 +344,7 @@ describe("heartbeat routes", () => {
     endpoint: {
       type: "peer",
       id: "a".repeat(64),
-      relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+      relay_url: "https://use4.relay.cmux.dev/",
     },
   };
 

--- a/workers/presence/test/syncPairedMacs.test.ts
+++ b/workers/presence/test/syncPairedMacs.test.ts
@@ -134,7 +134,7 @@ describe("parsePairedMacBackup", () => {
                 id: "a".repeat(64),
                 direct_addrs: ["192.168.1.20:49152"],
                 relay_hint: "legacy-private-relay-hint",
-                relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+                relay_url: "https://use4.relay.cmux.dev/",
               },
             },
           ],
@@ -153,7 +153,7 @@ describe("parsePairedMacBackup", () => {
         endpoint: {
           type: "peer",
           id: "a".repeat(64),
-          relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+          relay_url: "https://use4.relay.cmux.dev/",
         },
       },
     ]);
@@ -175,7 +175,7 @@ describe("applyBackupOps", () => {
             id: "a".repeat(64),
             direct_addrs: ["192.168.1.20:49152"],
             relay_hint: "legacy-private-relay-hint",
-            relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+            relay_url: "https://use4.relay.cmux.dev/",
           },
         },
       ],
@@ -211,7 +211,7 @@ describe("applyBackupOps", () => {
         endpoint: {
           type: "peer",
           id: "a".repeat(64),
-          relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+          relay_url: "https://use4.relay.cmux.dev/",
         },
       },
     ]);

--- a/workers/presence/test/syncStorage.test.ts
+++ b/workers/presence/test/syncStorage.test.ts
@@ -598,7 +598,7 @@ describe("deriveDeviceRecord edge cases", () => {
                 id: "a".repeat(64),
                 direct_addrs: ["192.168.1.20:49152"],
                 relay_hint: "legacy-private-relay-hint",
-                relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+                relay_url: "https://use4.relay.cmux.dev/",
               },
             },
           ],
@@ -614,7 +614,7 @@ describe("deriveDeviceRecord edge cases", () => {
         endpoint: {
           type: "peer",
           id: "a".repeat(64),
-          relay_url: "https://use1-1.relay.lawrence.cmux.iroh.link/",
+          relay_url: "https://use4.relay.cmux.dev/",
         },
       },
     ]);

--- a/workers/presence/test/validate.test.ts
+++ b/workers/presence/test/validate.test.ts
@@ -3,7 +3,7 @@ import { MAX_REQUEST_BYTES, MAX_ROUTES, parseHeartbeat, readBoundedJson } from "
 
 const DEVICE_ID = "11111111-2222-4333-8444-555555555555";
 const IROH_ENDPOINT_ID = "a".repeat(64);
-const APPROVED_IROH_RELAY = "https://use1-1.relay.lawrence.cmux.iroh.link/";
+const APPROVED_IROH_RELAY = "https://use4.relay.cmux.dev/";
 
 function postRequest(
   body: string | ReadableStream<Uint8Array>,


### PR DESCRIPTION
Per Aziz's ask: updates PR #7840's broker fleet from the 4 hosted iroh.link relays to the 7 self-hosted `relay.cmux.dev` URLs (usc1, usw1, use4, euw4, apne1, apse1, ape1), in both lockstep allowlists (`web/services/iroh/publicationPolicy.ts` + `workers/presence/src/routePrivacy.ts`) and the tests referencing hosted URLs.

The self-hosted fleet runs iroh-relay 1.0.2 behind per-region MIG + L4 LB (zero-downtime upgrades, proven 180/180 probes during instance replacement), JWT-gated with per-endpoint connection caps + per-client bandwidth caps. Verified: web devices-route (25) + all 5 iroh suites (102) + presence worker (166) tests pass, web typecheck clean.

@azooz2003-bit merge this into #7840 when it looks good.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7949"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786483971&installation_id=133855650&pr_number=7949&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7949&signature=8208cf2cfb9f84c0af2baa9bfadb88661aa65337bc51e7730d54cf486cafa033"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changing the approved relay fleet affects which Iroh relay URLs clients can use after deploy; old lawrence.cmux.iroh.link URLs will no longer pass allowlist checks until endpoints report the new fleet.
> 
> **Overview**
> Replaces the **four** hosted `lawrence.cmux.iroh.link` relays with **seven** self-hosted `relay.cmux.dev` endpoints (usc1, usw1, use4, euw4, apne1, apse1, ape1) in the Iroh publication allowlists.
> 
> `web/services/iroh/publicationPolicy.ts` (`MANAGED_RELAY_URLS`) and `workers/presence/src/routePrivacy.ts` (`APPROVED_IROH_RELAY_URLS`) stay **lockstep**—only which relay URLs may be persisted or distributed changes; sanitization behavior is unchanged. Tests that used a hosted relay constant now point at `https://use4.relay.cmux.dev/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecad50011ff9aaf691373556b7be22e1af9dd156. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the iroh broker to our 7 self-hosted relays at `relay.cmux.dev` and update tests. Replaces the 4 hosted `iroh.link` relays and keeps the web and presence allowlists in sync.

- **Refactors**
  - Update allowlists in `web/services/iroh/publicationPolicy.ts` and `workers/presence/src/routePrivacy.ts` to the seven regions: usc1, usw1, use4, euw4, apne1, apse1, ape1.
  - Update tests to reference `https://use4.relay.cmux.dev/`.

<sup>Written for commit ecad50011ff9aaf691373556b7be22e1af9dd156. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

