### PR TITLE
Bootstrap initial App Store availability via public API

### DIFF
--- a/.github/workflows/ios-app-store.yml
+++ b/.github/workflows/ios-app-store.yml
@@ -263,6 +263,9 @@ jobs:
             --device-type IPAD_PRO_3GEN_129 \
             --replace
 
+      - name: Ensure App Store availability
+        run: python3 ios/scripts/asc_bootstrap_app_availability.py --app "$ASC_APP_ID"
+
       - name: Archive, export, and upload production build
         id: upload
         env:

--- a/ios/scripts/asc_bootstrap_app_availability.py
+++ b/ios/scripts/asc_bootstrap_app_availability.py
@@ -41,6 +41,17 @@ def _api_base() -> str:
     return override.rstrip("/")
 
 
+def _timeout_seconds() -> int:
+    raw = os.environ.get("ASC_TIMEOUT_SECONDS", "30")
+    try:
+        timeout = int(raw)
+    except ValueError as error:
+        raise RuntimeError("ASC_TIMEOUT_SECONDS must be an integer") from error
+    if not 1 <= timeout <= 600:
+        raise RuntimeError("ASC_TIMEOUT_SECONDS must be between 1 and 600")
+    return timeout
+
+
 def _error_code(body: Any) -> str:
     try:
         return str(((body.get("errors") or [{}])[0]).get("code", "unknown"))
@@ -53,6 +64,7 @@ def _request(
     base: str,
     method: str,
     path_or_url: str,
+    timeout: int,
     payload: dict[str, Any] | None = None,
 ) -> tuple[int, dict[str, Any]]:
     if path_or_url.startswith("/"):
@@ -69,7 +81,7 @@ def _request(
     request.add_header("Authorization", "Bearer " + token)
     request.add_header("Content-Type", "application/json")
     try:
-        with urllib.request.urlopen(request, timeout=30) as response:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
             return response.status, json.loads(response.read() or b"{}")
     except urllib.error.HTTPError as error:
         try:
@@ -79,12 +91,15 @@ def _request(
         return error.code, body
 
 
-def _existing_availability(token: str, base: str, app_id: str) -> str | None:
+def _existing_availability(
+    token: str, base: str, app_id: str, timeout: int
+) -> str | None:
     status, body = _request(
         token,
         base,
         "GET",
         f"/v1/apps/{urllib.parse.quote(app_id)}/appAvailabilityV2",
+        timeout,
     )
     if status == 404:
         return None
@@ -100,14 +115,14 @@ def _existing_availability(token: str, base: str, app_id: str) -> str | None:
     return str(data["id"])
 
 
-def _territory_ids(token: str, base: str) -> list[str]:
+def _territory_ids(token: str, base: str, timeout: int) -> list[str]:
     path: str | None = "/v1/territories?limit=200"
     territory_ids: set[str] = set()
     pages = 0
     while path:
         if pages >= MAX_TERRITORY_PAGES:
             raise RuntimeError("territory pagination exceeded safety limit")
-        status, body = _request(token, base, "GET", path)
+        status, body = _request(token, base, "GET", path, timeout)
         if status != 200:
             raise RuntimeError(
                 f"territory lookup HTTP {status} (code={_error_code(body)})"
@@ -163,20 +178,22 @@ def _create_payload(app_id: str, territory_ids: list[str]) -> dict[str, Any]:
 def bootstrap(app_id: str) -> tuple[str, int]:
     token = asc_max_build._token()
     base = _api_base()
-    existing_id = _existing_availability(token, base, app_id)
+    timeout = _timeout_seconds()
+    existing_id = _existing_availability(token, base, app_id, timeout)
     if existing_id:
         return existing_id, 0
 
-    territory_ids = _territory_ids(token, base)
+    territory_ids = _territory_ids(token, base, timeout)
     status, body = _request(
         token,
         base,
         "POST",
         "/v2/appAvailabilities",
+        timeout,
         _create_payload(app_id, territory_ids),
     )
     if status == 409:
-        existing_id = _existing_availability(token, base, app_id)
+        existing_id = _existing_availability(token, base, app_id, timeout)
         if existing_id:
             return existing_id, 0
     if status != 201:

--- a/ios/scripts/asc_bootstrap_app_availability.py
+++ b/ios/scripts/asc_bootstrap_app_availability.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Create initial public App Store availability when it does not exist.
+
+Apple exposes initial availability through the public App Store Connect API at
+POST /v2/appAvailabilities. The asc availability edit command only updates an
+existing record, so the production release lane needs this one-time bootstrap.
+
+The app is made available in every current territory, without pre-order, and
+future territories are enabled. Repeated runs are no-ops once the record exists.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from typing import Any
+
+import asc_max_build
+
+
+OFFICIAL_API_BASE = "https://api.appstoreconnect.apple.com"
+MAX_TERRITORY_PAGES = 20
+
+
+def _api_base() -> str:
+    override = os.environ.get("CMUX_ASC_API_BASE_URL")
+    if not override:
+        return OFFICIAL_API_BASE
+    parsed = urllib.parse.urlsplit(override)
+    if parsed.scheme not in {"http", "https"} or parsed.hostname not in {
+        "127.0.0.1",
+        "::1",
+        "localhost",
+    }:
+        raise RuntimeError("CMUX_ASC_API_BASE_URL is restricted to loopback tests")
+    return override.rstrip("/")
+
+
+def _error_code(body: Any) -> str:
+    try:
+        return str(((body.get("errors") or [{}])[0]).get("code", "unknown"))
+    except Exception:
+        return "unknown"
+
+
+def _request(
+    token: str,
+    base: str,
+    method: str,
+    path_or_url: str,
+    payload: dict[str, Any] | None = None,
+) -> tuple[int, dict[str, Any]]:
+    if path_or_url.startswith("/"):
+        url = base + path_or_url
+    else:
+        url = path_or_url
+        parsed_base = urllib.parse.urlsplit(base)
+        parsed_url = urllib.parse.urlsplit(url)
+        if (parsed_url.scheme, parsed_url.netloc) != (parsed_base.scheme, parsed_base.netloc):
+            raise RuntimeError("App Store Connect pagination changed API origin")
+
+    data = None if payload is None else json.dumps(payload).encode("utf-8")
+    request = urllib.request.Request(url, data=data, method=method)
+    request.add_header("Authorization", "Bearer " + token)
+    request.add_header("Content-Type", "application/json")
+    try:
+        with urllib.request.urlopen(request, timeout=30) as response:
+            return response.status, json.loads(response.read() or b"{}")
+    except urllib.error.HTTPError as error:
+        try:
+            body = json.loads(error.read() or b"{}")
+        except json.JSONDecodeError:
+            body = {}
+        return error.code, body
+
+
+def _existing_availability(token: str, base: str, app_id: str) -> str | None:
+    status, body = _request(
+        token,
+        base,
+        "GET",
+        f"/v1/apps/{urllib.parse.quote(app_id)}/appAvailabilityV2",
+    )
+    if status == 404:
+        return None
+    if status != 200:
+        raise RuntimeError(
+            f"availability lookup HTTP {status} (code={_error_code(body)})"
+        )
+    data = body.get("data")
+    if data is None:
+        return None
+    if not isinstance(data, dict) or not data.get("id"):
+        raise RuntimeError("availability lookup returned an unexpected resource")
+    return str(data["id"])
+
+
+def _territory_ids(token: str, base: str) -> list[str]:
+    path: str | None = "/v1/territories?limit=200"
+    territory_ids: set[str] = set()
+    pages = 0
+    while path:
+        if pages >= MAX_TERRITORY_PAGES:
+            raise RuntimeError("territory pagination exceeded safety limit")
+        status, body = _request(token, base, "GET", path)
+        if status != 200:
+            raise RuntimeError(
+                f"territory lookup HTTP {status} (code={_error_code(body)})"
+            )
+        data = body.get("data")
+        if not isinstance(data, list):
+            raise RuntimeError("territory lookup returned an unexpected resource")
+        for item in data:
+            if not isinstance(item, dict) or not item.get("id"):
+                raise RuntimeError("territory lookup returned an invalid territory")
+            territory_ids.add(str(item["id"]))
+        next_url = (body.get("links") or {}).get("next")
+        if next_url is not None and not isinstance(next_url, str):
+            raise RuntimeError("territory lookup returned an invalid next link")
+        path = next_url or None
+        pages += 1
+    if not territory_ids:
+        raise RuntimeError("territory lookup returned no territories")
+    return sorted(territory_ids)
+
+
+def _create_payload(app_id: str, territory_ids: list[str]) -> dict[str, Any]:
+    linkage: list[dict[str, str]] = []
+    included: list[dict[str, Any]] = []
+    for territory_id in territory_ids:
+        availability_id = f"availability-{territory_id}"
+        linkage.append({"type": "territoryAvailabilities", "id": availability_id})
+        included.append(
+            {
+                "type": "territoryAvailabilities",
+                "id": availability_id,
+                "attributes": {"available": True, "preOrderEnabled": False},
+                "relationships": {
+                    "territory": {
+                        "data": {"type": "territories", "id": territory_id}
+                    }
+                },
+            }
+        )
+    return {
+        "data": {
+            "type": "appAvailabilities",
+            "attributes": {"availableInNewTerritories": True},
+            "relationships": {
+                "app": {"data": {"type": "apps", "id": app_id}},
+                "territoryAvailabilities": {"data": linkage},
+            },
+        },
+        "included": included,
+    }
+
+
+def bootstrap(app_id: str) -> tuple[str, int]:
+    token = asc_max_build._token()
+    base = _api_base()
+    existing_id = _existing_availability(token, base, app_id)
+    if existing_id:
+        return existing_id, 0
+
+    territory_ids = _territory_ids(token, base)
+    status, body = _request(
+        token,
+        base,
+        "POST",
+        "/v2/appAvailabilities",
+        _create_payload(app_id, territory_ids),
+    )
+    if status == 409:
+        existing_id = _existing_availability(token, base, app_id)
+        if existing_id:
+            return existing_id, 0
+    if status != 201:
+        raise RuntimeError(
+            f"availability create HTTP {status} (code={_error_code(body)})"
+        )
+    data = body.get("data")
+    if not isinstance(data, dict) or not data.get("id"):
+        raise RuntimeError("availability create returned an unexpected resource")
+    return str(data["id"]), len(territory_ids)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--app", required=True, help="numeric App Store Connect app ID")
+    args = parser.parse_args()
+    if not args.app.isdigit():
+        raise RuntimeError("--app must be a numeric App Store Connect app ID")
+    availability_id, created_territories = bootstrap(args.app)
+    if created_territories:
+        print(
+            f"created App Store availability {availability_id} "
+            f"for {created_territories} territories"
+        )
+    else:
+        print(f"App Store availability already exists: {availability_id}")
+
+
+if __name__ == "__main__":
+    try:
+        main()
+    except Exception as error:
+        print(f"asc_bootstrap_app_availability: {error}", file=sys.stderr)
+        sys.exit(1)

--- a/ios/scripts/asc_bootstrap_app_availability.py
+++ b/ios/scripts/asc_bootstrap_app_availability.py
@@ -133,7 +133,7 @@ def _create_payload(app_id: str, territory_ids: list[str]) -> dict[str, Any]:
     linkage: list[dict[str, str]] = []
     included: list[dict[str, Any]] = []
     for territory_id in territory_ids:
-        availability_id = f"availability-{territory_id}"
+        availability_id = f"${{local-{territory_id.lower()}}}"
         linkage.append({"type": "territoryAvailabilities", "id": availability_id})
         included.append(
             {

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -8,6 +8,7 @@ import http.server
 import json
 import os
 import plistlib
+import re
 import shutil
 import stat
 import subprocess
@@ -1062,6 +1063,31 @@ def test_bootstrap_appstore_availability_creates_all_territories_once(tmp: Path)
             if self.path != "/v2/appAvailabilities":
                 self._write_json(404, {"errors": [{"code": "NOT_FOUND"}]})
                 return
+            data = body.get("data", {})
+            relationships = data.get("relationships", {})
+            territory_relationship = relationships.get("territoryAvailabilities", {})
+            linkage = territory_relationship.get("data", [])
+            included = body.get("included", [])
+            linkage_ids = {
+                item.get("id") for item in linkage if isinstance(item, dict)
+            }
+            included_ids = {
+                item.get("id") for item in included if isinstance(item, dict)
+            }
+            if (
+                linkage_ids != included_ids
+                or not linkage_ids
+                or not all(
+                    isinstance(item_id, str)
+                    and re.fullmatch(r"\$\{local-[a-z0-9-]+\}", item_id)
+                    for item_id in linkage_ids
+                )
+            ):
+                self._write_json(
+                    409,
+                    {"errors": [{"code": "ENTITY_ERROR.INCLUDED.INVALID_ID"}]},
+                )
+                return
             availability_created = True
             self._write_json(
                 201,
@@ -1135,7 +1161,7 @@ def test_bootstrap_appstore_availability_creates_all_territories_once(tmp: Path)
         )
         _check(
             {item.get("id") for item in linkage if isinstance(item, dict)}
-            == {"availability-USA", "availability-CAN", "availability-JPN"},
+            == {"${local-usa}", "${local-can}", "${local-jpn}"},
             "availability links every current territory",
         )
         _check(

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -1123,6 +1123,7 @@ def test_bootstrap_appstore_availability_creates_all_territories_once(tmp: Path)
                 "ASC_API_KEY_ID": "TESTKEY123",
                 "ASC_API_ISSUER_ID": "00000000-0000-0000-0000-000000000000",
                 "ASC_API_KEY_PATH": str(key_path),
+                "ASC_TIMEOUT_SECONDS": "120",
                 "CMUX_ASC_API_BASE_URL": f"http://127.0.0.1:{server.server_port}",
             }
         )
@@ -1180,6 +1181,26 @@ def test_bootstrap_appstore_availability_creates_all_territories_once(tmp: Path)
         _check(
             len([request for request in requests if request[0] == "POST"]) == 1,
             "existing availability is not created again",
+        )
+
+        requests_before_invalid_timeout = len(requests)
+        invalid_timeout_env = env.copy()
+        invalid_timeout_env["ASC_TIMEOUT_SECONDS"] = "invalid"
+        invalid_timeout = subprocess.run(
+            command,
+            env=invalid_timeout_env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        _check(
+            invalid_timeout.returncode != 0
+            and "ASC_TIMEOUT_SECONDS must be an integer" in invalid_timeout.stderr,
+            "availability bootstrap validates the configured API timeout",
+        )
+        _check(
+            len(requests) == requests_before_invalid_timeout,
+            "invalid timeout configuration fails before an API request",
         )
     finally:
         server.shutdown()

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import base64
+import http.server
 import json
 import os
 import plistlib
@@ -12,6 +13,8 @@ import stat
 import subprocess
 import sys
 import tempfile
+import threading
+import urllib.parse
 import zipfile
 from pathlib import Path
 
@@ -990,6 +993,174 @@ def test_validate_appstore_release_prepares_content_rights_and_build(
         _check(False, "submission state is prepared before canonical readiness validation")
 
 
+def test_bootstrap_appstore_availability_creates_all_territories_once(tmp: Path) -> None:
+    tmp.mkdir(parents=True, exist_ok=True)
+    requests: list[tuple[str, str, dict[str, object] | None]] = []
+    availability_created = False
+
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def log_message(self, format: str, *args: object) -> None:
+            pass
+
+        def _write_json(self, status: int, body: dict[str, object]) -> None:
+            payload = json.dumps(body).encode("utf-8")
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def do_GET(self) -> None:
+            nonlocal availability_created
+            parsed = urllib.parse.urlsplit(self.path)
+            requests.append(("GET", self.path, None))
+            _check(
+                self.headers.get("Authorization", "").startswith("Bearer "),
+                "availability bootstrap authenticates every API request",
+            )
+            if parsed.path == f"/v1/apps/{ASC_APP_ID}/appAvailabilityV2":
+                body: dict[str, object] = {
+                    "data": (
+                        {"type": "appAvailabilities", "id": "availability-1"}
+                        if availability_created
+                        else None
+                    )
+                }
+                self._write_json(200, body)
+                return
+            if parsed.path == "/v1/territories":
+                if urllib.parse.parse_qs(parsed.query).get("cursor") == ["next"]:
+                    self._write_json(
+                        200,
+                        {
+                            "data": [{"type": "territories", "id": "JPN"}],
+                            "links": {},
+                        },
+                    )
+                    return
+                host, port = self.server.server_address
+                self._write_json(
+                    200,
+                    {
+                        "data": [
+                            {"type": "territories", "id": "USA"},
+                            {"type": "territories", "id": "CAN"},
+                        ],
+                        "links": {
+                            "next": f"http://{host}:{port}/v1/territories?cursor=next"
+                        },
+                    },
+                )
+                return
+            self._write_json(404, {"errors": [{"code": "NOT_FOUND"}]})
+
+        def do_POST(self) -> None:
+            nonlocal availability_created
+            length = int(self.headers.get("Content-Length", "0"))
+            body = json.loads(self.rfile.read(length))
+            requests.append(("POST", self.path, body))
+            if self.path != "/v2/appAvailabilities":
+                self._write_json(404, {"errors": [{"code": "NOT_FOUND"}]})
+                return
+            availability_created = True
+            self._write_json(
+                201,
+                {"data": {"type": "appAvailabilities", "id": "availability-1"}},
+            )
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        key_path = tmp / "AuthKey_TEST.p8"
+        openssl = shutil.which("openssl")
+        _check(openssl is not None, "availability test found OpenSSL")
+        key_result = subprocess.run(
+            [
+                openssl or "openssl",
+                "ecparam",
+                "-name",
+                "prime256v1",
+                "-genkey",
+                "-noout",
+                "-out",
+                str(key_path),
+            ],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        _check(key_result.returncode == 0, "availability test generated an ES256 key")
+        env = os.environ.copy()
+        env.update(
+            {
+                "ASC_API_KEY_ID": "TESTKEY123",
+                "ASC_API_ISSUER_ID": "00000000-0000-0000-0000-000000000000",
+                "ASC_API_KEY_PATH": str(key_path),
+                "CMUX_ASC_API_BASE_URL": f"http://127.0.0.1:{server.server_port}",
+            }
+        )
+        command = [
+            sys.executable,
+            str(ROOT / "ios" / "scripts" / "asc_bootstrap_app_availability.py"),
+            "--app",
+            ASC_APP_ID,
+        ]
+        first = subprocess.run(command, env=env, capture_output=True, text=True, check=False)
+        if first.returncode != 0:
+            print(first.stdout)
+            print(first.stderr, file=sys.stderr)
+        _check(first.returncode == 0, "availability bootstrap creates initial availability")
+
+        post_requests = [request for request in requests if request[0] == "POST"]
+        _check(len(post_requests) == 1, "availability bootstrap creates exactly one record")
+        payload = post_requests[0][2] if post_requests else {}
+        data = payload.get("data", {}) if isinstance(payload, dict) else {}
+        attributes = data.get("attributes", {}) if isinstance(data, dict) else {}
+        relationships = data.get("relationships", {}) if isinstance(data, dict) else {}
+        territory_relationship = (
+            relationships.get("territoryAvailabilities", {})
+            if isinstance(relationships, dict)
+            else {}
+        )
+        linkage = (
+            territory_relationship.get("data", [])
+            if isinstance(territory_relationship, dict)
+            else []
+        )
+        included = payload.get("included", []) if isinstance(payload, dict) else []
+        _check(
+            attributes.get("availableInNewTerritories") is True,
+            "availability includes future App Store territories",
+        )
+        _check(
+            {item.get("id") for item in linkage if isinstance(item, dict)}
+            == {"availability-USA", "availability-CAN", "availability-JPN"},
+            "availability links every current territory",
+        )
+        _check(
+            len(included) == 3
+            and all(
+                isinstance(item, dict)
+                and item.get("attributes", {}).get("available") is True
+                and item.get("attributes", {}).get("preOrderEnabled") is False
+                for item in included
+            ),
+            "every territory is immediately available without pre-order",
+        )
+
+        second = subprocess.run(command, env=env, capture_output=True, text=True, check=False)
+        _check(second.returncode == 0, "availability bootstrap is idempotent")
+        _check(
+            len([request for request in requests if request[0] == "POST"]) == 1,
+            "existing availability is not created again",
+        )
+    finally:
+        server.shutdown()
+        server.server_close()
+        thread.join(timeout=5)
+
+
 def main() -> None:
     with tempfile.TemporaryDirectory() as temp_dir:
         tmp = Path(temp_dir)
@@ -1006,6 +1177,9 @@ def main() -> None:
         test_validate_appstore_release_requires_numeric_app_id(tmp / "validate-test", fakebin)
         test_validate_appstore_release_prepares_content_rights_and_build(
             tmp / "prepare-submission-test", fakebin
+        )
+        test_bootstrap_appstore_availability_creates_all_territories_once(
+            tmp / "availability-bootstrap-test"
         )
 
     if FAILURES:


### PR DESCRIPTION
## Summary
- create first-time App Store availability through Apple's supported `POST /v2/appAvailabilities` endpoint
- make cmux available in every current territory and automatically include future territories
- run the idempotent bootstrap before the production archive and upload

## Verification
- `python3 tests/test_ios_appstore_lane_identity.py`
- `python3 -m py_compile ios/scripts/asc_bootstrap_app_availability.py tests/test_ios_appstore_lane_identity.py`
- workflow YAML parse
- two-commit regression proof: first commit adds the failing behavior test, second implements the fix

## Context
The attached `1.0.0` build is already Apple `VALID`. Canonical readiness reports only `availability.missing`; this PR removes that blocker using Apple's public App Store Connect API, without the experimental private web-session API.

Official endpoint: https://developer.apple.com/documentation/appstoreconnectapi/post-v2-appavailabilities

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7980"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786530138&installation_id=133855650&pr_number=7980&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7980&signature=24b678516c1576f9afb36db45fe38d279ccd14ec4cb0f18ce57d323853220a8a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bootstrap initial App Store availability via Apple’s public API for all current and future territories (no pre-order). Adds a validated, configurable request timeout to prevent hanging ASC calls.

- **New Features**
  - Added `ios/scripts/asc_bootstrap_app_availability.py` to create initial availability via `POST /v2/appAvailabilities` and enable future territories; tests cover pagination, idempotency, and timeout validation.
  - Integrated into `.github/workflows/ios-app-store.yml` to run before the production archive and upload.

- **Bug Fixes**
  - Unblocks release readiness by creating the initial availability and using Apple inline local IDs for `territoryAvailabilities` to satisfy API validation.
  - Honors `ASC_TIMEOUT_SECONDS` (1–600s, default 30) for all App Store Connect requests; invalid values fail fast.

<sup>Written for commit 5b68367b1bb6c6a34ae06bb368beb055b6ae3553. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an automated “App Store availability” setup step before production builds are archived and validated.
  * Automatically creates app availability across all current territories, enables future territories, and disables pre-orders.
  * Re-running the setup is safe and avoids duplicate availability records (handles potential race conditions).

* **Tests**
  * Added a test using a local fake App Store Connect API to verify authentication, paginated territory handling, correct request payloads, idempotency across repeated runs, and early failure on invalid timeout input.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->