### PR TITLE
Lower mobile-viewport Mac font floor (6pt→2pt) so narrow panes fill the phone

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/MobileViewportFitGeometry.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/MobileViewportFitGeometry.swift
@@ -21,7 +21,16 @@ public struct MobileViewportFitGeometry {
     public let verticalNonGridPixels: Int
 
     /// The minimum runtime font size used by mobile viewport fitting.
-    public static let defaultFontFloorPointSize: Float = 6
+    ///
+    /// This is a rendering-safety floor, not a legibility floor: mobile viewport
+    /// fitting only runs while a phone/tablet is mirroring the pane, and in that
+    /// state the person is reading the phone, not the Mac. So the Mac font may
+    /// shrink well past readable size to grant the mobile viewer its full column
+    /// width instead of letterboxing it. A too-high floor (the old 6pt) caps the
+    /// grant on narrow Mac panes (half-screen windows, splits) and leaves a dead
+    /// band on a wide phone in landscape. 2pt keeps cells safely above sub-pixel
+    /// while covering realistic narrow-pane / wide-viewer combinations.
+    public static let defaultFontFloorPointSize: Float = 2
 
     /// Creates geometry for one measured pane/cell state.
     ///

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/MobileViewportFitGeometryTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/MobileViewportFitGeometryTests.swift
@@ -36,6 +36,18 @@ struct MobileViewportFitGeometryTests {
         #expect(font == 7.5)
     }
 
+    @Test func narrowPaneForMobileViewerShrinksBelowLegibilityFloor() {
+        // A narrow Mac pane (e.g. a half-screen window) mirroring a wide phone in
+        // landscape needs a sub-6pt runtime font to fit the phone's full column
+        // grant. The Mac is not being read here — the viewer is on the phone — so
+        // fitting must shrink past the old 6pt legibility floor to grant the
+        // phone's full width instead of letterboxing it. 300px / (90 cols * 10px)
+        // = 1/3, so the target is base(12) * 1/3 = 4pt, below the old floor.
+        let font = geometry(paneWidthPx: 300, paneHeightPx: 10_000, cellWidthPx: 10, cellHeightPx: 20)
+            .targetFontPointSize(baseFontPointSize: 12, currentFontPointSize: 12, columns: 90, rows: 24)
+        #expect(font == 4)
+    }
+
     @Test func floorClampAndPerAxisFallbackCapTheGrant() {
         let target = geometry(paneWidthPx: 300, paneHeightPx: 120, cellWidthPx: 10, cellHeightPx: 20)
             .targetFontPointSize(


### PR DESCRIPTION
## Problem

When a phone/tablet in landscape mirrors a **narrow** Mac pane (half-screen window, a split), the phone reports its full landscape column capacity (e.g. 158 cols) but the terminal renders letterboxed with a dead band on the right (~63% fill).

Root cause: mobile viewport fitting shrinks the Mac pane's font so the phone's full column grant fits, but it stops at a **6pt font floor**. On a narrow pane the phone's grant needs a sub-6pt font, so the Mac clamps at 6pt, grants fewer columns than the phone can show, and the phone letterboxes the rest.

## Fix

The 6pt floor was a Mac **legibility** floor. But mobile viewport fitting only runs while a phone/tablet is mirroring the pane, and in that state the person is reading the phone, not the Mac. So the floor should be a **rendering-safety** floor, not a legibility one. Lowering it to 2pt lets the Mac font shrink enough to grant the phone's full width, so the mirror fills the screen. Ghostty supports `set_font_size` down to 1pt with cell width down to 1px, so 2pt is safely renderable.

Two commits (red/green): the first adds a failing test (a narrow pane needs a 4pt fit, clamped to 6pt under the old floor); the second lowers the floor and turns it green.

## Follow-up (backlog)

A small expandable indicator on the Mac noting the pane is being viewed from a phone, explaining the tiny Mac font.

## Verification

- Unit: `MobileViewportFitGeometryTests.narrowPaneForMobileViewerShrinksBelowLegibilityFloor` (red→green).
- Root cause confirmed on an iPhone simulator in landscape mirroring a narrow (596pt) Mac pane: phone reports 158 cols, old floor caps the grant at 100, phone renders ~63%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7957"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786498094&installation_id=133855650&pr_number=7957&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7957&signature=fdfcdcd675e7a22b7660c544dd68f75ada793b2832115c62af8481903ba43f24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized mobile-mirror rendering constant change with a targeted unit test; no auth, data, or broad API surface impact.
> 
> **Overview**
> **Lowers the default minimum Mac runtime font** used during mobile viewport fitting from **6pt to 2pt**, so a narrow Mac pane can shrink the terminal font enough to honor the phone/tablet’s full column grant instead of letterboxing with empty space on the viewer.
> 
> The change reframes `defaultFontFloorPointSize` as a **rendering-safety** bound (readable only on the mobile mirror, not on the Mac) and documents why the old 6pt legibility floor blocked realistic narrow-pane / wide-phone-landscape cases.
> 
> Adds **`narrowPaneForMobileViewerShrinksBelowLegibilityFloor`** to assert a 300px-wide pane with a 90-column grant yields a **4pt** target font under the new floor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e63e218fb7b9fb7643c055cd3dbbab4641b6bad6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the mobile-viewport font floor from 6pt to 2pt so mirrored phones/tablets get full column width from narrow Mac panes. This removes landscape letterboxing and dead space by letting the Mac shrink further while the phone is the reader.

- **Bug Fixes**
  - Changed `defaultFontFloorPointSize` to 2pt (rendering-safety floor, not legibility) so narrow panes can grant the phone’s full columns.
  - Added unit test `narrowPaneForMobileViewerShrinksBelowLegibilityFloor` asserting a 4pt fit on narrow panes; now passes.

<sup>Written for commit e63e218fb7b9fb7643c055cd3dbbab4641b6bad6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved mobile viewer fitting for narrow panes by allowing smaller font sizes when needed to display the available content.
  * Prevented layout issues caused by the previous minimum font-size restriction.

* **Tests**
  * Added coverage verifying that narrow mobile-viewer panes can render at a 4-point font size when required.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->