### PR TITLE
Restore titlebar icon sizing

### DIFF
--- a/Sources/Update/UpdateTitlebarAccessory.swift
+++ b/Sources/Update/UpdateTitlebarAccessory.swift
@@ -15,7 +15,7 @@ enum TitlebarControlsStyle: Int, CaseIterable, Identifiable {
     case softButtons
 
     static let storageKey = "titlebarControlsStyle"
-    static let defaultStyle = TitlebarControlsStyle.compact
+    static let defaultStyle = TitlebarControlsStyle.classic
     static var defaultRawValue: Int { defaultStyle.rawValue }
 
     var id: Int { rawValue }

--- a/cmuxTests/UpdatePillReleaseVisibilityTests.swift
+++ b/cmuxTests/UpdatePillReleaseVisibilityTests.swift
@@ -286,19 +286,19 @@ struct TitlebarControlsSizingPolicyTests {
     }
 
     @Test
-    func testTitlebarControlsDefaultStyleIsCompact() {
-        let suiteName = "TitlebarControlsDefaultStyleIsCompact-\(UUID().uuidString)"
+    func testTitlebarControlsDefaultStyleIsClassic() {
+        let suiteName = "TitlebarControlsDefaultStyleIsClassic-\(UUID().uuidString)"
         let defaults = UserDefaults(suiteName: suiteName)!
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        checkEqual(TitlebarControlsStyle.defaultStyle, .compact)
-        checkEqual(TitlebarControlsStyle.stored(in: defaults), .compact)
-
-        defaults.set(TitlebarControlsStyle.classic.rawValue, forKey: TitlebarControlsStyle.storageKey)
+        checkEqual(TitlebarControlsStyle.defaultStyle, .classic)
         checkEqual(TitlebarControlsStyle.stored(in: defaults), .classic)
 
-        defaults.set(999, forKey: TitlebarControlsStyle.storageKey)
+        defaults.set(TitlebarControlsStyle.compact.rawValue, forKey: TitlebarControlsStyle.storageKey)
         checkEqual(TitlebarControlsStyle.stored(in: defaults), .compact)
+
+        defaults.set(999, forKey: TitlebarControlsStyle.storageKey)
+        checkEqual(TitlebarControlsStyle.stored(in: defaults), .classic)
     }
 
     @Test


### PR DESCRIPTION
## Summary
- restore classic titlebar controls as the default
- keep compact controls available as an explicit style
- cover default and invalid stored-value fallback behavior

## Testing
- `xcrun swiftc -frontend -parse Sources/Update/UpdateTitlebarAccessory.swift cmuxTests/UpdatePillReleaseVisibilityTests.swift`
- tagged macOS cloud build `sbicon` passed: https://github.com/manaflow-ai/cmux/actions/runs/29303527253
- tagged debug socket identified `com.cmuxterm.app.debug.sbicon`; `debug.window.screenshot` captured the restored top-left controls
- focused `cmux-unit` execution was attempted twice, but local Xcode workers stalled before source compilation; CI will run the app-host suite

## Localization
- no user-facing strings changed

## Issues
- Plain-text task: nightly titlebar icons are smaller than main