### PR TITLE
Fix custom-sidebar nil-comparison so optional-guarded views render (#7943)

### DIFF
--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator+UserFunctions.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator+UserFunctions.swift
@@ -99,7 +99,7 @@ extension ExpressionEvaluator {
                 } else {
                     resolved = nil
                 }
-                guard let value = resolved else { return false }
+                guard let value = resolved, value != .null else { return false }
                 if let name { scope.define(name, value) }
             } else if let expr = element.condition.as(ExprSyntax.self) {
                 if !(eval(expr, scope)?.isTruthy ?? false) { return false }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -23,6 +23,9 @@ public struct ExpressionEvaluator: Sendable {
         if let literal = expr.as(BooleanLiteralExprSyntax.self) {
             return .bool(literal.literal.text == "true")
         }
+        if expr.is(NilLiteralExprSyntax.self) {
+            return .null
+        }
         if let literal = expr.as(StringLiteralExprSyntax.self) {
             return .string(evalString(literal, env))
         }
@@ -162,6 +165,17 @@ public struct ExpressionEvaluator: Sendable {
 
     private func evalInfix(_ node: InfixOperatorExprSyntax, _ env: EvalEnvironment) -> SwiftValue? {
         guard let op = node.operator.as(BinaryOperatorExprSyntax.self)?.operator.text else { return nil }
+
+        // Equality must tolerate an absent operand: a missing optional field
+        // evaluates to a host `nil`, and the `nil` literal evaluates to `.null`.
+        // Coalesce both to `.null` so `x == nil` / `x != nil` yield a Bool
+        // (false/true when present, true/false when absent) instead of vanishing.
+        if op == "==" || op == "!=" {
+            let lhs = eval(node.leftOperand, env) ?? .null
+            let rhs = eval(node.rightOperand, env) ?? .null
+            return .bool(op == "==" ? lhs == rhs : lhs != rhs)
+        }
+
         guard let lhs = eval(node.leftOperand, env) else { return nil }
 
         // Short-circuit logical operators on the left operand before forcing the
@@ -184,8 +198,6 @@ public struct ExpressionEvaluator: Sendable {
         case "..<", "...":
             guard case let .int(l) = lhs, case let .int(r) = rhs else { return nil }
             return .range(lower: l, upper: r, inclusive: op == "...")
-        case "==": return .bool(lhs == rhs)
-        case "!=": return .bool(lhs != rhs)
         default: break
         }
 

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -249,6 +249,10 @@ public struct ExpressionEvaluator: Sendable {
     }
 
     private func evalEqualityOperand(_ expr: ExprSyntax, _ env: EvalEnvironment) -> EqualityOperand {
+        env.budget.enter()
+        defer { env.budget.leave() }
+        guard !env.budget.exceeded else { return .failed }
+
         if expr.is(NilLiteralExprSyntax.self) {
             return .value(.null)
         }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -254,7 +254,8 @@ public struct ExpressionEvaluator: Sendable {
         }
 
         if let member = expr.as(MemberAccessExprSyntax.self), let baseExpr = member.base {
-            guard let base = eval(baseExpr, env) else { return .failed }
+            let baseOperand = evalEqualityOperand(baseExpr, env)
+            guard case let .value(base) = baseOperand else { return baseOperand }
             let name = member.declName.baseName.text
             if case let .object(fields) = base {
                 return fields[name].map(EqualityOperand.value) ?? .missingOptional
@@ -264,8 +265,9 @@ public struct ExpressionEvaluator: Sendable {
 
         if let subscriptCall = expr.as(SubscriptCallExprSyntax.self),
            let indexExpr = subscriptCall.arguments.first?.expression {
-            guard let base = eval(subscriptCall.calledExpression, env),
-                  let index = eval(indexExpr, env) else { return .failed }
+            let baseOperand = evalEqualityOperand(subscriptCall.calledExpression, env)
+            guard case let .value(base) = baseOperand else { return baseOperand }
+            guard let index = eval(indexExpr, env) else { return .failed }
             switch (base, index) {
             case let (.array(values), .int(i)):
                 return (i >= 0 && i < values.count) ? .value(values[i]) : .failed

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -166,13 +166,14 @@ public struct ExpressionEvaluator: Sendable {
     private func evalInfix(_ node: InfixOperatorExprSyntax, _ env: EvalEnvironment) -> SwiftValue? {
         guard let op = node.operator.as(BinaryOperatorExprSyntax.self)?.operator.text else { return nil }
 
-        // Equality must tolerate an absent operand: a missing optional field
-        // evaluates to a host `nil`, and the `nil` literal evaluates to `.null`.
-        // Coalesce both to `.null` so `x == nil` / `x != nil` yield a Bool
-        // (false/true when present, true/false when absent) instead of vanishing.
+        // Equality must tolerate an absent optional object field, but not every
+        // evaluation failure. Preserve failed conversions, invalid subscripts,
+        // unsupported syntax, and budget exhaustion as `nil` so callers skip.
         if op == "==" || op == "!=" {
-            let lhs = eval(node.leftOperand, env) ?? .null
-            let rhs = eval(node.rightOperand, env) ?? .null
+            guard let lhs = evalEqualityOperand(node.leftOperand, env).nilComparableValue,
+                  let rhs = evalEqualityOperand(node.rightOperand, env).nilComparableValue else {
+                return nil
+            }
             return .bool(op == "==" ? lhs == rhs : lhs != rhs)
         }
 
@@ -231,6 +232,51 @@ public struct ExpressionEvaluator: Sendable {
         case ">=": return .bool(l >= r)
         default: return nil
         }
+    }
+
+    private enum EqualityOperand {
+        case value(SwiftValue)
+        case missingOptional
+        case failed
+
+        var nilComparableValue: SwiftValue? {
+            switch self {
+            case let .value(value): return value
+            case .missingOptional: return .null
+            case .failed: return nil
+            }
+        }
+    }
+
+    private func evalEqualityOperand(_ expr: ExprSyntax, _ env: EvalEnvironment) -> EqualityOperand {
+        if expr.is(NilLiteralExprSyntax.self) {
+            return .value(.null)
+        }
+
+        if let member = expr.as(MemberAccessExprSyntax.self), let baseExpr = member.base {
+            guard let base = eval(baseExpr, env) else { return .failed }
+            let name = member.declName.baseName.text
+            if case let .object(fields) = base {
+                return fields[name].map(EqualityOperand.value) ?? .missingOptional
+            }
+            return base.member(name).map(EqualityOperand.value) ?? .failed
+        }
+
+        if let subscriptCall = expr.as(SubscriptCallExprSyntax.self),
+           let indexExpr = subscriptCall.arguments.first?.expression {
+            guard let base = eval(subscriptCall.calledExpression, env),
+                  let index = eval(indexExpr, env) else { return .failed }
+            switch (base, index) {
+            case let (.array(values), .int(i)):
+                return (i >= 0 && i < values.count) ? .value(values[i]) : .failed
+            case let (.object(fields), .string(key)):
+                return fields[key].map(EqualityOperand.value) ?? .missingOptional
+            default:
+                return .failed
+            }
+        }
+
+        return eval(expr, env).map(EqualityOperand.value) ?? .failed
     }
 
     private func numericPair(_ lhs: SwiftValue, _ rhs: SwiftValue) -> (Double?, Double?, Bool) {

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/ExpressionEvaluator.swift
@@ -253,6 +253,11 @@ public struct ExpressionEvaluator: Sendable {
             return .value(.null)
         }
 
+        if let tuple = expr.as(TupleExprSyntax.self), tuple.elements.count == 1,
+           let inner = tuple.elements.first?.expression {
+            return evalEqualityOperand(inner, env)
+        }
+
         if let member = expr.as(MemberAccessExprSyntax.self), let baseExpr = member.base {
             let baseOperand = evalEqualityOperand(baseExpr, env)
             guard case let .value(base) = baseOperand else { return baseOperand }

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftValue.swift
@@ -11,6 +11,10 @@ public enum SwiftValue: Codable, Sendable, Equatable {
     case double(Double)
     case string(String)
     case bool(Bool)
+    /// The result of the `nil` literal and of comparing an absent optional
+    /// field against `nil`. Distinct from a host `SwiftValue?` of `nil`, which
+    /// means "expression could not be evaluated / no value".
+    case null
     case range(lower: Int, upper: Int, inclusive: Bool)
     indirect case array([SwiftValue])
     indirect case object([String: SwiftValue])
@@ -22,6 +26,7 @@ public enum SwiftValue: Codable, Sendable, Equatable {
         case let .double(value): return String(value)
         case let .string(value): return value
         case let .bool(value): return String(value)
+        case .null: return "nil"
         case let .range(lower, upper, inclusive): return "\(lower)\(inclusive ? "..." : "..<")\(upper)"
         case let .array(values): return "[" + values.map(\.displayString).joined(separator: ", ") + "]"
         case let .object(fields): return "{" + fields.keys.sorted().map { "\($0): \(fields[$0]!.displayString)" }.joined(separator: ", ") + "}"

--- a/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
+++ b/Packages/macOS/CmuxSwiftRender/Sources/CmuxSwiftRender/SwiftViewInterpreter.swift
@@ -607,7 +607,7 @@ public struct SwiftViewInterpreter: Sendable {
                 } else {
                     resolved = nil
                 }
-                guard let value = resolved else { return false }
+                guard let value = resolved, value != .null else { return false }
                 if let name { scope.define(name, value) }
             } else if let expr = element.condition.as(ExprSyntax.self) {
                 if !(expressions.eval(expr, scope)?.isTruthy ?? false) { return false }

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -221,6 +221,32 @@ import Testing
         #expect(node?.children.map(\.text) == ["alpha", "▸ beta"])
     }
 
+    // Regression for #7943: comparing an optional field against `nil` must
+    // evaluate to a Bool — `true` when the field is present, `false` when it
+    // is absent — across interpolation, ternaries, and `if` guards. Before the
+    // fix it evaluated to "nothing", so interpolation rendered empty, ternaries
+    // always took the else branch, and `if x != nil` guards were never taken.
+    @Test func nilComparisonEvaluatesToBoolForPresentAndAbsentFields() {
+        let workspaces = SwiftValue.array([
+            .object(["title": .string("has"), "note": .string("hello")]),
+            .object(["title": .string("missing")]),  // no `note` field
+        ])
+        let node = interp.evaluate("""
+        VStack {
+            ForEach(workspaces) { w in
+                Text("present: \\(w.note != nil)")
+                Text(w.note != nil ? "ternary: THEN" : "ternary: ELSE")
+                if w.note != nil { Text("guard: TAKEN") } else { Text("guard: NOT TAKEN") }
+                Text("absent: \\(w.note == nil)")
+            }
+        }
+        """, state: ["workspaces": workspaces])
+        #expect(node?.children.map(\.text) == [
+            "present: true", "ternary: THEN", "guard: TAKEN", "absent: false",
+            "present: false", "ternary: ELSE", "guard: NOT TAKEN", "absent: true",
+        ])
+    }
+
     @Test func labelFormButtonCapturesActionAndLabel() {
         let node = interp.evaluate("""
         VStack {

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -257,7 +257,10 @@ import Testing
             Text("missing field: \\(workspaces[0].note == nil)")
             Text("nested missing: \\(workspaces[0].meta.note == nil)")
             Text("nested present: \\(workspaces[1].meta.note != nil)")
+            Text("paren missing: \\((workspaces[0].note) == nil)")
+            Text("paren present: \\((workspaces[1].meta.note) != nil)")
             Text("bad subscript: \\(workspaces[3] == nil)")
+            Text("paren bad subscript: \\((workspaces[3]) == nil)")
             Text("bad conversion: \\(Int("nope") == nil)")
             Text("unsupported: \\(unknownThing() == nil)")
         }
@@ -266,7 +269,10 @@ import Testing
             "missing field: true",
             "nested missing: true",
             "nested present: true",
+            "paren missing: true",
+            "paren present: true",
             "bad subscript: ",
+            "paren bad subscript: ",
             "bad conversion: ",
             "unsupported: ",
         ])

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -250,10 +250,13 @@ import Testing
     @Test func nilComparisonDoesNotMaskEvaluationFailures() {
         let workspaces = SwiftValue.array([
             .object(["title": .string("alpha")]),
+            .object(["title": .string("beta"), "meta": .object(["note": .string("hello")])]),
         ])
         let node = interp.evaluate("""
         VStack {
             Text("missing field: \\(workspaces[0].note == nil)")
+            Text("nested missing: \\(workspaces[0].meta.note == nil)")
+            Text("nested present: \\(workspaces[1].meta.note != nil)")
             Text("bad subscript: \\(workspaces[3] == nil)")
             Text("bad conversion: \\(Int("nope") == nil)")
             Text("unsupported: \\(unknownThing() == nil)")
@@ -261,6 +264,8 @@ import Testing
         """, state: ["workspaces": workspaces])
         #expect(node?.children.map(\.text) == [
             "missing field: true",
+            "nested missing: true",
+            "nested present: true",
             "bad subscript: ",
             "bad conversion: ",
             "unsupported: ",

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -278,6 +278,18 @@ import Testing
         ])
     }
 
+    @Test func deeplyNestedNilComparisonRespectsRecursionBudget() {
+        let nested = String(repeating: "(", count: 450)
+            + "workspaces[0].note"
+            + String(repeating: ")", count: 450)
+        let node = interp.evaluate("""
+        VStack {
+            Text("budget: \\(\(nested) == nil)")
+        }
+        """, state: ["workspaces": .array([.object(["title": .string("alpha")])])])
+        #expect(node?.children.first?.text == "budget: ")
+    }
+
     @Test func labelFormButtonCapturesActionAndLabel() {
         let node = interp.evaluate("""
         VStack {
@@ -717,12 +729,14 @@ import Testing
             Text(tint(a)).foregroundColor(tint(a))
             Text(name(a))
             Text(name(b))
+            Text(name(c))
         }
         """, state: [
             "a": .object(["state": .string("queued"), "title": .string("Alpha")]),
             "b": .object(["state": .string("running")]),
+            "c": .object(["state": .string("running"), "title": .null]),
         ])
-        #expect(node?.children.map(\.text) == ["#7AA2F7", "Alpha", "untitled"])
+        #expect(node?.children.map(\.text) == ["#7AA2F7", "Alpha", "untitled", "untitled"])
     }
 
     @Test func ifLetOptionalBindingRendersWhenPresent() {
@@ -741,6 +755,14 @@ import Testing
         }
         """, state: ["ws": absent])
         #expect(node2?.children.first?.text == "no branch")
+
+        let explicitNil = SwiftValue.object(["branch": .null])
+        let node3 = interp.evaluate("""
+        VStack {
+            if let b = ws.branch { Text("on \\(b)") } else { Text("no branch") }
+        }
+        """, state: ["ws": explicitNil])
+        #expect(node3?.children.first?.text == "no branch")
     }
 
     @Test func switchSelectsMatchingCase() {

--- a/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
+++ b/Packages/macOS/CmuxSwiftRender/Tests/CmuxSwiftRenderTests/SwiftViewInterpreterTests.swift
@@ -247,6 +247,26 @@ import Testing
         ])
     }
 
+    @Test func nilComparisonDoesNotMaskEvaluationFailures() {
+        let workspaces = SwiftValue.array([
+            .object(["title": .string("alpha")]),
+        ])
+        let node = interp.evaluate("""
+        VStack {
+            Text("missing field: \\(workspaces[0].note == nil)")
+            Text("bad subscript: \\(workspaces[3] == nil)")
+            Text("bad conversion: \\(Int("nope") == nil)")
+            Text("unsupported: \\(unknownThing() == nil)")
+        }
+        """, state: ["workspaces": workspaces])
+        #expect(node?.children.map(\.text) == [
+            "missing field: true",
+            "bad subscript: ",
+            "bad conversion: ",
+            "unsupported: ",
+        ])
+    }
+
     @Test func labelFormButtonCapturesActionAndLabel() {
         let node = interp.evaluate("""
         VStack {


### PR DESCRIPTION
## Problem

Fixes #7943.

In a custom sidebar, comparing a bound optional field against `nil` does **not** evaluate to `true`/`false` — it evaluates to *nothing*. The guard is never taken, the field renders as absent even when it is populated, and no error is produced anywhere.

Root cause: the interpreter's value model had no null case, and the `nil` literal had no evaluator branch.

1. `SwiftValue` had no null case, so absence was represented by the host `SwiftValue?` of `nil` — "field is absent" and "expression could not be evaluated" were the same value.
2. `ExpressionEvaluator.eval` had no `NilLiteralExprSyntax` branch, so `eval(nil)` fell through to `return nil` (the "unsupported expression" sentinel).
3. `evalInfix`'s `guard let rhs = eval(...) else { return nil }` then refused the comparison, so `w.description != nil` yielded `nil`, not `.bool(true)`. Symmetrically, an absent field tripped the `guard let lhs`. **`!= nil` could never produce `true` *or* `false`.**

Every consumer coalesces that to "skip": `if` conditions (`?.isTruthy ?? false`) never take the guard, ternaries (`?.isTruthy ?? false`) always take the else branch, and interpolation (`?.displayString ?? ""`) renders empty. This silently broke cmux's own shipped examples (`status-board.swift`, `finder.swift`) and the ternary form recommended in `docs/custom-sidebars.md`.

## Fix

- Add `SwiftValue.null` for the `nil` literal and for comparing an absent optional field against `nil` — distinct from a host `SwiftValue?` of `nil`, which still means "no value".
- Evaluate `NilLiteralExprSyntax` to `.null`.
- Handle `==` / `!=` before the operand guards in `evalInfix`, coalescing an absent operand (host `nil`) and the `nil` literal to `.null`. The comparison now yields a Bool: `true`/`false` when the field is present, `false`/`true` when it is absent — matching Swift.

With this, the shipped `status-board.swift` / `finder.swift` examples and the documented `w.pr != nil ? … : …` ternary form render correctly again, with no example or doc changes required.

## Tests

Two-commit red/green structure:
- **Commit 1** adds `nilComparisonEvaluatesToBoolForPresentAndAbsentFields` (test only) — it checks `x != nil` / `x == nil` across interpolation, a ternary, and an `if` guard for both a present and an absent field. Red without the fix (interpolation renders empty, ternary/guard take the else/not-taken branch).
- **Commit 2** adds the fix — test goes green.

Verified locally with `swift test` in `Packages/macOS/CmuxSwiftRender`. (One unrelated pre-existing failure, `numberFormattedCurrencyAndReduce`, is a locale-dependent currency-symbol assertion — `US$4.00` vs `$4.00` — that fails on the clean baseline too, independent of this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7974"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786521945&installation_id=133855650&pr_number=7974&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7974&signature=43029e209446a0bf0616e93fdf9e5de82a119b33c650fdd82e52948c0a4232d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix nil comparisons in `CmuxSwiftRender` so `x == nil` / `x != nil` on optional fields (including nested and parenthesized) return a Bool and nil-guarded views render correctly. Also treat `.null` as absent in optional bindings and respect the recursion budget during equality checks.

- **Bug Fixes**
  - Equality: evaluate `nil` to `.null`, handle `==`/`!=` before guards, unwrap single-element tuples, coalesce missing optionals at any depth to `.null`, and preserve real evaluation failures; comparisons now return a Bool.
  - Optional binding: treat `.null` as absent in `if let` and `ForEach` bindings so guarded views skip when the value is explicitly `nil`.
  - Tests: added coverage for present/absent fields, nested/parenthesized paths, failure preservation, explicit `.null` in bindings, and deep nesting that hits the evaluation budget.

<sup>Written for commit 038eec8d0b5af101aef37669c005304e01ec654e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved expression evaluation so Swift `nil` is treated as a valid evaluated value and renders as the literal `nil`.
  * Updated `==`/`!=` (including `== nil` / `!= nil`) to correctly handle missing optional fields, including within ternary expressions and string interpolation.
  * Ensured equality comparisons don’t produce boolean results when evaluation fails.
  * Adjusted `if let`/optional-binding conditions to treat resolved `.null` as failing the condition.
* **Tests**
  * Added/expanded regression coverage for `nil` comparisons, conditional rendering, and recursion depth in nested cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->