### PR TITLE
Preserve Codex YOLO permissions across resume repair

### DIFF
--- a/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
+++ b/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
@@ -78,8 +78,16 @@ extension CMUXCLI {
         kind: String,
         current: AgentHookLaunchCommandRecord?,
         mapped: ClaudeHookSessionRecord?,
-        transcriptPath: String? = nil
+        transcriptPath: String? = nil,
+        currentPID: Int? = nil
     ) -> AgentHookLaunchCommandRecord? {
+        if kind == "codex",
+           let currentPID,
+           currentPID == mapped?.pid,
+           !codexLaunchHasExplicitPermissions(current),
+           codexLaunchHasExplicitPermissions(mapped?.launchCommand) {
+            return mapped?.launchCommand
+        }
         let selected: AgentHookLaunchCommandRecord? = {
             if normalizedHookValue(current?.source)?.lowercased() == "rejected" {
                 return current

--- a/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
+++ b/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
@@ -1,8 +1,10 @@
 import Foundation
 import CMUXAgentLaunch
 
-enum CodexLaunchPermissionPolicy {
-    static func hasExplicitArguments(_ launchCommand: AgentHookLaunchCommandRecord?) -> Bool {
+extension CMUXCLI {
+    private static let codexPermissionEvidenceTailBytes = 256 * 1024
+
+    private func codexLaunchHasExplicitPermissions(_ launchCommand: AgentHookLaunchCommandRecord?) -> Bool {
         guard let launchCommand,
               AgentLaunchCaptureTrust.launcherDescribesKind(launchCommand.launcher, kind: "codex") else {
             return false
@@ -25,12 +27,17 @@ enum CodexLaunchPermissionPolicy {
             }
             if argument == "-c" || argument == "--config",
                index + 1 < arguments.count,
-               configOverridesPermissions(arguments[index + 1]) {
+               codexConfigOverridesPermissions(arguments[index + 1]) {
                 return true
             }
             if argument.hasPrefix("-c=") || argument.hasPrefix("--config=") {
-                let value = String(argument.split(separator: "=", maxSplits: 1)[1])
-                if configOverridesPermissions(value) {
+                let components = argument.split(
+                    separator: "=",
+                    maxSplits: 1,
+                    omittingEmptySubsequences: false
+                )
+                if components.count == 2,
+                   codexConfigOverridesPermissions(String(components[1])) {
                     return true
                 }
             }
@@ -38,21 +45,11 @@ enum CodexLaunchPermissionPolicy {
         return false
     }
 
-    static func wouldDropExplicitArguments(
-        existing: AgentHookLaunchCommandRecord?,
-        incoming: AgentHookLaunchCommandRecord?
-    ) -> Bool {
-        hasExplicitArguments(existing) && !hasExplicitArguments(incoming)
-    }
-
-    private static func configOverridesPermissions(_ value: String) -> Bool {
+    private func codexConfigOverridesPermissions(_ value: String) -> Bool {
         let key = value.split(separator: "=", maxSplits: 1).first?
             .trimmingCharacters(in: .whitespacesAndNewlines)
         return key == "approval_policy" || key == "sandbox_mode"
     }
-}
-
-extension CMUXCLI {
     func agentHookSessionHasDurableResumeEvidence(
         kind: String,
         launchCommand: AgentHookLaunchCommandRecord?
@@ -80,36 +77,38 @@ extension CMUXCLI {
     func preferredAgentHookResumeLaunchCommand(
         kind: String,
         current: AgentHookLaunchCommandRecord?,
-        mapped: ClaudeHookSessionRecord?
+        mapped: ClaudeHookSessionRecord?,
+        transcriptPath: String? = nil
     ) -> AgentHookLaunchCommandRecord? {
-        if normalizedHookValue(current?.source)?.lowercased() == "rejected" {
-            return current
-        }
-        let mappedLaunchCommand = kind == "codex"
-            ? repairedCodexLaunchCommand(mapped)
-            : mapped?.launchCommand
-        if kind == "codex",
-           let current,
-           let mappedLaunchCommand,
-           !CodexLaunchPermissionPolicy.hasExplicitArguments(current),
-           CodexLaunchPermissionPolicy.hasExplicitArguments(mappedLaunchCommand) {
-            return mappedLaunchCommand
-        }
-        let currentSource = normalizedHookValue(current?.source)?.lowercased()
-        if let current, currentSource != "default", agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: current) {
-            return current
-        }
-        if let launchCommand = mappedLaunchCommand,
-           agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: launchCommand) {
-            return launchCommand
-        }
-        if let current, currentSource == "default", agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: current) {
-            return current
-        }
-        if agentHookMappedSessionHasDurableTargetEvidence(kind: kind, mapped: mapped) {
-            return nil
-        }
-        return current ?? mappedLaunchCommand
+        let selected: AgentHookLaunchCommandRecord? = {
+            if normalizedHookValue(current?.source)?.lowercased() == "rejected" {
+                return current
+            }
+            let currentSource = normalizedHookValue(current?.source)?.lowercased()
+            if let current,
+               currentSource != "default",
+               agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: current) {
+                return current
+            }
+            if let mappedLaunchCommand = mapped?.launchCommand,
+               agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: mappedLaunchCommand) {
+                return mappedLaunchCommand
+            }
+            if let current,
+               currentSource == "default",
+               agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: current) {
+                return current
+            }
+            if agentHookMappedSessionHasDurableTargetEvidence(kind: kind, mapped: mapped) {
+                return nil
+            }
+            return current ?? mapped?.launchCommand
+        }()
+        guard kind == "codex" else { return selected }
+        return repairedCodexLaunchCommand(
+            selected,
+            transcriptPath: transcriptPath
+        )
     }
 
     func preferredAgentHookResumeWorkingDirectory(
@@ -170,17 +169,20 @@ extension CMUXCLI {
     }
 
     private func repairedCodexLaunchCommand(
-        _ mapped: ClaudeHookSessionRecord?
+        _ launchCommand: AgentHookLaunchCommandRecord?,
+        transcriptPath: String?
     ) -> AgentHookLaunchCommandRecord? {
-        guard let mapped, var launchCommand = mapped.launchCommand else { return nil }
-        guard !CodexLaunchPermissionPolicy.hasExplicitArguments(launchCommand),
+        guard var launchCommand else { return nil }
+        guard !codexLaunchHasExplicitPermissions(launchCommand),
               let capturedAt = launchCommand.capturedAt,
-              let transcriptPath = normalizedHookValue(mapped.transcriptPath),
-              let permissionArguments = codexPermissionArguments(
-                  transcriptPath: transcriptPath,
-                  before: capturedAt
-              ),
-              !permissionArguments.isEmpty else {
+              let transcriptPath = normalizedHookValue(transcriptPath) else {
+            return launchCommand
+        }
+        let permissionArguments = codexPermissionArguments(
+            transcriptPath: transcriptPath,
+            before: capturedAt
+        )
+        guard !permissionArguments.isEmpty else {
             return launchCommand
         }
         launchCommand.arguments.append(contentsOf: permissionArguments)
@@ -190,17 +192,28 @@ extension CMUXCLI {
     private func codexPermissionArguments(
         transcriptPath: String,
         before capturedAt: TimeInterval
-    ) -> [String]? {
+    ) -> [String] {
         let expandedPath = (transcriptPath as NSString).expandingTildeInPath
-        guard let handle = FileHandle(forReadingAtPath: expandedPath) else { return nil }
+        guard let handle = FileHandle(forReadingAtPath: expandedPath) else { return [] }
         defer { try? handle.close() }
-        guard let data = try? handle.read(upToCount: 4 * 1024 * 1024) else { return nil }
+        guard let endOffset = try? handle.seekToEnd() else { return [] }
+        let startOffset = endOffset > UInt64(Self.codexPermissionEvidenceTailBytes)
+            ? endOffset - UInt64(Self.codexPermissionEvidenceTailBytes)
+            : 0
+        do {
+            try handle.seek(toOffset: startOffset)
+        } catch {
+            return []
+        }
+        guard var data = try? handle.readToEnd() else { return [] }
+        if startOffset > 0,
+           let firstNewline = data.firstIndex(of: 0x0A) {
+            data.removeSubrange(data.startIndex...firstNewline)
+        }
 
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        var approvalPolicy: String?
-        var sandboxMode: String?
-        for line in data.split(separator: 0x0A) {
+        for line in data.split(separator: 0x0A).reversed() {
             guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
                   object["type"] as? String == "turn_context",
                   let timestamp = object["timestamp"] as? String,
@@ -208,32 +221,31 @@ extension CMUXCLI {
                 continue
             }
             if date.timeIntervalSince1970 >= capturedAt {
-                break
+                continue
             }
             guard let payload = object["payload"] as? [String: Any] else { continue }
-            if let value = normalizedHookValue(payload["approval_policy"] as? String) {
-                approvalPolicy = value
-            }
+            let approvalPolicy = normalizedHookValue(payload["approval_policy"] as? String)
+            var sandboxMode: String?
             if let sandbox = payload["sandbox_policy"] as? [String: Any],
                let value = normalizedHookValue(sandbox["type"] as? String) {
                 sandboxMode = value
             }
+            if approvalPolicy == "never", sandboxMode == "danger-full-access" {
+                return ["--yolo"]
+            }
+            if approvalPolicy == "never", sandboxMode == "disabled" {
+                return ["--dangerously-bypass-approvals-and-sandbox"]
+            }
+            var arguments: [String] = []
+            if let approvalPolicy {
+                arguments.append(contentsOf: ["-a", approvalPolicy])
+            }
+            if let sandboxMode,
+               ["read-only", "workspace-write", "danger-full-access"].contains(sandboxMode) {
+                arguments.append(contentsOf: ["-s", sandboxMode])
+            }
+            return arguments
         }
-
-        if approvalPolicy == "never", sandboxMode == "danger-full-access" {
-            return ["--yolo"]
-        }
-        if approvalPolicy == "never", sandboxMode == "disabled" {
-            return ["--dangerously-bypass-approvals-and-sandbox"]
-        }
-        var arguments: [String] = []
-        if let approvalPolicy {
-            arguments.append(contentsOf: ["-a", approvalPolicy])
-        }
-        if let sandboxMode,
-           ["read-only", "workspace-write", "danger-full-access"].contains(sandboxMode) {
-            arguments.append(contentsOf: ["-s", sandboxMode])
-        }
-        return arguments.isEmpty ? nil : arguments
+        return []
     }
 }

--- a/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
+++ b/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
@@ -2,7 +2,7 @@ import Foundation
 import CMUXAgentLaunch
 
 extension CMUXCLI {
-    private static let codexPermissionEvidenceTailBytes = 256 * 1024
+    private static let codexPermissionEvidenceChunkBytes = 64 * 1024
 
     private func codexLaunchHasExplicitPermissions(_ launchCommand: AgentHookLaunchCommandRecord?) -> Bool {
         guard let launchCommand,
@@ -81,6 +81,9 @@ extension CMUXCLI {
         transcriptPath: String? = nil,
         currentPID: Int? = nil
     ) -> AgentHookLaunchCommandRecord? {
+        if normalizedHookValue(current?.source)?.lowercased() == "rejected" {
+            return current
+        }
         if kind == "codex",
            let currentPID,
            currentPID == mapped?.pid,
@@ -89,9 +92,6 @@ extension CMUXCLI {
             return mapped?.launchCommand
         }
         let selected: AgentHookLaunchCommandRecord? = {
-            if normalizedHookValue(current?.source)?.lowercased() == "rejected" {
-                return current
-            }
             let currentSource = normalizedHookValue(current?.source)?.lowercased()
             if let current,
                currentSource != "default",
@@ -205,55 +205,68 @@ extension CMUXCLI {
         guard let handle = FileHandle(forReadingAtPath: expandedPath) else { return [] }
         defer { try? handle.close() }
         guard let endOffset = try? handle.seekToEnd() else { return [] }
-        let startOffset = endOffset > UInt64(Self.codexPermissionEvidenceTailBytes)
-            ? endOffset - UInt64(Self.codexPermissionEvidenceTailBytes)
-            : 0
-        do {
-            try handle.seek(toOffset: startOffset)
-        } catch {
-            return []
-        }
-        guard var data = try? handle.readToEnd() else { return [] }
-        if startOffset > 0,
-           let firstNewline = data.firstIndex(of: 0x0A) {
-            data.removeSubrange(data.startIndex...firstNewline)
-        }
-
         let formatter = ISO8601DateFormatter()
         formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-        for line in data.split(separator: 0x0A).reversed() {
-            guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
-                  object["type"] as? String == "turn_context",
-                  let timestamp = object["timestamp"] as? String,
-                  let date = formatter.date(from: timestamp) else {
-                continue
+        var offset = endOffset
+        var pending = Data()
+        while offset > 0 {
+            let byteCount = min(UInt64(Self.codexPermissionEvidenceChunkBytes), offset)
+            offset -= byteCount
+            do {
+                try handle.seek(toOffset: offset)
+            } catch {
+                return []
             }
-            if date.timeIntervalSince1970 >= capturedAt {
-                continue
+            guard let chunk = try? handle.read(upToCount: Int(byteCount)) else { return [] }
+            pending.insert(contentsOf: chunk, at: pending.startIndex)
+            while let newline = pending.lastIndex(of: 0x0A) {
+                let lineStart = pending.index(after: newline)
+                let line = Data(pending[lineStart...])
+                pending.removeSubrange(newline...)
+                if let arguments = codexPermissionArguments(
+                    from: line,
+                    before: capturedAt,
+                    formatter: formatter
+                ) {
+                    return arguments
+                }
             }
-            guard let payload = object["payload"] as? [String: Any] else { continue }
-            let approvalPolicy = normalizedHookValue(payload["approval_policy"] as? String)
-            var sandboxMode: String?
-            if let sandbox = payload["sandbox_policy"] as? [String: Any],
-               let value = normalizedHookValue(sandbox["type"] as? String) {
-                sandboxMode = value
-            }
-            if approvalPolicy == "never", sandboxMode == "danger-full-access" {
-                return ["--yolo"]
-            }
-            if approvalPolicy == "never", sandboxMode == "disabled" {
-                return ["--dangerously-bypass-approvals-and-sandbox"]
-            }
-            var arguments: [String] = []
-            if let approvalPolicy {
-                arguments.append(contentsOf: ["-a", approvalPolicy])
-            }
-            if let sandboxMode,
-               ["read-only", "workspace-write", "danger-full-access"].contains(sandboxMode) {
-                arguments.append(contentsOf: ["-s", sandboxMode])
-            }
-            return arguments
         }
-        return []
+        return codexPermissionArguments(from: pending, before: capturedAt, formatter: formatter) ?? []
+    }
+
+    private func codexPermissionArguments(
+        from line: Data,
+        before capturedAt: TimeInterval,
+        formatter: ISO8601DateFormatter
+    ) -> [String]? {
+        guard !line.isEmpty,
+              let object = try? JSONSerialization.jsonObject(with: line) as? [String: Any],
+              object["type"] as? String == "turn_context",
+              let timestamp = object["timestamp"] as? String,
+              let date = formatter.date(from: timestamp),
+              date.timeIntervalSince1970 < capturedAt,
+              let payload = object["payload"] as? [String: Any] else {
+            return nil
+        }
+        let approvalPolicy = normalizedHookValue(payload["approval_policy"] as? String)
+        let sandboxMode = (payload["sandbox_policy"] as? [String: Any]).flatMap {
+            normalizedHookValue($0["type"] as? String)
+        }
+        if approvalPolicy == "never", sandboxMode == "danger-full-access" {
+            return ["--yolo"]
+        }
+        if approvalPolicy == "never", sandboxMode == "disabled" {
+            return ["--dangerously-bypass-approvals-and-sandbox"]
+        }
+        var arguments: [String] = []
+        if let approvalPolicy {
+            arguments.append(contentsOf: ["-a", approvalPolicy])
+        }
+        if let sandboxMode,
+           ["read-only", "workspace-write", "danger-full-access"].contains(sandboxMode) {
+            arguments.append(contentsOf: ["-s", sandboxMode])
+        }
+        return arguments.isEmpty ? nil : arguments
     }
 }

--- a/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
+++ b/CLI/CMUXCLI+AgentHookRestoreEvidence.swift
@@ -1,4 +1,56 @@
 import Foundation
+import CMUXAgentLaunch
+
+enum CodexLaunchPermissionPolicy {
+    static func hasExplicitArguments(_ launchCommand: AgentHookLaunchCommandRecord?) -> Bool {
+        guard let launchCommand,
+              AgentLaunchCaptureTrust.launcherDescribesKind(launchCommand.launcher, kind: "codex") else {
+            return false
+        }
+        let arguments = launchCommand.arguments
+        for (index, argument) in arguments.enumerated() {
+            if [
+                "--yolo",
+                "--full-auto",
+                "--dangerously-bypass-approvals-and-sandbox",
+                "-a",
+                "--ask-for-approval",
+                "-s",
+                "--sandbox",
+            ].contains(argument) {
+                return true
+            }
+            if argument.hasPrefix("--ask-for-approval=") || argument.hasPrefix("--sandbox=") {
+                return true
+            }
+            if argument == "-c" || argument == "--config",
+               index + 1 < arguments.count,
+               configOverridesPermissions(arguments[index + 1]) {
+                return true
+            }
+            if argument.hasPrefix("-c=") || argument.hasPrefix("--config=") {
+                let value = String(argument.split(separator: "=", maxSplits: 1)[1])
+                if configOverridesPermissions(value) {
+                    return true
+                }
+            }
+        }
+        return false
+    }
+
+    static func wouldDropExplicitArguments(
+        existing: AgentHookLaunchCommandRecord?,
+        incoming: AgentHookLaunchCommandRecord?
+    ) -> Bool {
+        hasExplicitArguments(existing) && !hasExplicitArguments(incoming)
+    }
+
+    private static func configOverridesPermissions(_ value: String) -> Bool {
+        let key = value.split(separator: "=", maxSplits: 1).first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return key == "approval_policy" || key == "sandbox_mode"
+    }
+}
 
 extension CMUXCLI {
     func agentHookSessionHasDurableResumeEvidence(
@@ -33,11 +85,21 @@ extension CMUXCLI {
         if normalizedHookValue(current?.source)?.lowercased() == "rejected" {
             return current
         }
+        let mappedLaunchCommand = kind == "codex"
+            ? repairedCodexLaunchCommand(mapped)
+            : mapped?.launchCommand
+        if kind == "codex",
+           let current,
+           let mappedLaunchCommand,
+           !CodexLaunchPermissionPolicy.hasExplicitArguments(current),
+           CodexLaunchPermissionPolicy.hasExplicitArguments(mappedLaunchCommand) {
+            return mappedLaunchCommand
+        }
         let currentSource = normalizedHookValue(current?.source)?.lowercased()
         if let current, currentSource != "default", agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: current) {
             return current
         }
-        if let launchCommand = mapped?.launchCommand,
+        if let launchCommand = mappedLaunchCommand,
            agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: launchCommand) {
             return launchCommand
         }
@@ -47,7 +109,7 @@ extension CMUXCLI {
         if agentHookMappedSessionHasDurableTargetEvidence(kind: kind, mapped: mapped) {
             return nil
         }
-        return current ?? mapped?.launchCommand
+        return current ?? mappedLaunchCommand
     }
 
     func preferredAgentHookResumeWorkingDirectory(
@@ -105,5 +167,73 @@ extension CMUXCLI {
         normalizedHookValue(environment?["CODEX_HOME"]) == nil
             && (normalizedHookValue(environment?["ANTHROPIC_BASE_URL"]) != nil
                 || normalizedHookValue(environment?["CLAUDE_CONFIG_DIR"]) != nil)
+    }
+
+    private func repairedCodexLaunchCommand(
+        _ mapped: ClaudeHookSessionRecord?
+    ) -> AgentHookLaunchCommandRecord? {
+        guard let mapped, var launchCommand = mapped.launchCommand else { return nil }
+        guard !CodexLaunchPermissionPolicy.hasExplicitArguments(launchCommand),
+              let capturedAt = launchCommand.capturedAt,
+              let transcriptPath = normalizedHookValue(mapped.transcriptPath),
+              let permissionArguments = codexPermissionArguments(
+                  transcriptPath: transcriptPath,
+                  before: capturedAt
+              ),
+              !permissionArguments.isEmpty else {
+            return launchCommand
+        }
+        launchCommand.arguments.append(contentsOf: permissionArguments)
+        return launchCommand
+    }
+
+    private func codexPermissionArguments(
+        transcriptPath: String,
+        before capturedAt: TimeInterval
+    ) -> [String]? {
+        let expandedPath = (transcriptPath as NSString).expandingTildeInPath
+        guard let handle = FileHandle(forReadingAtPath: expandedPath) else { return nil }
+        defer { try? handle.close() }
+        guard let data = try? handle.read(upToCount: 4 * 1024 * 1024) else { return nil }
+
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        var approvalPolicy: String?
+        var sandboxMode: String?
+        for line in data.split(separator: 0x0A) {
+            guard let object = try? JSONSerialization.jsonObject(with: Data(line)) as? [String: Any],
+                  object["type"] as? String == "turn_context",
+                  let timestamp = object["timestamp"] as? String,
+                  let date = formatter.date(from: timestamp) else {
+                continue
+            }
+            if date.timeIntervalSince1970 >= capturedAt {
+                break
+            }
+            guard let payload = object["payload"] as? [String: Any] else { continue }
+            if let value = normalizedHookValue(payload["approval_policy"] as? String) {
+                approvalPolicy = value
+            }
+            if let sandbox = payload["sandbox_policy"] as? [String: Any],
+               let value = normalizedHookValue(sandbox["type"] as? String) {
+                sandboxMode = value
+            }
+        }
+
+        if approvalPolicy == "never", sandboxMode == "danger-full-access" {
+            return ["--yolo"]
+        }
+        if approvalPolicy == "never", sandboxMode == "disabled" {
+            return ["--dangerously-bypass-approvals-and-sandbox"]
+        }
+        var arguments: [String] = []
+        if let approvalPolicy {
+            arguments.append(contentsOf: ["-a", approvalPolicy])
+        }
+        if let sandboxMode,
+           ["read-only", "workspace-write", "danger-full-access"].contains(sandboxMode) {
+            arguments.append(contentsOf: ["-s", sandboxMode])
+        }
+        return arguments.isEmpty ? nil : arguments
     }
 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30645,19 +30645,11 @@ export default CMUXSessionRestore;
             let workspaceId = target.workspaceId
             let surfaceId = target.surfaceId
             let pid = mapped?.pid ?? inferredPID
-            let launchCommand = agentLaunchCommandFromEnvironment(
-                env,
-                fallbackPID: pid,
-                fallbackKind: def.name,
-                cwd: hookCwd ?? mapped?.cwd
-            )
+            let launchCommand = agentLaunchCommandFromEnvironment(env, fallbackPID: pid, fallbackKind: def.name, cwd: hookCwd ?? mapped?.cwd)
             let transcriptPathForStore = input.transcriptPath ?? mapped?.transcriptPath
             let resumeLaunchCommand = preferredAgentHookResumeLaunchCommand(
-                kind: def.name,
-                current: launchCommand,
-                mapped: mapped,
-                transcriptPath: transcriptPathForStore,
-                currentPID: pid
+                kind: def.name, current: launchCommand, mapped: mapped,
+                transcriptPath: transcriptPathForStore, currentPID: pid
             )
             let activePromptTurnStack = mapped?.activePromptTurnIds?
                 .compactMap({ normalizedHookValue($0) }) ?? []

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30521,6 +30521,10 @@ export default CMUXSessionRestore;
                 fallbackKind: def.name,
                 cwd: hookCwd ?? mapped?.cwd
             )
+            let resumeLaunchCommand = preferredAgentHookResumeLaunchCommand(
+                kind: def.name, current: launchCommand, mapped: mapped,
+                transcriptPath: input.transcriptPath ?? mapped?.transcriptPath, currentPID: pid
+            )
             func codexSessionStartWentStaleAfterAccept() -> Bool {
                 def.name == "codex" && ((try? store.codexSessionStartIsStale(
                     sessionId: sessionId,
@@ -30538,7 +30542,7 @@ export default CMUXSessionRestore;
                         cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
                         transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         pid: pid,
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
+                        launchCommand: resumeLaunchCommand,
                         agentLifecycle: .unknown,
                         runtimeStatus: suppressVisibleMutations ? nil : .running,
                         updateRuntimeStatus: !suppressVisibleMutations
@@ -30551,7 +30555,7 @@ export default CMUXSessionRestore;
                         cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
                         transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         pid: pid,
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
+                        launchCommand: resumeLaunchCommand,
                         agentLifecycle: .unknown,
                         runtimeStatus: suppressVisibleMutations ? nil : .running,
                         updateRuntimeStatus: !suppressVisibleMutations
@@ -30611,7 +30615,7 @@ export default CMUXSessionRestore;
                         displayName: def.displayName,
                         sessionId: sessionId,
                         cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid)
+                        launchCommand: resumeLaunchCommand
                     )
                 }
             }
@@ -31019,6 +31023,10 @@ export default CMUXSessionRestore;
             let rawCwd = hookCwd ?? mapped?.cwd
             let launchCommand = agentLaunchCommandFromEnvironment(env, fallbackPID: pid, fallbackKind: def.name, cwd: rawCwd)
             let cwd = preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped)
+            let resumeLaunchCommand = preferredAgentHookResumeLaunchCommand(
+                kind: def.name, current: launchCommand, mapped: mapped,
+                transcriptPath: input.transcriptPath ?? mapped?.transcriptPath, currentPID: pid
+            )
             let grokAssistantMessage: String? = {
                 guard def.name == "grok" else { return nil }
                 return latestGrokAssistantMessage(
@@ -31104,7 +31112,7 @@ export default CMUXSessionRestore;
                     turnId: input.turnId,
                     terminalActivePromptTurnIds: terminalActivePromptTurnIdsForStop,
                     pid: pid,
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
+                    launchCommand: resumeLaunchCommand,
                     agentLifecycle: lifecycleAfterStop,
                     lastSubtitle: nil,
                     lastBody: nil,
@@ -31131,7 +31139,7 @@ export default CMUXSessionRestore;
                 try? store.upsert(sessionId: sessionId, workspaceId: workspaceId, surfaceId: surfaceId, cwd: cwd,
                                   transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                                   pid: pid,
-                                  launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
+                                  launchCommand: resumeLaunchCommand,
                                   agentLifecycle: lifecycleAfterStop,
                                   lastSubtitle: subtitle,
                                   lastBody: body,
@@ -31147,7 +31155,7 @@ export default CMUXSessionRestore;
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: cwd,
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid)
+                    launchCommand: resumeLaunchCommand
                 )
             }
             if let pid, !suppressVisibleMutations {
@@ -31326,6 +31334,10 @@ export default CMUXSessionRestore;
                 fallbackKind: def.name,
                 cwd: hookCwd ?? mapped?.cwd
             )
+            let resumeLaunchCommand = preferredAgentHookResumeLaunchCommand(
+                kind: def.name, current: launchCommand, mapped: mapped,
+                transcriptPath: input.transcriptPath ?? mapped?.transcriptPath, currentPID: pid
+            )
             let suppressVisibleMutations = shouldSuppressNestedAgentVisibleMutations(currentAgentPID: pid, env: env)
             if !sessionId.isEmpty, !suppressVisibleMutations {
                 try? store.markNotificationResolved(
@@ -31335,7 +31347,7 @@ export default CMUXSessionRestore;
                     cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
                     transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                     pid: pid,
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
+                    launchCommand: resumeLaunchCommand,
                     agentLifecycle: .running,
                     runtimeStatus: .running
                 )
@@ -31347,7 +31359,7 @@ export default CMUXSessionRestore;
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid)
+                    launchCommand: resumeLaunchCommand
                 )
             }
             if let pid, !suppressVisibleMutations {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1110,9 +1110,9 @@ final class ClaudeHookSessionStore {
             // Persist an argv-bearing record always. Persist an argv-less, env-only record (the
             // CODEX_HOME / CLAUDE_CONFIG_DIR fallback for a plain agent whose launch argv couldn't be
             // captured) only when we don't already hold an argv-bearing one — so the durable store
-            // keeps the non-default home for the fork/resume path. A bare Codex argv cannot erase an
-            // explicit mode; changing it requires an option, so generated resumes cannot drop `--yolo`.
-            if (incomingHasArguments && !CodexLaunchPermissionPolicy.wouldDropExplicitArguments(existing: record.launchCommand, incoming: launchCommand)) || normalizeOptional(launchCommand.source)?.lowercased() == "rejected" || (normalizeOptional(launchCommand.source)?.lowercased() == "default" && !existingHasArguments && normalizeOptional(record.launchCommand?.environment?["CODEX_HOME"]) == nil) || (incomingHasEnvironment && !existingHasArguments) {
+            // keeps the non-default home for the fork/resume path without ever downgrading a richer
+            // earlier capture to an env-only stub.
+            if incomingHasArguments || normalizeOptional(launchCommand.source)?.lowercased() == "rejected" || (normalizeOptional(launchCommand.source)?.lowercased() == "default" && !existingHasArguments && normalizeOptional(record.launchCommand?.environment?["CODEX_HOME"]) == nil) || (incomingHasEnvironment && !existingHasArguments) {
                 record.launchCommand = launchCommand
             }
         }
@@ -30652,6 +30652,12 @@ export default CMUXSessionRestore;
                 cwd: hookCwd ?? mapped?.cwd
             )
             let transcriptPathForStore = input.transcriptPath ?? mapped?.transcriptPath
+            let resumeLaunchCommand = preferredAgentHookResumeLaunchCommand(
+                kind: def.name,
+                current: launchCommand,
+                mapped: mapped,
+                transcriptPath: transcriptPathForStore
+            )
             let activePromptTurnStack = mapped?.activePromptTurnIds?
                 .compactMap({ normalizedHookValue($0) }) ?? []
             let activePromptTurnId = activePromptTurnStack.last ?? normalizedHookValue(mapped?.activePromptTurnId)
@@ -30791,7 +30797,7 @@ export default CMUXSessionRestore;
                         previousActivePromptTurnIsTerminal: previousActivePromptTurnIsTerminal,
                         terminalActivePromptTurnIds: terminalActivePromptTurnIds,
                         pid: pid,
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped),
+                        launchCommand: resumeLaunchCommand,
                         agentLifecycle: .running,
                         autoNameMessages: autoNamingMessages(
                             for: def,
@@ -30848,7 +30854,7 @@ export default CMUXSessionRestore;
                         transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         turnId: input.turnId,
                         pid: pid,
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped)
+                        launchCommand: resumeLaunchCommand
                     )) ?? false
                 } else {
                     try? store.upsert(
@@ -30858,7 +30864,7 @@ export default CMUXSessionRestore;
                         cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
                         transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         pid: pid,
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped),
+                        launchCommand: resumeLaunchCommand,
                         agentLifecycle: .running,
                         runtimeStatus: .running,
                         updateRuntimeStatus: true
@@ -30878,7 +30884,7 @@ export default CMUXSessionRestore;
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped)
+                    launchCommand: resumeLaunchCommand
                 )
                 if codexPromptTurnWentTerminal() {
                     stopStaleCodexPromptSubmit(restoreVisibleState: true)

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30538,7 +30538,7 @@ export default CMUXSessionRestore;
                         cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
                         transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         pid: pid,
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped),
+                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
                         agentLifecycle: .unknown,
                         runtimeStatus: suppressVisibleMutations ? nil : .running,
                         updateRuntimeStatus: !suppressVisibleMutations
@@ -30551,7 +30551,7 @@ export default CMUXSessionRestore;
                         cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
                         transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                         pid: pid,
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped),
+                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
                         agentLifecycle: .unknown,
                         runtimeStatus: suppressVisibleMutations ? nil : .running,
                         updateRuntimeStatus: !suppressVisibleMutations
@@ -30611,7 +30611,7 @@ export default CMUXSessionRestore;
                         displayName: def.displayName,
                         sessionId: sessionId,
                         cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
-                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped)
+                        launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid)
                     )
                 }
             }
@@ -30656,7 +30656,8 @@ export default CMUXSessionRestore;
                 kind: def.name,
                 current: launchCommand,
                 mapped: mapped,
-                transcriptPath: transcriptPathForStore
+                transcriptPath: transcriptPathForStore,
+                currentPID: pid
             )
             let activePromptTurnStack = mapped?.activePromptTurnIds?
                 .compactMap({ normalizedHookValue($0) }) ?? []
@@ -31111,7 +31112,7 @@ export default CMUXSessionRestore;
                     turnId: input.turnId,
                     terminalActivePromptTurnIds: terminalActivePromptTurnIdsForStop,
                     pid: pid,
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped),
+                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
                     agentLifecycle: lifecycleAfterStop,
                     lastSubtitle: nil,
                     lastBody: nil,
@@ -31138,7 +31139,7 @@ export default CMUXSessionRestore;
                 try? store.upsert(sessionId: sessionId, workspaceId: workspaceId, surfaceId: surfaceId, cwd: cwd,
                                   transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                                   pid: pid,
-                                  launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped),
+                                  launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
                                   agentLifecycle: lifecycleAfterStop,
                                   lastSubtitle: subtitle,
                                   lastBody: body,
@@ -31154,7 +31155,7 @@ export default CMUXSessionRestore;
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: cwd,
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped)
+                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid)
                 )
             }
             if let pid, !suppressVisibleMutations {
@@ -31342,7 +31343,7 @@ export default CMUXSessionRestore;
                     cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
                     transcriptPath: input.transcriptPath ?? mapped?.transcriptPath,
                     pid: pid,
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped),
+                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid),
                     agentLifecycle: .running,
                     runtimeStatus: .running
                 )
@@ -31354,7 +31355,7 @@ export default CMUXSessionRestore;
                     displayName: def.displayName,
                     sessionId: sessionId,
                     cwd: preferredAgentHookResumeWorkingDirectory(kind: def.name, current: launchCommand, currentCwd: hookCwd, mapped: mapped),
-                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped)
+                    launchCommand: preferredAgentHookResumeLaunchCommand(kind: def.name, current: launchCommand, mapped: mapped, currentPID: pid)
                 )
             }
             if let pid, !suppressVisibleMutations {

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -1110,9 +1110,9 @@ final class ClaudeHookSessionStore {
             // Persist an argv-bearing record always. Persist an argv-less, env-only record (the
             // CODEX_HOME / CLAUDE_CONFIG_DIR fallback for a plain agent whose launch argv couldn't be
             // captured) only when we don't already hold an argv-bearing one — so the durable store
-            // keeps the non-default home for the fork/resume path without ever downgrading a richer
-            // earlier capture to an env-only stub.
-            if incomingHasArguments || normalizeOptional(launchCommand.source)?.lowercased() == "rejected" || (normalizeOptional(launchCommand.source)?.lowercased() == "default" && !existingHasArguments && normalizeOptional(record.launchCommand?.environment?["CODEX_HOME"]) == nil) || (incomingHasEnvironment && !existingHasArguments) {
+            // keeps the non-default home for the fork/resume path. A bare Codex argv cannot erase an
+            // explicit mode; changing it requires an option, so generated resumes cannot drop `--yolo`.
+            if (incomingHasArguments && !CodexLaunchPermissionPolicy.wouldDropExplicitArguments(existing: record.launchCommand, incoming: launchCommand)) || normalizeOptional(launchCommand.source)?.lowercased() == "rejected" || (normalizeOptional(launchCommand.source)?.lowercased() == "default" && !existingHasArguments && normalizeOptional(record.launchCommand?.environment?["CODEX_HOME"]) == nil) || (incomingHasEnvironment && !existingHasArguments) {
                 record.launchCommand = launchCommand
             }
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -366,6 +366,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */; };
 		C0D3F1F10000000000000103 /* CLICodexHookTimeoutRegressionTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F10000000000000104 /* CLICodexHookTimeoutRegressionTestSupport.swift */; };
 		C6711A010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6711B010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift */; };
+		C0D3F1F20000000000000103 /* CLICodexYoloResumePersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D3F1F20000000000000104 /* CLICodexYoloResumePersistenceTests.swift */; };
 		E295EA3753206FE3FFCA6C0A /* CLIExplicitSurfaceRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */; };
 		C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */; };
 		C46790000000000000000003 /* CLIForwardingLaunchRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */; };
@@ -2224,6 +2225,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTests.swift; sourceTree = "<group>"; };
 		C0D3F1F10000000000000104 /* CLICodexHookTimeoutRegressionTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexHookTimeoutRegressionTestSupport.swift; sourceTree = "<group>"; };
 		C6711B010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexWeakEnvironmentRestoreBindingTests.swift; sourceTree = "<group>"; };
+		C0D3F1F20000000000000104 /* CLICodexYoloResumePersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLICodexYoloResumePersistenceTests.swift; sourceTree = "<group>"; };
 		1590EE4F01FEF02D40A48698 /* CLIExplicitSurfaceRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIExplicitSurfaceRoutingTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000002 /* CLIForwardingLaunchArgumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CLIForwardingLaunchArgumentTests.swift; sourceTree = "<group>"; };
 		C46790000000000000000004 /* CLIForwardingLaunchRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CLIForwardingLaunchRouter.swift; sourceTree = "<group>"; };
@@ -5448,6 +5450,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B05553B10000000000000002 /* CLITmuxCompatRemoteSplitTests.swift */,
 				7837E0067837E0067837E006 /* CLITmuxCompatResizePaneTests.swift */,
 				C0D3F1F00000000000000104 /* CLICodexHookTimeoutRegressionTests.swift */,
+				C0D3F1F20000000000000104 /* CLICodexYoloResumePersistenceTests.swift */,
 				C0D3F1F10000000000000104 /* CLICodexHookTimeoutRegressionTestSupport.swift */,
 				C6711B010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift */,
 				A5D41208A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift */,
@@ -7278,6 +7281,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0D3F1F00000000000000103 /* CLICodexHookTimeoutRegressionTests.swift in Sources */,
 				C0D3F1F10000000000000103 /* CLICodexHookTimeoutRegressionTestSupport.swift in Sources */,
 				C6711A010000000000000001 /* CLICodexWeakEnvironmentRestoreBindingTests.swift in Sources */,
+				C0D3F1F20000000000000103 /* CLICodexYoloResumePersistenceTests.swift in Sources */,
 					E295EA3753206FE3FFCA6C0A /* CLIExplicitSurfaceRoutingTests.swift in Sources */,
 				C46790000000000000000001 /* CLIForwardingLaunchArgumentTests.swift in Sources */,
 				A5D41207A1B2C3D4E5F60718 /* CLIGenericHookPersistenceTests.swift in Sources */,

--- a/cmuxTests/CLICodexYoloResumePersistenceTests.swift
+++ b/cmuxTests/CLICodexYoloResumePersistenceTests.swift
@@ -3,14 +3,27 @@ import XCTest
 import Darwin
 
 extension CLINotifyProcessIntegrationRegressionTests {
-    /// A weak, nonempty Codex argv must neither replace `--yolo` nor prevent repairing a legacy
-    /// binding from the rollout context immediately preceding its capture.
-    func testCodexHookPreservesOrRepairsStoredYoloLaunch() throws {
+    /// A bare Codex argv must persist the current turn's effective permissions, including when a
+    /// legacy record lacks a transcript path or an older policy falls outside the rollout tail.
+    func testCodexHookRepairsStoredPermissionsFromCurrentTurn() throws {
         let cliPath = try bundledCLIPath()
         let executable = "/Users/example/.bun/bin/codex"
-        let scenarios: [(name: String, storedArguments: [String], hasRollout: Bool)] = [
-            ("rich", [executable, "--yolo"], false),
-            ("legacy-bare", [executable], true),
+        let scenarios: [(
+            name: String,
+            storedArguments: [String],
+            approvalPolicy: String,
+            sandboxMode: String,
+            prefixBytes: Int,
+            expectedArguments: [String]
+        )] = [
+            (
+                "legacy-bare", [executable], "never", "danger-full-access", 4 * 1024 * 1024 + 1,
+                [executable, "--yolo"]
+            ),
+            (
+                "current-plain", [executable, "--yolo"], "on-request", "workspace-write", 0,
+                [executable, "-a", "on-request", "-s", "workspace-write"]
+            ),
         ]
 
         for (index, scenario) in scenarios.enumerated() {
@@ -32,14 +45,17 @@ extension CLINotifyProcessIntegrationRegressionTests {
 
             let now = Date().timeIntervalSince1970
             let transcriptURL = root.appendingPathComponent("rollout.jsonl")
-            if scenario.hasRollout {
-                let formatter = ISO8601DateFormatter()
-                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
-                let timestamp = formatter.string(from: Date(timeIntervalSince1970: now - 120))
-                let line = #"{"timestamp":"\#(timestamp)","type":"turn_context","payload":{"approval_policy":"never","sandbox_policy":{"type":"danger-full-access"}}}"#
-                try (line + "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
-            }
-            var record: [String: Any] = [
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            let timestamp = formatter.string(from: Date(timeIntervalSince1970: now - 120))
+            let padding = String(repeating: "x", count: scenario.prefixBytes)
+            let line = #"{"timestamp":"\#(timestamp)","type":"turn_context","payload":{"approval_policy":"\#(scenario.approvalPolicy)","sandbox_policy":{"type":"\#(scenario.sandboxMode)"}}}"#
+            try (padding + "\n" + line + "\n").write(
+                to: transcriptURL,
+                atomically: true,
+                encoding: .utf8
+            )
+            let record: [String: Any] = [
                 "sessionId": sessionId, "workspaceId": workspaceId, "surfaceId": surfaceId,
                 "cwd": root.path, "startedAt": now - 300, "updatedAt": now,
                 "launchCommand": [
@@ -48,7 +64,6 @@ extension CLINotifyProcessIntegrationRegressionTests {
                     "capturedAt": now - 60, "source": "environment",
                 ],
             ]
-            if scenario.hasRollout { record["transcriptPath"] = transcriptURL.path }
             let storeURL = root.appendingPathComponent("codex-hook-sessions.json")
             try JSONSerialization.data(
                 withJSONObject: ["version": 1, "sessions": [sessionId: record]],
@@ -92,7 +107,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 executablePath: cliPath,
                 arguments: ["hooks", "codex", "prompt-submit"],
                 environment: environment,
-                standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#,
+                standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(root.path)","transcript_path":"\#(transcriptURL.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#,
                 timeout: 5
             )
             wait(for: [serverHandled], timeout: 5)
@@ -103,7 +118,11 @@ extension CLINotifyProcessIntegrationRegressionTests {
             let sessions = try XCTUnwrap(json["sessions"] as? [String: Any])
             let persisted = try XCTUnwrap(sessions[sessionId] as? [String: Any])
             let launchCommand = try XCTUnwrap(persisted["launchCommand"] as? [String: Any])
-            XCTAssertEqual(launchCommand["arguments"] as? [String], [executable, "--yolo"], scenario.name)
+            XCTAssertEqual(
+                launchCommand["arguments"] as? [String],
+                scenario.expectedArguments,
+                scenario.name
+            )
 
             let commands = state.snapshot()
             let resumeParams = commands.compactMap { command -> [String: Any]? in
@@ -112,7 +131,9 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 return payload["params"] as? [String: Any]
             }.last
             let command = try XCTUnwrap(resumeParams?["command"] as? String, commands.joined(separator: "\n"))
-            XCTAssertTrue(command.contains("'--yolo'"), "\(scenario.name): \(command)")
+            for argument in scenario.expectedArguments.dropFirst() {
+                XCTAssertTrue(command.contains("'\(argument)'"), "\(scenario.name): \(command)")
+            }
         }
     }
 }

--- a/cmuxTests/CLICodexYoloResumePersistenceTests.swift
+++ b/cmuxTests/CLICodexYoloResumePersistenceTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import XCTest
+import Darwin
+
+extension CLINotifyProcessIntegrationRegressionTests {
+    /// A weak, nonempty Codex argv must neither replace `--yolo` nor prevent repairing a legacy
+    /// binding from the rollout context immediately preceding its capture.
+    func testCodexHookPreservesOrRepairsStoredYoloLaunch() throws {
+        let cliPath = try bundledCLIPath()
+        let executable = "/Users/example/.bun/bin/codex"
+        let scenarios: [(name: String, storedArguments: [String], hasRollout: Bool)] = [
+            ("rich", [executable, "--yolo"], false),
+            ("legacy-bare", [executable], true),
+        ]
+
+        for (index, scenario) in scenarios.enumerated() {
+            let socketPath = makeSocketPath("codex-yolo-\(scenario.name)")
+            let listenerFD = try bindUnixSocket(at: socketPath)
+            let state = MockSocketServerState()
+            let root = FileManager.default.temporaryDirectory
+                .appendingPathComponent("cmux-codex-yolo-\(UUID().uuidString)", isDirectory: true)
+            let workspaceId = "11111111-1111-1111-1111-111111111111"
+            let surfaceId = "22222222-2222-2222-2222-222222222222"
+            let sessionId = "codex-yolo-\(scenario.name)-session"
+            let ttyName = "ttys30\(index + 3)"
+            try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+            defer {
+                Darwin.close(listenerFD)
+                unlink(socketPath)
+                try? FileManager.default.removeItem(at: root)
+            }
+
+            let now = Date().timeIntervalSince1970
+            let transcriptURL = root.appendingPathComponent("rollout.jsonl")
+            if scenario.hasRollout {
+                let formatter = ISO8601DateFormatter()
+                formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+                let timestamp = formatter.string(from: Date(timeIntervalSince1970: now - 120))
+                let line = #"{"timestamp":"\#(timestamp)","type":"turn_context","payload":{"approval_policy":"never","sandbox_policy":{"type":"danger-full-access"}}}"#
+                try (line + "\n").write(to: transcriptURL, atomically: true, encoding: .utf8)
+            }
+            var record: [String: Any] = [
+                "sessionId": sessionId, "workspaceId": workspaceId, "surfaceId": surfaceId,
+                "cwd": root.path, "startedAt": now - 300, "updatedAt": now,
+                "launchCommand": [
+                    "launcher": "codex", "executablePath": executable,
+                    "arguments": scenario.storedArguments, "workingDirectory": root.path,
+                    "capturedAt": now - 60, "source": "environment",
+                ],
+            ]
+            if scenario.hasRollout { record["transcriptPath"] = transcriptURL.path }
+            let storeURL = root.appendingPathComponent("codex-hook-sessions.json")
+            try JSONSerialization.data(
+                withJSONObject: ["version": 1, "sessions": [sessionId: record]],
+                options: [.prettyPrinted]
+            ).write(to: storeURL, options: .atomic)
+
+            let serverHandled = startMockServer(listenerFD: listenerFD, state: state) { line in
+                guard let payload = self.jsonObject(line) else { return "OK" }
+                guard let id = payload["id"] as? String, let method = payload["method"] as? String else {
+                    return self.malformedRequestResponse(id: payload["id"] as? String, raw: line)
+                }
+                switch method {
+                case "surface.list": return self.surfaceListResponse(id: id, surfaceId: surfaceId)
+                case "debug.terminals":
+                    return self.v2Response(id: id, ok: true, result: [
+                        "terminals": [["tty": ttyName, "workspace_id": workspaceId, "surface_id": surfaceId]],
+                    ])
+                case "surface.resume.set": return self.v2Response(id: id, ok: true, result: ["ok": true])
+                case "feed.push": return self.v2Response(id: id, ok: true, result: [:])
+                default:
+                    return self.v2Response(id: id, ok: false, error: [
+                        "code": "unrecognized_method", "message": "unexpected method: \(method)",
+                    ])
+                }
+            }
+
+            var environment = ProcessInfo.processInfo.environment
+            environment["HOME"] = root.path
+            environment["CMUX_SOCKET_PATH"] = socketPath
+            environment["CMUX_WORKSPACE_ID"] = workspaceId
+            environment["CMUX_SURFACE_ID"] = surfaceId
+            environment["CMUX_CLI_TTY_NAME"] = ttyName
+            environment["CMUX_AGENT_HOOK_STATE_DIR"] = root.path
+            environment["CMUX_AGENT_LAUNCH_KIND"] = "codex"
+            environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = executable
+            environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated([executable])
+            environment["CMUX_AGENT_LAUNCH_CWD"] = root.path
+            environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+
+            let result = runProcess(
+                executablePath: cliPath,
+                arguments: ["hooks", "codex", "prompt-submit"],
+                environment: environment,
+                standardInput: #"{"session_id":"\#(sessionId)","cwd":"\#(root.path)","hook_event_name":"UserPromptSubmit","prompt":"continue"}"#,
+                timeout: 5
+            )
+            wait(for: [serverHandled], timeout: 5)
+            XCTAssertFalse(result.timedOut, "\(scenario.name): \(result.stderr)")
+            XCTAssertEqual(result.status, 0, "\(scenario.name): \(result.stderr)")
+
+            let json = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: storeURL)) as? [String: Any])
+            let sessions = try XCTUnwrap(json["sessions"] as? [String: Any])
+            let persisted = try XCTUnwrap(sessions[sessionId] as? [String: Any])
+            let launchCommand = try XCTUnwrap(persisted["launchCommand"] as? [String: Any])
+            XCTAssertEqual(launchCommand["arguments"] as? [String], [executable, "--yolo"], scenario.name)
+
+            let commands = state.snapshot()
+            let resumeParams = commands.compactMap { command -> [String: Any]? in
+                guard let payload = self.jsonObject(command),
+                      payload["method"] as? String == "surface.resume.set" else { return nil }
+                return payload["params"] as? [String: Any]
+            }.last
+            let command = try XCTUnwrap(resumeParams?["command"] as? String, commands.joined(separator: "\n"))
+            XCTAssertTrue(command.contains("'--yolo'"), "\(scenario.name): \(command)")
+        }
+    }
+}

--- a/cmuxTests/CLICodexYoloResumePersistenceTests.swift
+++ b/cmuxTests/CLICodexYoloResumePersistenceTests.swift
@@ -30,8 +30,8 @@ extension CLINotifyProcessIntegrationRegressionTests {
                 [executable, "-a", "on-request", "-s", "workspace-write"]
             ),
             (
-                "same-process-large-tail", [executable, "--yolo"], "never", "danger-full-access",
-                0, 256 * 1024 + 1, 4300, 4300,
+                "legacy-bare-large-tail", [executable], "never", "danger-full-access",
+                0, 256 * 1024 + 1, 4300, 4400,
                 [executable, "--yolo"]
             ),
         ]

--- a/cmuxTests/CLICodexYoloResumePersistenceTests.swift
+++ b/cmuxTests/CLICodexYoloResumePersistenceTests.swift
@@ -4,7 +4,7 @@ import Darwin
 
 extension CLINotifyProcessIntegrationRegressionTests {
     /// A bare Codex argv must persist the current turn's effective permissions, including when a
-    /// legacy record lacks a transcript path or an older policy falls outside the rollout tail.
+    /// legacy record lacks a transcript path or same-process evidence falls outside the rollout tail.
     func testCodexHookRepairsStoredPermissionsFromCurrentTurn() throws {
         let cliPath = try bundledCLIPath()
         let executable = "/Users/example/.bun/bin/codex"
@@ -14,15 +14,25 @@ extension CLINotifyProcessIntegrationRegressionTests {
             approvalPolicy: String,
             sandboxMode: String,
             prefixBytes: Int,
+            suffixBytes: Int,
+            mappedPID: Int,
+            currentPID: Int,
             expectedArguments: [String]
         )] = [
             (
-                "legacy-bare", [executable], "never", "danger-full-access", 4 * 1024 * 1024 + 1,
+                "legacy-bare", [executable], "never", "danger-full-access",
+                4 * 1024 * 1024 + 1, 0, 4100, 4100,
                 [executable, "--yolo"]
             ),
             (
-                "current-plain", [executable, "--yolo"], "on-request", "workspace-write", 0,
+                "current-plain", [executable, "--yolo"], "on-request", "workspace-write",
+                0, 0, 4100, 4200,
                 [executable, "-a", "on-request", "-s", "workspace-write"]
+            ),
+            (
+                "same-process-large-tail", [executable, "--yolo"], "never", "danger-full-access",
+                0, 256 * 1024 + 1, 4300, 4300,
+                [executable, "--yolo"]
             ),
         ]
 
@@ -48,16 +58,17 @@ extension CLINotifyProcessIntegrationRegressionTests {
             let formatter = ISO8601DateFormatter()
             formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
             let timestamp = formatter.string(from: Date(timeIntervalSince1970: now - 120))
-            let padding = String(repeating: "x", count: scenario.prefixBytes)
+            let prefix = String(repeating: "x", count: scenario.prefixBytes)
+            let suffix = String(repeating: "x", count: scenario.suffixBytes)
             let line = #"{"timestamp":"\#(timestamp)","type":"turn_context","payload":{"approval_policy":"\#(scenario.approvalPolicy)","sandbox_policy":{"type":"\#(scenario.sandboxMode)"}}}"#
-            try (padding + "\n" + line + "\n").write(
+            try (prefix + "\n" + line + "\n" + suffix).write(
                 to: transcriptURL,
                 atomically: true,
                 encoding: .utf8
             )
             let record: [String: Any] = [
                 "sessionId": sessionId, "workspaceId": workspaceId, "surfaceId": surfaceId,
-                "cwd": root.path, "startedAt": now - 300, "updatedAt": now,
+                "cwd": root.path, "startedAt": now - 300, "updatedAt": now, "pid": scenario.mappedPID,
                 "launchCommand": [
                     "launcher": "codex", "executablePath": executable,
                     "arguments": scenario.storedArguments, "workingDirectory": root.path,
@@ -101,6 +112,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
             environment["CMUX_AGENT_LAUNCH_EXECUTABLE"] = executable
             environment["CMUX_AGENT_LAUNCH_ARGV_B64"] = base64NULSeparated([executable])
             environment["CMUX_AGENT_LAUNCH_CWD"] = root.path
+            environment["CMUX_CODEX_PID"] = String(scenario.currentPID)
             environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
 
             let result = runProcess(


### PR DESCRIPTION
Summary:
- prevent a bare Codex hook capture from overwriting stored explicit permission arguments
- repair legacy bare Codex launch records from the rollout turn context captured before the hook event
- cover both preservation and legacy repair with a wired regression test

Testing:
- tagged `cyolo` cloud build succeeded
- runtime preflight repaired `[codex]` to `[codex, --yolo]` and published a resume command containing `--yolo`
- `xcrun swiftc -parse CLI/CMUXCLI+AgentHookRestoreEvidence.swift CLI/cmux.swift cmuxTests/CLICodexYoloResumePersistenceTests.swift`
- `git diff --check`
- focused cloud XCTest blocked before compilation because the fleet image lacks Zig; wired CI test is running

Related: https://github.com/manaflow-ai/cmux/issues/7867

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Codex durable-resume restoration so explicit approval/sandbox permission arguments are retained (including `--yolo` and related flags/options).
  * Automatically repairs older stored Codex resume commands by inferring missing permission arguments from the latest available transcript turn.
  * Refines which Codex resume command is chosen to avoid unintentionally dropping permission settings.
* **Tests**
  * Added an integration regression test to verify Codex Yolo resume persistence and permission-argument repair behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->