### PR TITLE
Fix iOS recovery from stalled mobile RPC writes

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -65,6 +65,16 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         await session.tearDown(error: .connectionClosed)
     }
 
+    /// Drops the current transport while preserving this client's route and ticket.
+    ///
+    /// The next request lazily establishes a fresh transport. Call this only
+    /// after a liveness probe or availability failure proves the
+    /// persistent session is stale; ordinary response timeouts remain isolated
+    /// to their request.
+    public func resetConnectionForRecovery() async {
+        await session.tearDown(error: .connectionClosed)
+    }
+
     /// Subscribe to server-pushed events. Returns a stream of envelopes
     /// matching any of the requested topics. Cancel by terminating iteration.
     public func subscribe(to topics: Set<String>) async -> AsyncStream<MobileEventEnvelope> {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -59,15 +59,17 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         )
     }
 
-    /// Tear down the persistent transport (called when the client is
-    /// replaced or the user signs out).
+    /// Atomically detaches the persistent transport (called when the client is
+    /// replaced or the user signs out). Physical close cleanup is serialized
+    /// separately so a transport callback cannot block logical disconnect.
     public func disconnect() async {
         await session.tearDown(error: .connectionClosed)
     }
 
     /// Drops the current transport while preserving this client's route and ticket.
     ///
-    /// The next request lazily establishes a fresh transport. Call this only
+    /// The next request lazily establishes a fresh transport while physical
+    /// cleanup of the detached transport proceeds separately. Call this only
     /// after a liveness probe or availability failure proves the
     /// persistent session is stale; ordinary response timeouts remain isolated
     /// to their request.

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+ReadLoop.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+ReadLoop.swift
@@ -1,0 +1,47 @@
+internal import CMUXMobileCore
+import Foundation
+
+extension MobileCoreRPCSession {
+    func readLoop(
+        transport: any CmxByteTransport,
+        connectionID: UUID
+    ) async {
+        var buffer = Data()
+        while !Task.isCancelled {
+            let chunk: Data?
+            do {
+                chunk = try await transport.receive()
+            } catch {
+                await tearDownIfInstalled(
+                    connectionID: connectionID,
+                    error: .connectionClosed
+                )
+                return
+            }
+            guard let chunk, !chunk.isEmpty else {
+                if chunk == nil {
+                    await tearDownIfInstalled(
+                        connectionID: connectionID,
+                        error: .connectionClosed
+                    )
+                    return
+                }
+                continue
+            }
+            buffer.append(chunk)
+            let frames: [Data]
+            do {
+                frames = try MobileSyncFrameCodec.decodeFrames(from: &buffer)
+            } catch {
+                await tearDownIfInstalled(
+                    connectionID: connectionID,
+                    error: .invalidResponse
+                )
+                return
+            }
+            for frame in frames {
+                dispatch(frame: frame)
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+ReadLoop.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+ReadLoop.swift
@@ -28,6 +28,10 @@ extension MobileCoreRPCSession {
                 }
                 continue
             }
+            guard !Task.isCancelled,
+                  installedConnectionID == connectionID else {
+                return
+            }
             buffer.append(chunk)
             let frames: [Data]
             do {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+TransportClose.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+TransportClose.swift
@@ -1,0 +1,30 @@
+internal import CMUXMobileCore
+import Foundation
+
+extension MobileCoreRPCSession {
+    /// Serializes detached transport cleanup without letting a non-cooperative
+    /// `close()` callback block session recovery or create unbounded tasks.
+    /// While one close is active, only the newest replacement is retained.
+    func enqueueTransportClose(_ transport: any CmxByteTransport) {
+        guard transportCloseTask == nil else {
+            pendingTransportClose = transport
+            return
+        }
+
+        let taskID = UUID()
+        transportCloseTaskID = taskID
+        transportCloseTask = Task.detached { [weak self] in
+            await transport.close()
+            await self?.transportCloseDidFinish(taskID: taskID)
+        }
+    }
+
+    private func transportCloseDidFinish(taskID: UUID) {
+        guard transportCloseTaskID == taskID else { return }
+        transportCloseTask = nil
+        transportCloseTaskID = nil
+        guard let pendingTransportClose else { return }
+        self.pendingTransportClose = nil
+        enqueueTransportClose(pendingTransportClose)
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+TransportClose.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+TransportClose.swift
@@ -4,10 +4,11 @@ import Foundation
 extension MobileCoreRPCSession {
     /// Serializes detached transport cleanup without letting a non-cooperative
     /// `close()` callback block session recovery or create unbounded tasks.
-    /// While one close is active, only the newest replacement is retained.
+    /// Connection creation is backpressured while the one pending slot is full,
+    /// so every detached transport reaches `close()` without unbounded growth.
     func enqueueTransportClose(_ transport: any CmxByteTransport) {
         guard transportCloseTask == nil else {
-            pendingTransportClose = transport
+            pendingTransportCloses.append(transport)
             return
         }
 
@@ -23,8 +24,8 @@ extension MobileCoreRPCSession {
         guard transportCloseTaskID == taskID else { return }
         transportCloseTask = nil
         transportCloseTaskID = nil
-        guard let pendingTransportClose else { return }
-        self.pendingTransportClose = nil
-        enqueueTransportClose(pendingTransportClose)
+        guard !pendingTransportCloses.isEmpty else { return }
+        let nextTransport = pendingTransportCloses.removeFirst()
+        enqueueTransportClose(nextTransport)
     }
 }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+WriteLoop.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+WriteLoop.swift
@@ -1,0 +1,51 @@
+internal import CMUXMobileCore
+import Foundation
+
+extension MobileCoreRPCSession {
+    func writeLoop(
+        transport: any CmxByteTransport,
+        connectionID: UUID,
+        frames: AsyncStream<PendingWrite>
+    ) async {
+        for await write in frames {
+            if Task.isCancelled { return }
+            guard shouldSendQueuedWrite(write) else { continue }
+
+            let sendTask = Task {
+                try await transport.send(write.frame)
+            }
+            activeWrite = (connectionID, write.requestID, sendTask)
+            do {
+                try await sendTask.value
+                clearActiveWrite(
+                    connectionID: connectionID,
+                    requestID: write.requestID
+                )
+            } catch {
+                clearActiveWrite(
+                    connectionID: connectionID,
+                    requestID: write.requestID
+                )
+                await tearDownIfInstalled(
+                    connectionID: connectionID,
+                    error: .connectionClosed
+                )
+                return
+            }
+        }
+    }
+
+    private func clearActiveWrite(connectionID: UUID, requestID: String) {
+        guard activeWrite?.connectionID == connectionID,
+              activeWrite?.requestID == requestID else { return }
+        activeWrite = nil
+    }
+
+    func tearDownIfInstalled(
+        connectionID: UUID,
+        error: MobileShellConnectionError
+    ) async {
+        guard installedConnectionID == connectionID else { return }
+        await tearDown(error: error)
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+WriteLoop.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession+WriteLoop.swift
@@ -41,6 +41,14 @@ extension MobileCoreRPCSession {
         activeWrite = nil
     }
 
+    func recycleTransportIfActiveWrite(requestID: String) async -> Bool {
+        guard activeWrite?.requestID == requestID else { return false }
+        activeWrite?.task.cancel()
+        activeWrite = nil
+        await tearDown(error: .connectionClosed)
+        return true
+    }
+
     func tearDownIfInstalled(
         connectionID: UUID,
         error: MobileShellConnectionError

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -19,7 +19,7 @@ actor MobileCoreRPCSession {
         let continuation: AsyncStream<MobileEventEnvelope>.Continuation
     }
 
-    private struct PendingWrite: Sendable {
+    struct PendingWrite: Sendable {
         let id: UUID
         let requestID: String
         let frame: Data
@@ -34,7 +34,7 @@ actor MobileCoreRPCSession {
     private let didReceiveConnectedCandidate: ConnectedCandidateHook?
     private var transport: (any CmxByteTransport)?
     private var connectionTask: ConnectingTask?
-    private var installedConnectionID: UUID?
+    var installedConnectionID: UUID?
     private var readerTask: Task<Void, Never>?
     private var pending: [String: PendingContinuation] = [:]
     private var requestTimeoutTasks: [String: Task<Void, Never>] = [:]
@@ -47,6 +47,11 @@ actor MobileCoreRPCSession {
     private var isTearingDown: Bool = false
     private var writeQueue: AsyncStream<PendingWrite>.Continuation?
     private var writerTask: Task<Void, Never>?
+    var activeWrite: (
+        connectionID: UUID,
+        requestID: String,
+        task: Task<Void, any Error>
+    )?
 
     init(
         connectAttemptKey: String? = nil,
@@ -163,20 +168,23 @@ actor MobileCoreRPCSession {
         }
         writeQueue?.finish()
         writeQueue = nil
+        activeWrite?.task.cancel()
+        activeWrite = nil
         writerTask?.cancel()
         writerTask = nil
         let connecting = connectionTask
         connecting?.task.cancel()
         connectionTask = nil
         installedConnectionID = nil
-        if let transport {
-            await transport.close()
-        }
+        let transportToClose = transport
         transport = nil
         readerTask?.cancel()
         readerTask = nil
-        if let connecting { await abandonConnectionTask(connecting) }
         isTearingDown = false
+        if let transportToClose {
+            await transportToClose.close()
+        }
+        if let connecting { await abandonConnectionTask(connecting) }
     }
 
     // MARK: - private
@@ -286,12 +294,19 @@ actor MobileCoreRPCSession {
         transport = candidate
         await connectAttemptRegistry.recordSuccessfulConnect(lease: connectLease)
         readerTask = Task { [weak self] in
-            await self?.readLoop(transport: candidate)
+            await self?.readLoop(
+                transport: candidate,
+                connectionID: connectionID
+            )
         }
         let (stream, continuation) = AsyncStream<PendingWrite>.makeStream(bufferingPolicy: .unbounded)
         writeQueue = continuation
         writerTask = Task { [weak self] in
-            await self?.writeLoop(transport: candidate, frames: stream)
+            await self?.writeLoop(
+                transport: candidate,
+                connectionID: connectionID,
+                frames: stream
+            )
         }
         if callerCancelled {
             throw CancellationError()
@@ -371,53 +386,7 @@ actor MobileCoreRPCSession {
         }
     }
 
-    private func writeLoop(transport: any CmxByteTransport, frames: AsyncStream<PendingWrite>) async {
-        for await write in frames {
-            if Task.isCancelled { return }
-            guard shouldSendQueuedWrite(write) else {
-                continue
-            }
-            do {
-                try await transport.send(write.frame)
-            } catch {
-                await tearDown(error: .connectionClosed)
-                return
-            }
-        }
-    }
-
-    private func readLoop(transport: any CmxByteTransport) async {
-        var buffer = Data()
-        while !Task.isCancelled {
-            let chunk: Data?
-            do {
-                chunk = try await transport.receive()
-            } catch {
-                await tearDown(error: .connectionClosed)
-                return
-            }
-            guard let chunk, !chunk.isEmpty else {
-                if chunk == nil {
-                    await tearDown(error: .connectionClosed)
-                    return
-                }
-                continue
-            }
-            buffer.append(chunk)
-            let frames: [Data]
-            do {
-                frames = try MobileSyncFrameCodec.decodeFrames(from: &buffer)
-            } catch {
-                await tearDown(error: .invalidResponse)
-                return
-            }
-            for frame in frames {
-                dispatch(frame: frame)
-            }
-        }
-    }
-
-    private func dispatch(frame: Data) {
+    func dispatch(frame: Data) {
         let parsed = try? JSONSerialization.jsonObject(with: frame) as? [String: Any]
         guard let envelope = parsed else { return }
         if (envelope["kind"] as? String) == "event" {
@@ -477,16 +446,23 @@ actor MobileCoreRPCSession {
         cont.resume(returning: .failure(.requestTimedOut))
     }
 
-    private func timeoutPendingRequest(requestID: String) {
+    private func timeoutPendingRequest(requestID: String) async {
         guard let cont = pending.removeValue(forKey: requestID) else { return }
+        var timeoutError = MobileShellConnectionError.requestTimedOut
         requestTimeoutTasks.removeValue(forKey: requestID)?.cancel()
         if let queuedWriteID = queuedWriteIDs.removeValue(forKey: requestID) {
             cancelledQueuedWriteIDs.insert(queuedWriteID)
         }
-        cont.resume(returning: .failure(.requestTimedOut))
+        if activeWrite?.requestID == requestID {
+            timeoutError = .transportWriteTimedOut
+            activeWrite?.task.cancel()
+            activeWrite = nil
+            await tearDown(error: .connectionClosed)
+        }
+        cont.resume(returning: .failure(timeoutError))
     }
 
-    private func shouldSendQueuedWrite(_ write: PendingWrite) -> Bool {
+    func shouldSendQueuedWrite(_ write: PendingWrite) -> Bool {
         if cancelledQueuedWriteIDs.remove(write.id) != nil {
             return false
         }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -49,7 +49,7 @@ actor MobileCoreRPCSession {
     private var writerTask: Task<Void, Never>?
     var transportCloseTask: Task<Void, Never>?
     var transportCloseTaskID: UUID?
-    var pendingTransportClose: (any CmxByteTransport)?
+    var pendingTransportCloses: [any CmxByteTransport] = []
     var activeWrite: (
         connectionID: UUID,
         requestID: String,
@@ -195,6 +195,13 @@ actor MobileCoreRPCSession {
 
     private func ensureConnected(timeoutNanoseconds: UInt64) async throws -> any CmxByteTransport {
         if let transport { return transport }
+        // One active close plus one queued close is the cleanup capacity. Do
+        // not create another transport until a slot opens: otherwise a close
+        // implementation that stalls could force either unbounded retention or
+        // dropping a transport without ever invoking its cleanup contract.
+        guard pendingTransportCloses.isEmpty else {
+            throw MobileShellConnectionError.connectionClosed
+        }
 
         let waiterID = UUID()
         let connectionID: UUID

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -47,6 +47,9 @@ actor MobileCoreRPCSession {
     private var isTearingDown: Bool = false
     private var writeQueue: AsyncStream<PendingWrite>.Continuation?
     private var writerTask: Task<Void, Never>?
+    var transportCloseTask: Task<Void, Never>?
+    var transportCloseTaskID: UUID?
+    var pendingTransportClose: (any CmxByteTransport)?
     var activeWrite: (
         connectionID: UUID,
         requestID: String,
@@ -73,6 +76,7 @@ actor MobileCoreRPCSession {
         connectionTask?.task.cancel()
         readerTask?.cancel()
         writerTask?.cancel()
+        transportCloseTask?.cancel()
         writeQueue?.finish()
     }
 
@@ -182,11 +186,7 @@ actor MobileCoreRPCSession {
         readerTask = nil
         isTearingDown = false
         if let transportToClose {
-            // Session state is already detached, so a transport whose close
-            // callback stalls cannot hold recovery or the UI in limbo.
-            Task.detached {
-                await transportToClose.close()
-            }
+            enqueueTransportClose(transportToClose)
         }
         if let connecting { await abandonConnectionTask(connecting) }
     }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -182,7 +182,11 @@ actor MobileCoreRPCSession {
         readerTask = nil
         isTearingDown = false
         if let transportToClose {
-            await transportToClose.close()
+            // Session state is already detached, so a transport whose close
+            // callback stalls cannot hold recovery or the UI in limbo.
+            Task.detached {
+                await transportToClose.close()
+            }
         }
         if let connecting { await abandonConnectionTask(connecting) }
     }
@@ -437,12 +441,13 @@ actor MobileCoreRPCSession {
         requestTimeoutTasks.removeValue(forKey: requestID)?.cancel()
         cont.resume(returning: .failure(error))
     }
-    private func cancelPendingRequest(requestID: String) {
+    private func cancelPendingRequest(requestID: String) async {
         guard let cont = pending.removeValue(forKey: requestID) else { return }
         requestTimeoutTasks.removeValue(forKey: requestID)?.cancel()
         if let queuedWriteID = queuedWriteIDs.removeValue(forKey: requestID) {
             cancelledQueuedWriteIDs.insert(queuedWriteID)
         }
+        _ = await recycleTransportIfActiveWrite(requestID: requestID)
         cont.resume(returning: .failure(.requestTimedOut))
     }
 
@@ -453,11 +458,8 @@ actor MobileCoreRPCSession {
         if let queuedWriteID = queuedWriteIDs.removeValue(forKey: requestID) {
             cancelledQueuedWriteIDs.insert(queuedWriteID)
         }
-        if activeWrite?.requestID == requestID {
+        if await recycleTransportIfActiveWrite(requestID: requestID) {
             timeoutError = .transportWriteTimedOut
-            activeWrite?.task.cancel()
-            activeWrite = nil
-            await tearDown(error: .connectionClosed)
         }
         cont.resume(returning: .failure(timeoutError))
     }

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileShellConnectionError.swift
@@ -9,6 +9,8 @@ public enum MobileShellConnectionError: LocalizedError {
     case connectionClosed
     /// A request exceeded its timeout deadline.
     case requestTimedOut
+    /// A request timed out while its frame was still blocked in transport.send.
+    case transportWriteTimedOut
     /// A manual host did not advertise a secure route.
     case insecureManualRoute
     /// The attach ticket expired and no fallback was available.
@@ -28,7 +30,7 @@ public enum MobileShellConnectionError: LocalizedError {
             return "Invalid mobile sync response"
         case .connectionClosed:
             return "Mobile sync connection closed"
-        case .requestTimedOut:
+        case .requestTimedOut, .transportWriteTimedOut:
             return "Mobile sync request timed out"
         case .insecureManualRoute:
             return "Manual host did not advertise a secure mobile sync route"

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/ControllableResponseTransport.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/ControllableResponseTransport.swift
@@ -1,0 +1,68 @@
+import CMUXMobileCore
+import Foundation
+@testable import CmuxMobileRPC
+
+actor ControllableResponseTransport: CmxByteTransport {
+    private let closeEndsReceive: Bool
+    private var queuedFrames: [Data] = []
+    private var receiveWaiters: [CheckedContinuation<Data?, Never>] = []
+    private var sentRequestIDs: [String] = []
+    private var sendCountWaiters: [(Int, CheckedContinuation<Void, Never>)] = []
+    private var isClosed = false
+
+    init(closeEndsReceive: Bool) {
+        self.closeEndsReceive = closeEndsReceive
+    }
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? {
+        if !queuedFrames.isEmpty { return queuedFrames.removeFirst() }
+        if isClosed, closeEndsReceive { return nil }
+        return await withCheckedContinuation { receiveWaiters.append($0) }
+    }
+
+    func send(_ data: Data) async throws {
+        var buffer = data
+        for payload in try MobileSyncFrameCodec.decodeFrames(from: &buffer) {
+            let request = try recordedRPCRequest(from: payload)
+            sentRequestIDs.append(request.id ?? "")
+        }
+        let ready = sendCountWaiters.filter { sentRequestIDs.count >= $0.0 }
+        sendCountWaiters.removeAll { sentRequestIDs.count >= $0.0 }
+        for (_, waiter) in ready { waiter.resume() }
+    }
+
+    func close() async {
+        isClosed = true
+        guard closeEndsReceive else { return }
+        finishReceiving()
+    }
+
+    func waitUntilSent(count: Int) async {
+        if sentRequestIDs.count >= count { return }
+        await withCheckedContinuation { sendCountWaiters.append((count, $0)) }
+    }
+
+    func deliverResponse(id: String, status: String) throws {
+        let response: [String: Any] = [
+            "id": id,
+            "ok": true,
+            "result": ["status": status],
+        ]
+        let payload = try JSONSerialization.data(withJSONObject: response)
+        let frame = try MobileSyncFrameCodec.encodeFrame(payload)
+        if let waiter = receiveWaiters.first {
+            receiveWaiters.removeFirst()
+            waiter.resume(returning: frame)
+        } else {
+            queuedFrames.append(frame)
+        }
+    }
+
+    func finishReceiving() {
+        let waiters = receiveWaiters
+        receiveWaiters = []
+        for waiter in waiters { waiter.resume(returning: nil) }
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStaleReaderRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStaleReaderRecoveryTests.swift
@@ -1,0 +1,87 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobileRPC
+
+@Suite struct MobileCoreRPCStaleReaderRecoveryTests {
+    @Test func staleReaderCannotAnswerReplacementSessionRequest() async throws {
+        let stale = ControllableResponseTransport(closeEndsReceive: false)
+        let replacement = ControllableResponseTransport(closeEndsReceive: true)
+        let factory = SequencedTransportFactory([stale, replacement])
+        let client = try makeClient(factory: factory)
+
+        let oldRequest = try inputRequest(id: "old-pending")
+        let oldTask = Task {
+            try await client.sendRequest(oldRequest, timeoutNanoseconds: 60 * 1_000_000_000)
+        }
+        await stale.waitUntilSent(count: 1)
+        await client.resetConnectionForRecovery()
+        _ = try? await oldTask.value
+
+        let completion = AsyncFlag()
+        let reusedID = "reused-after-reset"
+        let replacementTask = Task {
+            let data = try await client.sendRequest(
+                inputRequest(id: reusedID),
+                timeoutNanoseconds: 60 * 1_000_000_000
+            )
+            await completion.set()
+            return data
+        }
+        await replacement.waitUntilSent(count: 1)
+
+        try await stale.deliverResponse(id: reusedID, status: "stale")
+        for _ in 0..<100 where !(await completion.isSet()) {
+            await Task.yield()
+        }
+        #expect(!(await completion.isSet()))
+
+        try await replacement.deliverResponse(id: reusedID, status: "fresh")
+        let data = try await replacementTask.value
+        let response = try #require(
+            JSONSerialization.jsonObject(with: data) as? [String: String]
+        )
+        #expect(response["status"] == "fresh")
+
+        await stale.finishReceiving()
+        await client.disconnect()
+    }
+
+    private func makeClient(
+        factory: any CmxByteTransportFactory
+    ) throws -> MobileCoreRPCClient {
+        let route = try hostPortRoute(
+            kind: .debugLoopback,
+            host: "127.0.0.1",
+            port: 59136
+        )
+        let runtime = TestMobileSyncRuntime(transportFactory: factory)
+        let ticket = try CmxAttachTicket(
+            workspaceID: "workspace-main",
+            terminalID: "terminal-main",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(60),
+            authToken: "ticket-secret"
+        )
+        return MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            allowsStackAuthFallback: true
+        )
+    }
+
+    private func inputRequest(id: String) throws -> Data {
+        try MobileCoreRPCClient.requestData(
+            method: "terminal.input",
+            params: [
+                "workspace_id": "workspace-main",
+                "terminal_id": "terminal-main",
+                "text": "x",
+            ],
+            id: id
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
@@ -1,0 +1,82 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobileRPC
+
+@Suite struct MobileCoreRPCStalledWriteRecoveryTests {
+    @Test func timedOutInFlightWriteRecyclesTransportForNextRequest() async throws {
+        let stalled = StalledWriteTransport()
+        let recovery = ResponseTimeoutSurvivalTransport()
+        let factory = StalledWriteRecoveryTransportFactory(
+            stalled: stalled,
+            recovery: recovery
+        )
+        let route = try hostPortRoute(
+            kind: .debugLoopback,
+            host: "127.0.0.1",
+            port: 59135
+        )
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: factory,
+            rpcRequestTimeoutNanoseconds: 50_000_000
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "workspace-main",
+            terminalID: "terminal-main",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(60),
+            authToken: "ticket-secret"
+        )
+        let client = MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            allowsStackAuthFallback: true
+        )
+
+        let stalledRequest = try MobileCoreRPCClient.requestData(
+            method: "terminal.input",
+            params: [
+                "workspace_id": "workspace-main",
+                "terminal_id": "terminal-main",
+                "text": "a",
+            ],
+            id: "stalled-write"
+        )
+        do {
+            _ = try await client.sendRequest(stalledRequest)
+            Issue.record("Expected the stalled write to time out")
+        } catch MobileShellConnectionError.requestTimedOut {
+        } catch {
+            Issue.record("Expected requestTimedOut, got \(error)")
+        }
+
+        let retryRequest = try MobileCoreRPCClient.requestData(
+            method: "terminal.input",
+            params: [
+                "workspace_id": "workspace-main",
+                "terminal_id": "terminal-main",
+                "text": "b",
+            ],
+            id: "second-after-timeout"
+        )
+        do {
+            let data = try await client.sendRequest(
+                retryRequest,
+                timeoutNanoseconds: 500_000_000
+            )
+            let response = try #require(
+                JSONSerialization.jsonObject(with: data) as? [String: String]
+            )
+            #expect(response["status"] == "ok")
+        } catch {
+            Issue.record("The request after a stalled write should reconnect, got \(error)")
+        }
+
+        #expect(factory.createdTransportCount() == 2)
+        #expect(await stalled.closed())
+        await client.disconnect()
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
@@ -171,8 +171,64 @@ import Testing
         await client.disconnect()
     }
 
+    @Test func transportCloseCleanupRetainsOnlyNewestPendingTransport() async throws {
+        let first = StalledWriteTransport(hangsOnClose: true)
+        let superseded = StalledWriteTransport(hangsOnClose: true)
+        let newest = StalledWriteTransport(hangsOnClose: true)
+        let factory = SequencedTransportFactory([first, superseded, newest])
+        let client = try makeClient(factory: factory)
+
+        let firstTask = Task {
+            try await client.sendRequest(
+                inputRequest(id: "close-first", text: "a"),
+                timeoutNanoseconds: 60 * 1_000_000_000
+            )
+        }
+        await first.waitUntilSendStarted()
+        await client.resetConnectionForRecovery()
+        await first.waitUntilCloseStarted()
+
+        let supersededTask = Task {
+            try await client.sendRequest(
+                inputRequest(id: "close-superseded", text: "b"),
+                timeoutNanoseconds: 60 * 1_000_000_000
+            )
+        }
+        await superseded.waitUntilSendStarted()
+        await client.resetConnectionForRecovery()
+
+        let newestTask = Task {
+            try await client.sendRequest(
+                inputRequest(id: "close-newest", text: "c"),
+                timeoutNanoseconds: 60 * 1_000_000_000
+            )
+        }
+        await newest.waitUntilSendStarted()
+        await client.resetConnectionForRecovery()
+
+        #expect(await first.closed())
+        #expect(!(await superseded.closed()))
+        #expect(!(await newest.closed()))
+        #expect(factory.createdTransportCount() == 3)
+
+        await first.releaseClose()
+        await newest.waitUntilCloseStarted()
+        #expect(!(await superseded.closed()))
+
+        await newest.releaseClose()
+        await superseded.releaseClose()
+        await superseded.close()
+        await first.failStalledSend()
+        await superseded.failStalledSend()
+        await newest.failStalledSend()
+        _ = try? await firstTask.value
+        _ = try? await supersededTask.value
+        _ = try? await newestTask.value
+        await client.disconnect()
+    }
+
     private func makeClient(
-        factory: StalledWriteRecoveryTransportFactory
+        factory: any CmxByteTransportFactory
     ) throws -> MobileCoreRPCClient {
         let route = try hostPortRoute(
             kind: .debugLoopback,

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
@@ -48,9 +48,9 @@ import Testing
         do {
             _ = try await client.sendRequest(stalledRequest)
             Issue.record("Expected the stalled write to time out")
-        } catch MobileShellConnectionError.requestTimedOut {
+        } catch MobileShellConnectionError.transportWriteTimedOut {
         } catch {
-            Issue.record("Expected requestTimedOut, got \(error)")
+            Issue.record("Expected transportWriteTimedOut, got \(error)")
         }
 
         let retryRequest = try MobileCoreRPCClient.requestData(
@@ -74,6 +74,23 @@ import Testing
         } catch {
             Issue.record("The request after a stalled write should reconnect, got \(error)")
         }
+
+        // A cancelled send may unwind after its replacement transport is live.
+        // Its stale writer must not tear down the newer connection.
+        await stalled.failStalledSend()
+        let requestAfterLateFailure = try MobileCoreRPCClient.requestData(
+            method: "terminal.input",
+            params: [
+                "workspace_id": "workspace-main",
+                "terminal_id": "terminal-main",
+                "text": "c",
+            ],
+            id: "third-after-late-failure"
+        )
+        _ = try await client.sendRequest(
+            requestAfterLateFailure,
+            timeoutNanoseconds: 500_000_000
+        )
 
         #expect(factory.createdTransportCount() == 2)
         #expect(await stalled.closed())

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
@@ -96,4 +96,119 @@ import Testing
         #expect(await stalled.closed())
         await client.disconnect()
     }
+
+    @Test func cancelledInFlightWriteRecyclesTransportForNextRequest() async throws {
+        let stalled = StalledWriteTransport()
+        let recovery = ResponseTimeoutSurvivalTransport()
+        let factory = StalledWriteRecoveryTransportFactory(
+            stalled: stalled,
+            recovery: recovery
+        )
+        let client = try makeClient(factory: factory)
+        let stalledRequest = try inputRequest(id: "cancelled-stalled-write", text: "a")
+        let cancelledTask = Task {
+            try await client.sendRequest(
+                stalledRequest,
+                timeoutNanoseconds: 60 * 1_000_000_000
+            )
+        }
+
+        await stalled.waitUntilSendStarted()
+        cancelledTask.cancel()
+        do {
+            _ = try await cancelledTask.value
+            Issue.record("Expected the stalled request to be cancelled")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+
+        let retry = try inputRequest(id: "second-after-cancel", text: "b")
+        _ = try await client.sendRequest(retry, timeoutNanoseconds: 500_000_000)
+
+        #expect(factory.createdTransportCount() == 2)
+        #expect(await stalled.closed())
+        await stalled.failStalledSend()
+        await client.disconnect()
+    }
+
+    @Test func recoveryResetDoesNotWaitForHangingTransportClose() async throws {
+        let stalled = StalledWriteTransport(hangsOnClose: true)
+        let recovery = ResponseTimeoutSurvivalTransport()
+        let factory = StalledWriteRecoveryTransportFactory(
+            stalled: stalled,
+            recovery: recovery
+        )
+        let client = try makeClient(factory: factory)
+        let firstRequest = try inputRequest(id: "first-before-reset", text: "a")
+        let firstTask = Task {
+            try await client.sendRequest(
+                firstRequest,
+                timeoutNanoseconds: 60 * 1_000_000_000
+            )
+        }
+
+        await stalled.waitUntilSendStarted()
+        let resetFinished = AsyncFlag()
+        let resetTask = Task {
+            await client.resetConnectionForRecovery()
+            await resetFinished.set()
+        }
+        await stalled.waitUntilCloseStarted()
+        for _ in 0..<100 where !(await resetFinished.isSet()) {
+            await Task.yield()
+        }
+        #expect(await resetFinished.isSet())
+
+        let retry = try inputRequest(id: "second-after-hanging-close", text: "b")
+        _ = try await client.sendRequest(retry, timeoutNanoseconds: 500_000_000)
+        #expect(factory.createdTransportCount() == 2)
+
+        await stalled.releaseClose()
+        await stalled.failStalledSend()
+        await resetTask.value
+        _ = try? await firstTask.value
+        await client.disconnect()
+    }
+
+    private func makeClient(
+        factory: StalledWriteRecoveryTransportFactory
+    ) throws -> MobileCoreRPCClient {
+        let route = try hostPortRoute(
+            kind: .debugLoopback,
+            host: "127.0.0.1",
+            port: 59135
+        )
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: factory,
+            rpcRequestTimeoutNanoseconds: 60 * 1_000_000_000
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "workspace-main",
+            terminalID: "terminal-main",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(60),
+            authToken: "ticket-secret"
+        )
+        return MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            allowsStackAuthFallback: true
+        )
+    }
+
+    private func inputRequest(id: String, text: String) throws -> Data {
+        try MobileCoreRPCClient.requestData(
+            method: "terminal.input",
+            params: [
+                "workspace_id": "workspace-main",
+                "terminal_id": "terminal-main",
+                "text": text,
+            ],
+            id: id
+        )
+    }
 }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCStalledWriteRecoveryTests.swift
@@ -171,7 +171,7 @@ import Testing
         await client.disconnect()
     }
 
-    @Test func transportCloseCleanupRetainsOnlyNewestPendingTransport() async throws {
+    @Test func transportCloseCleanupBackpressuresWithoutDroppingPendingTransport() async throws {
         let first = StalledWriteTransport(hangsOnClose: true)
         let superseded = StalledWriteTransport(hangsOnClose: true)
         let newest = StalledWriteTransport(hangsOnClose: true)
@@ -197,6 +197,25 @@ import Testing
         await superseded.waitUntilSendStarted()
         await client.resetConnectionForRecovery()
 
+        do {
+            _ = try await client.sendRequest(
+                inputRequest(id: "blocked-while-close-queue-full", text: "c"),
+                timeoutNanoseconds: 500_000_000
+            )
+            Issue.record("Expected connection creation to wait for close capacity")
+        } catch MobileShellConnectionError.connectionClosed {
+        } catch {
+            Issue.record("Expected connectionClosed, got \(error)")
+        }
+
+        #expect(await first.closed())
+        #expect(!(await superseded.closed()))
+        #expect(!(await newest.closed()))
+        #expect(factory.createdTransportCount() == 2)
+
+        await first.releaseClose()
+        await superseded.waitUntilCloseStarted()
+
         let newestTask = Task {
             try await client.sendRequest(
                 inputRequest(id: "close-newest", text: "c"),
@@ -205,19 +224,11 @@ import Testing
         }
         await newest.waitUntilSendStarted()
         await client.resetConnectionForRecovery()
-
-        #expect(await first.closed())
-        #expect(!(await superseded.closed()))
-        #expect(!(await newest.closed()))
         #expect(factory.createdTransportCount() == 3)
 
-        await first.releaseClose()
-        await newest.waitUntilCloseStarted()
-        #expect(!(await superseded.closed()))
-
-        await newest.releaseClose()
         await superseded.releaseClose()
-        await superseded.close()
+        await newest.waitUntilCloseStarted()
+        await newest.releaseClose()
         await first.failStalledSend()
         await superseded.failStalledSend()
         await newest.failStalledSend()

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/ResponseTimeoutSurvivalTransport.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/ResponseTimeoutSurvivalTransport.swift
@@ -28,7 +28,10 @@ actor ResponseTimeoutSurvivalTransport: CmxByteTransport {
         sentPayloads.append(contentsOf: payloads)
         for payload in payloads {
             let request = try recordedRPCRequest(from: payload)
-            guard request.id == "second-after-timeout" else { continue }
+            guard [
+                "second-after-timeout",
+                "third-after-late-failure",
+            ].contains(request.id) else { continue }
             try enqueueResponse(id: request.id)
         }
     }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/ResponseTimeoutSurvivalTransport.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/ResponseTimeoutSurvivalTransport.swift
@@ -29,6 +29,8 @@ actor ResponseTimeoutSurvivalTransport: CmxByteTransport {
         for payload in payloads {
             let request = try recordedRPCRequest(from: payload)
             guard [
+                "second-after-cancel",
+                "second-after-hanging-close",
                 "second-after-timeout",
                 "third-after-late-failure",
             ].contains(request.id) else { continue }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/SequencedTransportFactory.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/SequencedTransportFactory.swift
@@ -1,0 +1,25 @@
+import CMUXMobileCore
+import Foundation
+
+final class SequencedTransportFactory: @unchecked Sendable, CmxByteTransportFactory {
+    private let lock = NSLock()
+    private let transports: [any CmxByteTransport]
+    private var nextIndex = 0
+
+    init(_ transports: [any CmxByteTransport]) {
+        precondition(!transports.isEmpty)
+        self.transports = transports
+    }
+
+    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        lock.withLock {
+            let index = min(nextIndex, transports.count - 1)
+            nextIndex += 1
+            return transports[index]
+        }
+    }
+
+    func createdTransportCount() -> Int {
+        lock.withLock { nextIndex }
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteRecoveryTransportFactory.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteRecoveryTransportFactory.swift
@@ -1,0 +1,29 @@
+import CMUXMobileCore
+import Foundation
+
+final class StalledWriteRecoveryTransportFactory: @unchecked Sendable, CmxByteTransportFactory {
+    // Test-only synchronous factory conformance; the lock protects only the creation count.
+    private let lock = NSLock()
+    private let stalled: StalledWriteTransport
+    private let recovery: ResponseTimeoutSurvivalTransport
+    private var creationCount = 0
+
+    init(
+        stalled: StalledWriteTransport,
+        recovery: ResponseTimeoutSurvivalTransport
+    ) {
+        self.stalled = stalled
+        self.recovery = recovery
+    }
+
+    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        lock.withLock {
+            creationCount += 1
+            return creationCount == 1 ? stalled : recovery
+        }
+    }
+
+    func createdTransportCount() -> Int {
+        lock.withLock { creationCount }
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteTransport.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteTransport.swift
@@ -1,0 +1,41 @@
+import CMUXMobileCore
+import Foundation
+
+actor StalledWriteTransport: CmxByteTransport {
+    private var receiveWaiters: [CheckedContinuation<Data?, Never>] = []
+    private var sendWaiter: CheckedContinuation<Void, any Error>?
+    private var isClosed = false
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? {
+        if isClosed {
+            return nil
+        }
+        return await withCheckedContinuation { continuation in
+            receiveWaiters.append(continuation)
+        }
+    }
+
+    func send(_ data: Data) async throws {
+        try await withCheckedThrowingContinuation { continuation in
+            sendWaiter = continuation
+        }
+    }
+
+    func close() async {
+        guard !isClosed else { return }
+        isClosed = true
+        sendWaiter?.resume(throwing: CancellationError())
+        sendWaiter = nil
+        let waiters = receiveWaiters
+        receiveWaiters = []
+        for waiter in waiters {
+            waiter.resume(returning: nil)
+        }
+    }
+
+    func closed() -> Bool {
+        isClosed
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteTransport.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteTransport.swift
@@ -4,7 +4,17 @@ import Foundation
 actor StalledWriteTransport: CmxByteTransport {
     private var receiveWaiters: [CheckedContinuation<Data?, Never>] = []
     private var sendWaiter: CheckedContinuation<Void, any Error>?
+    private var sendStarted = false
+    private var sendStartWaiters: [CheckedContinuation<Void, Never>] = []
     private var isClosed = false
+    private var closeStartWaiters: [CheckedContinuation<Void, Never>] = []
+    private let hangsOnClose: Bool
+    private var closeRelease: CheckedContinuation<Void, Never>?
+    private var closeReleased = false
+
+    init(hangsOnClose: Bool = false) {
+        self.hangsOnClose = hangsOnClose
+    }
 
     func connect() async throws {}
 
@@ -18,6 +28,9 @@ actor StalledWriteTransport: CmxByteTransport {
     }
 
     func send(_ data: Data) async throws {
+        sendStarted = true
+        for waiter in sendStartWaiters { waiter.resume() }
+        sendStartWaiters = []
         try await withCheckedThrowingContinuation { continuation in
             sendWaiter = continuation
         }
@@ -26,11 +39,15 @@ actor StalledWriteTransport: CmxByteTransport {
     func close() async {
         guard !isClosed else { return }
         isClosed = true
+        for waiter in closeStartWaiters { waiter.resume() }
+        closeStartWaiters = []
         let waiters = receiveWaiters
         receiveWaiters = []
         for waiter in waiters {
             waiter.resume(returning: nil)
         }
+        guard hangsOnClose, !closeReleased else { return }
+        await withCheckedContinuation { closeRelease = $0 }
     }
 
     func failStalledSend() {
@@ -40,5 +57,21 @@ actor StalledWriteTransport: CmxByteTransport {
 
     func closed() -> Bool {
         isClosed
+    }
+
+    func waitUntilSendStarted() async {
+        if sendStarted { return }
+        await withCheckedContinuation { sendStartWaiters.append($0) }
+    }
+
+    func waitUntilCloseStarted() async {
+        if isClosed { return }
+        await withCheckedContinuation { closeStartWaiters.append($0) }
+    }
+
+    func releaseClose() {
+        closeReleased = true
+        closeRelease?.resume()
+        closeRelease = nil
     }
 }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteTransport.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/StalledWriteTransport.swift
@@ -26,13 +26,16 @@ actor StalledWriteTransport: CmxByteTransport {
     func close() async {
         guard !isClosed else { return }
         isClosed = true
-        sendWaiter?.resume(throwing: CancellationError())
-        sendWaiter = nil
         let waiters = receiveWaiters
         receiveWaiters = []
         for waiter in waiters {
             waiter.resume(returning: nil)
         }
+    }
+
+    func failStalledSend() {
+        sendWaiter?.resume(throwing: CancellationError())
+        sendWaiter = nil
     }
 
     func closed() -> Bool {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionRecoveryState.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileConnectionRecoveryState.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// The foreground session recovery phase owned by one single-flight attempt.
+enum MobileConnectionRecoveryState: Equatable {
+    case resettingSession(UUID)
+    case awaitingResetSubscription(UUID)
+    case reconnectingStoredRoute(UUID)
+    case awaitingStoredRouteSubscription(UUID)
+
+    var id: UUID {
+        switch self {
+        case .resettingSession(let id),
+             .awaitingResetSubscription(let id),
+             .reconnectingStoredRoute(let id),
+             .awaitingStoredRouteSubscription(let id):
+            id
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -369,7 +369,7 @@ extension MobilePairingFailureCategory {
 
         if let connectionError = error as? MobileShellConnectionError {
             switch connectionError {
-            case .requestTimedOut:
+            case .requestTimedOut, .transportWriteTimedOut:
                 return .handshakeTimedOut(host: host, port: port)
             case .insecureManualRoute:
                 return .unsupportedRoute

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
@@ -3,9 +3,21 @@ import Foundation
 
 @MainActor
 extension MobileShellComposite {
-    func markMacConnectionHealthy() {
+    func markMacConnectionHealthy(completingRecovery: Bool = false) {
         guard connectionState == .connected else {
             macConnectionStatus = .unavailable
+            return
+        }
+        if completingRecovery {
+            completeMobileConnectionRecovery()
+        } else if case .reconnectingStoredRoute(let recoveryID) = connectionRecoveryState {
+            connectionRecoveryState = .awaitingStoredRouteSubscription(recoveryID)
+        }
+        if connectionRecoveryState != nil {
+            macConnectionStatus = .reconnecting
+            isRecoveringConnection = true
+            connectionRecoveryFailed = false
+            connectionRequiresReauth = false
             return
         }
         macConnectionStatus = .connected
@@ -44,7 +56,7 @@ extension MobileShellComposite {
     /// re-subscribe the foreground session.
     func recoverMobileConnection(trigger: RecoveryTrigger) {
         guard remoteClient != nil || pairedMacStore != nil else { return }
-        guard recoveryID == nil else { return }
+        guard connectionRecoveryState == nil else { return }
         if connectionState == .connected,
            remoteClient != nil,
            !trigger.resetsConnectedSession {
@@ -54,65 +66,122 @@ extension MobileShellComposite {
         }
 
         let recoveryID = UUID()
-        self.recoveryID = recoveryID
         isRecoveringConnection = true
         connectionRecoveryFailed = false
         let stackUserID = lastReconnectStackUserID
         let connectedClient = connectionState == .connected ? remoteClient : nil
         let connectedGeneration = connectionGeneration
-        recoveryTask?.cancel()
+        if connectedClient == nil
+            || (trigger == .manual && macConnectionStatus == .unavailable) {
+            connectionRecoveryState = .reconnectingStoredRoute(recoveryID)
+            startStoredRouteRecovery(recoveryID: recoveryID, stackUserID: stackUserID)
+            return
+        }
+        guard let connectedClient else { return }
+
+        connectionRecoveryState = .resettingSession(recoveryID)
         recoveryTask = Task { @MainActor [weak self] in
-            var isAwaitingSubscriptionAck = false
-            defer {
-                if self?.recoveryID == recoveryID {
-                    self?.recoveryID = nil
-                    self?.recoveryTask = nil
-                    if !isAwaitingSubscriptionAck {
-                        self?.isRecoveringConnection = false
-                    }
-                }
-            }
             guard let self else { return }
-            if let connectedClient {
-                isAwaitingSubscriptionAck = await self.resetRemoteSessionForRecovery(
-                    client: connectedClient,
-                    expectedGeneration: connectedGeneration,
-                    reason: "networkRecovery.\(trigger)"
-                )
-                guard self.recoveryID == recoveryID, !Task.isCancelled else { return }
-                if self.multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
-                    self.scheduleSecondaryAggregation()
-                }
-                return
-            }
-            guard self.connectionState != .connected else { return }
-            let reconnected = await self.reconnectActiveMacIfAvailable(
-                stackUserID: stackUserID,
-                preservingConnectionRecoveryOnFailure: true
+            let isAwaitingSubscriptionAck = await self.resetRemoteSessionForRecovery(
+                client: connectedClient,
+                expectedGeneration: connectedGeneration,
+                recoveryID: recoveryID,
+                reason: "networkRecovery.\(trigger)"
             )
             guard self.recoveryID == recoveryID, !Task.isCancelled else { return }
-            if !reconnected {
-                self.connectionRecoveryFailed = true
+            guard isAwaitingSubscriptionAck else {
+                self.startStoredRouteRecovery(
+                    recoveryID: recoveryID,
+                    stackUserID: stackUserID
+                )
+                return
+            }
+            if self.multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
+                self.scheduleSecondaryAggregation()
             }
         }
     }
 
     func cancelMobileConnectionRecovery() {
-        recoveryID = nil
+        connectionRecoveryState = nil
         recoveryTask?.cancel()
         recoveryTask = nil
         isRecoveringConnection = false
+    }
+
+    func completeMobileConnectionRecovery() {
+        guard connectionRecoveryState != nil else { return }
+        connectionRecoveryState = nil
+        recoveryTask = nil
+        isRecoveringConnection = false
+        connectionRecoveryFailed = false
+    }
+
+    @discardableResult
+    func handleMobileConnectionRecoverySubscriptionFailure() -> Bool {
+        guard let recoveryState = connectionRecoveryState else { return false }
+        switch recoveryState {
+        case .resettingSession(let recoveryID),
+             .awaitingResetSubscription(let recoveryID):
+            startStoredRouteRecovery(
+                recoveryID: recoveryID,
+                stackUserID: lastReconnectStackUserID
+            )
+        case .reconnectingStoredRoute, .awaitingStoredRouteSubscription:
+            connectionRecoveryState = nil
+            recoveryTask = nil
+            markMacConnectionUnavailable()
+        }
+        return true
+    }
+
+    private func startStoredRouteRecovery(recoveryID: UUID, stackUserID: String?) {
+        guard self.recoveryID == recoveryID else { return }
+        connectionRecoveryState = .reconnectingStoredRoute(recoveryID)
+        markMacConnectionReconnecting()
+        stopTerminalRefreshPolling()
+        connectionState = .disconnected
+        clearRemoteConnectionContext(
+            preservingOtherMacWorkspaceState: true,
+            preservingConnectionRecovery: true
+        )
+        recoveryTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            let reconnected = await self.reconnectActiveMacIfAvailable(
+                stackUserID: stackUserID,
+                preservingConnectionRecoveryOnFailure: true
+            )
+            guard self.recoveryID == recoveryID, !Task.isCancelled else { return }
+            guard reconnected else {
+                self.connectionRecoveryState = nil
+                self.recoveryTask = nil
+                self.markMacConnectionUnavailable()
+                self.connectionRecoveryFailed = true
+                return
+            }
+            guard self.runtime?.supportsServerPushEvents == true else {
+                self.completeMobileConnectionRecovery()
+                self.markMacConnectionHealthy()
+                return
+            }
+            if case .reconnectingStoredRoute = self.connectionRecoveryState {
+                self.connectionRecoveryState = .awaitingStoredRouteSubscription(recoveryID)
+            }
+            self.markMacConnectionReconnecting()
+        }
     }
 
     /// Replaces only the stale transport while preserving the paired-Mac session context.
     func resetRemoteSessionForRecovery(
         client: MobileCoreRPCClient,
         expectedGeneration: UUID,
+        recoveryID: UUID,
         reason: String
     ) async -> Bool {
         guard connectionState == .connected,
               remoteClient === client,
-              connectionGeneration == expectedGeneration else {
+              connectionGeneration == expectedGeneration,
+              self.recoveryID == recoveryID else {
             return false
         }
 
@@ -124,9 +193,11 @@ extension MobileShellComposite {
 
         guard connectionState == .connected,
               remoteClient === client,
-              connectionGeneration == recoveryGeneration else {
+              connectionGeneration == recoveryGeneration,
+              self.recoveryID == recoveryID else {
             return false
         }
+        connectionRecoveryState = .awaitingResetSubscription(recoveryID)
         resyncTerminalOutput(reason: reason, restartEventStream: true)
         return true
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
@@ -1,0 +1,66 @@
+internal import CmuxMobileRPC
+import Foundation
+
+@MainActor
+extension MobileShellComposite {
+    func markMacConnectionHealthy() {
+        guard connectionState == .connected else {
+            macConnectionStatus = .unavailable
+            return
+        }
+        macConnectionStatus = .connected
+        isRecoveringConnection = false
+        connectionRecoveryFailed = false
+        connectionRequiresReauth = false
+    }
+
+    func markMacConnectionReconnecting() {
+        guard connectionState == .connected, remoteClient != nil else {
+            macConnectionStatus = .unavailable
+            return
+        }
+        macConnectionStatus = .reconnecting
+        isRecoveringConnection = true
+        connectionRecoveryFailed = false
+    }
+
+    func markMacConnectionUnavailable() {
+        guard connectionState == .connected else {
+            macConnectionStatus = .unavailable
+            return
+        }
+        macConnectionStatus = .unavailable
+        isRecoveringConnection = false
+        connectionRecoveryFailed = true
+    }
+
+    func recoverMacConnectionIfNeeded(after error: any Error) {
+        guard MobileShellMacAvailabilityFailureClassifier().isAvailabilityFailure(error) else { return }
+        markMacConnectionReconnecting()
+        recoverMobileConnection(trigger: .availabilityFailure)
+    }
+
+    /// Replaces only the stale transport while preserving the paired-Mac session context.
+    func resetRemoteSessionForRecovery(
+        client: MobileCoreRPCClient,
+        expectedGeneration: UUID,
+        reason: String
+    ) async -> Bool {
+        guard connectionState == .connected,
+              remoteClient === client,
+              connectionGeneration == expectedGeneration else {
+            return false
+        }
+
+        markMacConnectionReconnecting()
+        connectionGeneration = UUID()
+        stopTerminalRefreshPolling()
+        await client.resetConnectionForRecovery()
+
+        guard connectionState == .connected, remoteClient === client else {
+            return false
+        }
+        resyncTerminalOutput(reason: reason, restartEventStream: true)
+        return true
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
@@ -40,6 +40,67 @@ extension MobileShellComposite {
         recoverMobileConnection(trigger: .availabilityFailure)
     }
 
+    /// Single-flight owner for every recovery trigger that can replace or
+    /// re-subscribe the foreground session.
+    func recoverMobileConnection(trigger: RecoveryTrigger) {
+        guard remoteClient != nil || pairedMacStore != nil else { return }
+        guard recoveryID == nil else { return }
+        if connectionState == .connected,
+           remoteClient != nil,
+           !trigger.resetsConnectedSession {
+            markMacConnectionReconnecting()
+            resyncTerminalOutput(reason: "networkRecovery.\(trigger)", restartEventStream: true)
+            return
+        }
+
+        let recoveryID = UUID()
+        self.recoveryID = recoveryID
+        isRecoveringConnection = true
+        connectionRecoveryFailed = false
+        let stackUserID = lastReconnectStackUserID
+        let connectedClient = connectionState == .connected ? remoteClient : nil
+        let connectedGeneration = connectionGeneration
+        recoveryTask?.cancel()
+        recoveryTask = Task { @MainActor [weak self] in
+            var isAwaitingSubscriptionAck = false
+            defer {
+                if self?.recoveryID == recoveryID {
+                    self?.recoveryID = nil
+                    self?.recoveryTask = nil
+                    if !isAwaitingSubscriptionAck {
+                        self?.isRecoveringConnection = false
+                    }
+                }
+            }
+            guard let self else { return }
+            if let connectedClient {
+                isAwaitingSubscriptionAck = await self.resetRemoteSessionForRecovery(
+                    client: connectedClient,
+                    expectedGeneration: connectedGeneration,
+                    reason: "networkRecovery.\(trigger)"
+                )
+                guard self.recoveryID == recoveryID, !Task.isCancelled else { return }
+                if self.multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
+                    self.scheduleSecondaryAggregation()
+                }
+                return
+            }
+            guard self.connectionState != .connected else { return }
+            let reconnected = await self.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
+            guard self.recoveryID == recoveryID, !Task.isCancelled else { return }
+            if !reconnected {
+                self.connectionRecoveryFailed = true
+            }
+        }
+    }
+
+    func cancelMobileConnectionRecovery() {
+        recoveryID = nil
+        recoveryTask?.cancel()
+        recoveryTask = nil
+        isRecoveringConnection = false
+    }
+
     /// Replaces only the stale transport while preserving the paired-Mac session context.
     func resetRemoteSessionForRecovery(
         client: MobileCoreRPCClient,
@@ -53,11 +114,14 @@ extension MobileShellComposite {
         }
 
         markMacConnectionReconnecting()
-        connectionGeneration = UUID()
+        let recoveryGeneration = UUID()
+        connectionGeneration = recoveryGeneration
         stopTerminalRefreshPolling()
         await client.resetConnectionForRecovery()
 
-        guard connectionState == .connected, remoteClient === client else {
+        guard connectionState == .connected,
+              remoteClient === client,
+              connectionGeneration == recoveryGeneration else {
             return false
         }
         resyncTerminalOutput(reason: reason, restartEventStream: true)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SessionRecovery.swift
@@ -86,7 +86,10 @@ extension MobileShellComposite {
                 return
             }
             guard self.connectionState != .connected else { return }
-            let reconnected = await self.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
+            let reconnected = await self.reconnectActiveMacIfAvailable(
+                stackUserID: stackUserID,
+                preservingConnectionRecoveryOnFailure: true
+            )
             guard self.recoveryID == recoveryID, !Task.isCancelled else { return }
             if !reconnected {
                 self.connectionRecoveryFailed = true

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -364,15 +364,17 @@ extension MobileShellComposite {
             let request = try MobileCoreRPCClient.requestData(method: method, params: params)
             _ = try await client.sendRequest(request)
         } catch {
-            if disconnectForAuthorizationFailureIfNeeded(error) {
+            let isCurrentForegroundRequest = target.isForeground
+                && remoteClient === client
+                && connectionGeneration == requestGeneration
+            if isCurrentForegroundRequest,
+               disconnectForAuthorizationFailureIfNeeded(error) {
                 return .failure(.authorizationFailed(hostDisplayName: hostDisplayName))
             }
             // Only the foreground connection's health drives the foreground
             // unavailable/reconnect UI; a failed write to a secondary Mac must not
             // tear the foreground session down.
-            if target.isForeground,
-               remoteClient === client,
-               connectionGeneration == requestGeneration {
+            if isCurrentForegroundRequest {
                 recoverMacConnectionIfNeeded(after: error)
             }
             mobileShellLog.error("workspace mutation failed action=\(actionName, privacy: .public) id=\(logID, privacy: .public) error=\(String(describing: error), privacy: .public)")

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -359,6 +359,7 @@ extension MobileShellComposite {
             await refreshWorkspaces()
             return .failure(.notConnected(hostDisplayName: hostDisplayName))
         }
+        let requestGeneration = connectionGeneration
         do {
             let request = try MobileCoreRPCClient.requestData(method: method, params: params)
             _ = try await client.sendRequest(request)
@@ -369,7 +370,9 @@ extension MobileShellComposite {
             // Only the foreground connection's health drives the foreground
             // unavailable/reconnect UI; a failed write to a secondary Mac must not
             // tear the foreground session down.
-            if target.isForeground {
+            if target.isForeground,
+               remoteClient === client,
+               connectionGeneration == requestGeneration {
                 recoverMacConnectionIfNeeded(after: error)
             }
             mobileShellLog.error("workspace mutation failed action=\(actionName, privacy: .public) id=\(logID, privacy: .public) error=\(String(describing: error), privacy: .public)")

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -370,7 +370,7 @@ extension MobileShellComposite {
             // unavailable/reconnect UI; a failed write to a secondary Mac must not
             // tear the foreground session down.
             if target.isForeground {
-                markMacConnectionUnavailableIfNeeded(after: error)
+                recoverMacConnectionIfNeeded(after: error)
             }
             mobileShellLog.error("workspace mutation failed action=\(actionName, privacy: .public) id=\(logID, privacy: .public) error=\(String(describing: error), privacy: .public)")
             await refreshAfterWorkspaceMutation(target)
@@ -413,7 +413,7 @@ extension MobileShellComposite {
         switch connectionError {
         case .connectionClosed:
             return .notConnected(hostDisplayName: hostDisplayName)
-        case .requestTimedOut:
+        case .requestTimedOut, .transportWriteTimedOut:
             return .requestTimedOut(hostDisplayName: hostDisplayName)
         case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
             return .authorizationFailed(hostDisplayName: hostDisplayName)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceCreateRequest.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceCreateRequest.swift
@@ -82,7 +82,7 @@ extension MobileShellComposite {
             if disconnectForAuthorizationFailureIfNeeded(error) {
                 return .failure(.authorizationFailed(hostDisplayName: connectedHostName))
             }
-            markMacConnectionUnavailableIfNeeded(after: error)
+            recoverMacConnectionIfNeeded(after: error)
             if appliesOperationalError {
                 applyOperationalError(error)
             }
@@ -90,7 +90,7 @@ extension MobileShellComposite {
                 switch connectionError {
                 case .connectionClosed:
                     return .failure(.notConnected(hostDisplayName: connectedHostName))
-                case .requestTimedOut:
+                case .requestTimedOut, .transportWriteTimedOut:
                     return .failure(.requestTimedOut(hostDisplayName: connectedHostName))
                 case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
                     return .failure(.authorizationFailed(hostDisplayName: connectedHostName))

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1506,7 +1506,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         port: Int,
         pairedMacDeviceID: String,
         instanceTag: String?,
-        ifStillCurrent: (() -> Bool)? = nil
+        ifStillCurrent: (() -> Bool)? = nil,
+        preservingConnectionRecoveryOnFailure: Bool = false
     ) async {
         await connectManualHost(
             name: name,
@@ -1517,7 +1518,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 storedInstanceTag: instanceTag
             ),
             recordsPairingAttempt: false,
-            ifStillCurrent: ifStillCurrent
+            ifStillCurrent: ifStillCurrent,
+            preservingConnectionRecoveryOnFailure: preservingConnectionRecoveryOnFailure
         )
     }
 
@@ -1533,7 +1535,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         pairedMacDeviceID: String? = nil,
         instanceTagExpectation: MobileMacInstanceTagExpectation = .adopt,
         recordsPairingAttempt: Bool,
-        ifStillCurrent: (() -> Bool)? = nil
+        ifStillCurrent: (() -> Bool)? = nil,
+        preservingConnectionRecoveryOnFailure: Bool = false
     ) async {
         let trimmedName = name.trimmingCharacters(in: .whitespacesAndNewlines)
         guard let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(host) else {
@@ -1541,7 +1544,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             connectionErrorGuidance = nil
             connectionState = .disconnected
             macConnectionStatus = .unavailable
-            clearRemoteConnectionContext()
+            clearRemoteConnectionContext(
+                preservingConnectionRecovery: preservingConnectionRecoveryOnFailure
+            )
             analytics.capture("ios_pairing_failed", [
                 "method": .string("manual"),
                 "reason": .string("invalid_host"),
@@ -1555,7 +1560,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             connectionErrorGuidance = nil
             connectionState = .disconnected
             macConnectionStatus = .unavailable
-            clearRemoteConnectionContext()
+            clearRemoteConnectionContext(
+                preservingConnectionRecovery: preservingConnectionRecoveryOnFailure
+            )
             analytics.capture("ios_pairing_failed", [
                 "method": .string("manual"),
                 "reason": .string("invalid_port"),
@@ -1571,7 +1578,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         // Fast offline preflight: fail immediately instead of stacking
         // per-route timeouts into the opaque ~60s blob.
         let manualRoutes = directRoute.map { [$0] } ?? []
-        guard await failPairingIfOffline(attemptID: attemptID, phase: "preflight", routes: manualRoutes) == .proceed else { return }
+        guard await failPairingIfOffline(
+            attemptID: attemptID,
+            phase: "preflight",
+            routes: manualRoutes,
+            preservingConnectionRecoveryOnFailure: preservingConnectionRecoveryOnFailure
+        ) == .proceed else { return }
         do {
             let ticket = try await manualHostTicket(
                 name: trimmedName,
@@ -1599,21 +1611,28 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             guard isCurrentPairingAttempt(attemptID) else { return }
             connectionState = .disconnected
             macConnectionStatus = .unavailable
-            clearRemoteConnectionContext()
+            clearRemoteConnectionContext(
+                preservingConnectionRecovery: preservingConnectionRecoveryOnFailure
+            )
         } catch {
             guard isCurrentPairingAttempt(attemptID) else { return }
             mobileShellLog.error("manual host pairing failed: \(String(describing: error), privacy: .private)")
             // A definitive auth failure (expired/invalid token after the
             // refresh-then-retry in the RPC layer already gave up) must drive the
             // re-auth prompt, not the generic "could not connect / Retry" banner.
-            if disconnectForAuthorizationFailureIfNeeded(error) {
+            if disconnectForAuthorizationFailureIfNeeded(
+                error,
+                preservingConnectionRecovery: preservingConnectionRecoveryOnFailure
+            ) {
                 return
             }
             let category = MobilePairingFailureCategory.classify(error: error, route: activeRoute ?? directRoute)
             applyPairingFailure(category, phase: "connect")
             connectionState = .disconnected
             macConnectionStatus = .unavailable
-            clearRemoteConnectionContext()
+            clearRemoteConnectionContext(
+                preservingConnectionRecovery: preservingConnectionRecoveryOnFailure
+            )
         }
     }
 
@@ -1623,6 +1642,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// manual host flow. Auth tokens never persist; we always re-mint.
     @discardableResult
     public func reconnectActiveMacIfAvailable(stackUserID: String?) async -> Bool {
+        await reconnectActiveMacIfAvailable(
+            stackUserID: stackUserID,
+            preservingConnectionRecoveryOnFailure: false
+        )
+    }
+
+    @discardableResult
+    func reconnectActiveMacIfAvailable(
+        stackUserID: String?,
+        preservingConnectionRecoveryOnFailure: Bool
+    ) async -> Bool {
         lastReconnectStackUserID = stackUserID
         startObservingNetworkPathChanges()
         // Claim this attempt's generation. Only the current generation may resolve
@@ -1747,7 +1777,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     host: route.host,
                     port: route.port,
                     pairedMacDeviceID: mac.macDeviceID,
-                    instanceTag: mac.instanceTag)
+                    instanceTag: mac.instanceTag,
+                    preservingConnectionRecoveryOnFailure: preservingConnectionRecoveryOnFailure)
                 if connectionState == .connected { break }
             }
             if connectionState != .connected,
@@ -1765,7 +1796,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         host: route.host,
                         port: route.port,
                         pairedMacDeviceID: mac.macDeviceID,
-                        instanceTag: mac.instanceTag)
+                        instanceTag: mac.instanceTag,
+                        preservingConnectionRecoveryOnFailure: preservingConnectionRecoveryOnFailure)
                     if connectionState == .connected { break }
                 }
             }
@@ -5064,10 +5096,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectedHostName = ""
     }
 
-    private func clearRemoteConnectionContext(preservingOtherMacWorkspaceState: Bool = false) {
+    private func clearRemoteConnectionContext(
+        preservingOtherMacWorkspaceState: Bool = false,
+        preservingConnectionRecovery: Bool = false
+    ) {
         connectionGeneration = UUID()
         connectionAttemptGeneration = UUID()
-        cancelMobileConnectionRecovery()
+        if !preservingConnectionRecovery {
+            cancelMobileConnectionRecovery()
+        }
         cancelRemoteOperationTasks()
         clearActiveConnectionContext()
         macConnectionStatus = .unavailable
@@ -5441,7 +5478,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func failPairingIfOffline(
         attemptID: UUID,
         phase: String,
-        routes: [CmxAttachRoute]
+        routes: [CmxAttachRoute],
+        preservingConnectionRecoveryOnFailure: Bool = false
     ) async -> PairingPreflightOutcome {
         if routes.contains(where: MobileShellRouteAuthPolicy.routeIsLoopback) { return .proceed }
         guard await reachability.isOnline == false else { return .proceed }
@@ -5451,7 +5489,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         applyPairingFailure(.offline, phase: phase)
         connectionState = .disconnected
         macConnectionStatus = .unavailable
-        clearRemoteConnectionContext()
+        clearRemoteConnectionContext(
+            preservingConnectionRecovery: preservingConnectionRecoveryOnFailure
+        )
         return .failedOffline
     }
 
@@ -6204,13 +6244,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // and silently swallow the handshake's failure verdict (its ack
             // guard sees a newer listenerID), so a closed transport would
             // loop `reconnecting` forever. A stream that dies before its
-            // handshake completes is a failed start, so send that verdict
-            // through the same single-flight recovery owner as every other
-            // transport failure.
-            mobileShellLog.info("terminal event stream ended before subscribe ack, recovering")
-            MobileDebugLog.anchormux("sync.stream_ended before subscribe ack; recovering")
+            // handshake completes is a failed start. Converge to the bounded
+            // unavailable state instead of continuously replacing a transport
+            // that has never established a subscription.
+            mobileShellLog.info("terminal event stream ended before subscribe ack, marking unavailable")
+            MobileDebugLog.anchormux("sync.stream_ended before subscribe ack; failed start")
             diagnosticLog?.record(DiagnosticEvent(.error))
-            recoverMobileConnection(trigger: .eventStreamEnded)
+            stopTerminalRefreshPolling()
+            markMacConnectionUnavailable()
             return
         }
         mobileShellLog.info("terminal event stream ended, recovering")
@@ -7385,7 +7426,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return true
     }
 
-    func disconnectForAuthorizationFailureIfNeeded(_ error: any Error) -> Bool {
+    func disconnectForAuthorizationFailureIfNeeded(
+        _ error: any Error,
+        preservingConnectionRecovery: Bool = false
+    ) -> Bool {
         guard Self.shouldDisconnectForAuthorizationFailure(error) else {
             return false
         }
@@ -7400,7 +7444,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectionRequiresReauth = true
         connectionState = .disconnected
         macConnectionStatus = .unavailable
-        clearRemoteConnectionContext()
+        clearRemoteConnectionContext(
+            preservingConnectionRecovery: preservingConnectionRecovery
+        )
         // Only emits while a pairing attempt is in flight: `recordPairingFailed`
         // no-ops once `pairingAttemptMethod` is nil (cleared on success and by
         // `invalidatePairingAttempt`), so live-connection auth failures that

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1394,10 +1394,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// True while an automatic reconnect is in progress after a network change
     /// or drop.
-    public private(set) var isRecoveringConnection: Bool = false
+    public internal(set) var isRecoveringConnection: Bool = false
     /// True when automatic recovery could not restore the connection; the UI
     /// surfaces a manual Retry control in this state.
-    public private(set) var connectionRecoveryFailed: Bool = false {
+    public internal(set) var connectionRecoveryFailed: Bool = false {
         didSet {
             // Fire once on the false→true edge ("stuck disconnected, Retry is
             // dead"): the recovery-rate denominator.
@@ -1415,7 +1415,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Retrying cannot fix this, so the UI surfaces the auth message and a
     /// Sign Out action instead of a Retry control. ``connectionError`` carries
     /// the user-facing reason.
-    public private(set) var connectionRequiresReauth: Bool = false
+    public internal(set) var connectionRequiresReauth: Bool = false
 
     private var networkPathObservationStarted = false
     private var networkPathObservationTask: Task<Void, Never>?
@@ -1424,14 +1424,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private var lastReconnectStackUserID: String?
 
     enum RecoveryTrigger: CustomStringConvertible {
+        case availabilityFailure
         case networkChange
         case manual
         case presencePush
 
         var reschedulesSecondaryAggregation: Bool { self != .presencePush }
+        var resetsConnectedSession: Bool { self != .presencePush }
 
         var description: String {
             switch self {
+            case .availabilityFailure: return "availabilityFailure"
             case .networkChange: return "networkChange"
             case .manual: return "manual"
             case .presencePush: return "presencePush"
@@ -1463,20 +1466,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         recoverMobileConnection(trigger: .manual)
     }
 
-    /// Single guarded recovery entry for every trigger (network change, manual
-    /// Retry). When still connected, a network move usually only broke the event
-    /// stream while input keeps flowing over the surviving connection, so a
-    /// resync re-subscribes and requests a render-grid replay to repaint.
-    /// Otherwise the connection dropped, so reconnect once; on failure the UI
-    /// shows Retry and the next network change re-attempts automatically.
+    /// Single guarded recovery entry for availability failures, network changes,
+    /// and manual Retry. A transport failure, real path transition, or explicit
+    /// retry rotates the persistent connection; a presence refresh only repairs
+    /// the event subscription. Network.framework then owns transient waiting and
+    /// backoff for the fresh connection.
     func recoverMobileConnection(trigger: RecoveryTrigger) {
         guard remoteClient != nil || pairedMacStore != nil else { return }
-        if connectionState == .connected, remoteClient != nil {
+        if connectionState == .connected,
+           remoteClient != nil,
+           !trigger.resetsConnectedSession {
             markMacConnectionReconnecting()
             resyncTerminalOutput(reason: "networkRecovery.\(trigger)", restartEventStream: true)
-            if multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
-                scheduleSecondaryAggregation()
-            }
             return
         }
         guard !recoveryInFlight else { return }
@@ -1484,13 +1485,30 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         isRecoveringConnection = true
         connectionRecoveryFailed = false
         let stackUserID = lastReconnectStackUserID
+        let connectedClient = connectionState == .connected ? remoteClient : nil
+        let connectedGeneration = connectionGeneration
         recoveryTask?.cancel()
         recoveryTask = Task { @MainActor [weak self] in
+            var isAwaitingSubscriptionAck = false
             defer {
                 self?.recoveryInFlight = false
-                self?.isRecoveringConnection = false
+                if !isAwaitingSubscriptionAck {
+                    self?.isRecoveringConnection = false
+                }
             }
-            guard let self, self.connectionState != .connected else { return }
+            guard let self else { return }
+            if let connectedClient {
+                isAwaitingSubscriptionAck = await self.resetRemoteSessionForRecovery(
+                    client: connectedClient,
+                    expectedGeneration: connectedGeneration,
+                    reason: "networkRecovery.\(trigger)"
+                )
+                if self.multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
+                    self.scheduleSecondaryAggregation()
+                }
+                return
+            }
+            guard self.connectionState != .connected else { return }
             let reconnected = await self.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
             if !reconnected, !Task.isCancelled {
                 self.connectionRecoveryFailed = true
@@ -5529,42 +5547,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             && isSignedIn
     }
 
-    func markMacConnectionHealthy() {
-        guard connectionState == .connected else {
-            macConnectionStatus = .unavailable
-            return
-        }
-        macConnectionStatus = .connected
-        isRecoveringConnection = false
-        connectionRecoveryFailed = false
-        connectionRequiresReauth = false
-    }
-
-    private func markMacConnectionReconnecting() {
-        guard connectionState == .connected, remoteClient != nil else {
-            macConnectionStatus = .unavailable
-            return
-        }
-        macConnectionStatus = .reconnecting
-        isRecoveringConnection = true
-        connectionRecoveryFailed = false
-    }
-
-    private func markMacConnectionUnavailable() {
-        guard connectionState == .connected else {
-            macConnectionStatus = .unavailable
-            return
-        }
-        macConnectionStatus = .unavailable
-        isRecoveringConnection = false
-        connectionRecoveryFailed = true
-    }
-
-    func markMacConnectionUnavailableIfNeeded(after error: any Error) {
-        guard MobileShellMacAvailabilityFailureClassifier().isAvailabilityFailure(error) else { return }
-        markMacConnectionUnavailable()
-    }
-
     func syncSelectedTerminalForWorkspace() {
         guard let selectedWorkspace else {
             selectedTerminalID = nil
@@ -5742,7 +5724,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             guard generation == connectionGeneration, !Task.isCancelled else { return }
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
-            markMacConnectionUnavailableIfNeeded(after: error)
+            recoverMacConnectionIfNeeded(after: error)
             applyOperationalError(error)
         }
     }
@@ -5803,7 +5785,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             guard generation == connectionGeneration else { return }
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return }
-            markMacConnectionUnavailableIfNeeded(after: error)
+            recoverMacConnectionIfNeeded(after: error)
             applyOperationalError(error)
         }
     }
@@ -5887,7 +5869,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             guard generation == connectionGeneration else { return false }
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return false }
-            markMacConnectionUnavailableIfNeeded(after: error)
+            recoverMacConnectionIfNeeded(after: error)
             applyOperationalError(error)
             return false
         }
@@ -5984,7 +5966,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         } catch {
             guard generation == connectionGeneration else { return false }
             guard !disconnectForAuthorizationFailureIfNeeded(error) else { return false }
-            markMacConnectionUnavailableIfNeeded(after: error)
+            recoverMacConnectionIfNeeded(after: error)
             applyOperationalError(error)
             return false
         }
@@ -6491,12 +6473,16 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             MobileDebugLog.anchormux("sync.liveness re-subscribe silentMs=\(silentMs)")
             self.diagnosticLog?.record(DiagnosticEvent(.livenessResubscribe, ms: UInt32(clamping: silentMs)))
             mobileShellLog.info("render-grid stream silent for \(silentMs, privacy: .public)ms and subscription probe failed, re-subscribing")
-            // resyncTerminalOutput(restartEventStream: true) stops the wedged
-            // listener (which cancels this watchdog via stopTerminalRefreshPolling)
-            // and starts a fresh subscription + watchdog, then replays every
-            // surface so the phone catches up on the deltas it missed while the
-            // stream was dead.
-            self.resyncTerminalOutput(reason: "liveness", restartEventStream: true)
+            // Rotate the wedged transport, then start a fresh subscription and
+            // replay every surface so the phone catches up on missed deltas.
+            let generation = self.connectionGeneration
+            if !(await self.resetRemoteSessionForRecovery(
+                client: client,
+                expectedGeneration: generation,
+                reason: "liveness"
+            )) {
+                self.resyncTerminalOutput(reason: "liveness", restartEventStream: true)
+            }
         }
     }
 
@@ -7520,7 +7506,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 || normalizedMessage.contains("invalid token")
                 || normalizedMessage.contains("expired token")
                 || normalizedMessage.contains("token expired")
-        case .invalidResponse, .connectionClosed, .requestTimedOut:
+        case .invalidResponse, .connectionClosed, .requestTimedOut, .transportWriteTimedOut:
             return false
         }
     }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1419,28 +1419,9 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private var networkPathObservationStarted = false
     private var networkPathObservationTask: Task<Void, Never>?
-    private var recoveryInFlight = false
-    private var recoveryTask: Task<Void, Never>?
-    private var lastReconnectStackUserID: String?
-
-    enum RecoveryTrigger: CustomStringConvertible {
-        case availabilityFailure
-        case networkChange
-        case manual
-        case presencePush
-
-        var reschedulesSecondaryAggregation: Bool { self != .presencePush }
-        var resetsConnectedSession: Bool { self != .presencePush }
-
-        var description: String {
-            switch self {
-            case .availabilityFailure: return "availabilityFailure"
-            case .networkChange: return "networkChange"
-            case .manual: return "manual"
-            case .presencePush: return "presencePush"
-            }
-        }
-    }
+    var recoveryID: UUID?
+    var recoveryTask: Task<Void, Never>?
+    var lastReconnectStackUserID: String?
 
     /// Begin observing meaningful network path changes (Wi-Fi<->cellular,
     /// offline->online) so a live terminal recovers when the network moves out
@@ -1464,56 +1445,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     public func retryMobileConnection() {
         connectionRecoveryFailed = false
         recoverMobileConnection(trigger: .manual)
-    }
-
-    /// Single guarded recovery entry for availability failures, network changes,
-    /// and manual Retry. A transport failure, real path transition, or explicit
-    /// retry rotates the persistent connection; a presence refresh only repairs
-    /// the event subscription. Network.framework then owns transient waiting and
-    /// backoff for the fresh connection.
-    func recoverMobileConnection(trigger: RecoveryTrigger) {
-        guard remoteClient != nil || pairedMacStore != nil else { return }
-        if connectionState == .connected,
-           remoteClient != nil,
-           !trigger.resetsConnectedSession {
-            markMacConnectionReconnecting()
-            resyncTerminalOutput(reason: "networkRecovery.\(trigger)", restartEventStream: true)
-            return
-        }
-        guard !recoveryInFlight else { return }
-        recoveryInFlight = true
-        isRecoveringConnection = true
-        connectionRecoveryFailed = false
-        let stackUserID = lastReconnectStackUserID
-        let connectedClient = connectionState == .connected ? remoteClient : nil
-        let connectedGeneration = connectionGeneration
-        recoveryTask?.cancel()
-        recoveryTask = Task { @MainActor [weak self] in
-            var isAwaitingSubscriptionAck = false
-            defer {
-                self?.recoveryInFlight = false
-                if !isAwaitingSubscriptionAck {
-                    self?.isRecoveringConnection = false
-                }
-            }
-            guard let self else { return }
-            if let connectedClient {
-                isAwaitingSubscriptionAck = await self.resetRemoteSessionForRecovery(
-                    client: connectedClient,
-                    expectedGeneration: connectedGeneration,
-                    reason: "networkRecovery.\(trigger)"
-                )
-                if self.multiMacAggregationEnabled, trigger.reschedulesSecondaryAggregation {
-                    self.scheduleSecondaryAggregation()
-                }
-                return
-            }
-            guard self.connectionState != .connected else { return }
-            let reconnected = await self.reconnectActiveMacIfAvailable(stackUserID: stackUserID)
-            if !reconnected, !Task.isCancelled {
-                self.connectionRecoveryFailed = true
-            }
-        }
     }
 
     public func connectPreviewHost() {
@@ -5136,6 +5067,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     private func clearRemoteConnectionContext(preservingOtherMacWorkspaceState: Bool = false) {
         connectionGeneration = UUID()
         connectionAttemptGeneration = UUID()
+        cancelMobileConnectionRecovery()
         cancelRemoteOperationTasks()
         clearActiveConnectionContext()
         macConnectionStatus = .unavailable
@@ -6271,23 +6203,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // ever delivered. Restarting here would supersede the generation
             // and silently swallow the handshake's failure verdict (its ack
             // guard sees a newer listenerID), so a closed transport would
-            // loop `reconnecting` forever. Converge instead: a stream that
-            // dies before its handshake completes IS a failed start.
-            mobileShellLog.info("terminal event stream ended before subscribe ack, marking unavailable")
-            MobileDebugLog.anchormux("sync.stream_ended before subscribe ack; failed start")
+            // loop `reconnecting` forever. A stream that dies before its
+            // handshake completes is a failed start, so send that verdict
+            // through the same single-flight recovery owner as every other
+            // transport failure.
+            mobileShellLog.info("terminal event stream ended before subscribe ack, recovering")
+            MobileDebugLog.anchormux("sync.stream_ended before subscribe ack; recovering")
             diagnosticLog?.record(DiagnosticEvent(.error))
-            stopTerminalRefreshPolling()
-            markMacConnectionUnavailable()
+            recoverMobileConnection(trigger: .eventStreamEnded)
             return
         }
-        mobileShellLog.info("terminal event stream ended, restarting")
-        MobileDebugLog.anchormux("sync.stream_ended restarting (render-grid push stopped; falling back to poll)")
+        mobileShellLog.info("terminal event stream ended, recovering")
+        MobileDebugLog.anchormux("sync.stream_ended recovering (render-grid push stopped)")
         diagnosticLog?.record(DiagnosticEvent(.streamEnded))
-        markMacConnectionReconnecting()
-        terminalEventListenerTask = nil
-        terminalEventListenerID = nil
-        startTerminalRefreshPolling()
-        scheduleWorkspaceListRefreshFromEvent()
+        recoverMobileConnection(trigger: .eventStreamEnded)
     }
 
     // MARK: - Render-grid liveness watchdog
@@ -6475,14 +6404,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             mobileShellLog.info("render-grid stream silent for \(silentMs, privacy: .public)ms and subscription probe failed, re-subscribing")
             // Rotate the wedged transport, then start a fresh subscription and
             // replay every surface so the phone catches up on missed deltas.
-            let generation = self.connectionGeneration
-            if !(await self.resetRemoteSessionForRecovery(
-                client: client,
-                expectedGeneration: generation,
-                reason: "liveness"
-            )) {
-                self.resyncTerminalOutput(reason: "liveness", restartEventStream: true)
-            }
+            self.recoverMobileConnection(trigger: .liveness)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1419,7 +1419,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     private var networkPathObservationStarted = false
     private var networkPathObservationTask: Task<Void, Never>?
-    var recoveryID: UUID?
+    var connectionRecoveryState: MobileConnectionRecoveryState?
+    var recoveryID: UUID? { connectionRecoveryState?.id }
     var recoveryTask: Task<Void, Never>?
     var lastReconnectStackUserID: String?
 
@@ -5096,7 +5097,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         connectedHostName = ""
     }
 
-    private func clearRemoteConnectionContext(
+    func clearRemoteConnectionContext(
         preservingOtherMacWorkspaceState: Bool = false,
         preservingConnectionRecovery: Bool = false
     ) {
@@ -6221,10 +6222,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 MobileDebugLog.anchormux("sync.subscribe_failed reason=start")
                 self.diagnosticLog?.record(DiagnosticEvent(.error))
                 self.stopTerminalRefreshPolling()
+                if self.handleMobileConnectionRecoverySubscriptionFailure() {
+                    return
+                }
                 self.markMacConnectionUnavailable()
                 return
             }
-            self.markMacConnectionHealthy()
+            self.markMacConnectionHealthy(completingRecovery: true)
             MobileDebugLog.anchormux("sync.subscribe_ok topics=\(topics.count) transport=\(transport)")
             self.scheduleNotificationReconcile(client: client)
         }
@@ -6244,13 +6248,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             // and silently swallow the handshake's failure verdict (its ack
             // guard sees a newer listenerID), so a closed transport would
             // loop `reconnecting` forever. A stream that dies before its
-            // handshake completes is a failed start. Converge to the bounded
-            // unavailable state instead of continuously replacing a transport
-            // that has never established a subscription.
-            mobileShellLog.info("terminal event stream ended before subscribe ack, marking unavailable")
+            // handshake completes is a failed start. Recovery replacements get
+            // one route-level fallback; an initial connection still converges
+            // unavailable instead of continuously replacing a transport that
+            // has never established a subscription.
+            mobileShellLog.info("terminal event stream ended before subscribe ack")
             MobileDebugLog.anchormux("sync.stream_ended before subscribe ack; failed start")
             diagnosticLog?.record(DiagnosticEvent(.error))
             stopTerminalRefreshPolling()
+            if handleMobileConnectionRecoverySubscriptionFailure() {
+                return
+            }
             markMacConnectionUnavailable()
             return
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellMacAvailabilityFailureClassifier.swift
@@ -10,9 +10,10 @@ struct MobileShellMacAvailabilityFailureClassifier {
             return false
         }
         switch shellError {
-        case .connectionClosed, .requestTimedOut:
+        case .connectionClosed, .transportWriteTimedOut:
             return true
-        case .invalidResponse, .insecureManualRoute, .attachTicketExpired, .authorizationFailed, .accountMismatch, .rpcError:
+        case .requestTimedOut, .invalidResponse, .insecureManualRoute, .attachTicketExpired,
+             .authorizationFailed, .accountMismatch, .rpcError:
             // .accountMismatch means the Mac is reachable but signed in to a
             // different account; that is an auth problem, not a Mac-availability one.
             return false

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellRecoveryTrigger.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellRecoveryTrigger.swift
@@ -1,0 +1,24 @@
+extension MobileShellComposite {
+    enum RecoveryTrigger: CustomStringConvertible {
+        case availabilityFailure
+        case eventStreamEnded
+        case liveness
+        case networkChange
+        case manual
+        case presencePush
+
+        var reschedulesSecondaryAggregation: Bool { self != .presencePush }
+        var resetsConnectedSession: Bool { self != .presencePush }
+
+        var description: String {
+            switch self {
+            case .availabilityFailure: return "availabilityFailure"
+            case .eventStreamEnded: return "eventStreamEnded"
+            case .liveness: return "liveness"
+            case .networkChange: return "networkChange"
+            case .manual: return "manual"
+            case .presencePush: return "presencePush"
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -34,6 +34,7 @@ actor LivenessHostRouter {
     private var heldHostStatusRequestNumbers: Set<Int> = []
     private var workspaceListRequestCount = 0
     private var heldWorkspaceListRequestNumbers: Set<Int> = []
+    private var holdWorkspaceAction = false
     private var subscribeRequestCount = 0
     private var heldSubscribeRequestNumbers: Set<Int> = []
     private var holdSubscribe = false
@@ -210,6 +211,10 @@ actor LivenessHostRouter {
         heldWorkspaceListRequestNumbers.insert(number)
     }
 
+    func holdNextWorkspaceAction() {
+        holdWorkspaceAction = true
+    }
+
     /// Hold the Nth `mobile.events.subscribe` request (1-based) forever,
     /// modeling a dead push path whose probe never completes.
     func holdSubscribeRequest(number: Int) {
@@ -249,6 +254,7 @@ actor LivenessHostRouter {
         holdSubscribe = false
         heldHostStatusRequestNumbers = []
         heldWorkspaceListRequestNumbers = []
+        holdWorkspaceAction = false
         heldSubscribeRequestNumbers = []
         heldReplayRequestNumbers = []
         heldReplayResponsesRemaining = 0
@@ -301,6 +307,16 @@ actor LivenessHostRouter {
             if let macInstanceTag { result["mac_instance_tag"] = macInstanceTag }
             if let macDisplayName { result["mac_display_name"] = macDisplayName }
             return try? Self.resultFrame(id: id, result: result)
+        case "workspace.action":
+            if holdWorkspaceAction {
+                holdWorkspaceAction = false
+                await park()
+            }
+            return try? Self.errorFrame(
+                id: id,
+                message: "workspace action unavailable",
+                code: "unavailable"
+            )
         case "mobile.events.subscribe":
             subscribeRequestCount += 1
             if holdSubscribe || heldSubscribeRequestNumbers.contains(subscribeRequestCount) {
@@ -398,11 +414,17 @@ actor LivenessHostRouter {
         return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
     }
 
-    private static func errorFrame(id: String?, message: String) throws -> Data {
+    private static func errorFrame(
+        id: String?,
+        message: String,
+        code: String? = nil
+    ) throws -> Data {
+        var error: [String: Any] = ["message": message]
+        if let code { error["code"] = code }
         let envelope: [String: Any] = [
             "id": id ?? UUID().uuidString,
             "ok": false,
-            "error": ["message": message],
+            "error": error,
         ]
         return try MobileSyncFrameCodec.encodeFrame(JSONSerialization.data(withJSONObject: envelope))
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -408,32 +408,6 @@ actor LivenessHostRouter {
     }
 }
 
-/// Holds the live transport instance so the test can push unsolicited
-/// server-side event frames through the same receive path production uses.
-final class TransportBox: @unchecked Sendable {
-    private let lock = NSLock()
-    private var transport: LivenessTransport?
-
-    func set(_ transport: LivenessTransport) {
-        lock.withLock { self.transport = transport }
-    }
-
-    func get() -> LivenessTransport? {
-        lock.withLock { transport }
-    }
-}
-
-struct LivenessTransportFactory: CmxByteTransportFactory {
-    let router: LivenessHostRouter
-    let box: TransportBox
-
-    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
-        let transport = LivenessTransport(router: router)
-        box.set(transport)
-        return transport
-    }
-}
-
 actor LivenessTransport: CmxByteTransport {
     private let router: LivenessHostRouter
     private var pendingFrames: [Data] = []

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTestSupport.swift
@@ -35,6 +35,7 @@ actor LivenessHostRouter {
     private var workspaceListRequestCount = 0
     private var heldWorkspaceListRequestNumbers: Set<Int> = []
     private var holdWorkspaceAction = false
+    private var workspaceActionErrorCode = "unavailable"
     private var subscribeRequestCount = 0
     private var heldSubscribeRequestNumbers: Set<Int> = []
     private var holdSubscribe = false
@@ -211,8 +212,9 @@ actor LivenessHostRouter {
         heldWorkspaceListRequestNumbers.insert(number)
     }
 
-    func holdNextWorkspaceAction() {
+    func holdNextWorkspaceAction(errorCode: String = "unavailable") {
         holdWorkspaceAction = true
+        workspaceActionErrorCode = errorCode
     }
 
     /// Hold the Nth `mobile.events.subscribe` request (1-based) forever,
@@ -315,7 +317,7 @@ actor LivenessHostRouter {
             return try? Self.errorFrame(
                 id: id,
                 message: "workspace action unavailable",
-                code: "unavailable"
+                code: workspaceActionErrorCode
             )
         case "mobile.events.subscribe":
             subscribeRequestCount += 1

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRenderGridLivenessTests.swift
@@ -513,42 +513,6 @@ import Testing
     collector.unmount()
 }
 
-/// The watchdog's original purpose (the ~85s silent-death hang) must keep
-/// working: silence past the threshold plus a host that stops answering the
-/// probe must still tear down and re-subscribe.
-@MainActor
-@Test func watchdogStillResubscribesGenuinelyDeadStream() async throws {
-    let clock = TestClock()
-    let router = LivenessHostRouter()
-    let box = TransportBox()
-    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
-    defer {
-        Task { await router.releaseAllHeld() }
-    }
-
-    let sawSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
-    #expect(sawSubscribe, "listener must establish the push subscription")
-    let hostStatusCountBeforeFailure = await router.count(of: "mobile.host.status")
-
-    // The host stops answering the next mobile.events.subscribe (the
-    // watchdog's re-assert probe), modeling a dead push path while the
-    // request had already left the phone.
-    await router.holdSubscribeRequest(number: 2)
-    clock.advance(by: 10)
-    store.debugRunRenderGridLivenessCheckForTesting()
-
-    // Recovery restarts the listener, which re-resolves capabilities. A new
-    // mobile.host.status request is the teardown-and-restart proof.
-    let restarted = try await pollUntil(attempts: 600) {
-        await router.count(of: "mobile.host.status") > hostStatusCountBeforeFailure
-    }
-    #expect(
-        restarted,
-        "a stream that is silent past the threshold AND whose host stops answering the subscription probe must still be torn down and re-subscribed"
-    )
-    await router.releaseAllHeld()
-}
-
 /// A transport that drops before the start handshake completes must converge
 /// to `.unavailable`, not livelock in `.reconnecting`: without the guard, the
 /// stream-end restart supersedes the listener generation, so the parked start

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
@@ -10,6 +10,7 @@ import Testing
 @Test func failedReplacementSubscriptionEscalatesToLatestStoredRoute() async throws {
     let clock = TestClock()
     let router = LivenessHostRouter()
+    await router.setHostIdentity(deviceID: nil, instanceTag: nil)
     let box = TransportBox()
     let factory = RouteRecordingTransportFactory(
         router: router,
@@ -68,6 +69,7 @@ import Testing
     )
     store.activeTicket = staleTicket
     store.activeRoute = staleRoute
+    store.activeMacInstanceTag = "default"
     store.foregroundMacDeviceID = "test-mac"
     store.lastReconnectStackUserID = "user-1"
     store.replaceRemoteClient(with: MobileCoreRPCClient(
@@ -86,7 +88,7 @@ import Testing
     await box.get()?.close()
 
     let escalated = try await pollUntil(attempts: 600) {
-        store.activeRoute?.endpoint == freshRoute.endpoint
+        factory.attemptedPorts().contains(51_001)
             && store.macConnectionStatus == .connected
             && store.recoveryID == nil
     }
@@ -110,7 +112,7 @@ import Testing
     store.retryMobileConnection()
 
     let retriedStoredRoute = try await pollUntil(attempts: 600) {
-        store.activeRoute?.endpoint == retryRoute.endpoint
+        factory.attemptedPorts().contains(51_002)
             && store.macConnectionStatus == .connected
             && store.recoveryID == nil
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
@@ -24,12 +24,12 @@ import Testing
         databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
     )
     let staleRoute = try CmxAttachRoute(
-        id: "stale",
+        id: "debug_loopback",
         kind: .debugLoopback,
         endpoint: .hostPort(host: "127.0.0.1", port: 51_000)
     )
     let freshRoute = try CmxAttachRoute(
-        id: "fresh",
+        id: "debug_loopback",
         kind: .debugLoopback,
         endpoint: .hostPort(host: "127.0.0.1", port: 51_001)
     )
@@ -87,7 +87,7 @@ import Testing
     #expect(escalated, "failed replacement subscription must refresh the stored route")
 
     let retryRoute = try CmxAttachRoute(
-        id: "retry",
+        id: "debug_loopback",
         kind: .debugLoopback,
         endpoint: .hostPort(host: "127.0.0.1", port: 51_002)
     )

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
@@ -36,7 +36,7 @@ import Testing
     try await pairedStore.upsert(
         macDeviceID: "test-mac",
         displayName: "Test Mac",
-        routes: [staleRoute],
+        routes: [freshRoute],
         markActive: true,
         stackUserID: "user-1",
         teamID: nil,
@@ -50,6 +50,7 @@ import Testing
     let store = MobileShellComposite(
         runtime: runtime,
         isSignedIn: true,
+        connectionState: .connected,
         pairedMacStore: pairedStore,
         identityProvider: StaticIdentityProvider(userID: "user-1"),
         reachability: AlwaysOnlineReachability(),
@@ -57,20 +58,25 @@ import Testing
             suiteName: "route-recovery-\(UUID().uuidString)"
         )!
     )
-    await store.loadPairedMacs()
-    #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
-    #expect(await router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
-
-    try await pairedStore.upsert(
+    let staleTicket = try CmxAttachTicket(
+        workspaceID: "live-workspace",
+        terminalID: "live-terminal",
         macDeviceID: "test-mac",
-        displayName: "Test Mac",
-        routes: [freshRoute],
-        markActive: true,
-        stackUserID: "user-1",
-        teamID: nil,
-        now: clock.now.addingTimeInterval(1)
+        macDisplayName: "Test Mac",
+        routes: [staleRoute],
+        expiresAt: clock.now.addingTimeInterval(3_600)
     )
-    let replacementSubscribe = await router.count(of: "mobile.events.subscribe") + 1
+    store.activeTicket = staleTicket
+    store.activeRoute = staleRoute
+    store.foregroundMacDeviceID = "test-mac"
+    store.lastReconnectStackUserID = "user-1"
+    store.replaceRemoteClient(with: MobileCoreRPCClient(
+        runtime: runtime,
+        route: staleRoute,
+        ticket: staleTicket,
+        allowsStackAuthFallback: true
+    ))
+    let replacementSubscribe = 1
     await router.holdSubscribeRequest(number: replacementSubscribe)
     store.recoverMobileConnection(trigger: .manual)
     #expect(await router.waitForCount(
@@ -98,7 +104,7 @@ import Testing
         markActive: true,
         stackUserID: "user-1",
         teamID: nil,
-        now: clock.now.addingTimeInterval(2)
+        now: clock.now.addingTimeInterval(1)
     )
     store.markMacConnectionUnavailable()
     store.retryMobileConnection()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellRouteRecoveryTests.swift
@@ -1,0 +1,114 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileRPC
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+@MainActor
+@Test func failedReplacementSubscriptionEscalatesToLatestStoredRoute() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let factory = RouteRecordingTransportFactory(
+        router: router,
+        box: box,
+        failingPorts: []
+    )
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let pairedStore = try MobilePairedMacStore(
+        databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+    )
+    let staleRoute = try CmxAttachRoute(
+        id: "stale",
+        kind: .debugLoopback,
+        endpoint: .hostPort(host: "127.0.0.1", port: 51_000)
+    )
+    let freshRoute = try CmxAttachRoute(
+        id: "fresh",
+        kind: .debugLoopback,
+        endpoint: .hostPort(host: "127.0.0.1", port: 51_001)
+    )
+    try await pairedStore.upsert(
+        macDeviceID: "test-mac",
+        displayName: "Test Mac",
+        routes: [staleRoute],
+        markActive: true,
+        stackUserID: "user-1",
+        teamID: nil,
+        now: clock.now
+    )
+    let runtime = LivenessTestRuntime(
+        transportFactory: factory,
+        now: { clock.now },
+        supportedRouteKinds: [.debugLoopback]
+    )
+    let store = MobileShellComposite(
+        runtime: runtime,
+        isSignedIn: true,
+        pairedMacStore: pairedStore,
+        identityProvider: StaticIdentityProvider(userID: "user-1"),
+        reachability: AlwaysOnlineReachability(),
+        pairingHintDefaults: UserDefaults(
+            suiteName: "route-recovery-\(UUID().uuidString)"
+        )!
+    )
+    await store.loadPairedMacs()
+    #expect(await store.reconnectActiveMacIfAvailable(stackUserID: "user-1"))
+    #expect(await router.waitForCount(of: "mobile.events.subscribe", atLeast: 1))
+
+    try await pairedStore.upsert(
+        macDeviceID: "test-mac",
+        displayName: "Test Mac",
+        routes: [freshRoute],
+        markActive: true,
+        stackUserID: "user-1",
+        teamID: nil,
+        now: clock.now.addingTimeInterval(1)
+    )
+    let replacementSubscribe = await router.count(of: "mobile.events.subscribe") + 1
+    await router.holdSubscribeRequest(number: replacementSubscribe)
+    store.recoverMobileConnection(trigger: .manual)
+    #expect(await router.waitForCount(
+        of: "mobile.events.subscribe",
+        atLeast: replacementSubscribe
+    ))
+    await box.get()?.close()
+
+    let escalated = try await pollUntil(attempts: 600) {
+        store.activeRoute?.endpoint == freshRoute.endpoint
+            && store.macConnectionStatus == .connected
+            && store.recoveryID == nil
+    }
+    #expect(escalated, "failed replacement subscription must refresh the stored route")
+
+    let retryRoute = try CmxAttachRoute(
+        id: "retry",
+        kind: .debugLoopback,
+        endpoint: .hostPort(host: "127.0.0.1", port: 51_002)
+    )
+    try await pairedStore.upsert(
+        macDeviceID: "test-mac",
+        displayName: "Test Mac",
+        routes: [retryRoute],
+        markActive: true,
+        stackUserID: "user-1",
+        teamID: nil,
+        now: clock.now.addingTimeInterval(2)
+    )
+    store.markMacConnectionUnavailable()
+    store.retryMobileConnection()
+
+    let retriedStoredRoute = try await pollUntil(attempts: 600) {
+        store.activeRoute?.endpoint == retryRoute.endpoint
+            && store.macConnectionStatus == .connected
+            && store.recoveryID == nil
+    }
+    #expect(retriedStoredRoute, "Retry from unavailable must refresh the stored route")
+    #expect(factory.attemptedPorts().contains(51_001))
+    #expect(factory.attemptedPorts().contains(51_002))
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTestSupport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTestSupport.swift
@@ -1,0 +1,37 @@
+import CMUXMobileCore
+import CmuxMobileRPC
+import Foundation
+
+/// Holds the live transport instance so tests can push unsolicited server-side
+/// event frames and verify when recovery replaces the persistent connection.
+final class TransportBox: @unchecked Sendable {
+    private let lock = NSLock()
+    private var transport: LivenessTransport?
+    private var transportCreationCount = 0
+
+    func set(_ transport: LivenessTransport) {
+        lock.withLock {
+            self.transport = transport
+            transportCreationCount += 1
+        }
+    }
+
+    func get() -> LivenessTransport? {
+        lock.withLock { transport }
+    }
+
+    func createdTransportCount() -> Int {
+        lock.withLock { transportCreationCount }
+    }
+}
+
+struct LivenessTransportFactory: CmxByteTransportFactory {
+    let router: LivenessHostRouter
+    let box: TransportBox
+
+    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        let transport = LivenessTransport(router: router)
+        box.set(transport)
+        return transport
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTests.swift
@@ -1,0 +1,95 @@
+import CmuxMobileRPC
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+/// The watchdog's original purpose (the ~85s silent-death hang) must keep
+/// working: silence past the threshold plus a host that stops answering the
+/// probe must still tear down and re-subscribe on a fresh transport.
+@MainActor
+@Test func watchdogStillResubscribesGenuinelyDeadStream() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+    defer {
+        Task { await router.releaseAllHeld() }
+    }
+
+    let sawSubscribe = try await pollUntil { await router.count(of: "mobile.events.subscribe") >= 1 }
+    #expect(sawSubscribe, "listener must establish the push subscription")
+    let hostStatusCountBeforeFailure = await router.count(of: "mobile.host.status")
+
+    // Model a dead push path after the request has already left the phone.
+    await router.holdSubscribeRequest(number: 2)
+    clock.advance(by: 10)
+    store.debugRunRenderGridLivenessCheckForTesting()
+
+    let restarted = try await pollUntil(attempts: 600) {
+        await router.count(of: "mobile.host.status") > hostStatusCountBeforeFailure
+    }
+    #expect(
+        restarted,
+        "a silent stream whose host stops answering the subscription probe must restart"
+    )
+    #expect(
+        box.createdTransportCount() == 2,
+        "a failed positive-liveness probe must rotate the stale transport"
+    )
+    await router.releaseAllHeld()
+}
+
+/// Retry is a session recovery action, not just a new subscription on the old
+/// socket. The route/ticket/store stay mounted while the transport is replaced.
+@MainActor
+@Test func manualRetryRotatesPersistentTransportAndResubscribes() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+    let hostStatusCount = await router.count(of: "mobile.host.status")
+    let subscribeCount = await router.count(of: "mobile.events.subscribe")
+
+    store.retryMobileConnection()
+
+    #expect(await router.waitForCount(
+        of: "mobile.host.status",
+        atLeast: hostStatusCount + 1
+    ))
+    #expect(await router.waitForCount(
+        of: "mobile.events.subscribe",
+        atLeast: subscribeCount + 1
+    ))
+    #expect(box.createdTransportCount() == 2)
+    #expect(store.connectionState == .connected)
+}
+
+/// A transport-level request failure should enter automatic recovery instead
+/// of immediately presenting the manual Retry state from issue #8005.
+@MainActor
+@Test func availabilityFailureAutomaticallyRotatesPersistentTransport() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+    let hostStatusCount = await router.count(of: "mobile.host.status")
+
+    store.recoverMacConnectionIfNeeded(
+        after: MobileShellConnectionError.requestTimedOut
+    )
+    #expect(box.createdTransportCount() == 1)
+    #expect(store.macConnectionStatus == .connected)
+
+    store.recoverMacConnectionIfNeeded(
+        after: MobileShellConnectionError.transportWriteTimedOut
+    )
+
+    #expect(await router.waitForCount(
+        of: "mobile.host.status",
+        atLeast: hostStatusCount + 1
+    ))
+    #expect(box.createdTransportCount() == 2)
+    #expect(!store.connectionRecoveryFailed)
+    #expect(store.macConnectionStatus != .unavailable)
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTests.swift
@@ -55,11 +55,13 @@ import Testing
 
     #expect(await router.waitForCount(
         of: "mobile.host.status",
-        atLeast: hostStatusCount + 1
+        atLeast: hostStatusCount + 1,
+        timeoutNanoseconds: 10_000_000_000
     ))
     #expect(await router.waitForCount(
         of: "mobile.events.subscribe",
-        atLeast: subscribeCount + 1
+        atLeast: subscribeCount + 1,
+        timeoutNanoseconds: 10_000_000_000
     ))
     #expect(box.createdTransportCount() == 2)
     #expect(store.connectionState == .connected)
@@ -87,7 +89,8 @@ import Testing
 
     #expect(await router.waitForCount(
         of: "mobile.host.status",
-        atLeast: hostStatusCount + 1
+        atLeast: hostStatusCount + 1,
+        timeoutNanoseconds: 10_000_000_000
     ))
     #expect(box.createdTransportCount() == 2)
     #expect(!store.connectionRecoveryFailed)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellSessionRecoveryTests.swift
@@ -93,3 +93,23 @@ import Testing
     #expect(!store.connectionRecoveryFailed)
     #expect(store.macConnectionStatus != .unavailable)
 }
+
+/// Recovery triggers share one owner, so a path transition or Retry arriving
+/// behind a failed liveness verdict cannot rotate the replacement again.
+@MainActor
+@Test func concurrentRecoveryTriggersRotateTransportOnce() async throws {
+    let clock = TestClock()
+    let router = LivenessHostRouter()
+    let box = TransportBox()
+    let store = try await makeConnectedStore(router: router, box: box, clock: clock)
+    let hostStatusCount = await router.count(of: "mobile.host.status")
+
+    store.recoverMobileConnection(trigger: .liveness)
+    store.recoverMobileConnection(trigger: .networkChange)
+
+    #expect(await router.waitForCount(
+        of: "mobile.host.status",
+        atLeast: hostStatusCount + 1
+    ))
+    #expect(box.createdTransportCount() == 2)
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceRecoveryGenerationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceRecoveryGenerationTests.swift
@@ -20,7 +20,7 @@ import Testing
         clock: clock
     )
     let workspaceID = try #require(store.workspaces.first?.id)
-    await staleRouter.holdNextWorkspaceAction()
+    await staleRouter.holdNextWorkspaceAction(errorCode: "unauthorized")
 
     let mutation = Task { @MainActor in
         await store.renameWorkspace(id: workspaceID, title: "Renamed")
@@ -40,5 +40,7 @@ import Testing
     _ = await mutation.value
 
     #expect(await replacementRouter.count(of: "mobile.host.status") == 0)
+    #expect(store.connectionState == .connected)
+    #expect(!store.connectionRequiresReauth)
     #expect(store.macConnectionStatus != .reconnecting)
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceRecoveryGenerationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileShellWorkspaceRecoveryGenerationTests.swift
@@ -1,0 +1,44 @@
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Test func staleWorkspaceFailureDoesNotRecoverReplacementClient() async throws {
+    let clock = TestClock()
+    let staleRouter = LivenessHostRouter()
+    let staleBox = TransportBox()
+    await staleRouter.setCapabilities([
+        "events.v1",
+        "terminal.render_grid.v1",
+        "terminal.replay.v1",
+        "workspace.actions.v1",
+    ])
+    let store = try await makeConnectedStore(
+        router: staleRouter,
+        box: staleBox,
+        clock: clock
+    )
+    let workspaceID = try #require(store.workspaces.first?.id)
+    await staleRouter.holdNextWorkspaceAction()
+
+    let mutation = Task { @MainActor in
+        await store.renameWorkspace(id: workspaceID, title: "Renamed")
+    }
+    #expect(await staleRouter.waitForCount(of: "workspace.action", atLeast: 1))
+
+    let replacementRouter = LivenessHostRouter()
+    let replacementBox = TransportBox()
+    try installFreshLivenessRemoteClient(
+        on: store,
+        router: replacementRouter,
+        box: replacementBox,
+        clock: clock
+    )
+    store.connectionGeneration = UUID()
+    await staleRouter.releaseAllHeld()
+    _ = await mutation.value
+
+    #expect(await replacementRouter.count(of: "mobile.host.status") == 0)
+    #expect(store.macConnectionStatus != .reconnecting)
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/ReconnectRouteSelectionTests.swift
@@ -370,11 +370,11 @@ import Testing
     }
 }
 
-private enum RouteRecordingTransportError: Error {
+enum RouteRecordingTransportError: Error {
     case routeFailed
 }
 
-private final class RouteRecordingTransportFactory: CmxByteTransportFactory, @unchecked Sendable {
+final class RouteRecordingTransportFactory: CmxByteTransportFactory, @unchecked Sendable {
     private let router: LivenessHostRouter
     private let box: TransportBox
     private let failingPorts: Set<Int>
@@ -455,7 +455,7 @@ private final class RouteRecordingTransportFactory: CmxByteTransportFactory, @un
     }
 }
 
-private actor HeldFailingConnectTransport: CmxByteTransport {
+actor HeldFailingConnectTransport: CmxByteTransport {
     private let factory: RouteRecordingTransportFactory
 
     init(factory: RouteRecordingTransportFactory) {


### PR DESCRIPTION
## Summary

- track the active serialized RPC write and recycle the persistent transport only when that write itself exceeds the request deadline
- distinguish a blocked transport send from an ordinary response-only timeout, leaving healthy multiplexed sessions intact
- route write stalls, failed liveness probes, network transitions, and manual Retry through one transport-rotation path that preserves the paired-Mac ticket, route, workspace state, terminal surfaces, and stable event stream ID
- keep the iOS UI in automatic `Reconnecting…` until the replacement subscription is acknowledged, falling back to the existing Retry state only when the fresh subscription fails
- bind read/write loop teardown to its connection generation so a late failure from an old socket cannot close its replacement

## Root cause

`MobileCoreRPCSession` serializes frames through one writer task. If `CmxByteTransport.send` never received its `contentProcessed` callback, the request timeout removed the response continuation but left the writer parked forever. Later keystrokes, keepalives, and re-subscriptions queued behind that write. Existing recovery paths then re-subscribed on the same wedged session, which explains why Tailscale remained healthy while every cmux workspace became Disconnected.

The transport already lets Network.framework own transient `.waiting` retry/backoff. This change does not add sleeps or inflate a timeout; it replaces only a session proven stale by a blocked send or failed positive-liveness probe.

## Regression proof

Commit `eef873e72f` adds the failing test without the fix. Before commit `86ea04298b`, the first send timed out, the second request also timed out, only one transport was created, and the stalled transport never closed.

The fixed test additionally releases the old stalled writer after transport #2 is live and proves that late failure cannot tear down the replacement connection.

## Verification

- `/usr/bin/arch -arm64 /usr/bin/xcrun swift test --package-path Packages/iOS/CmuxMobileRPC` — 79 tests passed
- `/usr/bin/arch -arm64 /usr/bin/xcrun swift test --package-path Packages/iOS/CmuxMobileShell` — 482 tests passed
- `python3 scripts/swift_file_length_budget.py --base-ref origin/main` — passed
- `python3 scripts/check-package-resolved-policy.py` — passed
- `./scripts/lint-ios-package-conventions.sh` — passed with baseline warnings only
- `git diff --check` — passed

I chose deterministic injected-transport coverage over cloud/device video: the reported failure is a physical tailnet timing issue, while the regression directly stalls `transport.send`, exercises the real RPC writer/session state machine, and verifies automatic shell recovery without relying on radio conditions. No XCUITest or local app build was run.

## Localization audit

No user-facing copy was added or changed. The existing localized Reconnecting, Connection lost, and Retry surfaces are reused, so `Resources/Localizable.xcstrings` and the English/Japanese catalogs require no changes.

## Related work

This is complementary to #7876: that PR centralizes broader connectivity lifecycle ownership, while this change fixes the lower-level persistent-writer wedge and ensures recovery rotates a stale transport rather than repairing streams on the same session.

Closes #8005

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8012"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786578194&installation_id=133855650&pr_number=8012&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8012&signature=f0e5a8aaf1e386988e9fc06e4e016f2b57942fff3e249cfa820fb4034601de02"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS drops when an RPC write stalls by detecting blocked `transport.send`, rotating only the stale transport, and auto‑resubscribing without losing session state. If the replacement subscription fails, we now refresh the latest stored route and reconnect before falling back to Retry. Addresses #8005.

- **Bug Fixes**
  - `CmuxMobileRPC`: Track the active write; if a request times out while still in `send`, cancel it, surface `transportWriteTimedOut`, and recycle only the transport (healthy multiplexed sessions stay intact).
  - `CmuxMobileRPC`: Split read/write loops and bind teardown to a connection generation; serialize detached transport cleanup (`enqueueTransportClose`) so one close is in‑flight and one queued, backpressuring new connections to avoid leaks or livelock; add `MobileCoreRPCClient.resetConnectionForRecovery()` to drop just the transport.
  - `CmuxMobileShell`: Route write stalls, failed liveness probes, event‑stream end, network changes, and manual Retry through one single‑flight recovery that rotates the transport and preserves workspace/terminals; keep automatic Reconnecting until the new subscription ACK.
  - `CmuxMobileShell`: If the replacement subscription fails, escalate to reconnect using the latest stored route; Retry from Unavailable also refreshes the stored route.
  - Error handling/UI: Add `MobileShellConnectionError.transportWriteTimedOut`; classify it as a Mac‑availability failure. Plain `requestTimedOut` is response‑scoped and does not trigger availability recovery.
  - Tests: Cover stalled‑write timeout/cancel and late‑failure isolation, serialized/queued transport close with connection backpressure, manual Retry rotating the transport, automatic recovery on availability failures, single‑flight across concurrent triggers, failed replacement subscription escalating to the stored route, and generation‑scoped workspace failures.

<sup>Written for commit 96bb9d3e5b4fb1423ef881b639bf9898fd1352cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

