### PR TITLE
Fix custom sidebar optional nil comparisons

### DIFF
--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator+UserFunctions.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator+UserFunctions.swift
@@ -90,17 +90,8 @@ extension ExpressionEvaluator {
     private func conditionsPass(_ conditions: ConditionElementListSyntax, _ scope: EvalEnvironment) -> Bool {
         for element in conditions {
             if let binding = element.condition.as(OptionalBindingConditionSyntax.self) {
-                let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
-                let resolved: SwiftValue?
-                if let initializer = binding.initializer?.value {
-                    resolved = eval(initializer, scope)
-                } else if let name {
-                    resolved = scope.lookup(name)
-                } else {
-                    resolved = nil
-                }
-                guard let value = resolved, value != .null else { return false }
-                if let name { scope.define(name, value) }
+                guard let resolved = resolveOptionalBinding(binding, scope) else { return false }
+                if let name = resolved.name { scope.define(name, resolved.value) }
             } else if let expr = element.condition.as(ExprSyntax.self) {
                 if !(eval(expr, scope)?.isTruthy ?? false) { return false }
             } else {

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator+UserFunctions.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator+UserFunctions.swift
@@ -99,7 +99,7 @@ extension ExpressionEvaluator {
                 } else {
                     resolved = nil
                 }
-                guard let value = resolved else { return false }
+                guard let value = resolved, value != .null else { return false }
                 if let name { scope.define(name, value) }
             } else if let expr = element.condition.as(ExprSyntax.self) {
                 if !(eval(expr, scope)?.isTruthy ?? false) { return false }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -152,6 +152,25 @@ public struct ExpressionEvaluator: Sendable {
         return result
     }
 
+    /// Resolves a supported optional binding while preserving the distinction
+    /// between an absent value (`.null`) and an expression we cannot evaluate.
+    func resolveOptionalBinding(
+        _ binding: OptionalBindingConditionSyntax,
+        _ env: EvalEnvironment
+    ) -> (name: String?, value: SwiftValue)? {
+        let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
+        let resolved: SwiftValue?
+        if let initializer = binding.initializer?.value {
+            resolved = eval(initializer, env)
+        } else if let name {
+            resolved = env.lookup(name)
+        } else {
+            resolved = nil
+        }
+        guard let value = resolved, value != .null else { return nil }
+        return (name, value)
+    }
+
     // MARK: - Operators
 
     private func evalPrefix(_ op: String, _ value: SwiftValue?) -> SwiftValue? {
@@ -298,8 +317,8 @@ public struct ExpressionEvaluator: Sendable {
                 }
                 return acc
             case "first":
-                guard let closure else { return values.first }
-                return values.first { evalClosure(closure, $0, env)?.isTruthy ?? false }
+                guard let closure else { return values.first ?? .null }
+                return values.first { evalClosure(closure, $0, env)?.isTruthy ?? false } ?? .null
             case "contains":
                 if let closure { return .bool(values.contains { evalClosure(closure, $0, env)?.isTruthy ?? false }) }
                 guard let firstArg, let needle = eval(firstArg, env) else { return nil }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -254,9 +254,13 @@ public struct ExpressionEvaluator: Sendable {
     /// absent values.
     private func evalEqualityOperand(_ expr: ExprSyntax, _ env: EvalEnvironment) -> SwiftValue? {
         if let member = expr.as(MemberAccessExprSyntax.self),
-           let baseExpression = member.base,
-           case let .object(fields)? = eval(baseExpression, env) {
-            return fields[member.declName.baseName.text] ?? .null
+           let baseExpression = member.base {
+            guard let base = evalEqualityOperand(baseExpression, env) else { return nil }
+            if case .null = base { return .null }
+            if case let .object(fields) = base {
+                return fields[member.declName.baseName.text] ?? .null
+            }
+            return base.member(member.declName.baseName.text)
         }
         return eval(expr, env)
     }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -230,16 +230,16 @@ public struct ExpressionEvaluator: Sendable {
     }
 
     /// Equality is the one context where a missing object field has a value:
-    /// it represents an absent optional and therefore compares equal to `nil`.
-    /// Other evaluation failures remain `nil` so typos and unsupported syntax
-    /// do not silently masquerade as an absent value.
+    /// data contexts omit absent optionals, so that lookup compares equal to
+    /// `nil`. Other evaluation failures stay unresolved instead of becoming
+    /// absent values.
     private func evalEqualityOperand(_ expr: ExprSyntax, _ env: EvalEnvironment) -> SwiftValue? {
-        if let value = eval(expr, env) { return value }
-        guard let member = expr.as(MemberAccessExprSyntax.self),
-              let baseExpression = member.base,
-              case let .object(fields)? = eval(baseExpression, env),
-              fields[member.declName.baseName.text] == nil else { return nil }
-        return .null
+        if let member = expr.as(MemberAccessExprSyntax.self),
+           let baseExpression = member.base,
+           case let .object(fields)? = eval(baseExpression, env) {
+            return fields[member.declName.baseName.text] ?? .null
+        }
+        return eval(expr, env)
     }
 
     private func numericPair(_ lhs: SwiftValue, _ rhs: SwiftValue) -> (Double?, Double?, Bool) {

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -23,6 +23,9 @@ public struct ExpressionEvaluator: Sendable {
         if let literal = expr.as(BooleanLiteralExprSyntax.self) {
             return .bool(literal.literal.text == "true")
         }
+        if expr.is(NilLiteralExprSyntax.self) {
+            return .null
+        }
         if let literal = expr.as(StringLiteralExprSyntax.self) {
             return .string(evalString(literal, env))
         }
@@ -162,6 +165,13 @@ public struct ExpressionEvaluator: Sendable {
 
     private func evalInfix(_ node: InfixOperatorExprSyntax, _ env: EvalEnvironment) -> SwiftValue? {
         guard let op = node.operator.as(BinaryOperatorExprSyntax.self)?.operator.text else { return nil }
+
+        if op == "==" || op == "!=" {
+            guard let lhs = evalEqualityOperand(node.leftOperand, env),
+                  let rhs = evalEqualityOperand(node.rightOperand, env) else { return nil }
+            return .bool(op == "==" ? lhs == rhs : lhs != rhs)
+        }
+
         guard let lhs = eval(node.leftOperand, env) else { return nil }
 
         // Short-circuit logical operators on the left operand before forcing the
@@ -184,8 +194,6 @@ public struct ExpressionEvaluator: Sendable {
         case "..<", "...":
             guard case let .int(l) = lhs, case let .int(r) = rhs else { return nil }
             return .range(lower: l, upper: r, inclusive: op == "...")
-        case "==": return .bool(lhs == rhs)
-        case "!=": return .bool(lhs != rhs)
         default: break
         }
 
@@ -219,6 +227,19 @@ public struct ExpressionEvaluator: Sendable {
         case ">=": return .bool(l >= r)
         default: return nil
         }
+    }
+
+    /// Equality is the one context where a missing object field has a value:
+    /// it represents an absent optional and therefore compares equal to `nil`.
+    /// Other evaluation failures remain `nil` so typos and unsupported syntax
+    /// do not silently masquerade as an absent value.
+    private func evalEqualityOperand(_ expr: ExprSyntax, _ env: EvalEnvironment) -> SwiftValue? {
+        if let value = eval(expr, env) { return value }
+        guard let member = expr.as(MemberAccessExprSyntax.self),
+              let baseExpression = member.base,
+              case let .object(fields)? = eval(baseExpression, env),
+              fields[member.declName.baseName.text] == nil else { return nil }
+        return .null
     }
 
     private func numericPair(_ lhs: SwiftValue, _ rhs: SwiftValue) -> (Double?, Double?, Bool) {

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
@@ -7,6 +7,7 @@ import Foundation
 /// identifiers, string interpolations, loop sequences, and `if` conditions
 /// to these.
 public enum SwiftValue: Codable, Sendable, Equatable {
+    case null
     case int(Int)
     case double(Double)
     case string(String)
@@ -18,6 +19,7 @@ public enum SwiftValue: Codable, Sendable, Equatable {
     /// How the value renders inside a string interpolation.
     public var displayString: String {
         switch self {
+        case .null: return "nil"
         case let .int(value): return String(value)
         case let .double(value): return String(value)
         case let .string(value): return value

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
@@ -40,8 +40,8 @@ public enum SwiftValue: Codable, Sendable, Equatable {
             if name == "count" { return .int(values.count) }
             if name == "isEmpty" { return .bool(values.isEmpty) }
             if name == "indices" { return .array(values.indices.map { .int($0) }) }
-            if name == "first" { return values.first }
-            if name == "last" { return values.last }
+            if name == "first" { return values.first ?? .null }
+            if name == "last" { return values.last ?? .null }
             return nil
         case let .string(value):
             if name == "count" { return .int(value.count) }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
@@ -607,7 +607,7 @@ public struct SwiftViewInterpreter: Sendable {
                 } else {
                     resolved = nil
                 }
-                guard let value = resolved else { return false }
+                guard let value = resolved, value != .null else { return false }
                 if let name { scope.define(name, value) }
             } else if let expr = element.condition.as(ExprSyntax.self) {
                 if !(expressions.eval(expr, scope)?.isTruthy ?? false) { return false }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
@@ -598,17 +598,8 @@ public struct SwiftViewInterpreter: Sendable {
     private func conditionsPass(_ conditions: ConditionElementListSyntax, _ scope: EvalEnvironment) -> Bool {
         for element in conditions {
             if let binding = element.condition.as(OptionalBindingConditionSyntax.self) {
-                let name = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text
-                let resolved: SwiftValue?
-                if let initializer = binding.initializer?.value {
-                    resolved = expressions.eval(initializer, scope)
-                } else if let name {
-                    resolved = scope.lookup(name) // shorthand `if let name`
-                } else {
-                    resolved = nil
-                }
-                guard let value = resolved, value != .null else { return false }
-                if let name { scope.define(name, value) }
+                guard let resolved = expressions.resolveOptionalBinding(binding, scope) else { return false }
+                if let name = resolved.name { scope.define(name, resolved.value) }
             } else if let expr = element.condition.as(ExprSyntax.self) {
                 if !(expressions.eval(expr, scope)?.isTruthy ?? false) { return false }
             } else {

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -332,6 +332,17 @@ import Testing
         #expect(node?.children.last?.modifiers.first(where: { $0.name == "foregroundColor" })?.firstValue == "#FF3B30")
     }
 
+    @Test func valueFunctionOptionalBindingRejectsNilLiteral() {
+        let node = interp.evaluate("""
+        func label() -> String {
+            if let value = nil { return "unexpected: \\(value)" }
+            return "ok"
+        }
+        VStack { Text(label()) }
+        """)
+        #expect(node?.children.first?.text == "ok")
+    }
+
     @Test func userViewFunctionHelper() {
         let node = interp.evaluate("""
         func row(title) -> some View {

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -266,7 +266,10 @@ import Testing
 
     @Test func optionalMemberComparisonsDistinguishPresentAndAbsentValues() {
         let workspaces = SwiftValue.array([
-            .object(["description": .string("hello")]),
+            .object([
+                "description": .string("hello"),
+                "profile": .object(["name": .string("cmux")]),
+            ]),
             .object([:]),
         ])
         let empty = SwiftValue.array([])
@@ -282,6 +285,8 @@ import Testing
                 Text(w.description != nil ? "present" : "absent")
                 if w.description == nil { Text("missing") }
                 if w.description != nil { Text("value: \\(w.description)") }
+                if w.profile.name != nil { Text("nested: \\(w.profile.name)") }
+                if w.profile.name == nil { Text("nested-missing") }
                 if let description = w.description {
                     Text("bound: \\(description)")
                 } else {
@@ -292,8 +297,8 @@ import Testing
         """, state: ["workspaces": workspaces, "empty": empty])
         #expect(node?.children.map(\.text) == [
             "nil-equal", "empty-first", "no-selected",
-            "present", "value: hello", "bound: hello",
-            "absent", "missing", "unbound",
+            "present", "value: hello", "nested: cmux", "bound: hello",
+            "absent", "missing", "nested-missing", "unbound",
         ])
     }
 

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -264,6 +264,34 @@ import Testing
         #expect(node?.children.map(\.text) == ["other", "one", "other"])
     }
 
+    @Test func optionalMemberComparisonsDistinguishPresentAndAbsentValues() {
+        let workspaces = SwiftValue.array([
+            .object(["description": .string("hello")]),
+            .object([:]),
+        ])
+        let node = interp.evaluate("""
+        VStack {
+            Text(nil == nil ? "nil-equal" : "bad")
+            if let impossible = nil { Text("unexpected: \\(impossible)") }
+            ForEach(workspaces) { w in
+                Text(w.description != nil ? "present" : "absent")
+                if w.description == nil { Text("missing") }
+                if w.description != nil { Text("value: \\(w.description)") }
+                if let description = w.description {
+                    Text("bound: \\(description)")
+                } else {
+                    Text("unbound")
+                }
+            }
+        }
+        """, state: ["workspaces": workspaces])
+        #expect(node?.children.map(\.text) == [
+            "nil-equal",
+            "present", "value: hello", "bound: hello",
+            "absent", "missing", "unbound",
+        ])
+    }
+
     @Test func arrayFilterMapSortedFirstContains() {
         let ws = SwiftValue.array([
             .object(["title": .string("beta"), "selected": .bool(false), "n": .int(2)]),

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -269,10 +269,15 @@ import Testing
             .object(["description": .string("hello")]),
             .object([:]),
         ])
+        let empty = SwiftValue.array([])
         let node = interp.evaluate("""
         VStack {
             Text(nil == nil ? "nil-equal" : "bad")
+            Text(empty.first == nil ? "empty-first" : "bad")
+            if unknownValue() == nil { Text("unsupported-treated-as-absent") }
             if let impossible = nil { Text("unexpected: \\(impossible)") }
+            let selected = workspaces.first { $0.selected }
+            if selected == nil { Text("no-selected") }
             ForEach(workspaces) { w in
                 Text(w.description != nil ? "present" : "absent")
                 if w.description == nil { Text("missing") }
@@ -284,9 +289,9 @@ import Testing
                 }
             }
         }
-        """, state: ["workspaces": workspaces])
+        """, state: ["workspaces": workspaces, "empty": empty])
         #expect(node?.children.map(\.text) == [
-            "nil-equal",
+            "nil-equal", "empty-first", "no-selected",
             "present", "value: hello", "bound: hello",
             "absent", "missing", "unbound",
         ])


### PR DESCRIPTION
## Summary

- Add an explicit runtime `nil` value to the custom sidebar expression interpreter.
- Make `== nil` and `!= nil` distinguish present object members from omitted optional members without treating unsupported expressions as absent values.
- Preserve optional-binding behavior so `if let` still rejects absent and explicit `nil` values.
- Add behavior-level coverage for literal, present-member, absent-member, ternary, conditional, and optional-binding paths.

Fixes [GH-7943](https://github.com/manaflow-ai/cmux/issues/7943).

## Testing

- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag fix-sidebar-nil` — tagged Debug app build succeeded.
- `git diff --check origin/main...HEAD`
- Per repository policy, tests were not run locally; the new `CmuxSwiftRender` behavior test is intended to run in CI.
- The normal Ghostty CLI helper build was attempted with Zig 0.15.2 but the Xcode run-script environment failed to link libSystem symbols, so the successful tagged build used the repository's Mach-O stub path for that unrelated helper.

## Demo Video

Not applicable: this is a headless expression-interpreter fix covered by a runtime behavior test.

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7971"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786521336&installation_id=133855650&pr_number=7971&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7971&signature=621dc3a3d1527e8c44e190450d8ed6773681a7ced22989ff95fc5b0b6e03ef8e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix sidebar expression evaluation so `== nil`/`!= nil` correctly distinguish missing optionals from present values, including nested member chains. Adds a runtime `nil`, and keeps `if let` rejecting both absent and explicit `nil`; resolves GH-7943.

- **Bug Fixes**
  - Parse `nil` and add `.null` to `SwiftValue` (renders as "nil").
  - Equality: treat missing object members as `nil` only for `==`/`!=` and propagate `nil` through nested member chains; other eval failures aren’t coerced.
  - Return `nil` for empty `.first`/`.last` and for `first {}` so comparisons with `nil` work.
  - Keep optional binding strict via a shared resolver; `if let` rejects absent fields and `nil` in views and value helpers.
  - Add tests for `nil` literal and `nil == nil`, empty-first/last, nested present/absent checks, and value-helper `nil` binding.

<sup>Written for commit f8979b342252982ecf4d5ab966abd907e60daab6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `nil` vs absent-optional handling across expression evaluation and string interpolation (renders as `nil`).
  * Optional member comparisons now distinguish missing fields from present values when compared to `nil`.
  * `if let` optional bindings correctly reject resolved `nil`, including `nil` literals.
  * Array `.first` with no matches now yields `nil` instead of `nil`/empty ambiguity.
* **Tests**
  * Added coverage for present vs absent optionals, optional-member comparison behavior, and `nil` binding rejection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->