### PR TITLE
Add debug-only iOS Design Gallery: four candidate design systems

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryEntryView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryEntryView.swift
@@ -1,0 +1,40 @@
+#if DEBUG
+import SwiftUI
+
+/// The root view for the DEBUG `CMUX_DESIGN_GALLERY` environment entry point.
+///
+/// Mounts the gallery root list for `CMUX_DESIGN_GALLERY=1`, or jumps straight
+/// to one candidate's page for deep values such as `phosphor:specimen:dark`
+/// (see ``DesignGalleryRoute`` for the grammar). Deep routing exists so
+/// screenshot sweeps and UI tests can capture every candidate page without
+/// scripting taps through the gallery navigation.
+///
+/// ```swift
+/// // In the app's DEBUG root override chain:
+/// DesignGalleryEntryView(environmentValue: galleryValue)
+/// ```
+public struct DesignGalleryEntryView: View {
+    private let route: DesignGalleryRoute?
+
+    /// Creates the entry view from the raw `CMUX_DESIGN_GALLERY` value.
+    /// - Parameter environmentValue: The environment-variable value; any
+    ///   non-empty, non-`0` value mounts the gallery.
+    public init(environmentValue: String) {
+        self.route = DesignGalleryRoute(environmentValue: environmentValue)
+    }
+
+    public var body: some View {
+        if let route, let system = route.system {
+            NavigationStack {
+                DesignGalleryShell(
+                    system: system,
+                    initialPage: route.page,
+                    initialScheme: route.scheme
+                )
+            }
+        } else {
+            DesignGalleryScreen()
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryFixtures.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryFixtures.swift
@@ -290,8 +290,8 @@ struct DesignGalleryFixtures {
     ]
 
     static let settings = GallerySettingsFixture(
-        accountEmail: "aziz@manaflow.ai",
-        pairedMacName: "Aziz's MacBook Pro",
+        accountEmail: "dev@example.com",
+        pairedMacName: "Dev MacBook Pro",
         pairedMacStatus: "Connected · Tailscale",
         appVersion: "1.4.2 (890)",
         notificationsEnabled: true,

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryFixtures.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryFixtures.swift
@@ -1,0 +1,301 @@
+#if DEBUG
+/// The lifecycle state of an agent represented in gallery fixture data.
+enum GalleryAgentState: CaseIterable {
+    case needsYou
+    case running
+    case done
+    case failed
+    case idle
+}
+
+/// A static workspace row shared by every candidate's hub screen.
+struct GalleryWorkspaceFixture: Identifiable {
+    let id: Int
+    let name: String
+    let branch: String
+    let agentName: String
+    let state: GalleryAgentState
+    let elapsedText: String
+    let absoluteTimeText: String
+    let detailText: String
+    let pendingQuestion: String?
+}
+
+/// A terminal transcript line shared by every candidate's session screen.
+struct GalleryTerminalLine: Identifiable {
+    /// The semantic color role a candidate maps into its own palette.
+    enum Tone {
+        case plain
+        case dim
+        case accent
+        case success
+        case warning
+        case error
+    }
+
+    let id: Int
+    let text: String
+    let tone: Tone
+}
+
+/// A conversation item shared by every candidate's chat screen.
+struct GalleryChatEntry: Identifiable {
+    /// The participant or presentation role of a fixture conversation item.
+    enum Role {
+        case user
+        case agent
+        case tool
+        case approval
+    }
+
+    let id: Int
+    let role: Role
+    let text: String
+    let timeText: String
+    let toolCommand: String?
+    let toolOutput: String?
+    let question: String?
+}
+
+/// A dated group in the gallery's shared activity feed.
+struct GalleryActivityDay {
+    let dayLabel: String
+    let entries: [GalleryActivityEntry]
+}
+
+/// A single event in the gallery's shared activity feed.
+struct GalleryActivityEntry: Identifiable {
+    let id: Int
+    let timeText: String
+    let state: GalleryAgentState
+    let text: String
+    let unread: Bool
+}
+
+/// Static account and preference values shared by candidate settings screens.
+struct GallerySettingsFixture {
+    let accountEmail: String
+    let pairedMacName: String
+    let pairedMacStatus: String
+    let appVersion: String
+    let notificationsEnabled: Bool
+    let terminalFontSize: String
+}
+
+/// Shared static data rendered by every candidate design system.
+struct DesignGalleryFixtures {
+    static let workspaces: [GalleryWorkspaceFixture] = [
+        GalleryWorkspaceFixture(
+            id: 1,
+            name: "cmux",
+            branch: "feat-ios-design-gallery",
+            agentName: "Claude",
+            state: .needsYou,
+            elapsedText: "2m",
+            absoluteTimeText: "14:32",
+            detailText: "Proposed a 4-system gallery plan",
+            pendingQuestion: "Plan adds 24 screens behind the debug menu. Approve?"
+        ),
+        GalleryWorkspaceFixture(
+            id: 2,
+            name: "cmux",
+            branch: "fix-sidebar-ports",
+            agentName: "Codex",
+            state: .running,
+            elapsedText: "12m",
+            absoluteTimeText: "14:22",
+            detailText: "Running tests: 214 of 356 passed",
+            pendingQuestion: nil
+        ),
+        GalleryWorkspaceFixture(
+            id: 3,
+            name: "zed",
+            branch: "ghostty-pane-resize",
+            agentName: "Claude",
+            state: .running,
+            elapsedText: "4m",
+            absoluteTimeText: "14:30",
+            detailText: "Editing crates/terminal_view/src/split.rs",
+            pendingQuestion: nil
+        ),
+        GalleryWorkspaceFixture(
+            id: 4,
+            name: "web",
+            branch: "pricing-page-copy",
+            agentName: "Codex",
+            state: .done,
+            elapsedText: "1h",
+            absoluteTimeText: "13:31",
+            detailText: "PR #7841 opened, CI green",
+            pendingQuestion: nil
+        ),
+        GalleryWorkspaceFixture(
+            id: 5,
+            name: "cmux",
+            branch: "issue-7691-port-collision",
+            agentName: "Claude",
+            state: .failed,
+            elapsedText: "3h",
+            absoluteTimeText: "11:12",
+            detailText: "Build failed: linker error in GhosttyKit",
+            pendingQuestion: nil
+        ),
+        GalleryWorkspaceFixture(
+            id: 6,
+            name: "dotfiles",
+            branch: "main",
+            agentName: "Codex",
+            state: .idle,
+            elapsedText: "2d",
+            absoluteTimeText: "Jul 11",
+            detailText: "No activity",
+            pendingQuestion: nil
+        ),
+    ]
+
+    static let terminalLines: [GalleryTerminalLine] = [
+        GalleryTerminalLine(id: 1, text: "$ ./scripts/reload.sh --tag dsgal", tone: .accent),
+        GalleryTerminalLine(id: 2, text: "Resolving Swift package dependencies", tone: .dim),
+        GalleryTerminalLine(id: 3, text: "[1/8] Compiling CmuxMobileSupport", tone: .dim),
+        GalleryTerminalLine(id: 4, text: "[2/8] Compiling CmuxMobileShell", tone: .dim),
+        GalleryTerminalLine(id: 5, text: "warning: cached module was built with an older SDK", tone: .warning),
+        GalleryTerminalLine(id: 6, text: "[3/8] Compiling CmuxMobileShellUI", tone: .plain),
+        GalleryTerminalLine(id: 7, text: "error: dependency scan failed for MobileTerminalKit", tone: .error),
+        GalleryTerminalLine(id: 8, text: "Retrying dependency scan with a clean module cache", tone: .dim),
+        GalleryTerminalLine(id: 9, text: "[4/8] Compiling CmuxMobileTerminalKit", tone: .plain),
+        GalleryTerminalLine(id: 10, text: "[5/8] Linking cmux DEV dsgal", tone: .dim),
+        GalleryTerminalLine(id: 11, text: "[6/8] Running CmuxMobileShellUITests", tone: .dim),
+        GalleryTerminalLine(id: 12, text: "Test Suite Passed: 42 tests, 0 failures", tone: .success),
+        GalleryTerminalLine(id: 13, text: "[8/8] Signing cmux DEV dsgal.app", tone: .dim),
+        GalleryTerminalLine(id: 14, text: "Build succeeded", tone: .success),
+    ]
+
+    static let chatEntries: [GalleryChatEntry] = [
+        GalleryChatEntry(
+            id: 1,
+            role: .user,
+            text: "Fix the sidebar port flicker and add a regression test",
+            timeText: "14:20",
+            toolCommand: nil,
+            toolOutput: nil,
+            question: nil
+        ),
+        GalleryChatEntry(
+            id: 2,
+            role: .agent,
+            text: "I’ll trace the shared port-status update path and reproduce the stale scan transition. Then I’ll add behavior-level coverage before applying the fix.",
+            timeText: "14:21",
+            toolCommand: nil,
+            toolOutput: nil,
+            question: nil
+        ),
+        GalleryChatEntry(
+            id: 3,
+            role: .tool,
+            text: "Build and test",
+            timeText: "14:28",
+            toolCommand: "./scripts/reload.sh --tag sbport",
+            toolOutput: "Compiling CmuxMobileShellUI\nTest Suite Passed: 18 tests, 0 failures\nBuild succeeded",
+            question: nil
+        ),
+        GalleryChatEntry(
+            id: 4,
+            role: .agent,
+            text: "Tests pass. One design question remains.",
+            timeText: "14:30",
+            toolCommand: nil,
+            toolOutput: nil,
+            question: nil
+        ),
+        GalleryChatEntry(
+            id: 5,
+            role: .approval,
+            text: "",
+            timeText: "14:31",
+            toolCommand: nil,
+            toolOutput: nil,
+            question: "Should the port badge hide when the scan is stale, or show the last-known port dimmed?"
+        ),
+    ]
+
+    static let approvalActions = ["Approve", "Deny"]
+
+    static let activityDays: [GalleryActivityDay] = [
+        GalleryActivityDay(
+            dayLabel: "Today",
+            entries: [
+                GalleryActivityEntry(
+                    id: 1,
+                    timeText: "14:32",
+                    state: .needsYou,
+                    text: "Claude needs your input on cmux",
+                    unread: true
+                ),
+                GalleryActivityEntry(
+                    id: 2,
+                    timeText: "14:27",
+                    state: .done,
+                    text: "CI green on PR #7952",
+                    unread: true
+                ),
+                GalleryActivityEntry(
+                    id: 3,
+                    timeText: "13:31",
+                    state: .done,
+                    text: "Codex finished pricing-page-copy",
+                    unread: false
+                ),
+                GalleryActivityEntry(
+                    id: 4,
+                    timeText: "11:12",
+                    state: .failed,
+                    text: "Build failed on issue-7691",
+                    unread: true
+                ),
+                GalleryActivityEntry(
+                    id: 5,
+                    timeText: "10:48",
+                    state: .running,
+                    text: "Claude is running tests on ghostty-pane-resize",
+                    unread: false
+                ),
+            ]
+        ),
+        GalleryActivityDay(
+            dayLabel: "Yesterday",
+            entries: [
+                GalleryActivityEntry(
+                    id: 6,
+                    timeText: "18:04",
+                    state: .running,
+                    text: "Codex started sidebar performance profiling",
+                    unread: false
+                ),
+                GalleryActivityEntry(
+                    id: 7,
+                    timeText: "16:19",
+                    state: .idle,
+                    text: "dotfiles has no recent agent activity",
+                    unread: false
+                ),
+                GalleryActivityEntry(
+                    id: 8,
+                    timeText: "09:42",
+                    state: .done,
+                    text: "Claude completed terminal input cleanup",
+                    unread: false
+                ),
+            ]
+        ),
+    ]
+
+    static let settings = GallerySettingsFixture(
+        accountEmail: "aziz@manaflow.ai",
+        pairedMacName: "Aziz's MacBook Pro",
+        pairedMacStatus: "Connected · Tailscale",
+        appVersion: "1.4.2 (890)",
+        notificationsEnabled: true,
+        terminalFontSize: "13"
+    )
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryPage.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryPage.swift
@@ -1,0 +1,46 @@
+#if DEBUG
+import CmuxMobileSupport
+
+/// A screen category shared by every candidate design system in the gallery.
+enum DesignGalleryPage: String, CaseIterable, Identifiable {
+    case hub
+    case session
+    case chat
+    case activity
+    case settings
+    case specimen
+
+    /// The stable identifier used by gallery navigation controls.
+    var id: String { rawValue }
+
+    /// The localized title displayed in gallery navigation and placeholders.
+    var title: String {
+        switch self {
+        case .hub:
+            L10n.string("mobile.designGallery.page.hub", defaultValue: "Hub")
+        case .session:
+            L10n.string("mobile.designGallery.page.session", defaultValue: "Session")
+        case .chat:
+            L10n.string("mobile.designGallery.page.chat", defaultValue: "Chat")
+        case .activity:
+            L10n.string("mobile.designGallery.page.activity", defaultValue: "Activity")
+        case .settings:
+            L10n.string("mobile.designGallery.page.settings", defaultValue: "Settings")
+        case .specimen:
+            L10n.string("mobile.designGallery.page.specimen", defaultValue: "Specimen")
+        }
+    }
+
+    /// The SF Symbol used for the page in the bottom picker.
+    var symbolName: String {
+        switch self {
+        case .hub: "square.grid.2x2"
+        case .session: "terminal"
+        case .chat: "bubble.left.and.bubble.right"
+        case .activity: "bell"
+        case .settings: "gearshape"
+        case .specimen: "paintpalette"
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryRoute.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryRoute.swift
@@ -1,0 +1,42 @@
+#if DEBUG
+import SwiftUI
+
+/// A parsed deep route into the design gallery, used by the DEBUG
+/// `CMUX_DESIGN_GALLERY` environment entry point.
+///
+/// Accepted forms, colon-separated and case-insensitive:
+/// - `1` — the gallery root (system list)
+/// - `<system>` — one candidate at its hub page, e.g. `phosphor`
+/// - `<system>:<page>` — one candidate at a page, e.g. `atelier:chat`
+/// - `<system>:<page>:<light|dark>` — with a forced color scheme,
+///   e.g. `phosphor:specimen:light`
+///
+/// Unrecognized systems, pages, or schemes fall back component-wise (root,
+/// `.hub`, and the system's default scheme respectively) so a typo still
+/// lands somewhere useful in a debug run.
+struct DesignGalleryRoute: Equatable {
+    /// The candidate to open, or `nil` for the gallery root list.
+    let system: DesignGallerySystem?
+    /// The page to open when a candidate is routed.
+    let page: DesignGalleryPage
+    /// The forced color scheme, or `nil` for the candidate's default.
+    let scheme: ColorScheme?
+
+    /// Parses a route from the raw environment-variable value.
+    /// - Parameter environmentValue: The value of `CMUX_DESIGN_GALLERY`.
+    /// - Returns: `nil` when the value is empty or `0` (gallery disabled).
+    init?(environmentValue: String) {
+        let trimmed = environmentValue.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !trimmed.isEmpty, trimmed != "0" else { return nil }
+
+        let parts = trimmed.split(separator: ":").map(String.init)
+        self.system = parts.first.flatMap(DesignGallerySystem.init(rawValue:))
+        self.page = parts.count > 1 ? DesignGalleryPage(rawValue: parts[1]) ?? .hub : .hub
+        switch parts.count > 2 ? parts[2] : nil {
+        case "light": self.scheme = .light
+        case "dark": self.scheme = .dark
+        default: self.scheme = nil
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryScreen.swift
@@ -1,0 +1,58 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Presents the debug-only catalog of static iOS design-system candidates.
+///
+/// Use this screen from debug navigation or the `CMUX_DESIGN_GALLERY=1`
+/// environment entry point. It does not connect to live application data.
+public struct DesignGalleryScreen: View {
+    @Environment(\.dismiss) private var dismiss
+
+    /// Creates the root design-gallery browser.
+    public init() {}
+
+    /// The gallery's navigation hierarchy and dismissal control.
+    public var body: some View {
+        NavigationStack {
+            List {
+                Section {
+                    ForEach(DesignGallerySystem.allCases) { system in
+                        NavigationLink {
+                            DesignGalleryShell(system: system)
+                        } label: {
+                            HStack(alignment: .firstTextBaseline, spacing: 12) {
+                                Text(system.number)
+                                    .font(.subheadline.monospaced())
+                                    .foregroundStyle(.secondary)
+                                VStack(alignment: .leading, spacing: 3) {
+                                    Text(system.displayName)
+                                        .font(.headline)
+                                    Text(system.tagline)
+                                        .font(.subheadline)
+                                        .foregroundStyle(.secondary)
+                                }
+                            }
+                            .padding(.vertical, 4)
+                        }
+                        .accessibilityIdentifier("DesignGallerySystem-\(system.rawValue)")
+                    }
+                } footer: {
+                    Text(L10n.string(
+                        "mobile.designGallery.footer",
+                        defaultValue: "Static design-system candidates. No live data."
+                    ))
+                }
+            }
+            .navigationTitle(L10n.string("mobile.designGallery.title", defaultValue: "Design Gallery"))
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button(L10n.string("mobile.common.done", defaultValue: "Done")) {
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryShell.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryShell.swift
@@ -9,9 +9,22 @@ struct DesignGalleryShell: View {
     @State private var page: DesignGalleryPage = .hub
     @State private var colorSchemeOverride: ColorScheme
 
-    init(system: DesignGallerySystem) {
+    /// Creates the browser for one candidate.
+    /// - Parameters:
+    ///   - system: The candidate design system to browse.
+    ///   - initialPage: The page shown first; defaults to the hub.
+    ///   - initialScheme: A forced starting color scheme, or `nil` for the
+    ///     candidate's default (dark for Phosphor, light otherwise).
+    init(
+        system: DesignGallerySystem,
+        initialPage: DesignGalleryPage = .hub,
+        initialScheme: ColorScheme? = nil
+    ) {
         self.system = system
-        _colorSchemeOverride = State(initialValue: system == .phosphor ? .dark : .light)
+        _page = State(initialValue: initialPage)
+        _colorSchemeOverride = State(
+            initialValue: initialScheme ?? (system == .phosphor ? .dark : .light)
+        )
     }
 
     var body: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryShell.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryShell.swift
@@ -1,0 +1,76 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Browses the six shared pages rendered by one candidate design system.
+struct DesignGalleryShell: View {
+    let system: DesignGallerySystem
+
+    @State private var page: DesignGalleryPage = .hub
+    @State private var colorSchemeOverride: ColorScheme
+
+    init(system: DesignGallerySystem) {
+        self.system = system
+        _colorSchemeOverride = State(initialValue: system == .phosphor ? .dark : .light)
+    }
+
+    var body: some View {
+        ZStack {
+            system.content(page: page)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .environment(\.colorScheme, colorSchemeOverride)
+        }
+        .navigationTitle("\(system.number) \(system.displayName)")
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+            ToolbarItem(placement: .topBarTrailing) {
+                Button {
+                    colorSchemeOverride = colorSchemeOverride == .dark ? .light : .dark
+                } label: {
+                    Image(systemName: colorSchemeOverride == .dark ? "sun.max" : "moon")
+                }
+                .accessibilityLabel(L10n.string(
+                    "mobile.designGallery.schemeToggle.accessibilityLabel",
+                    defaultValue: "Toggle Light or Dark Appearance"
+                ))
+                .accessibilityIdentifier("DesignGallerySchemeToggle")
+            }
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            pagePicker
+                .background(.bar)
+        }
+    }
+
+    private var pagePicker: some View {
+        HStack(spacing: 4) {
+            ForEach(DesignGalleryPage.allCases) { candidatePage in
+                Button {
+                    page = candidatePage
+                } label: {
+                    VStack(spacing: 2) {
+                        Image(systemName: candidatePage.symbolName)
+                            .font(.body)
+                        Text(candidatePage.title)
+                            .font(.caption2)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                    }
+                    .frame(minWidth: 44, maxWidth: .infinity, minHeight: 44)
+                    .padding(.horizontal, 2)
+                    .foregroundStyle(page == candidatePage ? Color.accentColor : Color.secondary)
+                    .background {
+                        Capsule()
+                            .fill(page == candidatePage ? Color.accentColor.opacity(0.14) : Color.clear)
+                    }
+                    .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("DesignGalleryPage-\(candidatePage.rawValue)")
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 6)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryShell.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGalleryShell.swift
@@ -31,8 +31,11 @@ struct DesignGalleryShell: View {
         ZStack {
             system.content(page: page)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .environment(\.colorScheme, colorSchemeOverride)
         }
+        // The whole presentation (candidate content, page chips, navigation
+        // chrome, status bar) follows the forced scheme so scheme-specific
+        // review sees one coherent appearance.
+        .preferredColorScheme(colorSchemeOverride)
         .navigationTitle("\(system.number) \(system.displayName)")
         .navigationBarTitleDisplayMode(.inline)
         .toolbar {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGallerySystem.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/DesignGallerySystem.swift
@@ -1,0 +1,78 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// A candidate visual system available in the static design gallery.
+enum DesignGallerySystem: String, CaseIterable, Identifiable {
+    case phosphor
+    case atelier
+    case meridian
+    case signal
+
+    /// The stable identifier used by gallery navigation.
+    var id: String { rawValue }
+
+    /// The presentation-order number assigned to the candidate.
+    var number: String {
+        switch self {
+        case .phosphor: "01"
+        case .atelier: "02"
+        case .meridian: "03"
+        case .signal: "04"
+        }
+    }
+
+    /// The candidate's proper name.
+    var displayName: String {
+        switch self {
+        case .phosphor: "Phosphor"
+        case .atelier: "Atelier"
+        case .meridian: "Meridian"
+        case .signal: "Signal"
+        }
+    }
+
+    /// The localized one-line identity of the candidate.
+    var tagline: String {
+        switch self {
+        case .phosphor:
+            L10n.string(
+                "mobile.designGallery.system.phosphor.tagline",
+                defaultValue: "Terminal-native instrument"
+            )
+        case .atelier:
+            L10n.string(
+                "mobile.designGallery.system.atelier.tagline",
+                defaultValue: "Warm humanist companion"
+            )
+        case .meridian:
+            L10n.string(
+                "mobile.designGallery.system.meridian.tagline",
+                defaultValue: "Liquid-glass native"
+            )
+        case .signal:
+            L10n.string(
+                "mobile.designGallery.system.signal.tagline",
+                defaultValue: "Swiss status board"
+            )
+        }
+    }
+
+    /// Builds the selected page with this candidate's root gallery view.
+    /// - Parameter page: The shared gallery page the candidate should render.
+    /// - Returns: The candidate's static representation of `page`.
+    @ViewBuilder
+    func content(page: DesignGalleryPage) -> some View {
+        switch self {
+        case .phosphor:
+            PhosphorGallery(page: page)
+        case .atelier:
+            AtelierGallery(page: page)
+        case .meridian:
+            MeridianGallery(page: page)
+        case .signal:
+            SignalGallery(page: page)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierActivityEntryView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierActivityEntryView.swift
@@ -1,0 +1,49 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders one activity event as a journal sentence with redundant state signaling.
+struct AtelierActivityEntryView: View {
+    let entry: GalleryActivityEntry
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+        let color = theme.color(for: entry.state)
+
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(color.opacity(0.16))
+                    .frame(width: 22, height: 22)
+                Image(systemName: theme.symbol(for: entry.state))
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(color)
+            }
+            .padding(.top, 1)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(entry.text)
+                    .font(.system(size: 16, weight: entry.unread ? .medium : .regular))
+                    .foregroundStyle(theme.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text("\(theme.label(for: entry.state)) · \(entry.timeText)")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(color)
+            }
+
+            Spacer(minLength: 8)
+
+            if entry.unread {
+                Circle()
+                    .fill(theme.accent)
+                    .frame(width: 6, height: 6)
+                    .padding(.top, 8)
+                    .accessibilityLabel("Unread")
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+        .accessibilityElement(children: .combine)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierActivityScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierActivityScreen.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import SwiftUI
+
+/// Presents every shared activity entry as a spacious chronological journal.
+struct AtelierActivityScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 28) {
+                Text("Activity")
+                    .font(.system(size: 28, weight: .semibold, design: .serif))
+                    .foregroundStyle(theme.textPrimary)
+
+                ForEach(Array(DesignGalleryFixtures.activityDays.enumerated()), id: \.offset) { _, day in
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text(day.dayLabel)
+                            .font(.system(size: 20, weight: .semibold, design: .serif))
+                            .foregroundStyle(theme.textPrimary)
+
+                        ForEach(day.entries) { entry in
+                            AtelierActivityEntryView(entry: entry)
+
+                            if entry.id != day.entries.last?.id {
+                                Divider()
+                                    .overlay(theme.hairline)
+                                    .padding(.leading, 34)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 28)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.background)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierActivityScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierActivityScreen.swift
@@ -37,7 +37,7 @@ struct AtelierActivityScreen: View {
             .padding(.bottom, 28)
         }
         .scrollIndicators(.hidden)
-        .background(theme.background)
+        .background(theme.background.ignoresSafeArea())
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatEntryView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatEntryView.swift
@@ -1,0 +1,117 @@
+#if DEBUG
+import SwiftUI
+
+/// Maps a shared conversation fixture entry into Atelier's conversational components.
+struct AtelierChatEntryView: View {
+    let entry: GalleryChatEntry
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    @ViewBuilder
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        switch entry.role {
+        case .user:
+            HStack {
+                Spacer(minLength: 48)
+                VStack(alignment: .trailing, spacing: 8) {
+                    Text(entry.text)
+                        .font(.system(size: 16))
+                        .foregroundStyle(theme.textPrimary)
+                        .multilineTextAlignment(.leading)
+                    Text(entry.timeText)
+                        .font(.system(size: 13))
+                        .foregroundStyle(theme.textTertiary)
+                }
+                .padding(16)
+                .background(
+                    theme.accent.opacity(0.10),
+                    in: RoundedRectangle(cornerRadius: 18, style: .continuous)
+                )
+            }
+        case .agent:
+            VStack(alignment: .leading, spacing: 8) {
+                Text(entry.text)
+                    .font(.system(size: 16))
+                    .foregroundStyle(theme.textPrimary)
+                    .lineSpacing(6.4)
+                    .fixedSize(horizontal: false, vertical: true)
+                Text(entry.timeText)
+                    .font(.system(size: 13))
+                    .foregroundStyle(theme.textTertiary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+        case .tool:
+            VStack(alignment: .leading, spacing: 12) {
+                HStack {
+                    Image(systemName: "terminal")
+                        .foregroundStyle(theme.accent)
+                    Text("Ran a command")
+                        .font(.system(size: 16, weight: .semibold, design: .serif))
+                        .foregroundStyle(theme.textPrimary)
+                    Spacer()
+                    Text(entry.timeText)
+                        .font(.system(size: 13))
+                        .foregroundStyle(theme.textTertiary)
+                }
+
+                Text(entry.text)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(theme.textSecondary)
+
+                if let command = entry.toolCommand {
+                    Text(command)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(theme.textPrimary)
+                }
+
+                if let output = entry.toolOutput {
+                    Text(output)
+                        .font(.system(size: 12, design: .monospaced))
+                        .foregroundStyle(theme.textSecondary)
+                        .lineSpacing(4)
+                }
+            }
+            .padding(16)
+            .background(theme.inset, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+        case .approval:
+            VStack(alignment: .leading, spacing: 16) {
+                AtelierStatusMark(state: .needsYou)
+
+                if let question = entry.question {
+                    Text(question)
+                        .font(.system(size: 19, weight: .semibold, design: .serif))
+                        .italic()
+                        .foregroundStyle(theme.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                Button(action: {}) {
+                    Text(DesignGalleryFixtures.approvalActions[0])
+                        .font(.system(size: 16, weight: .semibold))
+                        .foregroundStyle(theme.accentForeground)
+                        .frame(maxWidth: .infinity, minHeight: 52)
+                        .background(theme.accent, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                }
+                .buttonStyle(AtelierPressButtonStyle())
+
+                Button(action: {}) {
+                    Text("Not yet")
+                        .font(.system(size: 16, weight: .medium))
+                        .foregroundStyle(theme.textSecondary)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                }
+                .buttonStyle(AtelierPressButtonStyle())
+            }
+            .padding(16)
+            .background(theme.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(theme.hairline, lineWidth: 1)
+            }
+            .shadow(color: theme.cardShadow, radius: 12, x: 0, y: 2)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatScreen.swift
@@ -33,6 +33,7 @@ struct AtelierChatScreen: View {
             .padding(.bottom, 16)
         }
         .scrollIndicators(.hidden)
+        .defaultScrollAnchor(.bottom)
         .background(theme.background)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             AtelierComposer(placeholder: "Reply to Claude…")

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatScreen.swift
@@ -34,7 +34,7 @@ struct AtelierChatScreen: View {
         }
         .scrollIndicators(.hidden)
         .defaultScrollAnchor(.bottom)
-        .background(theme.background)
+        .background(theme.background.ignoresSafeArea())
         .safeAreaInset(edge: .bottom, spacing: 0) {
             AtelierComposer(placeholder: "Reply to Claude…")
                 .background(theme.background.opacity(0.92))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierChatScreen.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders the full shared agent conversation with Atelier's generous rhythm.
+struct AtelierChatScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+        let workspace = DesignGalleryFixtures.workspaces[0]
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 24) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Conversation")
+                        .font(.system(size: 28, weight: .semibold, design: .serif))
+                        .foregroundStyle(theme.textPrimary)
+                    HStack(spacing: 8) {
+                        AtelierStatusMark(state: workspace.state)
+                        Text("· \(workspace.name)")
+                            .font(.system(size: 13))
+                            .foregroundStyle(theme.textTertiary)
+                    }
+                }
+                .padding(.bottom, 4)
+
+                ForEach(DesignGalleryFixtures.chatEntries) { entry in
+                    AtelierChatEntryView(entry: entry)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.background)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            AtelierComposer(placeholder: "Reply to Claude…")
+                .background(theme.background.opacity(0.92))
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierComposer.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierComposer.swift
@@ -1,0 +1,48 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Provides Atelier's fixed warm-glass conversational composer pill.
+struct AtelierComposer: View {
+    let placeholder: String
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        HStack(spacing: 10) {
+            Button(action: {}) {
+                Image(systemName: "plus")
+                    .font(.system(size: 16, weight: .semibold))
+                    .foregroundStyle(theme.textSecondary)
+                    .frame(width: 44, height: 44)
+                    .contentShape(Circle())
+            }
+            .buttonStyle(AtelierPressButtonStyle())
+
+            Text(placeholder)
+                .font(.system(size: 16))
+                .foregroundStyle(theme.textTertiary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            Button(action: {}) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 15, weight: .bold))
+                    .foregroundStyle(theme.accentForeground)
+                    .frame(width: 44, height: 44)
+                    .background(theme.accent, in: Circle())
+                    .contentShape(Circle())
+            }
+            .buttonStyle(AtelierPressButtonStyle())
+        }
+        .padding(.horizontal, 6)
+        .padding(.vertical, 4)
+        .mobileGlassPill()
+        .background(theme.background.opacity(0.50), in: Capsule())
+        .shadow(color: theme.cardShadow, radius: 12, x: 0, y: 2)
+        .padding(.horizontal, 20)
+        .padding(.vertical, 8)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierGallery.swift
@@ -1,0 +1,14 @@
+#if DEBUG
+import SwiftUI
+
+/// Placeholder root for the Atelier candidate's future six-screen gallery.
+struct AtelierGallery: View {
+    let page: DesignGalleryPage
+
+    var body: some View {
+        Text("\(DesignGallerySystem.atelier.number) \(DesignGallerySystem.atelier.displayName) — \(page.title)")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.systemBackground))
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierGallery.swift
@@ -31,7 +31,7 @@ struct AtelierGallery: View {
         .transition(.opacity)
         .animation(.easeInOut(duration: 0.25), value: page)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-        .background(theme.background)
+        .background(theme.background.ignoresSafeArea())
         .tint(theme.accent)
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierGallery.swift
@@ -1,14 +1,38 @@
 #if DEBUG
 import SwiftUI
 
-/// Placeholder root for the Atelier candidate's future six-screen gallery.
+/// Routes gallery pages into the six static Atelier design-system screens.
 struct AtelierGallery: View {
     let page: DesignGalleryPage
 
+    @Environment(\.colorScheme) private var colorScheme
+
+    @ViewBuilder
     var body: some View {
-        Text("\(DesignGallerySystem.atelier.number) \(DesignGallerySystem.atelier.displayName) — \(page.title)")
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(.systemBackground))
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        Group {
+            switch page {
+            case .hub:
+                AtelierHubScreen()
+            case .session:
+                AtelierSessionScreen()
+            case .chat:
+                AtelierChatScreen()
+            case .activity:
+                AtelierActivityScreen()
+            case .settings:
+                AtelierSettingsScreen()
+            case .specimen:
+                AtelierSpecimenScreen()
+            }
+        }
+        .id(page)
+        .transition(.opacity)
+        .animation(.easeInOut(duration: 0.25), value: page)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.background)
+        .tint(theme.accent)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierHubScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierHubScreen.swift
@@ -29,7 +29,7 @@ struct AtelierHubScreen: View {
             .padding(.bottom, 24)
         }
         .scrollIndicators(.hidden)
-        .background(theme.background)
+        .background(theme.background.ignoresSafeArea())
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierHubScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierHubScreen.swift
@@ -1,0 +1,35 @@
+#if DEBUG
+import SwiftUI
+
+/// Shows every workspace fixture in Atelier's low-density, action-forward hub.
+struct AtelierHubScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Your agents")
+                        .font(.system(size: 28, weight: .semibold, design: .serif))
+                        .foregroundStyle(theme.textPrimary)
+                    Text("A quiet view of what needs you now.")
+                        .font(.system(size: 16))
+                        .foregroundStyle(theme.textSecondary)
+                }
+                .padding(.bottom, 8)
+
+                ForEach(DesignGalleryFixtures.workspaces) { workspace in
+                    AtelierWorkspaceCard(workspace: workspace)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 24)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.background)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierPaletteSwatch.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierPaletteSwatch.swift
@@ -1,0 +1,35 @@
+#if DEBUG
+import SwiftUI
+
+/// Labels one exact Atelier palette token with its color and hexadecimal value.
+struct AtelierPaletteSwatch: View {
+    let name: String
+    let hex: String
+    let color: Color
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        HStack(spacing: 12) {
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(color)
+                .frame(width: 52, height: 52)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 12, style: .continuous)
+                        .stroke(theme.hairline, lineWidth: 1)
+                }
+            VStack(alignment: .leading, spacing: 3) {
+                Text(name)
+                    .font(.system(size: 16, weight: .medium, design: .serif))
+                    .foregroundStyle(theme.textPrimary)
+                Text(hex)
+                    .font(.system(size: 12, design: .monospaced))
+                    .foregroundStyle(theme.textSecondary)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierPressButtonStyle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierPressButtonStyle.swift
@@ -1,0 +1,20 @@
+#if DEBUG
+import SwiftUI
+
+/// Gives Atelier controls a gentle spring press without changing their visual language.
+struct AtelierPressButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.975 : 1)
+            .opacity(configuration.isPressed ? 0.86 : 1)
+            .animation(
+                reduceMotion
+                    ? .easeInOut(duration: 0.25)
+                    : .spring(response: 0.5, dampingFraction: 0.85),
+                value: configuration.isPressed
+            )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSessionScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSessionScreen.swift
@@ -1,0 +1,64 @@
+#if DEBUG
+import SwiftUI
+
+/// Frames the complete terminal transcript as a dark artifact on warm paper.
+struct AtelierSessionScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+        let workspace = DesignGalleryFixtures.workspaces[1]
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Session")
+                        .font(.system(size: 28, weight: .semibold, design: .serif))
+                        .foregroundStyle(theme.textPrimary)
+                    Text("\(workspace.name) · \(workspace.branch)")
+                        .font(.system(size: 16))
+                        .foregroundStyle(theme.textSecondary)
+                }
+
+                VStack(alignment: .leading, spacing: 16) {
+                    HStack {
+                        AtelierStatusMark(state: workspace.state)
+                        Spacer()
+                        Text("\(workspace.agentName) · \(workspace.elapsedText)")
+                            .font(.system(size: 13))
+                            .foregroundStyle(theme.textTertiary)
+                    }
+
+                    VStack(alignment: .leading, spacing: 7) {
+                        ForEach(DesignGalleryFixtures.terminalLines) { line in
+                            AtelierTerminalLineView(line: line)
+                        }
+                    }
+                    .padding(16)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(
+                        theme.terminalBackground,
+                        in: RoundedRectangle(cornerRadius: 12, style: .continuous)
+                    )
+                }
+                .padding(16)
+                .background(theme.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 18, style: .continuous)
+                        .stroke(theme.hairline, lineWidth: 1)
+                }
+                .shadow(color: theme.cardShadow, radius: 12, x: 0, y: 2)
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 16)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.background)
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            AtelierComposer(placeholder: "Send a message…")
+                .background(theme.background.opacity(0.92))
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSessionScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSessionScreen.swift
@@ -54,7 +54,7 @@ struct AtelierSessionScreen: View {
             .padding(.bottom, 16)
         }
         .scrollIndicators(.hidden)
-        .background(theme.background)
+        .background(theme.background.ignoresSafeArea())
         .safeAreaInset(edge: .bottom, spacing: 0) {
             AtelierComposer(placeholder: "Send a message…")
                 .background(theme.background.opacity(0.92))

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsGroup.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsGroup.swift
@@ -1,0 +1,38 @@
+#if DEBUG
+import SwiftUI
+
+/// Wraps a settings section in Atelier's serif label and warm card surface.
+struct AtelierSettingsGroup<Content: View>: View {
+    let title: String
+    let content: Content
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    init(title: String, @ViewBuilder content: () -> Content) {
+        self.title = title
+        self.content = content()
+    }
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.system(size: 19, weight: .semibold, design: .serif))
+                .foregroundStyle(theme.textPrimary)
+                .padding(.leading, 4)
+
+            VStack(spacing: 0) {
+                content
+            }
+            .padding(.horizontal, 16)
+            .background(theme.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(theme.hairline, lineWidth: 1)
+            }
+            .shadow(color: theme.cardShadow, radius: 12, x: 0, y: 2)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsRow.swift
@@ -1,0 +1,32 @@
+#if DEBUG
+import SwiftUI
+
+/// Lays out one roomy settings value row with an optional symbol.
+struct AtelierSettingsRow: View {
+    let label: String
+    let value: String
+    let symbol: String
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        HStack(spacing: 12) {
+            Image(systemName: symbol)
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(theme.accent)
+                .frame(width: 24)
+            Text(label)
+                .font(.system(size: 16))
+                .foregroundStyle(theme.textPrimary)
+            Spacer(minLength: 12)
+            Text(value)
+                .font(.system(size: 13))
+                .foregroundStyle(theme.textSecondary)
+                .multilineTextAlignment(.trailing)
+        }
+        .frame(maxWidth: .infinity, minHeight: 56)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsScreen.swift
@@ -70,7 +70,7 @@ struct AtelierSettingsScreen: View {
             .padding(.bottom, 28)
         }
         .scrollIndicators(.hidden)
-        .background(theme.background)
+        .background(theme.background.ignoresSafeArea())
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSettingsScreen.swift
@@ -1,0 +1,76 @@
+#if DEBUG
+import SwiftUI
+
+/// Shows shared account and preference fixtures in four roomy card groups.
+struct AtelierSettingsScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var appearance = "System"
+    @State private var notificationsEnabled = DesignGalleryFixtures.settings.notificationsEnabled
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+        let settings = DesignGalleryFixtures.settings
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Settings")
+                    .font(.system(size: 28, weight: .semibold, design: .serif))
+                    .foregroundStyle(theme.textPrimary)
+
+                AtelierSettingsGroup(title: "Account") {
+                    AtelierSettingsRow(label: "Email", value: settings.accountEmail, symbol: "person.crop.circle")
+                    Divider().overlay(theme.hairline)
+                    AtelierSettingsRow(label: "Version", value: settings.appVersion, symbol: "info.circle")
+                }
+
+                AtelierSettingsGroup(title: "Paired Mac") {
+                    AtelierSettingsRow(label: settings.pairedMacName, value: settings.pairedMacStatus, symbol: "laptopcomputer")
+                }
+
+                AtelierSettingsGroup(title: "Appearance") {
+                    VStack(alignment: .leading, spacing: 8) {
+                        Text("Color scheme")
+                            .font(.system(size: 16))
+                            .foregroundStyle(theme.textPrimary)
+                        Picker("Color scheme", selection: $appearance) {
+                            Text("Light").tag("Light")
+                            Text("System").tag("System")
+                            Text("Dark").tag("Dark")
+                        }
+                        .pickerStyle(.segmented)
+                    }
+                    .frame(minHeight: 72)
+                    Divider().overlay(theme.hairline)
+                    AtelierSettingsRow(label: "Terminal font", value: "\(settings.terminalFontSize) pt", symbol: "textformat.size")
+                }
+
+                AtelierSettingsGroup(title: "Notifications") {
+                    Toggle(isOn: $notificationsEnabled) {
+                        HStack(spacing: 12) {
+                            Image(systemName: "bell")
+                                .font(.system(size: 15, weight: .medium))
+                                .foregroundStyle(theme.accent)
+                                .frame(width: 24)
+                            VStack(alignment: .leading, spacing: 3) {
+                                Text("Agent updates")
+                                    .font(.system(size: 16))
+                                    .foregroundStyle(theme.textPrimary)
+                                Text(notificationsEnabled ? "On" : "Off")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(theme.textSecondary)
+                            }
+                        }
+                    }
+                    .tint(theme.accent)
+                    .frame(minHeight: 56)
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 28)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.background)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSpecimenScreen.swift
@@ -99,7 +99,7 @@ struct AtelierSpecimenScreen: View {
             .padding(.bottom, 32)
         }
         .scrollIndicators(.hidden)
-        .background(theme.background)
+        .background(theme.background.ignoresSafeArea())
     }
 
     @ViewBuilder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierSpecimenScreen.swift
@@ -1,0 +1,137 @@
+#if DEBUG
+import SwiftUI
+
+/// Collects Atelier's palette, typography, states, shapes, controls, and glass treatment.
+struct AtelierSpecimenScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 32) {
+                Text("Atelier specimen")
+                    .font(.system(size: 28, weight: .semibold, design: .serif))
+                    .foregroundStyle(theme.textPrimary)
+
+                specimenSection(title: "Palette", theme: theme) {
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible())], spacing: 12) {
+                        AtelierPaletteSwatch(name: "bg0 · Paper", hex: schemeHex(light: "#F7F3EC", dark: "#201C18"), color: theme.background)
+                        AtelierPaletteSwatch(name: "bg1 · Card", hex: schemeHex(light: "#FFFFFF", dark: "#2A251F"), color: theme.card)
+                        AtelierPaletteSwatch(name: "bg2 · Inset", hex: schemeHex(light: "#EFE9DE", dark: "#363028"), color: theme.inset)
+                        AtelierPaletteSwatch(name: "hairline", hex: schemeHex(light: "#2A2520 · 10%", dark: "#EDE7DE · 10%"), color: theme.hairline)
+                        AtelierPaletteSwatch(name: "text.primary · Ink", hex: schemeHex(light: "#2A2520", dark: "#EDE7DE"), color: theme.textPrimary)
+                        AtelierPaletteSwatch(name: "text.secondary", hex: schemeHex(light: "#6B6259", dark: "#B3A99C"), color: theme.textSecondary)
+                        AtelierPaletteSwatch(name: "text.tertiary", hex: schemeHex(light: "#A39B8F", dark: "#7A7166"), color: theme.textTertiary)
+                        AtelierPaletteSwatch(name: "accent · Terracotta", hex: schemeHex(light: "#C15F3C", dark: "#D97757"), color: theme.accent)
+                        AtelierPaletteSwatch(name: "needsYou · Ochre", hex: schemeHex(light: "#B07818", dark: "#D9A03F"), color: theme.needsYou)
+                        AtelierPaletteSwatch(name: "running · Slate", hex: schemeHex(light: "#5F7484", dark: "#8FA5B5"), color: theme.running)
+                        AtelierPaletteSwatch(name: "done · Sage", hex: schemeHex(light: "#5F7D58", dark: "#8CAB84"), color: theme.done)
+                        AtelierPaletteSwatch(name: "failed · Brick", hex: schemeHex(light: "#A84632", dark: "#CC6B55"), color: theme.failed)
+                        AtelierPaletteSwatch(name: "idle", hex: schemeHex(light: "#A39B8F", dark: "#7A7166"), color: theme.idle)
+                    }
+                }
+
+                specimenSection(title: "Type", theme: theme) {
+                    VStack(alignment: .leading, spacing: 18) {
+                        typeSample("Screen title · 28 semibold serif", size: 28, weight: .semibold, design: .serif, theme: theme)
+                        typeSample("Card title · 19 semibold serif", size: 19, weight: .semibold, design: .serif, theme: theme)
+                        typeSample("Body · 16 regular", size: 16, weight: .regular, design: .default, theme: theme)
+                        typeSample("Caption · 13 regular", size: 13, weight: .regular, design: .default, theme: theme)
+                        typeSample("Mono block · 12 regular", size: 12, weight: .regular, design: .monospaced, theme: theme)
+                    }
+                }
+
+                specimenSection(title: "States", theme: theme) {
+                    VStack(alignment: .leading, spacing: 14) {
+                        ForEach(Array(GalleryAgentState.allCases.enumerated()), id: \.offset) { _, state in
+                            AtelierStatusMark(state: state)
+                        }
+                    }
+                }
+
+                specimenSection(title: "Components", theme: theme) {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 12) {
+                            Button(action: {}) {
+                                Text(DesignGalleryFixtures.approvalActions[0])
+                                    .font(.system(size: 16, weight: .semibold))
+                                    .foregroundStyle(theme.accentForeground)
+                                    .frame(maxWidth: .infinity, minHeight: 52)
+                                    .background(theme.accent, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            }
+                            .buttonStyle(AtelierPressButtonStyle())
+
+                            Button(action: {}) {
+                                Text("Not yet")
+                                    .font(.system(size: 16, weight: .medium))
+                                    .foregroundStyle(theme.textPrimary)
+                                    .frame(maxWidth: .infinity, minHeight: 52)
+                                    .background(theme.inset, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                            }
+                            .buttonStyle(AtelierPressButtonStyle())
+                        }
+
+                        VStack(alignment: .leading, spacing: 10) {
+                            Text("Warm card")
+                                .font(.system(size: 19, weight: .semibold, design: .serif))
+                                .foregroundStyle(theme.textPrimary)
+                            Text("One calm surface, one clear next action.")
+                                .font(.system(size: 16))
+                                .foregroundStyle(theme.textSecondary)
+                        }
+                        .padding(16)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(theme.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 18, style: .continuous)
+                                .stroke(theme.hairline, lineWidth: 1)
+                        }
+                        .shadow(color: theme.cardShadow, radius: 12, x: 0, y: 2)
+
+                        AtelierComposer(placeholder: "Send a message…")
+                            .padding(.horizontal, -20)
+                    }
+                }
+            }
+            .padding(.horizontal, 20)
+            .padding(.top, 24)
+            .padding(.bottom, 32)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.background)
+    }
+
+    @ViewBuilder
+    private func specimenSection<Content: View>(
+        title: String,
+        theme: AtelierTheme,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(title)
+                .font(.system(size: 20, weight: .semibold, design: .serif))
+                .foregroundStyle(theme.textPrimary)
+            content()
+        }
+    }
+
+    @ViewBuilder
+    private func typeSample(
+        _ text: String,
+        size: CGFloat,
+        weight: Font.Weight,
+        design: Font.Design,
+        theme: AtelierTheme
+    ) -> some View {
+        Text(text)
+            .font(.system(size: size, weight: weight, design: design))
+            .foregroundStyle(theme.textPrimary)
+            .minimumScaleFactor(0.7)
+    }
+
+    private func schemeHex(light: String, dark: String) -> String {
+        colorScheme == .dark ? dark : light
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierStatusMark.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierStatusMark.swift
@@ -1,0 +1,46 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays state with color, symbol, and a plain-language word label.
+struct AtelierStatusMark: View {
+    let state: GalleryAgentState
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var isBreathing = false
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+        let statusColor = theme.color(for: state)
+
+        HStack(spacing: 7) {
+            ZStack {
+                Circle()
+                    .fill(statusColor.opacity(0.16))
+                    .frame(width: 20, height: 20)
+                Image(systemName: theme.symbol(for: state))
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(statusColor)
+            }
+            .scaleEffect(state == .running && isBreathing && !reduceMotion ? 1.15 : 1)
+            .animation(
+                reduceMotion ? .easeInOut(duration: 0.25) : .easeInOut(duration: 3).repeatForever(autoreverses: true),
+                value: isBreathing
+            )
+
+            Text(theme.label(for: state))
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(statusColor)
+        }
+        .onAppear {
+            if state == .running && !reduceMotion {
+                isBreathing = true
+            }
+        }
+        .onChange(of: reduceMotion) { _, shouldReduce in
+            isBreathing = state == .running && !shouldReduce
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierTerminalLineView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierTerminalLineView.swift
@@ -1,0 +1,31 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders one terminal fixture line in the fixed dark artifact palette.
+struct AtelierTerminalLineView: View {
+    let line: GalleryTerminalLine
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        Text(line.text)
+            .font(.system(size: 12, weight: .regular, design: .monospaced))
+            .foregroundStyle(lineColor(theme: theme))
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func lineColor(theme: AtelierTheme) -> Color {
+        switch line.tone {
+        case .plain: theme.terminalPlain
+        case .dim: theme.terminalDim
+        case .accent: theme.terminalAccent
+        case .success: theme.terminalSuccess
+        case .warning: theme.terminalWarning
+        case .error: theme.terminalError
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierTheme.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierTheme.swift
@@ -1,0 +1,105 @@
+#if DEBUG
+import SwiftUI
+
+/// Resolves Atelier's exact light and dark color tokens for the active scheme.
+struct AtelierTheme {
+    let background: Color
+    let card: Color
+    let inset: Color
+    let hairline: Color
+    let textPrimary: Color
+    let textSecondary: Color
+    let textTertiary: Color
+    let accent: Color
+    let accentForeground: Color
+    let needsYou: Color
+    let running: Color
+    let done: Color
+    let failed: Color
+    let idle: Color
+    let cardShadow: Color
+    let terminalBackground: Color
+    let terminalPlain: Color
+    let terminalDim: Color
+    let terminalAccent: Color
+    let terminalSuccess: Color
+    let terminalWarning: Color
+    let terminalError: Color
+
+    init(scheme: ColorScheme) {
+        if scheme == .dark {
+            background = Color(red: 32.0 / 255.0, green: 28.0 / 255.0, blue: 24.0 / 255.0)
+            card = Color(red: 42.0 / 255.0, green: 37.0 / 255.0, blue: 31.0 / 255.0)
+            inset = Color(red: 54.0 / 255.0, green: 48.0 / 255.0, blue: 40.0 / 255.0)
+            hairline = Color(red: 237.0 / 255.0, green: 231.0 / 255.0, blue: 222.0 / 255.0).opacity(0.10)
+            textPrimary = Color(red: 237.0 / 255.0, green: 231.0 / 255.0, blue: 222.0 / 255.0)
+            textSecondary = Color(red: 179.0 / 255.0, green: 169.0 / 255.0, blue: 156.0 / 255.0)
+            textTertiary = Color(red: 122.0 / 255.0, green: 113.0 / 255.0, blue: 102.0 / 255.0)
+            accent = Color(red: 217.0 / 255.0, green: 119.0 / 255.0, blue: 87.0 / 255.0)
+            needsYou = Color(red: 217.0 / 255.0, green: 160.0 / 255.0, blue: 63.0 / 255.0)
+            running = Color(red: 143.0 / 255.0, green: 165.0 / 255.0, blue: 181.0 / 255.0)
+            done = Color(red: 140.0 / 255.0, green: 171.0 / 255.0, blue: 132.0 / 255.0)
+            failed = Color(red: 204.0 / 255.0, green: 107.0 / 255.0, blue: 85.0 / 255.0)
+            idle = Color(red: 122.0 / 255.0, green: 113.0 / 255.0, blue: 102.0 / 255.0)
+            cardShadow = .clear
+        } else {
+            background = Color(red: 247.0 / 255.0, green: 243.0 / 255.0, blue: 236.0 / 255.0)
+            card = Color(red: 255.0 / 255.0, green: 255.0 / 255.0, blue: 255.0 / 255.0)
+            inset = Color(red: 239.0 / 255.0, green: 233.0 / 255.0, blue: 222.0 / 255.0)
+            hairline = Color(red: 42.0 / 255.0, green: 37.0 / 255.0, blue: 32.0 / 255.0).opacity(0.10)
+            textPrimary = Color(red: 42.0 / 255.0, green: 37.0 / 255.0, blue: 32.0 / 255.0)
+            textSecondary = Color(red: 107.0 / 255.0, green: 98.0 / 255.0, blue: 89.0 / 255.0)
+            textTertiary = Color(red: 163.0 / 255.0, green: 155.0 / 255.0, blue: 143.0 / 255.0)
+            accent = Color(red: 193.0 / 255.0, green: 95.0 / 255.0, blue: 60.0 / 255.0)
+            needsYou = Color(red: 176.0 / 255.0, green: 120.0 / 255.0, blue: 24.0 / 255.0)
+            running = Color(red: 95.0 / 255.0, green: 116.0 / 255.0, blue: 132.0 / 255.0)
+            done = Color(red: 95.0 / 255.0, green: 125.0 / 255.0, blue: 88.0 / 255.0)
+            failed = Color(red: 168.0 / 255.0, green: 70.0 / 255.0, blue: 50.0 / 255.0)
+            idle = Color(red: 163.0 / 255.0, green: 155.0 / 255.0, blue: 143.0 / 255.0)
+            cardShadow = Color.black.opacity(0.06)
+        }
+
+        terminalBackground = Color(red: 32.0 / 255.0, green: 28.0 / 255.0, blue: 24.0 / 255.0)
+        accentForeground = Color(red: 255.0 / 255.0, green: 255.0 / 255.0, blue: 255.0 / 255.0)
+        terminalPlain = Color(red: 237.0 / 255.0, green: 231.0 / 255.0, blue: 222.0 / 255.0)
+        terminalDim = Color(red: 179.0 / 255.0, green: 169.0 / 255.0, blue: 156.0 / 255.0)
+        terminalAccent = Color(red: 217.0 / 255.0, green: 119.0 / 255.0, blue: 87.0 / 255.0)
+        terminalSuccess = Color(red: 140.0 / 255.0, green: 171.0 / 255.0, blue: 132.0 / 255.0)
+        terminalWarning = Color(red: 217.0 / 255.0, green: 160.0 / 255.0, blue: 63.0 / 255.0)
+        terminalError = Color(red: 204.0 / 255.0, green: 107.0 / 255.0, blue: 85.0 / 255.0)
+    }
+
+    /// Returns the semantic color for a shared fixture state.
+    func color(for state: GalleryAgentState) -> Color {
+        switch state {
+        case .needsYou: needsYou
+        case .running: running
+        case .done: done
+        case .failed: failed
+        case .idle: idle
+        }
+    }
+
+    /// Returns Atelier's plain-language label for a shared fixture state.
+    func label(for state: GalleryAgentState) -> String {
+        switch state {
+        case .needsYou: "Waiting for you"
+        case .running: "Working…"
+        case .done: "Finished"
+        case .failed: "Failed"
+        case .idle: "Idle"
+        }
+    }
+
+    /// Returns a redundant symbol encoding for a shared fixture state.
+    func symbol(for state: GalleryAgentState) -> String {
+        switch state {
+        case .needsYou: "exclamationmark"
+        case .running: "arrow.trianglehead.2.clockwise.rotate.90"
+        case .done: "checkmark"
+        case .failed: "xmark"
+        case .idle: "pause.fill"
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierWorkspaceCard.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Atelier/AtelierWorkspaceCard.swift
@@ -1,0 +1,84 @@
+#if DEBUG
+import SwiftUI
+
+/// Presents one workspace as a calm card with an embedded next action when needed.
+struct AtelierWorkspaceCard: View {
+    let workspace: GalleryWorkspaceFixture
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = AtelierTheme(scheme: colorScheme)
+
+        Button(action: {}) {
+            HStack(spacing: 0) {
+                if workspace.state == .needsYou {
+                    RoundedRectangle(cornerRadius: 2, style: .continuous)
+                        .fill(theme.needsYou)
+                        .frame(width: 4)
+                        .padding(.vertical, 4)
+                        .padding(.trailing, 16)
+                }
+
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .firstTextBaseline, spacing: 12) {
+                        VStack(alignment: .leading, spacing: 3) {
+                            Text(workspace.name)
+                                .font(.system(size: 19, weight: .semibold, design: .serif))
+                                .foregroundStyle(theme.textPrimary)
+                            Text(workspace.branch)
+                                .font(.system(size: 13))
+                                .foregroundStyle(theme.textTertiary)
+                                .lineLimit(1)
+                        }
+
+                        Spacer(minLength: 8)
+
+                        Text(workspace.elapsedText)
+                            .font(.system(size: 13))
+                            .foregroundStyle(theme.textTertiary)
+                    }
+
+                    AtelierStatusMark(state: workspace.state)
+
+                    if let question = workspace.pendingQuestion {
+                        Text(question)
+                            .font(.system(size: 16, weight: .regular, design: .serif))
+                            .italic()
+                            .foregroundStyle(theme.textPrimary)
+                            .fixedSize(horizontal: false, vertical: true)
+
+                        Text("Review request")
+                            .font(.system(size: 16, weight: .semibold))
+                            .foregroundStyle(theme.accentForeground)
+                            .frame(maxWidth: .infinity, minHeight: 52)
+                            .background(theme.accent, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+                    } else {
+                        Text(workspace.detailText)
+                            .font(.system(size: 16))
+                            .foregroundStyle(theme.textSecondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    Text("\(workspace.agentName) · \(workspace.absoluteTimeText)")
+                        .font(.system(size: 13))
+                        .foregroundStyle(theme.textTertiary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .padding(16)
+            .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+            .background(theme.card, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+            .overlay {
+                RoundedRectangle(cornerRadius: 18, style: .continuous)
+                    .stroke(theme.hairline, lineWidth: 1)
+            }
+            .shadow(color: theme.cardShadow, radius: 12, x: 0, y: 2)
+            .contentShape(RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+        .buttonStyle(AtelierPressButtonStyle())
+        .accessibilityElement(children: .combine)
+        .accessibilityHint(workspace.state == .needsYou ? "Review request" : "Open workspace")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianActionCluster.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianActionCluster.swift
@@ -1,0 +1,59 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Groups Meridian's session actions in morph-ready glass circles with a material fallback.
+struct MeridianActionCluster: View {
+    let approvalPending: Bool
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        if #available(iOS 26.0, *) {
+            GlassEffectContainer(spacing: 12) {
+                buttonRow
+            }
+        } else {
+            buttonRow
+        }
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private var buttonRow: some View {
+        HStack(spacing: 12) {
+            circleButton(symbol: "keyboard", label: "Show keyboard", prominent: false)
+            circleButton(
+                symbol: "checkmark",
+                label: DesignGalleryFixtures.approvalActions[0],
+                prominent: approvalPending
+            )
+            circleButton(symbol: "ellipsis", label: "More actions", prominent: false)
+        }
+    }
+
+    private func circleButton(
+        symbol: String,
+        label: String,
+        prominent: Bool
+    ) -> some View {
+        Button {} label: {
+            Image(systemName: symbol)
+                .font(.headline)
+                .foregroundStyle(prominent ? theme.accentForeground : theme.label)
+                .frame(width: 48, height: 48)
+                .background {
+                    if prominent {
+                        Circle().fill(theme.accent)
+                    }
+                }
+                .mobileGlassCircle()
+                .contentShape(Circle())
+        }
+        .buttonStyle(MeridianPressButtonStyle())
+        .accessibilityLabel(label)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianActivityRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianActivityRow.swift
@@ -1,0 +1,47 @@
+#if DEBUG
+import SwiftUI
+
+/// Presents one notification-style activity fixture with status and unread redundancy.
+struct MeridianActivityRow: View {
+    let entry: GalleryActivityEntry
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            MeridianStatusSymbol(state: entry.state, font: .headline)
+                .frame(width: 30, height: 30)
+
+            VStack(alignment: .leading, spacing: 5) {
+                Text(entry.text)
+                    .font(entry.unread ? .body.weight(.semibold) : .body)
+                    .foregroundStyle(theme.label)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                HStack(spacing: 6) {
+                    Text(theme.label(for: entry.state))
+                        .foregroundStyle(theme.color(for: entry.state))
+                    Text("·")
+                    Text(entry.timeText)
+                }
+                .font(.caption)
+                .foregroundStyle(theme.secondaryLabel)
+            }
+
+            if entry.unread {
+                Circle()
+                    .fill(theme.accent)
+                    .frame(width: 8, height: 8)
+                    .padding(.top, 7)
+                    .accessibilityLabel("Unread")
+            }
+        }
+        .padding(.vertical, 7)
+        .frame(minHeight: 58)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianActivityScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianActivityScreen.swift
@@ -1,0 +1,38 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders every shared activity day and event as a native notification-center list.
+struct MeridianActivityScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Activity")
+                .font(.largeTitle.weight(.bold))
+                .foregroundStyle(theme.label)
+                .padding(.horizontal, theme.horizontalInset)
+                .padding(.top, 14)
+                .padding(.bottom, 6)
+
+            List {
+                ForEach(Array(DesignGalleryFixtures.activityDays.enumerated()), id: \.offset) { _, day in
+                    Section(day.dayLabel) {
+                        ForEach(day.entries) { entry in
+                            MeridianActivityRow(entry: entry)
+                        }
+                    }
+                }
+            }
+            .listStyle(.plain)
+            .scrollContentBackground(.hidden)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.background.ignoresSafeArea())
+        .tint(theme.accent)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianChatEntryView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianChatEntryView.swift
@@ -1,0 +1,128 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders one fixture conversation entry in its role-specific Meridian treatment.
+struct MeridianChatEntryView: View {
+    let entry: GalleryChatEntry
+
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var outputExpanded = true
+
+    var body: some View {
+        switch entry.role {
+        case .user:
+            userMessage
+        case .agent:
+            agentMessage
+        case .tool:
+            toolCard
+        case .approval:
+            approvalCard
+        }
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private var userMessage: some View {
+        VStack(alignment: .trailing, spacing: 5) {
+            Text(entry.text)
+                .font(.body)
+                .foregroundStyle(theme.label)
+                .padding(.horizontal, 15)
+                .padding(.vertical, 11)
+                .background(
+                    theme.secondaryBackground,
+                    in: RoundedRectangle(cornerRadius: 20, style: .continuous)
+                )
+            Text(entry.timeText)
+                .font(.caption)
+                .foregroundStyle(theme.tertiaryLabel)
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .padding(.leading, 48)
+    }
+
+    private var agentMessage: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            Text(entry.text)
+                .font(.body)
+                .foregroundStyle(theme.label)
+            Text(entry.timeText)
+                .font(.caption)
+                .foregroundStyle(theme.tertiaryLabel)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.trailing, 28)
+    }
+
+    private var toolCard: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Label(entry.text, systemImage: "wrench.and.screwdriver")
+                .font(.headline)
+                .foregroundStyle(theme.label)
+
+            if let command = entry.toolCommand {
+                Text(command)
+                    .font(.subheadline.monospaced())
+                    .foregroundStyle(theme.accent)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+
+            if let output = entry.toolOutput {
+                DisclosureGroup("Output", isExpanded: $outputExpanded) {
+                    Text(output)
+                        .font(.caption.monospaced())
+                        .foregroundStyle(theme.secondaryLabel)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding(.top, 8)
+                }
+                .font(.subheadline)
+                .tint(theme.secondaryLabel)
+            }
+
+            Text(entry.timeText)
+                .font(.caption)
+                .foregroundStyle(theme.tertiaryLabel)
+        }
+        .padding(16)
+        .background(
+            theme.secondaryBackground,
+            in: RoundedRectangle(cornerRadius: theme.cardRadius, style: .continuous)
+        )
+    }
+
+    private var approvalCard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Label("Approval requested", systemImage: "person.crop.circle.badge.exclamationmark")
+                .font(.headline)
+                .foregroundStyle(theme.needsYou)
+
+            Text(entry.question ?? entry.text)
+                .font(.body)
+                .foregroundStyle(theme.label)
+
+            HStack(spacing: 12) {
+                Button(DesignGalleryFixtures.approvalActions[1]) {}
+                    .buttonStyle(.bordered)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+
+                Button(DesignGalleryFixtures.approvalActions[0]) {}
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+            }
+            .tint(theme.accent)
+
+            Text(entry.timeText)
+                .font(.caption)
+                .foregroundStyle(theme.tertiaryLabel)
+        }
+        .padding(16)
+        .background(
+            theme.secondaryBackground,
+            in: RoundedRectangle(cornerRadius: theme.cardRadius, style: .continuous)
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianChatScreen.swift
@@ -22,6 +22,7 @@ struct MeridianChatScreen: View {
             .padding(.bottom, 12)
         }
         .scrollDismissesKeyboard(.interactively)
+        .defaultScrollAnchor(.bottom)
         .background(theme.background.ignoresSafeArea())
         .safeAreaInset(edge: .bottom, spacing: 8) {
             MeridianComposer()

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianChatScreen.swift
@@ -1,0 +1,37 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays the full shared conversation with native chat metrics and a glass composer.
+struct MeridianChatScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 22) {
+                Text("Chat")
+                    .font(.largeTitle.weight(.bold))
+                    .foregroundStyle(theme.label)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                ForEach(DesignGalleryFixtures.chatEntries) { entry in
+                    MeridianChatEntryView(entry: entry)
+                }
+            }
+            .padding(.horizontal, theme.horizontalInset)
+            .padding(.top, 14)
+            .padding(.bottom, 12)
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .background(theme.background.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 8) {
+            MeridianComposer()
+                .padding(.horizontal, 12)
+        }
+        .tint(theme.accent)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianComposer.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianComposer.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Provides Meridian's glass capsule chat composer with tactile inert controls.
+struct MeridianComposer: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 4) {
+            iconButton(symbol: "plus", label: "Add attachment")
+
+            Text("Message")
+                .font(.body)
+                .foregroundStyle(theme.secondaryLabel)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 8)
+
+            iconButton(symbol: "waveform", label: "Voice input")
+        }
+        .padding(6)
+        .frame(minHeight: 56)
+        .mobileGlassPill()
+        .tint(theme.accent)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private func iconButton(symbol: String, label: String) -> some View {
+        Button {} label: {
+            Image(systemName: symbol)
+                .font(.headline)
+                .foregroundStyle(theme.label)
+                .frame(width: 44, height: 44)
+                .contentShape(Circle())
+        }
+        .buttonStyle(MeridianPressButtonStyle())
+        .accessibilityLabel(label)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianFloatingTabBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianFloatingTabBar.swift
@@ -1,0 +1,70 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Renders Meridian's bottom-centered glass navigation capsule.
+struct MeridianFloatingTabBar: View {
+    let selectedPage: DesignGalleryPage
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 2) {
+            tabButton(title: "Home", symbol: "house.fill", page: .hub)
+            tabButton(title: "Activity", symbol: "bell.fill", page: .activity)
+            tabButton(title: "Settings", symbol: "gearshape.fill", page: .settings)
+        }
+        .padding(6)
+        .mobileGlassPill()
+        .tint(theme.accent)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private var selectedRootPage: DesignGalleryPage {
+        switch selectedPage {
+        case .activity: .activity
+        case .settings: .settings
+        default: .hub
+        }
+    }
+
+    @ViewBuilder
+    private func tabButton(title: String, symbol: String, page: DesignGalleryPage) -> some View {
+        let isSelected = selectedRootPage == page
+        Button {} label: {
+            VStack(spacing: 2) {
+                Image(systemName: symbol)
+                    .font(.body)
+                    .frame(height: 20)
+                    .overlay(alignment: .topTrailing) {
+                        if page == .hub, needsYouCount > 0 {
+                            Text("\(needsYouCount)")
+                                .font(.caption.weight(.bold))
+                                .foregroundStyle(theme.accentForeground)
+                                .frame(minWidth: 18, minHeight: 18)
+                                .background(theme.needsYou, in: Circle())
+                                .offset(x: 10, y: -7)
+                        }
+                    }
+                Text(title)
+                    .font(.caption)
+            }
+            .foregroundStyle(isSelected ? theme.accent : theme.secondaryLabel)
+            .frame(maxWidth: .infinity, minHeight: 44)
+            .padding(.horizontal, 8)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(MeridianPressButtonStyle())
+        .accessibilityAddTraits(isSelected ? .isSelected : [])
+    }
+
+    private var needsYouCount: Int {
+        DesignGalleryFixtures.workspaces.reduce(into: 0) { count, workspace in
+            if case .needsYou = workspace.state { count += 1 }
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianGallery.swift
@@ -1,14 +1,42 @@
 #if DEBUG
 import SwiftUI
 
-/// Placeholder root for the Meridian candidate's future six-screen gallery.
+/// Routes the gallery's shared page selection into the Meridian design system.
 struct MeridianGallery: View {
     let page: DesignGalleryPage
 
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
-        Text("\(DesignGallerySystem.meridian.number) \(DesignGallerySystem.meridian.displayName) — \(page.title)")
+        pageContent
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(.systemBackground))
+            .background(theme.background.ignoresSafeArea())
+            .safeAreaInset(edge: .bottom, spacing: 8) {
+                MeridianFloatingTabBar(selectedPage: page)
+                    .padding(.horizontal, 48)
+            }
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    @ViewBuilder
+    private var pageContent: some View {
+        switch page {
+        case .hub:
+            MeridianHubScreen()
+        case .session:
+            MeridianSessionScreen()
+        case .chat:
+            MeridianChatScreen()
+        case .activity:
+            MeridianActivityScreen()
+        case .settings:
+            MeridianSettingsScreen()
+        case .specimen:
+            MeridianSpecimenScreen()
+        }
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianGallery.swift
@@ -1,0 +1,14 @@
+#if DEBUG
+import SwiftUI
+
+/// Placeholder root for the Meridian candidate's future six-screen gallery.
+struct MeridianGallery: View {
+    let page: DesignGalleryPage
+
+    var body: some View {
+        Text("\(DesignGallerySystem.meridian.number) \(DesignGallerySystem.meridian.displayName) — \(page.title)")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.systemBackground))
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianHubScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianHubScreen.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders Meridian's promoted needs-you section and complete workspace hub.
+struct MeridianHubScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("cmux")
+                .font(.largeTitle.weight(.bold))
+                .foregroundStyle(theme.label)
+                .padding(.horizontal, theme.horizontalInset)
+                .padding(.top, 14)
+                .padding(.bottom, 4)
+
+            List {
+                Section("For you") {
+                    ForEach(DesignGalleryFixtures.workspaces.prefix(1)) { workspace in
+                        MeridianWorkspaceRow(workspace: workspace)
+                            .listRowBackground(theme.needsYou.opacity(0.09))
+                    }
+                }
+
+                Section("Workspaces") {
+                    ForEach(DesignGalleryFixtures.workspaces.dropFirst()) { workspace in
+                        MeridianWorkspaceRow(workspace: workspace)
+                    }
+                }
+            }
+            .listStyle(.insetGrouped)
+            .scrollContentBackground(.hidden)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.background.ignoresSafeArea())
+        .tint(theme.accent)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianPaletteSwatch.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianPaletteSwatch.swift
@@ -1,0 +1,40 @@
+#if DEBUG
+import SwiftUI
+
+/// Labels a Meridian palette token with its current reference sRGB or RGBA value.
+struct MeridianPaletteSwatch: View {
+    let name: String
+    let hex: String
+    let color: Color
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        HStack(spacing: 10) {
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(color)
+                .frame(width: 40, height: 40)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10, style: .continuous)
+                        .stroke(theme.separator, lineWidth: 0.5)
+                }
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(name)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(theme.label)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.75)
+                Text(hex)
+                    .font(.caption.monospaced())
+                    .foregroundStyle(theme.secondaryLabel)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 48, alignment: .leading)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianPressButtonStyle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianPressButtonStyle.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+import SwiftUI
+
+/// Gives inert gallery buttons a tactile press response while honoring Reduce Motion.
+struct MeridianPressButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.96 : 1)
+            .opacity(configuration.isPressed ? 0.72 : 1)
+            .animation(reduceMotion ? nil : .spring(), value: configuration.isPressed)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSchemePreview.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSchemePreview.swift
@@ -1,0 +1,45 @@
+#if DEBUG
+import SwiftUI
+
+/// Shows Meridian's accent and status tints over one forced system appearance.
+struct MeridianSchemePreview: View {
+    let title: String
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(theme.label)
+
+            HStack(spacing: 10) {
+                statusChip(.needsYou)
+                statusChip(.running)
+                statusChip(.done)
+                statusChip(.failed)
+                statusChip(.idle)
+            }
+        }
+        .padding(14)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            theme.background,
+            in: RoundedRectangle(cornerRadius: theme.cardRadius, style: .continuous)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: theme.cardRadius, style: .continuous)
+                .stroke(theme.separator, lineWidth: 0.5)
+        }
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private func statusChip(_ state: GalleryAgentState) -> some View {
+        MeridianStatusSymbol(state: state, font: .headline)
+            .frame(width: 26, height: 26)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSessionScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSessionScreen.swift
@@ -1,0 +1,61 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Renders the full terminal transcript edge-to-edge beneath floating glass session chrome.
+struct MeridianSessionScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 7) {
+                ForEach(DesignGalleryFixtures.terminalLines) { line in
+                    MeridianTerminalLineView(line: line)
+                }
+            }
+            .padding(.horizontal, 14)
+            .padding(.top, 78)
+            .padding(.bottom, 18)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.background.ignoresSafeArea())
+        .overlay(alignment: .top) {
+            statusCapsule
+                .padding(.top, 10)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 8) {
+            HStack {
+                Spacer()
+                MeridianActionCluster(approvalPending: true)
+            }
+            .padding(.horizontal, theme.horizontalInset)
+        }
+        .tint(theme.accent)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private var statusCapsule: some View {
+        let workspace = DesignGalleryFixtures.workspaces[0]
+        return HStack(spacing: 9) {
+            MeridianStatusSymbol(state: workspace.state, font: .headline)
+            Text(workspace.name)
+                .font(.headline)
+            Text(workspace.branch)
+                .font(.caption.monospaced())
+                .foregroundStyle(theme.secondaryLabel)
+                .lineLimit(1)
+            Text(workspace.elapsedText)
+                .font(.caption)
+                .foregroundStyle(theme.secondaryLabel)
+        }
+        .foregroundStyle(theme.label)
+        .padding(.horizontal, 14)
+        .frame(minHeight: 44)
+        .mobileGlassPill()
+        .padding(.horizontal, 20)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSettingsScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSettingsScreen.swift
@@ -1,0 +1,69 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders the shared settings fixture as a deliberately first-party inset-grouped form.
+struct MeridianSettingsScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var notificationsEnabled = DesignGalleryFixtures.settings.notificationsEnabled
+    @State private var appearance = "System"
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Settings")
+                .font(.largeTitle.weight(.bold))
+                .foregroundStyle(theme.label)
+                .padding(.horizontal, theme.horizontalInset)
+                .padding(.top, 14)
+                .padding(.bottom, 4)
+
+            Form {
+                Section("Account") {
+                    LabeledContent("Signed in as", value: settings.accountEmail)
+                }
+
+                Section("Paired Mac") {
+                    LabeledContent {
+                        Text(settings.pairedMacStatus)
+                            .foregroundStyle(theme.done)
+                    } label: {
+                        Label(settings.pairedMacName, systemImage: "desktopcomputer")
+                    }
+                }
+
+                Section("Appearance") {
+                    Picker("Appearance", selection: $appearance) {
+                        Text("System").tag("System")
+                        Text("Light").tag("Light")
+                        Text("Dark").tag("Dark")
+                    }
+                    .pickerStyle(.segmented)
+                }
+
+                Section("Notifications") {
+                    Toggle("Agent activity", isOn: $notificationsEnabled)
+                }
+
+                Section("Terminal") {
+                    LabeledContent("Font size", value: settings.terminalFontSize)
+                }
+
+                Section("About") {
+                    LabeledContent("Version", value: settings.appVersion)
+                }
+            }
+            .scrollContentBackground(.hidden)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.background.ignoresSafeArea())
+        .tint(theme.accent)
+    }
+
+    private var settings: GallerySettingsFixture {
+        DesignGalleryFixtures.settings
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianSpecimenScreen.swift
@@ -1,0 +1,153 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Collects Meridian's palette, type ramp, statuses, and core glass components.
+struct MeridianSpecimenScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 24) {
+                Text("Meridian")
+                    .font(.largeTitle.weight(.bold))
+                    .foregroundStyle(theme.label)
+
+                specimenSection(title: "Palette") {
+                    LazyVGrid(columns: paletteColumns, alignment: .leading, spacing: 12) {
+                        MeridianPaletteSwatch(name: "systemBackground", hex: theme.backgroundHex, color: theme.background)
+                        MeridianPaletteSwatch(name: "secondarySystemBackground", hex: theme.secondaryBackgroundHex, color: theme.secondaryBackground)
+                        MeridianPaletteSwatch(name: "tertiarySystemFill", hex: theme.tertiaryFillHex, color: theme.tertiaryFill)
+                        MeridianPaletteSwatch(name: "label", hex: theme.labelHex, color: theme.label)
+                        MeridianPaletteSwatch(name: "secondaryLabel", hex: theme.secondaryLabelHex, color: theme.secondaryLabel)
+                        MeridianPaletteSwatch(name: "tertiaryLabel", hex: theme.tertiaryLabelHex, color: theme.tertiaryLabel)
+                        MeridianPaletteSwatch(name: "accent", hex: theme.accentHex, color: theme.accent)
+                        MeridianPaletteSwatch(name: "needsYou", hex: theme.needsYouHex, color: theme.needsYou)
+                        MeridianPaletteSwatch(name: "running", hex: theme.accentHex, color: theme.running)
+                        MeridianPaletteSwatch(name: "done", hex: theme.doneHex, color: theme.done)
+                        MeridianPaletteSwatch(name: "failed", hex: theme.failedHex, color: theme.failed)
+                        MeridianPaletteSwatch(name: "idle", hex: theme.tertiaryLabelHex, color: theme.idle)
+                    }
+                }
+
+                specimenSection(title: "Light & dark") {
+                    VStack(spacing: 12) {
+                        MeridianSchemePreview(title: "Light")
+                            .environment(\.colorScheme, .light)
+                        MeridianSchemePreview(title: "Dark")
+                            .environment(\.colorScheme, .dark)
+                    }
+                }
+
+                specimenSection(title: "Dynamic Type") {
+                    VStack(alignment: .leading, spacing: 16) {
+                        MeridianTypeSample(role: "Large Title", sample: "Content first", font: .largeTitle)
+                        MeridianTypeSample(role: "Headline", sample: "Workspace status", font: .headline)
+                        MeridianTypeSample(role: "Body", sample: "Agent response and settings copy", font: .body)
+                        MeridianTypeSample(role: "Subheadline", sample: "Supporting information", font: .subheadline)
+                        MeridianTypeSample(role: "Caption", sample: "14:32 · two minutes ago", font: .caption)
+                        MeridianTypeSample(role: "Mono branch", sample: "feat-ios-design-gallery", font: .subheadline.monospaced())
+                    }
+                }
+
+                specimenSection(title: "Status vocabulary") {
+                    VStack(spacing: 12) {
+                        statusRow(.needsYou)
+                        statusRow(.failed)
+                        statusRow(.running)
+                        statusRow(.done)
+                        statusRow(.idle)
+                    }
+                }
+
+                specimenSection(title: "Glass chrome") {
+                    VStack(spacing: 16) {
+                        HStack(spacing: 12) {
+                            glassCircle(symbol: "keyboard", label: "Keyboard")
+                            glassCircle(symbol: "ellipsis", label: "More")
+                            Button(DesignGalleryFixtures.approvalActions[0]) {}
+                                .mobileGlassProminentButton()
+                                .tint(theme.accent)
+                                .frame(minHeight: 44)
+                        }
+
+                        MeridianComposer()
+
+                        VStack(spacing: 8) {
+                            Capsule()
+                                .fill(theme.tertiaryLabel)
+                                .frame(width: 36, height: 5)
+                            Text("Sheet grabber region")
+                                .font(.caption)
+                                .foregroundStyle(theme.secondaryLabel)
+                        }
+                        .frame(maxWidth: .infinity, minHeight: 54)
+                        .mobileGlassField(cornerRadius: theme.cardRadius)
+
+                        MeridianFloatingTabBar(selectedPage: .hub)
+                    }
+                }
+            }
+            .padding(.horizontal, theme.horizontalInset)
+            .padding(.top, 14)
+            .padding(.bottom, 20)
+        }
+        .background(theme.background.ignoresSafeArea())
+        .tint(theme.accent)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private var paletteColumns: [GridItem] {
+        [GridItem(.adaptive(minimum: 150), spacing: 12)]
+    }
+
+    private func specimenSection<Content: View>(
+        title: String,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(theme.label)
+            content()
+        }
+        .padding(16)
+        .background(
+            theme.secondaryBackground,
+            in: RoundedRectangle(cornerRadius: theme.cardRadius, style: .continuous)
+        )
+    }
+
+    private func statusRow(_ state: GalleryAgentState) -> some View {
+        HStack(spacing: 12) {
+            MeridianStatusSymbol(state: state, font: .headline)
+                .frame(width: 30, height: 30)
+            Text(theme.label(for: state))
+                .font(.body.weight(.semibold))
+                .foregroundStyle(theme.label)
+            Spacer()
+            Text(theme.symbolName(for: state))
+                .font(.caption.monospaced())
+                .foregroundStyle(theme.secondaryLabel)
+                .lineLimit(1)
+                .minimumScaleFactor(0.7)
+        }
+        .frame(minHeight: 44)
+    }
+
+    private func glassCircle(symbol: String, label: String) -> some View {
+        Button {} label: {
+            Image(systemName: symbol)
+                .font(.headline)
+                .foregroundStyle(theme.label)
+                .frame(width: 48, height: 48)
+                .mobileGlassCircle()
+        }
+        .buttonStyle(MeridianPressButtonStyle())
+        .accessibilityLabel(label)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianStatusSymbol.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianStatusSymbol.swift
@@ -1,0 +1,36 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays Meridian's symbol-and-color status encoding, including the running pulse.
+struct MeridianStatusSymbol: View {
+    let state: GalleryAgentState
+    var font: Font = .body
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var pulseActive = false
+
+    var body: some View {
+        Image(systemName: theme.symbolName(for: state))
+            .font(font)
+            .foregroundStyle(theme.color(for: state))
+            .symbolEffect(.pulse, options: .repeating, isActive: pulseActive)
+            .accessibilityLabel(theme.label(for: state))
+            .onAppear {
+                pulseActive = isRunning && !reduceMotion
+            }
+            .onChange(of: reduceMotion) { _, newValue in
+                pulseActive = isRunning && !newValue
+            }
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private var isRunning: Bool {
+        if case .running = state { return true }
+        return false
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianStatusSymbol.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianStatusSymbol.swift
@@ -29,8 +29,7 @@ struct MeridianStatusSymbol: View {
     }
 
     private var isRunning: Bool {
-        if case .running = state { return true }
-        return false
+        state == .running
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianTerminalLineView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianTerminalLineView.swift
@@ -1,0 +1,33 @@
+#if DEBUG
+import SwiftUI
+
+/// Maps one complete terminal transcript line into Meridian's semantic palette.
+struct MeridianTerminalLineView: View {
+    let line: GalleryTerminalLine
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Text(line.text)
+            .font(.system(size: 13, weight: .regular, design: .monospaced))
+            .foregroundStyle(lineColor)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .textSelection(.enabled)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+
+    private var lineColor: Color {
+        switch line.tone {
+        case .plain: theme.label
+        case .dim: theme.secondaryLabel
+        case .accent: theme.accent
+        case .success: theme.done
+        case .warning: theme.needsYou
+        case .error: theme.failed
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianTheme.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianTheme.swift
@@ -1,0 +1,90 @@
+#if DEBUG
+import SwiftUI
+import UIKit
+
+/// Resolves Meridian's semantic system palette and exact indigo accent for one appearance.
+struct MeridianTheme {
+    let scheme: ColorScheme
+    let background: Color
+    let secondaryBackground: Color
+    let tertiaryFill: Color
+    let label: Color
+    let secondaryLabel: Color
+    let tertiaryLabel: Color
+    let separator: Color
+    let accentForeground: Color
+    let accent: Color
+    let needsYou: Color
+    let running: Color
+    let done: Color
+    let failed: Color
+    let idle: Color
+
+    let cardRadius: CGFloat = 26
+    let horizontalInset: CGFloat = 20
+
+    init(scheme: ColorScheme) {
+        self.scheme = scheme
+        background = Color(uiColor: .systemBackground)
+        secondaryBackground = Color(uiColor: .secondarySystemBackground)
+        tertiaryFill = Color(uiColor: .tertiarySystemFill)
+        label = Color(uiColor: .label)
+        secondaryLabel = Color(uiColor: .secondaryLabel)
+        tertiaryLabel = Color(uiColor: .tertiaryLabel)
+        separator = Color(uiColor: .separator)
+        accentForeground = Color(uiColor: .white)
+        accent = scheme == .dark
+            ? Color(red: 122.0 / 255.0, green: 122.0 / 255.0, blue: 232.0 / 255.0)
+            : Color(red: 91.0 / 255.0, green: 91.0 / 255.0, blue: 214.0 / 255.0)
+        needsYou = Color(uiColor: .systemOrange)
+        running = accent
+        done = Color(uiColor: .systemGreen)
+        failed = Color(uiColor: .systemRed)
+        idle = Color(uiColor: .tertiaryLabel)
+    }
+
+    /// Returns the redundantly encoded tint for an agent lifecycle state.
+    func color(for state: GalleryAgentState) -> Color {
+        switch state {
+        case .needsYou: needsYou
+        case .running: running
+        case .done: done
+        case .failed: failed
+        case .idle: idle
+        }
+    }
+
+    /// Returns Meridian's binding SF Symbol for an agent lifecycle state.
+    func symbolName(for state: GalleryAgentState) -> String {
+        switch state {
+        case .needsYou: "person.crop.circle.badge.exclamationmark"
+        case .running: "arrow.triangle.2.circlepath"
+        case .done: "checkmark.circle.fill"
+        case .failed: "xmark.circle.fill"
+        case .idle: "moon.zzz"
+        }
+    }
+
+    /// Returns the word paired with a status symbol so state never relies on color alone.
+    func label(for state: GalleryAgentState) -> String {
+        switch state {
+        case .needsYou: "Needs you"
+        case .running: "Running"
+        case .done: "Done"
+        case .failed: "Failed"
+        case .idle: "Idle"
+        }
+    }
+
+    var backgroundHex: String { scheme == .dark ? "#000000" : "#FFFFFF" }
+    var secondaryBackgroundHex: String { scheme == .dark ? "#1C1C1E" : "#F2F2F7" }
+    var tertiaryFillHex: String { scheme == .dark ? "#7676803D" : "#7676801F" }
+    var labelHex: String { scheme == .dark ? "#FFFFFF" : "#000000" }
+    var secondaryLabelHex: String { scheme == .dark ? "#EBEBF599" : "#3C3C4399" }
+    var tertiaryLabelHex: String { scheme == .dark ? "#EBEBF54D" : "#3C3C434D" }
+    var accentHex: String { scheme == .dark ? "#7A7AE8" : "#5B5BD6" }
+    var needsYouHex: String { scheme == .dark ? "#FF9F0A" : "#FF9500" }
+    var doneHex: String { scheme == .dark ? "#30D158" : "#34C759" }
+    var failedHex: String { scheme == .dark ? "#FF453A" : "#FF3B30" }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianTypeSample.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianTypeSample.swift
@@ -1,0 +1,28 @@
+#if DEBUG
+import SwiftUI
+
+/// Pairs a Meridian Dynamic Type role name with a live SF Pro sample.
+struct MeridianTypeSample: View {
+    let role: String
+    let sample: String
+    let font: Font
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 3) {
+            Text(role)
+                .font(.caption)
+                .foregroundStyle(theme.secondaryLabel)
+            Text(sample)
+                .font(font)
+                .foregroundStyle(theme.label)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianWorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Meridian/MeridianWorkspaceRow.swift
@@ -1,0 +1,71 @@
+#if DEBUG
+import SwiftUI
+
+/// Presents one shared workspace fixture using Meridian's native list metrics.
+struct MeridianWorkspaceRow: View {
+    let workspace: GalleryWorkspaceFixture
+
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        Button {} label: {
+            HStack(alignment: .top, spacing: 12) {
+                MeridianStatusSymbol(state: workspace.state, font: .headline)
+                    .frame(width: 28, height: 28)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack(alignment: .firstTextBaseline) {
+                        Text(workspace.name)
+                            .font(.headline)
+                            .foregroundStyle(theme.label)
+                        Spacer(minLength: 8)
+                        Text(workspace.elapsedText)
+                            .font(.caption)
+                            .foregroundStyle(theme.tertiaryLabel)
+                    }
+
+                    Text(workspace.branch)
+                        .font(.subheadline.monospaced())
+                        .foregroundStyle(theme.secondaryLabel)
+                        .lineLimit(1)
+
+                    Text("\(workspace.agentName) · \(workspace.detailText)")
+                        .font(.caption)
+                        .foregroundStyle(theme.secondaryLabel)
+                        .lineLimit(2)
+
+                    if let pendingQuestion = workspace.pendingQuestion {
+                        Text(pendingQuestion)
+                            .font(.subheadline)
+                            .foregroundStyle(theme.needsYou)
+                            .padding(.top, 2)
+                    }
+                }
+            }
+            .padding(.vertical, 8)
+            .frame(maxWidth: .infinity, minHeight: 64, alignment: .leading)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(MeridianPressButtonStyle())
+        .swipeActions(edge: .trailing, allowsFullSwipe: workspace.pendingQuestion != nil) {
+            if workspace.pendingQuestion != nil {
+                Button(DesignGalleryFixtures.approvalActions[0]) {}
+                    .tint(theme.accent)
+            } else {
+                Button("Open") {}
+                    .tint(theme.accent)
+            }
+        }
+        .contextMenu {
+            Button("Open workspace") {}
+            if workspace.pendingQuestion != nil {
+                Button(DesignGalleryFixtures.approvalActions[0]) {}
+            }
+        }
+    }
+
+    private var theme: MeridianTheme {
+        MeridianTheme(scheme: colorScheme)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityRow.swift
@@ -1,0 +1,58 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays one compact activity event with redundant status information.
+struct PhosphorActivityRow: View {
+    let entry: GalleryActivityEntry
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+        let statusColor = theme.statusColor(entry.state)
+
+        HStack(spacing: 8) {
+            PhosphorStatusDot(state: entry.state)
+
+            Image(systemName: theme.statusSymbol(entry.state))
+                .font(.system(size: 9, weight: .bold))
+                .foregroundStyle(statusColor)
+                .frame(width: 12)
+
+            Text(entry.text)
+                .font(theme.isNeedsYou(entry.state) ? typography.bodySemibold : typography.body)
+                .foregroundStyle(theme.textPrimary)
+                .lineLimit(1)
+                .minimumScaleFactor(0.82)
+
+            Spacer(minLength: 6)
+
+            if entry.unread {
+                Circle()
+                    .fill(statusColor)
+                    .frame(width: 4, height: 4)
+                    .accessibilityHidden(true)
+            }
+
+            Text(entry.timeText)
+                .font(typography.monoCaption)
+                .monospacedDigit()
+                .foregroundStyle(theme.textSecondary)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 44)
+        .background(theme.bg1)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.hairline)
+                .frame(height: 1)
+                .padding(.leading, 40)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(theme.statusLabel(entry.state)), \(entry.text), \(entry.timeText)\(entry.unread ? ", unread" : "")"
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityRow.swift
@@ -6,7 +6,7 @@ struct PhosphorActivityRow: View {
     let entry: GalleryActivityEntry
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityScreen.swift
@@ -1,0 +1,45 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders every fixture event in Phosphor's single dense chronological feed.
+struct PhosphorActivityScreen: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var feedVisible = false
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        ScrollView {
+            LazyVStack(spacing: 0, pinnedViews: [.sectionHeaders]) {
+                ForEach(DesignGalleryFixtures.activityDays, id: \.dayLabel) { day in
+                    Section {
+                        ForEach(day.entries) { entry in
+                            PhosphorActivityRow(entry: entry)
+                                .opacity(feedVisible ? 1.0 : 0.0)
+                                .offset(y: reduceMotion || feedVisible ? 0 : 4)
+                        }
+                    } header: {
+                        Text(day.dayLabel.uppercased())
+                            .font(typography.caption)
+                            .tracking(0.8)
+                            .foregroundStyle(theme.textTertiary)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 12)
+                            .frame(height: 32)
+                            .background(theme.bg0)
+                    }
+                }
+            }
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.bg0.ignoresSafeArea())
+        .onAppear {
+            withAnimation(.easeOut(duration: reduceMotion ? 0.15 : 0.18)) {
+                feedVisible = true
+            }
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorActivityScreen.swift
@@ -6,7 +6,7 @@ struct PhosphorActivityScreen: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
     @State private var feedVisible = false
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorAppearanceControl.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorAppearanceControl.swift
@@ -6,7 +6,7 @@ struct PhosphorAppearanceControl: View {
     @Binding var selection: Int
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     private let choices = ["System", "Light", "Dark"]
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorAppearanceControl.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorAppearanceControl.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import SwiftUI
+
+/// Supplies a custom three-way appearance selector without default picker chrome.
+struct PhosphorAppearanceControl: View {
+    @Binding var selection: Int
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    private let choices = ["System", "Light", "Dark"]
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        HStack(spacing: 4) {
+            ForEach(Array(choices.enumerated()), id: \.offset) { index, choice in
+                Button {
+                    selection = index
+                } label: {
+                    Text(choice)
+                        .font(selection == index ? typography.captionSemibold : typography.caption)
+                        .foregroundStyle(selection == index ? theme.textPrimary : theme.textSecondary)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                        .background {
+                            if selection == index {
+                                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                    .fill(theme.bg1)
+                                    .overlay {
+                                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                            .stroke(theme.hairline, lineWidth: 1)
+                                    }
+                            }
+                        }
+                }
+                .buttonStyle(PhosphorPressButtonStyle())
+            }
+        }
+        .padding(4)
+        .background(theme.bg2, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorApprovalCard.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorApprovalCard.swift
@@ -7,7 +7,7 @@ struct PhosphorApprovalCard: View {
     let timeText: String
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorApprovalCard.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorApprovalCard.swift
@@ -1,0 +1,65 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays an amber approval request with paired, clearly separated responses.
+struct PhosphorApprovalCard: View {
+    let question: String
+    let timeText: String
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(spacing: 8) {
+                PhosphorStatusDot(state: .needsYou)
+                Image(systemName: theme.statusSymbol(.needsYou))
+                    .font(.system(size: 11, weight: .bold))
+                Text("Approval required")
+                    .font(typography.captionSemibold)
+                Spacer(minLength: 8)
+                Text(timeText)
+                    .font(typography.monoCaption)
+                    .monospacedDigit()
+            }
+            .foregroundStyle(theme.statusNeedsYou)
+
+            Text(question)
+                .font(typography.body)
+                .foregroundStyle(theme.textPrimary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            HStack(spacing: 12) {
+                Button(action: {}) {
+                    Text(DesignGalleryFixtures.approvalActions[1])
+                        .font(typography.bodySemibold)
+                        .foregroundStyle(theme.statusFailed)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                        .background(theme.bg2, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                }
+                .buttonStyle(PhosphorPressButtonStyle())
+
+                Button(action: {}) {
+                    Text(DesignGalleryFixtures.approvalActions[0])
+                        .font(typography.bodySemibold)
+                        .foregroundStyle(theme.isDark ? theme.textPrimary : theme.bg1)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                        .background(
+                            theme.accent,
+                            in: RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        )
+                }
+                .buttonStyle(PhosphorPressButtonStyle())
+            }
+        }
+        .padding(12)
+        .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(theme.statusNeedsYou, lineWidth: 1)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatEntryView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatEntryView.swift
@@ -6,7 +6,7 @@ struct PhosphorChatEntryView: View {
     let entry: GalleryChatEntry
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     @ViewBuilder
     var body: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatEntryView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatEntryView.swift
@@ -1,0 +1,72 @@
+#if DEBUG
+import SwiftUI
+
+/// Maps each shared conversation role into Phosphor's flat message treatment.
+struct PhosphorChatEntryView: View {
+    let entry: GalleryChatEntry
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    @ViewBuilder
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        switch entry.role {
+        case .user:
+            HStack {
+                Spacer(minLength: 44)
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(entry.text)
+                        .font(typography.body)
+                        .foregroundStyle(theme.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Text(entry.timeText)
+                        .font(typography.monoCaption)
+                        .monospacedDigit()
+                        .foregroundStyle(theme.textTertiary)
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+                .background(theme.bg2, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+            }
+
+        case .agent:
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 10, weight: .bold))
+                        .foregroundStyle(theme.accent)
+                    Text("Agent")
+                        .font(typography.captionSemibold)
+                        .foregroundStyle(theme.textSecondary)
+                    Text(entry.timeText)
+                        .font(typography.monoCaption)
+                        .monospacedDigit()
+                        .foregroundStyle(theme.textTertiary)
+                }
+                Text(entry.text)
+                    .font(typography.body)
+                    .foregroundStyle(theme.textPrimary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+        case .tool:
+            if let command = entry.toolCommand, let output = entry.toolOutput {
+                PhosphorToolCard(
+                    title: entry.text,
+                    command: command,
+                    output: output,
+                    timeText: entry.timeText
+                )
+            }
+
+        case .approval:
+            if let question = entry.question {
+                PhosphorApprovalCard(question: question, timeText: entry.timeText)
+            }
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatScreen.swift
@@ -1,0 +1,32 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders the complete shared conversation as a dense, bubble-light transcript.
+struct PhosphorChatScreen: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var entriesVisible = false
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 16) {
+                ForEach(DesignGalleryFixtures.chatEntries) { entry in
+                    PhosphorChatEntryView(entry: entry)
+                        .opacity(entriesVisible ? 1.0 : 0.0)
+                        .offset(y: reduceMotion || entriesVisible ? 0 : 4)
+                }
+            }
+            .padding(12)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.bg0.ignoresSafeArea())
+        .onAppear {
+            withAnimation(.easeOut(duration: reduceMotion ? 0.15 : 0.18)) {
+                entriesVisible = true
+            }
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorChatScreen.swift
@@ -21,6 +21,7 @@ struct PhosphorChatScreen: View {
             .padding(12)
         }
         .scrollIndicators(.hidden)
+        .defaultScrollAnchor(.bottom)
         .background(theme.bg0.ignoresSafeArea())
         .onAppear {
             withAnimation(.easeOut(duration: reduceMotion ? 0.15 : 0.18)) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorCommandBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorCommandBar.swift
@@ -7,7 +7,7 @@ struct PhosphorCommandBar: View {
     let showsApprove: Bool
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorCommandBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorCommandBar.swift
@@ -1,0 +1,47 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Presents Phosphor's two thumb-reachable hub commands on compatible glass.
+struct PhosphorCommandBar: View {
+    let showsApprove: Bool
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        HStack(spacing: 8) {
+            if showsApprove {
+                Button(action: {}) {
+                    Label("Approve", systemImage: "checkmark")
+                        .font(typography.bodySemibold)
+                        .foregroundStyle(theme.statusNeedsYou)
+                        .frame(maxWidth: .infinity, minHeight: 44)
+                        .background(
+                            theme.statusNeedsYou.opacity(0.16),
+                            in: RoundedRectangle(cornerRadius: 8, style: .continuous)
+                        )
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                                .stroke(theme.statusNeedsYou.opacity(0.55), lineWidth: 1)
+                        }
+                }
+                .buttonStyle(PhosphorPressButtonStyle())
+            }
+
+            Button(action: {}) {
+                Label("New workspace", systemImage: "plus")
+                    .font(typography.bodySemibold)
+                    .foregroundStyle(theme.isDark ? theme.textPrimary : theme.bg1)
+                    .frame(maxWidth: .infinity, minHeight: 44)
+                    .background(theme.accent, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(PhosphorPressButtonStyle())
+        }
+        .padding(8)
+        .mobileGlassField(cornerRadius: 12)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorGallery.swift
@@ -1,14 +1,28 @@
 #if DEBUG
 import SwiftUI
 
-/// Placeholder root for the Phosphor candidate's future six-screen gallery.
+/// Routes gallery pages into the six Phosphor design-system specimens.
 struct PhosphorGallery: View {
     let page: DesignGalleryPage
 
     var body: some View {
-        Text("\(DesignGallerySystem.phosphor.number) \(DesignGallerySystem.phosphor.displayName) — \(page.title)")
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(.systemBackground))
+        Group {
+            switch page {
+            case .hub:
+                PhosphorHubScreen()
+            case .session:
+                PhosphorSessionScreen()
+            case .chat:
+                PhosphorChatScreen()
+            case .activity:
+                PhosphorActivityScreen()
+            case .settings:
+                PhosphorSettingsScreen()
+            case .specimen:
+                PhosphorSpecimenScreen()
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorGallery.swift
@@ -1,0 +1,14 @@
+#if DEBUG
+import SwiftUI
+
+/// Placeholder root for the Phosphor candidate's future six-screen gallery.
+struct PhosphorGallery: View {
+    let page: DesignGalleryPage
+
+    var body: some View {
+        Text("\(DesignGallerySystem.phosphor.number) \(DesignGallerySystem.phosphor.displayName) — \(page.title)")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.systemBackground))
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorHubScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorHubScreen.swift
@@ -6,7 +6,7 @@ struct PhosphorHubScreen: View {
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorScheme) private var colorScheme
     @State private var rowsVisible = false
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorHubScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorHubScreen.swift
@@ -30,7 +30,7 @@ struct PhosphorHubScreen: View {
                         }
                 }
             } header: {
-                Text("1 needs you · 2 running · 1 done")
+                Text(statusSummary)
                     .font(typography.monoCaptionMedium)
                     .monospacedDigit()
                     .foregroundStyle(theme.textSecondary)
@@ -64,6 +64,19 @@ struct PhosphorHubScreen: View {
         DesignGalleryFixtures.workspaces.sorted {
             theme.statusRank($0.state) < theme.statusRank($1.state)
         }
+    }
+
+    /// The fixture-derived status counts, in attention order, nonzero only.
+    private var statusSummary: String {
+        let labels: [(GalleryAgentState, String)] = [
+            (.needsYou, "needs you"), (.failed, "failed"), (.running, "running"),
+            (.done, "done"), (.idle, "idle"),
+        ]
+        return labels.compactMap { state, label in
+            let count = DesignGalleryFixtures.workspaces.filter { $0.state == state }.count
+            return count > 0 ? "\(count) \(label)" : nil
+        }
+        .joined(separator: " · ")
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorHubScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorHubScreen.swift
@@ -1,0 +1,69 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders Phosphor's status-sorted workspace attention queue.
+struct PhosphorHubScreen: View {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var rowsVisible = false
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        List {
+            Section {
+                ForEach(sortedWorkspaces(theme: theme)) { workspace in
+                    PhosphorWorkspaceRow(workspace: workspace)
+                        .opacity(rowsVisible ? 1.0 : 0.0)
+                        .offset(y: reduceMotion || rowsVisible ? 0 : 4)
+                        .listRowInsets(EdgeInsets(top: 0, leading: 12, bottom: 0, trailing: 12))
+                        .listRowSeparator(.hidden)
+                        .listRowBackground(theme.bg0)
+                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                            Button(theme.isNeedsYou(workspace.state) ? "Approve" : "Reply", action: {})
+                                .tint(theme.isNeedsYou(workspace.state) ? theme.statusNeedsYou : theme.accent)
+                        }
+                        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+                            Button("Mark read", action: {})
+                                .tint(theme.bg2)
+                        }
+                }
+            } header: {
+                Text("1 needs you · 2 running · 1 done")
+                    .font(typography.monoCaptionMedium)
+                    .monospacedDigit()
+                    .foregroundStyle(theme.textSecondary)
+                    .textCase(nil)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 12)
+                    .frame(height: 32)
+                    .background(theme.bg1)
+                    .overlay(alignment: .bottom) {
+                        Rectangle().fill(theme.hairline).frame(height: 1)
+                    }
+                    .listRowInsets(EdgeInsets())
+            }
+        }
+        .listStyle(.plain)
+        .scrollContentBackground(.hidden)
+        .background(theme.bg0.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            PhosphorCommandBar(showsApprove: true)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+        }
+        .onAppear {
+            withAnimation(.easeOut(duration: reduceMotion ? 0.15 : 0.18)) {
+                rowsVisible = true
+            }
+        }
+    }
+
+    private func sortedWorkspaces(theme: PhosphorTheme) -> [GalleryWorkspaceFixture] {
+        DesignGalleryFixtures.workspaces.sorted {
+            theme.statusRank($0.state) < theme.statusRank($1.state)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorPressButtonStyle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorPressButtonStyle.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+import SwiftUI
+
+/// Gives inert Phosphor gallery controls a fast, restrained pressed affordance.
+struct PhosphorPressButtonStyle: ButtonStyle {
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? 0.72 : 1.0)
+            .scaleEffect(configuration.isPressed && !reduceMotion ? 0.98 : 1.0)
+            .animation(.easeOut(duration: 0.15), value: configuration.isPressed)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionHeader.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionHeader.swift
@@ -6,7 +6,7 @@ struct PhosphorSessionHeader: View {
     let workspace: GalleryWorkspaceFixture
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionHeader.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionHeader.swift
@@ -1,0 +1,51 @@
+#if DEBUG
+import SwiftUI
+
+/// Keeps the active agent's state visible above the full-bleed terminal.
+struct PhosphorSessionHeader: View {
+    let workspace: GalleryWorkspaceFixture
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+        let statusColor = theme.statusColor(workspace.state)
+
+        HStack(spacing: 8) {
+            PhosphorStatusDot(state: workspace.state)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(workspace.agentName)
+                    .font(typography.bodySemibold)
+                    .foregroundStyle(theme.textPrimary)
+                Text(workspace.branch)
+                    .font(typography.monoCaption)
+                    .foregroundStyle(theme.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            Image(systemName: theme.statusSymbol(workspace.state))
+                .font(.system(size: 11, weight: .bold))
+                .foregroundStyle(statusColor)
+
+            Text(theme.statusLabel(workspace.state))
+                .font(typography.captionSemibold)
+                .foregroundStyle(statusColor)
+
+            Text(workspace.elapsedText)
+                .font(typography.dataMedium)
+                .monospacedDigit()
+                .foregroundStyle(theme.textSecondary)
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 52)
+        .background(theme.bg1)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(theme.hairline).frame(height: 1)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionScreen.swift
@@ -1,0 +1,43 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders the complete fixture transcript as Phosphor's primary content surface.
+struct PhosphorSessionScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var command = ""
+    private var typography = PhosphorTypography()
+
+    private let workspace = DesignGalleryFixtures.workspaces[1]
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        VStack(spacing: 0) {
+            PhosphorSessionHeader(workspace: workspace)
+
+            ScrollView([.horizontal, .vertical]) {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    ForEach(DesignGalleryFixtures.terminalLines) { line in
+                        Text(line.text)
+                            .font(typography.terminal)
+                            .foregroundStyle(theme.terminalColor(line.tone))
+                            .fixedSize(horizontal: true, vertical: false)
+                            .frame(height: 15.6, alignment: .leading)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.vertical, 12)
+            }
+            .scrollIndicators(.hidden)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+            .background(theme.bg0)
+        }
+        .background(theme.bg0.ignoresSafeArea())
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            PhosphorTerminalAccessory(command: $command)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 8)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSessionScreen.swift
@@ -5,7 +5,7 @@ import SwiftUI
 struct PhosphorSessionScreen: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var command = ""
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     private let workspace = DesignGalleryFixtures.workspaces[1]
 
@@ -29,6 +29,7 @@ struct PhosphorSessionScreen: View {
                 .padding(.vertical, 12)
             }
             .scrollIndicators(.hidden)
+            .defaultScrollAnchor(.topLeading)
             .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .background(theme.bg0)
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsRow.swift
@@ -9,7 +9,7 @@ struct PhosphorSettingsRow: View {
     let showsChevron: Bool
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsRow.swift
@@ -1,0 +1,59 @@
+#if DEBUG
+import SwiftUI
+
+/// Presents one opaque Phosphor settings row with an optional mono value.
+struct PhosphorSettingsRow: View {
+    let symbol: String
+    let title: String
+    let value: String?
+    let showsChevron: Bool
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        Button(action: {}) {
+            HStack(spacing: 8) {
+                Image(systemName: symbol)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(theme.accent)
+                    .frame(width: 24)
+
+                Text(title)
+                    .font(typography.body)
+                    .foregroundStyle(theme.textPrimary)
+
+                Spacer(minLength: 8)
+
+                if let value {
+                    Text(value)
+                        .font(typography.data)
+                        .monospacedDigit()
+                        .foregroundStyle(theme.textSecondary)
+                        .lineLimit(1)
+                        .minimumScaleFactor(0.72)
+                }
+
+                if showsChevron {
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 11, weight: .semibold))
+                        .foregroundStyle(theme.textTertiary)
+                }
+            }
+            .padding(.horizontal, 12)
+            .frame(minHeight: 52)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(PhosphorPressButtonStyle())
+        .background(theme.bg1)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.hairline)
+                .frame(height: 1)
+                .padding(.leading, 48)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsScreen.swift
@@ -6,7 +6,7 @@ struct PhosphorSettingsScreen: View {
     @Environment(\.colorScheme) private var colorScheme
     @State private var notificationsEnabled = DesignGalleryFixtures.settings.notificationsEnabled
     @State private var appearanceSelection = 0
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSettingsScreen.swift
@@ -1,0 +1,91 @@
+#if DEBUG
+import SwiftUI
+
+/// Re-skins the complete settings fixture as opaque grouped Phosphor controls.
+struct PhosphorSettingsScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var notificationsEnabled = DesignGalleryFixtures.settings.notificationsEnabled
+    @State private var appearanceSelection = 0
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+        let settings = DesignGalleryFixtures.settings
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 20) {
+                sectionLabel("ACCOUNT", theme: theme)
+                PhosphorSettingsRow(
+                    symbol: "person.crop.circle",
+                    title: "Signed in",
+                    value: settings.accountEmail,
+                    showsChevron: true
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                sectionLabel("PAIRED MAC", theme: theme)
+                VStack(spacing: 0) {
+                    PhosphorSettingsRow(
+                        symbol: "laptopcomputer",
+                        title: "Mac",
+                        value: settings.pairedMacName,
+                        showsChevron: true
+                    )
+                    PhosphorSettingsRow(
+                        symbol: "checkmark.circle",
+                        title: "Connection",
+                        value: settings.pairedMacStatus,
+                        showsChevron: false
+                    )
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                sectionLabel("APPEARANCE", theme: theme)
+                PhosphorAppearanceControl(selection: $appearanceSelection)
+
+                sectionLabel("PREFERENCES", theme: theme)
+                VStack(spacing: 0) {
+                    Toggle(isOn: $notificationsEnabled) {
+                        Label("Notifications", systemImage: "bell")
+                            .font(typography.body)
+                            .foregroundStyle(theme.textPrimary)
+                    }
+                    .tint(theme.accent)
+                    .padding(.horizontal, 12)
+                    .frame(minHeight: 52)
+                    .background(theme.bg1)
+                    .overlay(alignment: .bottom) {
+                        Rectangle().fill(theme.hairline).frame(height: 1).padding(.leading, 48)
+                    }
+
+                    PhosphorSettingsRow(
+                        symbol: "textformat.size",
+                        title: "Terminal font",
+                        value: settings.terminalFontSize,
+                        showsChevron: true
+                    )
+                    PhosphorSettingsRow(
+                        symbol: "info.circle",
+                        title: "Version",
+                        value: settings.appVersion,
+                        showsChevron: false
+                    )
+                }
+                .clipShape(RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .padding(12)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+
+    private func sectionLabel(_ text: String, theme: PhosphorTheme) -> some View {
+        Text(text)
+            .font(typography.caption)
+            .tracking(0.8)
+            .foregroundStyle(theme.textTertiary)
+            .padding(.leading, 4)
+            .padding(.bottom, -12)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSpecimenScreen.swift
@@ -4,7 +4,7 @@ import SwiftUI
 /// Displays Phosphor's complete palette, type scale, states, and core controls.
 struct PhosphorSpecimenScreen: View {
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSpecimenScreen.swift
@@ -137,12 +137,14 @@ struct PhosphorSpecimenScreen: View {
                     Text("TOOL CARD")
                         .font(typography.monoCaption)
                         .foregroundStyle(theme.textTertiary)
-                    PhosphorToolCard(
-                        title: DesignGalleryFixtures.chatEntries[2].text,
-                        command: DesignGalleryFixtures.chatEntries[2].toolCommand ?? "",
-                        output: DesignGalleryFixtures.chatEntries[2].toolOutput ?? "",
-                        timeText: DesignGalleryFixtures.chatEntries[2].timeText
-                    )
+                    if let entry = DesignGalleryFixtures.chatEntries.first(where: { $0.role == .tool }) {
+                        PhosphorToolCard(
+                            title: entry.text,
+                            command: entry.toolCommand ?? "",
+                            output: entry.toolOutput ?? "",
+                            timeText: entry.timeText
+                        )
+                    }
                 }
                 .padding(12)
                 .frame(width: 320, alignment: .leading)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorSpecimenScreen.swift
@@ -1,0 +1,201 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays Phosphor's complete palette, type scale, states, and core controls.
+struct PhosphorSpecimenScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                sectionTitle("PALETTE", theme: theme)
+                paletteGrid(theme: theme)
+
+                sectionTitle("TYPE SCALE", theme: theme)
+                typeScale(theme: theme)
+
+                sectionTitle("STATUS ENCODING", theme: theme)
+                statusGrid(theme: theme)
+
+                sectionTitle("CORE COMPONENTS", theme: theme)
+                componentRail(theme: theme)
+            }
+            .padding(12)
+        }
+        .scrollIndicators(.hidden)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+
+    private func sectionTitle(_ text: String, theme: PhosphorTheme) -> some View {
+        Text(text)
+            .font(typography.caption)
+            .tracking(0.8)
+            .foregroundStyle(theme.textTertiary)
+    }
+
+    private func paletteGrid(theme: PhosphorTheme) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
+            spacing: 8
+        ) {
+            ForEach(Array(palette(theme: theme).enumerated()), id: \.offset) { _, swatch in
+                HStack(spacing: 8) {
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(swatch.2)
+                        .frame(width: 36, height: 36)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                                .stroke(theme.hairline, lineWidth: 1)
+                        }
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(swatch.0)
+                            .font(typography.captionSemibold)
+                            .foregroundStyle(theme.textPrimary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                        Text(swatch.1)
+                            .font(typography.monoCaption)
+                            .foregroundStyle(theme.textSecondary)
+                            .lineLimit(1)
+                            .minimumScaleFactor(0.7)
+                    }
+                    Spacer(minLength: 0)
+                }
+                .padding(8)
+                .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+        }
+    }
+
+    private func typeScale(theme: PhosphorTheme) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            typeRow("Title · SF Pro 17 Semibold", sample: "Agent status", font: typography.title, theme: theme)
+            typeRow("Body · SF Pro 15 Regular", sample: "Terminal is the hero.", font: typography.body, theme: theme)
+            typeRow("Caption · SF Pro 12 Regular", sample: "UPDATED 2 MINUTES AGO", font: typography.caption, theme: theme)
+            typeRow("Data · SF Mono 13", sample: "feat-ios-design-gallery · 14:32", font: typography.data, theme: theme)
+            typeRow("Terminal · SF Mono 12 / 1.3", sample: "$ ./scripts/reload.sh --tag dsgal", font: typography.terminal, theme: theme)
+        }
+        .padding(12)
+        .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+    }
+
+    private func typeRow(
+        _ role: String,
+        sample: String,
+        font: Font,
+        theme: PhosphorTheme
+    ) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(role)
+                .font(typography.monoCaption)
+                .foregroundStyle(theme.textTertiary)
+            Text(sample)
+                .font(font)
+                .foregroundStyle(theme.textPrimary)
+        }
+    }
+
+    private func statusGrid(theme: PhosphorTheme) -> some View {
+        LazyVGrid(
+            columns: [GridItem(.flexible(), spacing: 8), GridItem(.flexible(), spacing: 8)],
+            alignment: .leading,
+            spacing: 8
+        ) {
+            ForEach(Array(specimenStates.enumerated()), id: \.offset) { index, state in
+                HStack(spacing: 8) {
+                    PhosphorStatusDot(state: state)
+                    PhosphorStatusChip(state: state)
+                    Spacer(minLength: 0)
+                    Text(["2m", "3h", "12m", "1h", "2d"][index])
+                        .font(typography.data)
+                        .monospacedDigit()
+                        .foregroundStyle(theme.statusColor(state))
+                }
+                .padding(8)
+                .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+        }
+    }
+
+    private func componentRail(theme: PhosphorTheme) -> some View {
+        ScrollView(.horizontal) {
+            HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("COMMAND BAR")
+                        .font(typography.monoCaption)
+                        .foregroundStyle(theme.textTertiary)
+                    PhosphorCommandBar(showsApprove: true)
+                }
+                .padding(12)
+                .frame(width: 320, alignment: .leading)
+                .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("TOOL CARD")
+                        .font(typography.monoCaption)
+                        .foregroundStyle(theme.textTertiary)
+                    PhosphorToolCard(
+                        title: DesignGalleryFixtures.chatEntries[2].text,
+                        command: DesignGalleryFixtures.chatEntries[2].toolCommand ?? "",
+                        output: DesignGalleryFixtures.chatEntries[2].toolOutput ?? "",
+                        timeText: DesignGalleryFixtures.chatEntries[2].timeText
+                    )
+                }
+                .padding(12)
+                .frame(width: 320, alignment: .leading)
+                .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+
+                VStack(alignment: .leading, spacing: 12) {
+                    Text("BUTTONS")
+                        .font(typography.monoCaption)
+                        .foregroundStyle(theme.textTertiary)
+                    HStack(spacing: 8) {
+                        Button("Secondary", action: {})
+                            .font(typography.bodySemibold)
+                            .foregroundStyle(theme.textPrimary)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .background(theme.bg2, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                            .buttonStyle(PhosphorPressButtonStyle())
+                        Button("Primary", action: {})
+                            .font(typography.bodySemibold)
+                            .foregroundStyle(theme.isDark ? theme.textPrimary : theme.bg1)
+                            .frame(maxWidth: .infinity, minHeight: 44)
+                            .background(theme.accent, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+                            .buttonStyle(PhosphorPressButtonStyle())
+                    }
+                }
+                .padding(12)
+                .frame(width: 280, alignment: .leading)
+                .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+        }
+        .scrollIndicators(.hidden)
+    }
+
+    private func palette(theme: PhosphorTheme) -> [(String, String, Color)] {
+        let dark = theme.isDark
+        return [
+            ("bg0", dark ? "#0A0B0D" : "#F2F3F5", theme.bg0),
+            ("bg1", dark ? "#111318" : "#FFFFFF", theme.bg1),
+            ("bg2", dark ? "#1A1D24" : "#E9EBEE", theme.bg2),
+            ("hairline", dark ? "#FFFFFF · 8%" : "#000000 · 10%", theme.hairline),
+            ("text.primary", dark ? "#E8EAED" : "#1A1D24", theme.textPrimary),
+            ("text.secondary", dark ? "#9BA1AC" : "#5C6370", theme.textSecondary),
+            ("text.tertiary", dark ? "#5C6370" : "#9BA1AC", theme.textTertiary),
+            ("accent", dark ? "#4D9DFF" : "#1D6FE0", theme.accent),
+            ("status.needsYou", dark ? "#FFB224" : "#B87700", theme.statusNeedsYou),
+            ("status.running", dark ? "#4D9DFF" : "#1D6FE0", theme.statusRunning),
+            ("status.done", dark ? "#3DD68C" : "#17804F", theme.statusDone),
+            ("status.failed", dark ? "#FF5D5D" : "#C93030", theme.statusFailed),
+            ("status.idle", dark ? "#5C6370" : "#9BA1AC", theme.statusIdle),
+        ]
+    }
+
+    private var specimenStates: [GalleryAgentState] {
+        [.needsYou, .failed, .running, .done, .idle]
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorStatusChip.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorStatusChip.swift
@@ -1,0 +1,28 @@
+#if DEBUG
+import SwiftUI
+
+/// Encodes one gallery state with a tint, glyph, and explicit word label.
+struct PhosphorStatusChip: View {
+    let state: GalleryAgentState
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+        let color = theme.statusColor(state)
+
+        HStack(spacing: 4) {
+            Image(systemName: theme.statusSymbol(state))
+                .font(.system(size: 10, weight: .bold))
+            Text(theme.statusLabel(state))
+                .font(typography.caption)
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, 8)
+        .frame(minHeight: 24)
+        .background(color.opacity(0.16), in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+        .accessibilityElement(children: .combine)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorStatusChip.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorStatusChip.swift
@@ -6,7 +6,7 @@ struct PhosphorStatusChip: View {
     let state: GalleryAgentState
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorStatusDot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorStatusDot.swift
@@ -1,0 +1,31 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders the Phosphor eight-point status signal, including the needs-you pulse.
+struct PhosphorStatusDot: View {
+    let state: GalleryAgentState
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var pulseIsBright = false
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        Circle()
+            .fill(theme.statusColor(state))
+            .frame(width: 8, height: 8)
+            .opacity(theme.isNeedsYou(state) && !reduceMotion ? (pulseIsBright ? 1.0 : 0.6) : 1.0)
+            .onAppear {
+                guard theme.isNeedsYou(state), !reduceMotion else {
+                    pulseIsBright = true
+                    return
+                }
+                withAnimation(.easeInOut(duration: 1.0).repeatForever(autoreverses: true)) {
+                    pulseIsBright = true
+                }
+            }
+            .accessibilityHidden(true)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTerminalAccessory.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTerminalAccessory.swift
@@ -1,0 +1,42 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Provides Phosphor's glass-backed terminal command input and send target.
+struct PhosphorTerminalAccessory: View {
+    @Binding var command: String
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        HStack(spacing: 8) {
+            Text("$")
+                .font(typography.dataSemibold)
+                .foregroundStyle(theme.accent)
+
+            TextField("Send command…", text: $command)
+                .font(typography.data)
+                .foregroundStyle(theme.textPrimary)
+                .textInputAutocapitalization(.never)
+                .autocorrectionDisabled()
+                .frame(minHeight: 44)
+
+            Button(action: {}) {
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 14, weight: .bold))
+                    .foregroundStyle(theme.isDark ? theme.textPrimary : theme.bg1)
+                    .frame(width: 44, height: 44)
+                    .background(theme.accent, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+            }
+            .buttonStyle(PhosphorPressButtonStyle())
+            .accessibilityLabel("Send command")
+        }
+        .padding(.leading, 12)
+        .padding(.trailing, 8)
+        .mobileGlassField(cornerRadius: 12)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTerminalAccessory.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTerminalAccessory.swift
@@ -7,7 +7,7 @@ struct PhosphorTerminalAccessory: View {
     @Binding var command: String
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTheme.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTheme.swift
@@ -1,0 +1,114 @@
+#if DEBUG
+import SwiftUI
+
+/// Resolves every Phosphor palette token for the gallery's current color scheme.
+struct PhosphorTheme {
+    let isDark: Bool
+    let bg0: Color
+    let bg1: Color
+    let bg2: Color
+    let hairline: Color
+    let textPrimary: Color
+    let textSecondary: Color
+    let textTertiary: Color
+    let accent: Color
+    let statusNeedsYou: Color
+    let statusRunning: Color
+    let statusDone: Color
+    let statusFailed: Color
+    let statusIdle: Color
+
+    init(scheme: ColorScheme) {
+        isDark = scheme == .dark
+
+        if scheme == .dark {
+            bg0 = Color(red: 10.0 / 255.0, green: 11.0 / 255.0, blue: 13.0 / 255.0)
+            bg1 = Color(red: 17.0 / 255.0, green: 19.0 / 255.0, blue: 24.0 / 255.0)
+            bg2 = Color(red: 26.0 / 255.0, green: 29.0 / 255.0, blue: 36.0 / 255.0)
+            hairline = Color(red: 1.0, green: 1.0, blue: 1.0).opacity(0.08)
+            textPrimary = Color(red: 232.0 / 255.0, green: 234.0 / 255.0, blue: 237.0 / 255.0)
+            textSecondary = Color(red: 155.0 / 255.0, green: 161.0 / 255.0, blue: 172.0 / 255.0)
+            textTertiary = Color(red: 92.0 / 255.0, green: 99.0 / 255.0, blue: 112.0 / 255.0)
+            accent = Color(red: 77.0 / 255.0, green: 157.0 / 255.0, blue: 1.0)
+            statusNeedsYou = Color(red: 1.0, green: 178.0 / 255.0, blue: 36.0 / 255.0)
+            statusRunning = Color(red: 77.0 / 255.0, green: 157.0 / 255.0, blue: 1.0)
+            statusDone = Color(red: 61.0 / 255.0, green: 214.0 / 255.0, blue: 140.0 / 255.0)
+            statusFailed = Color(red: 1.0, green: 93.0 / 255.0, blue: 93.0 / 255.0)
+            statusIdle = Color(red: 92.0 / 255.0, green: 99.0 / 255.0, blue: 112.0 / 255.0)
+        } else {
+            bg0 = Color(red: 242.0 / 255.0, green: 243.0 / 255.0, blue: 245.0 / 255.0)
+            bg1 = Color(red: 1.0, green: 1.0, blue: 1.0)
+            bg2 = Color(red: 233.0 / 255.0, green: 235.0 / 255.0, blue: 238.0 / 255.0)
+            hairline = Color(red: 0.0, green: 0.0, blue: 0.0).opacity(0.10)
+            textPrimary = Color(red: 26.0 / 255.0, green: 29.0 / 255.0, blue: 36.0 / 255.0)
+            textSecondary = Color(red: 92.0 / 255.0, green: 99.0 / 255.0, blue: 112.0 / 255.0)
+            textTertiary = Color(red: 155.0 / 255.0, green: 161.0 / 255.0, blue: 172.0 / 255.0)
+            accent = Color(red: 29.0 / 255.0, green: 111.0 / 255.0, blue: 224.0 / 255.0)
+            statusNeedsYou = Color(red: 184.0 / 255.0, green: 119.0 / 255.0, blue: 0.0)
+            statusRunning = Color(red: 29.0 / 255.0, green: 111.0 / 255.0, blue: 224.0 / 255.0)
+            statusDone = Color(red: 23.0 / 255.0, green: 128.0 / 255.0, blue: 79.0 / 255.0)
+            statusFailed = Color(red: 201.0 / 255.0, green: 48.0 / 255.0, blue: 48.0 / 255.0)
+            statusIdle = Color(red: 155.0 / 255.0, green: 161.0 / 255.0, blue: 172.0 / 255.0)
+        }
+    }
+
+    func statusColor(_ state: GalleryAgentState) -> Color {
+        switch state {
+        case .needsYou: statusNeedsYou
+        case .running: statusRunning
+        case .done: statusDone
+        case .failed: statusFailed
+        case .idle: statusIdle
+        }
+    }
+
+    func statusLabel(_ state: GalleryAgentState) -> String {
+        switch state {
+        case .needsYou: "Needs you"
+        case .running: "Running"
+        case .done: "Done"
+        case .failed: "Failed"
+        case .idle: "Idle"
+        }
+    }
+
+    func statusSymbol(_ state: GalleryAgentState) -> String {
+        switch state {
+        case .needsYou: "exclamationmark"
+        case .running: "waveform.path.ecg"
+        case .done: "checkmark"
+        case .failed: "xmark"
+        case .idle: "minus"
+        }
+    }
+
+    func statusRank(_ state: GalleryAgentState) -> Int {
+        switch state {
+        case .needsYou: 0
+        case .failed: 1
+        case .running: 2
+        case .done: 3
+        case .idle: 4
+        }
+    }
+
+    func isNeedsYou(_ state: GalleryAgentState) -> Bool {
+        if case .needsYou = state {
+            true
+        } else {
+            false
+        }
+    }
+
+    func terminalColor(_ tone: GalleryTerminalLine.Tone) -> Color {
+        switch tone {
+        case .plain: textPrimary
+        case .dim: textTertiary
+        case .accent: accent
+        case .success: statusDone
+        case .warning: statusNeedsYou
+        case .error: statusFailed
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorToolCard.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorToolCard.swift
@@ -9,7 +9,7 @@ struct PhosphorToolCard: View {
     let timeText: String
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorToolCard.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorToolCard.swift
@@ -1,0 +1,53 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders a bordered tool invocation with command and three-line output preview.
+struct PhosphorToolCard: View {
+    let title: String
+    let command: String
+    let output: String
+    let timeText: String
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                Image(systemName: "terminal")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(theme.accent)
+                Text(title)
+                    .font(typography.bodySemibold)
+                    .foregroundStyle(theme.textPrimary)
+                Spacer(minLength: 8)
+                Text(timeText)
+                    .font(typography.monoCaption)
+                    .monospacedDigit()
+                    .foregroundStyle(theme.textTertiary)
+            }
+
+            Text(command)
+                .font(typography.data)
+                .foregroundStyle(theme.accent)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(8)
+                .background(theme.bg2, in: RoundedRectangle(cornerRadius: 6, style: .continuous))
+
+            Text(output)
+                .font(typography.monoCaption)
+                .foregroundStyle(theme.textTertiary)
+                .lineLimit(3)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(12)
+        .background(theme.bg1, in: RoundedRectangle(cornerRadius: 8, style: .continuous))
+        .overlay {
+            RoundedRectangle(cornerRadius: 8, style: .continuous)
+                .stroke(theme.hairline, lineWidth: 1)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTypography.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorTypography.swift
@@ -1,0 +1,23 @@
+#if DEBUG
+import SwiftUI
+
+/// Scales Phosphor's exact base type roles with Dynamic Type, excluding terminal text.
+struct PhosphorTypography: DynamicProperty {
+    @ScaledMetric(relativeTo: .headline) private var titleSize: CGFloat = 17
+    @ScaledMetric(relativeTo: .body) private var bodySize: CGFloat = 15
+    @ScaledMetric(relativeTo: .caption) private var captionSize: CGFloat = 12
+    @ScaledMetric(relativeTo: .body) private var dataSize: CGFloat = 13
+
+    var title: Font { .system(size: titleSize, weight: .semibold) }
+    var body: Font { .system(size: bodySize, weight: .regular) }
+    var bodySemibold: Font { .system(size: bodySize, weight: .semibold) }
+    var caption: Font { .system(size: captionSize, weight: .regular) }
+    var captionSemibold: Font { .system(size: captionSize, weight: .semibold) }
+    var data: Font { .system(size: dataSize, weight: .regular, design: .monospaced) }
+    var dataMedium: Font { .system(size: dataSize, weight: .medium, design: .monospaced) }
+    var dataSemibold: Font { .system(size: dataSize, weight: .semibold, design: .monospaced) }
+    var monoCaption: Font { .system(size: captionSize, weight: .regular, design: .monospaced) }
+    var monoCaptionMedium: Font { .system(size: captionSize, weight: .medium, design: .monospaced) }
+    var terminal: Font { .system(size: 12, weight: .regular, design: .monospaced) }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorWorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorWorkspaceRow.swift
@@ -6,7 +6,7 @@ struct PhosphorWorkspaceRow: View {
     let workspace: GalleryWorkspaceFixture
 
     @Environment(\.colorScheme) private var colorScheme
-    private var typography = PhosphorTypography()
+    private let typography = PhosphorTypography()
 
     var body: some View {
         let theme = PhosphorTheme(scheme: colorScheme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorWorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Phosphor/PhosphorWorkspaceRow.swift
@@ -1,0 +1,73 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays one dense workspace snapshot in Phosphor's attention queue.
+struct PhosphorWorkspaceRow: View {
+    let workspace: GalleryWorkspaceFixture
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var typography = PhosphorTypography()
+
+    var body: some View {
+        let theme = PhosphorTheme(scheme: colorScheme)
+        let statusColor = theme.statusColor(workspace.state)
+
+        HStack(spacing: 8) {
+            VStack(spacing: 4) {
+                PhosphorStatusDot(state: workspace.state)
+                Image(systemName: theme.statusSymbol(workspace.state))
+                    .font(.system(size: 9, weight: .bold))
+                    .foregroundStyle(statusColor)
+            }
+            .frame(width: 14)
+
+            VStack(alignment: .leading, spacing: 4) {
+                HStack(spacing: 8) {
+                    Text(workspace.name)
+                        .font(typography.bodySemibold)
+                        .foregroundStyle(theme.textPrimary)
+                    Text(workspace.agentName)
+                        .font(typography.caption)
+                        .foregroundStyle(theme.textTertiary)
+                }
+
+                Text(workspace.branch)
+                    .font(typography.monoCaption)
+                    .foregroundStyle(theme.textSecondary)
+                    .lineLimit(1)
+            }
+
+            Spacer(minLength: 8)
+
+            VStack(alignment: .trailing, spacing: 4) {
+                Text(workspace.elapsedText)
+                    .font(typography.dataMedium)
+                    .monospacedDigit()
+                    .foregroundStyle(statusColor)
+                Text(theme.statusLabel(workspace.state))
+                    .font(typography.caption)
+                    .foregroundStyle(theme.textTertiary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 52)
+        .background {
+            if theme.isNeedsYou(workspace.state) {
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(theme.statusNeedsYou.opacity(0.16))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 8, style: .continuous)
+                            .stroke(theme.statusNeedsYou, lineWidth: 1)
+                    }
+            } else {
+                Rectangle().fill(theme.bg1)
+            }
+        }
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(
+            "\(workspace.name), \(workspace.branch), \(theme.statusLabel(workspace.state)), \(workspace.elapsedText), \(workspace.detailText)"
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalActionButtons.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalActionButtons.swift
@@ -1,0 +1,23 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders the shared Approve and Deny action row used across Signal screens.
+struct SignalActionButtons: View {
+    let theme: SignalTheme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            ForEach(Array(DesignGalleryFixtures.approvalActions.enumerated()), id: \.offset) { index, title in
+                Button(action: {}) {
+                    Text(title)
+                        .frame(maxWidth: .infinity)
+                }
+                .buttonStyle(SignalPressButtonStyle(
+                    role: index == 0 ? .primary : .secondary,
+                    theme: theme
+                ))
+            }
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalActivityRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalActivityRow.swift
@@ -1,0 +1,52 @@
+#if DEBUG
+import SwiftUI
+
+/// Aligns an activity time, status square, and event text into a fixed table row.
+struct SignalActivityRow: View {
+    let entry: GalleryActivityEntry
+    let theme: SignalTheme
+
+    private var status: SignalStatusStyle {
+        SignalStatusStyle(state: entry.state, theme: theme)
+    }
+
+    var body: some View {
+        Button(action: {}) {
+            HStack(spacing: 10) {
+                Text(entry.timeText)
+                    .font(.system(.footnote, design: .monospaced, weight: .regular))
+                    .foregroundStyle(theme.secondaryText)
+                    .frame(width: 48, alignment: .leading)
+
+                SignalStatusSquare(color: status.color)
+
+                Text(entry.text)
+                    .font(.system(
+                        .subheadline,
+                        design: .default,
+                        weight: entry.unread ? .semibold : .regular
+                    ))
+                    .foregroundStyle(entry.unread ? theme.ink : theme.secondaryText)
+                    .lineLimit(2)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text(status.symbol)
+                    .font(.system(.footnote, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(entry.unread ? theme.ink : theme.secondaryText)
+                    .frame(width: 16)
+            }
+            .padding(.horizontal, 10)
+            .frame(minHeight: 44)
+            .background(theme.surface)
+            .contentShape(Rectangle())
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(theme.hairline)
+                    .frame(height: 1)
+            }
+        }
+        .buttonStyle(SignalRowButtonStyle())
+        .accessibilityLabel("\(entry.timeText), \(status.label), \(entry.text)")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalActivityScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalActivityScreen.swift
@@ -1,0 +1,55 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays every fixture event in Signal's absolute-time activity table.
+struct SignalActivityScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = SignalTheme(scheme: colorScheme)
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                ForEach(Array(DesignGalleryFixtures.activityDays.enumerated()), id: \.offset) { _, day in
+                    VStack(spacing: 0) {
+                        HStack {
+                            SignalSectionLabel(text: day.dayLabel, color: theme.ink)
+                            Spacer()
+                            Text("\(day.entries.count)")
+                                .font(.system(.footnote, design: .monospaced, weight: .regular))
+                                .foregroundStyle(theme.secondaryText)
+                        }
+                        .frame(minHeight: 24)
+
+                        ForEach(day.entries) { entry in
+                            SignalActivityRow(entry: entry, theme: theme)
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 112)
+            .padding(.bottom, 16)
+        }
+        .overlay(alignment: .top) {
+            VStack(spacing: 6) {
+                Text("Activity")
+                    .font(.system(.title, design: .default, weight: .heavy))
+                    .foregroundStyle(theme.ink)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .frame(minHeight: 38)
+                    .background(theme.bg0)
+
+                SignalSummaryStrip(theme: theme)
+            }
+            .padding(.top, 8)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            SignalTriageBar(theme: theme)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalChatEntryRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalChatEntryRow.swift
@@ -1,0 +1,102 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders one conversation fixture as a timestamped Signal log entry.
+struct SignalChatEntryRow: View {
+    let entry: GalleryChatEntry
+    let theme: SignalTheme
+
+    private var roleLabel: String {
+        switch entry.role {
+        case .user: "YOU"
+        case .agent, .approval: "AGENT"
+        case .tool: "TOOL"
+        }
+    }
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+                SignalSectionLabel(text: roleLabel, color: theme.ink)
+                Text(entry.timeText)
+                    .font(.system(.footnote, design: .monospaced, weight: .regular))
+                    .foregroundStyle(theme.secondaryText)
+            }
+            .frame(width: 58, alignment: .leading)
+
+            content
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.vertical, 12)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.hairline)
+                .frame(height: 1)
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch entry.role {
+        case .user, .agent:
+            Text(entry.text)
+                .font(.system(.subheadline, design: .default, weight: .regular))
+                .foregroundStyle(theme.ink)
+                .fixedSize(horizontal: false, vertical: true)
+        case .tool:
+            VStack(alignment: .leading, spacing: 8) {
+                Text(entry.text)
+                    .font(.system(.subheadline, design: .default, weight: .semibold))
+                    .foregroundStyle(theme.ink)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    if let command = entry.toolCommand {
+                        Text(command)
+                            .font(.system(.footnote, design: .monospaced, weight: .semibold))
+                            .foregroundStyle(theme.ink)
+                    }
+                    if let output = entry.toolOutput {
+                        Text(output)
+                            .font(.system(.footnote, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.secondaryText)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(theme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 4)
+                        .stroke(theme.hairline, lineWidth: 1)
+                }
+            }
+        case .approval:
+            VStack(alignment: .leading, spacing: 10) {
+                let status = SignalStatusStyle(state: .needsYou, theme: theme)
+                HStack(spacing: 6) {
+                    SignalStatusSquare(color: status.color)
+                    SignalSectionLabel(text: status.label, color: theme.ink)
+                    Text(status.symbol)
+                        .font(.system(.footnote, design: .monospaced, weight: .bold))
+                        .foregroundStyle(theme.ink)
+                }
+
+                if let question = entry.question {
+                    Text(question)
+                        .font(.system(.subheadline, design: .default, weight: .regular))
+                        .foregroundStyle(theme.ink)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+
+                SignalActionButtons(theme: theme)
+            }
+            .padding(10)
+            .background(theme.surface)
+            .overlay {
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(theme.hairline, lineWidth: 1)
+            }
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalChatScreen.swift
@@ -22,6 +22,7 @@ struct SignalChatScreen: View {
             .padding(.horizontal, 16)
             .padding(.vertical, 16)
         }
+        .defaultScrollAnchor(.bottom)
         .safeAreaInset(edge: .bottom, spacing: 0) {
             SignalTriageBar(theme: theme)
         }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalChatScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalChatScreen.swift
@@ -1,0 +1,32 @@
+#if DEBUG
+import SwiftUI
+
+/// Presents the complete fixture conversation as a compact timestamped log.
+struct SignalChatScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = SignalTheme(scheme: colorScheme)
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                Text("Chat")
+                    .font(.system(.title, design: .default, weight: .heavy))
+                    .foregroundStyle(theme.ink)
+                    .padding(.bottom, 16)
+
+                ForEach(DesignGalleryFixtures.chatEntries) { entry in
+                    SignalChatEntryRow(entry: entry, theme: theme)
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            SignalTriageBar(theme: theme)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalGallery.swift
@@ -1,0 +1,14 @@
+#if DEBUG
+import SwiftUI
+
+/// Placeholder root for the Signal candidate's future six-screen gallery.
+struct SignalGallery: View {
+    let page: DesignGalleryPage
+
+    var body: some View {
+        Text("\(DesignGallerySystem.signal.number) \(DesignGallerySystem.signal.displayName) — \(page.title)")
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(Color(.systemBackground))
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalGallery.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalGallery.swift
@@ -1,14 +1,25 @@
 #if DEBUG
 import SwiftUI
 
-/// Placeholder root for the Signal candidate's future six-screen gallery.
+/// Routes gallery pages into the six static Signal design-system screens.
 struct SignalGallery: View {
     let page: DesignGalleryPage
 
     var body: some View {
-        Text("\(DesignGallerySystem.signal.number) \(DesignGallerySystem.signal.displayName) — \(page.title)")
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .background(Color(.systemBackground))
+        switch page {
+        case .hub:
+            SignalHubScreen()
+        case .session:
+            SignalSessionScreen()
+        case .chat:
+            SignalChatScreen()
+        case .activity:
+            SignalActivityScreen()
+        case .settings:
+            SignalSettingsScreen()
+        case .specimen:
+            SignalSpecimenScreen()
+        }
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalHubScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalHubScreen.swift
@@ -1,0 +1,74 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays all fixture workspaces as Signal's grouped, fixed-column fleet board.
+struct SignalHubScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = SignalTheme(scheme: colorScheme)
+        let statuses = [
+            GalleryAgentState.needsYou,
+            GalleryAgentState.failed,
+            GalleryAgentState.running,
+            GalleryAgentState.done,
+            GalleryAgentState.idle,
+        ]
+
+        ScrollView {
+            VStack(spacing: 24) {
+                ForEach(Array(statuses.enumerated()), id: \.offset) { _, state in
+                    let status = SignalStatusStyle(state: state, theme: theme)
+                    let workspaces = DesignGalleryFixtures.workspaces.filter { status.matches($0.state) }
+
+                    VStack(spacing: 0) {
+                        HStack(spacing: 8) {
+                            SignalStatusSquare(color: status.color)
+                            SignalSectionLabel(text: status.label, color: theme.ink)
+                            Text(status.symbol)
+                                .font(.system(.footnote, design: .monospaced, weight: .bold))
+                                .foregroundStyle(theme.ink)
+                            Spacer()
+                            Text("\(workspaces.count)")
+                                .font(.system(.footnote, design: .monospaced, weight: .regular))
+                                .foregroundStyle(theme.secondaryText)
+                        }
+                        .frame(minHeight: 24)
+
+                        ForEach(workspaces) { workspace in
+                            SignalWorkspaceRow(workspace: workspace, theme: theme)
+                                .overlay(alignment: .bottom) {
+                                    Rectangle()
+                                        .fill(theme.hairline)
+                                        .frame(height: 1)
+                                }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 16)
+            .padding(.top, 112)
+            .padding(.bottom, 16)
+        }
+        .overlay(alignment: .top) {
+            VStack(spacing: 6) {
+                Text("Hub")
+                    .font(.system(.title, design: .default, weight: .heavy))
+                    .foregroundStyle(theme.ink)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 16)
+                    .frame(minHeight: 38)
+                    .background(theme.bg0)
+
+                SignalSummaryStrip(theme: theme)
+            }
+            .padding(.top, 8)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            SignalTriageBar(theme: theme)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalLegendItem.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalLegendItem.swift
@@ -1,0 +1,28 @@
+#if DEBUG
+import SwiftUI
+
+/// Shows one fixed status mark with its fleet count and compact label.
+struct SignalLegendItem: View {
+    let style: SignalStatusStyle
+    let count: Int
+    let theme: SignalTheme
+
+    var body: some View {
+        VStack(spacing: 4) {
+            HStack(spacing: 5) {
+                SignalStatusSquare(color: style.color)
+                Text("\(count)")
+                    .font(.system(.footnote, design: .monospaced, weight: .semibold))
+                    .foregroundStyle(theme.ink)
+            }
+
+            SignalSectionLabel(text: style.compactLabel, color: theme.secondaryText)
+                .lineLimit(1)
+                .minimumScaleFactor(0.66)
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityElement(children: .combine)
+        .accessibilityLabel("\(style.label), \(count)")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalMetadataRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalMetadataRow.swift
@@ -1,0 +1,39 @@
+#if DEBUG
+import SwiftUI
+
+/// Presents one uppercase label and monospaced value in the Session spec table.
+struct SignalMetadataRow: View {
+    let label: String
+    let value: String
+    let state: GalleryAgentState?
+    let theme: SignalTheme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            SignalSectionLabel(text: label, color: theme.secondaryText)
+                .frame(width: 76, alignment: .leading)
+
+            if let state {
+                let style = SignalStatusStyle(state: state, theme: theme)
+                SignalStatusSquare(color: style.color)
+            }
+
+            Text(value)
+                .font(.system(.footnote, design: .monospaced, weight: .regular))
+                .foregroundStyle(theme.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.68)
+
+            Spacer(minLength: 0)
+        }
+        .padding(.horizontal, 12)
+        .frame(minHeight: 44)
+        .background(theme.surface)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.hairline)
+                .frame(height: 1)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalPaletteSwatch.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalPaletteSwatch.swift
@@ -1,0 +1,38 @@
+#if DEBUG
+import SwiftUI
+
+/// Labels a current-scheme Signal palette token with its exact specification value.
+struct SignalPaletteSwatch: View {
+    let name: String
+    let hex: String
+    let color: Color
+    let markSize: CGFloat
+    let theme: SignalTheme
+
+    var body: some View {
+        HStack(spacing: 8) {
+            Rectangle()
+                .fill(color)
+                .frame(width: markSize, height: markSize)
+                .overlay {
+                    Rectangle()
+                        .stroke(theme.hairline, lineWidth: 1)
+                }
+                .frame(width: 24, height: 24)
+
+            VStack(alignment: .leading, spacing: 1) {
+                Text(name)
+                    .font(.system(.caption2, design: .default, weight: .semibold))
+                    .tracking(0.88)
+                    .foregroundStyle(theme.ink)
+                    .lineLimit(1)
+                    .minimumScaleFactor(0.72)
+                Text(hex)
+                    .font(.system(.footnote, design: .monospaced, weight: .regular))
+                    .foregroundStyle(theme.secondaryText)
+            }
+        }
+        .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalPressButtonStyle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalPressButtonStyle.swift
@@ -1,0 +1,34 @@
+#if DEBUG
+import SwiftUI
+
+/// Gives Signal buttons a near-square monochrome treatment and crossfade press feedback.
+struct SignalPressButtonStyle: ButtonStyle {
+    /// The two app-wide Signal action treatments.
+    enum Role: Equatable {
+        case primary
+        case secondary
+    }
+
+    let role: Role
+    let theme: SignalTheme
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(.footnote, design: .monospaced, weight: .semibold))
+            .foregroundStyle(role == .primary ? theme.surface : theme.ink)
+            .padding(.horizontal, 14)
+            .frame(minWidth: 44, minHeight: 44)
+            .background {
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(role == .primary ? theme.ink : Color.clear)
+            }
+            .overlay {
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(role == .secondary ? theme.ink : Color.clear, lineWidth: 1)
+            }
+            .opacity(configuration.isPressed ? 0.62 : 1)
+            .animation(.linear(duration: 0.12), value: configuration.isPressed)
+            .contentShape(Rectangle())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalRowButtonStyle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalRowButtonStyle.swift
@@ -1,0 +1,12 @@
+#if DEBUG
+import SwiftUI
+
+/// Adds a restrained 120-millisecond opacity response to tappable Signal rows.
+struct SignalRowButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .opacity(configuration.isPressed ? 0.56 : 1)
+            .animation(.linear(duration: 0.12), value: configuration.isPressed)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSectionLabel.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSectionLabel.swift
@@ -1,0 +1,18 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders Signal's tracked, uppercase section-label type role.
+struct SignalSectionLabel: View {
+    let text: String
+    let color: Color
+
+    @ScaledMetric(relativeTo: .caption2) private var tracking = 0.88
+
+    var body: some View {
+        Text(text.uppercased())
+            .font(.system(.caption2, design: .default, weight: .semibold))
+            .tracking(tracking)
+            .foregroundStyle(color)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSessionScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSessionScreen.swift
@@ -1,0 +1,76 @@
+#if DEBUG
+import SwiftUI
+
+/// Shows fixture metadata, approval actions, and the complete terminal transcript.
+struct SignalSessionScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    private var workspace: GalleryWorkspaceFixture {
+        DesignGalleryFixtures.workspaces[0]
+    }
+
+    var body: some View {
+        let theme = SignalTheme(scheme: colorScheme)
+        let status = SignalStatusStyle(state: workspace.state, theme: theme)
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Session")
+                    .font(.system(.title, design: .default, weight: .heavy))
+                    .foregroundStyle(theme.ink)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Metadata", color: theme.secondaryText)
+
+                    VStack(spacing: 0) {
+                        SignalMetadataRow(label: "Agent", value: workspace.agentName, state: nil, theme: theme)
+                        SignalMetadataRow(label: "State", value: "\(status.label) \(status.symbol)", state: workspace.state, theme: theme)
+                        SignalMetadataRow(label: "Branch", value: workspace.branch, state: nil, theme: theme)
+                        SignalMetadataRow(label: "Elapsed", value: workspace.elapsedText, state: nil, theme: theme)
+                        SignalMetadataRow(label: "Port", value: "—", state: nil, theme: theme)
+                    }
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(theme.hairline, lineWidth: 1)
+                    }
+
+                    SignalActionButtons(theme: theme)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack {
+                        SignalSectionLabel(text: "Terminal", color: theme.secondaryText)
+                        Spacer()
+                        Text("14 LINES")
+                            .font(.system(.footnote, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.secondaryText)
+                    }
+
+                    ScrollView(.horizontal, showsIndicators: false) {
+                        VStack(alignment: .leading, spacing: 0) {
+                            ForEach(DesignGalleryFixtures.terminalLines) { line in
+                                SignalTerminalLineRow(line: line, theme: theme)
+                            }
+                        }
+                        .padding(12)
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(theme.surface)
+                    .clipShape(RoundedRectangle(cornerRadius: 4))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 4)
+                            .stroke(theme.hairline, lineWidth: 1)
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            SignalTriageBar(theme: theme)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSessionScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSessionScreen.swift
@@ -42,7 +42,7 @@ struct SignalSessionScreen: View {
                     HStack {
                         SignalSectionLabel(text: "Terminal", color: theme.secondaryText)
                         Spacer()
-                        Text("14 LINES")
+                        Text("\(DesignGalleryFixtures.terminalLines.count) LINES")
                             .font(.system(.footnote, design: .monospaced, weight: .regular))
                             .foregroundStyle(theme.secondaryText)
                     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSettingsScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSettingsScreen.swift
@@ -1,0 +1,99 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders fixture preferences as a sectioned Signal table with a teaching legend.
+struct SignalSettingsScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+    @State private var notificationsEnabled = DesignGalleryFixtures.settings.notificationsEnabled
+
+    var body: some View {
+        let theme = SignalTheme(scheme: colorScheme)
+        let fixture = DesignGalleryFixtures.settings
+        let statuses = [
+            GalleryAgentState.needsYou,
+            GalleryAgentState.failed,
+            GalleryAgentState.running,
+            GalleryAgentState.done,
+            GalleryAgentState.idle,
+        ]
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Settings")
+                    .font(.system(.title, design: .default, weight: .heavy))
+                    .foregroundStyle(theme.ink)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Account", color: theme.secondaryText)
+                    VStack(spacing: 0) {
+                        SignalSettingsValueRow(label: "Email", value: fixture.accountEmail, theme: theme)
+                        SignalSettingsValueRow(label: "Version", value: fixture.appVersion, theme: theme)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Paired Mac", color: theme.secondaryText)
+                    VStack(spacing: 0) {
+                        SignalSettingsValueRow(label: "Device", value: fixture.pairedMacName, theme: theme)
+                        SignalSettingsValueRow(label: "Status", value: fixture.pairedMacStatus, theme: theme)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Appearance", color: theme.secondaryText)
+                    SignalSettingsValueRow(
+                        label: "Mode",
+                        value: colorScheme == .dark ? "DARK" : "LIGHT",
+                        theme: theme
+                    )
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Preferences", color: theme.secondaryText)
+                    VStack(spacing: 0) {
+                        HStack(spacing: 12) {
+                            Text("Notifications")
+                                .font(.system(.subheadline, design: .default, weight: .regular))
+                                .foregroundStyle(theme.ink)
+                            Spacer()
+                            SignalToggleButton(isOn: $notificationsEnabled, theme: theme)
+                        }
+                        .padding(.horizontal, 10)
+                        .frame(minHeight: 56)
+                        .background(theme.surface)
+                        .overlay(alignment: .bottom) {
+                            Rectangle()
+                                .fill(theme.hairline)
+                                .frame(height: 1)
+                        }
+
+                        SignalSettingsValueRow(
+                            label: "Terminal font size",
+                            value: fixture.terminalFontSize,
+                            theme: theme
+                        )
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Legend", color: theme.secondaryText)
+                    VStack(spacing: 0) {
+                        ForEach(Array(statuses.enumerated()), id: \.offset) { _, state in
+                            SignalStatusMeaningRow(
+                                style: SignalStatusStyle(state: state, theme: theme),
+                                theme: theme
+                            )
+                        }
+                    }
+                }
+            }
+            .padding(16)
+        }
+        .safeAreaInset(edge: .bottom, spacing: 0) {
+            SignalTriageBar(theme: theme)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSettingsValueRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSettingsValueRow.swift
@@ -1,0 +1,35 @@
+#if DEBUG
+import SwiftUI
+
+/// Displays one Settings label and right-aligned monospaced fixture value.
+struct SignalSettingsValueRow: View {
+    let label: String
+    let value: String
+    let theme: SignalTheme
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Text(label)
+                .font(.system(.subheadline, design: .default, weight: .regular))
+                .foregroundStyle(theme.ink)
+
+            Spacer(minLength: 12)
+
+            Text(value)
+                .font(.system(.footnote, design: .monospaced, weight: .regular))
+                .foregroundStyle(theme.secondaryText)
+                .multilineTextAlignment(.trailing)
+                .lineLimit(2)
+                .minimumScaleFactor(0.74)
+        }
+        .padding(.horizontal, 10)
+        .frame(minHeight: 44)
+        .background(theme.surface)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.hairline)
+                .frame(height: 1)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSpecimenScreen.swift
@@ -126,14 +126,13 @@ struct SignalSpecimenScreen: View {
                 VStack(alignment: .leading, spacing: 12) {
                     SignalSectionLabel(text: "Core Components", color: theme.secondaryText)
 
-                    SignalWorkspaceRow(
-                        workspace: DesignGalleryFixtures.workspaces[1],
-                        theme: theme
-                    )
-                    .overlay(alignment: .bottom) {
-                        Rectangle()
-                            .fill(theme.hairline)
-                            .frame(height: 1)
+                    if let workspace = DesignGalleryFixtures.workspaces.first(where: { $0.state == .running }) {
+                        SignalWorkspaceRow(workspace: workspace, theme: theme)
+                            .overlay(alignment: .bottom) {
+                                Rectangle()
+                                    .fill(theme.hairline)
+                                    .frame(height: 1)
+                            }
                     }
 
                     SignalActionButtons(theme: theme)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSpecimenScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSpecimenScreen.swift
@@ -1,0 +1,149 @@
+#if DEBUG
+import SwiftUI
+
+/// Catalogs Signal's palette, type roles, statuses, and core components.
+struct SignalSpecimenScreen: View {
+    @Environment(\.colorScheme) private var colorScheme
+
+    var body: some View {
+        let theme = SignalTheme(scheme: colorScheme)
+        let statuses = [
+            GalleryAgentState.needsYou,
+            GalleryAgentState.failed,
+            GalleryAgentState.running,
+            GalleryAgentState.done,
+            GalleryAgentState.idle,
+        ]
+        let palette: [(String, String, Color, CGFloat)] = colorScheme == .dark ? [
+            ("BG0", "#121212", theme.bg0, 24),
+            ("SURFACE", "#1C1C1A", theme.surface, 24),
+            ("INK", "#F2F2F0", theme.ink, 24),
+            ("TEXT.SECONDARY", "#A3A39E", theme.secondaryText, 24),
+            ("HAIRLINE", "#F2F2F0 · 14%", theme.hairline, 24),
+            ("SIGNAL.NEEDSYOU", "#F0B429", theme.needsYou, 6),
+            ("SIGNAL.RUNNING", "#4A9EFF", theme.running, 6),
+            ("SIGNAL.DONE", "#34C471", theme.done, 6),
+            ("SIGNAL.FAILED", "#F0554A", theme.failed, 6),
+            ("SIGNAL.IDLE", "#6E6E69", theme.idle, 6),
+        ] : [
+            ("BG0", "#F5F5F4", theme.bg0, 24),
+            ("SURFACE", "#FFFFFF", theme.surface, 24),
+            ("INK", "#111111", theme.ink, 24),
+            ("TEXT.SECONDARY", "#555550", theme.secondaryText, 24),
+            ("HAIRLINE", "#111111 · 12%", theme.hairline, 24),
+            ("SIGNAL.NEEDSYOU", "#E8A200", theme.needsYou, 6),
+            ("SIGNAL.RUNNING", "#0A7AFF", theme.running, 6),
+            ("SIGNAL.DONE", "#1F9E55", theme.done, 6),
+            ("SIGNAL.FAILED", "#D93025", theme.failed, 6),
+            ("SIGNAL.IDLE", "#8A8A85", theme.idle, 6),
+        ]
+
+        ScrollView {
+            VStack(alignment: .leading, spacing: 24) {
+                Text("Specimen")
+                    .font(.system(.title, design: .default, weight: .heavy))
+                    .foregroundStyle(theme.ink)
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Palette", color: theme.secondaryText)
+                    LazyVGrid(
+                        columns: [GridItem(.flexible(), spacing: 12), GridItem(.flexible())],
+                        alignment: .leading,
+                        spacing: 4
+                    ) {
+                        ForEach(Array(palette.enumerated()), id: \.offset) { _, token in
+                            SignalPaletteSwatch(
+                                name: token.0,
+                                hex: token.1,
+                                color: token.2,
+                                markSize: token.3,
+                                theme: theme
+                            )
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    SignalSectionLabel(text: "Type Scale", color: theme.secondaryText)
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("SCREEN TITLE · 28 HEAVY")
+                            .font(.system(.caption2, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.secondaryText)
+                        Text("Fleet status")
+                            .font(.system(.title, design: .default, weight: .heavy))
+                            .foregroundStyle(theme.ink)
+                    }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("SECTION LABEL · 11 SEMIBOLD")
+                            .font(.system(.caption2, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.secondaryText)
+                        SignalSectionLabel(text: "Needs You", color: theme.ink)
+                    }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("BODY · 15 REGULAR")
+                            .font(.system(.caption2, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.secondaryText)
+                        Text("Every pixel informs or is deleted.")
+                            .font(.system(.subheadline, design: .default, weight: .regular))
+                            .foregroundStyle(theme.ink)
+                    }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("DATA · SF MONO 13")
+                            .font(.system(.caption2, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.secondaryText)
+                        Text("14:32  ·  feat-ios-design-gallery  ·  2m")
+                            .font(.system(.footnote, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.ink)
+                            .minimumScaleFactor(0.7)
+                    }
+
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("TERMINAL · SF MONO 12")
+                            .font(.system(.caption2, design: .monospaced, weight: .regular))
+                            .foregroundStyle(theme.secondaryText)
+                        Text("$ ./scripts/reload.sh --tag dsgal")
+                            .font(.system(size: 12, weight: .regular, design: .monospaced))
+                            .foregroundStyle(theme.ink)
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    SignalSectionLabel(text: "Five Status Encodings", color: theme.secondaryText)
+                    VStack(spacing: 0) {
+                        ForEach(Array(statuses.enumerated()), id: \.offset) { _, state in
+                            SignalStatusMeaningRow(
+                                style: SignalStatusStyle(state: state, theme: theme),
+                                theme: theme
+                            )
+                        }
+                    }
+                }
+
+                VStack(alignment: .leading, spacing: 12) {
+                    SignalSectionLabel(text: "Core Components", color: theme.secondaryText)
+
+                    SignalWorkspaceRow(
+                        workspace: DesignGalleryFixtures.workspaces[1],
+                        theme: theme
+                    )
+                    .overlay(alignment: .bottom) {
+                        Rectangle()
+                            .fill(theme.hairline)
+                            .frame(height: 1)
+                    }
+
+                    SignalActionButtons(theme: theme)
+                    SignalTriageBar(theme: theme)
+                }
+            }
+            .padding(16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .background(theme.bg0.ignoresSafeArea())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusMeaningRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusMeaningRow.swift
@@ -1,0 +1,39 @@
+#if DEBUG
+import SwiftUI
+
+/// Teaches one Signal state through its square, word, symbol, and plain-language meaning.
+struct SignalStatusMeaningRow: View {
+    let style: SignalStatusStyle
+    let theme: SignalTheme
+
+    var body: some View {
+        HStack(spacing: 10) {
+            SignalStatusSquare(color: style.color)
+
+            Text(style.label)
+                .font(.system(.caption2, design: .default, weight: .semibold))
+                .tracking(0.88)
+                .foregroundStyle(theme.ink)
+                .frame(width: 74, alignment: .leading)
+
+            Text(style.symbol)
+                .font(.system(.footnote, design: .monospaced, weight: .bold))
+                .foregroundStyle(theme.ink)
+                .frame(width: 16)
+
+            Text(style.meaning)
+                .font(.system(.subheadline, design: .default, weight: .regular))
+                .foregroundStyle(theme.secondaryText)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .padding(.horizontal, 10)
+        .frame(minHeight: 44)
+        .background(theme.surface)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(theme.hairline)
+                .frame(height: 1)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusRail.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusRail.swift
@@ -1,0 +1,46 @@
+#if DEBUG
+import SwiftUI
+
+/// Draws a two-point status rail with the running-only linear shimmer.
+struct SignalStatusRail: View {
+    let style: SignalStatusStyle
+
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var shimmerPhase = 0.0
+
+    var body: some View {
+        GeometryReader { proxy in
+            Rectangle()
+                .fill(style.color.opacity(style.isRunning ? 0.34 : 1.0))
+                .overlay(alignment: .top) {
+                    if style.isRunning {
+                        Rectangle()
+                            .fill(style.color)
+                            .frame(height: max(10, proxy.size.height * 0.32))
+                            .offset(y: reduceMotion ? proxy.size.height * 0.34 : (-proxy.size.height * 0.32) + (proxy.size.height * 1.32 * shimmerPhase))
+                    }
+                }
+                .clipped()
+        }
+        .frame(width: 2)
+        .onAppear {
+            guard style.isRunning, !reduceMotion else { return }
+            withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+                shimmerPhase = 1
+            }
+        }
+        .onChange(of: reduceMotion) { _, shouldReduce in
+            if shouldReduce {
+                withAnimation(.linear(duration: 0.12)) {
+                    shimmerPhase = 0
+                }
+            } else if style.isRunning {
+                withAnimation(.linear(duration: 1.5).repeatForever(autoreverses: false)) {
+                    shimmerPhase = 1
+                }
+            }
+        }
+        .accessibilityHidden(true)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusSquare.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusSquare.swift
@@ -1,0 +1,15 @@
+#if DEBUG
+import SwiftUI
+
+/// Draws the six-point square used for every compact Signal status mark.
+struct SignalStatusSquare: View {
+    let color: Color
+
+    var body: some View {
+        Rectangle()
+            .fill(color)
+            .frame(width: 6, height: 6)
+            .accessibilityHidden(true)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusStyle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalStatusStyle.swift
@@ -1,0 +1,62 @@
+#if DEBUG
+import SwiftUI
+
+/// Supplies Signal's redundant word, symbol, meaning, and fixed color for one state.
+struct SignalStatusStyle {
+    let state: GalleryAgentState
+    let label: String
+    let compactLabel: String
+    let symbol: String
+    let meaning: String
+    let color: Color
+
+    init(state: GalleryAgentState, theme: SignalTheme) {
+        self.state = state
+        color = theme.color(for: state)
+
+        switch state {
+        case .needsYou:
+            label = "NEEDS YOU"
+            compactLabel = "NEEDS"
+            symbol = "!"
+            meaning = "Waiting for a decision"
+        case .failed:
+            label = "FAILED"
+            compactLabel = "FAILED"
+            symbol = "×"
+            meaning = "Stopped with an error"
+        case .running:
+            label = "RUNNING"
+            compactLabel = "RUN"
+            symbol = "→"
+            meaning = "Actively working"
+        case .done:
+            label = "DONE"
+            compactLabel = "DONE"
+            symbol = "✓"
+            meaning = "Completed successfully"
+        case .idle:
+            label = "IDLE"
+            compactLabel = "IDLE"
+            symbol = "–"
+            meaning = "No recent activity"
+        }
+    }
+
+    /// Indicates whether another fixture state occupies this style's taxonomy slot.
+    func matches(_ other: GalleryAgentState) -> Bool {
+        switch (state, other) {
+        case (.needsYou, .needsYou), (.failed, .failed), (.running, .running),
+             (.done, .done), (.idle, .idle):
+            true
+        default:
+            false
+        }
+    }
+
+    /// Indicates whether the status uses Signal's running shimmer.
+    var isRunning: Bool {
+        if case .running = state { true } else { false }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSummaryStrip.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalSummaryStrip.swift
@@ -1,0 +1,32 @@
+#if DEBUG
+import CmuxMobileSupport
+import SwiftUI
+
+/// Presents the pinned fleet legend at Signal's sole Liquid Glass site.
+struct SignalSummaryStrip: View {
+    let theme: SignalTheme
+
+    private var statuses: [GalleryAgentState] {
+        [.needsYou, .failed, .running, .done, .idle]
+    }
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(Array(statuses.enumerated()), id: \.offset) { _, state in
+                let style = SignalStatusStyle(state: state, theme: theme)
+                let count = DesignGalleryFixtures.workspaces.filter { style.matches($0.state) }.count
+                SignalLegendItem(style: style, count: count, theme: theme)
+            }
+        }
+        .padding(.horizontal, 8)
+        .padding(.vertical, 7)
+        .mobileGlassField(cornerRadius: 4)
+        .overlay {
+            RoundedRectangle(cornerRadius: 4)
+                .stroke(theme.hairline, lineWidth: 1)
+        }
+        .allowsHitTesting(false)
+        .padding(.horizontal, 16)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalTerminalLineRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalTerminalLineRow.swift
@@ -1,0 +1,30 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders one fixed-size terminal line while preserving its fixture tone through weight and contrast.
+struct SignalTerminalLineRow: View {
+    let line: GalleryTerminalLine
+    let theme: SignalTheme
+
+    private var foreground: Color {
+        if case .dim = line.tone { theme.secondaryText } else { theme.ink }
+    }
+
+    private var weight: Font.Weight {
+        switch line.tone {
+        case .success, .warning: .semibold
+        case .error: .bold
+        default: .regular
+        }
+    }
+
+    var body: some View {
+        Text(line.text)
+            .font(.system(size: 12, weight: weight, design: .monospaced))
+            .foregroundStyle(foreground)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .fixedSize(horizontal: true, vertical: false)
+            .padding(.vertical, 2)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalTheme.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalTheme.swift
@@ -1,0 +1,55 @@
+#if DEBUG
+import SwiftUI
+
+/// Resolves the complete Signal color token set for the active appearance.
+struct SignalTheme {
+    let bg0: Color
+    let surface: Color
+    let ink: Color
+    let secondaryText: Color
+    let hairline: Color
+    let needsYou: Color
+    let running: Color
+    let done: Color
+    let failed: Color
+    let idle: Color
+
+    init(scheme: ColorScheme) {
+        switch scheme {
+        case .dark:
+            bg0 = Color(red: 18.0 / 255.0, green: 18.0 / 255.0, blue: 18.0 / 255.0)
+            surface = Color(red: 28.0 / 255.0, green: 28.0 / 255.0, blue: 26.0 / 255.0)
+            ink = Color(red: 242.0 / 255.0, green: 242.0 / 255.0, blue: 240.0 / 255.0)
+            secondaryText = Color(red: 163.0 / 255.0, green: 163.0 / 255.0, blue: 158.0 / 255.0)
+            hairline = Color(red: 242.0 / 255.0, green: 242.0 / 255.0, blue: 240.0 / 255.0).opacity(0.14)
+            needsYou = Color(red: 240.0 / 255.0, green: 180.0 / 255.0, blue: 41.0 / 255.0)
+            running = Color(red: 74.0 / 255.0, green: 158.0 / 255.0, blue: 255.0 / 255.0)
+            done = Color(red: 52.0 / 255.0, green: 196.0 / 255.0, blue: 113.0 / 255.0)
+            failed = Color(red: 240.0 / 255.0, green: 85.0 / 255.0, blue: 74.0 / 255.0)
+            idle = Color(red: 110.0 / 255.0, green: 110.0 / 255.0, blue: 105.0 / 255.0)
+        default:
+            bg0 = Color(red: 245.0 / 255.0, green: 245.0 / 255.0, blue: 244.0 / 255.0)
+            surface = Color(red: 255.0 / 255.0, green: 255.0 / 255.0, blue: 255.0 / 255.0)
+            ink = Color(red: 17.0 / 255.0, green: 17.0 / 255.0, blue: 17.0 / 255.0)
+            secondaryText = Color(red: 85.0 / 255.0, green: 85.0 / 255.0, blue: 80.0 / 255.0)
+            hairline = Color(red: 17.0 / 255.0, green: 17.0 / 255.0, blue: 17.0 / 255.0).opacity(0.12)
+            needsYou = Color(red: 232.0 / 255.0, green: 162.0 / 255.0, blue: 0.0 / 255.0)
+            running = Color(red: 10.0 / 255.0, green: 122.0 / 255.0, blue: 255.0 / 255.0)
+            done = Color(red: 31.0 / 255.0, green: 158.0 / 255.0, blue: 85.0 / 255.0)
+            failed = Color(red: 217.0 / 255.0, green: 48.0 / 255.0, blue: 37.0 / 255.0)
+            idle = Color(red: 138.0 / 255.0, green: 138.0 / 255.0, blue: 133.0 / 255.0)
+        }
+    }
+
+    /// Returns the fixed Signal color assigned to an agent lifecycle state.
+    func color(for state: GalleryAgentState) -> Color {
+        switch state {
+        case .needsYou: needsYou
+        case .running: running
+        case .done: done
+        case .failed: failed
+        case .idle: idle
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalToggleButton.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalToggleButton.swift
@@ -1,0 +1,24 @@
+#if DEBUG
+import SwiftUI
+
+/// Provides a monochrome 44-point Settings toggle without decorative signal color.
+struct SignalToggleButton: View {
+    @Binding var isOn: Bool
+    let theme: SignalTheme
+
+    var body: some View {
+        Button {
+            withAnimation(.linear(duration: 0.12)) {
+                isOn.toggle()
+            }
+        } label: {
+            Text(isOn ? "ON" : "OFF")
+        }
+        .buttonStyle(SignalPressButtonStyle(
+            role: isOn ? .primary : .secondary,
+            theme: theme
+        ))
+        .accessibilityValue(isOn ? "On" : "Off")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalTriageBar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalTriageBar.swift
@@ -1,0 +1,39 @@
+#if DEBUG
+import SwiftUI
+
+/// Keeps the highest-priority fixture decision one thumb tap away.
+struct SignalTriageBar: View {
+    let theme: SignalTheme
+
+    private var priorityWorkspace: GalleryWorkspaceFixture {
+        DesignGalleryFixtures.workspaces[0]
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            SignalStatusSquare(color: theme.needsYou)
+
+            Text("NEEDS YOU · \(priorityWorkspace.name)/\(priorityWorkspace.branch) · \(priorityWorkspace.absoluteTimeText)")
+                .font(.system(.footnote, design: .monospaced, weight: .semibold))
+                .foregroundStyle(theme.ink)
+                .lineLimit(1)
+                .minimumScaleFactor(0.68)
+
+            Spacer(minLength: 0)
+
+            Button(action: {}) {
+                Text("Go")
+            }
+            .buttonStyle(SignalPressButtonStyle(role: .primary, theme: theme))
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(theme.surface)
+        .overlay(alignment: .top) {
+            Rectangle()
+                .fill(theme.hairline)
+                .frame(height: 1)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalWorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalWorkspaceRow.swift
@@ -43,10 +43,10 @@ struct SignalWorkspaceRow: View {
                 .foregroundStyle(theme.ink)
                 .frame(width: 92, alignment: .leading)
 
-                Text(workspace.elapsedText)
+                Text(workspace.absoluteTimeText)
                     .font(.system(.footnote, design: .monospaced, weight: .regular))
                     .foregroundStyle(theme.secondaryText)
-                    .frame(width: 42, alignment: .trailing)
+                    .frame(width: 52, alignment: .trailing)
                     .padding(.trailing, 10)
             }
             .frame(minHeight: 44)
@@ -69,7 +69,7 @@ struct SignalWorkspaceRow: View {
         } message: {
             Text(workspace.pendingQuestion ?? workspace.detailText)
         }
-        .accessibilityLabel("\(workspace.name), \(workspace.branch), \(status.label), \(workspace.elapsedText)")
+        .accessibilityLabel("\(workspace.name), \(workspace.branch), \(status.label), \(workspace.absoluteTimeText)")
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalWorkspaceRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DesignGallery/Systems/Signal/SignalWorkspaceRow.swift
@@ -1,0 +1,75 @@
+#if DEBUG
+import SwiftUI
+
+/// Renders a workspace in Signal's fixed name, state, and elapsed columns.
+struct SignalWorkspaceRow: View {
+    let workspace: GalleryWorkspaceFixture
+    let theme: SignalTheme
+
+    @State private var showsActions = false
+
+    private var status: SignalStatusStyle {
+        SignalStatusStyle(state: workspace.state, theme: theme)
+    }
+
+    var body: some View {
+        Button(action: {}) {
+            HStack(spacing: 0) {
+                SignalStatusRail(style: status)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(workspace.name)
+                        .font(.system(.subheadline, design: .default, weight: .semibold))
+                        .foregroundStyle(theme.ink)
+                    Text(workspace.branch)
+                        .font(.system(.footnote, design: .monospaced, weight: .regular))
+                        .foregroundStyle(theme.secondaryText)
+                        .lineLimit(1)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.leading, 10)
+
+                VStack(alignment: .leading, spacing: 1) {
+                    HStack(spacing: 5) {
+                        SignalStatusSquare(color: status.color)
+                        Text(status.label)
+                            .font(.system(.caption2, design: .default, weight: .semibold))
+                            .tracking(0.88)
+                    }
+                    Text(workspace.agentName)
+                        .font(.system(.footnote, design: .monospaced, weight: .regular))
+                        .foregroundStyle(theme.secondaryText)
+                }
+                .foregroundStyle(theme.ink)
+                .frame(width: 92, alignment: .leading)
+
+                Text(workspace.elapsedText)
+                    .font(.system(.footnote, design: .monospaced, weight: .regular))
+                    .foregroundStyle(theme.secondaryText)
+                    .frame(width: 42, alignment: .trailing)
+                    .padding(.trailing, 10)
+            }
+            .frame(minHeight: 44)
+            .background(theme.surface)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(SignalRowButtonStyle())
+        .simultaneousGesture(
+            LongPressGesture(minimumDuration: 0.45)
+                .onEnded { _ in showsActions = true }
+        )
+        .confirmationDialog(
+            workspace.branch,
+            isPresented: $showsActions,
+            titleVisibility: .visible
+        ) {
+            Button("Open", action: {})
+            Button("Copy Branch", action: {})
+            Button("Cancel", role: .cancel, action: {})
+        } message: {
+            Text(workspace.pendingQuestion ?? workspace.detailText)
+        }
+        .accessibilityLabel("\(workspace.name), \(workspace.branch), \(status.label), \(workspace.elapsedText)")
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -36,6 +36,7 @@ struct MobileSettingsView: View {
     @State private var showingOnboarding = false
     @State private var showingSetupHelp = false
     #if DEBUG
+    @State private var showingDesignGallery = false
     @State private var showingChatDemo = false
     @State private var showingTerminalDemo = false
     #endif
@@ -154,22 +155,19 @@ struct MobileSettingsView: View {
 
                 #if DEBUG
                 Section(L10n.string("mobile.settings.developer", defaultValue: "Developer")) {
-                    Button {
-                        showingChatDemo = true
-                    } label: {
-                        Label(
-                            L10n.string("mobile.settings.agentChatDemo", defaultValue: "Agent Chat Demo"),
-                            systemImage: "bubble.left.and.bubble.right"
-                        )
+                    Button { showingDesignGallery = true } label: {
+                        Label(L10n.string("mobile.settings.designGallery", defaultValue: "Design Gallery"),
+                              systemImage: "paintpalette")
+                    }
+                    .accessibilityIdentifier("MobileSettingsDesignGallery")
+                    Button { showingChatDemo = true } label: {
+                        Label(L10n.string("mobile.settings.agentChatDemo", defaultValue: "Agent Chat Demo"),
+                              systemImage: "bubble.left.and.bubble.right")
                     }
                     .accessibilityIdentifier("MobileSettingsAgentChatDemo")
-                    Button {
-                        showingTerminalDemo = true
-                    } label: {
-                        Label(
-                            L10n.string("mobile.settings.terminalLogDemo", defaultValue: "Terminal Log Demo"),
-                            systemImage: "terminal"
-                        )
+                    Button { showingTerminalDemo = true } label: {
+                        Label(L10n.string("mobile.settings.terminalLogDemo", defaultValue: "Terminal Log Demo"),
+                              systemImage: "terminal")
                     }
                     .accessibilityIdentifier("MobileSettingsTerminalLogDemo")
 
@@ -297,12 +295,9 @@ struct MobileSettingsView: View {
                 TerminalShortcutsSettingsView()
             }
             #if DEBUG
-            .fullScreenCover(isPresented: $showingChatDemo) {
-                AgentChatDemoScreen()
-            }
-            .fullScreenCover(isPresented: $showingTerminalDemo) {
-                TerminalLogDemoScreen()
-            }
+            .fullScreenCover(isPresented: $showingDesignGallery) { DesignGalleryScreen() }
+            .fullScreenCover(isPresented: $showingChatDemo) { AgentChatDemoScreen() }
+            .fullScreenCover(isPresented: $showingTerminalDemo) { TerminalLogDemoScreen() }
             #endif
             .sheet(isPresented: $showingHostPicker) {
                 if let store {

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -1956,6 +1956,227 @@
         }
       }
     },
+    "mobile.designGallery.footer": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Static design-system candidates. No live data."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "静的なデザインシステム候補です。ライブデータは使用していません。"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.page.activity": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Activity"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アクティビティ"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.page.chat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Chat"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "チャット"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.page.hub": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hub"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ハブ"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.page.session": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Session"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "セッション"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.page.settings": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Settings"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.page.specimen": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Specimen"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スペシメン"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.schemeToggle.accessibilityLabel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Toggle Light or Dark Appearance"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ライト／ダーク表示を切り替え"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.system.atelier.tagline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Warm humanist companion"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "温かみのある人間中心の相棒"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.system.meridian.tagline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid-glass native"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Liquid Glass ネイティブ"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.system.phosphor.tagline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Terminal-native instrument"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ターミナルネイティブなツール"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.system.signal.tagline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Swiss status board"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スイススタイルのステータスボード"
+          }
+        }
+      }
+    },
+    "mobile.designGallery.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design Gallery"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デザインギャラリー"
+          }
+        }
+      }
+    },
     "mobile.deviceTree.collapseHint": {
       "extractionState": "manual",
       "localizations": {
@@ -4502,6 +4723,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "エージェントチャットデモ"
+          }
+        }
+      }
+    },
+    "mobile.settings.designGallery": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Design Gallery"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "デザインギャラリー"
           }
         }
       }

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -22,8 +22,10 @@ private let mobileRootSceneLog = Logger(subsystem: "dev.cmux.ios", category: "mo
 ///
 /// Renders the live cmux mobile UI: a ``CMUXMobileAppView`` backed by a fresh
 /// ``CMUXMobileShellStore`` and the injected ``AuthCoordinator``. In DEBUG
-/// builds, setting the environment variable `CMUX_ZOOM_STRESS=1` instead mounts
-/// the terminal zoom-stress repro harness (`MobileZoomStressView`).
+/// builds, `CMUX_DESIGN_GALLERY=1` mounts ``DesignGalleryScreen`` and
+/// `CMUX_ZOOM_STRESS=1` mounts the terminal zoom-stress repro harness
+/// (`MobileZoomStressView`); `CMUX_BOTTOM_SCROLL_STRESS=1` mounts the terminal
+/// bottom-scroll repro harness (`MobileBottomScrollStressView`).
 ///
 /// The composition root (`cmuxApp`) builds the ``CMUXMobileRuntime`` and the
 /// ``MobileAuthComposition`` and hands them here. The scene injects the
@@ -245,6 +247,8 @@ public struct CMUXMobileRootScene: View {
             WorkspaceListLayoutPreviewView()
         } else if let recoveryStress = MobileRecoveryStressConfiguration.parse(arguments: ProcessInfo.processInfo.arguments) {
             MobileRecoveryStressView(configuration: recoveryStress)
+        } else if ProcessInfo.processInfo.environment["CMUX_DESIGN_GALLERY"] == "1" {
+            DesignGalleryScreen()
         } else if ProcessInfo.processInfo.environment["CMUX_ZOOM_STRESS"] == "1" {
             MobileZoomStressView()
         } else if ProcessInfo.processInfo.environment["CMUX_BOTTOM_SCROLL_STRESS"] == "1" {

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -22,7 +22,8 @@ private let mobileRootSceneLog = Logger(subsystem: "dev.cmux.ios", category: "mo
 ///
 /// Renders the live cmux mobile UI: a ``CMUXMobileAppView`` backed by a fresh
 /// ``CMUXMobileShellStore`` and the injected ``AuthCoordinator``. In DEBUG
-/// builds, `CMUX_DESIGN_GALLERY=1` mounts ``DesignGalleryScreen`` and
+/// builds, `CMUX_DESIGN_GALLERY` mounts the design gallery (`1` for the root
+/// list, or a deep route like `phosphor:specimen:dark`) and
 /// `CMUX_ZOOM_STRESS=1` mounts the terminal zoom-stress repro harness
 /// (`MobileZoomStressView`); `CMUX_BOTTOM_SCROLL_STRESS=1` mounts the terminal
 /// bottom-scroll repro harness (`MobileBottomScrollStressView`).
@@ -247,8 +248,9 @@ public struct CMUXMobileRootScene: View {
             WorkspaceListLayoutPreviewView()
         } else if let recoveryStress = MobileRecoveryStressConfiguration.parse(arguments: ProcessInfo.processInfo.arguments) {
             MobileRecoveryStressView(configuration: recoveryStress)
-        } else if ProcessInfo.processInfo.environment["CMUX_DESIGN_GALLERY"] == "1" {
-            DesignGalleryScreen()
+        } else if let galleryValue = ProcessInfo.processInfo.environment["CMUX_DESIGN_GALLERY"],
+                  !galleryValue.isEmpty, galleryValue != "0" {
+            DesignGalleryEntryView(environmentValue: galleryValue)
         } else if ProcessInfo.processInfo.environment["CMUX_ZOOM_STRESS"] == "1" {
             MobileZoomStressView()
         } else if ProcessInfo.processInfo.environment["CMUX_BOTTOM_SCROLL_STRESS"] == "1" {

--- a/ios/docs/design/README.md
+++ b/ios/docs/design/README.md
@@ -1,0 +1,39 @@
+# cmux iOS design-system candidates
+
+Four complete candidate design systems for the iOS app redesign, each expressed as a static, compiled gallery behind the debug menu (Design Gallery). Nothing here touches live app UI; the galleries exist so a direction can be picked by looking at real rendered screens instead of mockups.
+
+Every system renders the same six screens from the same fixture data (`GalleryFixtures`), so comparison is apples-to-apples:
+
+1. **Hub** — the agent/workspace list, the app's home
+2. **Session** — a streamed terminal view with status header and input affordance
+3. **Chat** — an agent conversation with a tool-call card and an approval request
+4. **Activity** — the notification/event feed
+5. **Settings** — account, paired Mac, appearance, notifications
+6. **Specimen** — the system's palette, type scale, and core components side by side
+
+## Shared rules (bind all four systems)
+
+- **Status taxonomy** is the app's core information and is fixed across systems: `needsYou > failed > running > done > idle`. Every system encodes state redundantly (color + symbol or word), never color alone.
+- Tap targets ≥ 44×44 pt. Primary actions live in the bottom half of the screen (thumb reach). Destructive actions are never adjacent to primary ones.
+- Both light and dark are first-class in every system; the gallery has a per-system light/dark toggle.
+- Reduce Motion degrades every animation to a crossfade.
+- Terminal content is user-scaled and exempt from Dynamic Type; all other text tracks it.
+
+## The four candidates
+
+| # | System | One-line identity | Density | Glass usage |
+|---|--------|-------------------|---------|-------------|
+| 01 | Phosphor | Terminal-native instrument, dark-first, the terminal is the hero | high | minimal: floating command bar only |
+| 02 | Atelier | Warm humanist companion, calm paper + serif accents | low | soft: nav on scroll + composer pill |
+| 03 | Meridian | Liquid-glass native, content edge-to-edge, chrome floats | medium | everywhere chrome exists |
+| 04 | Signal | Swiss status board, data-ink, fixed color legend | highest | single pinned summary strip |
+
+Per-system token specs live in `phosphor.md`, `atelier.md`, `meridian.md`, `signal.md`.
+
+## Philosophy sources
+
+- Norman, *Design of Everyday Things*: visibility of system status drives the Hub (01/04 especially); redundant signifiers for state; mapping — the same slot means the same thing on every screen (04's hard rule).
+- Claude iOS: warmth and calm as an anxiety-reducer when supervising agents (02).
+- ChatGPT iOS: monochrome chrome, content-first, minimal navigation (03).
+- iOS 26 HIG Liquid Glass: chrome floats above content and morphs; content itself is never glass (03, enforced everywhere).
+- Tufte: data-ink ratio; color only as signal (04).

--- a/ios/docs/design/atelier.md
+++ b/ios/docs/design/atelier.md
@@ -1,0 +1,55 @@
+# 02 Atelier — warm humanist companion
+
+Supervising agents is anxious work; Atelier's job is to lower the pulse. Warm paper surfaces, serif display type, generous space, and state expressed in plain words ("Waiting for you", "Working…", "Finished"). Inspired by the Claude iOS app's warmth. Fewer things on screen, each with a clear next action — Norman's one-good-conceptual-model over exhaustive display.
+
+## Color
+
+| Token | Light | Dark |
+|---|---|---|
+| bg0 (app) | #F7F3EC | #201C18 |
+| bg1 (card) | #FFFFFF | #2A251F |
+| bg2 (inset/pressed) | #EFE9DE | #363028 |
+| hairline | #2A2520 10% | #EDE7DE 10% |
+| text.primary (ink) | #2A2520 | #EDE7DE |
+| text.secondary | #6B6259 | #B3A99C |
+| text.tertiary | #A39B8F | #7A7166 |
+| accent (terracotta) | #C15F3C | #D97757 |
+| status.needsYou (ochre) | #B07818 | #D9A03F |
+| status.running (slate) | #5F7484 | #8FA5B5 |
+| status.done (sage) | #5F7D58 | #8CAB84 |
+| status.failed (brick) | #A84632 | #CC6B55 |
+| status.idle | #A39B8F | #7A7166 |
+
+Cards carry a soft shadow (y2, blur 12, black 6%) in light mode; dark mode uses bg-layer steps only.
+
+## Type
+
+- Display/titles and workspace names: New York (serif) — screen title 28 semibold, card title 19 semibold.
+- Body: SF Pro 16 regular, line height 1.4. Captions 13.
+- Mono only inside terminal/tool blocks: SF Mono 12.
+- State words are typeset, not badged: 13pt medium in the state's color.
+
+## Shape, density, spacing
+
+8pt grid. Screen margins 20. Cards radius 18, inner elements 12, composer pill 24 (capsule). Row/card min height 64. One agent = one card; the Hub shows ~4 cards per screen height, on purpose.
+
+## Glass
+
+Soft and warm, two sites: navigation bar background on scroll, and the bottom composer pill (Chat/Session). Warm-tinted (`bg0` at 50% under the material). Never on cards or content. Gated via `mobileGlass*` helpers.
+
+## Motion
+
+Gentle springs (response 0.5, damping 0.85) for card presses and sheet presentation. Status dot on "Working…" breathes (scale 1→1.15, 3s ease-in-out loop). Content transitions are 250ms fades. Nothing pulses in color.
+
+## Ergonomics
+
+Primary action is embedded in the card that needs it: a needs-you card ends with a full-width soft-terracotta `Review request` button (52pt). No swipe-only affordances; everything reachable by tap. Bottom composer pill is the single fixed control on conversational screens.
+
+## Screens
+
+- **Hub**: serif greeting header ("Your agents"), then cards. A needs-you card is promoted to the top with an ochre left-edge accent bar, a one-line quote of the agent's question in italic serif, and the `Review request` button. Running/done/idle cards: serif name, plain-word state line with dot, last-activity sentence in secondary.
+- **Session**: terminal presented as a framed artifact — a bg1 card with 18pt radius holding a dark terminal inset (always #201C18 even in light mode, mono 12), state line above it in words, composer pill below.
+- **Chat**: agent messages as plain text on bg0 with generous 24pt paragraph spacing; user messages in terracotta-tinted (10%) rounded card right-aligned. Tool call = bg2 inset card with serif label "Ran a command" + mono line. Approval = bg1 card, italic serif question, `Approve` (filled terracotta) above `Not yet` (plain text button), stacked full-width.
+- **Activity**: journal style — day headings in serif 20, entries as sentences ("Claude finished the sidebar fix · 3:12 PM") with state-colored dot, 16pt spacing, no boxes.
+- **Settings**: cards per group (Account, Paired Mac, Appearance, Notifications), serif section labels, roomy 56pt rows.
+- **Specimen**: palette as paint chips with names ("Terracotta", "Sage"), serif/type scale, state words row, buttons, cards, composer pill.

--- a/ios/docs/design/meridian.md
+++ b/ios/docs/design/meridian.md
@@ -1,0 +1,45 @@
+# 03 Meridian — liquid-glass native
+
+The most iOS-native candidate: content runs edge-to-edge and all chrome floats above it as Liquid Glass, per the iOS 26 HIG. Chrome is monochrome (ChatGPT-style) so the only saturated pixels on screen are status signals and the single accent. Where Phosphor builds its own world, Meridian disappears into the platform — lowest long-term maintenance, automatic fit with every OS release.
+
+## Color
+
+- Backgrounds: `systemBackground` / `secondarySystemBackground` / `tertiarySystemFill` — no custom surface colors at all.
+- Text: `label` / `secondaryLabel` / `tertiaryLabel`.
+- Accent: indigo #5B5BD6 (dark: #7A7AE8) — placeholder brand accent, used only for the primary action and selection.
+- Status: needsYou `systemOrange`, running accent-indigo, done `systemGreen`, failed `systemRed`, idle `tertiaryLabel`. Rendered as SF Symbols with tint, not custom dots: `person.crop.circle.badge.exclamationmark`, `arrow.triangle.2.circlepath`, `checkmark.circle.fill`, `xmark.circle.fill`, `moon.zzz`.
+- Chrome (toolbar icons, tab labels): monochrome `label`/`secondaryLabel` only.
+
+## Type
+
+SF Pro, standard Dynamic Type styles only: `.largeTitle` nav, `.headline` row titles, `.body`, `.subheadline`, `.caption`. Mono via `.monospaced()` design for terminal and branch names. No custom sizes.
+
+## Shape
+
+Concentric radii: full-bleed content, cards 26 (hugging device corners), controls capsule. Standard `insetGrouped` metrics for lists.
+
+## Glass
+
+Everywhere chrome exists, nowhere content does:
+- Floating capsule tab bar bottom-center: Home / Activity / Settings, glass, selected item tinted.
+- Session/Chat action cluster: `GlassEffectContainer` holding circular glass buttons (approve, keyboard, more) that would morph between states on iOS 26.
+- Composer: glass capsule field.
+- Nav large-title with scroll-edge effect; sheets with glass grabber region.
+All through the gated `mobileGlass*` helpers with iOS 18 material fallbacks.
+
+## Motion
+
+System defaults only: standard springs, `symbolEffect(.pulse)` on the running symbol, matched-geometry morph between tab bar and expanded controls where iOS 26 allows. Nothing custom-timed.
+
+## Ergonomics
+
+Floating tab bar keeps global nav permanently in thumb reach. Primary per-item actions via standard swipe actions and context menus (platform muscle memory). Approve appears both as a swipe action and as the prominent glass button in Session — one shared action, two entrypoints.
+
+## Screens
+
+- **Hub**: large-title "cmux". Needs-you items in a promoted "For you" `insetGrouped` section with tinted symbol + orange badge count on the tab bar; the rest in a plain section. Rows: headline name, subheadline branch (monospaced), trailing relative time; running rows show the pulsing symbol.
+- **Session**: edge-to-edge terminal mock behind everything; top status bar is a glass capsule (symbol + workspace + elapsed); bottom-right `GlassEffectContainer` cluster: keyboard, approve (accent-filled when pending), overflow.
+- **Chat**: standard chat metrics; agent messages plain `body` on background, user messages in `secondarySystemBackground` bubbles; tool call = `insetGrouped`-style card with monospaced command and DisclosureGroup output; approval = card with `.borderedProminent` (accent) Approve + `.bordered` Deny; composer is the glass capsule.
+- **Activity**: sectioned by day, standard list, tinted symbols per event type, unread dot in accent; mirrors notification center conventions.
+- **Settings**: pure `insetGrouped` system form — deliberately indistinguishable from a first-party app.
+- **Specimen**: accent + status tints over system backgrounds in both schemes, Dynamic Type ramp, glass elements row, symbol vocabulary with meanings.

--- a/ios/docs/design/phosphor.md
+++ b/ios/docs/design/phosphor.md
@@ -1,0 +1,54 @@
+# 01 Phosphor — terminal-native instrument
+
+The terminal is the hero; chrome recedes into layered near-black and never competes with it. Norman's "visibility of system status" is the prime directive: agent state is the loudest thing on every screen, encoded three ways (color, glyph, elapsed time). Dark-first because agents get supervised at night; light mode is a full peer, not an inversion.
+
+## Color
+
+| Token | Dark | Light |
+|---|---|---|
+| bg0 (app) | #0A0B0D | #F2F3F5 |
+| bg1 (card/row) | #111318 | #FFFFFF |
+| bg2 (elevated/pressed) | #1A1D24 | #E9EBEE |
+| hairline | white 8% | black 10% |
+| text.primary | #E8EAED | #1A1D24 |
+| text.secondary | #9BA1AC | #5C6370 |
+| text.tertiary | #5C6370 | #9BA1AC |
+| accent | #4D9DFF | #1D6FE0 |
+| status.needsYou | #FFB224 | #B87700 |
+| status.running | #4D9DFF | #1D6FE0 |
+| status.done | #3DD68C | #17804F |
+| status.failed | #FF5D5D | #C93030 |
+| status.idle | #5C6370 | #9BA1AC |
+
+Status colors appear as 8pt dots, chip tints at 16% opacity fills, and terminal-header accents. Never as large area fills.
+
+## Type
+
+- Chrome: SF Pro. Title 17 semibold, body 15 regular, caption 12 regular.
+- Data (branch names, ports, durations, counts, paths): SF Mono 13, monospaced digits everywhere numbers appear.
+- Terminal: SF Mono 12 default (user-scaled), line height 1.3.
+
+## Shape, density, spacing
+
+4pt grid. Screen margins 12. Rows 52pt. Radius: cards 8, chips 6, sheets 12. No shadows; separation is hairlines and bg-layer steps only.
+
+## Glass
+
+Two sites only: the floating bottom command bar (Hub) and the terminal input accessory (Session). Everything else opaque — glass over terminal content is banned for legibility. Use the `mobileGlass*` gated helpers.
+
+## Motion
+
+150–180ms easeOut. Rows appear with 4pt y-shift + fade. `needsYou` rows carry a 2s amber opacity pulse (0.6→1.0) on the status dot only. No springs on chrome, no bounce.
+
+## Ergonomics
+
+Floating bottom command bar with the two highest-value actions in thumb reach: `Approve` (when a needs-you item exists) and `New workspace`. Row swipe left = approve/reply, swipe right = mark read. All targets ≥44pt despite dense rows (row is the target).
+
+## Screens
+
+- **Hub**: attention queue, not a folder tree. Sorted needsYou > failed > running > done > idle. Row: status dot + workspace name (SF Pro semibold 15) + branch in SF Mono 12 secondary + right-aligned elapsed (mono). NeedsYou rows get a 16%-amber tint fill and 1px amber hairline. Sticky top strip: mono summary `1 needs you · 2 running · 1 done`.
+- **Session**: sticky status header (dot + agent name + state + elapsed, bg1, hairline below) above a full-bleed mock terminal block (bg0, mono 12, ANSI-colored fixture lines). Bottom: glass input accessory with mono text field + send.
+- **Chat**: flat message list, no bubbles for the agent (left-aligned text on bg0), user messages right-aligned in bg2 chip. Tool-call = bordered card, mono command line, collapsed output preview (3 lines, tertiary). Approval request = amber-hairline card with `Approve` / `Deny` side-by-side buttons pinned inside the card bottom.
+- **Activity**: single dense feed, day headers as 12pt uppercase tertiary labels, rows 44pt: status dot, event text (needs-you events semibold), mono relative time right.
+- **Settings**: standard grouped list re-skinned on bg1/bg2 with hairlines, mono values on the right (paired Mac name, version).
+- **Specimen**: palette swatches with hex labels (mono), type scale, dots/chips in all five states, command bar, buttons, tool-card.

--- a/ios/docs/design/signal.md
+++ b/ios/docs/design/signal.md
@@ -1,0 +1,49 @@
+# 04 Signal — Swiss status board
+
+Mission control for agents. Tufte's data-ink ratio: every pixel informs or is deleted; color exists only as signal, defined once in a legend the user learns and then sees applied identically on every screen (Norman's mapping — the same slot always means the same thing). Highest density of the four; the whole fleet is visible without scrolling.
+
+## Color
+
+| Token | Light | Dark |
+|---|---|---|
+| bg0 (app) | #F5F5F4 | #121212 |
+| surface | #FFFFFF | #1C1C1A |
+| ink | #111111 | #F2F2F0 |
+| text.secondary | #555550 | #A3A39E |
+| hairline | #111111 12% | #F2F2F0 14% |
+| signal.needsYou | #E8A200 | #F0B429 |
+| signal.running | #0A7AFF | #4A9EFF |
+| signal.done | #1F9E55 | #34C471 |
+| signal.failed | #D93025 | #F0554A |
+| signal.idle | #8A8A85 | #6E6E69 |
+
+Signal colors appear only as: 2pt row rails (left edge), 6pt squares (not dots — squares read as legend marks), and bar fills. Never as text color, never as tints, never decorative.
+
+## Type
+
+SF Pro with hard weight contrast: screen title 28 heavy; section labels 11 semibold UPPERCASE, tracking +0.08em; body 15 regular; ALL data (times, counts, durations, branches, ports) SF Mono 13. Timestamps absolute (`14:32`), never relative — a board is read, not felt.
+
+## Shape, density, spacing
+
+Radius 4 everywhere (near-square). Rows 44pt. Screen margins 16, intra-section spacing 1px hairlines, section gaps 24. True column alignment on the Hub: name | state | elapsed share fixed columns across all rows (mapping rule).
+
+## Glass
+
+Exactly one site: the pinned summary strip at the top of Hub and Activity gets glass so the board visibly scrolls beneath it — glass as functional layering proof, not decoration. Gated via `mobileGlass*`.
+
+## Motion
+
+120ms crossfades only. Running state shows a determinate-feeling 2px progress bar shimmer (linear, 1.5s) inside the row rail. No springs, no scale, no pulse. This system is what Reduce Motion already looks like.
+
+## Ergonomics
+
+Fixed bottom triage bar (surface, hairline top): shows the single highest-priority item (`NEEDS YOU · cmux/feat-gallery · 14:32`) with a `Go` button — one thumb tap from anywhere to the next decision. Row tap opens; row long-press shows a plain action sheet. Nothing hidden behind swipe.
+
+## Screens
+
+- **Hub**: glass summary strip: five legend squares with mono counts (`■3 ■1 ■2 ■0 ■1`) + label row. Below, a true table grouped by state, uppercase section labels (`NEEDS YOU`, `RUNNING`, `DONE`), rows with 2pt rail, name (semibold 15), branch mono 13 secondary, elapsed mono right-aligned in a fixed column. Triage bar bottom.
+- **Session**: metadata header as a two-column spec table (AGENT, STATE, BRANCH, ELAPSED, PORT — labels uppercase 11, values mono 13) above the terminal panel (surface, radius 4, mono 12); actions as a plain button row (`Approve` filled ink, `Deny` outlined) below the header, not floating.
+- **Chat**: transcript as a log — each entry has an uppercase role label (AGENT / YOU / TOOL) and mono timestamp in the left gutter, text right of gutter; tool entries in a hairline box with mono command; approval entry ends with the same `Approve`/`Deny` row as Session (one action design app-wide).
+- **Activity**: same table grammar as Hub — time (mono, absolute) | signal square | event text; day boundaries as uppercase labels; unread events in semibold ink, read in secondary.
+- **Settings**: sectioned table, uppercase group labels, mono values right; a `LEGEND` section restating the five signals with meanings — the system teaches itself.
+- **Specimen**: the legend, ink/surface palette, weight-contrast type scale, table row anatomy, triage bar, buttons.


### PR DESCRIPTION
A static Design Gallery behind Settings → Developer (DEBUG only) for picking the iOS redesign direction from real rendered screens instead of mockups. Four complete candidate design systems each render the same six screens (hub, session, chat, activity, settings, specimen) from shared fixtures, with a per-system light/dark toggle:

- 01 Phosphor — terminal-native instrument: dark-first layered neutrals, mono data, dense attention queue, glass only on the floating command bar and input accessory.
- 02 Atelier — warm humanist companion: paper surfaces, serif display type, plain-word states, one-agent-one-card hub with an embedded Review request action.
- 03 Meridian — liquid-glass native: system backgrounds and Dynamic Type only, monochrome chrome, floating glass tab bar and morph-ready action cluster.
- 04 Signal — Swiss status board: fixed five-signal color legend, true table columns, uppercase section labels, pinned triage bar.

Token specs and philosophy per system live in `ios/docs/design/`. Deep entry for screenshots/UI tests: `CMUX_DESIGN_GALLERY=1` or `<system>:<page>:<light|dark>` (DEBUG env, e.g. `phosphor:specimen:dark`).

Everything is `#if DEBUG`, files < 400 lines, no free functions, no ObservableObject, no timers. Liquid Glass goes through the gated `mobileGlass*` helpers or `#available(iOS 26)` with iOS 18 material fallbacks (deployment target 18.4). Gallery chrome adds 14 localized keys (en + ja); fixture and specimen content is intentionally unlocalized sample data, matching the `AgentChatDemoScreen` precedent.

Verified: tag `dsgal` built for an isolated iPhone 17 Pro simulator (iOS 26.5); 49-screenshot sweep across every system, page, and color scheme; all four systems render on-spec in both schemes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8030"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786584934&installation_id=133855650&pr_number=8030&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8030&signature=8289d82fc0b8610678be480913b6f0ec365b31130a77ace1f75f5c66fe87d420"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a debug-only iOS Design Gallery to compare four candidate design systems across six real screens. Forced `light|dark` in `CMUX_DESIGN_GALLERY` routes now applies to the entire gallery (shell and pages); no impact on release builds.

- **New Features**
  - Static gallery behind Settings → Developer → Design Gallery (DEBUG only); four systems render hub/session/chat/activity/settings/specimen from shared fixtures with light/dark toggle.
  - Deep routes via `CMUX_DESIGN_GALLERY`: `1`, `<system>`, `<system>:<page>`, `<system>:<page>:<light|dark>` (e.g. `phosphor:specimen:dark`); invalid parts fall back; forced scheme applies globally.
  - Uses iOS 26 Liquid Glass via `mobileGlass*` helpers or `#available(iOS 26)` with iOS 18 material fallbacks; localized gallery chrome (en, ja) and docs in `ios/docs/design`.

- **Bug Fixes**
  - Phosphor status summaries derived from fixtures; Signal hub/board shows absolute times; counts come from fixtures (no hardcoded indexes).
  - Atelier uses safe-area backgrounds; fixture identities are fictional to avoid real data.

<sup>Written for commit d44b1b26073b25c7e498581bae1e6192ee0a6cd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a debug-only iOS Design Gallery with four visual systems (Phosphor, Atelier, Meridian, Signal) and navigable screens (Hub, Session, Chat, Activity, Settings, Specimen).
  * Added deep-link style routing via `CMUX_DESIGN_GALLERY`, with on-screen paging and color-scheme controls (light/dark), honoring reduced-motion behavior.
  * Added fixture-based preview data to drive interactive gallery content.
* **Documentation**
  * Added design specifications for all four visual systems, including screen layouts, interaction patterns, accessibility, and motion rules.
* **Localization**
  * Added localized gallery titles, page labels, footer text, and accessibility strings (including scheme toggle).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->