### PR TITLE
Stabilize Next navigation web test mocks

### DIFF
--- a/web/tests/app-pricing-page.test.tsx
+++ b/web/tests/app-pricing-page.test.tsx
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import { stripeSubscriptions } from "../db/schema";
+import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
 const dbClientModule = await import("../db/client");
 const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
@@ -11,16 +12,9 @@ const redirect = mock((href: unknown) => {
   throw Object.assign(new Error("redirect"), { href });
 });
 
-// bun's mock.module replaces these modules process-wide, so each mock must
-// carry every export another test in the suite might import.
-mock.module("next/navigation", () => ({
-  redirect,
-  usePathname: () => "/",
-  notFound: () => {
-    throw new Error("notFound");
-  },
-  permanentRedirect: redirect,
-}));
+// bun's mock.module replaces these modules process-wide. Keep the shared
+// export set complete so this file cannot break an unrelated suite.
+mock.module("next/navigation", () => createNextNavigationMock(redirect));
 
 mock.module("next/headers", () => ({
   headers: async () =>

--- a/web/tests/app-pro-welcome-page.test.tsx
+++ b/web/tests/app-pro-welcome-page.test.tsx
@@ -19,6 +19,15 @@ mock.module("next/navigation", () => ({
 const { default: AppProWelcomePage } = await import("../app/app-pro-welcome/page");
 
 describe("app pro welcome page", () => {
+  test("keeps client navigation components importable after installing the navigation mock", async () => {
+    const navigation = await import("next/navigation");
+    const banner = await import("../app/[locale]/components/pro-welcome-banner");
+
+    expect(typeof navigation.useRouter).toBe("function");
+    expect(typeof navigation.useSearchParams).toBe("function");
+    expect(typeof banner.ProWelcomeBanner).toBe("function");
+  });
+
   test("redirects to the dashboard billing page outside the cmux app", async () => {
     await expect(
       AppProWelcomePage({ searchParams: Promise.resolve({}) }),

--- a/web/tests/app-pro-welcome-page.test.tsx
+++ b/web/tests/app-pro-welcome-page.test.tsx
@@ -1,20 +1,14 @@
 import { describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
 const redirect = mock((href: unknown) => {
   throw Object.assign(new Error("redirect"), { href });
 });
 
-// bun's mock.module replaces these modules process-wide, so each mock must
-// carry every export another test in the suite might import.
-mock.module("next/navigation", () => ({
-  redirect,
-  usePathname: () => "/",
-  notFound: () => {
-    throw new Error("notFound");
-  },
-  permanentRedirect: redirect,
-}));
+// bun's mock.module replaces these modules process-wide. Keep the shared
+// export set complete so this file cannot break an unrelated suite.
+mock.module("next/navigation", () => createNextNavigationMock(redirect));
 
 const { default: AppProWelcomePage } = await import("../app/app-pro-welcome/page");
 

--- a/web/tests/billing-success-page.test.tsx
+++ b/web/tests/billing-success-page.test.tsx
@@ -1,5 +1,6 @@
 import { describe, expect, mock, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
+import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
 const purchaseModule = await import("../services/billing/purchase");
 const stripeModule = await import("../services/billing/stripe");
@@ -13,14 +14,7 @@ const retrieveSession = mock(async () => ({
   subscription: { status: "active" },
 }));
 
-mock.module("next/navigation", () => ({
-  redirect,
-  usePathname: () => "/",
-  notFound: () => {
-    throw new Error("notFound");
-  },
-  permanentRedirect: redirect,
-}));
+mock.module("next/navigation", () => createNextNavigationMock(redirect));
 
 let acceptLanguage = "en";
 

--- a/web/tests/helpers/next-navigation-mock.ts
+++ b/web/tests/helpers/next-navigation-mock.ts
@@ -1,0 +1,24 @@
+type Redirect = (href: unknown) => unknown;
+
+const router = {
+  back: () => undefined,
+  forward: () => undefined,
+  refresh: () => undefined,
+  push: () => undefined,
+  replace: () => undefined,
+  prefetch: async () => undefined,
+};
+
+export function createNextNavigationMock(redirect: Redirect) {
+  return {
+    redirect,
+    permanentRedirect: redirect,
+    notFound: () => {
+      throw new Error("notFound");
+    },
+    usePathname: () => "/",
+    useRouter: () => router,
+    useSearchParams: () => new URLSearchParams(),
+    useServerInsertedHTML: () => undefined,
+  };
+}

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -3,6 +3,7 @@ import { renderToStaticMarkup } from "react-dom/server";
 
 import { stripeSubscriptions } from "../db/schema";
 import enMessages from "../messages/en.json";
+import { createNextNavigationMock } from "./helpers/next-navigation-mock";
 
 const dbClientModule = await import("../db/client");
 const realCloseCloudDbForTests = dbClientModule.closeCloudDbForTests;
@@ -18,6 +19,16 @@ const proUser = {
   update: mock(async () => undefined),
 };
 const getUser = mock(async () => proUser);
+const redirect = mock((href: unknown) => {
+  throw Object.assign(new Error("redirect"), { href });
+});
+
+mock.module("next/navigation", () => createNextNavigationMock(redirect));
+
+mock.module("next-intl", () => ({
+  useLocale: () => "en",
+  useTranslations: (namespace?: string) => translator(namespace),
+}));
 
 mock.module("next-intl/server", () => ({
   getTranslations: async (namespace?: string | { namespace?: string }) =>
@@ -27,10 +38,6 @@ mock.module("next-intl/server", () => ({
 
 mock.module("../app/[locale]/components/site-header", () => ({
   SiteHeader: () => <header />,
-}));
-
-mock.module("../app/[locale]/components/pro-welcome-banner", () => ({
-  ProWelcomeBanner: () => null,
 }));
 
 mock.module("../app/[locale]/components/pro-cta-link", () => ({

--- a/web/tests/pricing-page.test.tsx
+++ b/web/tests/pricing-page.test.tsx
@@ -26,6 +26,7 @@ const redirect = mock((href: unknown) => {
 mock.module("next/navigation", () => createNextNavigationMock(redirect));
 
 mock.module("next-intl", () => ({
+  NextIntlClientProvider: ({ children }: { children: React.ReactNode }) => children,
   useLocale: () => "en",
   useTranslations: (namespace?: string) => translator(namespace),
 }));


### PR DESCRIPTION
## Summary
- centralize the process-wide `next/navigation` mock used by web page tests
- include the client navigation hooks imported by unrelated suites
- add a regression that imports the affected client navigation component after the mock is installed

## Testing
- `bun test tests/app-pro-welcome-page.test.tsx tests/app-pricing-page.test.tsx tests/billing-success-page.test.tsx`
- `bun run typecheck`
- `bun test $(ls tests/*.test.ts tests/*.test.tsx | sort)` (661 passed, 91 skipped)

## CI failure
- Fixes the order-dependent web test failure in https://github.com/manaflow-ai/cmux/actions/runs/29267507687

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralizes a complete `next/navigation` mock for web tests to eliminate order-dependent CI failures and keep client hooks importable across suites. Also completes the pricing test setup by adding a `next-intl` client mock and rendering the real Pro welcome banner.

- **Bug Fixes**
  - Added `web/tests/helpers/next-navigation-mock.ts` and switched affected tests to use it.
  - Mock includes all needed exports: `redirect`, `permanentRedirect`, `notFound`, `usePathname`, `useRouter`, `useSearchParams`, `useServerInsertedHTML`.
  - Updated `app-pro-welcome-page`, `app-pricing-page`, `billing-success-page`, and `pricing-page` tests to use the shared, process-wide mock; `pricing-page` now renders the real Pro welcome banner and uses a `next-intl` client mock.
  - Added a regression test to ensure client navigation components still import after installing the mock.

<sup>Written for commit 1c6cf5543f52d8de979834c717473b38b4c685c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Standardized how `next/navigation` is mocked across pricing, billing-success, and app-pro welcome page tests using a shared helper.
  * Added coverage ensuring welcome-page client-side navigation hooks/components remain importable after the shared mock is installed.
  * Enhanced pricing page tests with a `next-intl` client-side mock and updated snapshots by removing the `ProWelcomeBanner` stub.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->