### PR TITLE
Sync canonical App Store metadata

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -157,8 +157,13 @@ jobs:
           set -euo pipefail
           VERSION="$(sed -nE 's/^[[:space:]]*CMUX_IOS_APPSTORE_MARKETING_VERSION[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\1/p' ios/Config/Shared.xcconfig | tail -n 1)"
           VERSION_METADATA_DIR="ios/AppStoreReview/metadata/version/$VERSION"
+          VERSION_METADATA_FILES=()
           shopt -s nullglob
-          VERSION_METADATA_FILES=("$VERSION_METADATA_DIR"/*.json)
+          for metadata_file in "$VERSION_METADATA_DIR"/*.json; do
+            if [ "${metadata_file##*/}" != "default.json" ]; then
+              VERSION_METADATA_FILES+=("$metadata_file")
+            fi
+          done
           shopt -u nullglob
           if [ "${#VERSION_METADATA_FILES[@]}" -eq 0 ]; then
             echo "No canonical App Store metadata found in $VERSION_METADATA_DIR" >&2

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -156,6 +156,14 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="$(sed -nE 's/^[[:space:]]*CMUX_IOS_APPSTORE_MARKETING_VERSION[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\1/p' ios/Config/Shared.xcconfig | tail -n 1)"
+          VERSION_METADATA_DIR="ios/AppStoreReview/metadata/version/$VERSION"
+          shopt -s nullglob
+          VERSION_METADATA_FILES=("$VERSION_METADATA_DIR"/*.json)
+          shopt -u nullglob
+          if [ "${#VERSION_METADATA_FILES[@]}" -eq 0 ]; then
+            echo "No canonical App Store metadata found in $VERSION_METADATA_DIR" >&2
+            exit 1
+          fi
           VERSION_ID="$(
             asc versions list --app "$ASC_APP_ID" --version "$VERSION" --platform IOS --output json |
               python3 -c 'import json,sys; body=json.load(sys.stdin); data=body.get("data") if isinstance(body,dict) else body; data=data if isinstance(data,list) else ([data] if isinstance(data,dict) else []); print(data[0].get("id", "") if data else "")'

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -212,7 +212,15 @@ jobs:
             --app "$ASC_APP_ID" \
             --version "$VERSION" \
             --platform IOS \
-            --dir ios/AppStoreReview/metadata
+            --dir ios/AppStoreReview/metadata \
+            --dry-run
+          asc metadata apply \
+            --app "$ASC_APP_ID" \
+            --version "$VERSION" \
+            --platform IOS \
+            --dir ios/AppStoreReview/metadata \
+            --allow-deletes \
+            --confirm
           asc screenshots validate \
             --path ios/AppStoreReview/screenshots/en-US/iphone \
             --device-type IPHONE_69

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -156,19 +156,24 @@ jobs:
         run: |
           set -euo pipefail
           VERSION="$(sed -nE 's/^[[:space:]]*CMUX_IOS_APPSTORE_MARKETING_VERSION[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\1/p' ios/Config/Shared.xcconfig | tail -n 1)"
-          VERSION_METADATA_DIR="ios/AppStoreReview/metadata/version/$VERSION"
-          VERSION_METADATA_FILES=()
-          shopt -s nullglob
-          for metadata_file in "$VERSION_METADATA_DIR"/*.json; do
-            if [ "${metadata_file##*/}" != "default.json" ]; then
-              VERSION_METADATA_FILES+=("$metadata_file")
+          require_locale_metadata() {
+            local metadata_dir="$1"
+            local metadata_file
+            local locale_file_count=0
+            shopt -s nullglob
+            for metadata_file in "$metadata_dir"/*.json; do
+              if [ "${metadata_file##*/}" != "default.json" ]; then
+                locale_file_count=$((locale_file_count + 1))
+              fi
+            done
+            shopt -u nullglob
+            if [ "$locale_file_count" -eq 0 ]; then
+              echo "No locale-specific App Store metadata found in $metadata_dir" >&2
+              exit 1
             fi
-          done
-          shopt -u nullglob
-          if [ "${#VERSION_METADATA_FILES[@]}" -eq 0 ]; then
-            echo "No canonical App Store metadata found in $VERSION_METADATA_DIR" >&2
-            exit 1
-          fi
+          }
+          require_locale_metadata "ios/AppStoreReview/metadata/version/$VERSION"
+          require_locale_metadata "ios/AppStoreReview/metadata/app-info"
           VERSION_ID="$(
             asc versions list --app "$ASC_APP_ID" --version "$VERSION" --platform IOS --output json |
               python3 -c 'import json,sys; body=json.load(sys.stdin); data=body.get("data") if isinstance(body,dict) else body; data=data if isinstance(data,list) else ([data] if isinstance(data,dict) else []); print(data[0].get("id", "") if data else "")'

--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -213,6 +213,8 @@ jobs:
             --version "$VERSION" \
             --platform IOS \
             --dir ios/AppStoreReview/metadata \
+            --allow-deletes \
+            --confirm \
             --dry-run
           asc metadata apply \
             --app "$ASC_APP_ID" \


### PR DESCRIPTION
The official App Store workflow now prints the metadata apply plan, then confirms deletion of stale remote localizations absent from `ios/AppStoreReview/metadata`.

This unblocks the real App Store Connect failure from https://github.com/manaflow-ai/cmux/actions/runs/29229445900 after the initial draft was successfully retargeted to `1.0.0`. Review credentials and review notes are separate version relationships and are not deleted by localization synchronization.

Verification:
- Executed the exact extracted workflow step against a behavior stub that required dry-run before confirmed delete authorization
- Parsed the workflow YAML and passed `bash -n` on the extracted step
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7967"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786516849&installation_id=133855650&pr_number=7967&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7967&signature=67665b70d81288748806358138713a203a24dc7a6426233cd49db700a280ce3c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the iOS App Store workflow to preview and then apply canonical metadata. We run `asc metadata apply` with `--allow-deletes --confirm --dry-run` to show the destructive plan, then run it again without `--dry-run` to remove stale remote localizations and unblock App Store Connect after retargeting to 1.0.0; the job now fails fast if no locale-specific metadata JSON (excluding `default.json`) exists in either `ios/AppStoreReview/metadata/version/<VERSION>` or `ios/AppStoreReview/metadata/app-info`.

<sup>Written for commit a4f5cf73af706e480abafc3f85ad9db938b5d2be. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS App Store metadata publishing by validating that version-scoped metadata exists before any updates are applied.
  * The workflow now fails early when the target version metadata directory contains no canonical `*.json` files (excluding `default.json`).
  * Metadata updates are now executed in two phases: a dry-run validation (including deletions) followed by the actual non-interactive apply that supports deletes automatically.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->