### PR TITLE
Harden long-uptime sidebar observation lifecycle (#7929)

### DIFF
--- a/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
+++ b/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
@@ -69,8 +69,18 @@ final class WorkspaceSidebarAgentRuntimeObservationModel {
 
     private func notifyChanged() {
         changeGeneration &+= 1
-        for continuation in changeObservers.values {
-            continuation.yield(())
+        // Termination cleanup arrives through a separate MainActor task. If
+        // that task is delayed by sidebar work, publication is the
+        // authoritative reconciliation point so dead observers cannot make
+        // every later event progressively more expensive.
+        var terminatedObserverIDs: [UUID] = []
+        for (id, continuation) in changeObservers {
+            if case .terminated = continuation.yield(()) {
+                terminatedObserverIDs.append(id)
+            }
+        }
+        for id in terminatedObserverIDs {
+            changeObservers[id] = nil
         }
     }
 }

--- a/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
+++ b/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
@@ -20,11 +20,7 @@ final class WorkspaceSidebarAgentRuntimeObservationModel {
     private(set) var changeGeneration: UInt64 = 0
 
     @ObservationIgnored
-    private var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
-
-#if DEBUG
-    var debugChangeObserverCount: Int { changeObservers.count }
-#endif
+    var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
 
     /// Emits whenever any runtime map changes.
     func changes() -> AsyncStream<Void> {

--- a/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
+++ b/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
@@ -22,6 +22,10 @@ final class WorkspaceSidebarAgentRuntimeObservationModel {
     @ObservationIgnored
     private var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
 
+#if DEBUG
+    var debugChangeObserverCount: Int { changeObservers.count }
+#endif
+
     /// Emits whenever any runtime map changes.
     func changes() -> AsyncStream<Void> {
         AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in

--- a/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
+++ b/Sources/WorkspaceSidebarAgentRuntimeObservationModel.swift
@@ -20,7 +20,7 @@ final class WorkspaceSidebarAgentRuntimeObservationModel {
     private(set) var changeGeneration: UInt64 = 0
 
     @ObservationIgnored
-    var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
+    private(set) var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
 
     /// Emits whenever any runtime map changes.
     func changes() -> AsyncStream<Void> {

--- a/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
+++ b/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
@@ -23,7 +23,7 @@ final class WorkspaceSidebarProcessTitleObservationModel {
     @ObservationIgnored
     private(set) var changeGeneration: UInt64 = 0
     @ObservationIgnored
-    var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
+    private(set) var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
     @ObservationIgnored
     private var hasUnobservedChange = false
     @ObservationIgnored

--- a/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
+++ b/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
@@ -24,6 +24,10 @@ final class WorkspaceSidebarProcessTitleObservationModel {
     private(set) var changeGeneration: UInt64 = 0
     @ObservationIgnored
     private var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
+
+#if DEBUG
+    var debugChangeObserverCount: Int { changeObservers.count }
+#endif
     @ObservationIgnored
     private var hasUnobservedChange = false
     @ObservationIgnored

--- a/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
+++ b/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
@@ -125,11 +125,20 @@ final class WorkspaceSidebarProcessTitleObservationModel {
     private func publishSettledChange() {
         cancelPendingProcessTitleChange()
         var delivered = false
-        for continuation in changeObservers.values {
+        // Termination cleanup arrives through a separate MainActor task. If
+        // that task is delayed by sidebar work, publication is the
+        // authoritative reconciliation point so dead observers cannot make
+        // every later title progressively more expensive.
+        var terminatedObserverIDs: [UUID] = []
+        for (id, continuation) in changeObservers {
             if case .terminated = continuation.yield(()) {
+                terminatedObserverIDs.append(id)
                 continue
             }
             delivered = true
+        }
+        for id in terminatedObserverIDs {
+            changeObservers[id] = nil
         }
         if delivered {
             changeGeneration &+= 1

--- a/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
+++ b/Sources/WorkspaceSidebarProcessTitleObservationModel.swift
@@ -23,11 +23,7 @@ final class WorkspaceSidebarProcessTitleObservationModel {
     @ObservationIgnored
     private(set) var changeGeneration: UInt64 = 0
     @ObservationIgnored
-    private var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
-
-#if DEBUG
-    var debugChangeObserverCount: Int { changeObservers.count }
-#endif
+    var changeObservers: [UUID: AsyncStream<Void>.Continuation] = [:]
     @ObservationIgnored
     private var hasUnobservedChange = false
     @ObservationIgnored

--- a/cmuxTests/WorkspaceSidebarProcessTitleObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarProcessTitleObservationTests.swift
@@ -10,6 +10,40 @@ import Testing
 
 @MainActor
 struct WorkspaceSidebarProcessTitleObservationTests {
+    @Test func runtimePublicationPrunesTerminatedObservationBurst() {
+        let model = WorkspaceSidebarAgentRuntimeObservationModel()
+        var observations = (0..<2_000).map { _ in model.changes() }
+
+        #expect(model.debugChangeObserverCount == observations.count)
+        observations.removeAll()
+
+        model.setAgentPIDs(["codex": 42])
+
+        #expect(
+            model.debugChangeObserverCount == 0,
+            "A runtime change must reconcile terminated observers instead of retaining and revisiting them on every later event."
+        )
+    }
+
+    @Test func processTitlePublicationPrunesTerminatedObservationBurst() {
+        let scheduler = ManualProcessTitleSettleScheduler()
+        let model = WorkspaceSidebarProcessTitleObservationModel(
+            schedule: scheduler.schedule(delay:action:)
+        )
+        var observations = (0..<2_000).map { _ in model.changes() }
+
+        #expect(model.debugChangeObserverCount == observations.count)
+        observations.removeAll()
+
+        model.processTitleDidChange()
+        scheduler.fireAll()
+
+        #expect(
+            model.debugChangeObserverCount == 0,
+            "A settled title publish must reconcile terminated observers instead of retaining and revisiting them on every later title."
+        )
+    }
+
     @Test func defersSustainedChurnUntilSettled() {
         let schedulers = (0..<16).map { _ in ManualProcessTitleSettleScheduler() }
         let models = schedulers.map { scheduler in

--- a/cmuxTests/WorkspaceSidebarProcessTitleObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarProcessTitleObservationTests.swift
@@ -14,13 +14,13 @@ struct WorkspaceSidebarProcessTitleObservationTests {
         let model = WorkspaceSidebarAgentRuntimeObservationModel()
         var observations = (0..<2_000).map { _ in model.changes() }
 
-        #expect(model.debugChangeObserverCount == observations.count)
+        #expect(model.changeObservers.count == observations.count)
         observations.removeAll()
 
         model.setAgentPIDs(["codex": 42])
 
         #expect(
-            model.debugChangeObserverCount == 0,
+            model.changeObservers.count == 0,
             "A runtime change must reconcile terminated observers instead of retaining and revisiting them on every later event."
         )
     }
@@ -32,14 +32,14 @@ struct WorkspaceSidebarProcessTitleObservationTests {
         )
         var observations = (0..<2_000).map { _ in model.changes() }
 
-        #expect(model.debugChangeObserverCount == observations.count)
+        #expect(model.changeObservers.count == observations.count)
         observations.removeAll()
 
         model.processTitleDidChange()
         scheduler.fireAll()
 
         #expect(
-            model.debugChangeObserverCount == 0,
+            model.changeObservers.count == 0,
             "A settled title publish must reconcile terminated observers instead of retaining and revisiting them on every later title."
         )
     }


### PR DESCRIPTION
## Summary

- Evaluated every plausible change from `v0.64.17` (`9ed29d81a39de3ba44e0654bbcf6bf67ca86d1fb`) through current main; the evidence and per-symptom verdict are posted on #7929.
- Confirmed that #7754 addresses the strongest 0.64.17 main-thread freeze mechanism: automatic process-title churn repeatedly invalidated the full sidebar view graph under many live agent panes.
- Harden the replacement/current-main observation lifecycle so terminated `AsyncStream` continuations cannot accumulate while deferred main-actor cleanup is starved.
- Keep this PR scoped to symptom (a). Quit recovery remains #7955; bounded restore-command concurrency remains #7956. Refs #7929.

## Root Cause And Scope

Both current-main sidebar observation models register continuations synchronously but remove them through a separate `Task { @MainActor ... }` from `onTermination`. Under main-actor saturation, terminated continuations remain in the registry and every later publication revisits them, increasing per-event work while cleanup falls further behind.

Publication is now the authoritative reconciliation point: it checks each `yield` result, removes every `.terminated` entry after iteration, and preserves the existing unobserved-title replay semantics when no live observer accepted the change. `onTermination` remains the prompt cleanup path when no later publication occurs. Registries expose internal read access with private setters so tests can inspect membership via `@testable` while each model remains the sole mutation owner.

This lifecycle hazard was introduced in the post-0.64.17 replacement observation models, so this PR does not claim that it caused the original 0.64.17 incident. It prevents the replacement path from developing the same positive-feedback accumulation class.

## Testing

- Expected red: test-only commit `0d87ddf4bf` — focused run https://github.com/manaflow-ai/cmux/actions/runs/29216298609 executes 11 tests and fails both new burst cases with 2,000 terminated observers retained.
- Fix green: commit `fcda70c721` — focused run https://github.com/manaflow-ai/cmux/actions/runs/29216298800 executes all 11 suite tests; both 2,000-observer cases pass in about 0.11 seconds.
- Policy-clean final HEAD: focused run https://github.com/manaflow-ai/cmux/actions/runs/29217089366 passed all 11 tests for `1d5f44342b8bf74652a2c6139340f7ad75a7acbc`.
- `./scripts/lint-pbxproj-test-wiring.sh`: passed, 449 test files checked.
- `git diff --check`: passed.
- Canonical autoreview: merge-conflict gate clean; structured Codex review found 0 findings; cmux/Aziz policy clean.
- `python3 scripts/swift_file_length_budget.py`: touched files are 82, 155, and 336 lines, below 500. The repository-wide command still reports five pre-existing overages on unchanged origin/main files; no budget TSV was changed.
- Local app launch and local `xcodebuild` were intentionally not run under the machine-safety constraints for #7929.

## Demo Video

- Video URL or attachment: unavailable. Cloud-mac run https://github.com/manaflow-ai/cmux-loader/actions/runs/29215933248 failed GUI readiness before CUA bootstrap: Calculator had zero visible windows, the frontmost process remained `loginwindow`, and the captured full-display diagnostic was black. No misleading video was produced.
- No local GUI build was launched, as required by the #7929 safety constraints.

## Localization Audit

No user-facing strings changed. The touched Swift files contain only internal observer bookkeeping, comments, and test failure text; `Resources/Localizable.xcstrings` and web locale catalogs are unaffected.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally — prohibited for this incident; focused GitHub macOS runs are used instead.
- [x] I added or updated tests for behavior changes.
- [x] I updated docs/changelog if needed — not needed for this internal lifecycle fix.
- [x] I requested bot reviews after my latest commit.
- [x] All code review bot comments are resolved.
- [x] All human review comments are resolved — none received.

🤖 Generated with Claude Code (via cmux HQ dispatch).