### PR TITLE
Honor -p for cmux SSH workspace ports

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9392,10 +9392,10 @@ struct CMUXCLI {
                 index += 1
             case "-p", "--port":
                 guard index + 1 < commandArgs.count else {
-                    throw CLIError(message: "ssh: \(arg) requires a value")
+                    throw CLIError(message: "ssh: --port requires a value")
                 }
                 guard let parsed = Int(commandArgs[index + 1]), parsed > 0, parsed <= 65535 else {
-                    throw CLIError(message: "ssh: \(arg) must be 1-65535")
+                    throw CLIError(message: "ssh: --port must be 1-65535")
                 }
                 port = parsed
                 index += 2

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -9390,12 +9390,12 @@ struct CMUXCLI {
             case "--":
                 passthrough = true
                 index += 1
-            case "--port":
+            case "-p", "--port":
                 guard index + 1 < commandArgs.count else {
-                    throw CLIError(message: "ssh: --port requires a value")
+                    throw CLIError(message: "ssh: \(arg) requires a value")
                 }
                 guard let parsed = Int(commandArgs[index + 1]), parsed > 0, parsed <= 65535 else {
-                    throw CLIError(message: "ssh: --port must be 1-65535")
+                    throw CLIError(message: "ssh: \(arg) must be 1-65535")
                 }
                 port = parsed
                 index += 2

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -1265,6 +1265,46 @@ import Testing
         XCTAssertFalse(openArguments.contains(workingDirectory.standardizedFileURL.path), openArguments.joined(separator: " "))
     }
 
+    @Test func testSSHShortPortConfiguresRemoteWorkspacePort() throws {
+        let cliPath = try bundledCLIPath()
+        let socketPath = "/tmp/cmux-ssh-short-port-\(UUID().uuidString.prefix(8)).sock"
+        let responder = try UnixSocketResponder(
+            path: socketPath,
+            response: #"{"ok":true,"result":{"workspace_id":"workspace:test","surface_id":"surface:test","window_id":"window:test","remote":{"state":"connected"}}}"#
+        )
+        defer { responder.stop() }
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+        let result = runProcess(
+            executablePath: cliPath,
+            arguments: [
+                "--socket", socketPath,
+                "ssh", "--no-focus", "dev@example.com", "-p", "45221",
+            ],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stdout)
+        XCTAssertEqual(result.status, 0, result.stdout)
+
+        let configureRequest = try XCTUnwrap(
+            responder.receivedRequests
+                .compactMap { request -> [String: Any]? in
+                    guard let data = request.data(using: .utf8) else { return nil }
+                    return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+                }
+                .first { ($0["method"] as? String) == "workspace.remote.configure" }
+        )
+        let params = try XCTUnwrap(configureRequest["params"] as? [String: Any])
+        XCTAssertEqual(params["port"] as? Int, 45221)
+    }
+
     func bundledCLIPath() throws -> String {
         try BundledCLITestSupport.bundledCLIPath(for: BundledCLILinkageTests.self)
     }


### PR DESCRIPTION
## Summary

- Treat `-p` as an alias of `--port` in `cmux ssh` option parsing.
- Reuse the existing `--port` validation diagnostics for both flag spellings.
- Add an executable-level regression test that verifies the short flag reaches `workspace.remote.configure` as port `45221`.

Fixes [GH-4734](https://github.com/manaflow-ai/cmux/issues/4734).

## Testing

- Local tests not run, per the repository policy that tests run in GitHub Actions or on the VM.
- `PATH=/opt/homebrew/opt/zig@0.15/bin:$PATH ./scripts/reload.sh --tag fix-4734-ssh-short-port` — succeeded after installing the Xcode Metal Toolchain component.
- `git diff --check origin/main...HEAD`

## Demo Video

CLI-only behavior change; no visual UI change.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [ ] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [x] All code review bot comments are resolved
- [x] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7969"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786521003&installation_id=133855650&pr_number=7969&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7969&signature=c6f17d0d85bcba17f3adc624f7f41734f58b86a945e2bb0bd744adef5363f381"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added support for the SSH `-p` shorthand when specifying the SSH port.
  * SSH port configuration now correctly propagates the specified port to the remote workspace request.
* **Tests**
  * Added a regression test to verify `ssh ... -p <port>` results in a `workspace.remote.configure` request with `params.port` set to the provided value.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->