### PR TITLE
Fix double-escaping in markdown viewer's inline codespan renderer

### DIFF
--- a/Resources/markdown-viewer/shell.html
+++ b/Resources/markdown-viewer/shell.html
@@ -1009,7 +1009,7 @@ html { scroll-behavior: smooth; }
     pedantic: false,
     renderer: {
       codespan(code) {
-        var raw = code || '';
+        var raw = decodeHTML(code || '');
         return '<code>' + escapeHtml(raw) + '</code>';
       },
       code(code, infostring, escaped) {


### PR DESCRIPTION
## Description
`Resources/markdown-viewer/shell.html`'s custom `codespan` renderer calls `escapeHtml()` on the text marked.js's tokenizer hands it, but that text is already HTML-escaped at that point (the tokenizer runs codespan content through its own `escape()` helper before invoking custom renderers). Escaping it again turns e.g. `<port>` into `&amp;lt;port&amp;gt;`, which renders in the browser as the literal text `&lt;port&gt;` instead of `<port>` — reproducible with any inline code span containing `<`, `>`, `&`, `"`, or `'`.

## Fix
Rather than simply dropping the `escapeHtml()` call (which would rely on trusting that marked always pre-escapes codespan input — a fragile assumption if that ever changes), this decodes through the existing `decodeHTML()` helper (the same safe `<textarea>`-based decode already used elsewhere in this file, e.g. for link titles) before escaping exactly once. That's correct for the current pre-escaped path, and stays safe even if some future/alternate code path calls this renderer with raw, un-escaped text.

## Testing
I wasn't able to get a full native build working in my environment to visually confirm in the running app — `main` fails to resolve Swift packages for me with `multiple packages ('cmuxmobileterminal', 'cmuxterminalcore') declare targets with a conflicting name: 'GhosttyKit'` (reproduced this on a clean `main` checkout with zero changes, so it's unrelated to this fix). I did verify the logic by tracing through both cases by hand:
- Pre-escaped input (current behavior): `&lt;port&gt;` → `decodeHTML` → `<port>` → `escapeHtml` → `&lt;port&gt;` (single escape, renders as `<port>`).
- Hypothetical raw input: `<script>alert(1)</script>` → `decodeHTML` (no entities to decode, returned as-is) → `escapeHtml` → properly escaped, not executable.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7958"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786499061&installation_id=133855650&pr_number=7958&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7958&signature=7090c3d8279cec4859968101e3dddfb1fb12ba2df68103707e1a37640582414a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line change in the markdown viewer’s inline-code path; decode-then-escape preserves XSS safety for the viewer HTML output.
> 
> **Overview**
> Fixes **inline code** in the markdown viewer showing literal entity text (e.g. `&lt;port&gt;` instead of `<port>`) when the span contains `<`, `>`, `&`, or quotes.
> 
> The custom `codespan` renderer in `shell.html` was calling `escapeHtml()` on text that **marked.js already HTML-escapes** before invoking custom renderers, which double-escaped those characters. The fix runs the tokenizer output through the existing `decodeHTML()` helper (same pattern as link titles), then `escapeHtml()` once so output is correct for pre-escaped input and still safe if raw text were ever passed in.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bde0c880a7b9eda0b197c969fd7987fea4d48540. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-escaped inline code in the markdown viewer so characters like <, >, and & render correctly. Updates the custom codespan renderer in `Resources/markdown-viewer/shell.html` to run `decodeHTML()` before `escapeHtml()`, ensuring a single escape even when `marked` pre-escapes the input.

<sup>Written for commit bde0c880a7b9eda0b197c969fd7987fea4d48540. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7958?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inline code rendering so HTML entities display correctly while remaining safely escaped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->