### PR TITLE
Retarget initial App Store draft

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -16,8 +16,8 @@ on:
         required: false
         default: false
         type: boolean
-      replace_initial_draft:
-        description: Replace the app's sole PREPARE_FOR_SUBMISSION version when creating the configured initial version
+      retarget_initial_draft:
+        description: Change the app's sole PREPARE_FOR_SUBMISSION version to the configured initial version
         required: false
         default: false
         type: boolean
@@ -43,7 +43,7 @@ jobs:
       INPUT_BUILD_NUMBER: ${{ github.event.inputs.build_number }}
       INPUT_COPY_METADATA_FROM: ${{ github.event.inputs.copy_metadata_from }}
       INPUT_SUBMIT_FOR_REVIEW: ${{ github.event.inputs.submit_for_review }}
-      INPUT_REPLACE_INITIAL_DRAFT: ${{ github.event.inputs.replace_initial_draft }}
+      INPUT_RETARGET_INITIAL_DRAFT: ${{ github.event.inputs.retarget_initial_draft }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -161,7 +161,7 @@ jobs:
               python3 -c 'import json,sys; body=json.load(sys.stdin); data=body.get("data") if isinstance(body,dict) else body; data=data if isinstance(data,list) else ([data] if isinstance(data,dict) else []); print(data[0].get("id", "") if data else "")'
           )"
           if [ -z "$VERSION_ID" ]; then
-            if [ "${INPUT_REPLACE_INITIAL_DRAFT:-false}" = "true" ]; then
+            if [ "${INPUT_RETARGET_INITIAL_DRAFT:-false}" = "true" ]; then
               ALL_VERSIONS_JSON="$(asc versions list --app "$ASC_APP_ID" --platform IOS --paginate --output json)"
               INITIAL_DRAFT="$(ALL_VERSIONS_JSON="$ALL_VERSIONS_JSON" python3 <<'PY'
           import json
@@ -172,30 +172,35 @@ jobs:
           data = body.get("data") if isinstance(body, dict) else body
           items = data if isinstance(data, list) else ([data] if isinstance(data, dict) else [])
           if len(items) != 1:
-              raise SystemExit(f"replace_initial_draft requires exactly one existing iOS version; found {len(items)}")
+              raise SystemExit(f"retarget_initial_draft requires exactly one existing iOS version; found {len(items)}")
           item = items[0]
           attrs = item.get("attributes", item)
           state = attrs.get("appStoreState") or attrs.get("state")
           version = attrs.get("versionString") or attrs.get("version") or "unknown"
           if state != "PREPARE_FOR_SUBMISSION":
-              raise SystemExit(f"refusing to replace iOS version {version} in state {state or 'unknown'}")
+              raise SystemExit(f"refusing to retarget iOS version {version} in state {state or 'unknown'}")
           print(f"{item.get('id', '')}\t{version}")
           PY
               )"
               IFS=$'\t' read -r INITIAL_DRAFT_ID INITIAL_DRAFT_VERSION <<< "$INITIAL_DRAFT"
               if [ -z "$INITIAL_DRAFT_ID" ]; then
-                echo "replace_initial_draft did not resolve a version id" >&2
+                echo "retarget_initial_draft did not resolve a version id" >&2
                 exit 1
               fi
-              echo "Replacing initial App Store draft $INITIAL_DRAFT_VERSION with $VERSION"
-              asc versions delete --version-id "$INITIAL_DRAFT_ID" --confirm
+              echo "Changing initial App Store draft $INITIAL_DRAFT_VERSION to $VERSION"
+              asc versions update \
+                --version-id "$INITIAL_DRAFT_ID" \
+                --version "$VERSION" \
+                --copyright "2026 Manaflow, Inc." \
+                --release-type MANUAL
+            else
+              asc versions create \
+                --app "$ASC_APP_ID" \
+                --version "$VERSION" \
+                --platform IOS \
+                --copyright "2026 Manaflow, Inc." \
+                --release-type MANUAL
             fi
-            asc versions create \
-              --app "$ASC_APP_ID" \
-              --version "$VERSION" \
-              --platform IOS \
-              --copyright "2026 Manaflow, Inc." \
-              --release-type MANUAL
           else
             asc versions update \
               --version-id "$VERSION_ID" \

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -16,6 +16,11 @@ on:
         required: false
         default: false
         type: boolean
+      replace_initial_draft:
+        description: Replace the app's sole PREPARE_FOR_SUBMISSION version when creating the configured initial version
+        required: false
+        default: false
+        type: boolean
 
 concurrency:
   group: ios-app-store-production
@@ -38,6 +43,7 @@ jobs:
       INPUT_BUILD_NUMBER: ${{ github.event.inputs.build_number }}
       INPUT_COPY_METADATA_FROM: ${{ github.event.inputs.copy_metadata_from }}
       INPUT_SUBMIT_FOR_REVIEW: ${{ github.event.inputs.submit_for_review }}
+      INPUT_REPLACE_INITIAL_DRAFT: ${{ github.event.inputs.replace_initial_draft }}
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -155,6 +161,35 @@ jobs:
               python3 -c 'import json,sys; body=json.load(sys.stdin); data=body.get("data") if isinstance(body,dict) else body; data=data if isinstance(data,list) else ([data] if isinstance(data,dict) else []); print(data[0].get("id", "") if data else "")'
           )"
           if [ -z "$VERSION_ID" ]; then
+            if [ "${INPUT_REPLACE_INITIAL_DRAFT:-false}" = "true" ]; then
+              ALL_VERSIONS_JSON="$(asc versions list --app "$ASC_APP_ID" --platform IOS --paginate --output json)"
+              INITIAL_DRAFT="$(ALL_VERSIONS_JSON="$ALL_VERSIONS_JSON" python3 <<'PY'
+          import json
+          import os
+          import sys
+
+          body = json.loads(os.environ["ALL_VERSIONS_JSON"])
+          data = body.get("data") if isinstance(body, dict) else body
+          items = data if isinstance(data, list) else ([data] if isinstance(data, dict) else [])
+          if len(items) != 1:
+              raise SystemExit(f"replace_initial_draft requires exactly one existing iOS version; found {len(items)}")
+          item = items[0]
+          attrs = item.get("attributes", item)
+          state = attrs.get("appStoreState") or attrs.get("state")
+          version = attrs.get("versionString") or attrs.get("version") or "unknown"
+          if state != "PREPARE_FOR_SUBMISSION":
+              raise SystemExit(f"refusing to replace iOS version {version} in state {state or 'unknown'}")
+          print(f"{item.get('id', '')}\t{version}")
+          PY
+              )"
+              IFS=$'\t' read -r INITIAL_DRAFT_ID INITIAL_DRAFT_VERSION <<< "$INITIAL_DRAFT"
+              if [ -z "$INITIAL_DRAFT_ID" ]; then
+                echo "replace_initial_draft did not resolve a version id" >&2
+                exit 1
+              fi
+              echo "Replacing initial App Store draft $INITIAL_DRAFT_VERSION with $VERSION"
+              asc versions delete --version-id "$INITIAL_DRAFT_ID" --confirm
+            fi
             asc versions create \
               --app "$ASC_APP_ID" \
               --version "$VERSION" \


### PR DESCRIPTION
## Summary
- add an explicit `retarget_initial_draft` production workflow input
- change only the sole iOS `PREPARE_FOR_SUBMISSION` version to the configured initial version
- preserve version-scoped metadata, screenshots, review details, and build relationships
- refuse submitted, released, rejected, or multi-version app state

## Context
Production run https://github.com/manaflow-ai/cmux/actions/runs/29226723164 could not create official version `1.0.0` because App Store Connect already has another initial draft version.

## Verification
- `python3 tests/test_ios_appstore_lane_identity.py`
- workflow YAML parse and extracted release-step `bash -n`
- behavior harness retargets sole `1.0.4` draft to `1.0.0` without delete/create
- behavior harness refuses `WAITING_FOR_REVIEW` without mutation

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Opt-in production workflow logic mutates App Store Connect version metadata; guards limit changes to a single draft in PREPARE_FOR_SUBMISSION, but mis-invocation could still retarget the wrong draft.
> 
> **Overview**
> Adds an optional **`retarget_initial_draft`** input to the production iOS App Store workflow so a run can align App Store Connect with the marketing version from `Shared.xcconfig` when that version does not exist yet.
> 
> When the flag is on and the target version is missing, the **Prepare App Store version and metadata** step lists all iOS versions, requires **exactly one** record in **`PREPARE_FOR_SUBMISSION`**, and then **`asc versions update`**s that draft’s version string (plus copyright and manual release type) instead of calling **`asc versions create`**. Any other app state (multiple versions, submitted/released drafts, etc.) fails the step with an explicit error. Default behavior is unchanged: create a new version when absent, or update the existing matching version when it already exists.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c37a5bb4f53e27049e5f6833c22a9dfc2d5d1cbd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional workflow setting to retarget the single existing iOS App Store draft to the configured version when the target version ID is missing.
  * Includes additional checks to ensure exactly one draft candidate exists and that it’s in the expected “ready for submission” state before updating it.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->