### PR TITLE
Remember the last textbox mode

### DIFF
--- a/Sources/App/TextBoxSubmitActionSettings.swift
+++ b/Sources/App/TextBoxSubmitActionSettings.swift
@@ -43,7 +43,7 @@ extension TerminalTextBoxInputSettings {
               !remembered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
-        guard defaults.string(forKey: lastSelectedSubmitActionDefaultKey) == defaultSubmitActionIDValue(defaults: defaults),
+        guard defaults.string(forKey: lastSelectedSubmitActionDefaultKey) == defaultSubmitActionConfigurationSnapshot(defaults: defaults),
               submitActions(defaults: defaults).contains(where: { $0.id == remembered }) else {
             defaults.removeObject(forKey: lastSelectedSubmitActionKey)
             defaults.removeObject(forKey: lastSelectedSubmitActionDefaultKey)
@@ -58,7 +58,12 @@ extension TerminalTextBoxInputSettings {
             return false
         }
         defaults.set(id, forKey: lastSelectedSubmitActionKey)
-        defaults.set(defaultSubmitActionIDValue(defaults: defaults), forKey: lastSelectedSubmitActionDefaultKey)
+        defaults.set(defaultSubmitActionConfigurationSnapshot(defaults: defaults), forKey: lastSelectedSubmitActionDefaultKey)
         return true
+    }
+
+    private static func defaultSubmitActionConfigurationSnapshot(defaults: UserDefaults) -> String {
+        guard defaults.object(forKey: defaultSubmitActionKey) != nil else { return "unset" }
+        return "set:\(defaults.string(forKey: defaultSubmitActionKey) ?? "")"
     }
 }

--- a/Sources/App/TextBoxSubmitActionSettings.swift
+++ b/Sources/App/TextBoxSubmitActionSettings.swift
@@ -37,4 +37,22 @@ extension TerminalTextBoxInputSettings {
         }
         return configured
     }
+
+    static func rememberedSubmitActionIDValue(defaults: UserDefaults = .standard) -> String? {
+        guard let remembered = defaults.string(forKey: lastSelectedSubmitActionKey),
+              !remembered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              submitActions(defaults: defaults).contains(where: { $0.id == remembered }) else {
+            return nil
+        }
+        return remembered
+    }
+
+    static func rememberSubmitActionID(_ id: String, defaults: UserDefaults = .standard) -> Bool {
+        guard !id.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              submitActions(defaults: defaults).contains(where: { $0.id == id }) else {
+            return false
+        }
+        defaults.set(id, forKey: lastSelectedSubmitActionKey)
+        return true
+    }
 }

--- a/Sources/App/TextBoxSubmitActionSettings.swift
+++ b/Sources/App/TextBoxSubmitActionSettings.swift
@@ -40,8 +40,13 @@ extension TerminalTextBoxInputSettings {
 
     static func rememberedSubmitActionIDValue(defaults: UserDefaults = .standard) -> String? {
         guard let remembered = defaults.string(forKey: lastSelectedSubmitActionKey),
-              !remembered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              !remembered.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        guard defaults.string(forKey: lastSelectedSubmitActionDefaultKey) == defaultSubmitActionIDValue(defaults: defaults),
               submitActions(defaults: defaults).contains(where: { $0.id == remembered }) else {
+            defaults.removeObject(forKey: lastSelectedSubmitActionKey)
+            defaults.removeObject(forKey: lastSelectedSubmitActionDefaultKey)
             return nil
         }
         return remembered
@@ -53,6 +58,7 @@ extension TerminalTextBoxInputSettings {
             return false
         }
         defaults.set(id, forKey: lastSelectedSubmitActionKey)
+        defaults.set(defaultSubmitActionIDValue(defaults: defaults), forKey: lastSelectedSubmitActionDefaultKey)
         return true
     }
 }

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -121,6 +121,7 @@ enum TerminalTextBoxInputSettings {
     static let submitActionsKey = "terminal.textBoxSubmitActions"
     static let defaultSubmitActionKey = "terminal.textBoxDefaultSubmitAction"
     static let lastSelectedSubmitActionKey = "terminal.textBoxLastSelectedSubmitAction"
+    static let lastSelectedSubmitActionDefaultKey = "terminal.textBoxLastSelectedSubmitActionDefault"
     static let defaultSubmitActionID = TextBoxSubmitAction.textEntryAction.id
 
     static func showOnNewTerminals(defaults: UserDefaults = .standard) -> Bool {

--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -120,6 +120,7 @@ enum TerminalTextBoxInputSettings {
     static let maximumMaxLines = 20
     static let submitActionsKey = "terminal.textBoxSubmitActions"
     static let defaultSubmitActionKey = "terminal.textBoxDefaultSubmitAction"
+    static let lastSelectedSubmitActionKey = "terminal.textBoxLastSelectedSubmitAction"
     static let defaultSubmitActionID = TextBoxSubmitAction.textEntryAction.id
 
     static func showOnNewTerminals(defaults: UserDefaults = .standard) -> Bool {

--- a/Sources/Panels/TerminalPanelTextBoxState.swift
+++ b/Sources/Panels/TerminalPanelTextBoxState.swift
@@ -11,8 +11,17 @@ final class TerminalPanelTextBoxState {
     private(set) var launchCommand: String?
     private var observedCommandRunningSinceLaunch = false
 
+    init(defaults: UserDefaults = .standard) {
+        selectedSubmitActionID = TerminalTextBoxInputSettings.rememberedSubmitActionIDValue(defaults: defaults)
+    }
+
     var pendingLaunchCommand: String? {
         observedCommandRunningSinceLaunch ? nil : launchCommand
+    }
+
+    func selectSubmitAction(_ id: String, defaults: UserDefaults = .standard) {
+        guard TerminalTextBoxInputSettings.rememberSubmitActionID(id, defaults: defaults) else { return }
+        selectedSubmitActionID = id
     }
 
     func recordLaunchCommand(_ rawCommand: String) {

--- a/Sources/Panels/TerminalPanelView.swift
+++ b/Sources/Panels/TerminalPanelView.swift
@@ -121,6 +121,9 @@ struct TerminalPanelView: View {
                     onToggleFocus: {
                         _ = panel.focusTextBoxInputOrTerminal()
                     },
+                    onSelectSubmitAction: { actionID in
+                        panel.textBoxState.selectSubmitAction(actionID)
+                    },
                     onRecordLaunchCommand: { command in
                         panel.recordTextBoxLaunchCommand(command)
                     },

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -2440,6 +2440,7 @@ struct TextBoxInputContainer: View {
     let allowsCommandTemplateSubmit: Bool
     let onFocusTextBox: () -> Void
     let onToggleFocus: () -> Void
+    let onSelectSubmitAction: (String) -> Void
     let onRecordLaunchCommand: (String) -> Void
     let onClearLaunchCommand: () -> Void
     let onEscape: () -> Void

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -2447,7 +2447,6 @@ struct TextBoxInputContainer: View {
     let onTextViewCreated: (TextBoxInputTextView) -> Void
     let onTextViewMovedToWindow: (TextBoxInputTextView) -> Void
     let onTextViewDismantled: (TextBoxInputTextView) -> Void
-
     @State private var textViewHeight: CGFloat = 0
     @State private var hasPendingAttachmentUpload = false
     @State private var hasMarkedText = false

--- a/Sources/TextBoxInput.swift
+++ b/Sources/TextBoxInput.swift
@@ -26,8 +26,8 @@ enum TextBoxLayout {
     static let iconSymbolSize: CGFloat = 13
     static let sendSymbolSize: CGFloat = 14
     static let buttonBottomPadding: CGFloat = 3
-    static let leadingButtonHorizontalOffset: CGFloat = -1
-    static let trailingButtonHorizontalOffset: CGFloat = 1
+    static let leadingButtonHorizontalOffset: CGFloat = -2
+    static let trailingButtonHorizontalOffset: CGFloat = 2
     static let attachmentControlSpacing: CGFloat = 2
     static var attachmentImageSize: CGFloat {
         GlobalFontMagnification.scaledSize(16)

--- a/Sources/TextBoxSubmitActionCycling.swift
+++ b/Sources/TextBoxSubmitActionCycling.swift
@@ -16,7 +16,7 @@ extension TextBoxInputContainer {
         ) else {
             return
         }
-        selectedSubmitActionID = nextID
+        onSelectSubmitAction(nextID)
     }
 
     private func refreshedShouldForceTextEntrySubmitAfterAgentPrune() -> Bool {

--- a/Sources/TextBoxSubmitActions.swift
+++ b/Sources/TextBoxSubmitActions.swift
@@ -336,7 +336,7 @@ extension TextBoxInputContainer {
             if allowsSubmitActionSelection {
                 ForEach(submitActions) { action in
                     Button {
-                        selectedSubmitActionID = action.id
+                        onSelectSubmitAction(action.id)
                     } label: {
                         submitActionMenuLabel(action)
                     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1608,6 +1608,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE7B400000000000000001 /* TextBoxSubmitActionCycling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B400000000000000002 /* TextBoxSubmitActionCycling.swift */; };
 		C0DE7B390000000000000001 /* TextBoxSubmitActionImageSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B390000000000000002 /* TextBoxSubmitActionImageSupport.swift */; };
 		C0DE7B3A0000000000000001 /* TextBoxSubmitActionKind.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B3A0000000000000002 /* TextBoxSubmitActionKind.swift */; };
+		C0DE7B410000000000000001 /* TextBoxSubmitActionMemoryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B410000000000000002 /* TextBoxSubmitActionMemoryTests.swift */; };
 		C0DE7B380000000000000001 /* TextBoxSubmitActionPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B380000000000000002 /* TextBoxSubmitActionPresentation.swift */; };
 		7725A0057725A0057725A005 /* TextBoxSubmitActionResolvedIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7725A0067725A0067725A006 /* TextBoxSubmitActionResolvedIcon.swift */; };
 		C0DE7B340000000000000001 /* TextBoxSubmitActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE7B340000000000000002 /* TextBoxSubmitActions.swift */; };
@@ -3376,6 +3377,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE7B400000000000000002 /* TextBoxSubmitActionCycling.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActionCycling.swift; sourceTree = "<group>"; };
 		C0DE7B390000000000000002 /* TextBoxSubmitActionImageSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActionImageSupport.swift; sourceTree = "<group>"; };
 		C0DE7B3A0000000000000002 /* TextBoxSubmitActionKind.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/TextBoxSubmitActionKind.swift; sourceTree = "<group>"; };
+		C0DE7B410000000000000002 /* TextBoxSubmitActionMemoryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActionMemoryTests.swift; sourceTree = "<group>"; };
 		C0DE7B380000000000000002 /* TextBoxSubmitActionPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActionPresentation.swift; sourceTree = "<group>"; };
 		7725A0067725A0067725A006 /* TextBoxSubmitActionResolvedIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActionResolvedIcon.swift; sourceTree = "<group>"; };
 		C0DE7B340000000000000002 /* TextBoxSubmitActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextBoxSubmitActions.swift; sourceTree = "<group>"; };
@@ -5201,6 +5203,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DEF0B30000000000000002 /* KeyboardShortcutSettingsFileStoreMigrationTests.swift */,
 				E3337002E3337002E3337002 /* KeyboardShortcutSettingsFileStoreStartupTests.swift */,
 				C0DE7B3C0000000000000002 /* TextBoxSubmitActionSettingsFileTests.swift */,
+				C0DE7B410000000000000002 /* TextBoxSubmitActionMemoryTests.swift */,
 				C0DE7B360000000000000002 /* TextBoxSubmitActionTests.swift */,
 				C34670020000000000000002 /* KeyboardShortcutContextTests.swift */,
 				C34670050000000000000002 /* KeyboardShortcutContextSwiftTests.swift */,
@@ -7540,6 +7543,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B7758A020000000000000001 /* TerminationWatchdogTests.swift in Sources */,
 				C0DE7B300000000000000001 /* TextBoxMentionCompletionTests.swift in Sources */,
 				7898A0010000000000000001 /* TextBoxMentionGitIgnoreProbeTests.swift in Sources */,
+				C0DE7B410000000000000001 /* TextBoxSubmitActionMemoryTests.swift in Sources */,
 				C0DE7B3C0000000000000001 /* TextBoxSubmitActionSettingsFileTests.swift in Sources */,
 				C0DE7B360000000000000001 /* TextBoxSubmitActionTests.swift in Sources */,
 				F50030040000000000000001 /* TitlebarInteractiveControlTests.swift in Sources */,

--- a/cmuxTests/TextBoxSubmitActionMemoryTests.swift
+++ b/cmuxTests/TextBoxSubmitActionMemoryTests.swift
@@ -55,16 +55,15 @@ struct TextBoxSubmitActionMemoryTests {
     @Test
     func testConfiguredDefaultChangeClearsRememberedMode() throws {
         let defaults = try makeIsolatedDefaults()
-        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
         let panelState = TerminalPanelTextBoxState(defaults: defaults)
 
         panelState.selectSubmitAction("codex", defaults: defaults)
-        defaults.set("claude", forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
 
         #expect(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID == nil)
-        #expect(TerminalTextBoxInputSettings.defaultSubmitActionIDValue(defaults: defaults) == "claude")
+        #expect(TerminalTextBoxInputSettings.defaultSubmitActionIDValue(defaults: defaults) == TextBoxSubmitAction.textEntryAction.id)
 
-        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+        defaults.removeObject(forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
         #expect(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID == nil)
     }
 

--- a/cmuxTests/TextBoxSubmitActionMemoryTests.swift
+++ b/cmuxTests/TextBoxSubmitActionMemoryTests.swift
@@ -1,0 +1,77 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+@MainActor
+struct TextBoxSubmitActionMemoryTests {
+    @Test
+    func testNewTextBoxesReuseLastExplicitModeAfterAgentSubmit() throws {
+        let defaults = try makeIsolatedDefaults()
+        let submittedPanelState = TerminalPanelTextBoxState(defaults: defaults)
+        let codex = try #require(TextBoxSubmitAction.builtInActions.first { $0.id == "codex" })
+
+        submittedPanelState.selectSubmitAction(codex.id, defaults: defaults)
+        submittedPanelState.selectedSubmitActionID = TextBoxInputContainer.panelSubmitActionIDAfterSuccessfulSubmit(
+            currentSubmitActionID: codex.id,
+            submittedAction: codex
+        )
+
+        #expect(submittedPanelState.selectedSubmitActionID == TextBoxSubmitAction.textEntryAction.id)
+        #expect(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID == codex.id)
+        #expect(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID == codex.id)
+    }
+
+    @Test
+    func testNewTextBoxesReuseLastExplicitCustomMode() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(
+            """
+            [
+              {
+                "id": "custom-router",
+                "title": "Custom Router",
+                "kind": "commandTemplate",
+                "commandTemplate": "router --prompt {{prompt}}",
+                "systemImage": "wand.and.stars",
+                "backgroundColorHex": "#123456"
+              }
+            ]
+            """,
+            forKey: TerminalTextBoxInputSettings.submitActionsKey
+        )
+        let sourcePanelState = TerminalPanelTextBoxState(defaults: defaults)
+
+        sourcePanelState.selectSubmitAction("custom-router", defaults: defaults)
+
+        #expect(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID == "custom-router")
+    }
+
+    @Test
+    func testConfiguredDefaultChangeClearsRememberedMode() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+        let panelState = TerminalPanelTextBoxState(defaults: defaults)
+
+        panelState.selectSubmitAction("codex", defaults: defaults)
+        defaults.set("claude", forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+
+        #expect(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID == nil)
+        #expect(TerminalTextBoxInputSettings.defaultSubmitActionIDValue(defaults: defaults) == "claude")
+
+        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+        #expect(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID == nil)
+    }
+
+    private func makeIsolatedDefaults() throws -> UserDefaults {
+        let suiteName = "TextBoxSubmitActionMemoryTests.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/cmuxTests/TextBoxSubmitActionTests.swift
+++ b/cmuxTests/TextBoxSubmitActionTests.swift
@@ -1011,6 +1011,22 @@ struct TextBoxSubmitActionTests {
     }
 
     @Test
+    func testConfiguredDefaultChangeClearsRememberedMode() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+        let panelState = TerminalPanelTextBoxState(defaults: defaults)
+
+        panelState.selectSubmitAction("codex", defaults: defaults)
+        defaults.set("claude", forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+
+        XCTAssertNil(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID)
+        XCTAssertEqual(TerminalTextBoxInputSettings.defaultSubmitActionIDValue(defaults: defaults), "claude")
+
+        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
+        XCTAssertNil(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID)
+    }
+
+    @Test
     func testUnknownNonIdleTerminalStillCyclesSubmitAction() {
         let actions = TextBoxSubmitAction.builtInActions
         let shouldForceTextEntry = TextBoxInputContainer.shouldForceTextEntrySubmit(

--- a/cmuxTests/TextBoxSubmitActionTests.swift
+++ b/cmuxTests/TextBoxSubmitActionTests.swift
@@ -969,6 +969,48 @@ struct TextBoxSubmitActionTests {
     }
 
     @Test
+    func testNewTextBoxesReuseLastExplicitModeAfterAgentSubmit() throws {
+        let defaults = try makeIsolatedDefaults()
+        let submittedPanelState = TerminalPanelTextBoxState(defaults: defaults)
+        let codex = try #require(TextBoxSubmitAction.builtInActions.first { $0.id == "codex" })
+
+        submittedPanelState.selectSubmitAction(codex.id, defaults: defaults)
+        submittedPanelState.selectedSubmitActionID = TextBoxInputContainer.panelSubmitActionIDAfterSuccessfulSubmit(
+            currentSubmitActionID: codex.id,
+            submittedAction: codex
+        )
+
+        XCTAssertEqual(submittedPanelState.selectedSubmitActionID, TextBoxSubmitAction.textEntryAction.id)
+        XCTAssertEqual(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID, codex.id)
+        XCTAssertEqual(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID, codex.id)
+    }
+
+    @Test
+    func testNewTextBoxesReuseLastExplicitCustomMode() throws {
+        let defaults = try makeIsolatedDefaults()
+        defaults.set(
+            """
+            [
+              {
+                "id": "custom-router",
+                "title": "Custom Router",
+                "kind": "commandTemplate",
+                "commandTemplate": "router --prompt {{prompt}}",
+                "systemImage": "wand.and.stars",
+                "backgroundColorHex": "#123456"
+              }
+            ]
+            """,
+            forKey: TerminalTextBoxInputSettings.submitActionsKey
+        )
+        let sourcePanelState = TerminalPanelTextBoxState(defaults: defaults)
+
+        sourcePanelState.selectSubmitAction("custom-router", defaults: defaults)
+
+        XCTAssertEqual(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID, "custom-router")
+    }
+
+    @Test
     func testUnknownNonIdleTerminalStillCyclesSubmitAction() {
         let actions = TextBoxSubmitAction.builtInActions
         let shouldForceTextEntry = TextBoxInputContainer.shouldForceTextEntrySubmit(

--- a/cmuxTests/TextBoxSubmitActionTests.swift
+++ b/cmuxTests/TextBoxSubmitActionTests.swift
@@ -969,64 +969,6 @@ struct TextBoxSubmitActionTests {
     }
 
     @Test
-    func testNewTextBoxesReuseLastExplicitModeAfterAgentSubmit() throws {
-        let defaults = try makeIsolatedDefaults()
-        let submittedPanelState = TerminalPanelTextBoxState(defaults: defaults)
-        let codex = try #require(TextBoxSubmitAction.builtInActions.first { $0.id == "codex" })
-
-        submittedPanelState.selectSubmitAction(codex.id, defaults: defaults)
-        submittedPanelState.selectedSubmitActionID = TextBoxInputContainer.panelSubmitActionIDAfterSuccessfulSubmit(
-            currentSubmitActionID: codex.id,
-            submittedAction: codex
-        )
-
-        XCTAssertEqual(submittedPanelState.selectedSubmitActionID, TextBoxSubmitAction.textEntryAction.id)
-        XCTAssertEqual(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID, codex.id)
-        XCTAssertEqual(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID, codex.id)
-    }
-
-    @Test
-    func testNewTextBoxesReuseLastExplicitCustomMode() throws {
-        let defaults = try makeIsolatedDefaults()
-        defaults.set(
-            """
-            [
-              {
-                "id": "custom-router",
-                "title": "Custom Router",
-                "kind": "commandTemplate",
-                "commandTemplate": "router --prompt {{prompt}}",
-                "systemImage": "wand.and.stars",
-                "backgroundColorHex": "#123456"
-              }
-            ]
-            """,
-            forKey: TerminalTextBoxInputSettings.submitActionsKey
-        )
-        let sourcePanelState = TerminalPanelTextBoxState(defaults: defaults)
-
-        sourcePanelState.selectSubmitAction("custom-router", defaults: defaults)
-
-        XCTAssertEqual(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID, "custom-router")
-    }
-
-    @Test
-    func testConfiguredDefaultChangeClearsRememberedMode() throws {
-        let defaults = try makeIsolatedDefaults()
-        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
-        let panelState = TerminalPanelTextBoxState(defaults: defaults)
-
-        panelState.selectSubmitAction("codex", defaults: defaults)
-        defaults.set("claude", forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
-
-        XCTAssertNil(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID)
-        XCTAssertEqual(TerminalTextBoxInputSettings.defaultSubmitActionIDValue(defaults: defaults), "claude")
-
-        defaults.set(TextBoxSubmitAction.textEntryAction.id, forKey: TerminalTextBoxInputSettings.defaultSubmitActionKey)
-        XCTAssertNil(TerminalPanelTextBoxState(defaults: defaults).selectedSubmitActionID)
-    }
-
-    @Test
     func testUnknownNonIdleTerminalStillCyclesSubmitAction() {
         let actions = TextBoxSubmitAction.builtInActions
         let shouldForceTextEntry = TextBoxInputContainer.shouldForceTextEntrySubmit(


### PR DESCRIPTION
## Summary

- remember the last explicitly selected textbox submit mode
- initialize new workspace and split textboxes from that mode
- validate remembered built-in and custom mode IDs against the current action catalog
- clear stale remembered state when the configured default changes
- move the plus one additional pixel left and submit one additional pixel right

## Tests

- regression tests added before the behavior fixes
- tagged macOS build txmode: https://github.com/manaflow-ai/cmux/actions/runs/29295956691
- exact UI preflight passed: select Codex, submit, create workspace, create right split; both new textboxes showed Codex
- final screenshot verified the outward button spacing in both split textboxes
- background autoreview owns current-head checks and focused regression coverage

## Dogfood

http://127.0.0.1:17320/txmode

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Remembers the selected submit action between text boxes and app sessions.
  * Restores saved selections when they remain valid and clears them when submit-action settings change.
  * Supports selecting and cycling through submit actions while keeping the saved selection synchronized.
* **Bug Fixes**
  * Prevents invalid or unavailable submit actions from being restored.
* **Tests**
  * Added coverage for remembered selections, custom actions, and changed or removed defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->