### PR TITLE
reload.sh: bound failure log dump to stop a disk-filling self-append loop

### DIFF
--- a/scripts/reload.sh
+++ b/scripts/reload.sh
@@ -594,7 +594,20 @@ reload_finalize() {
       echo "==> removed incomplete staged tagged app" >&2
     fi
     if [[ -s "$RELOAD_LOG" ]]; then
-      cat "$RELOAD_LOG" >&2
+      # Guard against a self-referential dump: if the caller redirected our stderr
+      # to the same path we use as RELOAD_LOG (e.g. `reload.sh > /tmp/cmux-reload-<tag>.log 2>&1`),
+      # then `cat "$RELOAD_LOG" >&2` appends the file to itself forever and fills the
+      # disk (this ran a log to 173GB overnight). Skip the dump when stderr and
+      # RELOAD_LOG share an inode; otherwise bound it with tail so a huge log can't
+      # flood the caller's output. Full log path is printed below either way.
+      local reload_log_ino reload_stderr_ino
+      reload_log_ino="$(stat -f '%d:%i' "$RELOAD_LOG" 2>/dev/null || echo log)"
+      reload_stderr_ino="$(stat -f '%d:%i' /dev/fd/2 2>/dev/null || echo err)"
+      if [[ "$reload_log_ino" == "$reload_stderr_ino" ]]; then
+        echo "==> (skipped log dump: stderr is the reload log itself)" >&2
+      else
+        tail -n 2000 "$RELOAD_LOG" >&2
+      fi
     fi
     echo "" >&2
     echo "==> reload FAILED (exit $rc) after ${elapsed}s" >&2


### PR DESCRIPTION
## Problem

On build failure, `reload_finalize` in `scripts/reload.sh` dumps the whole build log to stderr with `cat "$RELOAD_LOG" >&2`. `RELOAD_LOG` is a fixed path (`/tmp/cmux-reload-<tag>.log`), so if a caller redirects reload.sh's own stderr to that same path — e.g. `reload.sh --tag x > /tmp/cmux-reload-x.log 2>&1`, an easy mistake since that is exactly the path reload.sh prints in its output — the `cat` appends the file to itself in an unbounded loop.

This filled a disk to **173GB overnight** (signature: ~100k lines, only ~735 unique) before the disk filled and writes stopped.

## Fix

Guard the failure dump:
- Skip it entirely when stderr and `$RELOAD_LOG` resolve to the same inode (device+inode via `stat -f '%d:%i' /dev/fd/2`).
- Otherwise bound the dump with `tail -n 2000` so a large log can't flood the caller's output either.

The full log path is still printed, so nothing is lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8024"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786582841&installation_id=133855650&pr_number=8024&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8024&signature=cc01087a0552c521ee44412cc3f7190f70480310d8480acbbafa42eaa59ed210"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevented a disk-filling self-append loop in `scripts/reload.sh` by guarding and bounding failure log dumps. On failure, we now avoid dumping the log to itself and cap stderr output to 2000 lines.

- **Bug Fixes**
  - Skip dump when stderr and `$RELOAD_LOG` resolve to the same inode (checked via `stat` on `/dev/fd/2`).
  - Otherwise emit only `tail -n 2000` of the log to stderr; full log path is still printed.

<sup>Written for commit b0c9f627a6521ffeb5ac67f4a63b9dd437a87bee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented reload failures from endlessly appending logs to the same output file.
  * Limited displayed reload failure details to the latest 2,000 log lines when appropriate.
  * Improved reliability and protection against excessive disk usage during failed reloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->