### PR TITLE
Fix App Store screenshot readiness validation

### DIFF
--- a/ios/AppStoreReview/metadata-screenshots-checklist.md
+++ b/ios/AppStoreReview/metadata-screenshots-checklist.md
@@ -79,6 +79,6 @@ asc metadata validate --dir ios/AppStoreReview/metadata --output table
 ```
 
 ```bash
-asc screenshots validate --path ios/AppStoreReview/screenshots --device-type IPHONE_69 --output table
-asc screenshots validate --path ios/AppStoreReview/screenshots --device-type IPAD_PRO_3GEN_129 --output table
+asc screenshots validate --path ios/AppStoreReview/screenshots/en-US/iphone --device-type IPHONE_69 --output table
+asc screenshots validate --path ios/AppStoreReview/screenshots/en-US/ipad --device-type IPAD_PRO_3GEN_129 --output table
 ```

--- a/ios/scripts/validate-app-store-release.sh
+++ b/ios/scripts/validate-app-store-release.sh
@@ -55,6 +55,27 @@ read_xcconfig_setting() {
   sed -nE "s/^[[:space:]]*$key[[:space:]]*=[[:space:]]*([^[:space:]]+).*/\\1/p" "$file" 2>/dev/null | tail -n 1
 }
 
+resolve_screenshot_validation_path() {
+  local device_type="$1"
+  local device_dir=""
+  local canonical_path=""
+
+  case "$device_type" in
+    IPHONE_*) device_dir="iphone" ;;
+    IPAD_*) device_dir="ipad" ;;
+  esac
+
+  if [[ -n "$device_dir" ]]; then
+    canonical_path="$SCREENSHOTS_DIR/en-US/$device_dir"
+    if [[ -d "$canonical_path" ]]; then
+      printf '%s\n' "$canonical_path"
+      return
+    fi
+  fi
+
+  printf '%s\n' "$SCREENSHOTS_DIR"
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --app) APP="${2:-}"; shift 2 ;;
@@ -176,8 +197,9 @@ fi
 
 if [[ -d "$SCREENSHOTS_DIR" ]]; then
   for device_type in "${SCREENSHOT_DEVICE_TYPES[@]}"; do
-    note "validating screenshots at $SCREENSHOTS_DIR for $device_type"
-    asc screenshots validate --path "$SCREENSHOTS_DIR" --device-type "$device_type" --output table
+    screenshot_validation_path="$(resolve_screenshot_validation_path "$device_type")"
+    note "validating screenshots at $screenshot_validation_path for $device_type"
+    asc screenshots validate --path "$screenshot_validation_path" --device-type "$device_type" --output table
   done
 else
   note "no local screenshots dir at $SCREENSHOTS_DIR; use $CHECKLIST before staging"

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -926,6 +926,58 @@ def test_validate_appstore_release_requires_numeric_app_id(tmp: Path, fakebin: P
     _check("must be numeric" in bad_result.stderr, "validation helper explains that --app must be numeric")
 
 
+def test_validate_appstore_release_uses_device_screenshot_directories(
+    tmp: Path, fakebin: Path
+) -> None:
+    screenshots = tmp / "screenshots"
+    iphone = screenshots / "en-US" / "iphone"
+    ipad = screenshots / "en-US" / "ipad"
+    iphone.mkdir(parents=True)
+    ipad.mkdir(parents=True)
+    (iphone / "01-workspaces.png").write_bytes(b"iphone")
+    (ipad / "01-workspaces.png").write_bytes(b"ipad")
+
+    env = _base_env(tmp, fakebin)
+    result = _run(
+        [
+            "bash",
+            str(ROOT / "ios" / "scripts" / "validate-app-store-release.sh"),
+            "--app",
+            ASC_APP_ID,
+            "--version",
+            APPSTORE_MARKETING_VERSION,
+            "--screenshots-dir",
+            str(screenshots),
+            "--screenshot-device-type",
+            "IPHONE_69",
+            "--screenshot-device-type",
+            "IPAD_PRO_3GEN_129",
+        ],
+        env=env,
+        tmp=tmp,
+        log_failure=False,
+    )
+    _check(result.returncode == 0, "App Store validation accepts the canonical screenshot layout")
+
+    asc_calls = [
+        json.loads(line)
+        for line in (tmp / "asc.jsonl").read_text(encoding="utf-8").splitlines()
+    ]
+    screenshot_calls = [call for call in asc_calls if call[:2] == ["screenshots", "validate"]]
+    paths_by_device = {
+        call[call.index("--device-type") + 1]: call[call.index("--path") + 1]
+        for call in screenshot_calls
+    }
+    _check(
+        paths_by_device.get("IPHONE_69") == str(iphone),
+        "iPhone validation targets the directory containing iPhone images",
+    )
+    _check(
+        paths_by_device.get("IPAD_PRO_3GEN_129") == str(ipad),
+        "iPad validation targets the directory containing iPad images",
+    )
+
+
 def test_validate_appstore_release_prepares_content_rights_and_build(
     tmp: Path, fakebin: Path
 ) -> None:
@@ -1222,6 +1274,9 @@ def main() -> None:
         test_profile_installer_accepts_production_profile_by_default(tmp / "profile-test", fakebin)
         test_profile_installer_ignores_stale_primary_secret(tmp / "profile-stale-test", fakebin)
         test_validate_appstore_release_requires_numeric_app_id(tmp / "validate-test", fakebin)
+        test_validate_appstore_release_uses_device_screenshot_directories(
+            tmp / "validate-screenshots-test", fakebin
+        )
         test_validate_appstore_release_prepares_content_rights_and_build(
             tmp / "prepare-submission-test", fakebin
         )


### PR DESCRIPTION
Fixes the final submission preflight exposed by https://github.com/manaflow-ai/cmux/actions/runs/29246236675.

The release helper now resolves the canonical per-device screenshot directories before invoking `asc screenshots validate`. The PR preserves custom direct paths and adds a two-commit behavior regression proving the old parent-directory call fails.

Verification: `python3 tests/test_ios_appstore_lane_identity.py`; `bash -n ios/scripts/validate-app-store-release.sh`; `git diff --check`.

No app runtime behavior changes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7982"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786534702&installation_id=133855650&pr_number=7982&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7982&signature=4a6eb0dd4743cd2e887ccc8ef59c312c36cb8b63ca7c4025e81758fe53403893"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes App Store screenshot validation by targeting device-specific directories (`en-US/iphone` and `en-US/ipad`) instead of the parent folder. Prevents preflight failures during final submission.

- **Bug Fixes**
  - Resolve per-device paths for `asc screenshots validate` by mapping `IPHONE_*` to `en-US/iphone` and `IPAD_*` to `en-US/ipad`, with a fallback to the given screenshots dir.
  - Preserve custom direct paths.
  - Add tests and update the checklist to use the correct per-device paths.

<sup>Written for commit 70229843cb37b6831f4c1b17c815ce7a10f92175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7982?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS App Store screenshot validation to use locale-specific, device-specific screenshot directories for both iPhone and iPad.
  * Added fallback behavior to keep validation working when device-specific folders aren’t present.

* **Tests**
  * Added a test to confirm validation targets the correct screenshot directories for each device type.

* **Documentation**
  * Updated the iOS App Store Review screenshot validation commands to validate from the correct locale/device paths with explicit device type arguments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->