### PR TITLE
Fix CI-blocking Swift file length budget: shrink TerminalPanel.swift below the 900-line hard cap

### DIFF
--- a/Sources/Panels/TerminalPanel+TextBoxInput.swift
+++ b/Sources/Panels/TerminalPanel+TextBoxInput.swift
@@ -1,0 +1,365 @@
+import AppKit
+import Foundation
+
+/// The TextBox composer subsystem for ``TerminalPanel``: activation, focus arbitration
+/// with the terminal surface, escape handling, draft preservation/restoration, and the
+/// DEBUG-only inline fixture.
+extension TerminalPanel {
+    func recordTextBoxLaunchCommand(_ command: String) {
+        guard let boundedContext = TextBoxAgentDetection.boundedLaunchCommandContext(from: command) else { return }
+        textBoxState.recordLaunchCommand(boundedContext)
+    }
+
+    func clearTextBoxLaunchCommand() {
+        textBoxState.clearLaunchCommand()
+    }
+
+    func preferTextBoxInputWhenActivated() {
+        isTextBoxActive = true
+        textBoxInputFocusIntent = .textBox
+        shouldFocusTextBoxWhenAvailable = true
+        shouldOpenTextBoxFilePickerWhenAvailable = false
+        shouldHideTextBoxOnNextEscape = false
+        focusTextBoxIfNeeded()
+    }
+
+    func showTextBoxInputWhenAvailable() {
+        isTextBoxActive = true
+        textBoxInputFocusIntent = .terminal
+        shouldFocusTextBoxWhenAvailable = false
+        shouldOpenTextBoxFilePickerWhenAvailable = false
+        shouldHideTextBoxOnNextEscape = false
+    }
+
+    func registerTextBoxInputView(_ view: TextBoxInputTextView) {
+        textBoxInputView = view
+        // Registration runs from NSViewRepresentable.makeNSView; restoring drafts here must not
+        // write SwiftUI/Combine bindings while SwiftUI is constructing the subtree.
+        if let restoredTextBoxDraft {
+            self.restoredTextBoxDraft = nil
+            view.installSessionDraft(restoredTextBoxDraft, notifyingTextChange: false)
+        } else if let preservedTextBoxAttributedContent {
+            self.preservedTextBoxAttributedContent = nil
+            view.installPreservedContent(preservedTextBoxAttributedContent, notifyingTextChange: false)
+        }
+        focusTextBoxIfNeeded()
+#if DEBUG
+        applyPendingDebugTextBoxInlineFixtureIfNeeded()
+#endif
+    }
+
+    func textBoxInputViewDidMoveToWindow(_ view: TextBoxInputTextView) {
+        guard textBoxInputView === view else { return }
+        focusTextBoxIfNeeded()
+#if DEBUG
+        applyPendingDebugTextBoxInlineFixtureIfNeeded()
+#endif
+    }
+
+    @discardableResult
+    func toggleTextBoxInput() -> Bool {
+        if isTextBoxActive {
+            hideTextBoxInput()
+            return true
+        }
+
+        return focusTextBoxInput()
+    }
+
+    @discardableResult
+    func focusTextBoxInputOrTerminal() -> Bool {
+        if isTextBoxActive,
+           textBoxInputFocusIntent == .textBox {
+            shouldHideTextBoxOnNextEscape = false
+            let didFocusTerminal = focusTerminalSurface(respectForeignFirstResponder: false)
+            if !didFocusTerminal {
+                textBoxInputFocusIntent = .textBox
+            }
+            return didFocusTerminal
+        }
+
+        return focusTextBoxInput()
+    }
+
+    @discardableResult
+    func attachFileToTextBoxInput() -> Bool {
+        textBoxInputFocusIntent = .textBox
+        isTextBoxActive = true
+        shouldFocusTextBoxWhenAvailable = true
+        shouldOpenTextBoxFilePickerWhenAvailable = true
+        shouldHideTextBoxOnNextEscape = false
+        let hasMountedTextBox = textBoxInputView?.window != nil
+        let didFocusTextBox = focusTextBoxIfNeeded()
+        return didFocusTextBox || !hasMountedTextBox
+    }
+
+    func textBoxDidBecomeFocused() {
+        shouldHideTextBoxOnNextEscape = false
+        isTextBoxActive = true
+        textBoxInputFocusIntent = .textBox
+        surface.setFocus(false)
+        hostedView.setActive(false)
+    }
+
+    func terminalDidBecomeFocused() {
+        guard isTextBoxActive else { return }
+        shouldFocusTextBoxWhenAvailable = false
+        shouldOpenTextBoxFilePickerWhenAvailable = false
+        textBoxInputFocusIntent = .terminal
+    }
+
+    func handleTextBoxEscape() {
+        let hadTextBoxView = textBoxInputView != nil
+        let didFocusTerminal = focusTerminalSurface(
+            respectForeignFirstResponder: false,
+            clearTextBoxHideArm: false
+        )
+        shouldHideTextBoxOnNextEscape = isTextBoxActive && (hadTextBoxView || didFocusTerminal)
+    }
+
+    @discardableResult
+    func consumeTextBoxHideEscapeIfArmed(in window: NSWindow?) -> Bool {
+        guard isTextBoxActive,
+              shouldHideTextBoxOnNextEscape else {
+            return false
+        }
+        guard textBoxOrSurfaceOwnsEscapeContext(in: window) else {
+            shouldHideTextBoxOnNextEscape = false
+            return false
+        }
+        hideTextBoxInput()
+        return true
+    }
+
+    func clearTextBoxHideEscapeArm() {
+        shouldHideTextBoxOnNextEscape = false
+    }
+
+    private func hideTextBoxInput() {
+        shouldHideTextBoxOnNextEscape = false
+        shouldFocusTextBoxWhenAvailable = false
+        shouldOpenTextBoxFilePickerWhenAvailable = false
+        textBoxInputFocusIntent = .hidden
+        preserveTextBoxContentFromView()
+        isTextBoxActive = false
+        textBoxInputView = nil
+        focusTerminalSurface(respectForeignFirstResponder: false)
+    }
+
+    private func preserveTextBoxContentFromView() {
+        guard let textBoxInputView else { return }
+        preserveTextBoxContentForUnmount(from: textBoxInputView)
+    }
+
+    func preserveTextBoxContentForUnmount(from textBoxInputView: TextBoxInputTextView) {
+        // Dismantle can run while AttributeGraph is destroying this subtree. Cache only
+        // non-published draft state here; normal editing keeps the published bindings current.
+        if isClosingPanel {
+            assert(
+                didDiscardTextBoxContentForClose,
+                "close() must discard TextBox content before SwiftUI dismantles the TextBox view"
+            )
+            recordTextBoxViewUnmounted(textBoxInputView)
+            return
+        }
+        let preservedContent = textBoxInputView.attributedContentForPreservation()
+        textBoxInputView.invalidatePendingAttachmentUploads()
+        preservedTextBoxAttributedContent = NSAttributedString(
+            attributedString: preservedContent
+        )
+        recordTextBoxViewUnmounted(textBoxInputView)
+    }
+
+    private func recordTextBoxViewUnmounted(_ textBoxInputView: TextBoxInputTextView) {
+        guard self.textBoxInputView === textBoxInputView else { return }
+        self.textBoxInputView = nil
+    }
+
+    func discardTextBoxContentForClose(from textBoxInputView: TextBoxInputTextView? = nil) {
+        didDiscardTextBoxContentForClose = true
+        let currentTextView = textBoxInputView ?? self.textBoxInputView
+        let attachmentsToCleanup = currentTextView?.inlineAttachments() ?? textBoxAttachments
+        if let currentTextView {
+            currentTextView.clearContent(cleanupAttachmentFiles: true)
+            currentTextView.discardUndoHistoryAndCleanupPendingAttachmentFiles()
+        } else if !attachmentsToCleanup.isEmpty {
+            let cleanupTextView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
+            cleanupTextView.cleanupDisposableAttachmentFiles(
+                attachmentsToCleanup,
+                preservingActiveInlineAttachments: false
+            )
+        }
+        restoredTextBoxDraft = nil
+        preservedTextBoxAttributedContent = nil
+        textBoxContent = ""
+        textBoxAttachments = []
+        isTextBoxActive = false
+        textBoxInputFocusIntent = .hidden
+        shouldFocusTextBoxWhenAvailable = false
+        shouldOpenTextBoxFilePickerWhenAvailable = false
+        shouldHideTextBoxOnNextEscape = false
+        if self.textBoxInputView === currentTextView {
+            self.textBoxInputView = nil
+        }
+    }
+
+    func sessionTextBoxDraftSnapshot() -> SessionTextBoxInputDraftSnapshot? {
+        if let textBoxInputView {
+            return textBoxInputView.sessionDraftSnapshot(isActive: isTextBoxActive)
+        }
+
+        if let restoredTextBoxDraft {
+            return restoredTextBoxDraft
+        }
+
+        if let preservedTextBoxAttributedContent {
+            return TextBoxInputTextView.sessionDraftSnapshot(
+                from: preservedTextBoxAttributedContent,
+                isActive: isTextBoxActive
+            )
+        }
+
+        return TextBoxInputTextView.sessionDraftSnapshot(
+            text: textBoxContent,
+            attachments: textBoxAttachments,
+            isActive: isTextBoxActive
+        )
+    }
+
+    func restoreSessionTextBoxDraft(_ draft: SessionTextBoxInputDraftSnapshot?) {
+        guard let draft,
+              !draft.parts.isEmpty else {
+            restoredTextBoxDraft = nil
+            preservedTextBoxAttributedContent = nil
+            textBoxContent = ""
+            textBoxAttachments = []
+            isTextBoxActive = false
+            textBoxInputFocusIntent = .hidden
+            shouldFocusTextBoxWhenAvailable = false
+            shouldOpenTextBoxFilePickerWhenAvailable = false
+            shouldHideTextBoxOnNextEscape = false
+            return
+        }
+
+        restoredTextBoxDraft = draft
+        preservedTextBoxAttributedContent = nil
+        textBoxContent = TextBoxInputTextView.plainText(from: draft)
+        textBoxAttachments = TextBoxInputTextView.attachments(from: draft)
+        isTextBoxActive = draft.isActive
+        textBoxInputFocusIntent = draft.isActive ? .textBox : .hidden
+        shouldFocusTextBoxWhenAvailable = false
+        shouldOpenTextBoxFilePickerWhenAvailable = false
+        shouldHideTextBoxOnNextEscape = false
+    }
+
+    @discardableResult
+    private func focusTextBoxIfNeeded() -> Bool {
+        guard shouldFocusTextBoxWhenAvailable,
+              isTextBoxActive,
+              let textBoxInputView,
+              let window = textBoxInputView.window else { return false }
+        guard window.makeFirstResponder(textBoxInputView) else { return false }
+        shouldFocusTextBoxWhenAvailable = false
+        textBoxInputFocusIntent = .textBox
+        surface.setFocus(false)
+        hostedView.setActive(false)
+        if shouldOpenTextBoxFilePickerWhenAvailable {
+            shouldOpenTextBoxFilePickerWhenAvailable = false
+            textBoxInputView.openFilePicker()
+        }
+        return true
+    }
+
+    @discardableResult
+    func focusTextBoxInput() -> Bool {
+        textBoxInputFocusIntent = .textBox
+        isTextBoxActive = true
+        shouldFocusTextBoxWhenAvailable = true
+        shouldHideTextBoxOnNextEscape = false
+        let hasMountedTextBox = textBoxInputView?.window != nil
+        let didFocusTextBox = focusTextBoxIfNeeded()
+        return didFocusTextBox || !hasMountedTextBox
+    }
+
+    func textBoxOwnsResponder(_ responder: NSResponder?) -> Bool {
+        guard let responder,
+              let textBoxInputView else { return false }
+        if responder === textBoxInputView {
+            return true
+        }
+        guard let view = responder as? NSView else { return false }
+        return view.isDescendant(of: textBoxInputView)
+    }
+
+    private func textBoxOrSurfaceOwnsResponder(in window: NSWindow?) -> Bool {
+        guard let window else { return false }
+        if window === hostedView.window,
+           hostedView.isSurfaceViewFirstResponder() {
+            return true
+        }
+        guard let responder = window.firstResponder else { return false }
+        if textBoxOwnsResponder(responder) {
+            return true
+        }
+        return hostedView.ownedPanelFocusIntent(for: responder) == .surface
+    }
+
+    private func textBoxOrSurfaceOwnsEscapeContext(in window: NSWindow?) -> Bool {
+        guard let window else { return false }
+        return textBoxOrSurfaceOwnsResponder(in: window)
+    }
+
+#if DEBUG
+    @discardableResult
+    func installDebugTextBoxInlineFixture(
+        localURL: URL?,
+        beforeText: String,
+        afterText: String
+    ) -> Bool {
+        textBoxInputFocusIntent = .textBox
+        isTextBoxActive = true
+        shouldFocusTextBoxWhenAvailable = true
+
+        let fixture = DebugTextBoxInlineFixture(
+            localURL: localURL?.standardizedFileURL,
+            beforeText: beforeText,
+            afterText: afterText
+        )
+
+        pendingDebugTextBoxInlineFixture = fixture
+        applyPendingDebugTextBoxInlineFixtureIfNeeded()
+        return true
+    }
+
+    private func applyPendingDebugTextBoxInlineFixtureIfNeeded() {
+        guard let fixture = pendingDebugTextBoxInlineFixture,
+              let textBoxInputView,
+              let textBoxWindow = textBoxInputView.window,
+              textBoxWindow === hostedView.window else { return }
+        pendingDebugTextBoxInlineFixture = nil
+        applyDebugTextBoxInlineFixture(fixture, to: textBoxInputView)
+    }
+
+    private func applyDebugTextBoxInlineFixture(
+        _ fixture: DebugTextBoxInlineFixture,
+        to textBoxInputView: TextBoxInputTextView
+    ) {
+        textBoxInputView.window?.makeFirstResponder(textBoxInputView)
+        let attachment = fixture.localURL.map {
+                TextBoxAttachment(
+                    localURL: $0,
+                    submissionText: TextBoxAttachment.submissionText(forLocalFileURL: $0)
+                )
+        }
+        textBoxContent = fixture.beforeText + fixture.afterText
+        textBoxAttachments = attachment.map { [$0] } ?? []
+        textBoxInputView.installInlineControlFixture(
+            attachment,
+            beforeText: fixture.beforeText,
+            afterText: fixture.afterText
+        )
+        textBoxContent = textBoxInputView.plainText()
+        textBoxAttachments = textBoxInputView.inlineAttachments()
+    }
+#endif
+}

--- a/Sources/Panels/TerminalPanel.swift
+++ b/Sources/Panels/TerminalPanel.swift
@@ -35,7 +35,7 @@ enum AgentHibernationResumePreparation: Equatable {
 /// This allows TerminalSurface to be used within the bonsplit-based layout system.
 @MainActor
 final class TerminalPanel: Panel, ObservableObject {
-    private enum TextBoxInputFocusIntent: Equatable {
+    enum TextBoxInputFocusIntent: Equatable {
         case hidden
         case terminal
         case textBox
@@ -75,22 +75,24 @@ final class TerminalPanel: Panel, ObservableObject {
     @Published var textBoxContent: String = ""
     @Published var textBoxAttachments: [TextBoxAttachment] = []
     weak var textBoxInputView: TextBoxInputTextView?
-    private var shouldFocusTextBoxWhenAvailable = false
-    private var shouldOpenTextBoxFilePickerWhenAvailable = false
-    private var shouldHideTextBoxOnNextEscape = false
-    private var textBoxInputFocusIntent: TextBoxInputFocusIntent = .hidden
-    private var preservedTextBoxAttributedContent: NSAttributedString?
-    private var restoredTextBoxDraft: SessionTextBoxInputDraftSnapshot?
-    private var isClosingPanel = false
-    private var didDiscardTextBoxContentForClose = false
+    // TextBox composer state below is internal (not private) because the subsystem's
+    // methods live in TerminalPanel+TextBoxInput.swift; extensions cannot add storage.
+    var shouldFocusTextBoxWhenAvailable = false
+    var shouldOpenTextBoxFilePickerWhenAvailable = false
+    var shouldHideTextBoxOnNextEscape = false
+    var textBoxInputFocusIntent: TextBoxInputFocusIntent = .hidden
+    var preservedTextBoxAttributedContent: NSAttributedString?
+    var restoredTextBoxDraft: SessionTextBoxInputDraftSnapshot?
+    var isClosingPanel = false
+    var didDiscardTextBoxContentForClose = false
 #if DEBUG
-    private struct DebugTextBoxInlineFixture {
+    struct DebugTextBoxInlineFixture {
         let localURL: URL?
         let beforeText: String
         let afterText: String
     }
 
-    private var pendingDebugTextBoxInlineFixture: DebugTextBoxInlineFixture?
+    var pendingDebugTextBoxInlineFixture: DebugTextBoxInlineFixture?
 
     var debugHasPendingTextBoxFocusRequest: Bool {
         shouldFocusTextBoxWhenAvailable || shouldOpenTextBoxFilePickerWhenAvailable
@@ -135,15 +137,6 @@ final class TerminalPanel: Panel, ObservableObject {
             shellActivity.state = state
         }
         textBoxState.updateShellActivityState(state)
-    }
-
-    func recordTextBoxLaunchCommand(_ command: String) {
-        guard let boundedContext = TextBoxAgentDetection.boundedLaunchCommandContext(from: command) else { return }
-        textBoxState.recordLaunchCommand(boundedContext)
-    }
-
-    func clearTextBoxLaunchCommand() {
-        textBoxState.clearLaunchCommand()
     }
 
     var isDirty: Bool {
@@ -268,327 +261,6 @@ final class TerminalPanel: Panel, ObservableObject {
         tmuxLayoutReport = report
     }
 
-    func preferTextBoxInputWhenActivated() {
-        isTextBoxActive = true
-        textBoxInputFocusIntent = .textBox
-        shouldFocusTextBoxWhenAvailable = true
-        shouldOpenTextBoxFilePickerWhenAvailable = false
-        shouldHideTextBoxOnNextEscape = false
-        focusTextBoxIfNeeded()
-    }
-
-    func showTextBoxInputWhenAvailable() {
-        isTextBoxActive = true
-        textBoxInputFocusIntent = .terminal
-        shouldFocusTextBoxWhenAvailable = false
-        shouldOpenTextBoxFilePickerWhenAvailable = false
-        shouldHideTextBoxOnNextEscape = false
-    }
-
-    func registerTextBoxInputView(_ view: TextBoxInputTextView) {
-        textBoxInputView = view
-        // Registration runs from NSViewRepresentable.makeNSView; restoring drafts here must not
-        // write SwiftUI/Combine bindings while SwiftUI is constructing the subtree.
-        if let restoredTextBoxDraft {
-            self.restoredTextBoxDraft = nil
-            view.installSessionDraft(restoredTextBoxDraft, notifyingTextChange: false)
-        } else if let preservedTextBoxAttributedContent {
-            self.preservedTextBoxAttributedContent = nil
-            view.installPreservedContent(preservedTextBoxAttributedContent, notifyingTextChange: false)
-        }
-        focusTextBoxIfNeeded()
-#if DEBUG
-        applyPendingDebugTextBoxInlineFixtureIfNeeded()
-#endif
-    }
-
-    func textBoxInputViewDidMoveToWindow(_ view: TextBoxInputTextView) {
-        guard textBoxInputView === view else { return }
-        focusTextBoxIfNeeded()
-#if DEBUG
-        applyPendingDebugTextBoxInlineFixtureIfNeeded()
-#endif
-    }
-
-    @discardableResult
-    func toggleTextBoxInput() -> Bool {
-        if isTextBoxActive {
-            hideTextBoxInput()
-            return true
-        }
-
-        return focusTextBoxInput()
-    }
-
-    @discardableResult
-    func focusTextBoxInputOrTerminal() -> Bool {
-        if isTextBoxActive,
-           textBoxInputFocusIntent == .textBox {
-            shouldHideTextBoxOnNextEscape = false
-            let didFocusTerminal = focusTerminalSurface(respectForeignFirstResponder: false)
-            if !didFocusTerminal {
-                textBoxInputFocusIntent = .textBox
-            }
-            return didFocusTerminal
-        }
-
-        return focusTextBoxInput()
-    }
-
-    @discardableResult
-    func attachFileToTextBoxInput() -> Bool {
-        textBoxInputFocusIntent = .textBox
-        isTextBoxActive = true
-        shouldFocusTextBoxWhenAvailable = true
-        shouldOpenTextBoxFilePickerWhenAvailable = true
-        shouldHideTextBoxOnNextEscape = false
-        let hasMountedTextBox = textBoxInputView?.window != nil
-        let didFocusTextBox = focusTextBoxIfNeeded()
-        return didFocusTextBox || !hasMountedTextBox
-    }
-
-    func textBoxDidBecomeFocused() {
-        shouldHideTextBoxOnNextEscape = false
-        isTextBoxActive = true
-        textBoxInputFocusIntent = .textBox
-        surface.setFocus(false)
-        hostedView.setActive(false)
-    }
-
-    func terminalDidBecomeFocused() {
-        guard isTextBoxActive else { return }
-        shouldFocusTextBoxWhenAvailable = false
-        shouldOpenTextBoxFilePickerWhenAvailable = false
-        textBoxInputFocusIntent = .terminal
-    }
-
-    func handleTextBoxEscape() {
-        let hadTextBoxView = textBoxInputView != nil
-        let didFocusTerminal = focusTerminalSurface(
-            respectForeignFirstResponder: false,
-            clearTextBoxHideArm: false
-        )
-        shouldHideTextBoxOnNextEscape = isTextBoxActive && (hadTextBoxView || didFocusTerminal)
-    }
-
-    @discardableResult
-    func consumeTextBoxHideEscapeIfArmed(in window: NSWindow?) -> Bool {
-        guard isTextBoxActive,
-              shouldHideTextBoxOnNextEscape else {
-            return false
-        }
-        guard textBoxOrSurfaceOwnsEscapeContext(in: window) else {
-            shouldHideTextBoxOnNextEscape = false
-            return false
-        }
-        hideTextBoxInput()
-        return true
-    }
-
-    func clearTextBoxHideEscapeArm() {
-        shouldHideTextBoxOnNextEscape = false
-    }
-
-    private func hideTextBoxInput() {
-        shouldHideTextBoxOnNextEscape = false
-        shouldFocusTextBoxWhenAvailable = false
-        shouldOpenTextBoxFilePickerWhenAvailable = false
-        textBoxInputFocusIntent = .hidden
-        preserveTextBoxContentFromView()
-        isTextBoxActive = false
-        textBoxInputView = nil
-        focusTerminalSurface(respectForeignFirstResponder: false)
-    }
-
-    private func preserveTextBoxContentFromView() {
-        guard let textBoxInputView else { return }
-        preserveTextBoxContentForUnmount(from: textBoxInputView)
-    }
-
-    func preserveTextBoxContentForUnmount(from textBoxInputView: TextBoxInputTextView) {
-        // Dismantle can run while AttributeGraph is destroying this subtree. Cache only
-        // non-published draft state here; normal editing keeps the published bindings current.
-        if isClosingPanel {
-            assert(
-                didDiscardTextBoxContentForClose,
-                "close() must discard TextBox content before SwiftUI dismantles the TextBox view"
-            )
-            recordTextBoxViewUnmounted(textBoxInputView)
-            return
-        }
-        let preservedContent = textBoxInputView.attributedContentForPreservation()
-        textBoxInputView.invalidatePendingAttachmentUploads()
-        preservedTextBoxAttributedContent = NSAttributedString(
-            attributedString: preservedContent
-        )
-        recordTextBoxViewUnmounted(textBoxInputView)
-    }
-
-    private func recordTextBoxViewUnmounted(_ textBoxInputView: TextBoxInputTextView) {
-        guard self.textBoxInputView === textBoxInputView else { return }
-        self.textBoxInputView = nil
-    }
-
-    private func discardTextBoxContentForClose(from textBoxInputView: TextBoxInputTextView? = nil) {
-        didDiscardTextBoxContentForClose = true
-        let currentTextView = textBoxInputView ?? self.textBoxInputView
-        let attachmentsToCleanup = currentTextView?.inlineAttachments() ?? textBoxAttachments
-        if let currentTextView {
-            currentTextView.clearContent(cleanupAttachmentFiles: true)
-            currentTextView.discardUndoHistoryAndCleanupPendingAttachmentFiles()
-        } else if !attachmentsToCleanup.isEmpty {
-            let cleanupTextView = TextBoxInputTextView(frame: NSRect(x: 0, y: 0, width: 1, height: 1))
-            cleanupTextView.cleanupDisposableAttachmentFiles(
-                attachmentsToCleanup,
-                preservingActiveInlineAttachments: false
-            )
-        }
-        restoredTextBoxDraft = nil
-        preservedTextBoxAttributedContent = nil
-        textBoxContent = ""
-        textBoxAttachments = []
-        isTextBoxActive = false
-        textBoxInputFocusIntent = .hidden
-        shouldFocusTextBoxWhenAvailable = false
-        shouldOpenTextBoxFilePickerWhenAvailable = false
-        shouldHideTextBoxOnNextEscape = false
-        if self.textBoxInputView === currentTextView {
-            self.textBoxInputView = nil
-        }
-    }
-
-    func sessionTextBoxDraftSnapshot() -> SessionTextBoxInputDraftSnapshot? {
-        if let textBoxInputView {
-            return textBoxInputView.sessionDraftSnapshot(isActive: isTextBoxActive)
-        }
-
-        if let restoredTextBoxDraft {
-            return restoredTextBoxDraft
-        }
-
-        if let preservedTextBoxAttributedContent {
-            return TextBoxInputTextView.sessionDraftSnapshot(
-                from: preservedTextBoxAttributedContent,
-                isActive: isTextBoxActive
-            )
-        }
-
-        return TextBoxInputTextView.sessionDraftSnapshot(
-            text: textBoxContent,
-            attachments: textBoxAttachments,
-            isActive: isTextBoxActive
-        )
-    }
-
-    func restoreSessionTextBoxDraft(_ draft: SessionTextBoxInputDraftSnapshot?) {
-        guard let draft,
-              !draft.parts.isEmpty else {
-            restoredTextBoxDraft = nil
-            preservedTextBoxAttributedContent = nil
-            textBoxContent = ""
-            textBoxAttachments = []
-            isTextBoxActive = false
-            textBoxInputFocusIntent = .hidden
-            shouldFocusTextBoxWhenAvailable = false
-            shouldOpenTextBoxFilePickerWhenAvailable = false
-            shouldHideTextBoxOnNextEscape = false
-            return
-        }
-
-        restoredTextBoxDraft = draft
-        preservedTextBoxAttributedContent = nil
-        textBoxContent = TextBoxInputTextView.plainText(from: draft)
-        textBoxAttachments = TextBoxInputTextView.attachments(from: draft)
-        isTextBoxActive = draft.isActive
-        textBoxInputFocusIntent = draft.isActive ? .textBox : .hidden
-        shouldFocusTextBoxWhenAvailable = false
-        shouldOpenTextBoxFilePickerWhenAvailable = false
-        shouldHideTextBoxOnNextEscape = false
-    }
-
-    @discardableResult
-    private func focusTextBoxIfNeeded() -> Bool {
-        guard shouldFocusTextBoxWhenAvailable,
-              isTextBoxActive,
-              let textBoxInputView,
-              let window = textBoxInputView.window else { return false }
-        guard window.makeFirstResponder(textBoxInputView) else { return false }
-        shouldFocusTextBoxWhenAvailable = false
-        textBoxInputFocusIntent = .textBox
-        surface.setFocus(false)
-        hostedView.setActive(false)
-        if shouldOpenTextBoxFilePickerWhenAvailable {
-            shouldOpenTextBoxFilePickerWhenAvailable = false
-            textBoxInputView.openFilePicker()
-        }
-        return true
-    }
-
-    @discardableResult
-    private func focusTextBoxInput() -> Bool {
-        textBoxInputFocusIntent = .textBox
-        isTextBoxActive = true
-        shouldFocusTextBoxWhenAvailable = true
-        shouldHideTextBoxOnNextEscape = false
-        let hasMountedTextBox = textBoxInputView?.window != nil
-        let didFocusTextBox = focusTextBoxIfNeeded()
-        return didFocusTextBox || !hasMountedTextBox
-    }
-
-#if DEBUG
-    @discardableResult
-    func installDebugTextBoxInlineFixture(
-        localURL: URL?,
-        beforeText: String,
-        afterText: String
-    ) -> Bool {
-        textBoxInputFocusIntent = .textBox
-        isTextBoxActive = true
-        shouldFocusTextBoxWhenAvailable = true
-
-        let fixture = DebugTextBoxInlineFixture(
-            localURL: localURL?.standardizedFileURL,
-            beforeText: beforeText,
-            afterText: afterText
-        )
-
-        pendingDebugTextBoxInlineFixture = fixture
-        applyPendingDebugTextBoxInlineFixtureIfNeeded()
-        return true
-    }
-
-    private func applyPendingDebugTextBoxInlineFixtureIfNeeded() {
-        guard let fixture = pendingDebugTextBoxInlineFixture,
-              let textBoxInputView,
-              let textBoxWindow = textBoxInputView.window,
-              textBoxWindow === hostedView.window else { return }
-        pendingDebugTextBoxInlineFixture = nil
-        applyDebugTextBoxInlineFixture(fixture, to: textBoxInputView)
-    }
-
-    private func applyDebugTextBoxInlineFixture(
-        _ fixture: DebugTextBoxInlineFixture,
-        to textBoxInputView: TextBoxInputTextView
-    ) {
-        textBoxInputView.window?.makeFirstResponder(textBoxInputView)
-        let attachment = fixture.localURL.map {
-                TextBoxAttachment(
-                    localURL: $0,
-                    submissionText: TextBoxAttachment.submissionText(forLocalFileURL: $0)
-                )
-        }
-        textBoxContent = fixture.beforeText + fixture.afterText
-        textBoxAttachments = attachment.map { [$0] } ?? []
-        textBoxInputView.installInlineControlFixture(
-            attachment,
-            beforeText: fixture.beforeText,
-            afterText: fixture.afterText
-        )
-        textBoxContent = textBoxInputView.plainText()
-        textBoxAttachments = textBoxInputView.inlineAttachments()
-    }
-#endif
-
     func focus() {
         if isAgentHibernated {
             _ = requestAgentHibernationResume(focus: true)
@@ -598,7 +270,7 @@ final class TerminalPanel: Panel, ObservableObject {
     }
 
     @discardableResult
-    private func focusTerminalSurface(
+    func focusTerminalSurface(
         respectForeignFirstResponder: Bool,
         clearTextBoxHideArm: Bool = true
     ) -> Bool {
@@ -897,33 +569,5 @@ final class TerminalPanel: Panel, ObservableObject {
             return true
         }
         return hostedView.yieldPanelFocusIntent(target, in: window)
-    }
-
-    private func textBoxOwnsResponder(_ responder: NSResponder?) -> Bool {
-        guard let responder,
-              let textBoxInputView else { return false }
-        if responder === textBoxInputView {
-            return true
-        }
-        guard let view = responder as? NSView else { return false }
-        return view.isDescendant(of: textBoxInputView)
-    }
-
-    private func textBoxOrSurfaceOwnsResponder(in window: NSWindow?) -> Bool {
-        guard let window else { return false }
-        if window === hostedView.window,
-           hostedView.isSurfaceViewFirstResponder() {
-            return true
-        }
-        guard let responder = window.firstResponder else { return false }
-        if textBoxOwnsResponder(responder) {
-            return true
-        }
-        return hostedView.ownedPanelFocusIntent(for: responder) == .surface
-    }
-
-    private func textBoxOrSurfaceOwnsEscapeContext(in window: NSWindow?) -> Bool {
-        guard let window else { return false }
-        return textBoxOrSurfaceOwnsResponder(in: window)
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1524,6 +1524,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */; };
 		A5F100000000000000000007 /* TerminalPanel+NotificationScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F100000000000000000008 /* TerminalPanel+NotificationScroll.swift */; };
 		791101010000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791101020000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift */; };
+		B0F7EA010000000000000001 /* TerminalPanel+TextBoxInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0F7EA020000000000000001 /* TerminalPanel+TextBoxInput.swift */; };
 		A5001401 /* TerminalPanel.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001411 /* TerminalPanel.swift */; };
 		E8B3D5F71A2C49608B7D5E31 /* TerminalPanelCreationOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2A6C8E40D5B17293C8F6A42 /* TerminalPanelCreationOutcome.swift */; };
 		C0DE5A410000000000000001 /* TerminalPanelShellActivityModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE5A410000000000000002 /* TerminalPanelShellActivityModel.swift */; };
@@ -3257,6 +3258,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneDropTargetView.swift; sourceTree = "<group>"; };
 		A5F100000000000000000008 /* TerminalPanel+NotificationScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/TerminalPanel+NotificationScroll.swift"; sourceTree = "<group>"; };
 		791101020000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/TerminalPanel+SessionScrollbackReplay.swift"; sourceTree = "<group>"; };
+		B0F7EA020000000000000001 /* TerminalPanel+TextBoxInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/TerminalPanel+TextBoxInput.swift"; sourceTree = "<group>"; };
 		A5001411 /* TerminalPanel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanel.swift; sourceTree = "<group>"; };
 		F2A6C8E40D5B17293C8F6A42 /* TerminalPanelCreationOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPanelCreationOutcome.swift; sourceTree = "<group>"; };
 		C0DE5A410000000000000002 /* TerminalPanelShellActivityModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/TerminalPanelShellActivityModel.swift; sourceTree = "<group>"; };
@@ -4375,6 +4377,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001411 /* TerminalPanel.swift */,
 				791101020000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift */,
 				A5F100000000000000000008 /* TerminalPanel+NotificationScroll.swift */,
+				B0F7EA020000000000000001 /* TerminalPanel+TextBoxInput.swift */,
 				C0DE5A410000000000000002 /* TerminalPanelShellActivityModel.swift */,
 				C0DE6B420000000000000002 /* TerminalPanelTextBoxState.swift */,
 				B42450020000000000000001 /* BrowserHiddenWebViewDiscardPolicy.swift */,
@@ -6677,6 +6680,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */,
 				A5F100000000000000000007 /* TerminalPanel+NotificationScroll.swift in Sources */,
 				791101010000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift in Sources */,
+				B0F7EA010000000000000001 /* TerminalPanel+TextBoxInput.swift in Sources */,
 				A5001401 /* TerminalPanel.swift in Sources */,
 				E8B3D5F71A2C49608B7D5E31 /* TerminalPanelCreationOutcome.swift in Sources */,
 				C0DE5A410000000000000001 /* TerminalPanelShellActivityModel.swift in Sources */,


### PR DESCRIPTION
## Urgency

Every PR that touches `Sources/Panels/TerminalPanel.swift` currently fails required CI (`workflow-guard-tests` → "Validate Swift file length budget", cascading into `linux-preflight`, `tests`, and `ci-status`). This PR restores headroom so those PRs can go green again.

## Root cause

`Sources/Panels/TerminalPanel.swift` sits at **929 lines on main — 29 lines over the 900-line hard cap** — with a checked-in budget of exactly 929 (zero headroom). This is the tail end of a budget race: #7914 ("Preserve one-shot SSH output after disconnect") landed with a "keep session persistence within file budget" fix-up that left the file at exactly the budget ceiling, above the hard cap.

The budget script's PR gate (`--base-ref`/`--merge-ref`) tolerates an *unchanged* over-cap file, but fails any PR whose speculative merge with main grows it at all:

```
+3 Sources/Panels/TerminalPanel.swift
   actual=932 budget=929
   reason=hard cap 900
```

(observed on `task-notification-preserve-terminal-scroll`, run 29262836544 — that PR adds 3 lines to the panel and fails through no fault of its own beyond +3 growth.)

## Why extraction instead of a TSV bump

Raising the TSV entry would not help: the `hard cap 900` failure fires independently of the checked-in budget, so any growth on a 929-line file keeps failing. Shrinking the file fixes the actual condition, requires **no budget TSV change** (so it cannot conflict with other open PRs), and pays down the debt the budget exists to track.

## Change

Pure mechanical extraction, no behavior changes:

- Move the TextBox composer subsystem out of `TerminalPanel.swift` into a new `Sources/Panels/TerminalPanel+TextBoxInput.swift` (activation, terminal/TextBox focus arbitration, escape handling, draft preservation/restoration, responder-ownership helpers, and the DEBUG inline fixture). This follows the existing `TerminalPanel+NotificationScroll.swift` / `TerminalPanel+SessionScrollbackReplay.swift` pattern.
- Stored TextBox state stays in the class (extensions cannot add storage) and drops `private` so the extension file can reach it; a comment on the cluster records why. Methods still called from `TerminalPanel.swift` (`discardTextBoxContentForClose`, `focusTextBoxInput`, `textBoxOwnsResponder`) become internal; everything else stays `private` within the new file.
- Wire the new file into `cmux.xcodeproj/project.pbxproj` (4 entries mirroring the sibling extension file); `scripts/normalize-pbxproj.py` and `scripts/check-pbxproj.sh` pass.

Line counts: `TerminalPanel.swift` **929 → 573** (well under the 900 hard cap, 356 lines of headroom under its 929 budget); new file **365** lines (under the 500-line tracking threshold).

## Verification

`python3 scripts/swift_file_length_budget.py --budget .github/swift-file-length-budget.tsv --base-ref "$(git merge-base origin/main HEAD)"`:

```
All scanned cmux-owned Swift files: 962384 line(s) across 4506 Swift file(s)
Tracked Swift files >= 500 lines: 467315 line(s) across 255 Swift file(s)
Allowed Swift file length budget: 470186 line(s) across 255 Swift file(s)
Swift file length budget respected.

Budget can be reduced:
...
-356 Sources/Panels/TerminalPanel.swift
   actual=573 budget=929
...
```

- `./tests/test_ci_swift_file_length_budget.sh` (the exact failing guard test): **passes** locally (merge-tree cases skipped by local git version; they run on CI).
- `scripts/normalize-pbxproj.py`, `scripts/check-pbxproj.sh`, `scripts/lint-pbxproj-test-wiring.sh`: pass.
- Both Swift files parse cleanly; full compile is covered by PR CI (local disk too full for an Xcode build).
- Localization audit: no user-facing strings added, removed, or changed — pure code motion; nothing to localize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7986"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786551961&installation_id=133855650&pr_number=7986&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7986&signature=cd467766b3682aa813af048783631c1b07589f313c82594a7e4373a0b5aa1fa0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Extracted the TextBox input subsystem from `TerminalPanel.swift` into `TerminalPanel+TextBoxInput.swift` to get under the 900-line hard cap and unblock CI. No behavior changes; restores headroom so panel changes can pass budget checks.

- **Refactors**
  - Moved TextBox activation, focus/escape handling, draft preserve/restore, and DEBUG fixture into a new extension, matching existing panel extension files.
  - Kept TextBox state in the class; relaxed access where needed (e.g., `TextBoxInputFocusIntent`, state vars, debug fixture) and exposed `focusTerminalSurface` for extension use.
  - Wired the new file into `cmux.xcodeproj`. `TerminalPanel.swift` 929→573 lines; new file is 365 lines. No budget TSV update needed; hard cap now respected.

<sup>Written for commit 2bbd65fda4d35317c6c230f4b959e2a3632b40a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7986?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a text-box composer to terminal panels with improved activation and focus handling.
  * Preserves drafts and attachments when switching focus or temporarily unmounting the panel.
  * Restores saved composer content when returning to a session.
  * Added Escape-key behavior for hiding the composer and returning focus to the terminal.

* **Bug Fixes**
  * Prevented terminal tabs from incorrectly displaying a dirty-state indicator during composer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->