### PR TITLE
Fix iOS terminal picker menu flicker and blocked scrolling

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenu.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenu.swift
@@ -1,0 +1,114 @@
+import CmuxMobileSupport
+import SwiftUI
+
+/// Snapshot-isolated native menu for switching the active workspace surface.
+struct TerminalPickerMenu: View, Equatable {
+    let value: TerminalPickerMenuValue
+    let actions: TerminalPickerMenuActions
+    #if DEBUG
+    private let diagnostics = TerminalPickerMenuDiagnostics()
+    #endif
+
+    nonisolated static func == (lhs: Self, rhs: Self) -> Bool {
+        lhs.value == rhs.value
+    }
+
+    var body: some View {
+        Menu {
+            instrumentedMenuContent
+        } label: {
+            Label(
+                value.selectedName ?? L10n.string("mobile.terminal.select", defaultValue: "Terminal"),
+                systemImage: "rectangle.stack"
+            )
+            .labelStyle(.iconOnly)
+        }
+        .foregroundStyle(TerminalPalette.foreground)
+        .accessibilityLabel(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals"))
+        .accessibilityIdentifier("MobileTerminalDropdown")
+        .accessibilityValue(value.selectedName ?? "")
+    }
+
+    @ViewBuilder
+    private var instrumentedMenuContent: some View {
+        #if DEBUG
+        let _ = diagnostics.recordContentBuilderEvaluation(rowCount: value.rows.count)
+        #endif
+        menuContent
+    }
+
+    @ViewBuilder
+    private var menuContent: some View {
+        Section(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals")) {
+            ForEach(value.rows) { terminal in
+                Button {
+                    actions.selectTerminal(terminal.id)
+                } label: {
+                    Label(
+                        terminal.name,
+                        systemImage: terminal.id == value.selectedID && !value.hasActiveBrowser
+                            ? "checkmark.circle.fill"
+                            : "terminal"
+                    )
+                }
+                .accessibilityIdentifier("MobileTerminalMenuItem-\(terminal.id.rawValue)")
+            }
+        }
+
+        Section {
+            Button(action: actions.createWorkspace) {
+                Label(
+                    L10n.string("mobile.workspace.new", defaultValue: "New Workspace"),
+                    systemImage: "plus.square.on.square"
+                )
+            }
+            .disabled(!value.canCreateWorkspace)
+            .accessibilityIdentifier("MobileNewWorkspaceMenuItem")
+
+            Button(action: actions.createTerminal) {
+                Label(L10n.string("mobile.terminal.new", defaultValue: "New Terminal"), systemImage: "plus")
+            }
+            .accessibilityIdentifier("MobileNewTerminalMenuItem")
+
+            Button(action: actions.openBrowser) {
+                Label(
+                    L10n.string("mobile.browser.new", defaultValue: "New Browser"),
+                    systemImage: value.hasActiveBrowser ? "checkmark.circle.fill" : "globe"
+                )
+            }
+            .accessibilityIdentifier("MobileNewBrowserMenuItem")
+        }
+
+        #if canImport(UIKit)
+        Section {
+            if !value.hasActiveBrowser && !value.isChatMode {
+                Button(action: actions.openTextSheet) {
+                    Label(
+                        L10n.string("mobile.terminal.viewAsText", defaultValue: "View as Text"),
+                        systemImage: "doc.plaintext"
+                    )
+                }
+                .accessibilityIdentifier("MobileViewAsTextMenuItem")
+            }
+
+            #if DEBUG
+            Button(action: actions.copyDebugLogs) {
+                Label(
+                    L10n.string("mobile.debug.copyLogs", defaultValue: "Copy Debug Logs"),
+                    systemImage: "doc.on.clipboard"
+                )
+            }
+            .accessibilityIdentifier("MobileCopyDebugLogsMenuItem")
+            #endif
+
+            Button(action: actions.sendFeedback) {
+                Label(
+                    L10n.string("mobile.feedback.send", defaultValue: "Send Feedback"),
+                    systemImage: "paperplane"
+                )
+            }
+            .accessibilityIdentifier("MobileSendFeedbackMenuItem")
+        }
+        #endif
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuActions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuActions.swift
@@ -1,0 +1,12 @@
+import CmuxMobileShellModel
+
+/// User actions emitted by ``TerminalPickerMenu`` without exposing mutable stores to its row subtree.
+struct TerminalPickerMenuActions {
+    let selectTerminal: (MobileTerminalPreview.ID) -> Void
+    let createWorkspace: () -> Void
+    let createTerminal: () -> Void
+    let openBrowser: () -> Void
+    let openTextSheet: () -> Void
+    let copyDebugLogs: () -> Void
+    let sendFeedback: () -> Void
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuDiagnostics.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuDiagnostics.swift
@@ -1,0 +1,41 @@
+#if DEBUG
+import Foundation
+import OSLog
+
+/// DEBUG-only events for counting terminal-picker menu evaluation and snapshot writes.
+struct TerminalPickerMenuDiagnostics {
+    private let logger = Logger(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
+        category: "TerminalPickerMenu"
+    )
+    private let signpostLog = OSLog(
+        subsystem: Bundle.main.bundleIdentifier ?? "com.cmuxterm.app",
+        category: "TerminalPickerMenu"
+    )
+
+    func recordContentBuilderEvaluation(rowCount: Int) {
+        logger.debug("content-builder evaluated rows=\(rowCount, privacy: .public)")
+        os_signpost(
+            .event,
+            log: signpostLog,
+            name: "ContentBuilderEvaluation",
+            "rows=%{public}d",
+            rowCount
+        )
+    }
+
+    func recordRowsWrite(rowCount: Int, includesTitleChanges: Bool) {
+        logger.debug(
+            "snapshot rows write rows=\(rowCount, privacy: .public) includeTitles=\(includesTitleChanges, privacy: .public)"
+        )
+        os_signpost(
+            .event,
+            log: signpostLog,
+            name: "SnapshotRowsWrite",
+            "rows=%{public}d includeTitles=%{public}d",
+            rowCount,
+            includesTitleChanges ? 1 : 0
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuValue.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPickerMenuValue.swift
@@ -1,0 +1,30 @@
+import CmuxMobileShellModel
+
+/// Immutable state that determines the native terminal picker's presented menu.
+struct TerminalPickerMenuValue: Equatable {
+    let rows: [TerminalPickerMenuRow]
+    let selectedID: MobileTerminalPreview.ID?
+    let selectedName: String?
+    let canCreateWorkspace: Bool
+    let hasActiveBrowser: Bool
+    let isChatMode: Bool
+
+    init(
+        liveTerminals: [MobileTerminalPreview],
+        snapshotRows: [TerminalPickerMenuRow],
+        selectedID: MobileTerminalPreview.ID?,
+        canCreateWorkspace: Bool,
+        hasActiveBrowser: Bool,
+        isChatMode: Bool
+    ) {
+        rows = snapshotRows.isEmpty
+            ? liveTerminals.map(TerminalPickerMenuRow.init)
+            : snapshotRows
+        let selection = rows.resolvedTerminalPickerSelection(selectedID: selectedID)
+        self.selectedID = selection?.id
+        selectedName = selection?.name
+        self.canCreateWorkspace = canCreateWorkspace
+        self.hasActiveBrowser = hasActiveBrowser
+        self.isChatMode = isChatMode
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+MenuState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+MenuState.swift
@@ -45,12 +45,24 @@ extension WorkspaceDetailView {
         let rows = terminalPickerLiveRows
         if includeTitleChanges {
             guard terminalPickerRows != rows else { return }
+            #if DEBUG
+            TerminalPickerMenuDiagnostics().recordRowsWrite(
+                rowCount: rows.count,
+                includesTitleChanges: true
+            )
+            #endif
             terminalPickerRows = rows
             return
         }
         guard terminalPickerRows.isEmpty
             || TerminalPickerMenuMembership(terminalPickerRows) != TerminalPickerMenuMembership(rows)
         else { return }
+        #if DEBUG
+        TerminalPickerMenuDiagnostics().recordRowsWrite(
+            rowCount: rows.count,
+            includesTitleChanges: false
+        )
+        #endif
         terminalPickerRows = rows
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -350,99 +350,33 @@ struct WorkspaceDetailView: View {
     // Native menu keeps press-drag-release selection and routes through
     // `selectTerminalFromPicker`; keyboard-dismiss-on-open is unavailable.
     var terminalPickerToolbarButton: some View {
-        let rows = terminalPickerRows.isEmpty ? terminalPickerLiveRows : terminalPickerRows
-        let selection = terminalPickerLiveRows.resolvedTerminalPickerSelection(selectedID: store.selectedTerminalID)
-
-        return Menu {
-            terminalPickerMenuContent(rows: rows, selectedID: selection?.id)
-        } label: {
-            Label(
-                selection?.name ?? L10n.string("mobile.terminal.select", defaultValue: "Terminal"),
-                systemImage: "rectangle.stack"
+        TerminalPickerMenu(
+            value: TerminalPickerMenuValue(
+                liveTerminals: workspace.terminals,
+                snapshotRows: terminalPickerRows,
+                selectedID: store.selectedTerminalID,
+                canCreateWorkspace: canCreateWorkspace,
+                hasActiveBrowser: activeBrowser != nil,
+                isChatMode: isChatMode
+            ),
+            actions: TerminalPickerMenuActions(
+                selectTerminal: selectTerminalFromPicker,
+                createWorkspace: createWorkspaceFromToolbar,
+                createTerminal: createTerminalFromToolbar,
+                openBrowser: openBrowserFromToolbar,
+                openTextSheet: openTextSheetFromMenu,
+                copyDebugLogs: {
+                    #if DEBUG
+                    copyDebugLogsFromMenu()
+                    #endif
+                },
+                sendFeedback: openFeedbackComposerFromMenu
             )
-            .labelStyle(.iconOnly)
-        }
-        .foregroundStyle(TerminalPalette.foreground)
-        .accessibilityLabel(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals"))
-        .accessibilityIdentifier("MobileTerminalDropdown")
-        .accessibilityValue(selection?.name ?? "")
+        )
+        .equatable()
         .simultaneousGesture(TapGesture().onEnded { syncTerminalPickerRows(includeTitleChanges: true) })
         .onAppear { syncTerminalPickerRows(includeTitleChanges: true) }
         .onChange(of: terminalPickerLiveMembership) { _, _ in syncTerminalPickerRows() }
-    }
-
-    @ViewBuilder
-    private func terminalPickerMenuContent(
-        rows: [TerminalPickerMenuRow],
-        selectedID: MobileTerminalPreview.ID?
-    ) -> some View {
-        Section(L10n.string("mobile.terminal.picker.title", defaultValue: "Terminals")) {
-            ForEach(rows) { terminal in
-                Button {
-                    selectTerminalFromPicker(terminal.id)
-                } label: {
-                    Label(
-                        terminal.name,
-                        systemImage: terminal.id == selectedID && activeBrowser == nil
-                            ? "checkmark.circle.fill"
-                            : "terminal"
-                    )
-                }
-                .accessibilityIdentifier("MobileTerminalMenuItem-\(terminal.id.rawValue)")
-            }
-        }
-
-        Section {
-            Button(action: createWorkspaceFromToolbar) {
-                Label(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"), systemImage: "plus.square.on.square")
-            }
-            .disabled(!canCreateWorkspace)
-            .accessibilityIdentifier("MobileNewWorkspaceMenuItem")
-
-            Button(action: createTerminalFromToolbar) {
-                Label(L10n.string("mobile.terminal.new", defaultValue: "New Terminal"), systemImage: "plus")
-            }
-            .accessibilityIdentifier("MobileNewTerminalMenuItem")
-
-            Button(action: openBrowserFromToolbar) {
-                Label(
-                    L10n.string("mobile.browser.new", defaultValue: "New Browser"),
-                    systemImage: activeBrowser == nil ? "globe" : "checkmark.circle.fill"
-                )
-            }
-            .accessibilityIdentifier("MobileNewBrowserMenuItem")
-        }
-
-        #if canImport(UIKit)
-        Section {
-            // Only while the terminal pane is showing: browser and chat modes
-            // do not mount a terminal surface for text capture.
-            if activeBrowser == nil && !isChatMode {
-                Button(action: openTextSheetFromMenu) {
-                    Label(
-                        L10n.string("mobile.terminal.viewAsText", defaultValue: "View as Text"),
-                        systemImage: "doc.plaintext"
-                    )
-                }
-                .accessibilityIdentifier("MobileViewAsTextMenuItem")
-            }
-
-            #if DEBUG
-            Button(action: copyDebugLogsFromMenu) {
-                Label(L10n.string("mobile.debug.copyLogs", defaultValue: "Copy Debug Logs"), systemImage: "doc.on.clipboard")
-            }
-            .accessibilityIdentifier("MobileCopyDebugLogsMenuItem")
-            #endif
-
-            Button(action: openFeedbackComposerFromMenu) {
-                Label(
-                    L10n.string("mobile.feedback.send", defaultValue: "Send Feedback"),
-                    systemImage: "paperplane"
-                )
-            }
-            .accessibilityIdentifier("MobileSendFeedbackMenuItem")
-        }
-        #endif
     }
 
     #if canImport(UIKit)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
@@ -1,0 +1,72 @@
+import CmuxMobileShellModel
+import Testing
+@testable import CmuxMobileShellUI
+
+@Suite struct TerminalPickerMenuValueTests {
+    @Test func previewChurnDoesNotChangeSeededMenuValueButMembershipDoes() {
+        let terminal = MobileTerminalPreview(id: "terminal-1", name: "Build")
+        let snapshotRows = [TerminalPickerMenuRow(terminal)]
+        let baseline = menuValue(liveTerminals: [terminal], snapshotRows: snapshotRows)
+
+        var churnedTerminal = terminal
+        churnedTerminal.name = "Build output"
+        churnedTerminal.isFocused = true
+        churnedTerminal.viewportFit = MobileTerminalViewportFit(
+            effective: MobileTerminalViewportSize(columns: 80, rows: 24),
+            client: MobileTerminalViewportSize(columns: 100, rows: 30),
+            isCurrentClientLimiting: false
+        )
+        let previewChurn = menuValue(liveTerminals: [churnedTerminal], snapshotRows: snapshotRows)
+
+        let addedTerminal = MobileTerminalPreview(id: "terminal-2", name: "Tests")
+        let membershipRows = snapshotRows + [TerminalPickerMenuRow(addedTerminal)]
+        let membershipChange = menuValue(
+            liveTerminals: [churnedTerminal, addedTerminal],
+            snapshotRows: membershipRows
+        )
+
+        #expect(previewChurn == baseline)
+        #expect(membershipChange != baseline)
+    }
+
+    @Test func selectionIsResolvedFromTheRowsDisplayedByTheMenu() {
+        let liveTerminals = [
+            MobileTerminalPreview(id: "terminal-live", name: "Live")
+        ]
+        let snapshotRows = [
+            TerminalPickerMenuRow(MobileTerminalPreview(id: "terminal-snapshot", name: "Snapshot")),
+            TerminalPickerMenuRow(MobileTerminalPreview(id: "terminal-selected", name: "Selected")),
+        ]
+
+        let selected = menuValue(
+            liveTerminals: liveTerminals,
+            snapshotRows: snapshotRows,
+            selectedID: "terminal-selected"
+        )
+        let staleSelection = menuValue(
+            liveTerminals: liveTerminals,
+            snapshotRows: snapshotRows,
+            selectedID: "terminal-live"
+        )
+
+        #expect(selected.selectedID == MobileTerminalPreview.ID(rawValue: "terminal-selected"))
+        #expect(selected.selectedName == "Selected")
+        #expect(staleSelection.selectedID == MobileTerminalPreview.ID(rawValue: "terminal-snapshot"))
+        #expect(staleSelection.selectedName == "Snapshot")
+    }
+
+    private func menuValue(
+        liveTerminals: [MobileTerminalPreview],
+        snapshotRows: [TerminalPickerMenuRow],
+        selectedID: MobileTerminalPreview.ID? = "terminal-1"
+    ) -> TerminalPickerMenuValue {
+        TerminalPickerMenuValue(
+            liveTerminals: liveTerminals,
+            snapshotRows: snapshotRows,
+            selectedID: selectedID,
+            canCreateWorkspace: true,
+            hasActiveBrowser: false,
+            isChatMode: false
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalPickerMenuValueTests.swift
@@ -8,24 +8,27 @@ import Testing
         let snapshotRows = [TerminalPickerMenuRow(terminal)]
         let baseline = menuValue(liveTerminals: [terminal], snapshotRows: snapshotRows)
 
-        var churnedTerminal = terminal
-        churnedTerminal.name = "Build output"
-        churnedTerminal.isFocused = true
-        churnedTerminal.viewportFit = MobileTerminalViewportFit(
+        var titleOnlyTerminal = terminal
+        titleOnlyTerminal.name = "Build output"
+        let titleOnlyChange = menuValue(liveTerminals: [titleOnlyTerminal], snapshotRows: snapshotRows)
+
+        var viewportOnlyTerminal = terminal
+        viewportOnlyTerminal.viewportFit = MobileTerminalViewportFit(
             effective: MobileTerminalViewportSize(columns: 80, rows: 24),
             client: MobileTerminalViewportSize(columns: 100, rows: 30),
             isCurrentClientLimiting: false
         )
-        let previewChurn = menuValue(liveTerminals: [churnedTerminal], snapshotRows: snapshotRows)
+        let viewportOnlyChange = menuValue(liveTerminals: [viewportOnlyTerminal], snapshotRows: snapshotRows)
 
         let addedTerminal = MobileTerminalPreview(id: "terminal-2", name: "Tests")
         let membershipRows = snapshotRows + [TerminalPickerMenuRow(addedTerminal)]
         let membershipChange = menuValue(
-            liveTerminals: [churnedTerminal, addedTerminal],
+            liveTerminals: [viewportOnlyTerminal, addedTerminal],
             snapshotRows: membershipRows
         )
 
-        #expect(previewChurn == baseline)
+        #expect(titleOnlyChange == baseline)
+        #expect(viewportOnlyChange == baseline)
         #expect(membershipChange != baseline)
     }
 
@@ -53,6 +56,23 @@ import Testing
         #expect(selected.selectedName == "Selected")
         #expect(staleSelection.selectedID == MobileTerminalPreview.ID(rawValue: "terminal-snapshot"))
         #expect(staleSelection.selectedName == "Snapshot")
+    }
+
+    @Test func emptySnapshotUsesLiveRowsAndHandlesNoTerminals() {
+        let liveTerminal = MobileTerminalPreview(id: "terminal-live", name: "Live")
+        let firstOpen = menuValue(
+            liveTerminals: [liveTerminal],
+            snapshotRows: [],
+            selectedID: "missing"
+        )
+        let noTerminals = menuValue(liveTerminals: [], snapshotRows: [], selectedID: "missing")
+
+        #expect(firstOpen.rows == [TerminalPickerMenuRow(liveTerminal)])
+        #expect(firstOpen.selectedID == liveTerminal.id)
+        #expect(firstOpen.selectedName == liveTerminal.name)
+        #expect(noTerminals.rows.isEmpty)
+        #expect(noTerminals.selectedID == nil)
+        #expect(noTerminals.selectedName == nil)
     }
 
     private func menuValue(


### PR DESCRIPTION
The terminal picker toolbar menu flickered while open: every live preview update from the Mac (~2Hz title/viewportFit churn in `MobileTerminalPreview`) re-rendered `WorkspaceDetailView`, re-evaluated the `Menu` content closure, and made iOS rebuild the presented UIMenu. Each rebuild cross-faded the menu text (the visible opacity pulse, measured at 3.5 luminance peak-to-peak with a dominant ~2Hz component) and cancelled in-flight scroll gestures, so an overflowing menu could not be scrolled.

Fix: the picker now lives in `TerminalPickerMenu`, an `Equatable` child view applied with `.equatable()`. Its only inputs are `TerminalPickerMenuValue` (row snapshot, selection resolved from that same snapshot, capability/browser/chat flags) and a `TerminalPickerMenuActions` closure bundle excluded from equality. Preview/title/viewport churn produces an equal value, so SwiftUI skips the child body and the presented UIMenu is never rebuilt; membership changes, selection changes, browser/chat mode, and the New Workspace capability still change the value and update the open menu once. The existing `syncTerminalPickerRows` event paths (tap, onAppear, membership onChange, selection onChange) are unchanged. DEBUG-only Logger/os_signpost diagnostics count content-builder evaluations and snapshot writes.

Commits follow the red/green regression policy: the first commit adds `TerminalPickerMenuValueTests` against the not-yet-existing value seam (CI red), the second adds the fix (green). Tests cover title-only vs membership changes, selection resolution from snapshot rows, and the empty-snapshot first-open fallback.

Simulator evidence (before/after video with per-frame luminance analysis) is being captured and will be posted on this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7959"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786499372&installation_id=133855650&pr_number=7959&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7959&signature=a8acff11f8e41eaeabe5602b12c16b62acbb17ceee679b54acb3b4bba1247657"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized SwiftUI toolbar refactor with tests and DEBUG-only instrumentation; menu actions and sync behavior are preserved.
> 
> **Overview**
> Fixes **iOS terminal picker flicker and broken scrolling** when live `MobileTerminalPreview` updates (~2Hz title/viewport churn) kept rebuilding the native `UIMenu` from `WorkspaceDetailView`.
> 
> The inline toolbar `Menu` is replaced by **`TerminalPickerMenu`**, an **`Equatable`** child with **`.equatable()`**. It only compares **`TerminalPickerMenuValue`** (snapshot rows, selection resolved from those rows, browser/chat/capability flags); **`TerminalPickerMenuActions`** closures are excluded from equality. Title/viewport-only live churn leaves the value unchanged so SwiftUI skips the child body and the open menu is not rebuilt; membership, selection, mode, and capability changes still update once. Existing **`syncTerminalPickerRows`** triggers (tap, appear, membership/selection) are unchanged.
> 
> **DEBUG** adds Logger/os_signpost for menu content evaluation and snapshot writes. **`TerminalPickerMenuValueTests`** lock snapshot-vs-live equality and selection resolution.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 74daa96dcab2b8553815274b702dc916d7010ac0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the iOS terminal picker flicker and cancelled scrolling by moving the menu into an Equatable child with a stable snapshot. The menu no longer rebuilds during live preview/title/viewport updates, so scrolling stays smooth.

- **Bug Fixes**
  - Extracted picker into `TerminalPickerMenu` and applied `.equatable()` so equal `TerminalPickerMenuValue` skips recompute.
  - Added `TerminalPickerMenuValue` (snapshot-based rows; selection resolved from the snapshot) and `TerminalPickerMenuActions` (excluded from equality).
  - Menu now updates only on membership/selection/browser/chat/capability changes; ignores preview churn, removing the ~2Hz cross-fade and preserving in-flight scroll.
  - Kept existing sync event paths; added DEBUG diagnostics and `TerminalPickerMenuValueTests` to cover title-only vs membership changes, selection resolution, and empty-snapshot fallback.

<sup>Written for commit 74daa96dcab2b8553815274b702dc916d7010ac0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a native terminal picker menu for switching terminals and workspaces.
  * Added actions to create workspaces and terminals, open a browser, view text, copy debug logs, and send feedback.
  * Added visual indicators for the selected terminal and active browser.

* **Bug Fixes**
  * Improved selection handling when terminal lists change or contain outdated selections.

* **Tests**
  * Added coverage for terminal list updates, selection resolution, and empty-state behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->