### PR TITLE
Restore modern Settings window chrome

### DIFF
--- a/Sources/App/SettingsWindowFactory.swift
+++ b/Sources/App/SettingsWindowFactory.swift
@@ -32,7 +32,9 @@ enum SettingsWindowFactory {
         )
         // The AppKit owner configures the toolbar explicitly below; bridge only
         // SwiftUI's navigation title so an implicit scene toolbar can never
-        // replace or remove the Settings chrome contract.
+        // replace or remove the Settings chrome contract. The sidebar search
+        // remains inside the hosted NavigationSplitView: `.searchable` with
+        // `.sidebar` placement does not require toolbar bridging.
         hostingController.sceneBridgingOptions = [.title]
         let window = SettingsHostWindow(contentViewController: hostingController)
         window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
@@ -57,10 +59,6 @@ enum SettingsWindowFactory {
         toolbar.autosavesConfiguration = false
         toolbar.displayMode = .iconOnly
         toolbar.insertItem(withItemIdentifier: .toggleSidebar, at: 0)
-        if let sidebarToggle = toolbar.items.first(where: { $0.itemIdentifier == .toggleSidebar }) {
-            sidebarToggle.target = window
-            sidebarToggle.action = #selector(SettingsHostWindow.toggleSidebar(_:))
-        }
         window.toolbar = toolbar
         window.toolbarStyle = .unifiedCompact
     }
@@ -117,6 +115,18 @@ class SettingsHostWindow: NSWindow, NSToolbarDelegate {
         // AppKit creates its standard toggle-sidebar item itself and does not
         // ask the delegate for it. No custom identifiers are allowed here.
         nil
+    }
+
+    func toolbarWillAddItem(_ notification: Notification) {
+        guard
+            let sidebarToggle = notification.userInfo?[NSToolbarUserInfoKey.itemKey] as? NSToolbarItem,
+            sidebarToggle.itemIdentifier == .toggleSidebar
+        else { return }
+        // AppKit may recreate standard items when the toolbar attaches to a
+        // window. Configure every inserted instance so the live item always
+        // uses the shared Settings toggle path.
+        sidebarToggle.target = self
+        sidebarToggle.action = #selector(toggleSidebar(_:))
     }
 
     override func close() {

--- a/Sources/App/SettingsWindowFactory.swift
+++ b/Sources/App/SettingsWindowFactory.swift
@@ -52,6 +52,7 @@ enum SettingsWindowFactory {
         window.titlebarSeparatorStyle = .none
 
         let toolbar = NSToolbar(identifier: toolbarIdentifier)
+        toolbar.delegate = window
         toolbar.allowsUserCustomization = false
         toolbar.autosavesConfiguration = false
         toolbar.displayMode = .iconOnly
@@ -91,13 +92,31 @@ extension SettingsWindowPresenter {
 /// window even when a foreign `willClose` observer re-enters `show()` before
 /// the presenter's own observer runs (notification-observer order is not a
 /// lifecycle invariant).
-class SettingsHostWindow: NSWindow {
+class SettingsHostWindow: NSWindow, NSToolbarDelegate {
     private(set) var isClosingSettingsWindow = false
 
     /// Receives the standard AppKit toolbar item's `toggleSidebar:` action and
     /// forwards it through the same route as the app menu command.
     @objc func toggleSidebar(_ sender: Any?) {
         SettingsWindowPresenter.requestSidebarToggle()
+    }
+
+    func toolbarDefaultItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.toggleSidebar]
+    }
+
+    func toolbarAllowedItemIdentifiers(_ toolbar: NSToolbar) -> [NSToolbarItem.Identifier] {
+        [.toggleSidebar]
+    }
+
+    func toolbar(
+        _ toolbar: NSToolbar,
+        itemForItemIdentifier itemIdentifier: NSToolbarItem.Identifier,
+        willBeInsertedIntoToolbar flag: Bool
+    ) -> NSToolbarItem? {
+        // AppKit creates its standard toggle-sidebar item itself and does not
+        // ask the delegate for it. No custom identifiers are allowed here.
+        nil
     }
 
     override func close() {

--- a/Sources/App/SettingsWindowFactory.swift
+++ b/Sources/App/SettingsWindowFactory.swift
@@ -14,6 +14,7 @@ import os
 @MainActor
 enum SettingsWindowFactory {
     private nonisolated static let log = Logger(subsystem: "com.cmuxterm.app", category: "Settings")
+    static let toolbarIdentifier = NSToolbar.Identifier("cmux.settings.toolbar")
 
     /// `onContentAppear` is invoked from the hosted content's `onAppear`, so
     /// the presenter that owns this window learns when the content's
@@ -29,14 +30,38 @@ enum SettingsWindowFactory {
         let hostingController = NSHostingController(
             rootView: SettingsWindowHostRoot(onContentAppear: onContentAppear)
         )
-        // Bridge SwiftUI's navigation title, the sidebar toggle, and the
-        // search field into the AppKit window's titlebar/toolbar.
-        hostingController.sceneBridgingOptions = [.toolbars, .title]
+        // The AppKit owner configures the toolbar explicitly below; bridge only
+        // SwiftUI's navigation title so an implicit scene toolbar can never
+        // replace or remove the Settings chrome contract.
+        hostingController.sceneBridgingOptions = [.title]
         let window = SettingsHostWindow(contentViewController: hostingController)
-        window.styleMask = [.titled, .closable, .miniaturizable, .resizable]
+        window.styleMask = [.titled, .closable, .miniaturizable, .resizable, .fullSizeContentView]
         window.title = String(localized: "settings.title", defaultValue: "Settings")
+        configureChrome(on: window)
         window.setContentSize(NSSize(width: 980, height: 680))
         return window
+    }
+
+    /// Establishes the complete modern Settings chrome invariant at
+    /// construction time. The AppKit-owned window must also own its toolbar;
+    /// `sceneBridgingOptions` only forwards toolbar content explicitly declared
+    /// by a hosted SwiftUI view and otherwise leaves a bare legacy titlebar.
+    private static func configureChrome(on window: SettingsHostWindow) {
+        window.titlebarAppearsTransparent = true
+        window.titleVisibility = .hidden
+        window.titlebarSeparatorStyle = .none
+
+        let toolbar = NSToolbar(identifier: toolbarIdentifier)
+        toolbar.allowsUserCustomization = false
+        toolbar.autosavesConfiguration = false
+        toolbar.displayMode = .iconOnly
+        toolbar.insertItem(withItemIdentifier: .toggleSidebar, at: 0)
+        if let sidebarToggle = toolbar.items.first(where: { $0.itemIdentifier == .toggleSidebar }) {
+            sidebarToggle.target = window
+            sidebarToggle.action = #selector(SettingsHostWindow.toggleSidebar(_:))
+        }
+        window.toolbar = toolbar
+        window.toolbarStyle = .unifiedCompact
     }
 }
 
@@ -49,8 +74,15 @@ extension SettingsWindowPresenter {
     /// main actor and warn under strict concurrency.
     static func handleSidebarToggleIfSettingsWindowIsKey(keyWindow: NSWindow?) -> Bool {
         guard keyWindow?.identifier?.rawValue == windowIdentifier else { return false }
-        NotificationCenter.default.post(name: SettingsWindowRoot.sidebarToggleRequestName, object: nil)
+        requestSidebarToggle()
         return true
+    }
+
+    /// Shared mutation path for the toolbar item and the app's Toggle Left
+    /// Sidebar command. The SwiftUI split view owns the visibility state and
+    /// consumes this request in ``SettingsWindowRoot``.
+    static func requestSidebarToggle() {
+        NotificationCenter.default.post(name: SettingsWindowRoot.sidebarToggleRequestName, object: nil)
     }
 }
 
@@ -61,6 +93,12 @@ extension SettingsWindowPresenter {
 /// lifecycle invariant).
 class SettingsHostWindow: NSWindow {
     private(set) var isClosingSettingsWindow = false
+
+    /// Receives the standard AppKit toolbar item's `toggleSidebar:` action and
+    /// forwards it through the same route as the app menu command.
+    @objc func toggleSidebar(_ sender: Any?) {
+        SettingsWindowPresenter.requestSidebarToggle()
+    }
 
     override func close() {
         isClosingSettingsWindow = true

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1282,6 +1282,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D10000000000000000A00016 /* SettingsSidebarBetaBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00017 /* SettingsSidebarBetaBehaviorUITests.swift */; };
 		D10000000000000000A00014 /* SettingsTerminalBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */; };
 		D10000000000000000A00010 /* SettingsUITestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A00011 /* SettingsUITestSupport.swift */; };
+		D80100010000000000000001 /* SettingsWindowChromeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D80100010000000000000002 /* SettingsWindowChromeTests.swift */; };
 		D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090030000000000000002 /* SettingsWindowFactory.swift */; };
 		D37777030000000000000001 /* SettingsWindowGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777030000000000000002 /* SettingsWindowGeometry.swift */; };
 		D37777070000000000000001 /* SettingsWindowNavigationDelivery.swift in Sources */ = {isa = PBXBuildFile; fileRef = D37777070000000000000002 /* SettingsWindowNavigationDelivery.swift */; };
@@ -3058,6 +3059,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D10000000000000000A00017 /* SettingsSidebarBetaBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSidebarBetaBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00015 /* SettingsTerminalBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTerminalBehaviorUITests.swift; sourceTree = "<group>"; };
 		D10000000000000000A00011 /* SettingsUITestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsUITestSupport.swift; sourceTree = "<group>"; };
+		D80100010000000000000002 /* SettingsWindowChromeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsWindowChromeTests.swift; sourceTree = "<group>"; };
 		D36090030000000000000002 /* SettingsWindowFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowFactory.swift; sourceTree = "<group>"; };
 		D37777030000000000000002 /* SettingsWindowGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowGeometry.swift; sourceTree = "<group>"; };
 		D37777070000000000000002 /* SettingsWindowNavigationDelivery.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SettingsWindowNavigationDelivery.swift; sourceTree = "<group>"; };
@@ -5120,6 +5122,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D37777050000000000000002 /* AppDelegatePresentPreferencesWindowTests.swift */,
 				D37777020000000000000002 /* SettingsWindowNavigationRoutingTests.swift */,
 				D37777060000000000000002 /* SettingsWindowPresentationContractTests.swift */,
+				D80100010000000000000002 /* SettingsWindowChromeTests.swift */,
 				D36090010000000000000004 /* SettingsWindowPresenterTests.swift */,
 				D36090010000000000000006 /* CmuxMainWindowConstrainFrameTests.swift */,
 				D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */,
@@ -7461,6 +7464,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
 				583A675AA1224E8D82A44883 /* SetAutoTitleSocketTests.swift in Sources */,
 				A50019B2 /* SettingsSearchIndexTests.swift in Sources */,
+				D80100010000000000000001 /* SettingsWindowChromeTests.swift in Sources */,
 				D37777020000000000000001 /* SettingsWindowNavigationRoutingTests.swift in Sources */,
 				D37777010000000000000001 /* SettingsWindowOpenRegressionTests.swift in Sources */,
 				D37777060000000000000001 /* SettingsWindowPresentationContractTests.swift in Sources */,

--- a/cmuxTests/SettingsWindowChromeTests.swift
+++ b/cmuxTests/SettingsWindowChromeTests.swift
@@ -29,6 +29,7 @@ extension SettingsWindowSharedStateSuites {
             #expect(window.titlebarSeparatorStyle == .none)
 
             let toolbar = try #require(window.toolbar)
+            #expect(toolbar.delegate === window)
             #expect(!toolbar.allowsUserCustomization)
             #expect(!toolbar.autosavesConfiguration)
             #expect(toolbar.displayMode == .iconOnly)

--- a/cmuxTests/SettingsWindowChromeTests.swift
+++ b/cmuxTests/SettingsWindowChromeTests.swift
@@ -17,6 +17,7 @@ extension SettingsWindowSharedStateSuites {
         @Test func factoryBuildsModernUnifiedChromeWithWorkingSidebarToggle() throws {
             let window = SettingsWindowFactory.makeSettingsWindow(onContentAppear: {})
             defer {
+                window.orderOut(nil)
                 window.contentViewController = nil
                 window.contentView = nil
                 window.close()
@@ -34,6 +35,11 @@ extension SettingsWindowSharedStateSuites {
             #expect(!toolbar.autosavesConfiguration)
             #expect(toolbar.displayMode == .iconOnly)
 
+            // AppKit recreates standard items as a toolbar attaches to its
+            // live window. Assert the post-attachment item, not just the
+            // factory-time instance.
+            window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+            window.orderBack(nil)
             let sidebarToggle = try #require(
                 toolbar.items.first { $0.itemIdentifier == .toggleSidebar }
             )

--- a/cmuxTests/SettingsWindowChromeTests.swift
+++ b/cmuxTests/SettingsWindowChromeTests.swift
@@ -1,0 +1,50 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+#if DEBUG
+extension SettingsWindowSharedStateSuites {
+    /// Window-construction coverage for the modern Settings chrome contract
+    /// (https://github.com/manaflow-ai/cmux/issues/8010).
+    @MainActor
+    @Suite(.serialized)
+    struct SettingsWindowChromeTests {
+        @Test func factoryBuildsModernUnifiedChromeWithWorkingSidebarToggle() throws {
+            let window = SettingsWindowFactory.makeSettingsWindow(onContentAppear: {})
+            defer {
+                window.contentViewController = nil
+                window.contentView = nil
+                window.close()
+            }
+
+            #expect(window.styleMask.contains(.fullSizeContentView))
+            #expect(window.toolbarStyle == .unifiedCompact)
+            #expect(window.titlebarAppearsTransparent)
+            #expect(window.titleVisibility == .hidden)
+            #expect(window.titlebarSeparatorStyle == .none)
+
+            let toolbar = try #require(window.toolbar)
+            #expect(!toolbar.allowsUserCustomization)
+            #expect(!toolbar.autosavesConfiguration)
+            #expect(toolbar.displayMode == .iconOnly)
+
+            let sidebarToggle = try #require(
+                toolbar.items.first { $0.itemIdentifier == .toggleSidebar }
+            )
+            #expect(sidebarToggle.target === window)
+            #expect(sidebarToggle.action == #selector(NSSplitViewController.toggleSidebar(_:)))
+
+            let recorder = SettingsSidebarToggleRecorder()
+            defer { recorder.stopObserving() }
+            let action = try #require(sidebarToggle.action)
+            #expect(NSApp.sendAction(action, to: sidebarToggle.target, from: sidebarToggle))
+            #expect(recorder.receivedCount == 1)
+        }
+    }
+}
+#endif

--- a/cmuxTests/SettingsWindowNavigationRoutingTests.swift
+++ b/cmuxTests/SettingsWindowNavigationRoutingTests.swift
@@ -310,7 +310,7 @@ private final class SettingsNavigationTargetRecorder: NSObject {
 /// `SettingsWindowRoot.sidebarToggleRequestName`) so the test target does not
 /// depend on package-symbol visibility, which differs across toolchains.
 @MainActor
-private final class SettingsSidebarToggleRecorder: NSObject {
+final class SettingsSidebarToggleRecorder: NSObject {
     private(set) var receivedCount = 0
 
     override init() {


### PR DESCRIPTION
## Summary

- Make the AppKit-owned `SettingsWindowFactory` establish the complete modern chrome contract at construction: full-size content, transparent hidden titlebar, no legacy separator, and unified-compact toolbar.
- Install AppKit standard `toggleSidebar` toolbar chrome explicitly instead of assuming `NSHostingController.sceneBridgingOptions` will synthesize it.
- Route the toolbar item and the existing Toggle Left Sidebar command through one shared request path into the SwiftUI `NavigationSplitView` state.

## Root cause and architectural fix

PR #7783 correctly made AppKit the single lifecycle owner, but window chrome remained implicitly delegated to the hosted SwiftUI hierarchy. `sceneBridgingOptions = [.toolbars, .title]` forwards toolbar content explicitly declared by a hosted view; this Settings root declares navigation/search state but no toolbar content, so the AppKit factory returned a bare titled window.

The factory now owns the NSWindow chrome container and its standard AppKit toolbar, while SwiftUI continues to own navigation, sidebar visibility state, search, and Settings content. The invariant is established before `makeSettingsWindow` returns, independent of ordering or scene timing, without changing the synchronous construction, reuse/teardown, geometry, activation, or navigation-delivery guarantees from #7783/#7800.

## Regression coverage

Two-commit red/green structure:

1. `12dc775c4` adds `SettingsWindowChromeTests` only. It fails against the old factory because `.fullSizeContentView`, unified/transparent titlebar properties, and the toolbar are absent.
2. `2a9733c2b` implements the factory-owned chrome invariant.

The test asserts the constructed NSWindow contract, the standard sidebar toolbar item and target/action, and end-to-end delivery through the same sidebar-toggle notification used by the menu command. Pixel-level rendering of AppKit/SwiftUI chrome is not faked in unit coverage and remains a dogfood check.

## Related issue #5071

This covers #5071s visible legacy-chrome complaint in the current architecture: the older SwiftUI `Window` path discussed there was removed by #7783, and the AppKit factory fixed here is now the only Settings construction path. This PR intentionally does not restore or modify the removed SwiftUI scene lifecycle.

## Validation

- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `git diff --check`
- No local `xcodebuild` or XCUITest run, per issue task; app-target compilation and tests are delegated to CI.
- `python3 scripts/swift_file_length_budget.py` was run. It reports nine pre-existing unrelated files over their checked-in budgets; this PR does not touch either budget TSV, and all touched Swift files remain below 500 lines.

## Localization audit

No user-facing strings were added or changed. The toolbar uses AppKits standard `NSToolbarItem.Identifier.toggleSidebar`, including its system-localized label and accessibility description; the window title continues to use the existing localized `settings.title` key. No shortcuts, menus, schema text, docs, or locale catalogs changed.

Fixes #8010

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786578932&installation_id=133855650&pr_number=8015&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8015&signature=3a451c8c647223cd2de4b5524745d10766e5818a6a446a98375277c1e41e9b7e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores modern Settings window chrome with full-size content, a transparent hidden titlebar, and an AppKit-owned unified-compact toolbar. Adds a standard sidebar toggle with routing that persists even when AppKit recreates the item; fixes #8010.

- **Bug Fixes**
  - `SettingsWindowFactory` now builds chrome at construction: `.fullSizeContentView`, transparent/hidden titlebar, no separator, and `.unifiedCompact` toolbar. Bridges only `.title`. Creates an `NSToolbar` (identifier `cmux.settings.toolbar`) with `.iconOnly` display, no customization/autosave, inserts `.toggleSidebar`, and assigns it to the window.
  - `SettingsHostWindow` owns the toolbar contract: `NSToolbarDelegate` limits allowed/default items to `.toggleSidebar`, implements `toggleSidebar:` to call `SettingsWindowPresenter.requestSidebarToggle()`, and uses `toolbarWillAddItem` to configure every inserted standard item so target/action stay correct when AppKit recreates it. Added `SettingsWindowChromeTests`.

<sup>Written for commit 1d68eef65d1068d6b9563bf81671c7165ddddfb4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8015?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Settings windows now use a unified, modern toolbar and title bar appearance.
  * Added a sidebar toggle control to the settings toolbar.
  * Sidebar visibility can be toggled directly from the toolbar.

* **Bug Fixes**
  * Improved toolbar configuration and sidebar toggle action routing for more reliable settings navigation.

* **Tests**
  * Added coverage verifying settings window appearance, toolbar configuration, and sidebar toggle behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->