### PR TITLE
Add workspace group color inheritance

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -12179,6 +12179,19 @@ struct VerticalTabsSidebar: View {
     ) -> some View {
         let signpost = SidebarProfilingSignposts.begin("sidebar-workspace-row", "index=\(renderContext.tabIndexById[tab.id] ?? -1) workspace=\(sidebarShortTabId(tab.id)) selected=\(tabManager.selectedTabId == tab.id)")
         let index = renderContext.tabIndexById[tab.id] ?? 0
+        let workspaceGroupColorHex: String? = {
+            guard let groupId = tab.groupId,
+                  let group = renderContext.workspaceGroupById[groupId] else {
+                return nil
+            }
+            let anchorCwd = renderContext.workspaceById[group.anchorWorkspaceId]?.currentDirectory
+            let configuredColor = cmuxConfigStore.resolveWorkspaceGroupConfig(forCwd: anchorCwd)?.color
+            return group.customColor ?? configuredColor
+        }()
+        let effectiveColorHex = sidebarWorkspaceEffectiveColorHex(
+            workspaceColorHex: tab.customColor,
+            workspaceGroupColorHex: workspaceGroupColorHex
+        )
         let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
         let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
             ? renderContext.selectedContextTargetIds
@@ -12303,6 +12316,7 @@ struct VerticalTabsSidebar: View {
             notificationStore: notificationStore,
             tab: tab,
             index: index,
+            effectiveColorHex: effectiveColorHex,
             workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
                 at: index,
                 workspaceCount: renderContext.workspaceCount
@@ -12903,6 +12917,7 @@ struct TabItemView: View, Equatable {
     nonisolated static func == (lhs: TabItemView, rhs: TabItemView) -> Bool {
         lhs.tab === rhs.tab &&
         lhs.index == rhs.index &&
+        lhs.effectiveColorHex == rhs.effectiveColorHex &&
         lhs.workspaceShortcutDigit == rhs.workspaceShortcutDigit &&
         lhs.workspaceShortcutModifierSymbol == rhs.workspaceShortcutModifierSymbol &&
         lhs.canCloseWorkspace == rhs.canCloseWorkspace &&
@@ -12952,6 +12967,7 @@ struct TabItemView: View, Equatable {
 #endif
     let tab: Tab
     let index: Int
+    let effectiveColorHex: String?
     let workspaceShortcutDigit: Int?
     let workspaceShortcutModifierSymbol: String
     let canCloseWorkspace: Bool
@@ -13357,6 +13373,7 @@ struct TabItemView: View, Equatable {
             showsGitBranch: sidebarShowGitBranch,
             usesViewportAwarePath: sidebarUsesLastSegmentPath,
             showsAgentActivity: showsAgentActivity,
+            effectiveColorHex: effectiveColorHex,
             visibleAuxiliaryDetails: visibleAuxiliaryDetails
         )
     }
@@ -14309,7 +14326,7 @@ struct TabItemView: View, Equatable {
             title: tab.title,
             customDescription: settings.showsWorkspaceDescription ? sidebarVisibleCustomDescription : nil,
             isPinned: tab.isPinned,
-            customColorHex: tab.customColor,
+            customColorHex: effectiveColorHex,
             remoteWorkspaceSidebarText: remoteWorkspaceSidebarText,
             remoteConnectionStatusText: remoteConnectionStatusText,
             remoteStateHelpText: remoteStateHelpText,

--- a/Sources/Sidebar/SidebarAppearanceSupport.swift
+++ b/Sources/Sidebar/SidebarAppearanceSupport.swift
@@ -288,6 +288,13 @@ func sidebarWorkspaceRowExplicitRailNSColor(
     )
 }
 
+func sidebarWorkspaceEffectiveColorHex(
+    workspaceColorHex: String?,
+    workspaceGroupColorHex: String?
+) -> String? {
+    workspaceGroupColorHex ?? workspaceColorHex
+}
+
 func sidebarWorkspaceRowBackgroundStyle(
     activeTabIndicatorStyle: WorkspaceIndicatorStyle,
     isActive: Bool,

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -16,6 +16,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             lhs.name == rhs.name &&
             lhs.iconSymbol == rhs.iconSymbol &&
             lhs.tintHex == rhs.tintHex &&
+            lhs.hasCustomColor == rhs.hasCustomColor &&
             lhs.isCollapsed == rhs.isCollapsed &&
             lhs.isPinned == rhs.isPinned &&
             lhs.isAnchorActive == rhs.isAnchorActive &&
@@ -46,6 +47,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let name: String
     let iconSymbol: String
     let tintHex: String?
+    let hasCustomColor: Bool
     let isCollapsed: Bool
     let isPinned: Bool
     let isAnchorActive: Bool
@@ -76,6 +78,8 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let onRunResolvedItem: (CmuxResolvedConfigMenuAction) -> Void
     let onRename: () -> Void
     let onTogglePinned: () -> Void
+    let onSetColor: (String?) -> Void
+    let onChooseCustomColor: () -> Void
     let onMarkRead: () -> Void
     let onMarkUnread: () -> Void
     let onClearLatestNotifications: () -> Void
@@ -87,6 +91,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let onOpenDocs: () -> Void
 
     @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
+    @Environment(\.colorScheme) private var colorScheme
 
 #if DEBUG
     // Plain-value environment probe set only by SidebarLazyLayoutScaleTests;
@@ -107,6 +112,14 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
 
     private var displayedIconSymbol: String {
         RenderableSystemSymbol.resolvedWorkspaceGroupIcon(explicit: iconSymbol, configured: nil)
+    }
+
+    private func colorSwatch(for hex: String) -> NSColor {
+        WorkspaceTabColorSettings.displayNSColor(
+            hex: hex,
+            colorScheme: colorScheme,
+            forceBright: true
+        ) ?? NSColor(hex: hex) ?? .gray
     }
 
     private var shortcutHintPillText: String? {
@@ -342,6 +355,51 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                     ),
                 action: onTogglePinned
             )
+            Menu(
+                String(
+                    localized: "workspaceGroup.contextMenu.color",
+                    defaultValue: "Group Color"
+                )
+            ) {
+                let colorPalette = WorkspaceTabColorSettings.palette()
+
+                if hasCustomColor {
+                    Button {
+                        onSetColor(nil)
+                    } label: {
+                        Label(
+                            String(localized: "contextMenu.clearColor", defaultValue: "Clear Color"),
+                            systemImage: "xmark.circle"
+                        )
+                    }
+                }
+
+                Button(action: onChooseCustomColor) {
+                    Label(
+                        String(
+                            localized: "contextMenu.chooseCustomColor",
+                            defaultValue: "Choose Custom Color…"
+                        ),
+                        systemImage: "paintpalette"
+                    )
+                }
+
+                if !colorPalette.isEmpty {
+                    Divider()
+                }
+
+                ForEach(colorPalette, id: \.id) { entry in
+                    Button {
+                        onSetColor(entry.hex)
+                    } label: {
+                        Label {
+                            Text(entry.name)
+                        } icon: {
+                            Image(nsImage: coloredCircleImage(color: colorSwatch(for: entry.hex)))
+                        }
+                    }
+                }
+            }
             Divider()
             Button(
                 String(

--- a/Sources/SidebarWorkspaceSnapshotBuilder.swift
+++ b/Sources/SidebarWorkspaceSnapshotBuilder.swift
@@ -10,6 +10,7 @@ struct SidebarWorkspaceSnapshotBuilder {
         let showsGitBranch: Bool
         let usesViewportAwarePath: Bool
         let showsAgentActivity: Bool
+        let effectiveColorHex: String?
         let visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility
     }
 

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -75,6 +75,7 @@ extension VerticalTabsSidebar {
             name: group.name,
             iconSymbol: effectiveIcon,
             tintHex: effectiveColor,
+            hasCustomColor: group.customColor != nil,
             isCollapsed: group.isCollapsed,
             isPinned: group.isPinned,
             isAnchorActive: isAnchorActive,
@@ -137,6 +138,17 @@ extension VerticalTabsSidebar {
             },
             onTogglePinned: { [weak tabManager, groupId = group.id] in
                 tabManager?.toggleWorkspaceGroupPinned(groupId: groupId)
+            },
+            onSetColor: { [weak tabManager, groupId = group.id] hex in
+                tabManager?.setWorkspaceGroupColor(groupId: groupId, hex: hex)
+            },
+            onChooseCustomColor: { [weak tabManager, groupId = group.id, currentColor = effectiveColor] in
+                guard let tabManager else { return }
+                presentWorkspaceGroupColorPrompt(
+                    tabManager: tabManager,
+                    groupId: groupId,
+                    currentColor: currentColor
+                )
             },
             onMarkRead: { [weak notificationStore, anchorId = group.anchorWorkspaceId] in
                 notificationStore?.markRead(forTabId: anchorId)
@@ -204,5 +216,67 @@ extension VerticalTabsSidebar {
                 id: group.anchorWorkspaceId,
                 isEnabled: shouldCollectWorkspaceDropTargets
             )
+    }
+
+    private func presentWorkspaceGroupColorPrompt(
+        tabManager: TabManager,
+        groupId: UUID,
+        currentColor: String?
+    ) {
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "workspaceGroup.contextMenu.color",
+            defaultValue: "Group Color"
+        )
+        alert.informativeText = String(
+            localized: "alert.customColor.message",
+            defaultValue: "Enter a hex color in the format #RRGGBB."
+        )
+
+        let seed = currentColor ?? WorkspaceTabColorSettings.customPaletteEntries().first?.hex ?? ""
+        let input = NSTextField(string: seed)
+        input.placeholderString = "#1565C0"
+        input.frame = NSRect(x: 0, y: 0, width: 240, height: 22)
+        alert.accessoryView = input
+        alert.addButton(
+            withTitle: String(localized: "alert.customColor.apply", defaultValue: "Apply")
+        )
+        alert.addButton(
+            withTitle: String(localized: "alert.customColor.cancel", defaultValue: "Cancel")
+        )
+        alert.window.initialFirstResponder = input
+        input.selectText(nil)
+
+        guard runCmuxModalAlert(alert) == .alertFirstButtonReturn else { return }
+        guard let normalized = WorkspaceTabColorSettings.addCustomColor(input.stringValue) else {
+            presentInvalidWorkspaceGroupColorAlert(input.stringValue)
+            return
+        }
+        tabManager.setWorkspaceGroupColor(groupId: groupId, hex: normalized)
+    }
+
+    private func presentInvalidWorkspaceGroupColorAlert(_ value: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(
+            localized: "alert.invalidColor.title",
+            defaultValue: "Invalid Color"
+        )
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            alert.informativeText = String(
+                localized: "alert.invalidColor.emptyMessage",
+                defaultValue: "Enter a hex color in the format #RRGGBB."
+            )
+        } else {
+            alert.informativeText = String(
+                localized: "alert.invalidColor.invalidMessage",
+                defaultValue: "\"\(trimmed)\" is not a valid hex color. Use #RRGGBB."
+            )
+        }
+        alert.addButton(
+            withTitle: String(localized: "alert.invalidColor.ok", defaultValue: "OK")
+        )
+        _ = runCmuxModalAlert(alert)
     }
 }

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -10,6 +10,21 @@ import Testing
 #endif
 
 @Suite struct SidebarWorkspaceSnapshotRefreshPolicyTests {
+    @Test func workspaceGroupColorOverridesWorkspaceColor() {
+        #expect(sidebarWorkspaceEffectiveColorHex(
+            workspaceColorHex: "#C0392B",
+            workspaceGroupColorHex: "#1565C0"
+        ) == "#1565C0")
+        #expect(sidebarWorkspaceEffectiveColorHex(
+            workspaceColorHex: "#C0392B",
+            workspaceGroupColorHex: nil
+        ) == "#C0392B")
+        #expect(sidebarWorkspaceEffectiveColorHex(
+            workspaceColorHex: nil,
+            workspaceGroupColorHex: "#1565C0"
+        ) == "#1565C0")
+    }
+
     @Test func contextMenuPinChangeUpdatesDisplayedFieldsAndDefersNoisyFields() {
         let current = Self.snapshot(
             title: "lmao",
@@ -174,6 +189,7 @@ import Testing
         showsGitBranch: Bool = true,
         usesViewportAwarePath: Bool = false,
         showsAgentActivity: Bool = true,
+        effectiveColorHex: String? = nil,
         visibleAuxiliaryDetails: SidebarWorkspaceAuxiliaryDetailVisibility = SidebarWorkspaceAuxiliaryDetailVisibility(
             showsMetadata: true,
             showsLog: true,
@@ -189,6 +205,7 @@ import Testing
             showsGitBranch: showsGitBranch,
             usesViewportAwarePath: usesViewportAwarePath,
             showsAgentActivity: showsAgentActivity,
+            effectiveColorHex: effectiveColorHex,
             visibleAuxiliaryDetails: visibleAuxiliaryDetails
         )
     }


### PR DESCRIPTION
## Summary

- Add a reusable color picker to workspace group context menus.
- Render every workspace in a group with the group's effective color, including workspaces created later.
- Preserve per-workspace colors as fallback when a group color is cleared.
- Reuse the existing workspace color palette and custom hex flow, with localized "Group Color" copy.

This makes sidebar groups visually consistent and easier to scan.

## Testing

- Passed: focused `SidebarWorkspaceSnapshotRefreshPolicyTests` before rebasing onto the latest `main` (5 tests).
- Passed: Swift frontend parsing for all changed Swift files after rebasing onto the latest `main`.
- Passed: `python3 -m json.tool Resources/Localizable.xcstrings`.
- Passed: `git diff --check`.
- Passed: tagged Debug app build and launch with the existing groups restored through the tagged CLI.
- Blocked on latest `main`: the focused `xcodebuild` test target currently fails while compiling `CmuxTerminal` because `ghostty_surface_read_screen_tail_vt` is missing from the submodule revision recorded by upstream `main`. The failure is outside this PR's changed files.

## Demo Video

- Video URL or attachment: Not included.

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8051"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786610034&installation_id=133855650&pr_number=8051&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8051&signature=d4d3e8530fe3b002940b9a8977e7b982edaa693d1f7a5d1463b3d9a9d383e19d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add workspace group color inheritance so all workspaces in a group use the group’s color by default, with a simple “Group Color” picker in the group context menu. Clears revert to each workspace’s own color.

- **New Features**
  - Added “Group Color” context menu with palette, “Choose Custom Color…”, and “Clear Color”.
  - Workspaces render with the group’s effective color, including newly created ones.
  - Per-workspace colors act as fallback when a group color is cleared.
  - Reused existing workspace color palette and custom hex flow; added localized copy.

<sup>Written for commit 783187483d2003f819b8a4ec78dc4a20e3cdcee0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

