### PR TITLE
Use gear icon for iOS workspace settings

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -105,7 +105,7 @@ struct DisconnectedWorkspaceShellView: View {
         }
         .sheet(isPresented: $showingSettings) {
             // Reuse the same Settings sheet the workspace list opens from its
-            // 3-dots menu so the no-devices screen's chrome matches. There is no
+            // Settings button so the no-devices screen's chrome matches. There is no
             // connected host or QR to rescan here, but the store is forwarded so
             // a user whose active Mac went offline can still switch to another
             // paired Mac; the sheet also surfaces the account + Sign Out.
@@ -356,16 +356,17 @@ struct DisconnectedWorkspaceShellView: View {
     }
     #endif
 
-    /// The top-left 3-dots overflow, matching ``WorkspaceListView``'s
+    /// The top-left settings entrypoint, matching ``WorkspaceListView``'s
     /// `settingsMenu` so switching between the connected and no-devices screens
-    /// is not jarring. On iOS it opens the full Settings sheet (which holds Sign
-    /// Out); on macOS it is an inline menu with Sign Out as an item.
+    /// is not jarring. On iOS it is a Settings button that opens the full sheet
+    /// (which holds Sign Out); on macOS it is an inline overflow menu with Sign
+    /// Out as an item.
     private var settingsMenu: some View {
         #if os(iOS)
         Button {
             showingSettings = true
         } label: {
-            Image(systemName: "ellipsis.circle")
+            MobileWorkspaceSettingsIcon()
         }
         .accessibilityLabel(L10n.string("mobile.workspaces.settings", defaultValue: "Settings"))
         .accessibilityIdentifier("MobileWorkspaceSettingsMenu")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspaceSettingsIcon.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileWorkspaceSettingsIcon.swift
@@ -1,0 +1,9 @@
+import SwiftUI
+
+struct MobileWorkspaceSettingsIcon: View {
+    static let systemName = "gearshape"
+
+    var body: some View {
+        Image(systemName: Self.systemName)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -606,7 +606,7 @@ struct WorkspaceListView: View {
         Button {
             showingSettings = true
         } label: {
-            Image(systemName: "ellipsis.circle")
+            MobileWorkspaceSettingsIcon()
         }
         .accessibilityLabel(L10n.string("mobile.workspaces.settings", defaultValue: "Settings"))
         .accessibilityIdentifier("MobileWorkspaceSettingsMenu")

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/CmuxMobileShellUISmokeTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/CmuxMobileShellUISmokeTests.swift
@@ -1,11 +1,8 @@
 import Testing
 @testable import CmuxMobileShellUI
 
-/// CmuxMobileShellUI is UIKit-bound and iOS-only; its behavior is exercised by
-/// the app build and the lower-layer packages' suites. This smoke test keeps the
-/// test target valid for simulator-destination CI runs.
 @Suite struct CmuxMobileShellUISmokeTests {
-    @Test func moduleLinks() {
-        #expect(Bool(true))
+    @Test @MainActor func workspaceSettingsUsesConventionalSystemIcon() {
+        #expect(MobileWorkspaceSettingsIcon.systemName == "gearshape")
     }
 }


### PR DESCRIPTION
Changes the connected and disconnected iOS workspace Settings buttons from ellipsis.circle to gearshape through one shared icon view. The macOS overflow menus keep ellipsis.circle.

Test: xcodebuild test -workspace ios/cmux.xcworkspace -scheme cmux-ios -testPlan cmux -destination platform=iOS\ Simulator,id=5DCD5672-2E8C-4EC5-BD44-2F3F5AF04D52 -derivedDataPath /tmp/cmux-setico-ios-tests -only-testing:CmuxMobileShellUITests/CmuxMobileShellUISmokeTests -quiet

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/7993"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786560727&installation_id=133855650&pr_number=7993&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F7993&signature=75ce00d85645c1a36f4d35a8aeb1b588f8d472da7fc34cefa6dc00d85d1a0b58"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the iOS workspace Settings button to a gear icon for platform consistency. Introduces shared `MobileWorkspaceSettingsIcon` used in `WorkspaceListView` and `DisconnectedWorkspaceShellView`, updates a test to pin the icon; macOS overflow menus keep the ellipsis.

<sup>Written for commit 3be38896af2b9c6e1112d8ebdc051822f8c81b7a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/7993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI Updates**
  * Replaced the workspace settings menu’s three-dot icon with a gear icon on iOS.
  * Applied the updated icon consistently across workspace views while preserving accessibility labels and existing behavior.

* **Tests**
  * Added coverage verifying the settings icon uses the gear symbol.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->