### PR TITLE
Require analytics limiter configuration in production

### DIFF
--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -46,7 +46,7 @@ export const env = createEnv({
     CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
     CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
     CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID"),
-    CMUX_ANALYTICS_RATE_LIMIT_ID: z.string().min(1).optional(),
+    CMUX_ANALYTICS_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_ANALYTICS_RATE_LIMIT_ID"),
     STACK_SECRET_SERVER_KEY: z.string().min(1),
     // APNs push (iOS notifications). Optional: the app boots without them; the
     // push route returns a clear "not configured" error until they are set.

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -21,12 +21,23 @@ const isVercelNonPreviewDeployment =
   process.env.VERCEL === "1" &&
   typeof process.env.VERCEL_ENV === "string" &&
   process.env.VERCEL_ENV !== "preview";
+const isVercelProductionDeployment =
+  process.env.VERCEL === "1" && process.env.VERCEL_ENV === "production";
 const requireVercelNonPreviewValue = (name: string): z.ZodType<string | undefined> =>
   z.string().min(1).optional().superRefine((value, context) => {
     if (isVercelNonPreviewDeployment && !value) {
       context.addIssue({
         code: z.ZodIssueCode.custom,
         message: `${name} is required for deployed non-preview runtimes`,
+      });
+    }
+  });
+const requireVercelProductionValue = (name: string): z.ZodType<string | undefined> =>
+  z.string().min(1).optional().superRefine((value, context) => {
+    if (isVercelProductionDeployment && !value) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: `${name} is required for Vercel production runtimes`,
       });
     }
   });
@@ -46,7 +57,7 @@ export const env = createEnv({
     CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
     CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
     CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID"),
-    CMUX_ANALYTICS_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_ANALYTICS_RATE_LIMIT_ID"),
+    CMUX_ANALYTICS_RATE_LIMIT_ID: requireVercelProductionValue("CMUX_ANALYTICS_RATE_LIMIT_ID"),
     STACK_SECRET_SERVER_KEY: z.string().min(1),
     // APNs push (iOS notifications). Optional: the app boots without them; the
     // push route returns a clear "not configured" error until they are set.

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -58,6 +58,17 @@ describe("client config env validation", () => {
     expect(result.exitCode).not.toBe(0);
     expect(result.stderr).toContain("CMUX_ANALYTICS_RATE_LIMIT_ID is required");
   });
+
+  test("allows Vercel development without the analytics limiter id", () => {
+    const result = importEnv({
+      ...requiredEnv,
+      VERCEL: "1",
+      VERCEL_ENV: "development",
+      CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+    });
+
+    expect(result.exitCode).toBe(0);
+  });
 });
 
 function importEnv(env: Record<string, string>): { exitCode: number; stderr: string } {

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -35,12 +35,13 @@ describe("client config env validation", () => {
     expect(result.stderr).toContain("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID is required");
   });
 
-  test("accepts explicit Vercel production deployments with the limiter id", () => {
+  test("accepts explicit Vercel production deployments with both limiter ids", () => {
     const result = importEnv({
       ...requiredEnv,
       VERCEL: "1",
       VERCEL_ENV: "production",
       CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+      CMUX_ANALYTICS_RATE_LIMIT_ID: "analytics-rule",
     });
 
     expect(result.exitCode).toBe(0);

--- a/web/tests/client-config-env.test.ts
+++ b/web/tests/client-config-env.test.ts
@@ -45,6 +45,18 @@ describe("client config env validation", () => {
 
     expect(result.exitCode).toBe(0);
   });
+
+  test("requires the analytics limiter id in explicit Vercel production deployments", () => {
+    const result = importEnv({
+      ...requiredEnv,
+      VERCEL: "1",
+      VERCEL_ENV: "production",
+      CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: "client-config-rule",
+    });
+
+    expect(result.exitCode).not.toBe(0);
+    expect(result.stderr).toContain("CMUX_ANALYTICS_RATE_LIMIT_ID is required");
+  });
 });
 
 function importEnv(env: Record<string, string>): { exitCode: number; stderr: string } {


### PR DESCRIPTION
## Summary
- require the analytics Firewall rule ID during Vercel production builds
- cover the production environment contract with a red-then-green regression test
- document the live incident evidence and configuration recovery in the investigation

## Testing
- `cd web && bun test tests/client-config-env.test.ts tests/analytics-events-route.test.ts`
- `cd web && bun run typecheck`
- production `POST /api/analytics/events` with an empty batch returns 200 after enabling the `cmux-analytics` Firewall rule and environment variable
- local Next.js server on port 9400 returns 200 for `/`, `/handler/sign-in`, redirected `/handler/after-sign-in`, and an empty analytics batch

## Issues
- Related: https://github.com/manaflow-ai/cmux/issues/5569
- Incident source: Vercel error spike on `/api/analytics/events` starting July 13, 2026

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8009"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786577623&installation_id=133855650&pr_number=8009&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8009&signature=210221372afdc312cc185bfb10252e71b587b61f088ea766734c07c5c0c674e7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require `CMUX_ANALYTICS_RATE_LIMIT_ID` for Vercel production only; keep it optional for development and preview. Adds tests to enforce this and prevent 5xxs on POST `/api/analytics/events`.

- **Migration**
  - Set `CMUX_ANALYTICS_RATE_LIMIT_ID` in Vercel production to the analytics Firewall rule ID and ensure the rule is enabled.
  - No changes needed for Vercel development or preview.

<sup>Written for commit 8eb9f64696cdd75be8908676cc412ad211b3ce36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened production deployment environment validation to require the analytics rate-limit setting.
  * Preview deployments remain allowed without this additional configuration.
  * Improved failure behavior so missing production settings report the specific missing variable clearly.
* **Tests**
  * Updated and expanded environment validation tests to cover both required-production and allowed-development scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->