### PR TITLE
Prevent sidebar hover lifecycle reentry hangs

### DIFF
--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconciler.swift
@@ -12,4 +12,11 @@ struct SidebarWorkspaceRowHoverReconciler: NSViewRepresentable {
     func updateNSView(_ nsView: SidebarWorkspaceRowHoverReconcilerView, context: Context) {
         nsView.onPointerHoverChanged = onPointerHoverChanged
     }
+
+    static func dismantleNSView(
+        _ nsView: SidebarWorkspaceRowHoverReconcilerView,
+        coordinator: ()
+    ) {
+        nsView.stopHoverEventConsumption()
+    }
 }

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
@@ -99,6 +99,7 @@ final class SidebarWorkspaceRowHoverReconcilerView: NSView {
     }
 
     deinit {
-        stopHoverEventConsumption()
+        hoverEventsTask?.cancel()
+        hoverContinuation.finish()
     }
 }

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
@@ -75,6 +75,13 @@ final class SidebarWorkspaceRowHoverReconcilerView: NSView {
         reportPointerHovering(bounds.contains(pointInView), force: true)
     }
 
+    func stopHoverEventConsumption() {
+        onPointerHoverChanged = nil
+        hoverEventsTask?.cancel()
+        hoverEventsTask = nil
+        hoverContinuation.finish()
+    }
+
     private func reportPointerHovering(_ hovering: Bool, force: Bool = false) {
         guard force || lastReportedHover != hovering else { return }
         lastReportedHover = hovering
@@ -92,7 +99,6 @@ final class SidebarWorkspaceRowHoverReconcilerView: NSView {
     }
 
     deinit {
-        hoverEventsTask?.cancel()
-        hoverContinuation.finish()
+        stopHoverEventConsumption()
     }
 }

--- a/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
+++ b/Sources/Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift
@@ -1,9 +1,34 @@
 import AppKit
 
+@MainActor
 final class SidebarWorkspaceRowHoverReconcilerView: NSView {
     var onPointerHoverChanged: ((Bool) -> Void)?
+
+    /// AppKit lifecycle callbacks publish into this bounded stream. The
+    /// consumer task is the only path allowed to call back into SwiftUI, so
+    /// `updateTrackingAreas` and `viewDidMoveToWindow` always return before a
+    /// row's `@State` can change.
+    private let hoverEvents: AsyncStream<Bool>
+    private let hoverContinuation: AsyncStream<Bool>.Continuation
+    private var hoverEventsTask: Task<Void, Never>?
     private var trackingArea: NSTrackingArea?
     private var lastReportedHover: Bool?
+
+    override init(frame frameRect: NSRect) {
+        let (hoverEvents, hoverContinuation) = AsyncStream.makeStream(
+            of: Bool.self,
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        self.hoverEvents = hoverEvents
+        self.hoverContinuation = hoverContinuation
+        super.init(frame: frameRect)
+        startHoverEventConsumption()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
 
     override func updateTrackingAreas() {
         super.updateTrackingAreas()
@@ -53,6 +78,21 @@ final class SidebarWorkspaceRowHoverReconcilerView: NSView {
     private func reportPointerHovering(_ hovering: Bool, force: Bool = false) {
         guard force || lastReportedHover != hovering else { return }
         lastReportedHover = hovering
-        onPointerHoverChanged?(hovering)
+        hoverContinuation.yield(hovering)
+    }
+
+    private func startHoverEventConsumption() {
+        let hoverEvents = self.hoverEvents
+        hoverEventsTask = Task { @MainActor [weak self] in
+            for await hovering in hoverEvents {
+                guard let self, !Task.isCancelled else { return }
+                self.onPointerHoverChanged?(hovering)
+            }
+        }
+    }
+
+    deinit {
+        hoverEventsTask?.cancel()
+        hoverContinuation.finish()
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1370,6 +1370,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C9A5760FC9A5760FC9A5760F /* SidebarWorkspaceReorderDropView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57610C9A57610C9A57610 /* SidebarWorkspaceReorderDropView.swift */; };
 		C9A5760BC9A5760BC9A5760B /* SidebarWorkspaceReorderPendingDrop.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5760CC9A5760CC9A5760C /* SidebarWorkspaceReorderPendingDrop.swift */; };
 		D35450070000000000000007 /* SidebarWorkspaceRowHoverReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450070000000000000008 /* SidebarWorkspaceRowHoverReconciler.swift */; };
+		A80070010000000000000001 /* SidebarWorkspaceRowHoverReconcilerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A80070020000000000000001 /* SidebarWorkspaceRowHoverReconcilerTests.swift */; };
 		D35450070000000000000009 /* SidebarWorkspaceRowHoverReconcilerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3545007000000000000000A /* SidebarWorkspaceRowHoverReconcilerView.swift */; };
 		D3545007000000000000000B /* SidebarWorkspaceRowHoverTrackingModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3545007000000000000000C /* SidebarWorkspaceRowHoverTrackingModifier.swift */; };
 		D35450030000000000000003 /* SidebarWorkspaceRowMenuTrackingReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450030000000000000004 /* SidebarWorkspaceRowMenuTrackingReconciler.swift */; };
@@ -3146,6 +3147,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C9A57610C9A57610C9A57610 /* SidebarWorkspaceReorderDropView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceReorderDropView.swift; sourceTree = "<group>"; };
 		C9A5760CC9A5760CC9A5760C /* SidebarWorkspaceReorderPendingDrop.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceReorderPendingDrop.swift; sourceTree = "<group>"; };
 		D35450070000000000000008 /* SidebarWorkspaceRowHoverReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverReconciler.swift; sourceTree = "<group>"; };
+		A80070020000000000000001 /* SidebarWorkspaceRowHoverReconcilerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowHoverReconcilerTests.swift; sourceTree = "<group>"; };
 		D3545007000000000000000A /* SidebarWorkspaceRowHoverReconcilerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverReconcilerView.swift; sourceTree = "<group>"; };
 		D3545007000000000000000C /* SidebarWorkspaceRowHoverTrackingModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowHoverTrackingModifier.swift; sourceTree = "<group>"; };
 		D35450030000000000000004 /* SidebarWorkspaceRowMenuTrackingReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowMenuTrackingReconciler.swift; sourceTree = "<group>"; };
@@ -5197,6 +5199,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */,
 				C9A57506C9A57506C9A57506 /* SidebarWorkspaceScrollLayoutTests.swift */,
 				D41A7C02D41A7C02D41A7C02 /* SidebarLazyLayoutScaleTests.swift */,
+				A80070020000000000000001 /* SidebarWorkspaceRowHoverReconcilerTests.swift */,
 				C4A570030000000000000002 /* CanvasShortcutContextTests.swift */,
 				C0DEF0B30000000000000002 /* KeyboardShortcutSettingsFileStoreMigrationTests.swift */,
 				E3337002E3337002E3337002 /* KeyboardShortcutSettingsFileStoreStartupTests.swift */,
@@ -7489,6 +7492,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C135190000000000000000B1 /* SidebarWorkspaceGroupConfigOpenerTests.swift in Sources */,
 				C9A57303C9A57303C9A57303 /* SidebarWorkspaceGroupHeaderMetricsTests.swift in Sources */,
 				C9A57305C9A57305C9A57305 /* SidebarWorkspaceReorderDropOverlayHitTestingTests.swift in Sources */,
+				A80070010000000000000001 /* SidebarWorkspaceRowHoverReconcilerTests.swift in Sources */,
 				C9A57505C9A57505C9A57505 /* SidebarWorkspaceScrollLayoutTests.swift in Sources */,
 				C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */,
 					A6AC73040000000000000001 /* SidebarWorkspaceSnapshotAgentActivityTests.swift in Sources */,

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -220,6 +220,19 @@ final class SidebarLazyLayoutScaleTests {
         }
     }
 
+    @MainActor
+    private static func hoverReconcilerViews(in rootView: NSView) -> [SidebarWorkspaceRowHoverReconcilerView] {
+        var result: [SidebarWorkspaceRowHoverReconcilerView] = []
+        var pendingViews = [rootView]
+        while let view = pendingViews.popLast() {
+            if let reconciler = view as? SidebarWorkspaceRowHoverReconcilerView {
+                result.append(reconciler)
+            }
+            pendingViews.append(contentsOf: view.subviews)
+        }
+        return result
+    }
+
     /// Mounting the sidebar with 300 workspaces must realize only the rows a
     /// single viewport needs. Realizing all of them is the #5323/#6210 defeat:
     /// at scale, every subsequent update pays an O(N) layout pass and the main
@@ -349,6 +362,50 @@ final class SidebarLazyLayoutScaleTests {
             \(quietEvals) row bodies (workspace + group header) evaluated with no state \
             changes at all. The sidebar is re-invalidating itself — a layout/state feedback \
             loop (the #6556 signature). This livelocks the main thread at scale.
+            """
+        )
+    }
+
+    /// AppKit may invoke `updateTrackingAreas` repeatedly while SwiftUI is
+    /// reconciling a lazy row's platform children. A burst must collapse to a
+    /// bounded asynchronous delivery and then settle; calling row bindings on
+    /// this stack is the #8004 AttributeGraph/NSHostingView livelock.
+    @Test
+    @MainActor
+    func testTrackingAreaStormStaysBoundedAndConverges() async throws {
+        let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
+        defer { harness.tearDown() }
+
+        await Self.drainMainRunLoop(for: harness.window)
+        let rootView = try #require(harness.window.contentView)
+        let reconcilers = Self.hoverReconcilerViews(in: rootView)
+        #expect(!reconcilers.isEmpty, "The mounted viewport has no hover reconcilers; the stress path is not covered.")
+
+        harness.counter.reset()
+        for _ in 0..<100 {
+            for reconciler in reconcilers {
+                reconciler.updateTrackingAreas()
+            }
+        }
+        await Self.drainMainRunLoop(for: harness.window)
+
+        let stormEvals = harness.counter.workspaceRowBodies + harness.counter.groupHeaderBodies
+        #expect(
+            stormEvals < reconcilers.count * 4,
+            """
+            \(stormEvals) row bodies evaluated after 100 tracking-area passes across \
+            \(reconcilers.count) visible rows. AppKit lifecycle events must be coalesced before they update SwiftUI.
+            """
+        )
+
+        harness.counter.reset()
+        await Self.drainMainRunLoop(for: harness.window, iterations: 30)
+        let quietEvals = harness.counter.workspaceRowBodies + harness.counter.groupHeaderBodies
+        #expect(
+            quietEvals < 20,
+            """
+            \(quietEvals) row bodies evaluated after the tracking-area burst ended. The sidebar failed to converge \
+            and is still feeding SwiftUI state changes back into AppKit layout.
             """
         )
     }

--- a/cmuxTests/SidebarWorkspaceRowHoverReconcilerTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowHoverReconcilerTests.swift
@@ -64,4 +64,20 @@ import Testing
         }
         #expect(reportedHover == true)
     }
+
+    @Test @MainActor func dismantlingDropsBufferedHoverEvents() async {
+        var reportedHover: Bool?
+        let view = SidebarWorkspaceRowHoverReconcilerView()
+        view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
+        view.onPointerHoverChanged = { reportedHover = $0 }
+
+        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        SidebarWorkspaceRowHoverReconciler.dismantleNSView(view, coordinator: ())
+        await Task.yield()
+
+        #expect(
+            reportedHover == nil,
+            "Dismantling the representable must discard buffered hover events before row teardown state can be overwritten."
+        )
+    }
 }

--- a/cmuxTests/SidebarWorkspaceRowHoverReconcilerTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowHoverReconcilerTests.swift
@@ -1,0 +1,67 @@
+import AppKit
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite struct SidebarWorkspaceRowHoverReconcilerTests {
+    @Test @MainActor func restoresCloseButtonAfterLifecycleHoverReset() async {
+        var state = SidebarWorkspaceRowInteractionState()
+
+        let view = SidebarWorkspaceRowHoverReconcilerView()
+        view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            view.onPointerHoverChanged = {
+                state.setPointerHovering($0)
+                continuation.resume()
+            }
+            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        }
+        #expect(state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
+
+        state.setPointerHovering(false)
+        #expect(!state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
+
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            view.onPointerHoverChanged = {
+                state.setPointerHovering($0)
+                continuation.resume()
+            }
+            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        }
+
+        #expect(
+            state.shouldShowCloseButton(
+                canCloseWorkspace: true,
+                shortcutHintModeActive: false
+            ),
+            "When sidebar updates or row reuse clear SwiftUI hover state while the pointer is still inside the row, the AppKit hover reconciler must restore the close affordance without waiting for another mouse move."
+        )
+    }
+
+    @Test @MainActor func doesNotMutateSwiftUIOnTheAppKitLifecycleStack() async {
+        var reportedHover: Bool?
+        let view = SidebarWorkspaceRowHoverReconcilerView()
+        view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            view.onPointerHoverChanged = {
+                reportedHover = $0
+                continuation.resume()
+            }
+
+            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+
+            #expect(
+                reportedHover == nil,
+                """
+                AppKit hover reconciliation must not call into SwiftUI synchronously. The real row invokes this path \
+                from updateTrackingAreas and viewDidMoveToWindow; a synchronous Binding write there re-enters \
+                NSHostingView layout and can livelock AttributeGraph.
+                """
+            )
+        }
+        #expect(reportedHover == true)
+    }
+}

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -441,6 +441,24 @@ import Testing
         )
     }
 
+    @Test @MainActor func hoverReconcilerDoesNotMutateSwiftUIOnTheAppKitLifecycleStack() {
+        var reportedHover: Bool?
+        let view = SidebarWorkspaceRowHoverReconcilerView()
+        view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
+        view.onPointerHoverChanged = { reportedHover = $0 }
+
+        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+
+        #expect(
+            reportedHover == nil,
+            """
+            AppKit hover reconciliation must not call into SwiftUI synchronously. The real row invokes this path from \
+            updateTrackingAreas and viewDidMoveToWindow; a synchronous Binding write there re-enters NSHostingView \
+            layout and can livelock AttributeGraph.
+            """
+        )
+    }
+
     @Test func contextMenuAppearanceHidesExistingCloseButtonUntilPointerIsReconciled() {
         var state = SidebarWorkspaceRowInteractionState()
 

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -417,64 +417,6 @@ import Testing
         )
     }
 
-    @Test @MainActor func hoverReconcilerRestoresCloseButtonAfterLifecycleHoverReset() async {
-        var state = SidebarWorkspaceRowInteractionState()
-
-        let view = SidebarWorkspaceRowHoverReconcilerView()
-        view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            view.onPointerHoverChanged = {
-                state.setPointerHovering($0)
-                continuation.resume()
-            }
-            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
-        }
-        #expect(state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
-
-        state.setPointerHovering(false)
-        #expect(!state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
-
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            view.onPointerHoverChanged = {
-                state.setPointerHovering($0)
-                continuation.resume()
-            }
-            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
-        }
-
-        #expect(
-            state.shouldShowCloseButton(
-                canCloseWorkspace: true,
-                shortcutHintModeActive: false
-            ),
-            "When sidebar updates or row reuse clear SwiftUI hover state while the pointer is still inside the row, the AppKit hover reconciler must restore the close affordance without waiting for another mouse move."
-        )
-    }
-
-    @Test @MainActor func hoverReconcilerDoesNotMutateSwiftUIOnTheAppKitLifecycleStack() async {
-        var reportedHover: Bool?
-        let view = SidebarWorkspaceRowHoverReconcilerView()
-        view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
-        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
-            view.onPointerHoverChanged = {
-                reportedHover = $0
-                continuation.resume()
-            }
-
-            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
-
-            #expect(
-                reportedHover == nil,
-                """
-                AppKit hover reconciliation must not call into SwiftUI synchronously. The real row invokes this path \
-                from updateTrackingAreas and viewDidMoveToWindow; a synchronous Binding write there re-enters \
-                NSHostingView layout and can livelock AttributeGraph.
-                """
-            )
-        }
-        #expect(reportedHover == true)
-    }
-
     @Test func contextMenuAppearanceHidesExistingCloseButtonUntilPointerIsReconciled() {
         var state = SidebarWorkspaceRowInteractionState()
 

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -417,20 +417,30 @@ import Testing
         )
     }
 
-    @Test @MainActor func hoverReconcilerRestoresCloseButtonAfterLifecycleHoverReset() {
+    @Test @MainActor func hoverReconcilerRestoresCloseButtonAfterLifecycleHoverReset() async {
         var state = SidebarWorkspaceRowInteractionState()
 
         let view = SidebarWorkspaceRowHoverReconcilerView()
         view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
-        view.onPointerHoverChanged = { state.setPointerHovering($0) }
-
-        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            view.onPointerHoverChanged = {
+                state.setPointerHovering($0)
+                continuation.resume()
+            }
+            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        }
         #expect(state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
 
         state.setPointerHovering(false)
         #expect(!state.shouldShowCloseButton(canCloseWorkspace: true, shortcutHintModeActive: false))
 
-        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            view.onPointerHoverChanged = {
+                state.setPointerHovering($0)
+                continuation.resume()
+            }
+            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+        }
 
         #expect(
             state.shouldShowCloseButton(
@@ -441,22 +451,28 @@ import Testing
         )
     }
 
-    @Test @MainActor func hoverReconcilerDoesNotMutateSwiftUIOnTheAppKitLifecycleStack() {
+    @Test @MainActor func hoverReconcilerDoesNotMutateSwiftUIOnTheAppKitLifecycleStack() async {
         var reportedHover: Bool?
         let view = SidebarWorkspaceRowHoverReconcilerView()
         view.frame = NSRect(x: 0, y: 0, width: 120, height: 28)
-        view.onPointerHoverChanged = { reportedHover = $0 }
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            view.onPointerHoverChanged = {
+                reportedHover = $0
+                continuation.resume()
+            }
 
-        view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
+            view.reconcilePointerLocation(pointInView: NSPoint(x: 60, y: 14))
 
-        #expect(
-            reportedHover == nil,
-            """
-            AppKit hover reconciliation must not call into SwiftUI synchronously. The real row invokes this path from \
-            updateTrackingAreas and viewDidMoveToWindow; a synchronous Binding write there re-enters NSHostingView \
-            layout and can livelock AttributeGraph.
-            """
-        )
+            #expect(
+                reportedHover == nil,
+                """
+                AppKit hover reconciliation must not call into SwiftUI synchronously. The real row invokes this path \
+                from updateTrackingAreas and viewDidMoveToWindow; a synchronous Binding write there re-enters \
+                NSHostingView layout and can livelock AttributeGraph.
+                """
+            )
+        }
+        #expect(reportedHover == true)
     }
 
     @Test func contextMenuAppearanceHidesExistingCloseButtonUntilPointerIsReconciled() {


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/8004.

Routes AppKit hover reconciliation through a bounded `AsyncStream<Bool>` consumed by one stored `@MainActor` task per realized native hover view. `updateTrackingAreas` and `viewDidMoveToWindow` now return before SwiftUI row state can change, removing the synchronous AppKit-to-AttributeGraph reentry seen in both July 13 captures. Capacity one coalesces lifecycle bursts, and view teardown cancels the consumer.

The first commit adds the failing synchronous-callback regression. The second adds the fix and a 300-workspace stress test that invokes 100 tracking-area passes across every realized row, then checks bounded evaluation and convergence.

Evidence: https://github.com/manaflow-ai/cmux/issues/8004. Tagged app compile passed in https://github.com/manaflow-ai/cmux/actions/runs/29292333340. `scripts/check-sidebar-lazy-layout.py` passes. Local test execution is prohibited because it launches an untagged test host; local build-for-testing was attempted but blocked before compilation by machine-wide stuck Xcode external-tool probes, so CI owns test execution.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8007"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786577543&installation_id=133855650&pr_number=8007&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8007&signature=4ff105fc865cf995a9f7822ec7dc0b315ac0a27a5bb8fccc627e9df68ac6b926"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents sidebar livelock by routing AppKit hover events through a bounded async pipeline, coalescing bursts and deferring state updates off the AppKit stack. Stops hover delivery when rows dismantle and on deinit to avoid stale buffered updates; resolves #8004 and keeps the sidebar stable under heavy tracking-area churn.

- **Bug Fixes**
  - Coalesced hover lifecycle in `SidebarWorkspaceRowHoverReconcilerView` via capacity-1 `AsyncStream`, consumed by a single task; delivery is stopped in `dismantleNSView` and on deinit (no actor hop) to drop buffered events.
  - `updateTrackingAreas`/`viewDidMoveToWindow` return before any row state changes, removing synchronous AppKit→SwiftUI reentry.
  - Added a stress test that storms tracking areas and asserts bounded evaluations and convergence.
  - Split hover reconciler tests into `SidebarWorkspaceRowHoverReconcilerTests`; added synchronous-reentry and teardown-buffer tests, removed the old snapshot test.

<sup>Written for commit ed14d7a3e11114d1c1686e7f98d3d8792ff3de13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved sidebar workspace row hover handling by decoupling AppKit hover events from SwiftUI updates, reducing redundant hover updates and ensuring smoother, consistent pointer-state changes.
  - Fixed hover lifecycle behavior so row controls (such as the close affordance) correctly restore after SwiftUI hover resets.
  - Ensured hover-event handling properly halts and discards buffered events when the hover reconciler is dismantled.
- **Tests**
  - Added new hover reconciler test suite covering lifecycle reset and teardown (dismantling) behavior.
  - Added/expanded a stress test confirming tracking-area updates remain bounded and converge with large sidebars.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->