### PR TITLE
Accelerate nightly application builds

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,10 +158,10 @@ jobs:
 
       # Xcode 26 compilation caching reuses unchanged Swift/Clang compilation
       # results even though each nightly uses a clean DerivedData directory.
-      # Rotate the immutable Actions cache key weekly: the first nightly restores
-      # the newest compatible cache and saves that week's updated snapshot, while
-      # later nightlies avoid uploading another multi-GB copy. The post-build
-      # size guard below also prevents an unexpectedly large CAS from being saved.
+      # Rotate the immutable Actions cache key weekly: the first nightly saves
+      # that week's snapshot, while later nightlies restore it without uploading
+      # another multi-GB copy. Do not fall back across weeks, so a rejected cache
+      # cannot be restored forever. The post-build guard also caps snapshot size.
       - name: Compute Xcode compilation cache key
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         id: compilation-cache-key
@@ -176,8 +176,6 @@ jobs:
         with:
           path: build-universal/CompilationCache.noindex
           key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ steps.compilation-cache-key.outputs.utc_week }}
-          restore-keys: |
-            xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
 
       # Provide node/npm explicitly. The build/sign/notarize job can land on a
       # self-hosted macOS runner (the iOS-CI minis match the same label) that has

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -158,15 +158,16 @@ jobs:
 
       # Xcode 26 compilation caching reuses unchanged Swift/Clang compilation
       # results even though each nightly uses a clean DerivedData directory.
-      # Rotate the immutable Actions cache key daily: the first nightly restores
-      # the newest compatible cache and saves that day's updated snapshot, while
-      # later nightlies avoid uploading another multi-GB copy.
+      # Rotate the immutable Actions cache key weekly: the first nightly restores
+      # the newest compatible cache and saves that week's updated snapshot, while
+      # later nightlies avoid uploading another multi-GB copy. The post-build
+      # size guard below also prevents an unexpectedly large CAS from being saved.
       - name: Compute Xcode compilation cache key
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         id: compilation-cache-key
         run: |
           set -euo pipefail
-          echo "utc_day=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          echo "utc_week=$(date -u +%Y-W%W)" >> "$GITHUB_OUTPUT"
           echo "toolchain=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Xcode compilation results
@@ -174,7 +175,7 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build-universal/CompilationCache.noindex
-          key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ steps.compilation-cache-key.outputs.utc_day }}
+          key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ steps.compilation-cache-key.outputs.utc_week }}
           restore-keys: |
             xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
 
@@ -284,6 +285,23 @@ jobs:
           if [ "$HELPER_STATUS" -ne 0 ]; then
             echo "Universal Ghostty CLI helper build failed" >&2
             exit "$HELPER_STATUS"
+          fi
+
+      - name: Bound Xcode compilation cache size
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        run: |
+          set -euo pipefail
+          cache_path="build-universal/CompilationCache.noindex"
+          max_cache_kib=$((3 * 1024 * 1024))
+          if [ -d "$cache_path" ]; then
+            cache_kib=$(du -sk "$cache_path" | awk '{print $1}')
+          else
+            cache_kib=0
+          fi
+          echo "Xcode compilation cache size: ${cache_kib} KiB (limit: ${max_cache_kib} KiB)"
+          if [ "$cache_kib" -gt "$max_cache_kib" ]; then
+            echo "Xcode compilation cache exceeds 3 GiB; skipping this week's cache save"
+            rm -rf "$cache_path"
           fi
 
       - name: Inject universal Ghostty CLI helper

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -156,6 +156,28 @@ jobs:
           set -euo pipefail
           ./scripts/select-nightly-xcodes.sh
 
+      # Xcode 26 compilation caching reuses unchanged Swift/Clang compilation
+      # results even though each nightly uses a clean DerivedData directory.
+      # Rotate the immutable Actions cache key daily: the first nightly restores
+      # the newest compatible cache and saves that day's updated snapshot, while
+      # later nightlies avoid uploading another multi-GB copy.
+      - name: Compute Xcode compilation cache key
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        id: compilation-cache-key
+        run: |
+          set -euo pipefail
+          echo "utc_day=$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
+          echo "toolchain=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Xcode compilation results
+        if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build-universal/CompilationCache.noindex
+          key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ steps.compilation-cache-key.outputs.utc_day }}
+          restore-keys: |
+            xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
+
       # Provide node/npm explicitly. The build/sign/notarize job can land on a
       # self-hosted macOS runner (the iOS-CI minis match the same label) that has
       # no npm on PATH, so `npm install --global create-dmg` failed with
@@ -244,8 +266,11 @@ jobs:
           CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
             -destination 'generic/platform=macOS' \
             -clonedSourcePackagesDirPath .spm-cache \
+            -showBuildTimingSummary \
             ARCHS="arm64 x86_64" \
             ONLY_ACTIVE_ARCH=NO \
+            COMPILATION_CACHE_ENABLE_CACHING=YES \
+            COMPILER_INDEX_STORE_ENABLE=NO \
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
           APP_STATUS=$?
           set -e

--- a/scripts/build_remote_daemon_release_assets.sh
+++ b/scripts/build_remote_daemon_release_assets.sh
@@ -108,6 +108,8 @@ ENTRIES_FILE="$(mktemp "${TMPDIR:-/tmp}/cmuxd-remote-entries.XXXXXX")"
 trap 'rm -f "$ENTRIES_FILE"' EXIT
 : > "$ENTRIES_FILE"
 
+BUILD_PIDS=()
+BUILD_LABELS=()
 for target in "${TARGETS[@]}"; do
   read -r GOOS GOARCH <<<"$target"
   ASSET_NAME="cmuxd-remote-${GOOS}-${GOARCH}${SUFFIX_TAG}"
@@ -116,58 +118,49 @@ for target in "${TARGETS[@]}"; do
   # Build into a temp path first, then rename (the binary content is the same
   # regardless of suffix, so we build once and move).
   BUILD_PATH="${OUTPUT_DIR}/cmuxd-remote-${GOOS}-${GOARCH}.build"
-  (
-    cd "$DAEMON_ROOT"
-    GOOS="$GOOS" \
-    GOARCH="$GOARCH" \
-    CGO_ENABLED=0 \
-    go "${DAEMON_GO_BUILD_ARGS[@]}" \
-      -o "$BUILD_PATH" \
-      ./cmd/cmuxd-remote
-  )
+  GOOS="$GOOS" \
+  GOARCH="$GOARCH" \
+  CGO_ENABLED=0 \
+  go -C "$DAEMON_ROOT" "${DAEMON_GO_BUILD_ARGS[@]}" \
+    -o "$BUILD_PATH" \
+    ./cmd/cmuxd-remote &
+  BUILD_PIDS+=("$!")
+  BUILD_LABELS+=("${GOOS}/${GOARCH}")
+done
+
+BUILD_FAILED=0
+for index in "${!BUILD_PIDS[@]}"; do
+  if ! wait "${BUILD_PIDS[$index]}"; then
+    echo "error: cmuxd-remote build failed for ${BUILD_LABELS[$index]}" >&2
+    BUILD_FAILED=1
+  fi
+done
+if [[ "$BUILD_FAILED" -ne 0 ]]; then
+  exit 1
+fi
+
+# Assemble checksums and manifest entries in stable target order after every
+# parallel build succeeds. Parallel workers only write their own binary.
+for target in "${TARGETS[@]}"; do
+  read -r GOOS GOARCH <<<"$target"
+  ASSET_NAME="cmuxd-remote-${GOOS}-${GOARCH}${SUFFIX_TAG}"
+  OUTPUT_PATH="${OUTPUT_DIR}/${ASSET_NAME}"
+  BUILD_PATH="${OUTPUT_DIR}/cmuxd-remote-${GOOS}-${GOARCH}.build"
   mv "$BUILD_PATH" "$OUTPUT_PATH"
   chmod 755 "$OUTPUT_PATH"
-
   SHA256="$(shasum -a 256 "$OUTPUT_PATH" | awk '{print $1}')"
   printf '%s  %s\n' "$SHA256" "$ASSET_NAME" >> "$CHECKSUMS_PATH"
 
   printf '%s\t%s\t%s\t%s\n' "$GOOS" "$GOARCH" "$ASSET_NAME" "$SHA256" >> "$ENTRIES_FILE"
 done
 
-python3 - <<'PY' "$VERSION" "$RELEASE_TAG" "$REPO" "$CHECKSUMS_ASSET_NAME" "$CHECKSUMS_PATH" "$MANIFEST_PATH" "$ENTRIES_FILE"
-import json
-import sys
-import urllib.parse
-from pathlib import Path
-
-version, release_tag, repo, checksums_asset_name, checksums_path, manifest_path, entries_file = sys.argv[1:]
-quoted_tag = urllib.parse.quote(release_tag, safe="")
-release_url = f"https://github.com/{repo}/releases/download/{quoted_tag}"
-checksums_url = f"{release_url}/{urllib.parse.quote(checksums_asset_name, safe='')}"
-
-entries = []
-for line in Path(entries_file).read_text(encoding="utf-8").splitlines():
-    if not line.strip():
-        continue
-    go_os, go_arch, asset_name, sha256 = line.split("\t")
-    entries.append({
-        "goOS": go_os,
-        "goArch": go_arch,
-        "assetName": asset_name,
-        "downloadURL": f"{release_url}/{urllib.parse.quote(asset_name, safe='')}",
-        "sha256": sha256,
-    })
-
-manifest = {
-    "schemaVersion": 1,
-    "appVersion": version,
-    "releaseTag": release_tag,
-    "releaseURL": release_url,
-    "checksumsAssetName": checksums_asset_name,
-    "checksumsURL": checksums_url,
-    "entries": entries,
-}
-Path(manifest_path).write_text(json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8")
-PY
+python3 "$SCRIPT_DIR/generate_remote_daemon_release_manifest.py" \
+  "$VERSION" \
+  "$RELEASE_TAG" \
+  "$REPO" \
+  "$CHECKSUMS_ASSET_NAME" \
+  "$CHECKSUMS_PATH" \
+  "$MANIFEST_PATH" \
+  "$ENTRIES_FILE"
 
 echo "Built cmuxd-remote assets in ${OUTPUT_DIR}"

--- a/scripts/ci/detect_ci_change_areas.py
+++ b/scripts/ci/detect_ci_change_areas.py
@@ -81,6 +81,7 @@ def is_web_change(path: str) -> bool:
 def is_go_change(path: str) -> bool:
     return path.startswith("daemon/remote/") or path in {
         "scripts/build_remote_daemon_release_assets.sh",
+        "scripts/generate_remote_daemon_release_manifest.py",
         "tests/test_remote_daemon_release_assets.sh",
     }
 

--- a/scripts/generate_remote_daemon_release_manifest.py
+++ b/scripts/generate_remote_daemon_release_manifest.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Generate the release manifest after parallel remote-daemon builds finish."""
+
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+
+
+def main() -> None:
+    (
+        version,
+        release_tag,
+        repo,
+        checksums_asset_name,
+        checksums_path,
+        manifest_path,
+        entries_file,
+    ) = sys.argv[1:]
+
+    quoted_tag = urllib.parse.quote(release_tag, safe="")
+    release_url = f"https://github.com/{repo}/releases/download/{quoted_tag}"
+    checksums_url = (
+        f"{release_url}/{urllib.parse.quote(checksums_asset_name, safe='')}"
+    )
+
+    entries = []
+    for line in Path(entries_file).read_text(encoding="utf-8").splitlines():
+        if not line.strip():
+            continue
+        go_os, go_arch, asset_name, sha256 = line.split("\t")
+        entries.append(
+            {
+                "goOS": go_os,
+                "goArch": go_arch,
+                "assetName": asset_name,
+                "downloadURL": (
+                    f"{release_url}/{urllib.parse.quote(asset_name, safe='')}"
+                ),
+                "sha256": sha256,
+            }
+        )
+
+    manifest = {
+        "schemaVersion": 1,
+        "appVersion": version,
+        "releaseTag": release_tag,
+        "releaseURL": release_url,
+        "checksumsAssetName": checksums_asset_name,
+        "checksumsURL": checksums_url,
+        "entries": entries,
+    }
+    Path(manifest_path).write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 8:
+        raise SystemExit(
+            "usage: generate_remote_daemon_release_manifest.py "
+            "<version> <release-tag> <repo> <checksums-asset-name> "
+            "<checksums-path> <manifest-path> <entries-file>"
+        )
+    main()

--- a/tests/test_ci_change_areas.py
+++ b/tests/test_ci_change_areas.py
@@ -140,6 +140,10 @@ def test_remote_daemon_asset_builder_runs_go_validation() -> None:
     assert_areas(["scripts/build_remote_daemon_release_assets.sh"], macos=True, web=False, go=True)
 
 
+def test_remote_daemon_manifest_generator_runs_go_validation() -> None:
+    assert_areas(["scripts/generate_remote_daemon_release_manifest.py"], macos=True, web=False, go=True)
+
+
 def test_app_source_runs_macos() -> None:
     assert_areas(["Sources/AppDelegate.swift"], macos=True, web=False, go=False)
 

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -11,11 +11,28 @@ if ! awk '
   in_universal && /-destination '\''generic\/platform=macOS'\''/ { saw_universal_destination=1 }
   in_universal && /ARCHS="arm64 x86_64"/ { saw_universal_archs=1 }
   in_universal && /ONLY_ACTIVE_ARCH=NO/ { saw_universal_only_active_arch=1 }
+  in_universal && /COMPILATION_CACHE_ENABLE_CACHING=YES/ { saw_compilation_cache=1 }
+  in_universal && /COMPILER_INDEX_STORE_ENABLE=NO/ { saw_index_disabled=1 }
+  in_universal && /-showBuildTimingSummary/ { saw_timing_summary=1 }
   END {
-    exit !(saw_universal_destination && saw_universal_archs && saw_universal_only_active_arch)
+    exit !(saw_universal_destination && saw_universal_archs && saw_universal_only_active_arch && saw_compilation_cache && saw_index_disabled && saw_timing_summary)
   }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must build the nightly app as universal arm64+x86_64"
+  echo "FAIL: nightly workflow must build the universal app with compilation caching, no index store, and timing output"
+  exit 1
+fi
+
+if ! awk '
+  /^      - name: Cache Xcode compilation results/ { in_cache=1; next }
+  in_cache && /^      - name:/ { in_cache=0 }
+  in_cache && /path: build-universal\/CompilationCache\.noindex/ { saw_path=1 }
+  in_cache && /key: xcode-compilation-nightly-/ { saw_key=1 }
+  in_cache && /steps\.compilation-cache-key\.outputs\.toolchain/ { saw_toolchain=1 }
+  in_cache && /steps\.compilation-cache-key\.outputs\.utc_day/ { saw_day=1 }
+  in_cache && /restore-keys:/ { saw_restore=1 }
+  END { exit !(saw_path && saw_key && saw_toolchain && saw_day && saw_restore) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must restore a toolchain-scoped, daily Xcode compilation cache"
   exit 1
 fi
 

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -28,11 +28,22 @@ if ! awk '
   in_cache && /path: build-universal\/CompilationCache\.noindex/ { saw_path=1 }
   in_cache && /key: xcode-compilation-nightly-/ { saw_key=1 }
   in_cache && /steps\.compilation-cache-key\.outputs\.toolchain/ { saw_toolchain=1 }
-  in_cache && /steps\.compilation-cache-key\.outputs\.utc_day/ { saw_day=1 }
+  in_cache && /steps\.compilation-cache-key\.outputs\.utc_week/ { saw_week=1 }
   in_cache && /restore-keys:/ { saw_restore=1 }
-  END { exit !(saw_path && saw_key && saw_toolchain && saw_day && saw_restore) }
+  END { exit !(saw_path && saw_key && saw_toolchain && saw_week && saw_restore) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must restore a toolchain-scoped, daily Xcode compilation cache"
+  echo "FAIL: nightly workflow must restore a toolchain-scoped, weekly Xcode compilation cache"
+  exit 1
+fi
+
+if ! awk '
+  /^      - name: Bound Xcode compilation cache size/ { in_bound=1; next }
+  in_bound && /^      - name:/ { in_bound=0 }
+  in_bound && /max_cache_kib=\$\(\(3 \* 1024 \* 1024\)\)/ { saw_limit=1 }
+  in_bound && /rm -rf "\$cache_path"/ { saw_skip_save=1 }
+  END { exit !(saw_limit && saw_skip_save) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must skip saving Xcode compilation caches larger than 3 GiB"
   exit 1
 fi
 

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -30,9 +30,9 @@ if ! awk '
   in_cache && /steps\.compilation-cache-key\.outputs\.toolchain/ { saw_toolchain=1 }
   in_cache && /steps\.compilation-cache-key\.outputs\.utc_week/ { saw_week=1 }
   in_cache && /restore-keys:/ { saw_restore=1 }
-  END { exit !(saw_path && saw_key && saw_toolchain && saw_week && saw_restore) }
+  END { exit !(saw_path && saw_key && saw_toolchain && saw_week && !saw_restore) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must restore a toolchain-scoped, weekly Xcode compilation cache"
+  echo "FAIL: nightly workflow must use one toolchain-scoped cache per week without stale fallback"
   exit 1
 fi
 


### PR DESCRIPTION
Current cmux nightlies take about 24 minutes median versus Orca's 9 minutes. This reduces repeated compilation work without changing the signed application or release topology.

- persist Xcode 26 compilation results across nightly runners with a toolchain-scoped daily cache
- disable release-build index generation and print Xcode timing summaries
- compile the four remote-daemon targets concurrently while preserving deterministic manifests
- extend nightly workflow coverage for the cache and build flags

Tests:
- `actionlint .github/workflows/nightly.yml`
- `tests/test_remote_daemon_release_assets.sh`
- `tests/test_nightly_universal_build.sh`
- nightly Xcode selection, runner guard, DMG pinning, attestation, prune, and tag-auth workflow tests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speeds up nightly builds by caching Xcode 26 compilation, disabling the index store, and parallelizing remote-daemon builds. Output binaries, signatures, and release topology remain unchanged; the cache is toolchain-scoped, rotates weekly, and skips saving if over 3 GiB.

- **Refactors**
  - Added a toolchain-scoped, weekly `actions/cache` for `build-universal/CompilationCache.noindex` with no cross-week fallback and a 3 GiB size guard.
  - Set `COMPILATION_CACHE_ENABLE_CACHING=YES`, `COMPILER_INDEX_STORE_ENABLE=NO`, and `-showBuildTimingSummary` in the Release build.
  - Built all four remote-daemon targets concurrently, then computed checksums and wrote a stable manifest.
  - Moved manifest generation into `scripts/generate_remote_daemon_release_manifest.py`.
  - Extended nightly workflow tests to enforce weekly, no-fallback caching, the 3 GiB cap, and required build flags.

<sup>Written for commit 88519a68d45fc84af9f1dba4acedd329da19fe92. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Nightly macOS builds cache Xcode compilation results to speed up subsequent builds.
  * Nightly builds now include build timing summaries.
  * Cached Xcode compilation results are size-bounded to prevent oversized uploads.
* **Release Improvements**
  * Remote daemon release assets are built in parallel for faster release turnaround.
  * Release manifests and checksum files are generated more consistently and deterministically.
* **Tests**
  * Nightly workflow validations were strengthened to confirm cache, timing, and cache-size controls.
  * CI change-area classification coverage was updated to include the release manifest generator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->