### PR TITLE
Add terminalBackground/terminalForeground to workspace definitions

### DIFF
--- a/Sources/CmuxConfigExecutor+WorkspaceLaunch.swift
+++ b/Sources/CmuxConfigExecutor+WorkspaceLaunch.swift
@@ -161,10 +161,19 @@ extension CmuxConfigExecutor {
             tabManager.closeWorkspace(existingWorkspaceToClose)
         }
 
+        let terminalColorCommand = wsDef.terminalColorCommand
         if let layout = wsDef.layout {
-            newWorkspace.applyCustomLayout(layout, baseCwd: resolvedCwd, setupCommand: wsDef.setup)
-        } else if let setup = wsDef.setup {
-            newWorkspace.sendConfigSetupCommand(setup)
+            newWorkspace.applyCustomLayout(
+                layout,
+                baseCwd: resolvedCwd,
+                setupCommand: wsDef.setup,
+                terminalColorCommand: terminalColorCommand
+            )
+        } else {
+            let startupCommands = [terminalColorCommand, wsDef.setup].compactMap { $0 }
+            if !startupCommands.isEmpty {
+                newWorkspace.sendConfigSetupCommand(startupCommands.joined(separator: "\n"))
+            }
         }
         return true
     }

--- a/Sources/CmuxWorkspaceDefinition.swift
+++ b/Sources/CmuxWorkspaceDefinition.swift
@@ -4,6 +4,12 @@ struct CmuxWorkspaceDefinition: Codable, Sendable, Hashable {
     var name: String?
     var cwd: String?
     var color: String?
+    /// Terminal background color (`#RRGGBB`) applied via OSC 11 to every
+    /// terminal the workspace launches.
+    var terminalBackground: String?
+    /// Terminal foreground color (`#RRGGBB`) applied via OSC 10 to every
+    /// terminal the workspace launches.
+    var terminalForeground: String?
     /// User-defined environment variables inherited by every shell spawned in the
     /// workspace (issue #5995). Managed `CMUX_*` variables always win.
     var env: [String: String]?
@@ -16,6 +22,8 @@ struct CmuxWorkspaceDefinition: Codable, Sendable, Hashable {
         name: String? = nil,
         cwd: String? = nil,
         color: String? = nil,
+        terminalBackground: String? = nil,
+        terminalForeground: String? = nil,
         env: [String: String]? = nil,
         setup: String? = nil,
         layout: CmuxLayoutNode? = nil
@@ -23,6 +31,8 @@ struct CmuxWorkspaceDefinition: Codable, Sendable, Hashable {
         self.name = name
         self.cwd = cwd
         self.color = color
+        self.terminalBackground = terminalBackground
+        self.terminalForeground = terminalForeground
         self.env = env
         self.setup = setup
         self.layout = layout
@@ -54,5 +64,38 @@ struct CmuxWorkspaceDefinition: Codable, Sendable, Hashable {
         } else {
             color = nil
         }
+
+        terminalBackground = try Self.decodeTerminalColor(from: container, forKey: .terminalBackground)
+        terminalForeground = try Self.decodeTerminalColor(from: container, forKey: .terminalForeground)
+    }
+
+    private static func decodeTerminalColor(
+        from container: KeyedDecodingContainer<CodingKeys>,
+        forKey key: CodingKeys
+    ) throws -> String? {
+        guard let raw = try container.decodeIfPresent(String.self, forKey: key) else { return nil }
+        guard let normalized = WorkspaceTabColorSettings.normalizedHex(raw) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: key,
+                in: container,
+                debugDescription: "Invalid terminal color \"\(raw)\". Expected 6-digit hex format (#RRGGBB)"
+            )
+        }
+        return normalized
+    }
+
+    /// Shell command that applies `terminalBackground`/`terminalForeground` via
+    /// OSC 11/10, delivered on the same path as the `setup` command. The hex
+    /// values are re-normalized so the interpolation stays shell-safe.
+    var terminalColorCommand: String? {
+        var parts: [String] = []
+        if let hex = terminalBackground.flatMap(WorkspaceTabColorSettings.normalizedHex) {
+            parts.append("printf '\\033]11;%s\\007' '\(hex)'")
+        }
+        if let hex = terminalForeground.flatMap(WorkspaceTabColorSettings.normalizedHex) {
+            parts.append("printf '\\033]10;%s\\007' '\(hex)'")
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: "; ")
     }
 }

--- a/Sources/Workspace+CustomLayout.swift
+++ b/Sources/Workspace+CustomLayout.swift
@@ -6,7 +6,12 @@ import Foundation
 
 extension Workspace {
 
-    func applyCustomLayout(_ layout: CmuxLayoutNode, baseCwd: String, setupCommand: String? = nil) {
+    func applyCustomLayout(
+        _ layout: CmuxLayoutNode,
+        baseCwd: String,
+        setupCommand: String? = nil,
+        terminalColorCommand: String? = nil
+    ) {
         guard let rootPaneId = bonsplitController.allPaneIds.first else { return }
 
         var leaves: [(paneId: PaneID, surfaces: [CmuxSurfaceDefinition])] = []
@@ -22,6 +27,7 @@ extension Workspace {
                 leaf.paneId,
                 surfaces: leaf.surfaces,
                 baseCwd: baseCwd,
+                terminalColorCommand: terminalColorCommand,
                 focusPanelId: &focusPanelId,
                 pendingSetup: &pendingSetup
             )
@@ -101,6 +107,7 @@ extension Workspace {
         _ paneId: PaneID,
         surfaces: [CmuxSurfaceDefinition],
         baseCwd: String,
+        terminalColorCommand: String?,
         focusPanelId: inout UUID?,
         pendingSetup: inout String?
     ) {
@@ -117,6 +124,7 @@ extension Workspace {
                 inPane: paneId,
                 surface: firstSurface,
                 baseCwd: baseCwd,
+                terminalColorCommand: terminalColorCommand,
                 focusPanelId: &focusPanelId,
                 pendingSetup: &pendingSetup
             )
@@ -127,6 +135,7 @@ extension Workspace {
                 inPane: paneId,
                 surface: surfaces[surfaceIndex],
                 baseCwd: baseCwd,
+                terminalColorCommand: terminalColorCommand,
                 focusPanelId: &focusPanelId,
                 pendingSetup: &pendingSetup
             )
@@ -134,12 +143,17 @@ extension Workspace {
     }
 
     /// Consumes the workspace-level setup command on the first terminal surface it
-    /// reaches, sequencing it ahead of that surface's own `command`.
+    /// reaches, sequencing it ahead of that surface's own `command`. The terminal
+    /// color command is not consumed — it runs on every terminal surface.
     private static func dequeueInitialTerminalInput(
+        terminalColorCommand: String?,
         pendingSetup: inout String?,
         command: String?
     ) -> String? {
         var lines: [String] = []
+        if let terminalColorCommand {
+            lines.append(terminalColorCommand)
+        }
         if let setup = pendingSetup {
             lines.append(setup)
             pendingSetup = nil
@@ -156,6 +170,7 @@ extension Workspace {
         inPane paneId: PaneID,
         surface: CmuxSurfaceDefinition,
         baseCwd: String,
+        terminalColorCommand: String?,
         focusPanelId: inout UUID?,
         pendingSetup: inout String?
     ) {
@@ -172,7 +187,11 @@ extension Workspace {
                 _ = closePanel(panelId, force: true)
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
+                if let input = Self.dequeueInitialTerminalInput(
+                    terminalColorCommand: terminalColorCommand,
+                    pendingSetup: &pendingSetup,
+                    command: surface.command
+                ) {
                     sendInputWhenReady(input, to: panel)
                 }
             }
@@ -180,7 +199,11 @@ extension Workspace {
         case .terminal:
             if let name = surface.name { setPanelCustomTitle(panelId: panelId, title: name) }
             if surface.focus == true { focusPanelId = panelId }
-            if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command),
+            if let input = Self.dequeueInitialTerminalInput(
+                terminalColorCommand: terminalColorCommand,
+                pendingSetup: &pendingSetup,
+                command: surface.command
+            ),
                let terminal = terminalPanel(for: panelId) {
                 sendInputWhenReady(input, to: terminal)
             }
@@ -215,6 +238,7 @@ extension Workspace {
         inPane paneId: PaneID,
         surface: CmuxSurfaceDefinition,
         baseCwd: String,
+        terminalColorCommand: String?,
         focusPanelId: inout UUID?,
         pendingSetup: inout String?
     ) {
@@ -229,7 +253,11 @@ extension Workspace {
             ) {
                 if let name = surface.name { setPanelCustomTitle(panelId: panel.id, title: name) }
                 if surface.focus == true { focusPanelId = panel.id }
-                if let input = Self.dequeueInitialTerminalInput(pendingSetup: &pendingSetup, command: surface.command) {
+                if let input = Self.dequeueInitialTerminalInput(
+                    terminalColorCommand: terminalColorCommand,
+                    pendingSetup: &pendingSetup,
+                    command: surface.command
+                ) {
                     sendInputWhenReady(input, to: panel)
                 }
             }

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -1376,6 +1376,59 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertEqual(ws?.color, "#FF5733")
     }
 
+    func testDecodeWorkspaceTerminalColors() throws {
+        let json = """
+        {
+          "commands": [{
+            "name": "Dev env",
+            "workspace": {
+              "name": "Development",
+              "terminalBackground": "#1a1a3e",
+              "terminalForeground": "#F4F3F2"
+            }
+          }]
+        }
+        """
+        let config = try decode(json)
+        let ws = config.commands[0].workspace
+        XCTAssertEqual(ws?.terminalBackground, "#1A1A3E")
+        XCTAssertEqual(ws?.terminalForeground, "#F4F3F2")
+        XCTAssertEqual(
+            ws?.terminalColorCommand,
+            "printf '\\033]11;%s\\007' '#1A1A3E'; printf '\\033]10;%s\\007' '#F4F3F2'"
+        )
+    }
+
+    func testDecodeWorkspaceRejectsInvalidTerminalBackground() {
+        let json = """
+        {
+          "commands": [{
+            "name": "Dev env",
+            "workspace": {
+              "name": "Development",
+              "terminalBackground": "not-a-color"
+            }
+          }]
+        }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+
+    func testDecodeWorkspaceRejectsNamedTerminalForeground() {
+        let json = """
+        {
+          "commands": [{
+            "name": "Dev env",
+            "workspace": {
+              "name": "Development",
+              "terminalForeground": "Indigo"
+            }
+          }]
+        }
+        """
+        XCTAssertThrowsError(try decode(json))
+    }
+
     func testDecodeRestartBehaviors() throws {
         for behavior in ["new", "recreate", "ignore", "confirm"] {
             let json = """

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -58,7 +58,7 @@
     },
     "commands": {
       "title": "commands",
-      "description": "Custom shell commands and workspace layout definitions. Workspace definitions support name, cwd, color, env, layout, and setup (a bootstrap command sent to the first terminal before its own command).",
+      "description": "Custom shell commands and workspace layout definitions. Workspace definitions support name, cwd, color, env, layout, setup (a bootstrap command sent to the first terminal before its own command), terminalBackground, and terminalForeground (#RRGGBB hex colors applied via OSC 11/10 to every terminal the workspace launches).",
       "type": "array",
       "items": {
         "type": "object",


### PR DESCRIPTION
## What
Workspace definitions in `cmux.json` (`commands` array) gain two optional keys:

```jsonc
{
  "name": "Barcelona Vibes",
  "cwd": "~/Vibes/Barcelona",
  "terminalBackground": "#1A1A3E",
  "terminalForeground": "#F5A623"
}
```

Every terminal the workspace launches gets that background/foreground — the per-workspace equivalent of iTerm profiles, useful when you run one workspace per client/brand/environment and want instant visual context.

## How
Ghostty already honors per-surface OSC 11/10, and cmux already persists those across restores (#5997). This PR just delivers `printf '\033]11;%s\007' '#RRGGBB'` on the same path as the existing `setup` command. Unlike `setup` (first terminal only), the color command reaches **every** terminal pane in a layout. Colors are strict `#RRGGBB` (reuses `WorkspaceTabColorSettings.normalizedHex`), so the shell interpolation is injection-proof; invalid values fail decoding like an invalid `color`.

## Scope / known limits (v1)
- Launch-time terminals only — tabs/splits created later keep the global theme. Happy to extend to later surface-creation paths in a follow-up if you're open to the feature.
- The printf is briefly visible in scrollback, same as `setup`.
- Config-file only; no UI (avoids localization surface for v1).

## Tests
Three decode tests added beside the existing `color` test in `CmuxConfigTests` (normalization, invalid hex throws, palette names rejected). Structured as red/green commits per CLAUDE.md. **Draft PR: authored without local Xcode — relying on CI for build/test verification.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ky5zNXk9QSPqvseLkqNU6

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7985"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786541528&installation_id=133855650&pr_number=7985&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7985&signature=d25464b53a9a35085a5f70ca8d51a5fdc854921547186c1b44c0effbd4f76743"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add per-workspace terminal colors to `cmux.json` via `terminalBackground` and `terminalForeground`, applied to every terminal the workspace launches for clearer visual context.

- **New Features**
  - Add `terminalBackground` and `terminalForeground` on workspace definitions, strict `#RRGGBB` with normalization; invalid values fail decoding.
  - Deliver colors via OSC 11/10 on the same path as `setup`; for layouts, send to each terminal surface; without layout, prepend to startup commands.
  - Update `web/data/cmux.schema.json` to document the new keys.
  - Add decode tests for success and rejection cases.
  - v1 scope: launch-time terminals only (later splits/tabs keep global theme).

<sup>Written for commit e90a80b9637c6d158795d06ea1e1f8e29ddb10c7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

