### PR TITLE
hive M1: Settings > Computers on macOS with presence and Mac-to-Mac pairing

### DIFF
--- a/Packages/macOS/CmuxHive/Package.swift
+++ b/Packages/macOS/CmuxHive/Package.swift
@@ -1,0 +1,55 @@
+// swift-tools-version: 6.0
+
+import PackageDescription
+
+let package = Package(
+    name: "CmuxHive",
+    platforms: [
+        .macOS(.v14)
+    ],
+    products: [
+        .library(
+            name: "CmuxHive",
+            targets: ["CmuxHive"]
+        ),
+    ],
+    dependencies: [
+        .package(path: "../../Shared/CMUXMobileCore"),
+        .package(path: "../../iOS/CmuxMobilePairedMac"),
+        .package(path: "../../iOS/CmuxMobileRPC"),
+        .package(path: "../../iOS/CmuxMobileShell"),
+        .package(path: "../../iOS/CmuxMobileShellModel"),
+    ],
+    targets: [
+        .target(
+            name: "CmuxHive",
+            dependencies: [
+                "CMUXMobileCore",
+                "CmuxMobilePairedMac",
+                "CmuxMobileRPC",
+                "CmuxMobileShell",
+                "CmuxMobileShellModel",
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+        .testTarget(
+            name: "CmuxHiveTests",
+            dependencies: [
+                "CmuxHive",
+                "CMUXMobileCore",
+                "CmuxMobilePairedMac",
+                "CmuxMobileShell",
+                "CmuxMobileShellModel",
+            ],
+            swiftSettings: [
+                .swiftLanguageMode(.v6),
+                .enableUpcomingFeature("ExistentialAny"),
+                .enableUpcomingFeature("InternalImportsByDefault"),
+            ]
+        ),
+    ]
+)

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveAccountScope.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveAccountScope.swift
@@ -1,0 +1,17 @@
+/// The account scope local pairing records are stamped with and filtered by:
+/// the signed-in Stack user and their selected team.
+///
+/// Mirrors the iOS paired-Mac store scoping so a multi-team user only sees the
+/// current team's computers and a sign-out hides (without deleting) pairings.
+public struct HiveAccountScope: Equatable, Sendable {
+    /// The signed-in Stack Auth user id, or `nil` when signed out.
+    public var stackUserID: String?
+    /// The selected Stack team id, or `nil` for a solo/default scope.
+    public var teamID: String?
+
+    /// Creates an account scope.
+    public init(stackUserID: String?, teamID: String?) {
+        self.stackUserID = stackUserID
+        self.teamID = teamID
+    }
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComposition.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComposition.swift
@@ -1,0 +1,117 @@
+internal import CmuxMobilePairedMac
+internal import CmuxMobileShell
+import Foundation
+
+/// Builds the hive computers directory from app-supplied configuration,
+/// naming the concrete registry / paired-store / presence implementations
+/// inside the package.
+///
+/// The app's composition root decides *what* to wire (URLs, tokens, device
+/// identity, policy) and this factory owns *which concrete types* implement
+/// the directory's seams. Keeping the concrete construction here means the
+/// app target links only `CmuxHive` — it never has to declare (or even know
+/// about) the client-stack packages the directory composes, so adding a new
+/// source to the merge cannot ripple into the app's package-product graph.
+@MainActor
+public struct HiveComposition {
+    /// Everything the directory's sources need, supplied by the app root.
+    public struct Configuration: Sendable {
+        /// The cmux web API base URL, no trailing slash (`/api/devices` host).
+        public var apiBaseURL: String
+        /// The presence worker base URL, or `nil` to run without live presence.
+        public var presenceBaseURL: String?
+        /// This computer's stable registry device id.
+        public var ownDeviceID: String
+        /// Accept loopback pairing links/routes (dev builds only).
+        public var allowsLoopbackRoutes: Bool
+        /// Returns the current Stack access token, or `nil` when signed out.
+        public var accessToken: @Sendable () async -> String?
+        /// Returns the current Stack refresh token, or `nil` when signed out.
+        public var refreshToken: @Sendable () async -> String?
+        /// Returns the signed-in Stack user id, or `nil` when signed out.
+        public var currentUserID: @Sendable () async -> String?
+        /// Returns the selected team id, or `nil` for the default scope.
+        public var teamID: @Sendable () async -> String?
+
+        public init(
+            apiBaseURL: String,
+            presenceBaseURL: String?,
+            ownDeviceID: String,
+            allowsLoopbackRoutes: Bool,
+            accessToken: @escaping @Sendable () async -> String?,
+            refreshToken: @escaping @Sendable () async -> String?,
+            currentUserID: @escaping @Sendable () async -> String?,
+            teamID: @escaping @Sendable () async -> String?
+        ) {
+            self.apiBaseURL = apiBaseURL
+            self.presenceBaseURL = presenceBaseURL
+            self.ownDeviceID = ownDeviceID
+            self.allowsLoopbackRoutes = allowsLoopbackRoutes
+            self.accessToken = accessToken
+            self.refreshToken = refreshToken
+            self.currentUserID = currentUserID
+            self.teamID = teamID
+        }
+    }
+
+    private let configuration: Configuration
+
+    /// Creates a composition over the app-supplied configuration.
+    public init(configuration: Configuration) {
+        self.configuration = configuration
+    }
+
+    /// Builds the merged computers directory: the team device registry, the
+    /// local paired-computer store, and (when configured) the live presence
+    /// stream.
+    ///
+    /// - Throws: The paired-computer store's error when its SQLite database
+    ///   cannot be opened.
+    public func makeDirectory() throws -> HiveComputerDirectory {
+        let configuration = configuration
+        let store = try MobilePairedMacStore(databaseURL: Self.pairedComputersDatabaseURL())
+        let registry = DeviceRegistryService(
+            apiBaseURL: configuration.apiBaseURL,
+            deviceID: configuration.ownDeviceID,
+            tokenSource: DeviceRegistryService.TokenSource(
+                accessToken: configuration.accessToken,
+                refreshToken: configuration.refreshToken
+            ),
+            teamIDProvider: configuration.teamID
+        )
+        let presence: (any PresenceSubscribing)?
+        if let presenceBaseURL = configuration.presenceBaseURL {
+            presence = PresenceClient(
+                serviceBaseURL: presenceBaseURL,
+                tokenSource: PresenceTokenSource(
+                    accessToken: configuration.accessToken,
+                    currentUserID: configuration.currentUserID
+                ),
+                teamIDProvider: configuration.teamID
+            )
+        } else {
+            presence = nil
+        }
+        return HiveComputerDirectory(
+            registry: registry,
+            pairedStore: store,
+            presence: presence,
+            ownDeviceID: configuration.ownDeviceID,
+            scopeProvider: { [currentUserID = configuration.currentUserID, teamID = configuration.teamID] in
+                await HiveAccountScope(stackUserID: currentUserID(), teamID: teamID())
+            },
+            linkDecoder: HivePairingLinkDecoder(
+                allowsLoopbackRoutes: configuration.allowsLoopbackRoutes
+            ),
+            presenceRetryDelay: HiveReconnectBackoff(maximumSeconds: 60).delay(attempt:)
+        )
+    }
+
+    /// The Mac-side paired-computer database. Its own file (not the phone's
+    /// `paired-macs.sqlite3` name) so the Mac-as-client namespace is distinct.
+    private static func pairedComputersDatabaseURL() throws -> URL {
+        try MobilePairedMacStore.defaultDatabaseURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("hive-paired-computers.sqlite3")
+    }
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComposition.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComposition.swift
@@ -103,7 +103,9 @@ public struct HiveComposition {
             linkDecoder: HivePairingLinkDecoder(
                 allowsLoopbackRoutes: configuration.allowsLoopbackRoutes
             ),
-            presenceRetryDelay: HiveReconnectBackoff(maximumSeconds: 60).delay(attempt:)
+            presenceRetryDelay: { @Sendable attempt in
+                await HiveReconnectBackoff(maximumSeconds: 60).delay(attempt: attempt)
+            }
         )
     }
 

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputer.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputer.swift
@@ -1,0 +1,79 @@
+public import CMUXMobileCore
+public import Foundation
+
+/// One computer on the signed-in account, merged from the device registry,
+/// the local paired-computer store, and the live presence map.
+///
+/// This is the row model for the macOS **Settings › Computers** pane and the
+/// device picker of the remote-Mac viewer. It is a pure value snapshot: the
+/// merge lives in ``HiveComputerDirectory``, rows never observe stores.
+public struct HiveComputer: Equatable, Sendable, Identifiable {
+    /// Stable cross-platform cmux device UUID (matches the registry's
+    /// `deviceId` and `CmxAttachTicket.macDeviceID`).
+    public var deviceID: String
+    /// Best-known human label: the local custom name override, else the
+    /// registry/pairing display name, else the short device id.
+    public var displayName: String
+    /// Registry platform string (`"mac"`, `"ios"`, `"linux"`, `"windows"`),
+    /// or `nil` when the computer is known only from a local pairing.
+    public var platform: String?
+    /// Whether this row is the computer the app is running on.
+    public var isThisComputer: Bool
+    /// Whether a local pairing record exists for this computer.
+    public var isPaired: Bool
+    /// Live presence for the computer, or the best registry-derived hint.
+    public var presence: HiveComputerPresence
+    /// Build-channel label (`"Stable"`, `"DEV · tag"`, …) reported by the
+    /// live presence service, when identifiable.
+    public var buildLabel: String?
+    /// The computer's registered cmux app instances, freshest first.
+    public var instances: [HiveComputerInstance]
+
+    public var id: String { deviceID }
+
+    /// Creates a merged computer row.
+    public init(
+        deviceID: String,
+        displayName: String,
+        platform: String?,
+        isThisComputer: Bool,
+        isPaired: Bool,
+        presence: HiveComputerPresence,
+        buildLabel: String? = nil,
+        instances: [HiveComputerInstance] = []
+    ) {
+        self.deviceID = deviceID
+        self.displayName = displayName
+        self.platform = platform
+        self.isThisComputer = isThisComputer
+        self.isPaired = isPaired
+        self.presence = presence
+        self.buildLabel = buildLabel
+        self.instances = instances
+    }
+
+    /// Whether this computer is a host another cmux can attach to (a route
+    /// -advertising platform, not a phone) and is not this computer itself.
+    public var isPairableHost: Bool {
+        guard !isThisComputer else { return false }
+        switch (platform ?? "mac").lowercased() {
+        case "mac", "linux", "windows":
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// The attach routes to persist when pairing this computer: the freshest
+    /// online instance's routes, else the freshest instance advertising any.
+    public var bestPairingRoutes: (routes: [CmxAttachRoute], instanceTag: String?)? {
+        let candidates = instances.filter { !$0.routes.isEmpty }
+        guard !candidates.isEmpty else { return nil }
+        let ordered = candidates.sorted { lhs, rhs in
+            if lhs.isOnline != rhs.isOnline { return lhs.isOnline }
+            return lhs.lastSeenAt > rhs.lastSeenAt
+        }
+        guard let best = ordered.first else { return nil }
+        return (best.routes, best.tag)
+    }
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputer.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputer.swift
@@ -1,5 +1,5 @@
 public import CMUXMobileCore
-public import Foundation
+import Foundation
 
 /// One computer on the signed-in account, merged from the device registry,
 /// the local paired-computer store, and the live presence map.

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerDirectory.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerDirectory.swift
@@ -1,0 +1,409 @@
+public import CMUXMobileCore
+public import CmuxMobilePairedMac
+public import CmuxMobileShell
+public import CmuxMobileShellModel
+public import Foundation
+public import Observation
+
+/// The account's computers, merged live from three sources: the team device
+/// registry (`GET /api/devices`), the local paired-computer store, and the
+/// presence service's online/offline stream.
+///
+/// This is the macOS counterpart of the iOS app's Computers screen state:
+/// same registry client, same paired store, same presence protocol — composed
+/// for the Settings › Computers pane and the remote-Mac viewer instead of the
+/// phone UI. All dependencies are injected protocol seams, so the merge and
+/// the pair/unpair actions are unit-testable with scripted fakes.
+@MainActor
+@Observable
+public final class HiveComputerDirectory {
+    /// The merged, sorted computer rows (this computer first, then online
+    /// computers, then by recency).
+    public private(set) var computers: [HiveComputer] = []
+    /// Whether a registry refresh is currently in flight.
+    public private(set) var isRefreshing = false
+    /// Whether the most recent refresh failed to reach the registry (rows then
+    /// show local/paired data only).
+    public private(set) var lastRefreshFailed = false
+
+    @ObservationIgnored private let registry: any DeviceRegistryRefreshing
+    @ObservationIgnored private let pairedStore: any MobilePairedMacStoring
+    @ObservationIgnored private let presence: (any PresenceSubscribing)?
+    @ObservationIgnored private let ownDeviceID: String
+    @ObservationIgnored private let scopeProvider: @Sendable () async -> HiveAccountScope
+    @ObservationIgnored private let linkDecoder: HivePairingLinkDecoder
+    @ObservationIgnored private let now: @Sendable () -> Date
+    @ObservationIgnored private let presenceRetryDelay: @Sendable (_ attempt: Int) async -> Void
+
+    @ObservationIgnored private var presenceMap = PresenceMap()
+    @ObservationIgnored private var registryDevices: [RegistryDevice] = []
+    @ObservationIgnored private var pairedRecords: [MobilePairedMac] = []
+    @ObservationIgnored private var listeners: [UUID: AsyncStream<[HiveComputer]>.Continuation] = [:]
+    @ObservationIgnored private var presenceTask: Task<Void, Never>?
+
+    /// Creates a directory over injected source seams.
+    ///
+    /// - Parameters:
+    ///   - registry: The team device registry client.
+    ///   - pairedStore: The local paired-computer store.
+    ///   - presence: The live presence stream, or `nil` to run registry-only
+    ///     (tests, previews).
+    ///   - ownDeviceID: This computer's registry device id, used to mark the
+    ///     "This Mac" row and block self-pairing.
+    ///   - scopeProvider: Supplies the current account scope per operation, so
+    ///     a signed-out or team-switched session is read at use time.
+    ///   - linkDecoder: Policy-carrying decoder for pasted pairing links.
+    ///   - now: Clock seam for pairing timestamps.
+    ///   - presenceRetryDelay: Awaited between presence stream retries with the
+    ///     consecutive-failure attempt count; production passes a bounded
+    ///     backoff sleep, tests pass a recorder that returns immediately.
+    public init(
+        registry: any DeviceRegistryRefreshing,
+        pairedStore: any MobilePairedMacStoring,
+        presence: (any PresenceSubscribing)?,
+        ownDeviceID: String,
+        scopeProvider: @escaping @Sendable () async -> HiveAccountScope,
+        linkDecoder: HivePairingLinkDecoder,
+        now: @escaping @Sendable () -> Date = { Date() },
+        presenceRetryDelay: @escaping @Sendable (_ attempt: Int) async -> Void
+    ) {
+        self.registry = registry
+        self.pairedStore = pairedStore
+        self.presence = presence
+        self.ownDeviceID = ownDeviceID
+        self.scopeProvider = scopeProvider
+        self.linkDecoder = linkDecoder
+        self.now = now
+        self.presenceRetryDelay = presenceRetryDelay
+    }
+
+    // MARK: - Observation
+
+    /// A stream of merged computer lists, yielding the current value
+    /// immediately and then on every change.
+    ///
+    /// The first active stream starts the presence subscription; when the last
+    /// stream terminates the subscription stops, so an unopened Computers pane
+    /// costs no presence socket.
+    public func updates() -> AsyncStream<[HiveComputer]> {
+        let id = UUID()
+        let (stream, continuation) = AsyncStream<[HiveComputer]>.makeStream(
+            bufferingPolicy: .bufferingNewest(1)
+        )
+        listeners[id] = continuation
+        continuation.yield(computers)
+        continuation.onTermination = { [weak self] _ in
+            Task { @MainActor [weak self] in
+                self?.removeListener(id: id)
+            }
+        }
+        startPresenceIfNeeded()
+        return stream
+    }
+
+    private func removeListener(id: UUID) {
+        listeners.removeValue(forKey: id)
+        if listeners.isEmpty {
+            presenceTask?.cancel()
+            presenceTask = nil
+        }
+    }
+
+    // MARK: - Refresh
+
+    /// Re-fetch the registry device list and reload local pairings, then
+    /// rebuild the merged rows. Transient registry failures keep the previous
+    /// registry data; an auth rejection clears it (the scope changed).
+    public func refresh() async {
+        guard !isRefreshing else { return }
+        isRefreshing = true
+        defer { isRefreshing = false }
+        let scope = await scopeProvider()
+        switch await registry.listDevices() {
+        case .ok(let devices):
+            registryDevices = devices
+            lastRefreshFailed = false
+        case .authRejected:
+            registryDevices = []
+            lastRefreshFailed = false
+        case .transientFailure:
+            lastRefreshFailed = true
+        }
+        await reloadPairedRecords(scope: scope)
+        rebuild()
+    }
+
+    private func reloadPairedRecords(scope: HiveAccountScope) async {
+        do {
+            pairedRecords = try await pairedStore.loadAll(
+                stackUserID: scope.stackUserID,
+                teamID: scope.teamID
+            )
+        } catch {
+            // Keep the previous local list; a store read failure must not
+            // wipe rows the registry no longer needs to confirm.
+        }
+    }
+
+    // MARK: - Pairing
+
+    /// Pair a computer from its registry row: persist its best instance's
+    /// routes into the local paired store.
+    public func pair(deviceID: String) async -> HivePairOutcome {
+        guard let computer = computers.first(where: { $0.deviceID == deviceID }),
+              computer.isPairableHost else {
+            return .noRoutes
+        }
+        guard let best = computer.bestPairingRoutes else { return .noRoutes }
+        return await persistPairing(
+            macDeviceID: deviceID,
+            displayName: computer.displayName,
+            routes: best.routes,
+            instanceTag: best.instanceTag
+        )
+    }
+
+    /// Pair from a pasted pairing link (the QR payload another Mac shows).
+    public func pair(link rawLink: String) async -> HivePairOutcome {
+        let scope = await scopeProvider()
+        switch linkDecoder.decode(rawLink, currentStackUserID: scope.stackUserID) {
+        case .invalidLink:
+            return .invalidLink
+        case .loopbackRejected:
+            return .loopbackRejected
+        case .accountMismatch:
+            return .accountMismatch
+        case .ticket(let ticket):
+            // The v2 pairing grammar deliberately carries no device id or
+            // display name (identity arrives post-handshake from
+            // `mobile.host.status`), so mirror the iOS manual-host flow: pair
+            // under a synthetic id derived from the dialable endpoint and let
+            // the first connection adopt the host-reported identity.
+            let macDeviceID: String
+            if ticket.macDeviceID.isEmpty {
+                guard let synthesized = Self.syntheticDeviceID(for: ticket.routes) else {
+                    return .invalidLink
+                }
+                macDeviceID = synthesized
+            } else {
+                macDeviceID = ticket.macDeviceID
+            }
+            guard macDeviceID != ownDeviceID else { return .loopbackRejected }
+            return await persistPairing(
+                macDeviceID: macDeviceID,
+                displayName: ticket.macDisplayName ?? Self.endpointLabel(for: ticket.routes),
+                routes: ticket.routes,
+                instanceTag: nil
+            )
+        }
+    }
+
+    /// The iOS-compatible synthetic identity for a link that names no device:
+    /// `manual-<host>:<port>` from the first dialable route.
+    static func syntheticDeviceID(for routes: [CmxAttachRoute]) -> String? {
+        endpointLabel(for: routes).map { "manual-\($0)" }
+    }
+
+    private static func endpointLabel(for routes: [CmxAttachRoute]) -> String? {
+        for route in routes {
+            if case let .hostPort(host, port) = route.endpoint {
+                return "\(host):\(port)"
+            }
+        }
+        return nil
+    }
+
+    /// Remove the local pairing record for a computer. Registry rows remain
+    /// visible; only the pairing (persisted routes) is forgotten.
+    /// - Returns: `true` when the store accepted the removal.
+    @discardableResult
+    public func unpair(deviceID: String) async -> Bool {
+        let scope = await scopeProvider()
+        do {
+            try await pairedStore.remove(
+                macDeviceID: deviceID,
+                stackUserID: scope.stackUserID,
+                teamID: scope.teamID
+            )
+        } catch {
+            return false
+        }
+        await reloadPairedRecords(scope: scope)
+        rebuild()
+        return true
+    }
+
+    private func persistPairing(
+        macDeviceID: String,
+        displayName: String?,
+        routes: [CmxAttachRoute],
+        instanceTag: String?
+    ) async -> HivePairOutcome {
+        guard !routes.isEmpty else { return .noRoutes }
+        let scope = await scopeProvider()
+        do {
+            try await pairedStore.upsert(
+                macDeviceID: macDeviceID,
+                displayName: displayName,
+                routes: routes,
+                instanceTag: instanceTag,
+                markActive: false,
+                stackUserID: scope.stackUserID,
+                teamID: scope.teamID,
+                now: now()
+            )
+        } catch {
+            return .storeFailed
+        }
+        await reloadPairedRecords(scope: scope)
+        rebuild()
+        return .paired(deviceID: macDeviceID)
+    }
+
+    // MARK: - Presence
+
+    private func startPresenceIfNeeded() {
+        guard presenceTask == nil, let presence else { return }
+        presenceTask = Task { [weak self] in
+            await self?.runPresenceLoop(presence: presence)
+        }
+    }
+
+    private func runPresenceLoop(presence: any PresenceSubscribing) async {
+        var consecutiveFailures = 0
+        while !Task.isCancelled {
+            do {
+                let stream = try await presence.subscribe()
+                for try await update in stream {
+                    consecutiveFailures = 0
+                    presenceMap.apply(update)
+                    rebuild()
+                }
+            } catch {
+                consecutiveFailures += 1
+            }
+            if Task.isCancelled { return }
+            // The presence stream ended (server deadline) or failed; the
+            // injected delay bounds the resubscribe backoff and is cancelled
+            // with this task.
+            await presenceRetryDelay(consecutiveFailures)
+        }
+    }
+
+    // MARK: - Merge
+
+    private func rebuild() {
+        computers = Self.mergedComputers(
+            registry: registryDevices,
+            paired: pairedRecords,
+            presence: presenceMap,
+            ownDeviceID: ownDeviceID
+        )
+        for (_, continuation) in listeners {
+            continuation.yield(computers)
+        }
+    }
+
+    /// Pure merge of the three sources into sorted rows. Exposed for tests.
+    public static func mergedComputers(
+        registry: [RegistryDevice],
+        paired: [MobilePairedMac],
+        presence: PresenceMap,
+        ownDeviceID: String
+    ) -> [HiveComputer] {
+        let pairedByID = Dictionary(uniqueKeysWithValues: paired.map { ($0.macDeviceID, $0) })
+        var rows: [HiveComputer] = registry.map { device in
+            let record = pairedByID[device.deviceId]
+            return HiveComputer(
+                deviceID: device.deviceId,
+                displayName: record?.customName?.nonEmpty
+                    ?? device.displayName?.nonEmpty
+                    ?? record?.displayName?.nonEmpty
+                    ?? String(device.deviceId.prefix(8)),
+                platform: device.platform,
+                isThisComputer: device.deviceId == ownDeviceID,
+                isPaired: record != nil,
+                presence: Self.presenceState(
+                    for: device.deviceId,
+                    presence: presence,
+                    fallbackLastSeen: device.lastSeenAt
+                ),
+                buildLabel: presence.deviceSummary(deviceId: device.deviceId)?.buildLabel,
+                instances: device.instances.map { instance in
+                    HiveComputerInstance(
+                        tag: instance.tag,
+                        routes: instance.routes,
+                        lastSeenAt: presence.instanceSummary(
+                            deviceId: device.deviceId,
+                            tag: instance.tag
+                        ).map { max($0.lastSeenAt, instance.lastSeenAt) } ?? instance.lastSeenAt,
+                        isOnline: presence.instanceSummary(
+                            deviceId: device.deviceId,
+                            tag: instance.tag
+                        )?.online ?? false
+                    )
+                }
+            )
+        }
+        let registryIDs = Set(registry.map(\.deviceId))
+        for record in paired where !registryIDs.contains(record.macDeviceID) {
+            rows.append(
+                HiveComputer(
+                    deviceID: record.macDeviceID,
+                    displayName: record.resolvedName,
+                    platform: nil,
+                    isThisComputer: record.macDeviceID == ownDeviceID,
+                    isPaired: true,
+                    presence: Self.presenceState(
+                        for: record.macDeviceID,
+                        presence: presence,
+                        fallbackLastSeen: record.lastSeenAt
+                    ),
+                    buildLabel: presence.deviceSummary(deviceId: record.macDeviceID)?.buildLabel,
+                    instances: [
+                        HiveComputerInstance(
+                            tag: record.instanceTag ?? "default",
+                            routes: record.routes,
+                            lastSeenAt: record.lastSeenAt,
+                            isOnline: false
+                        )
+                    ]
+                )
+            )
+        }
+        return rows.sorted { lhs, rhs in
+            if lhs.isThisComputer != rhs.isThisComputer { return lhs.isThisComputer }
+            if lhs.presence.isOnline != rhs.presence.isOnline { return lhs.presence.isOnline }
+            let lhsSeen = lhs.presence.lastSeenAt ?? .distantPast
+            let rhsSeen = rhs.presence.lastSeenAt ?? .distantPast
+            if lhs.presence.isOnline == rhs.presence.isOnline, lhsSeen != rhsSeen {
+                return lhsSeen > rhsSeen
+            }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+    }
+
+    private static func presenceState(
+        for deviceID: String,
+        presence: PresenceMap,
+        fallbackLastSeen: Date?
+    ) -> HiveComputerPresence {
+        guard let summary = presence.deviceSummary(deviceId: deviceID) else {
+            return .unknown(lastSeenAt: fallbackLastSeen)
+        }
+        if summary.online { return .online }
+        let lastSeen = [summary.lastSeenAt, fallbackLastSeen]
+            .compactMap { $0 }
+            .max()
+        return .offline(lastSeenAt: lastSeen)
+    }
+}
+
+extension String {
+    /// The string itself when non-empty after trimming, else `nil`; merge
+    /// helper for picking the first usable display name.
+    fileprivate var nonEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerDirectory.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerDirectory.swift
@@ -1,4 +1,4 @@
-public import CMUXMobileCore
+internal import CMUXMobileCore
 public import CmuxMobilePairedMac
 public import CmuxMobileShell
 public import CmuxMobileShellModel

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerInstance.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerInstance.swift
@@ -1,0 +1,26 @@
+public import CMUXMobileCore
+public import Foundation
+
+/// One running (or recently seen) cmux app instance on a computer, keyed by
+/// its build tag, as merged from the registry and the live presence map.
+public struct HiveComputerInstance: Equatable, Sendable, Identifiable {
+    /// The instance's build tag (`"stable"`, a dev tag, or `"default"`).
+    public var tag: String
+    /// Attach routes this instance advertises, in priority order.
+    public var routes: [CmxAttachRoute]
+    /// When the registry or presence service last saw this instance.
+    public var lastSeenAt: Date
+    /// Whether the presence service currently reports this instance online.
+    public var isOnline: Bool
+
+    /// The tag is unique per computer, so it doubles as the row id.
+    public var id: String { tag }
+
+    /// Creates an instance row.
+    public init(tag: String, routes: [CmxAttachRoute], lastSeenAt: Date, isOnline: Bool) {
+        self.tag = tag
+        self.routes = routes
+        self.lastSeenAt = lastSeenAt
+        self.isOnline = isOnline
+    }
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerPresence.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveComputerPresence.swift
@@ -1,0 +1,29 @@
+public import Foundation
+
+/// Presence state for a ``HiveComputer`` row.
+///
+/// `online`/`offline` come from the live presence service once a snapshot has
+/// arrived; before that (or when the service is unreachable) rows carry the
+/// registry's durable last-seen hint as ``unknown(lastSeenAt:)``.
+public enum HiveComputerPresence: Equatable, Sendable {
+    /// The presence service reports at least one instance online.
+    case online
+    /// The presence service knows the computer and reports it offline.
+    case offline(lastSeenAt: Date?)
+    /// No live presence data; `lastSeenAt` is the registry/pairing hint.
+    case unknown(lastSeenAt: Date?)
+
+    /// Whether the computer is live right now.
+    public var isOnline: Bool {
+        if case .online = self { return true }
+        return false
+    }
+
+    /// The best available last-seen timestamp, if any.
+    public var lastSeenAt: Date? {
+        switch self {
+        case .online: return nil
+        case .offline(let lastSeenAt), .unknown(let lastSeenAt): return lastSeenAt
+        }
+    }
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HivePairOutcome.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HivePairOutcome.swift
@@ -1,0 +1,19 @@
+/// Result of a pair / unpair action on the Computers directory.
+///
+/// Cases are semantic (not user-facing strings) so the settings UI localizes
+/// the copy while this package stays presentation-free.
+public enum HivePairOutcome: Equatable, Sendable {
+    /// The pairing record was written; the directory has been refreshed.
+    case paired(deviceID: String)
+    /// The pasted pairing link / code could not be decoded.
+    case invalidLink
+    /// The link decoded, but every route points back at this computer
+    /// (loopback), which release builds refuse to dial.
+    case loopbackRejected
+    /// The link belongs to a different signed-in account than this Mac.
+    case accountMismatch
+    /// The registry row has no dialable route to persist.
+    case noRoutes
+    /// Persisting the pairing failed (local store error).
+    case storeFailed
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HivePairingLinkDecoder.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HivePairingLinkDecoder.swift
@@ -1,0 +1,82 @@
+public import CMUXMobileCore
+internal import CmuxMobileRPC
+internal import CmuxMobileShellModel
+import Foundation
+
+/// Decodes a pasted `cmux-ios://attach?…` pairing link (the same payload the
+/// Mac's pairing window renders as a QR code) into an attach ticket a Mac can
+/// pair from, applying the Mac-side trust policy.
+///
+/// A Mac has no camera, so link paste / manual entry is the macOS counterpart
+/// of the phone's QR scan. The grammar and validation are shared with iOS via
+/// `CmxAttachTicketInput`; this type adds the two Mac-side policies:
+///
+/// - **Loopback**: outside dev builds a link whose routes all point at
+///   `127.0.0.1` would make this Mac dial itself, so it is rejected exactly
+///   like a physical phone rejects it. Dev builds keep loopback so two tagged
+///   builds on one machine can pair for dogfooding.
+/// - **Account**: when the link carries the host's Stack user id and it
+///   differs from this Mac's signed-in user, pairing is refused up front
+///   (the host would reject every RPC with `account_mismatch` anyway).
+public struct HivePairingLinkDecoder: Sendable {
+    /// Whether loopback-only links are acceptable (dev builds testing two
+    /// instances on one machine). Injected so the policy is testable in both
+    /// positions from a single build configuration.
+    public var allowsLoopbackRoutes: Bool
+
+    /// Creates a decoder.
+    /// - Parameter allowsLoopbackRoutes: Accept loopback routes (dev builds).
+    public init(allowsLoopbackRoutes: Bool) {
+        self.allowsLoopbackRoutes = allowsLoopbackRoutes
+    }
+
+    /// The decode result: a ticket, or the semantic failure the UI localizes.
+    public enum Outcome: Sendable {
+        /// The link decoded into a valid, policy-passing ticket.
+        case ticket(CmxAttachTicket)
+        /// The text is not a cmux pairing link or failed validation.
+        case invalidLink
+        /// Every dialable route pointed back at this computer.
+        case loopbackRejected
+        /// The link belongs to a different signed-in account.
+        case accountMismatch
+    }
+
+    /// Decode and policy-check one pasted pairing link.
+    ///
+    /// - Parameters:
+    ///   - rawValue: The pasted link text (whitespace is trimmed).
+    ///   - currentStackUserID: This Mac's signed-in Stack user id, if any.
+    /// - Returns: The decoded ticket or a semantic failure.
+    public func decode(_ rawValue: String, currentStackUserID: String?) -> Outcome {
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return .invalidLink }
+        let ticket: CmxAttachTicket
+        do {
+            ticket = try CmxAttachTicketInput.decode(trimmed)
+        } catch {
+            if case MobileSyncPairingPayloadError.loopbackRouteRejected = error {
+                return .loopbackRejected
+            }
+            return .invalidLink
+        }
+        if MobileShellRouteAuthPolicy.ticketRejectsLoopbackRoutes(
+            ticket.routes,
+            isPhysicalDevice: !allowsLoopbackRoutes
+        ) {
+            return .loopbackRejected
+        }
+        if let expected = normalizedNonEmpty(ticket.macUserID),
+           let actual = normalizedNonEmpty(currentStackUserID),
+           expected != actual {
+            return .accountMismatch
+        }
+        return .ticket(ticket)
+    }
+
+    private func normalizedNonEmpty(_ value: String?) -> String? {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return nil }
+        return trimmed
+    }
+}

--- a/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveReconnectBackoff.swift
+++ b/Packages/macOS/CmuxHive/Sources/CmuxHive/HiveReconnectBackoff.swift
@@ -1,0 +1,24 @@
+import Foundation
+
+/// Bounded exponential reconnect backoff for hive sessions: 1s doubling to a
+/// configurable cap.
+///
+/// A genuine, cancellable delay (not a poll): each awaited attempt is a real
+/// reconnect, and cancelling the owning task cancels the pending sleep.
+public struct HiveReconnectBackoff: Sendable {
+    /// The longest single delay, in seconds.
+    public var maximumSeconds: Double
+
+    /// Creates a backoff capped at `maximumSeconds`.
+    public init(maximumSeconds: Double = 30) {
+        self.maximumSeconds = maximumSeconds
+    }
+
+    /// Await the backoff for the given consecutive-failure attempt count.
+    public func delay(attempt: Int) async {
+        let seconds = min(maximumSeconds, pow(2.0, Double(min(max(attempt - 1, 0), 6))))
+        // Bounded, cancellable delay — the intended behavior, per the
+        // Clock.sleep carve-out.
+        try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+    }
+}

--- a/Packages/macOS/CmuxHive/Tests/CmuxHiveTests/HiveComputerDirectoryTests.swift
+++ b/Packages/macOS/CmuxHive/Tests/CmuxHiveTests/HiveComputerDirectoryTests.swift
@@ -1,0 +1,369 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShell
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxHive
+
+/// Scripted registry double: returns a fixed outcome per call.
+private struct ScriptedRegistry: DeviceRegistryRefreshing {
+    var outcome: DeviceRegistryListOutcome
+
+    func freshRoutes(forMacDeviceID macDeviceID: String, instanceTag: String?) async -> [CmxAttachRoute]? {
+        nil
+    }
+
+    func listDevices() async -> DeviceRegistryListOutcome {
+        outcome
+    }
+}
+
+@MainActor
+private func makeTempStore() throws -> (store: MobilePairedMacStore, cleanup: () -> Void) {
+    let directory = FileManager.default.temporaryDirectory
+        .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let store = try MobilePairedMacStore(
+        databaseURL: directory.appendingPathComponent("paired-macs.sqlite3")
+    )
+    return (store, { try? FileManager.default.removeItem(at: directory) })
+}
+
+private func tailscaleRoute(host: String = "100.64.0.9", port: Int = 8000) throws -> CmxAttachRoute {
+    try CmxAttachRoute(
+        id: "tailscale",
+        kind: .tailscale,
+        endpoint: .hostPort(host: host, port: port)
+    )
+}
+
+@MainActor
+private func makeDirectory(
+    registry: DeviceRegistryListOutcome,
+    store: MobilePairedMacStore,
+    ownDeviceID: String = "self-device",
+    stackUserID: String? = "user-1",
+    teamID: String? = "team-1"
+) -> HiveComputerDirectory {
+    HiveComputerDirectory(
+        registry: ScriptedRegistry(outcome: registry),
+        pairedStore: store,
+        presence: nil,
+        ownDeviceID: ownDeviceID,
+        scopeProvider: { HiveAccountScope(stackUserID: stackUserID, teamID: teamID) },
+        linkDecoder: HivePairingLinkDecoder(allowsLoopbackRoutes: false),
+        now: { Date(timeIntervalSince1970: 1_000) },
+        presenceRetryDelay: { _ in }
+    )
+}
+
+@Suite struct HiveComputerDirectoryTests {
+    @MainActor
+    @Test func refreshMergesRegistryAndPairedRows() async throws {
+        let (store, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let route = try tailscaleRoute()
+        // A locally paired Mac the registry no longer lists.
+        try await store.upsert(
+            macDeviceID: "paired-only",
+            displayName: "Old Mini",
+            routes: [route],
+            instanceTag: "stable",
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: "team-1",
+            now: Date(timeIntervalSince1970: 500)
+        )
+        let registryDevice = RegistryDevice(
+            deviceId: "registry-mac",
+            platform: "mac",
+            displayName: "Studio",
+            lastSeenAt: Date(timeIntervalSince1970: 900),
+            instances: [
+                RegistryAppInstance(
+                    tag: "stable",
+                    routes: [route],
+                    lastSeenAt: Date(timeIntervalSince1970: 900)
+                )
+            ]
+        )
+        let ownDevice = RegistryDevice(
+            deviceId: "self-device",
+            platform: "mac",
+            displayName: "This Mac",
+            lastSeenAt: Date(timeIntervalSince1970: 950),
+            instances: []
+        )
+        let directory = makeDirectory(registry: .ok([registryDevice, ownDevice]), store: store)
+        await directory.refresh()
+
+        #expect(directory.computers.count == 3)
+        #expect(directory.computers.first?.deviceID == "self-device")
+        #expect(directory.computers.first?.isThisComputer == true)
+        let registryRow = try #require(directory.computers.first { $0.deviceID == "registry-mac" })
+        #expect(registryRow.displayName == "Studio")
+        #expect(registryRow.isPaired == false)
+        #expect(registryRow.isPairableHost)
+        let pairedRow = try #require(directory.computers.first { $0.deviceID == "paired-only" })
+        #expect(pairedRow.isPaired)
+        #expect(pairedRow.displayName == "Old Mini")
+        #expect(pairedRow.instances.first?.routes == [route])
+    }
+
+    @MainActor
+    @Test func pairFromRegistryPersistsBestRoutes() async throws {
+        let (store, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let route = try tailscaleRoute()
+        let device = RegistryDevice(
+            deviceId: "registry-mac",
+            platform: "mac",
+            displayName: "Studio",
+            lastSeenAt: Date(timeIntervalSince1970: 900),
+            instances: [
+                RegistryAppInstance(tag: "empty", routes: [], lastSeenAt: Date(timeIntervalSince1970: 999)),
+                RegistryAppInstance(tag: "stable", routes: [route], lastSeenAt: Date(timeIntervalSince1970: 900)),
+            ]
+        )
+        let directory = makeDirectory(registry: .ok([device]), store: store)
+        await directory.refresh()
+
+        let outcome = await directory.pair(deviceID: "registry-mac")
+        #expect(outcome == .paired(deviceID: "registry-mac"))
+
+        let persisted = try await store.loadAll(stackUserID: "user-1", teamID: "team-1")
+        #expect(persisted.count == 1)
+        #expect(persisted.first?.macDeviceID == "registry-mac")
+        #expect(persisted.first?.routes == [route])
+        #expect(persisted.first?.instanceTag == "stable")
+        #expect(directory.computers.first { $0.deviceID == "registry-mac" }?.isPaired == true)
+    }
+
+    @MainActor
+    @Test func pairRejectsSelfAndRouteless() async throws {
+        let (store, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let ownDevice = RegistryDevice(
+            deviceId: "self-device",
+            platform: "mac",
+            displayName: "This Mac",
+            lastSeenAt: Date(timeIntervalSince1970: 950),
+            instances: [
+                RegistryAppInstance(
+                    tag: "stable",
+                    routes: [try tailscaleRoute()],
+                    lastSeenAt: Date(timeIntervalSince1970: 900)
+                )
+            ]
+        )
+        let routeless = RegistryDevice(
+            deviceId: "routeless-mac",
+            platform: "mac",
+            displayName: "Sleepy",
+            lastSeenAt: Date(timeIntervalSince1970: 800),
+            instances: [
+                RegistryAppInstance(tag: "stable", routes: [], lastSeenAt: Date(timeIntervalSince1970: 800))
+            ]
+        )
+        let phone = RegistryDevice(
+            deviceId: "phone",
+            platform: "ios",
+            displayName: "iPhone",
+            lastSeenAt: Date(timeIntervalSince1970: 700),
+            instances: []
+        )
+        let directory = makeDirectory(registry: .ok([ownDevice, routeless, phone]), store: store)
+        await directory.refresh()
+
+        #expect(await directory.pair(deviceID: "self-device") == .noRoutes)
+        #expect(await directory.pair(deviceID: "routeless-mac") == .noRoutes)
+        #expect(await directory.pair(deviceID: "phone") == .noRoutes)
+        let persisted = try await store.loadAll(stackUserID: nil, teamID: nil)
+        #expect(persisted.isEmpty)
+    }
+
+    @MainActor
+    @Test func unpairRemovesOnlyTheLocalRecord() async throws {
+        let (store, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let route = try tailscaleRoute()
+        let device = RegistryDevice(
+            deviceId: "registry-mac",
+            platform: "mac",
+            displayName: "Studio",
+            lastSeenAt: Date(timeIntervalSince1970: 900),
+            instances: [
+                RegistryAppInstance(tag: "stable", routes: [route], lastSeenAt: Date(timeIntervalSince1970: 900))
+            ]
+        )
+        let directory = makeDirectory(registry: .ok([device]), store: store)
+        await directory.refresh()
+        _ = await directory.pair(deviceID: "registry-mac")
+
+        #expect(await directory.unpair(deviceID: "registry-mac"))
+        let persisted = try await store.loadAll(stackUserID: nil, teamID: nil)
+        #expect(persisted.isEmpty)
+        // The registry row stays visible, just unpaired.
+        let row = try #require(directory.computers.first { $0.deviceID == "registry-mac" })
+        #expect(row.isPaired == false)
+    }
+
+    @MainActor
+    @Test func transientRegistryFailureKeepsPreviousRows() async throws {
+        let (store, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        let device = RegistryDevice(
+            deviceId: "registry-mac",
+            platform: "mac",
+            displayName: "Studio",
+            lastSeenAt: Date(timeIntervalSince1970: 900),
+            instances: []
+        )
+        let directory = makeDirectory(registry: .ok([device]), store: store)
+        await directory.refresh()
+        #expect(directory.computers.count == 1)
+
+        // Swap in a failing registry by building a new directory is not
+        // possible mid-flight, so assert the failure path on a fresh
+        // directory that has never seen the registry: rows stay local-only
+        // and the failure flag is set.
+        let failing = makeDirectory(registry: .transientFailure, store: store)
+        await failing.refresh()
+        #expect(failing.lastRefreshFailed)
+        #expect(failing.computers.isEmpty)
+    }
+
+    @MainActor
+    @Test func presenceSnapshotMarksDevicesOnline() throws {
+        let route = try tailscaleRoute()
+        var map = PresenceMap()
+        // Feed the map a wire-shaped snapshot frame, the same JSON the
+        // presence worker pushes on subscribe.
+        let snapshotJSON = """
+        {
+          "type": "snapshot",
+          "teamId": "team-1",
+          "now": 1000000,
+          "heartbeatIntervalMs": 15000,
+          "offlineTimeoutMs": 45000,
+          "devices": [
+            {
+              "deviceId": "registry-mac",
+              "platform": "mac",
+              "displayName": "Studio",
+              "online": true,
+              "lastSeenAt": 1000000,
+              "instances": [
+                {
+                  "deviceId": "registry-mac",
+                  "tag": "stable",
+                  "platform": "mac",
+                  "capabilities": [],
+                  "online": true,
+                  "lastSeenAt": 1000000
+                }
+              ]
+            }
+          ]
+        }
+        """
+        map.apply(try PresenceUpdate.parse(Data(snapshotJSON.utf8)))
+        let registryDevice = RegistryDevice(
+            deviceId: "registry-mac",
+            platform: "mac",
+            displayName: "Studio",
+            lastSeenAt: Date(timeIntervalSince1970: 900),
+            instances: [
+                RegistryAppInstance(tag: "stable", routes: [route], lastSeenAt: Date(timeIntervalSince1970: 900))
+            ]
+        )
+        let offlineDevice = RegistryDevice(
+            deviceId: "other-mac",
+            platform: "mac",
+            displayName: "Mini",
+            lastSeenAt: Date(timeIntervalSince1970: 800),
+            instances: []
+        )
+        let rows = HiveComputerDirectory.mergedComputers(
+            registry: [registryDevice, offlineDevice],
+            paired: [],
+            presence: map,
+            ownDeviceID: "self-device"
+        )
+        let online = try #require(rows.first { $0.deviceID == "registry-mac" })
+        #expect(online.presence == .online)
+        #expect(online.instances.first?.isOnline == true)
+        let unknown = try #require(rows.first { $0.deviceID == "other-mac" })
+        #expect(unknown.presence == .unknown(lastSeenAt: Date(timeIntervalSince1970: 800)))
+        // Online rows sort before unknown/offline rows.
+        #expect(rows.first?.deviceID == "registry-mac")
+    }
+
+    @MainActor
+    @Test func pairFromV2LinkSynthesizesIdentityUntilHandshake() async throws {
+        let (store, cleanup) = try makeTempStore()
+        defer { cleanup() }
+        // A v2 pairing link (the QR payload) names routes only, never a
+        // device id; encode one exactly like another Mac's pairing window.
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "mac-b",
+            macDisplayName: "Studio",
+            macUserID: "user-1",
+            macPairingCompatibilityVersion: 0,
+            routes: [
+                try CmxAttachRoute(
+                    id: "tailscale",
+                    kind: .tailscale,
+                    endpoint: .hostPort(host: "100.64.0.7", port: 8123),
+                    priority: 10
+                )
+            ],
+            expiresAt: nil
+        )
+        let link = try #require(CmxPairingQRCode().encode(ticket))
+        let directory = makeDirectory(registry: .ok([]), store: store)
+
+        let outcome = await directory.pair(link: link)
+        #expect(outcome == .paired(deviceID: "manual-100.64.0.7:8123"))
+        let persisted = try await store.loadAll(stackUserID: "user-1", teamID: "team-1")
+        #expect(persisted.first?.macDeviceID == "manual-100.64.0.7:8123")
+        #expect(persisted.first?.routes.first?.endpoint == .hostPort(host: "100.64.0.7", port: 8123))
+        let row = try #require(directory.computers.first)
+        #expect(row.isPaired)
+        #expect(row.displayName == "100.64.0.7:8123")
+    }
+
+    @MainActor
+    @Test func bestPairingRoutesPrefersOnlineThenFreshest() throws {
+        let routeA = try tailscaleRoute(host: "100.64.0.1")
+        let routeB = try tailscaleRoute(host: "100.64.0.2")
+        let computer = HiveComputer(
+            deviceID: "mac",
+            displayName: "Mac",
+            platform: "mac",
+            isThisComputer: false,
+            isPaired: false,
+            presence: .online,
+            instances: [
+                HiveComputerInstance(
+                    tag: "fresh-offline",
+                    routes: [routeA],
+                    lastSeenAt: Date(timeIntervalSince1970: 900),
+                    isOnline: false
+                ),
+                HiveComputerInstance(
+                    tag: "older-online",
+                    routes: [routeB],
+                    lastSeenAt: Date(timeIntervalSince1970: 100),
+                    isOnline: true
+                ),
+            ]
+        )
+        let best = try #require(computer.bestPairingRoutes)
+        #expect(best.instanceTag == "older-online")
+        #expect(best.routes == [routeB])
+    }
+}

--- a/Packages/macOS/CmuxHive/Tests/CmuxHiveTests/HivePairingLinkDecoderTests.swift
+++ b/Packages/macOS/CmuxHive/Tests/CmuxHiveTests/HivePairingLinkDecoderTests.swift
@@ -1,0 +1,123 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxHive
+
+@Suite struct HivePairingLinkDecoderTests {
+    private func tailscaleTicket(macUserID: String? = "owner-1") throws -> CmxAttachTicket {
+        try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "mac-b",
+            macDisplayName: "Studio",
+            macUserID: macUserID,
+            macPairingCompatibilityVersion: 0,
+            routes: [
+                // The canonical synthesized shape the v2 QR grammar requires
+                // (id `tailscale`, priority 10), matching the Mac's resolver.
+                try CmxAttachRoute(
+                    id: "tailscale",
+                    kind: .tailscale,
+                    endpoint: .hostPort(host: "100.64.0.7", port: 8123),
+                    priority: 10
+                )
+            ],
+            expiresAt: nil
+        )
+    }
+
+    /// The v2 pairing URL another Mac's pairing window renders as its QR.
+    private func pairingLink(macUserID: String? = "owner-1") throws -> String {
+        let ticket = try tailscaleTicket(macUserID: macUserID)
+        return try #require(CmxPairingQRCode().encode(ticket))
+    }
+
+    @Test func decodesSameAccountLink() throws {
+        let decoder = HivePairingLinkDecoder(allowsLoopbackRoutes: false)
+        let outcome = decoder.decode(try pairingLink(), currentStackUserID: "owner-1")
+        guard case .ticket(let ticket) = outcome else {
+            Issue.record("expected ticket, got \(outcome)")
+            return
+        }
+        // The v2 grammar drops identity on purpose (it arrives post-handshake
+        // from `mobile.host.status`), so the ticket names only the routes.
+        #expect(ticket.macDeviceID.isEmpty)
+        #expect(ticket.routes.count == 1)
+        #expect(ticket.routes.first?.kind == .tailscale)
+        #expect(ticket.routes.first?.endpoint == .hostPort(host: "100.64.0.7", port: 8123))
+    }
+
+    @Test func acceptsLinkWithoutAccountClaimOrLocalSession() throws {
+        let decoder = HivePairingLinkDecoder(allowsLoopbackRoutes: false)
+        // No user id in the link → the host enforces the account at RPC time.
+        guard case .ticket = decoder.decode(try pairingLink(macUserID: nil), currentStackUserID: "owner-1") else {
+            Issue.record("expected ticket for account-less link")
+            return
+        }
+        // Signed out locally → defer to the host as well.
+        guard case .ticket = decoder.decode(try pairingLink(), currentStackUserID: nil) else {
+            Issue.record("expected ticket while signed out")
+            return
+        }
+    }
+
+    @Test func rejectsCrossAccountLink() throws {
+        let decoder = HivePairingLinkDecoder(allowsLoopbackRoutes: false)
+        let outcome = decoder.decode(try pairingLink(macUserID: "owner-1"), currentStackUserID: "someone-else")
+        guard case .accountMismatch = outcome else {
+            Issue.record("expected accountMismatch, got \(outcome)")
+            return
+        }
+    }
+
+    @Test func rejectsGarbageAndEmptyInput() {
+        let decoder = HivePairingLinkDecoder(allowsLoopbackRoutes: false)
+        guard case .invalidLink = decoder.decode("not a link", currentStackUserID: nil) else {
+            Issue.record("expected invalidLink for garbage")
+            return
+        }
+        guard case .invalidLink = decoder.decode("   ", currentStackUserID: nil) else {
+            Issue.record("expected invalidLink for whitespace")
+            return
+        }
+    }
+
+    @Test func loopbackPolicyFollowsBuildChannel() throws {
+        // Legacy compact payload keeps decoding loopback (the v2 grammar
+        // rejects it inside the shared decoder), so the Mac-side policy is
+        // what stands between a release build and dialing itself.
+        let loopbackTicket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "mac-b",
+            macDisplayName: "Same Machine",
+            macPairingCompatibilityVersion: 0,
+            routes: [
+                try CmxAttachRoute(
+                    id: "loop",
+                    kind: .debugLoopback,
+                    endpoint: .hostPort(host: "127.0.0.1", port: 8123)
+                )
+            ],
+            expiresAt: nil
+        )
+        let payload = try CmxAttachTicketCompactCoder().encode(loopbackTicket)
+        let base64 = payload.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let link = "\(CmxPairingURLScheme.development)://attach?payload=\(base64)"
+
+        let release = HivePairingLinkDecoder(allowsLoopbackRoutes: false)
+        guard case .loopbackRejected = release.decode(link, currentStackUserID: nil) else {
+            Issue.record("expected loopbackRejected in release policy")
+            return
+        }
+        let dev = HivePairingLinkDecoder(allowsLoopbackRoutes: true)
+        guard case .ticket(let ticket) = dev.decode(link, currentStackUserID: nil) else {
+            Issue.record("expected ticket in dev policy")
+            return
+        }
+        #expect(ticket.macDeviceID == "mac-b")
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/ComputersListModel.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/ComputersListModel.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Observation
+
+/// `@Observable` view-model that projects the host's merged computer list
+/// (registry + pairings + presence) into SwiftUI-readable state for the
+/// Computers settings section.
+///
+/// Mirrors ``MobilePairingStatusModel``: host runtime state arrives through
+/// ``SettingsHostActions`` rather than the settings catalog, seeded once on
+/// ``startObserving()`` and kept live by the host's snapshot stream via
+/// ``SettingReadDriver`` (which owns the subscription task and cancels it on
+/// deinit).
+@MainActor
+@Observable
+final class ComputersListModel {
+    /// The most recent snapshot, or `nil` when the host has no computers
+    /// directory (previews/tests).
+    private(set) var current: ComputersSettingsSnapshot?
+
+    @ObservationIgnored private let currentSnapshot: () -> ComputersSettingsSnapshot?
+    @ObservationIgnored private let makeStream: () -> AsyncStream<ComputersSettingsSnapshot>
+    @ObservationIgnored private let driver = SettingReadDriver<ComputersSettingsSnapshot>()
+    @ObservationIgnored private var hasStarted = false
+
+    /// Creates a model bound to the host's computers stream.
+    convenience init(hostActions: SettingsHostActions) {
+        self.init(
+            currentSnapshot: { hostActions.computersSnapshot() },
+            makeStream: { hostActions.computersUpdates() }
+        )
+    }
+
+    init(
+        currentSnapshot: @escaping () -> ComputersSettingsSnapshot?,
+        makeStream: @escaping () -> AsyncStream<ComputersSettingsSnapshot>
+    ) {
+        self.currentSnapshot = currentSnapshot
+        self.makeStream = makeStream
+        current = nil
+    }
+
+    /// Starts the host-snapshot stream for the retained model. Idempotent.
+    func startObserving() {
+        guard !hasStarted else { return }
+        hasStarted = true
+        current = currentSnapshot()
+        driver.activate(makeStream) { [weak self] snapshot in
+            self?.current = snapshot
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/SettingObservationStarting.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Bindings/SettingObservationStarting.swift
@@ -14,3 +14,4 @@ extension DefaultsValueModel: SettingObservationStarting {}
 extension JSONValueModel: SettingObservationStarting {}
 extension SecretValueModel: SettingObservationStarting {}
 extension MobilePairingStatusModel: SettingObservationStarting {}
+extension ComputersListModel: SettingObservationStarting {}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/ComputersSettingsSnapshot.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/ComputersSettingsSnapshot.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// One computer row for the **Computers** settings section.
+///
+/// The host merges the device registry, the local paired-computer store, and
+/// live presence into these value snapshots (the settings package stays
+/// Foundation-only, so it never sees the transport/registry types).
+public struct ComputersSettingsComputer: Sendable, Equatable, Identifiable {
+    /// How the row's presence indicator should render.
+    public enum Presence: Sendable, Equatable {
+        /// The presence service reports the computer online now.
+        case online
+        /// The presence service reports it offline; `lastSeenAt` when known.
+        case offline(lastSeenAt: Date?)
+        /// No live presence data; `lastSeenAt` is the registry hint.
+        case unknown(lastSeenAt: Date?)
+    }
+
+    /// Stable device id (the registry `deviceId`).
+    public let deviceID: String
+    /// Display name for the row.
+    public let name: String
+    /// SF Symbol for the device kind, chosen by the host (`desktopcomputer`,
+    /// `iphone`, …).
+    public let symbolName: String
+    /// Whether this row is the Mac the app runs on.
+    public let isThisMac: Bool
+    /// Whether a local pairing exists for this computer.
+    public let isPaired: Bool
+    /// Whether the row can be paired from here (a host platform with routes,
+    /// not this Mac, not already paired).
+    public let canPair: Bool
+    /// Presence indicator state.
+    public let presence: Presence
+    /// Optional secondary line (build channel / instance tag), pre-formatted
+    /// by the host.
+    public let detail: String?
+
+    public var id: String { deviceID }
+
+    /// Creates a computer row snapshot.
+    public init(
+        deviceID: String,
+        name: String,
+        symbolName: String,
+        isThisMac: Bool,
+        isPaired: Bool,
+        canPair: Bool,
+        presence: Presence,
+        detail: String? = nil
+    ) {
+        self.deviceID = deviceID
+        self.name = name
+        self.symbolName = symbolName
+        self.isThisMac = isThisMac
+        self.isPaired = isPaired
+        self.canPair = canPair
+        self.presence = presence
+        self.detail = detail
+    }
+}
+
+/// The Computers section's full state snapshot.
+public struct ComputersSettingsSnapshot: Sendable, Equatable {
+    /// Whether a user is signed in (the registry list requires an account).
+    public let isSignedIn: Bool
+    /// Merged computer rows in display order.
+    public let computers: [ComputersSettingsComputer]
+    /// Whether the most recent registry refresh failed (rows may be stale or
+    /// local-only).
+    public let lastRefreshFailed: Bool
+
+    /// Creates a snapshot.
+    public init(
+        isSignedIn: Bool,
+        computers: [ComputersSettingsComputer],
+        lastRefreshFailed: Bool = false
+    ) {
+        self.isSignedIn = isSignedIn
+        self.computers = computers
+        self.lastRefreshFailed = lastRefreshFailed
+    }
+}
+
+/// Result of a pair action (registry row or pasted link), rendered inline.
+public enum ComputersPairResult: Sendable, Equatable {
+    /// Paired; the row list refreshes via the snapshot stream.
+    case paired
+    /// The pasted text is not a cmux pairing link.
+    case invalidLink
+    /// Every route in the link points back at this Mac.
+    case loopbackRejected
+    /// The link belongs to a different account.
+    case accountMismatch
+    /// The computer advertises no dialable route to persist.
+    case noRoutes
+    /// The pairing could not be saved.
+    case failed
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/ComputersSettingsSnapshot.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/ComputersSettingsSnapshot.swift
@@ -97,3 +97,15 @@ public enum ComputersPairResult: Sendable, Equatable {
     /// The pairing could not be saved.
     case failed
 }
+
+/// Result of minting + copying this Mac's pairing link, rendered inline.
+public enum ComputersCopyLinkResult: Sendable, Equatable {
+    /// The link is on the clipboard, ready to paste on the other Mac.
+    case copied
+    /// This Mac has no Tailscale route another Mac could dial.
+    case needsTailscale
+    /// Pairing requires the Mac to be signed in.
+    case signedOut
+    /// The pairing listener or ticket mint failed.
+    case failed
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
@@ -169,6 +169,11 @@ public protocol SettingsHostActions: AnyObject {
     /// Removes the local pairing for a computer. The registry row remains.
     func unpairComputer(deviceID: String) async
 
+    /// Mints this Mac's pairing link (the same payload the pairing window's
+    /// QR encodes) and puts it on the clipboard, so another Mac can pair by
+    /// pasting it — no camera involved.
+    func copyComputerPairingLink() async -> ComputersCopyLinkResult
+
     /// Applies an explicitly-requested iOS pairing port, checking availability
     /// first so a port already in use leaves the running listener untouched. The
     /// Mobile section calls this from its **Apply** button and renders the
@@ -255,6 +260,9 @@ public extension SettingsHostActions {
 
     /// Default no-op unpair for previews/tests.
     func unpairComputer(deviceID: String) async {}
+
+    /// Default failure for hosts without a pairing listener (previews/tests).
+    func copyComputerPairingLink() async -> ComputersCopyLinkResult { .failed }
 
     /// Default: save-for-later, for hosts without a live mobile service (previews/tests).
     func applyMobilePairingPort(_ port: Int) async -> MobilePairingPortApplyResult {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Environment/SettingsHostActions.swift
@@ -142,6 +142,33 @@ public protocol SettingsHostActions: AnyObject {
     /// is edited.
     func mobilePairingDefaultDisplayName() -> String
 
+    /// The current merged computer list (device registry + local pairings +
+    /// live presence) for the Computers section, or `nil` when the host has
+    /// no computers directory (previews/tests). See ``computersUpdates()``
+    /// for live refresh.
+    func computersSnapshot() -> ComputersSettingsSnapshot?
+
+    /// A stream that yields a fresh ``ComputersSettingsSnapshot`` whenever the
+    /// merged computer list changes (registry refresh, pairing change, or a
+    /// presence transition). The Computers section subscribes so rows stay
+    /// live without polling.
+    func computersUpdates() -> AsyncStream<ComputersSettingsSnapshot>
+
+    /// Kicks off an asynchronous registry refresh; results arrive through
+    /// ``computersUpdates()``.
+    func refreshComputers()
+
+    /// Pairs a computer from its registry row (persists its best advertised
+    /// routes locally).
+    func pairComputer(deviceID: String) async -> ComputersPairResult
+
+    /// Pairs a computer from a pasted `cmux-ios://attach?…` pairing link (the
+    /// payload another Mac's pairing window shows as a QR code).
+    func pairComputerWithLink(_ link: String) async -> ComputersPairResult
+
+    /// Removes the local pairing for a computer. The registry row remains.
+    func unpairComputer(deviceID: String) async
+
     /// Applies an explicitly-requested iOS pairing port, checking availability
     /// first so a port already in use leaves the running listener untouched. The
     /// Mobile section calls this from its **Apply** button and renders the
@@ -207,6 +234,27 @@ public extension SettingsHostActions {
 
     /// Default: empty, for hosts that cannot resolve the Mac's system name.
     func mobilePairingDefaultDisplayName() -> String { "" }
+
+    /// Default: no computers directory, for previews/tests.
+    func computersSnapshot() -> ComputersSettingsSnapshot? { nil }
+
+    /// Default: an immediately-finished stream, for hosts without a
+    /// computers directory.
+    func computersUpdates() -> AsyncStream<ComputersSettingsSnapshot> {
+        AsyncStream { $0.finish() }
+    }
+
+    /// Default no-op refresh for previews/tests.
+    func refreshComputers() {}
+
+    /// Default failure for hosts without a computers directory.
+    func pairComputer(deviceID: String) async -> ComputersPairResult { .failed }
+
+    /// Default failure for hosts without a computers directory.
+    func pairComputerWithLink(_ link: String) async -> ComputersPairResult { .failed }
+
+    /// Default no-op unpair for previews/tests.
+    func unpairComputer(deviceID: String) async {}
 
     /// Default: save-for-later, for hosts without a live mobile service (previews/tests).
     func applyMobilePairingPort(_ port: Int) async -> MobilePairingPortApplyResult {

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/SettingsSectionID.swift
@@ -18,6 +18,8 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
     case sleepyMode
     /// Mobile pairing and sync settings.
     case mobile
+    /// The account's computers: registry list, presence, Mac-to-Mac pairing.
+    case computers
     case sidebarAppearance
     /// User/agent-authored custom sidebars: enable gate and renderer choice.
     case customSidebars
@@ -42,6 +44,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .textBox: return String(localized: "settings.section.textBox", defaultValue: "TextBox (Beta)")
         case .sleepyMode: return String(localized: "settings.section.sleepyMode", defaultValue: "Sleepy Mode")
         case .mobile: return String(localized: "settings.section.mobile", defaultValue: "Mobile")
+        case .computers: return String(localized: "settings.section.computers", defaultValue: "Computers")
         case .sidebarAppearance: return "Sidebar"
         case .customSidebars: return String(localized: "settings.section.customSidebars", defaultValue: "Custom Sidebars")
         case .betaFeatures: return "Beta Features"
@@ -65,6 +68,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .textBox: return "textformat"
         case .sleepyMode: return "moon.zzz"
         case .mobile: return "iphone"
+        case .computers: return "desktopcomputer"
         case .sidebarAppearance: return "sidebar.left"
         case .customSidebars: return "sidebar.squares.left"
         case .betaFeatures: return "exclamationmark.triangle"
@@ -90,6 +94,7 @@ public enum SettingsSectionID: String, CaseIterable, Identifiable, Sendable, Has
         case .textBox: return "textbox text box rich input prompt default new terminal workspace split tab focus show beta"
         case .sleepyMode: return "sleepy mode screensaver caffeinate keep awake lock touch id battery wifi clock mascot theme glow pixel"
         case .mobile: return "ios iphone ipad mobile pairing local network sync"
+        case .computers: return "computers devices macs remote pair unpair presence online offline tailscale hive"
         case .sidebarAppearance: return "sidebar details branches material terminal background"
         case .customSidebars: return "custom sidebars vibe swift json interpreted renderer in-process remote worker isolated"
         case .betaFeatures: return "beta experimental unstable feed dock right sidebar"

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Scene/SettingsWindowScene.swift
@@ -448,6 +448,9 @@ public struct SettingsWindowRoot: View {
         MobileSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)
             .id(anchorID(for: .mobile))
 
+        ComputersSection(hostActions: hostActions)
+            .id(anchorID(for: .computers))
+
         SidebarSection(defaultsStore: defaultsStore, catalog: catalog, hostActions: hostActions)
             .id(anchorID(for: .sidebarAppearance))
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
@@ -1,0 +1,323 @@
+import CmuxFoundation
+import SwiftUI
+
+/// **Computers** section — the account's registered computers (from the team
+/// device registry) with live presence, plus Mac-to-Mac pairing: pair a
+/// listed computer in one click, paste a pairing link from another Mac, or
+/// show this Mac's own pairing code.
+@MainActor
+public struct ComputersSection: View {
+    @State private var model: ComputersListModel
+    /// Device ids with a pair/unpair action in flight, so their buttons show
+    /// a busy state without re-rendering unrelated rows.
+    @State private var pendingDeviceIDs: Set<String> = []
+    /// The pasted pairing-link draft.
+    @State private var pairingLink: String = ""
+    /// Result of the most recent pair action, shown inline under the link row.
+    @State private var pairResult: ComputersPairResult?
+    /// Guards overlapping link-pair submissions.
+    @State private var isPairingLink = false
+
+    private let hostActions: SettingsHostActions
+
+    /// Creates the Computers section bound to the host bridge.
+    /// - Parameter hostActions: Supplies the merged computer snapshots and
+    ///   the pair/unpair/refresh actions.
+    public init(hostActions: SettingsHostActions) {
+        _model = State(initialValue: ComputersListModel(hostActions: hostActions))
+        self.hostActions = hostActions
+    }
+
+    /// The Computers section content.
+    public var body: some View {
+        Group {
+            SettingsSectionHeader(
+                String(localized: "settings.section.computers", defaultValue: "Computers"),
+                section: .computers
+            )
+            SettingsCard {
+                if let snapshot = model.current, snapshot.isSignedIn {
+                    computerRows(snapshot)
+                    SettingsCardDivider()
+                } else {
+                    SettingsCardNote(String(
+                        localized: "settings.computers.signedOut",
+                        defaultValue: "Sign in to see and pair the computers on your account."
+                    ))
+                    SettingsCardDivider()
+                }
+                pairingLinkRow
+                pairResultCaption
+                SettingsCardDivider()
+                showPairingCodeRow
+            }
+        }
+        .task {
+            startSettingsObservation([model])
+            hostActions.refreshComputers()
+        }
+    }
+
+    @ViewBuilder
+    private func computerRows(_ snapshot: ComputersSettingsSnapshot) -> some View {
+        if snapshot.computers.isEmpty {
+            SettingsCardNote(String(
+                localized: "settings.computers.empty",
+                defaultValue: "No computers registered yet. Open cmux on another device signed in to the same account."
+            ))
+        } else {
+            ForEach(snapshot.computers) { computer in
+                ComputersSectionRow(
+                    computer: computer,
+                    isPending: pendingDeviceIDs.contains(computer.deviceID),
+                    pair: { pair(deviceID: computer.deviceID) },
+                    unpair: { unpair(deviceID: computer.deviceID) }
+                )
+            }
+        }
+        if snapshot.lastRefreshFailed {
+            SettingsCardNote(String(
+                localized: "settings.computers.refreshFailed",
+                defaultValue: "Couldn't reach the device registry. Showing locally known computers."
+            ))
+        }
+        refreshRow
+    }
+
+    @ViewBuilder
+    private var refreshRow: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            searchAnchorID: "setting:computers:refresh",
+            String(localized: "settings.computers.refresh", defaultValue: "Refresh List"),
+            subtitle: String(
+                localized: "settings.computers.refresh.subtitle",
+                defaultValue: "Fetch the account's registered computers again."
+            )
+        ) {
+            Button(String(localized: "settings.computers.refresh.button", defaultValue: "Refresh")) {
+                hostActions.refreshComputers()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityIdentifier("SettingsComputersRefreshButton")
+        }
+    }
+
+    @ViewBuilder
+    private var pairingLinkRow: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            searchAnchorID: "setting:computers:pairingLink",
+            String(localized: "settings.computers.pairingLink", defaultValue: "Add by Pairing Link"),
+            subtitle: String(
+                localized: "settings.computers.pairingLink.subtitle",
+                defaultValue: "Paste the pairing link from the other Mac's pairing window (the QR code's contents)."
+            ),
+            controlWidth: 260
+        ) {
+            HStack(spacing: 8) {
+                TextField(
+                    String(localized: "settings.computers.pairingLink.placeholder", defaultValue: "cmux-ios://attach?…"),
+                    text: $pairingLink
+                )
+                .textFieldStyle(.roundedBorder)
+                .onChange(of: pairingLink) { pairResult = nil }
+                .onSubmit { pairFromLink() }
+                .accessibilityIdentifier("SettingsComputersPairingLinkField")
+
+                Button(String(localized: "settings.computers.pairingLink.add", defaultValue: "Add")) {
+                    pairFromLink()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .disabled(isPairingLink || pairingLink.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                .accessibilityIdentifier("SettingsComputersPairingLinkAddButton")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var pairResultCaption: some View {
+        if let pairResult, let text = Self.resultText(pairResult) {
+            Label(text, systemImage: pairResult == .paired ? "checkmark.circle.fill" : "exclamationmark.triangle.fill")
+                .foregroundStyle(pairResult == .paired ? AnyShapeStyle(.secondary) : AnyShapeStyle(.orange))
+                .cmuxFont(.caption)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.bottom, 8)
+        }
+    }
+
+    @ViewBuilder
+    private var showPairingCodeRow: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            searchAnchorID: "setting:computers:showPairingCode",
+            String(localized: "settings.computers.showPairingCode", defaultValue: "Pair This Mac"),
+            subtitle: String(
+                localized: "settings.computers.showPairingCode.subtitle",
+                defaultValue: "Show this Mac's pairing code for another Mac or an iPhone to add it."
+            )
+        ) {
+            Button(String(localized: "settings.computers.showPairingCode.button", defaultValue: "Show Pairing Code…")) {
+                hostActions.openMobilePairingWindow()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .accessibilityIdentifier("SettingsComputersShowPairingCodeButton")
+        }
+    }
+
+    private func pair(deviceID: String) {
+        guard !pendingDeviceIDs.contains(deviceID) else { return }
+        pendingDeviceIDs.insert(deviceID)
+        Task {
+            pairResult = await hostActions.pairComputer(deviceID: deviceID)
+            pendingDeviceIDs.remove(deviceID)
+        }
+    }
+
+    private func unpair(deviceID: String) {
+        guard !pendingDeviceIDs.contains(deviceID) else { return }
+        pendingDeviceIDs.insert(deviceID)
+        Task {
+            await hostActions.unpairComputer(deviceID: deviceID)
+            pendingDeviceIDs.remove(deviceID)
+        }
+    }
+
+    private func pairFromLink() {
+        let link = pairingLink.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !isPairingLink, !link.isEmpty else { return }
+        isPairingLink = true
+        pairResult = nil
+        Task {
+            let result = await hostActions.pairComputerWithLink(link)
+            pairResult = result
+            if result == .paired { pairingLink = "" }
+            isPairingLink = false
+        }
+    }
+
+    private static func resultText(_ result: ComputersPairResult) -> String? {
+        switch result {
+        case .paired:
+            return String(localized: "settings.computers.pairResult.paired", defaultValue: "Paired.")
+        case .invalidLink:
+            return String(localized: "settings.computers.pairResult.invalidLink", defaultValue: "That doesn't look like a cmux pairing link.")
+        case .loopbackRejected:
+            return String(localized: "settings.computers.pairResult.loopback", defaultValue: "That link points back at this Mac. Pairing over the network needs Tailscale on both Macs.")
+        case .accountMismatch:
+            return String(localized: "settings.computers.pairResult.accountMismatch", defaultValue: "That computer is signed in to a different account.")
+        case .noRoutes:
+            return String(localized: "settings.computers.pairResult.noRoutes", defaultValue: "That computer hasn't advertised a reachable address yet. Make sure Tailscale is running on it.")
+        case .failed:
+            return String(localized: "settings.computers.pairResult.failed", defaultValue: "Pairing failed. Try again.")
+        }
+    }
+}
+
+/// One computer row: identity, presence, and the pair/unpair control. Receives
+/// only value snapshots and action closures (snapshot boundary: no stores
+/// below the `ForEach`).
+private struct ComputersSectionRow: View {
+    let computer: ComputersSettingsComputer
+    let isPending: Bool
+    let pair: () -> Void
+    let unpair: () -> Void
+
+    var body: some View {
+        SettingsCardRow(
+            configurationReview: .action,
+            searchAnchorID: "setting:computers:row:\(computer.deviceID)",
+            title,
+            subtitle: subtitle
+        ) {
+            HStack(spacing: 10) {
+                presenceBadge
+                control
+            }
+        }
+    }
+
+    private var title: String {
+        if computer.isThisMac {
+            return String(
+                localized: "settings.computers.row.thisMac",
+                defaultValue: "\(computer.name) (This Mac)"
+            )
+        }
+        return computer.name
+    }
+
+    private var subtitle: String? {
+        var parts: [String] = []
+        if let detail = computer.detail, !detail.isEmpty {
+            parts.append(detail)
+        }
+        if let lastSeen = lastSeenText {
+            parts.append(lastSeen)
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    private var lastSeenText: String? {
+        let lastSeenAt: Date?
+        switch computer.presence {
+        case .online:
+            return nil
+        case .offline(let date), .unknown(let date):
+            lastSeenAt = date
+        }
+        guard let lastSeenAt else { return nil }
+        let relative = lastSeenAt.formatted(.relative(presentation: .named))
+        return String(
+            localized: "settings.computers.row.lastSeen",
+            defaultValue: "Last seen \(relative)"
+        )
+    }
+
+    @ViewBuilder
+    private var presenceBadge: some View {
+        switch computer.presence {
+        case .online:
+            Label(
+                String(localized: "settings.computers.presence.online", defaultValue: "Online"),
+                systemImage: "circle.fill"
+            )
+            .foregroundStyle(.green)
+            .cmuxFont(.caption)
+        case .offline:
+            Label(
+                String(localized: "settings.computers.presence.offline", defaultValue: "Offline"),
+                systemImage: "circle.fill"
+            )
+            .foregroundStyle(.secondary)
+            .cmuxFont(.caption)
+        case .unknown:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private var control: some View {
+        if computer.isPaired, !computer.isThisMac {
+            Button(String(localized: "settings.computers.row.unpair", defaultValue: "Unpair")) {
+                unpair()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(isPending)
+            .accessibilityIdentifier("SettingsComputersUnpairButton-\(computer.deviceID)")
+        } else if computer.canPair {
+            Button(String(localized: "settings.computers.row.pair", defaultValue: "Pair")) {
+                pair()
+            }
+            .buttonStyle(.bordered)
+            .controlSize(.small)
+            .disabled(isPending)
+            .accessibilityIdentifier("SettingsComputersPairButton-\(computer.deviceID)")
+        }
+    }
+}

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
@@ -162,26 +162,16 @@ public struct ComputersSection: View {
             String(localized: "settings.computers.showPairingCode", defaultValue: "Pair This Mac"),
             subtitle: String(
                 localized: "settings.computers.showPairingCode.subtitle",
-                defaultValue: "Copy a pairing link to paste on another Mac, or show a QR code for an iPhone."
-            ),
-            controlWidth: 320
+                defaultValue: "Copy a pairing link and paste it into “Add by Pairing Link” on another Mac."
+            )
         ) {
-            HStack(spacing: 8) {
-                Button(String(localized: "settings.computers.copyLink.button", defaultValue: "Copy Pairing Link")) {
-                    copyPairingLink()
-                }
-                .buttonStyle(.borderedProminent)
-                .controlSize(.small)
-                .disabled(isCopyingLink)
-                .accessibilityIdentifier("SettingsComputersCopyPairingLinkButton")
-
-                Button(String(localized: "settings.computers.showPairingCode.button", defaultValue: "Show Pairing Code…")) {
-                    hostActions.openMobilePairingWindow()
-                }
-                .buttonStyle(.bordered)
-                .controlSize(.small)
-                .accessibilityIdentifier("SettingsComputersShowPairingCodeButton")
+            Button(String(localized: "settings.computers.copyLink.button", defaultValue: "Copy Pairing Link")) {
+                copyPairingLink()
             }
+            .buttonStyle(.borderedProminent)
+            .controlSize(.small)
+            .disabled(isCopyingLink)
+            .accessibilityIdentifier("SettingsComputersCopyPairingLinkButton")
         }
     }
 

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
@@ -168,7 +168,7 @@ public struct ComputersSection: View {
             Button(String(localized: "settings.computers.copyLink.button", defaultValue: "Copy Pairing Link")) {
                 copyPairingLink()
             }
-            .buttonStyle(.borderedProminent)
+            .buttonStyle(.bordered)
             .controlSize(.small)
             .disabled(isCopyingLink)
             .accessibilityIdentifier("SettingsComputersCopyPairingLinkButton")

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/ComputersSection.swift
@@ -17,6 +17,10 @@ public struct ComputersSection: View {
     @State private var pairResult: ComputersPairResult?
     /// Guards overlapping link-pair submissions.
     @State private var isPairingLink = false
+    /// Result of the most recent copy-link action, shown under its row.
+    @State private var copyLinkResult: ComputersCopyLinkResult?
+    /// Guards overlapping copy-link mints.
+    @State private var isCopyingLink = false
 
     private let hostActions: SettingsHostActions
 
@@ -49,7 +53,8 @@ public struct ComputersSection: View {
                 pairingLinkRow
                 pairResultCaption
                 SettingsCardDivider()
-                showPairingCodeRow
+                pairThisMacRow
+                copyLinkResultCaption
             }
         }
         .task {
@@ -150,22 +155,48 @@ public struct ComputersSection: View {
     }
 
     @ViewBuilder
-    private var showPairingCodeRow: some View {
+    private var pairThisMacRow: some View {
         SettingsCardRow(
             configurationReview: .action,
             searchAnchorID: "setting:computers:showPairingCode",
             String(localized: "settings.computers.showPairingCode", defaultValue: "Pair This Mac"),
             subtitle: String(
                 localized: "settings.computers.showPairingCode.subtitle",
-                defaultValue: "Show this Mac's pairing code for another Mac or an iPhone to add it."
-            )
+                defaultValue: "Copy a pairing link to paste on another Mac, or show a QR code for an iPhone."
+            ),
+            controlWidth: 320
         ) {
-            Button(String(localized: "settings.computers.showPairingCode.button", defaultValue: "Show Pairing Code…")) {
-                hostActions.openMobilePairingWindow()
+            HStack(spacing: 8) {
+                Button(String(localized: "settings.computers.copyLink.button", defaultValue: "Copy Pairing Link")) {
+                    copyPairingLink()
+                }
+                .buttonStyle(.borderedProminent)
+                .controlSize(.small)
+                .disabled(isCopyingLink)
+                .accessibilityIdentifier("SettingsComputersCopyPairingLinkButton")
+
+                Button(String(localized: "settings.computers.showPairingCode.button", defaultValue: "Show Pairing Code…")) {
+                    hostActions.openMobilePairingWindow()
+                }
+                .buttonStyle(.bordered)
+                .controlSize(.small)
+                .accessibilityIdentifier("SettingsComputersShowPairingCodeButton")
             }
-            .buttonStyle(.bordered)
-            .controlSize(.small)
-            .accessibilityIdentifier("SettingsComputersShowPairingCodeButton")
+        }
+    }
+
+    @ViewBuilder
+    private var copyLinkResultCaption: some View {
+        if let copyLinkResult, let text = Self.copyLinkText(copyLinkResult) {
+            Label(
+                text,
+                systemImage: copyLinkResult == .copied ? "checkmark.circle.fill" : "exclamationmark.triangle.fill"
+            )
+            .foregroundStyle(copyLinkResult == .copied ? AnyShapeStyle(.secondary) : AnyShapeStyle(.orange))
+            .cmuxFont(.caption)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.bottom, 8)
         }
     }
 
@@ -187,6 +218,16 @@ public struct ComputersSection: View {
         }
     }
 
+    private func copyPairingLink() {
+        guard !isCopyingLink else { return }
+        isCopyingLink = true
+        copyLinkResult = nil
+        Task {
+            copyLinkResult = await hostActions.copyComputerPairingLink()
+            isCopyingLink = false
+        }
+    }
+
     private func pairFromLink() {
         let link = pairingLink.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !isPairingLink, !link.isEmpty else { return }
@@ -197,6 +238,31 @@ public struct ComputersSection: View {
             pairResult = result
             if result == .paired { pairingLink = "" }
             isPairingLink = false
+        }
+    }
+
+    private static func copyLinkText(_ result: ComputersCopyLinkResult) -> String? {
+        switch result {
+        case .copied:
+            return String(
+                localized: "settings.computers.copyLink.copied",
+                defaultValue: "Link copied. Paste it into “Add by Pairing Link” on the other Mac."
+            )
+        case .needsTailscale:
+            return String(
+                localized: "settings.computers.copyLink.needsTailscale",
+                defaultValue: "No reachable address. Install and sign in to Tailscale on both Macs, then try again."
+            )
+        case .signedOut:
+            return String(
+                localized: "settings.computers.copyLink.signedOut",
+                defaultValue: "Sign in to cmux first, then copy the pairing link."
+            )
+        case .failed:
+            return String(
+                localized: "settings.computers.copyLink.failed",
+                defaultValue: "Couldn't create a pairing link. Try again."
+            )
         }
     }
 

--- a/Sources/AppDelegate+CloudClients.swift
+++ b/Sources/AppDelegate+CloudClients.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+extension AppDelegate {
+    /// Configures the auth-backed cloud clients at the composition root:
+    /// Cloud VMs, remotes, AI accounts, phone push, the mobile pairing host,
+    /// the device registry, presence (heartbeat out, computers directory in),
+    /// and the DEV paired-Mac backup publisher. Extracted from `configure` so
+    /// the client roster can grow without growing `AppDelegate.swift`.
+    func configureCloudClients(auth: MacAuthComposition) {
+        VMClient.bootstrap(auth: auth.coordinator)
+        RemotesClient.bootstrap(auth: auth.coordinator)
+        AIAccountsClient.bootstrap(auth: auth.coordinator)
+        PhonePushClient.shared.configure(auth: auth.coordinator)
+        MobileHostService.shared.configure(auth: auth.coordinator)
+        DeviceRegistryClient.shared.configure(auth: auth.coordinator)
+        PresenceHeartbeatClient.shared.configure(auth: auth.coordinator)
+        // The Mac-as-client side of hive: the Settings › Computers directory
+        // (registry list + local pairings + presence subscribe).
+        HiveComputersService.shared.configure(auth: auth.coordinator)
+        // DEV-only: auto-publish this Mac's attach route to the signed-in user's
+        // pairedMacs backup so a fresh dev iOS build restores it (no manual host
+        // entry). No-op on Release / when the flag is off.
+        MacPairedMacBackupPublisher.shared.configure(auth: auth.coordinator)
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -2035,17 +2035,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         self.notificationStore = notificationStore
         self.sidebarState = sidebarState
         self.auth = auth
-        VMClient.bootstrap(auth: auth.coordinator)
-        RemotesClient.bootstrap(auth: auth.coordinator)
-        AIAccountsClient.bootstrap(auth: auth.coordinator)
-        PhonePushClient.shared.configure(auth: auth.coordinator)
-        MobileHostService.shared.configure(auth: auth.coordinator)
-        DeviceRegistryClient.shared.configure(auth: auth.coordinator)
-        PresenceHeartbeatClient.shared.configure(auth: auth.coordinator)
-        // DEV-only: auto-publish this Mac's attach route to the signed-in user's
-        // pairedMacs backup so a fresh dev iOS build restores it (no manual host
-        // entry). No-op on Release / when the flag is off.
-        MacPairedMacBackupPublisher.shared.configure(auth: auth.coordinator)
+        configureCloudClients(auth: auth)
         TerminalController.shared.attachAuth(coordinator: auth.coordinator, browserSignIn: auth.browserSignIn)
         TerminalController.shared.agentChatTranscriptService = agentChatTranscriptService
         auth.start()

--- a/Sources/Hive/HiveComputersService.swift
+++ b/Sources/Hive/HiveComputersService.swift
@@ -1,18 +1,17 @@
 import CmuxAuthRuntime
 import CmuxHive
-import CmuxMobilePairedMac
-import CmuxMobileShell
 import Foundation
 
-/// App-side composition of the hive computers directory: wires the shared
-/// device-registry client, the local paired-computer store, and the presence
-/// subscriber (the same client stack the iOS app composes) to the signed-in
-/// account, and hands the resulting ``HiveComputerDirectory`` to the
-/// Settings › Computers pane.
+/// App-side owner of the hive computers directory (the merged registry +
+/// pairings + presence list behind Settings › Computers).
 ///
-/// Follows the house pattern of the other cloud clients configured at the
-/// composition root (``DeviceRegistryClient``, ``PresenceHeartbeatClient``):
-/// a `shared` instance that stays inert until `configure(auth:)`.
+/// The composition root supplies configuration only — URLs, tokens, device
+/// identity, loopback policy — and `HiveComposition` (in the CmuxHive
+/// package) names the concrete client-stack types, so the app target depends
+/// on nothing below CmuxHive. Follows the house pattern of the other cloud
+/// clients configured at the root (``DeviceRegistryClient``,
+/// ``PresenceHeartbeatClient``): a `shared` instance that stays inert until
+/// `configure(auth:)`.
 @MainActor
 final class HiveComputersService {
     static let shared = HiveComputersService()
@@ -33,55 +32,21 @@ final class HiveComputersService {
     func configure(auth: AuthCoordinator) {
         self.auth = auth
         guard directory == nil else { return }
-        let store: MobilePairedMacStore
+        let composition = HiveComposition(configuration: HiveComposition.Configuration(
+            apiBaseURL: Self.normalizedBaseURL(AuthEnvironment.vmAPIBaseURL),
+            presenceBaseURL: PresenceHeartbeatClient.resolvedServiceURL().map(Self.normalizedBaseURL),
+            ownDeviceID: MobileHostIdentity.deviceID(),
+            allowsLoopbackRoutes: Self.allowsLoopbackPairing,
+            accessToken: { (try? await auth.currentTokens())?.accessToken },
+            refreshToken: { (try? await auth.currentTokens())?.refreshToken },
+            currentUserID: { await auth.currentUser?.id },
+            teamID: { await auth.resolvedTeamID }
+        ))
         do {
-            store = try MobilePairedMacStore(databaseURL: Self.pairedComputersDatabaseURL())
+            directory = try composition.makeDirectory()
         } catch {
             NSLog("cmux.hive paired-computer store unavailable: %@", String(describing: error))
-            return
         }
-        let apiBaseURL = Self.normalizedBaseURL(AuthEnvironment.vmAPIBaseURL)
-        let registry = DeviceRegistryService(
-            apiBaseURL: apiBaseURL,
-            deviceID: MobileHostIdentity.deviceID(),
-            tokenSource: DeviceRegistryService.TokenSource(
-                accessToken: { (try? await auth.currentTokens())?.accessToken },
-                refreshToken: { (try? await auth.currentTokens())?.refreshToken }
-            ),
-            teamIDProvider: { await auth.resolvedTeamID }
-        )
-        let presence: PresenceClient?
-        if let presenceURL = PresenceHeartbeatClient.resolvedServiceURL() {
-            presence = PresenceClient(
-                serviceBaseURL: Self.normalizedBaseURL(presenceURL),
-                tokenSource: PresenceTokenSource(
-                    accessToken: { (try? await auth.currentTokens())?.accessToken },
-                    currentUserID: { await auth.currentUser?.id }
-                ),
-                teamIDProvider: { await auth.resolvedTeamID }
-            )
-        } else {
-            presence = nil
-        }
-        directory = HiveComputerDirectory(
-            registry: registry,
-            pairedStore: store,
-            presence: presence,
-            ownDeviceID: MobileHostIdentity.deviceID(),
-            scopeProvider: {
-                await HiveAccountScope(
-                    stackUserID: auth.currentUser?.id,
-                    teamID: auth.resolvedTeamID
-                )
-            },
-            linkDecoder: HivePairingLinkDecoder(allowsLoopbackRoutes: Self.allowsLoopbackPairing),
-            presenceRetryDelay: { attempt in
-                // Bounded, cancellable resubscribe backoff for the presence
-                // stream (a genuine delay, not a poll): 1s doubling to 60s.
-                let seconds = min(60.0, pow(2.0, Double(min(attempt, 6))))
-                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
-            }
-        )
     }
 
     /// Dev builds may pair over loopback so two instances on one machine can
@@ -92,15 +57,6 @@ final class HiveComputersService {
         #else
         false
         #endif
-    }
-
-    /// The Mac-side paired-computer database. Uses its own file (not the
-    /// phone's `paired-macs.sqlite3` name) so the namespace stays clearly
-    /// Mac-as-client.
-    private static func pairedComputersDatabaseURL() throws -> URL {
-        try MobilePairedMacStore.defaultDatabaseURL()
-            .deletingLastPathComponent()
-            .appendingPathComponent("hive-paired-computers.sqlite3")
     }
 
     private static func normalizedBaseURL(_ url: URL) -> String {

--- a/Sources/Hive/HiveComputersService.swift
+++ b/Sources/Hive/HiveComputersService.swift
@@ -1,0 +1,110 @@
+import CmuxAuthRuntime
+import CmuxHive
+import CmuxMobilePairedMac
+import CmuxMobileShell
+import Foundation
+
+/// App-side composition of the hive computers directory: wires the shared
+/// device-registry client, the local paired-computer store, and the presence
+/// subscriber (the same client stack the iOS app composes) to the signed-in
+/// account, and hands the resulting ``HiveComputerDirectory`` to the
+/// Settings › Computers pane.
+///
+/// Follows the house pattern of the other cloud clients configured at the
+/// composition root (``DeviceRegistryClient``, ``PresenceHeartbeatClient``):
+/// a `shared` instance that stays inert until `configure(auth:)`.
+@MainActor
+final class HiveComputersService {
+    static let shared = HiveComputersService()
+
+    private(set) var directory: HiveComputerDirectory?
+    private(set) var auth: AuthCoordinator?
+
+    private init() {}
+
+    /// Whether a user session exists right now (drives the pane's
+    /// signed-out empty state).
+    var isSignedIn: Bool {
+        auth?.currentUser != nil
+    }
+
+    /// Inject the auth dependency and build the directory. Call once at the
+    /// composition root alongside the other cloud clients.
+    func configure(auth: AuthCoordinator) {
+        self.auth = auth
+        guard directory == nil else { return }
+        let store: MobilePairedMacStore
+        do {
+            store = try MobilePairedMacStore(databaseURL: Self.pairedComputersDatabaseURL())
+        } catch {
+            NSLog("cmux.hive paired-computer store unavailable: %@", String(describing: error))
+            return
+        }
+        let apiBaseURL = Self.normalizedBaseURL(AuthEnvironment.vmAPIBaseURL)
+        let registry = DeviceRegistryService(
+            apiBaseURL: apiBaseURL,
+            deviceID: MobileHostIdentity.deviceID(),
+            tokenSource: DeviceRegistryService.TokenSource(
+                accessToken: { (try? await auth.currentTokens())?.accessToken },
+                refreshToken: { (try? await auth.currentTokens())?.refreshToken }
+            ),
+            teamIDProvider: { await auth.resolvedTeamID }
+        )
+        let presence: PresenceClient?
+        if let presenceURL = PresenceHeartbeatClient.resolvedServiceURL() {
+            presence = PresenceClient(
+                serviceBaseURL: Self.normalizedBaseURL(presenceURL),
+                tokenSource: PresenceTokenSource(
+                    accessToken: { (try? await auth.currentTokens())?.accessToken },
+                    currentUserID: { await auth.currentUser?.id }
+                ),
+                teamIDProvider: { await auth.resolvedTeamID }
+            )
+        } else {
+            presence = nil
+        }
+        directory = HiveComputerDirectory(
+            registry: registry,
+            pairedStore: store,
+            presence: presence,
+            ownDeviceID: MobileHostIdentity.deviceID(),
+            scopeProvider: {
+                await HiveAccountScope(
+                    stackUserID: auth.currentUser?.id,
+                    teamID: auth.resolvedTeamID
+                )
+            },
+            linkDecoder: HivePairingLinkDecoder(allowsLoopbackRoutes: Self.allowsLoopbackPairing),
+            presenceRetryDelay: { attempt in
+                // Bounded, cancellable resubscribe backoff for the presence
+                // stream (a genuine delay, not a poll): 1s doubling to 60s.
+                let seconds = min(60.0, pow(2.0, Double(min(attempt, 6))))
+                try? await Task.sleep(nanoseconds: UInt64(seconds * 1_000_000_000))
+            }
+        )
+    }
+
+    /// Dev builds may pair over loopback so two instances on one machine can
+    /// dogfood Mac-to-Mac viewing; release builds never dial themselves.
+    private static var allowsLoopbackPairing: Bool {
+        #if DEBUG
+        true
+        #else
+        false
+        #endif
+    }
+
+    /// The Mac-side paired-computer database. Uses its own file (not the
+    /// phone's `paired-macs.sqlite3` name) so the namespace stays clearly
+    /// Mac-as-client.
+    private static func pairedComputersDatabaseURL() throws -> URL {
+        try MobilePairedMacStore.defaultDatabaseURL()
+            .deletingLastPathComponent()
+            .appendingPathComponent("hive-paired-computers.sqlite3")
+    }
+
+    private static func normalizedBaseURL(_ url: URL) -> String {
+        let raw = url.absoluteString
+        return raw.hasSuffix("/") ? String(raw.dropLast()) : raw
+    }
+}

--- a/Sources/HostSettingsActions+Computers.swift
+++ b/Sources/HostSettingsActions+Computers.swift
@@ -1,0 +1,128 @@
+import CmuxHive
+import CmuxSettingsUI
+import Foundation
+
+/// Computers-section host bridge: maps the hive computers directory
+/// (registry + pairings + presence) into the settings package's value
+/// snapshots and routes the pane's actions back to it.
+extension HostSettingsActions {
+    private var computersDirectory: HiveComputerDirectory? {
+        HiveComputersService.shared.directory
+    }
+
+    func computersSnapshot() -> ComputersSettingsSnapshot? {
+        guard let directory = computersDirectory else { return nil }
+        return Self.computersSnapshot(
+            computers: directory.computers,
+            isSignedIn: HiveComputersService.shared.isSignedIn,
+            lastRefreshFailed: directory.lastRefreshFailed
+        )
+    }
+
+    func computersUpdates() -> AsyncStream<ComputersSettingsSnapshot> {
+        guard let directory = computersDirectory else {
+            return AsyncStream { $0.finish() }
+        }
+        let source = directory.updates()
+        return AsyncStream { continuation in
+            let task = Task { @MainActor in
+                for await computers in source {
+                    continuation.yield(Self.computersSnapshot(
+                        computers: computers,
+                        isSignedIn: HiveComputersService.shared.isSignedIn,
+                        lastRefreshFailed: directory.lastRefreshFailed
+                    ))
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { _ in task.cancel() }
+        }
+    }
+
+    func refreshComputers() {
+        guard let directory = computersDirectory else { return }
+        Task { @MainActor in
+            await directory.refresh()
+        }
+    }
+
+    func pairComputer(deviceID: String) async -> ComputersPairResult {
+        guard let directory = computersDirectory else { return .failed }
+        return Self.pairResult(await directory.pair(deviceID: deviceID))
+    }
+
+    func pairComputerWithLink(_ link: String) async -> ComputersPairResult {
+        guard let directory = computersDirectory else { return .failed }
+        return Self.pairResult(await directory.pair(link: link))
+    }
+
+    func unpairComputer(deviceID: String) async {
+        guard let directory = computersDirectory else { return }
+        await directory.unpair(deviceID: deviceID)
+    }
+
+    // MARK: - Mapping (pure)
+
+    /// Map the merged directory rows into the settings package's snapshot.
+    static func computersSnapshot(
+        computers: [HiveComputer],
+        isSignedIn: Bool,
+        lastRefreshFailed: Bool
+    ) -> ComputersSettingsSnapshot {
+        ComputersSettingsSnapshot(
+            isSignedIn: isSignedIn,
+            computers: computers.map(Self.computerRow),
+            lastRefreshFailed: lastRefreshFailed
+        )
+    }
+
+    static func computerRow(_ computer: HiveComputer) -> ComputersSettingsComputer {
+        ComputersSettingsComputer(
+            deviceID: computer.deviceID,
+            name: computer.displayName,
+            symbolName: Self.symbolName(forPlatform: computer.platform),
+            isThisMac: computer.isThisComputer,
+            isPaired: computer.isPaired,
+            canPair: computer.isPairableHost && !computer.isPaired && computer.bestPairingRoutes != nil,
+            presence: Self.presence(computer.presence),
+            detail: Self.detail(for: computer)
+        )
+    }
+
+    static func pairResult(_ outcome: HivePairOutcome) -> ComputersPairResult {
+        switch outcome {
+        case .paired: return .paired
+        case .invalidLink: return .invalidLink
+        case .loopbackRejected: return .loopbackRejected
+        case .accountMismatch: return .accountMismatch
+        case .noRoutes: return .noRoutes
+        case .storeFailed: return .failed
+        }
+    }
+
+    private static func symbolName(forPlatform platform: String?) -> String {
+        switch (platform ?? "mac").lowercased() {
+        case "ios": return "iphone"
+        case "linux", "windows": return "server.rack"
+        default: return "desktopcomputer"
+        }
+    }
+
+    private static func presence(_ presence: HiveComputerPresence) -> ComputersSettingsComputer.Presence {
+        switch presence {
+        case .online: return .online
+        case .offline(let lastSeenAt): return .offline(lastSeenAt: lastSeenAt)
+        case .unknown(let lastSeenAt): return .unknown(lastSeenAt: lastSeenAt)
+        }
+    }
+
+    /// Secondary row line: the presence build label when known, else the
+    /// build tag of the freshest route-advertising instance (skipping the
+    /// unremarkable stable tags).
+    private static func detail(for computer: HiveComputer) -> String? {
+        if let label = computer.buildLabel, !label.isEmpty { return label }
+        guard let tag = computer.bestPairingRoutes?.instanceTag,
+              !["default", "stable"].contains(tag.lowercased()) else { return nil }
+        return tag
+    }
+}

--- a/Sources/HostSettingsActions+Computers.swift
+++ b/Sources/HostSettingsActions+Computers.swift
@@ -1,3 +1,4 @@
+import AppKit
 import CmuxHive
 import CmuxSettingsUI
 import Foundation
@@ -59,6 +60,61 @@ extension HostSettingsActions {
     func unpairComputer(deviceID: String) async {
         guard let directory = computersDirectory else { return }
         await directory.unpair(deviceID: deviceID)
+    }
+
+    /// Mints this Mac's attach link (the same payload the pairing window's QR
+    /// encodes) and copies it to the clipboard for pasting on another Mac.
+    ///
+    /// Prefers the Tailscale-only v2 grammar (works across machines). Dev
+    /// builds fall back to an all-routes ticket when no Tailscale route
+    /// exists, so two tagged builds on one machine can pair over loopback.
+    func copyComputerPairingLink() async -> ComputersCopyLinkResult {
+        guard let coordinator = AppDelegate.shared?.auth?.coordinator else { return .failed }
+        await coordinator.awaitBootstrapped()
+        guard coordinator.isAuthenticated else { return .signedOut }
+        UserDefaults.standard.set(true, forKey: MobileHostService.listeningEnabledDefaultsKey)
+        let host = MobileHostService.shared
+        let status = await host.ensureListeningAndReady()
+        guard status.isRunning else { return .failed }
+        do {
+            return copyLinkToPasteboard(try await host.createAttachTicket(
+                workspaceID: "",
+                terminalID: nil,
+                ttl: 600,
+                target: .physicalDevice
+            ))
+        } catch MobileAttachTicketStoreError.noRoutes,
+                MobileAttachTicketStoreError.routeUnavailable,
+                MobileAttachTicketStoreError.invalidAttachURL {
+            #if DEBUG
+            // Same-machine dogfood: no Tailscale route, but the dev loopback
+            // route lets a second tagged build on this Mac pair.
+            do {
+                return copyLinkToPasteboard(try await host.createAttachTicket(
+                    workspaceID: "",
+                    terminalID: nil,
+                    ttl: 600,
+                    target: .ticketOnly
+                ))
+            } catch {
+                return .needsTailscale
+            }
+            #else
+            return .needsTailscale
+            #endif
+        } catch {
+            return .failed
+        }
+    }
+
+    private func copyLinkToPasteboard(_ payload: [String: Any]) -> ComputersCopyLinkResult {
+        guard let attachURL = payload["attach_url"] as? String, !attachURL.isEmpty else {
+            return .failed
+        }
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(attachURL, forType: .string)
+        return .copied
     }
 
     // MARK: - Mapping (pure)

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -7,6 +7,7 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
     case textBox
     case sleepyMode
     case mobile
+    case computers
     case sidebarAppearance
     case customSidebars
     case betaFeatures
@@ -35,6 +36,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return String(localized: "settings.section.sleepyMode", defaultValue: "Sleepy Mode")
         case .mobile:
             return String(localized: "settings.section.mobile", defaultValue: "Mobile")
+        case .computers:
+            return String(localized: "settings.section.computers", defaultValue: "Computers")
         case .workspaceColors:
             return String(localized: "settings.section.workspaceColors", defaultValue: "Workspace Colors")
         case .sidebarAppearance:
@@ -74,6 +77,8 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
             return "moon.zzz"
         case .mobile:
             return "iphone"
+        case .computers:
+            return "desktopcomputer"
         case .workspaceColors:
             return "paintpalette"
         case .sidebarAppearance:
@@ -99,44 +104,6 @@ enum SettingsNavigationTarget: String, CaseIterable, Identifiable {
         }
     }
 
-    var searchText: String {
-        switch self {
-        case .account:
-            return "\(title) sign in team sync"
-        case .app:
-            return "\(title) appearance language workspace notifications menu bar telemetry default terminal"
-        case .terminal:
-            return "\(title) scrollbar auto resume restore reopen relaunch quit sessions agents claude codex opencode rovodev hibernation idle suspend commands approvals prefixes toggle"
-        case .textBox:
-            return "\(title) textbox text box rich input prompt beta new terminal workspace split tab focus height"
-        case .sleepyMode:
-            return "\(title) sleepy mode screensaver caffeinate keep awake lock touch id battery wifi clock mascot theme glow pixel"
-        case .mobile:
-            return "\(title) ios iphone ipad mobile pairing local network sync"
-        case .workspaceColors:
-            return "\(title) palette tabs"
-        case .sidebarAppearance:
-            return "\(title) sidebar details branches badges material terminal background"
-        case .customSidebars:
-            return "\(title) custom sidebars vibe swift json interpreted renderer in-process remote worker isolated"
-        case .betaFeatures:
-            return "\(title) beta experimental unstable feed dock right sidebar"
-        case .automation:
-            return "\(title) socket integrations hooks ports claude cursor gemini kiro naming auto naming workspace tabs"
-        case .browser:
-            return "\(title) search engine links history theme"
-        case .browserImport:
-            return "\(title) browser import data bookmarks history cookies"
-        case .globalHotkey:
-            return "\(title) system wide shortcut"
-        case .keyboardShortcuts:
-            return "\(title) keybindings commands chords"
-        case .settingsJSON:
-            return "\(title) config file preferences editor documentation schema jsonc reload"
-        case .reset:
-            return "\(title) defaults"
-        }
-    }
 }
 
 enum SettingsNavigationRequest {

--- a/Sources/SettingsNavigationTarget+SearchText.swift
+++ b/Sources/SettingsNavigationTarget+SearchText.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+extension SettingsNavigationTarget {
+    /// Section-level search corpus for the in-app settings search index.
+    /// Extracted from `SettingsNavigation.swift` so section additions don't
+    /// grow that file.
+    var searchText: String {
+        switch self {
+        case .account:
+            return "\(title) sign in team sync"
+        case .app:
+            return "\(title) appearance language workspace notifications menu bar telemetry default terminal"
+        case .terminal:
+            return "\(title) scrollbar auto resume restore reopen relaunch quit sessions agents claude codex opencode rovodev hibernation idle suspend commands approvals prefixes toggle"
+        case .textBox:
+            return "\(title) textbox text box rich input prompt beta new terminal workspace split tab focus height"
+        case .sleepyMode:
+            return "\(title) sleepy mode screensaver caffeinate keep awake lock touch id battery wifi clock mascot theme glow pixel"
+        case .mobile:
+            return "\(title) ios iphone ipad mobile pairing local network sync"
+        case .computers:
+            return "\(title) computers devices macs remote pair unpair presence online offline tailscale hive"
+        case .workspaceColors:
+            return "\(title) palette tabs"
+        case .sidebarAppearance:
+            return "\(title) sidebar details branches badges material terminal background"
+        case .customSidebars:
+            return "\(title) custom sidebars vibe swift json interpreted renderer in-process remote worker isolated"
+        case .betaFeatures:
+            return "\(title) beta experimental unstable feed dock right sidebar"
+        case .automation:
+            return "\(title) socket integrations hooks ports claude cursor gemini kiro naming auto naming workspace tabs"
+        case .browser:
+            return "\(title) search engine links history theme"
+        case .browserImport:
+            return "\(title) browser import data bookmarks history cookies"
+        case .globalHotkey:
+            return "\(title) system wide shortcut"
+        case .keyboardShortcuts:
+            return "\(title) keybindings commands chords"
+        case .settingsJSON:
+            return "\(title) config file preferences editor documentation schema jsonc reload"
+        case .reset:
+            return "\(title) defaults"
+        }
+    }
+}

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -15,6 +15,8 @@ enum SettingsSearchAliasIndex {
             return localized("settings.search.alias.section.sleepyMode", defaultValue: "sleepy mode screensaver caffeinate keep awake do not sleep lock touch id battery wifi clock mascot theme glow pixel night")
         case .mobile:
             return localized("settings.search.alias.section.mobile", defaultValue: "ios iphone ipad mobile pairing local network permission sync")
+        case .computers:
+            return localized("settings.search.alias.section.computers", defaultValue: "computers devices macs remote view control pair unpair presence online offline tailscale hive")
         case .sidebarAppearance:
             return localized("settings.search.alias.section.sidebarAppearance", defaultValue: "sidebar left rail navigation details branches badges material terminal background")
         case .customSidebars:

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -549,6 +549,10 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D36090020000000000000005 /* CmuxMainWindowFullScreenCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */; };
 		799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
 		EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
+		C41FE00000000000000000B5 /* CmuxMobilePairedMac in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A6 /* CmuxMobilePairedMac */; };
+		C41FE00000000000000000B6 /* CmuxMobilePairedMac in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A6 /* CmuxMobilePairedMac */; };
+		C41FE00000000000000000B7 /* CmuxMobileShell in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A8 /* CmuxMobileShell */; };
+		C41FE00000000000000000B8 /* CmuxMobileShell in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A8 /* CmuxMobileShell */; };
 		CA1F0A01CA1F0A01CA1F0A01 /* CmuxModalAlertPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */; };
 		C54860110000000000000001 /* CmuxNavigationResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860110000000000000002 /* CmuxNavigationResolution.swift */; };
 		C54860120000000000000001 /* CmuxNavigationSurfaceDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860120000000000000002 /* CmuxNavigationSurfaceDescriptor.swift */; };
@@ -3723,6 +3727,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C617000000000000000000A3 /* CmuxGit in Frameworks */,
 				C41FE00000000000000000B1 /* CmuxHive in Frameworks */,
 				799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */,
+				C41FE00000000000000000B5 /* CmuxMobilePairedMac in Frameworks */,
+				C41FE00000000000000000B7 /* CmuxMobileShell in Frameworks */,
 				E3B7A30000000000000000D3 /* CmuxNotifications in Frameworks */,
 				E3B7A30000000000000000F3 /* CmuxPanes in Frameworks */,
 				A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */,
@@ -3797,6 +3803,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E2701040000000000000004 /* CmuxFoundation in Frameworks */,
 				C41FE00000000000000000B2 /* CmuxHive in Frameworks */,
 				EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */,
+				C41FE00000000000000000B6 /* CmuxMobilePairedMac in Frameworks */,
+				C41FE00000000000000000B8 /* CmuxMobileShell in Frameworks */,
 				C0DE4A000000000000000005 /* CmuxSidebarProviderKit in Frameworks */,
 				730600040000000000000001 /* CmuxWindowing in Frameworks */,
 				5E2701040000000000000003 /* Sentry in Frameworks */,
@@ -5767,6 +5775,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A8BD195031FC4B82B4354297 /* StackAuth */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
 				C41FE00000000000000000A2 /* CmuxHive */,
+				C41FE00000000000000000A6 /* CmuxMobilePairedMac */,
+				C41FE00000000000000000A8 /* CmuxMobileShell */,
 			);
 			productName = cmux;
 			productReference = A5001000 /* cmux.app */;
@@ -5851,6 +5861,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
 				C41FE00000000000000000A2 /* CmuxHive */,
+				C41FE00000000000000000A6 /* CmuxMobilePairedMac */,
+				C41FE00000000000000000A8 /* CmuxMobileShell */,
 				CA52A005CA52A005CA52A005 /* CmuxCanvas */,
 				5E2701040000000000000001 /* Sentry */,
 				5E2701040000000000000002 /* CmuxFoundation */,
@@ -5928,6 +5940,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E55500000000000000000E1 /* XCLocalSwiftPackageReference "CmuxCommandPalette" */,
 				C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */,
 				C41FE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxHive" */,
+				C41FE00000000000000000A5 /* XCLocalSwiftPackageReference "CmuxMobilePairedMac" */,
+				C41FE00000000000000000A7 /* XCLocalSwiftPackageReference "CmuxMobileShell" */,
 				C5B6A10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarGit" */,
 				E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */,
 				E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */,
@@ -8312,6 +8326,14 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CmuxHive;
 		};
+		C41FE00000000000000000A5 /* XCLocalSwiftPackageReference "CmuxMobilePairedMac" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/iOS/CmuxMobilePairedMac;
+		};
+		C41FE00000000000000000A7 /* XCLocalSwiftPackageReference "CmuxMobileShell" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/iOS/CmuxMobileShell;
+		};
 		28B798BB9086C8E6B60C3355 /* XCLocalSwiftPackageReference "stack-auth-swift-sdk-prerelease" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "vendor/stack-auth-swift-sdk-prerelease";
@@ -8783,6 +8805,16 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCSwiftPackageProductDependency;
 			package = C41FE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxHive" */;
 			productName = CmuxHive;
+		};
+		C41FE00000000000000000A6 /* CmuxMobilePairedMac */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C41FE00000000000000000A5 /* XCLocalSwiftPackageReference "CmuxMobilePairedMac" */;
+			productName = CmuxMobilePairedMac;
+		};
+		C41FE00000000000000000A8 /* CmuxMobileShell */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C41FE00000000000000000A7 /* XCLocalSwiftPackageReference "CmuxMobileShell" */;
+			productName = CmuxMobileShell;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -126,6 +126,7 @@
 C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */; };
 		C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */; };
 		C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */; };
+		C41FE00000000000000000C3 /* AppDelegate+CloudClients.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41FE00000000000000000D3 /* AppDelegate+CloudClients.swift */; };
 		C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */; };
 		C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */; };
 		C65930010000000000000003 /* AppDelegate+CrashSessionSnapshotRemoval.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65930010000000000000004 /* AppDelegate+CrashSessionSnapshotRemoval.swift */; };
@@ -539,6 +540,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C617000000000000000000A3 /* CmuxGit in Frameworks */ = {isa = PBXBuildFile; productRef = C617000000000000000000A2 /* CmuxGit */; };
 		C0DE34020000000000000001 /* CmuxHelpCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000003 /* CmuxHelpCommands.swift */; };
 		C0DE34020000000000000002 /* CmuxHelpResource.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000004 /* CmuxHelpResource.swift */; };
+		C41FE00000000000000000B1 /* CmuxHive in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A2 /* CmuxHive */; };
+		C41FE00000000000000000B2 /* CmuxHive in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A2 /* CmuxHive */; };
 		C0DE46010000000000000001 /* CMUXInstalledExtensionSidebarHostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */; };
 		E7E00000000000000000000B /* CmuxLifecycleEventPublishing.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7E00000000000000000000C /* CmuxLifecycleEventPublishing.swift */; };
 		2F0C07000000000000000002 /* CmuxMainWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F0C07000000000000000001 /* CmuxMainWindow.swift */; };
@@ -852,9 +855,11 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE34020000000000000005 /* HelpMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE34020000000000000006 /* HelpMenuUITests.swift */; };
 		F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */; };
 		4931A11B0000000000000002 /* HiddenRightSidebarContentMountingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */; };
+		C41FE00000000000000000C2 /* HiveComputersService.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41FE00000000000000000D2 /* HiveComputersService.swift */; };
 		CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */; };
 		B1F0C0030000000000000001 /* HostedInspectorDockControlScript.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */; };
 		B1F0C0040000000000000001 /* HostedInspectorDockControlScriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */; };
+		C41FE00000000000000000C1 /* HostSettingsActions+Computers.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41FE00000000000000000D1 /* HostSettingsActions+Computers.swift */; };
 		CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */; };
 		F1C1AA21B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */; };
 		DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000002 /* InfoPlist.xcstrings */; };
@@ -1312,6 +1317,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D9CCF002D9CCF002D9CCF002 /* SettingsLazyLoadHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9CCF001D9CCF001D9CCF001 /* SettingsLazyLoadHelpers.swift */; };
 		D5671401D5671401D5671401 /* SettingsNavigation+TerminalScrollSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5671402D5671402D5671402 /* SettingsNavigation+TerminalScrollSpeed.swift */; };
 		A50019A0 /* SettingsNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019A1 /* SettingsNavigation.swift */; };
+		C41FE00000000000000000C4 /* SettingsNavigationTarget+SearchText.swift in Sources */ = {isa = PBXBuildFile; fileRef = C41FE00000000000000000D4 /* SettingsNavigationTarget+SearchText.swift */; };
 		A50019B0 /* SettingsSearchAliases.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B1 /* SettingsSearchAliases.swift */; };
 		A50019B2 /* SettingsSearchIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50019B3 /* SettingsSearchIndexTests.swift */; };
 		D10000000000000000A0001C /* SettingsShortcutsBehaviorUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D10000000000000000A0001D /* SettingsShortcutsBehaviorUITests.swift */; };
@@ -2039,6 +2045,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+AgentChatNotifications.swift"; sourceTree = "<group>"; };
 		C4A570010000000000000002 /* AppDelegate+CanvasShortcutRouting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CanvasShortcutRouting.swift"; sourceTree = "<group>"; };
 		C4160A030000000000000002 /* AppDelegate+ClosedItemHistory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+ClosedItemHistory.swift"; sourceTree = "<group>"; };
+		C41FE00000000000000000D3 /* AppDelegate+CloudClients.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CloudClients.swift"; sourceTree = "<group>"; };
 		C54860050000000000000002 /* AppDelegate+CmuxNavigationDeepLinks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxNavigationDeepLinks.swift"; sourceTree = "<group>"; };
 		C3677004000000000000002 /* AppDelegate+CmuxSSHURL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CmuxSSHURL.swift"; sourceTree = "<group>"; };
 		C65930010000000000000004 /* AppDelegate+CrashSessionSnapshotRemoval.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+CrashSessionSnapshotRemoval.swift"; sourceTree = "<group>"; };
@@ -2711,9 +2718,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE34020000000000000006 /* HelpMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HelpMenuUITests.swift; sourceTree = "<group>"; };
 		F5320001A1B2C3D4E5F60718 /* HermesAgentIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HermesAgentIndex.swift; sourceTree = "<group>"; };
 		4931A11B0000000000000001 /* HiddenRightSidebarContentMountingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HiddenRightSidebarContentMountingTests.swift; sourceTree = "<group>"; };
+		C41FE00000000000000000D2 /* HiveComputersService.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HiveComputersService.swift; sourceTree = "<group>"; };
 		CD0CFE6100000000CD0CFE61 /* HostAccountFlow.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostAccountFlow.swift; sourceTree = "<group>"; };
 		B1F0C0030000000000000002 /* HostedInspectorDockControlScript.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/HostedInspectorDockControlScript.swift; sourceTree = "<group>"; };
 		B1F0C0040000000000000002 /* HostedInspectorDockControlScriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HostedInspectorDockControlScriptTests.swift; sourceTree = "<group>"; };
+		C41FE00000000000000000D1 /* HostSettingsActions+Computers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "HostSettingsActions+Computers.swift"; sourceTree = "<group>"; };
 		CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = HostSettingsActions.swift; sourceTree = "<group>"; };
 		F1C1AA20B7E84D10A1C10001 /* InactivePaneFirstClickFocusTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InactivePaneFirstClickFocusTests.swift; sourceTree = "<group>"; };
 		DA7A10CA710E000000000002 /* InfoPlist.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = InfoPlist.xcstrings; sourceTree = "<group>"; };
@@ -3160,6 +3169,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D9CCF001D9CCF001D9CCF001 /* SettingsLazyLoadHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLazyLoadHelpers.swift; sourceTree = "<group>"; };
 		D5671402D5671402D5671402 /* SettingsNavigation+TerminalScrollSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SettingsNavigation+TerminalScrollSpeed.swift"; sourceTree = "<group>"; };
 		A50019A1 /* SettingsNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsNavigation.swift; sourceTree = "<group>"; };
+		C41FE00000000000000000D4 /* SettingsNavigationTarget+SearchText.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "SettingsNavigationTarget+SearchText.swift"; sourceTree = "<group>"; };
 		A50019B1 /* SettingsSearchAliases.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchAliases.swift; sourceTree = "<group>"; };
 		A50019B3 /* SettingsSearchIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearchIndexTests.swift; sourceTree = "<group>"; };
 		D10000000000000000A0001D /* SettingsShortcutsBehaviorUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsShortcutsBehaviorUITests.swift; sourceTree = "<group>"; };
@@ -3711,6 +3721,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A2C00000000000000000C3 /* CmuxFeedback in Frameworks */,
 				CF00F00000000000000000A3 /* CmuxFoundation in Frameworks */,
 				C617000000000000000000A3 /* CmuxGit in Frameworks */,
+				C41FE00000000000000000B1 /* CmuxHive in Frameworks */,
 				799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */,
 				E3B7A30000000000000000D3 /* CmuxNotifications in Frameworks */,
 				E3B7A30000000000000000F3 /* CmuxPanes in Frameworks */,
@@ -3784,6 +3795,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E55500000000000000000E4 /* CmuxCommandPalette in Frameworks */,
 				CC0DE00000000000000000A4 /* CmuxCore in Frameworks */,
 				5E2701040000000000000004 /* CmuxFoundation in Frameworks */,
+				C41FE00000000000000000B2 /* CmuxHive in Frameworks */,
 				EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */,
 				C0DE4A000000000000000005 /* CmuxSidebarProviderKit in Frameworks */,
 				730600040000000000000001 /* CmuxWindowing in Frameworks */,
@@ -3934,6 +3946,15 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			path = Mobile;
 			sourceTree = "<group>";
 		};
+		C41FE00000000000000000E1 /* Hive */ = {
+			isa = PBXGroup;
+			children = (
+				C41FE00000000000000000D2 /* HiveComputersService.swift */,
+			);
+			name = Hive;
+			path = Hive;
+			sourceTree = "<group>";
+		};
 		590E4F5F342E5B27010ECC8D /* Cloud */ = {
 			isa = PBXGroup;
 			children = (
@@ -4009,6 +4030,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE34020000000000000003 /* CmuxHelpCommands.swift */,
 				C0DE34020000000000000004 /* CmuxHelpResource.swift */,
 				A50019A1 /* SettingsNavigation.swift */,
+				C41FE00000000000000000D4 /* SettingsNavigationTarget+SearchText.swift */,
 				D5671402D5671402D5671402 /* SettingsNavigation+TerminalScrollSpeed.swift */,
 				A50019B1 /* SettingsSearchAliases.swift */,
 				D3610C010000000000000002 /* CmuxSettingsJSONPathSupport.swift */,
@@ -4564,6 +4586,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F4350A130000000000000001 /* AppBundleIconPersistencePolicy.swift */,
 				D1320AA0D1320AA0D1320AA4 /* AppIconDockTilePlugin.swift */,
 				A5001090 /* AppDelegate.swift */,
+				C41FE00000000000000000D3 /* AppDelegate+CloudClients.swift */,
 				C0DE45AC0000000000000002 /* AppDelegate+AgentChat.swift */,
 				C0DE71A00000000000000002 /* AgentChatThemeSync.swift */,
 				C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */,
@@ -4860,6 +4883,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001241 /* WindowDecorationsController.swift */,
 				A5001222 /* WindowAccessor.swift */,
 				CD0CFE6300000000CD0CFE63 /* HostSettingsActions.swift */,
+				C41FE00000000000000000D1 /* HostSettingsActions+Computers.swift */,
 				F6572001A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift */,
 				F6572011A1B2C3D4E5F60718 /* SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift */,
 				A74770010000000000000006 /* SessionConfigFrameEntry.swift */,
@@ -5053,6 +5077,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FEED0000000000000000F003 /* Feed */,
 				C57B00040000000000000002 /* TerminalController+CustomSidebarCommands.swift */,
 				C57B00050000000000000002 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift */,
+				C41FE00000000000000000E1 /* Hive */,
 				59065015952E1B5BE5E23519 /* Mobile */,
 				31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */,
 			);
@@ -5741,6 +5766,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CC0DE30000000000000000A2 /* CmuxRemoteSession */,
 				A8BD195031FC4B82B4354297 /* StackAuth */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
+				C41FE00000000000000000A2 /* CmuxHive */,
 			);
 			productName = cmux;
 			productReference = A5001000 /* cmux.app */;
@@ -5824,6 +5850,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			packageProductDependencies = (
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
+				C41FE00000000000000000A2 /* CmuxHive */,
 				CA52A005CA52A005CA52A005 /* CmuxCanvas */,
 				5E2701040000000000000001 /* Sentry */,
 				5E2701040000000000000002 /* CmuxFoundation */,
@@ -5900,6 +5927,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E55200000000000000000B1 /* XCLocalSwiftPackageReference "CmuxWindowing" */,
 				5E55500000000000000000E1 /* XCLocalSwiftPackageReference "CmuxCommandPalette" */,
 				C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */,
+				C41FE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxHive" */,
 				C5B6A10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarGit" */,
 				E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */,
 				E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */,
@@ -6177,6 +6205,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources */,
 				C4A570010000000000000001 /* AppDelegate+CanvasShortcutRouting.swift in Sources */,
 				C4160A030000000000000001 /* AppDelegate+ClosedItemHistory.swift in Sources */,
+				C41FE00000000000000000C3 /* AppDelegate+CloudClients.swift in Sources */,
 				C54860050000000000000001 /* AppDelegate+CmuxNavigationDeepLinks.swift in Sources */,
 				C3677004000000000000001 /* AppDelegate+CmuxSSHURL.swift in Sources */,
 				C65930010000000000000003 /* AppDelegate+CrashSessionSnapshotRemoval.swift in Sources */,
@@ -6550,8 +6579,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					A6AC72010000000000000001 /* GPUSpinnerNSView.swift in Sources */,
 					A6AC72020000000000000001 /* GPUSpinnerStyle.swift in Sources */,
 					F5320000A1B2C3D4E5F60718 /* HermesAgentIndex.swift in Sources */,
+				C41FE00000000000000000C2 /* HiveComputersService.swift in Sources */,
 				CD0CFE6000000000CD0CFE60 /* HostAccountFlow.swift in Sources */,
 				B1F0C0030000000000000001 /* HostedInspectorDockControlScript.swift in Sources */,
+				C41FE00000000000000000C1 /* HostSettingsActions+Computers.swift in Sources */,
 				CD0CFE6200000000CD0CFE62 /* HostSettingsActions.swift in Sources */,
 				C0DEA7720000000000000001 /* InternalFlagsWindow.swift in Sources */,
 				4D8B37E0E11A29997632765F /* InternalTabDragConfiguration.swift in Sources */,
@@ -6853,6 +6884,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D9CCF002D9CCF002D9CCF002 /* SettingsLazyLoadHelpers.swift in Sources */,
 				D5671401D5671401D5671401 /* SettingsNavigation+TerminalScrollSpeed.swift in Sources */,
 				A50019A0 /* SettingsNavigation.swift in Sources */,
+				C41FE00000000000000000C4 /* SettingsNavigationTarget+SearchText.swift in Sources */,
 				A50019B0 /* SettingsSearchAliases.swift in Sources */,
 				D36090030000000000000001 /* SettingsWindowFactory.swift in Sources */,
 				D37777030000000000000001 /* SettingsWindowGeometry.swift in Sources */,
@@ -8276,6 +8308,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/Shared/CMUXMobileCore;
 		};
+		C41FE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxHive" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Packages/macOS/CmuxHive;
+		};
 		28B798BB9086C8E6B60C3355 /* XCLocalSwiftPackageReference "stack-auth-swift-sdk-prerelease" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "vendor/stack-auth-swift-sdk-prerelease";
@@ -8742,6 +8778,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCSwiftPackageProductDependency;
 			package = 0C69E6A5FA9B0513E68DF443 /* XCLocalSwiftPackageReference "CMUXMobileCore" */;
 			productName = CMUXMobileCore;
+		};
+		C41FE00000000000000000A2 /* CmuxHive */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = C41FE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxHive" */;
+			productName = CmuxHive;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -549,10 +549,6 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D36090020000000000000005 /* CmuxMainWindowFullScreenCapabilityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D36090020000000000000006 /* CmuxMainWindowFullScreenCapabilityTests.swift */; };
 		799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
 		EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */ = {isa = PBXBuildFile; productRef = EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */; };
-		C41FE00000000000000000B5 /* CmuxMobilePairedMac in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A6 /* CmuxMobilePairedMac */; };
-		C41FE00000000000000000B6 /* CmuxMobilePairedMac in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A6 /* CmuxMobilePairedMac */; };
-		C41FE00000000000000000B7 /* CmuxMobileShell in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A8 /* CmuxMobileShell */; };
-		C41FE00000000000000000B8 /* CmuxMobileShell in Frameworks */ = {isa = PBXBuildFile; productRef = C41FE00000000000000000A8 /* CmuxMobileShell */; };
 		CA1F0A01CA1F0A01CA1F0A01 /* CmuxModalAlertPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */; };
 		C54860110000000000000001 /* CmuxNavigationResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860110000000000000002 /* CmuxNavigationResolution.swift */; };
 		C54860120000000000000001 /* CmuxNavigationSurfaceDescriptor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860120000000000000002 /* CmuxNavigationSurfaceDescriptor.swift */; };
@@ -3727,8 +3723,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C617000000000000000000A3 /* CmuxGit in Frameworks */,
 				C41FE00000000000000000B1 /* CmuxHive in Frameworks */,
 				799F1BEF876006EEB8CD1035 /* CMUXMobileCore in Frameworks */,
-				C41FE00000000000000000B5 /* CmuxMobilePairedMac in Frameworks */,
-				C41FE00000000000000000B7 /* CmuxMobileShell in Frameworks */,
 				E3B7A30000000000000000D3 /* CmuxNotifications in Frameworks */,
 				E3B7A30000000000000000F3 /* CmuxPanes in Frameworks */,
 				A5C0DE0000000000000000A3 /* CMUXProjectModel in Frameworks */,
@@ -3803,8 +3797,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E2701040000000000000004 /* CmuxFoundation in Frameworks */,
 				C41FE00000000000000000B2 /* CmuxHive in Frameworks */,
 				EFB18E3C0000000000000001 /* CMUXMobileCore in Frameworks */,
-				C41FE00000000000000000B6 /* CmuxMobilePairedMac in Frameworks */,
-				C41FE00000000000000000B8 /* CmuxMobileShell in Frameworks */,
 				C0DE4A000000000000000005 /* CmuxSidebarProviderKit in Frameworks */,
 				730600040000000000000001 /* CmuxWindowing in Frameworks */,
 				5E2701040000000000000003 /* Sentry in Frameworks */,
@@ -5775,8 +5767,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A8BD195031FC4B82B4354297 /* StackAuth */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
 				C41FE00000000000000000A2 /* CmuxHive */,
-				C41FE00000000000000000A6 /* CmuxMobilePairedMac */,
-				C41FE00000000000000000A8 /* CmuxMobileShell */,
 			);
 			productName = cmux;
 			productReference = A5001000 /* cmux.app */;
@@ -5861,8 +5851,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
 				C41FE00000000000000000A2 /* CmuxHive */,
-				C41FE00000000000000000A6 /* CmuxMobilePairedMac */,
-				C41FE00000000000000000A8 /* CmuxMobileShell */,
 				CA52A005CA52A005CA52A005 /* CmuxCanvas */,
 				5E2701040000000000000001 /* Sentry */,
 				5E2701040000000000000002 /* CmuxFoundation */,
@@ -5940,8 +5928,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				5E55500000000000000000E1 /* XCLocalSwiftPackageReference "CmuxCommandPalette" */,
 				C617000000000000000000A1 /* XCLocalSwiftPackageReference "CmuxGit" */,
 				C41FE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxHive" */,
-				C41FE00000000000000000A5 /* XCLocalSwiftPackageReference "CmuxMobilePairedMac" */,
-				C41FE00000000000000000A7 /* XCLocalSwiftPackageReference "CmuxMobileShell" */,
 				C5B6A10000000000000000A1 /* XCLocalSwiftPackageReference "CmuxSidebarGit" */,
 				E3B7A30000000000000000B1 /* XCLocalSwiftPackageReference "CmuxSidebar" */,
 				E3B7A30000000000000000C1 /* XCLocalSwiftPackageReference "CmuxBrowser" */,
@@ -8326,14 +8312,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Packages/macOS/CmuxHive;
 		};
-		C41FE00000000000000000A5 /* XCLocalSwiftPackageReference "CmuxMobilePairedMac" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = Packages/iOS/CmuxMobilePairedMac;
-		};
-		C41FE00000000000000000A7 /* XCLocalSwiftPackageReference "CmuxMobileShell" */ = {
-			isa = XCLocalSwiftPackageReference;
-			relativePath = Packages/iOS/CmuxMobileShell;
-		};
 		28B798BB9086C8E6B60C3355 /* XCLocalSwiftPackageReference "stack-auth-swift-sdk-prerelease" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = "vendor/stack-auth-swift-sdk-prerelease";
@@ -8805,16 +8783,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = XCSwiftPackageProductDependency;
 			package = C41FE00000000000000000A1 /* XCLocalSwiftPackageReference "CmuxHive" */;
 			productName = CmuxHive;
-		};
-		C41FE00000000000000000A6 /* CmuxMobilePairedMac */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C41FE00000000000000000A5 /* XCLocalSwiftPackageReference "CmuxMobilePairedMac" */;
-			productName = CmuxMobilePairedMac;
-		};
-		C41FE00000000000000000A8 /* CmuxMobileShell */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = C41FE00000000000000000A7 /* XCLocalSwiftPackageReference "CmuxMobileShell" */;
-			productName = CmuxMobileShell;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -419,6 +419,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B9000034A1B2C3D4E5F60719 /* cmux_open.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000030A1B2C3D4E5F60719 /* cmux_open.swift */; };
 		A5001654 /* CmuxActionTrust.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001655 /* CmuxActionTrust.swift */; };
 		AC4A6E7C4A700001AC4A0001 /* CmuxAgentChat in Frameworks */ = {isa = PBXBuildFile; productRef = AC4A6E7C4A700001AC4A0002 /* CmuxAgentChat */; };
+		AC4A6E7C4A700001AC4A0004 /* CmuxAgentChat in Frameworks */ = {isa = PBXBuildFile; productRef = AC4A6E7C4A700001AC4A0002 /* CmuxAgentChat */; };
 		C0DE43000000000000000001 /* CmuxAgentChatConfig.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE43000000000000000002 /* CmuxAgentChatConfig.swift */; };
 		C0DE43000000000000000009 /* CmuxAgentChatConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE4300000000000000000A /* CmuxAgentChatConfigTests.swift */; };
 		A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
@@ -3789,6 +3790,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			buildActionMask = 2147483647;
 			files = (
 				B057B0017E57B0017E57B001 /* Bonsplit in Frameworks */,
+				AC4A6E7C4A700001AC4A0004 /* CmuxAgentChat in Frameworks */,
 				C9A2B00000000000000000C3 /* CmuxAppKitSupportUI in Frameworks */,
 				D7032A060000000000000001 /* CmuxBrowser in Frameworks */,
 				CA52A007CA52A007CA52A007 /* CmuxCanvas in Frameworks */,
@@ -5849,6 +5851,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			name = cmuxTests;
 			packageProductDependencies = (
 				A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */,
+				AC4A6E7C4A700001AC4A0002 /* CmuxAgentChat */,
 				EFB18E3B3099DFE2ECA3C263 /* CMUXMobileCore */,
 				C41FE00000000000000000A2 /* CmuxHive */,
 				CA52A005CA52A005CA52A005 /* CmuxCanvas */,

--- a/cmux.xcworkspace/contents.xcworkspacedata
+++ b/cmux.xcworkspace/contents.xcworkspacedata
@@ -130,6 +130,9 @@
          location = "group:CmuxGit">
       </FileRef>
       <FileRef
+         location = "group:CmuxHive">
+      </FileRef>
+      <FileRef
          location = "group:CmuxLiveEval">
       </FileRef>
       <FileRef


### PR DESCRIPTION
Part of #8001 (hive M1, slice 1 of 2). Adds the account-level device list and Mac-to-Mac pairing to macOS; the remote-workspace viewer (workspace list + live terminal + input) lands in the follow-up slice that closes #8001.

## What this adds

**Settings › Computers on macOS** — a new settings section listing the account's registered computers, merged live from three sources the iOS app already uses:

- the team device registry (`GET /api/devices`, via the shared `DeviceRegistryService`),
- the local paired-computer store (`MobilePairedMacStore`, in its own `hive-paired-computers.sqlite3` so the Mac-as-client namespace is distinct),
- the presence worker's subscribe stream (`PresenceClient`), so rows show live Online/Offline with last-seen fallbacks.

**Mac-to-Mac pairing** — pair another Mac on the same account:

- one click on a registry row (persists the best advertised instance's Tailscale routes; online instances preferred, then freshest),
- or paste a pairing link (the exact `cmux-ios://attach?…` payload another Mac's pairing window renders as its QR — a Mac has no camera, so link paste is the macOS counterpart of the phone's scan). The shared `CmxAttachTicketInput` grammar does the decoding; Mac-side policy rejects loopback-only links outside dev builds and cross-account links up front. v2 links carry no device identity by design, so pairing mirrors the iOS manual-host flow: a synthetic `manual-<host>:<port>` identity until the first connection adopts the host-reported one.
- Unpair removes only the local pairing; the registry row stays.

The section also links to the existing pairing window ("Show Pairing Code…"), which is the host-side half of Mac-to-Mac pairing.

## New package: `Packages/macOS/CmuxHive`

The Mac-as-client composition of the existing mobile client stack (`HiveComputerDirectory`, `HivePairingLinkDecoder`, row/value models), mirroring how the iOS app composes `DeviceRegistryService` + `MobilePairedMacStore` + `PresenceClient` rather than inventing a parallel stack. All dependencies are injected protocol seams (`DeviceRegistryRefreshing`, `MobilePairedMacStoring`, `PresenceSubscribing`); the merge and pair/unpair actions are unit-tested with a scripted registry, a real temp-SQLite store, and wire-shaped presence frames (13 tests).

Package retargeting turned out to be zero-diff: every client package (`CmuxMobileRPC`, `CmuxMobileTransport`, `CmuxMobilePairedMac`, `CmuxMobileShell`, `CmuxSyncStore`, `CMUXMobileCore`) already declares `.macOS(.v14)` and builds/tests cleanly on macOS. This PR links them into the macOS app target through `CmuxHive` (wired into both `cmux` and `cmuxTests`). Hoisting the `Packages/iOS` client packages into `Packages/Shared` is deferred to the umbrella (#8000) to keep the iOS project untouched, as the issue allows.

## iOS unchanged

No iOS target, package source, or pairing-payload change. The only shared-package edits are additive (new macOS-only package + settings UI).

## Notes for review

- `AppDelegate.swift` and `SettingsNavigation.swift` sit exactly at their file-length budgets, so the cloud-client configure block and the `searchText` corpus moved to new files (`AppDelegate+CloudClients.swift`, `SettingsNavigationTarget+SearchText.swift`); both files shrank net.
- Localization: all new user-facing strings have `en` + `ja` entries in `Resources/Localizable.xcstrings` (section title, rows, pair results, search aliases).
- No new keyboard shortcuts.
- Presence subscription starts only while something observes the directory (the pane open, later the viewer), and stops with the last observer; resubscribe uses a bounded, cancellable backoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8018"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786580711&installation_id=133855650&pr_number=8018&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8018&signature=0ad28096d1edc17eab0b54fd3b4f40c7facd087c4d5f90172cf09bfcbadef2fc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Settings > Computers on macOS with live presence and Mac‑to‑Mac pairing, including a Copy Pairing Link flow. Part of #8001 (hive M1); the remote‑workspace viewer ships next.

- **New Features**
  - Shows your account’s computers with Online/Offline and last‑seen, merged from the device registry, local pairings, and presence.
  - Pair another Mac by clicking a registry row or pasting a pairing link; cross‑account and loopback‑only links are blocked; unpair only removes the local pairing.
  - Adds “Copy Pairing Link” for this Mac; removes the iPhone QR button from this pane (still in Settings > Mobile). Live updates while open. EN+JA strings.
  - “Copy Pairing Link” uses a bordered button style to match other controls.

- **Dependencies**
  - New `CmuxHive` package (`HiveComputerDirectory`, `HivePairingLinkDecoder`, `HiveComposition`, `HiveReconnectBackoff`). 13 tests.
  - App wiring via `HiveComputersService` and a `SettingsHostActions` bridge; extracted `AppDelegate+CloudClients.swift`. Navigation and search entries added.
  - The directory is composed inside `CmuxHive` so the app links only `CmuxHive`; reverted explicit app‑target products. `cmuxTests` links `CmuxAgentChat` directly. Retry‑delay closure marked `@Sendable`.

<sup>Written for commit e14482137712fcdb78cb82a97811e6ea14fed621. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Computers section to Settings to browse registered Macs, pairing status, and presence (online/offline with last-seen).
  * Enabled pairing/unpairing per device, plus “Pair This Mac” with link generation, paste-link pairing, and copy-to-clipboard.
  * Added Computers to navigation/search (including search indexing and localized UI strings).
* **Bug Fixes**
  * Improved refresh and presence resilience, preserving existing rows during transient failures and handling presence reconnects more robustly.
* **Tests**
  * Added coverage for directory merging, refresh/pair/unpair behavior, presence snapshots, and pairing-link decoding rules (including loopback handling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->