### PR TITLE
Remove update notes from initial App Store metadata

### DIFF
--- a/ios/AppStoreReview/metadata/version/1.0.0/en-US.json
+++ b/ios/AppStoreReview/metadata/version/1.0.0/en-US.json
@@ -2,6 +2,5 @@
   "description": "cmux for iPhone and iPad is the mobile companion to cmux on macOS. Connect to a Mac you control to view workspaces, monitor terminal sessions, send terminal input, and receive opt-in notifications while away from your desk.\n\nA Mac running cmux is required. During App Review, use the demo account and prepared review Mac provided in Review Information. Pair through the in-app Add Computer flow, open the App Review workspace, and send echo app-review-ok.\n\ncmux does not sell digital goods in the iOS app. Existing account entitlements are displayed without purchase or upgrade links.",
   "keywords": "terminal,mac,remote,developer,workspace,ssh,command line,notifications,companion",
   "marketingUrl": "https://cmux.com",
-  "supportUrl": "https://cmux.com/docs",
-  "whatsNew": "Initial App Store release."
+  "supportUrl": "https://cmux.com/docs"
 }


### PR DESCRIPTION
## Summary
- remove `whatsNew` from the official `1.0.0` metadata
- retain release notes for future update versions, where Apple permits the field

## Root cause
- App Store Connect rejects `whatsNew` on an app’s first release with `Attribute whatsNew cannot be edited at this time`

## Testing
- `jq -e . ios/AppStoreReview/metadata/version/1.0.0/en-US.json`
- `asc metadata validate --dir ios/AppStoreReview/metadata`
- production metadata apply after merge is the behavior-level regression proof

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7977"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786524246&installation_id=133855650&pr_number=7977&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7977&signature=28fc1c13562eb0df377ec0dcda9098f607573ffea91712a8b4e3a95415e1f5ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the whatsNew field from the iOS App Store metadata for version 1.0.0 to meet Apple’s first‑release rules and unblock submission, keeping release notes for future updates. This avoids the App Store Connect error “Attribute whatsNew cannot be edited at this time.”

<sup>Written for commit e46535a2378eb892fcb2ed57c46b0414aa23c2ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7977?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated App Store metadata formatting.
  * Removed the “What’s New” entry from the English release metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->