### PR TITLE
Remove status circle glyphs from sidebar workspace rows (again)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9929,10 +9929,9 @@ struct VerticalTabsSidebar: View {
     // behind the snapshot boundary (they receive a Bool/Int + closures).
     @State private var expandedChecklistWorkspaceIds: Set<UUID> = []
     @State private var checklistAddFieldActivationTokens: [UUID: Int] = [:]
-    // Which workspace row's status popover / checklist popover is open (at
-    // most one of each across the sidebar; opening one closes the other).
-    // Held at the container so rows stay behind the snapshot boundary.
-    @State private var statusPopoverWorkspaceId: UUID?
+    // Which workspace row's checklist popover is open (at most one across
+    // the sidebar). Held at the container so rows stay behind the snapshot
+    // boundary.
     @State private var checklistPopoverWorkspaceId: UUID?
     @State private var extensionSidebarUpdateToken: UInt64 = 0
     // Stable, memoized merged observation publishers for the extension
@@ -10429,7 +10428,6 @@ struct VerticalTabsSidebar: View {
             guard let workspaceId = notification.userInfo?[WorkspaceTodoActions.workspaceIdUserInfoKey] as? UUID,
                   tabManager.tabs.contains(where: { $0.id == workspaceId }) else { return }
             if WorkspaceTodoFeature.checklistStyle == .popover {
-                statusPopoverWorkspaceId = nil
                 checklistPopoverWorkspaceId = workspaceId
             } else {
                 expandedChecklistWorkspaceIds.insert(workspaceId)
@@ -10534,7 +10532,6 @@ struct VerticalTabsSidebar: View {
                 // Workspace switches produce no outside click for .transient auto-dismiss; close popovers explicitly.
                 if let dismissed = checklistPopoverWorkspaceId { checklistAddFieldActivationTokens[dismissed] = nil }
                 checklistPopoverWorkspaceId = nil
-                statusPopoverWorkspaceId = nil
             }
             .onChange(of: renderContext.workspaceIds) { oldWorkspaceIds, newWorkspaceIds in
                 guard shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(
@@ -12282,17 +12279,8 @@ struct VerticalTabsSidebar: View {
         let onConsumeChecklistAddFieldActivation: () -> Void = { [tabId = tab.id] in
             checklistAddFieldActivationTokens[tabId] = nil
         }
-        let onStatusPopoverPresentedChange: @MainActor (Bool) -> Void = { [tabId = tab.id] presented in
-            if presented {
-                checklistPopoverWorkspaceId = nil
-                statusPopoverWorkspaceId = tabId
-            } else if statusPopoverWorkspaceId == tabId {
-                statusPopoverWorkspaceId = nil
-            }
-        }
         let onChecklistPopoverPresentedChange: @MainActor (Bool) -> Void = { [tabId = tab.id] presented in
             if presented {
-                statusPopoverWorkspaceId = nil
                 checklistPopoverWorkspaceId = tabId
             } else if checklistPopoverWorkspaceId == tabId {
                 checklistPopoverWorkspaceId = nil
@@ -12338,9 +12326,7 @@ struct VerticalTabsSidebar: View {
             checklistAddFieldActivationToken: checklistAddFieldActivationTokens[tab.id] ?? 0,
             onToggleChecklistExpansion: onToggleChecklistExpansion,
             onConsumeChecklistAddFieldActivation: onConsumeChecklistAddFieldActivation,
-            isStatusPopoverPresented: statusPopoverWorkspaceId == tab.id,
             isChecklistPopoverPresented: checklistPopoverWorkspaceId == tab.id,
-            onStatusPopoverPresentedChange: onStatusPopoverPresentedChange,
             onChecklistPopoverPresentedChange: onChecklistPopoverPresentedChange,
             onContextMenuAppear: onContextMenuAppear,
             onContextMenuDisappear: onContextMenuDisappear
@@ -12924,7 +12910,6 @@ struct TabItemView: View, Equatable {
         lhs.isBonsplitWorkspaceDropActive == rhs.isBonsplitWorkspaceDropActive &&
         lhs.isChecklistExpanded == rhs.isChecklistExpanded &&
         lhs.checklistAddFieldActivationToken == rhs.checklistAddFieldActivationToken &&
-        lhs.isStatusPopoverPresented == rhs.isStatusPopoverPresented &&
         lhs.isChecklistPopoverPresented == rhs.isChecklistPopoverPresented &&
         lhs.settings == rhs.settings
     }
@@ -12994,12 +12979,10 @@ struct TabItemView: View, Equatable {
     let checklistAddFieldActivationToken: Int
     let onToggleChecklistExpansion: () -> Void
     let onConsumeChecklistAddFieldActivation: () -> Void
-    // The status and checklist popovers are per-workspace transient UI state
-    // owned by the sidebar container (UUID? there, at most one of each open),
-    // passed in as Bools + change closures like the checklist expansion.
-    let isStatusPopoverPresented: Bool
+    // The checklist popover is per-workspace transient UI state owned by the
+    // sidebar container (UUID? there, at most one open), passed in as a Bool
+    // + change closure like the checklist expansion.
     let isChecklistPopoverPresented: Bool
-    let onStatusPopoverPresentedChange: @MainActor (Bool) -> Void
     let onChecklistPopoverPresentedChange: @MainActor (Bool) -> Void
     /// Called from this row's contextMenu.onAppear so the parent can freeze
     /// `showsModifierShortcutHints` to the value it last passed in. Prevents
@@ -13415,30 +13398,6 @@ struct TabItemView: View, Equatable {
         let spinnerColor = usesInvertedActiveForeground ? selectedWorkspaceForegroundNSColor(opacity: 0.55) : .secondaryLabelColor
         let rowView = VStack(alignment: .leading, spacing: 4) {
             HStack(alignment: .sidebarTitleFirstLineCenter, spacing: titleRowSpacing) {
-
-                if let taskStatus = workspaceSnapshot.taskStatus {
-                    SidebarWorkspaceTaskStatusGlyphControl(
-                        status: taskStatus,
-                        inferred: workspaceSnapshot.taskStatusInferred ?? taskStatus,
-                        hasOverride: workspaceSnapshot.taskStatusHasOverride,
-                        usesMonochrome: usesInvertedActiveForeground,
-                        monochromeColor: activeSecondaryColor(0.85),
-                        neutralColor: activeSecondaryColor(0.6),
-                        fontScale: fontScale,
-                        isPopoverPresented: isStatusPopoverPresented,
-                        onPopoverPresentedChange: onStatusPopoverPresentedChange,
-                        onSelectLane: { [tab] status in
-                            WorkspaceTodoActions.applyStatusOverride(status, to: [tab])
-                        },
-                        onSelectNone: { [tab] in
-                            WorkspaceTodoActions.hideStatus(for: [tab])
-                        },
-                        onOptionToggleDone: { [tab] in
-                            WorkspaceTodoActions.toggleDone(for: tab)
-                        }
-                    )
-                    .padding(.top, 2)
-                }
 
                 if leadingSlotActive {
                     SidebarWorkspaceLeadingStatusSlot(showsBadge: badgeOnLeading, showsSpinner: spinnerOnLeading, unreadCount: unreadCount, side: badgeOnLeading ? scaledUnreadBadgeSize : scaledLoadingSpinnerSize, spinnerSide: scaledLoadingSpinnerSize, badgeFont: badgeFont, badgeFillColor: activeUnreadBadgeFillColor, badgeTextColor: activeUnreadBadgeTextColor, spinnerColor: spinnerColor, spinnerTooltip: spinnerTooltip)
@@ -14292,8 +14251,8 @@ struct TabItemView: View, Equatable {
         }()
         // Pure reads only: effective-status resolution never mutates; the
         // expired-override cleanup happens at explicit mutation entry points.
-        // A workspace can opt out of the status feature (None): no glyph slot
-        // is reserved.
+        // Sidebar rows draw no status glyph; the resolved status only feeds
+        // the done-row dim, and a workspace can opt out entirely (None).
         let workspaceStatusVisible = !tab.todoState.statusHidden
         let inferredTaskStatus = workspaceStatusVisible ? tab.inferredTaskStatus : nil
         let taskStatusResolution: WorkspaceTaskStatusOverride.Resolution? = inferredTaskStatus.map { inferred in
@@ -14335,10 +14294,6 @@ struct TabItemView: View, Equatable {
             finderDirectoryPath: WorkspaceFinderDirectoryResolver.path(for: tab),
             mediaActivity: tab.browserMediaActivity,
             taskStatus: taskStatusResolution?.effective,
-            taskStatusHasOverride: taskStatusResolution.map { resolution in
-                tab.todoState.statusOverride != nil && !resolution.shouldClearOverride
-            } ?? false,
-            taskStatusInferred: inferredTaskStatus,
             checklistItems: tab.todoState.checklist,
             checklistCompletedCount: checklistProgress.completedCount,
             checklistTotalCount: checklistProgress.totalCount,

--- a/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
+++ b/Sources/Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift
@@ -9,8 +9,6 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
         let finderDirectoryPath: String?
         let mediaActivity: BrowserMediaActivity
         let taskStatus: WorkspaceTaskStatus?
-        let taskStatusHasOverride: Bool
-        let taskStatusInferred: WorkspaceTaskStatus?
         let checklistItems: [WorkspaceChecklistItem]
         let checklistCompletedCount: Int
         let checklistTotalCount: Int
@@ -27,8 +25,6 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             finderDirectoryPath: finderDirectoryPath,
             mediaActivity: mediaActivity,
             taskStatus: taskStatus,
-            taskStatusHasOverride: taskStatusHasOverride,
-            taskStatusInferred: taskStatusInferred,
             checklistItems: checklistItems,
             checklistCompletedCount: checklistCompletedCount,
             checklistTotalCount: checklistTotalCount,
@@ -70,11 +66,9 @@ extension SidebarWorkspaceSnapshotBuilder.Snapshot {
             // visually worse than ordinary telemetry text while the menu is open.
             mediaActivity: snapshot.mediaActivity,
             // Todo status/checklist are mutated FROM this context menu (Status
-            // submenu, Mark as Done, checkbox clicks), so the glyph and
+            // submenu, Mark as Done, checkbox clicks), so the done-row dim and
             // checklist must reflect the change immediately, not on menu close.
             taskStatus: snapshot.taskStatus,
-            taskStatusHasOverride: snapshot.taskStatusHasOverride,
-            taskStatusInferred: snapshot.taskStatusInferred,
             checklistItems: snapshot.checklistItems,
             checklistCompletedCount: snapshot.checklistCompletedCount,
             checklistTotalCount: snapshot.checklistTotalCount,

--- a/Sources/SidebarWorkspaceSnapshotBuilder.swift
+++ b/Sources/SidebarWorkspaceSnapshotBuilder.swift
@@ -58,12 +58,10 @@ struct SidebarWorkspaceSnapshotBuilder {
         let finderDirectoryPath: String?
         let mediaActivity: BrowserMediaActivity
         // Workspace todo status/checklist; taskStatus is nil when the
-        // workspace opted out of status display (no glyph slot reserved).
+        // workspace opted out of status display. Drives only the done-row
+        // dim — sidebar rows draw no status glyph (issue: status circles
+        // must not appear on workspace rows).
         let taskStatus: WorkspaceTaskStatus?
-        let taskStatusHasOverride: Bool
-        /// The lane the live signals currently infer; feeds the status
-        /// popover's Auto row.
-        let taskStatusInferred: WorkspaceTaskStatus?
         let checklistItems: [WorkspaceChecklistItem]
         let checklistCompletedCount: Int
         let checklistTotalCount: Int

--- a/Sources/SidebarWorkspaceStatusPopover.swift
+++ b/Sources/SidebarWorkspaceStatusPopover.swift
@@ -5,9 +5,11 @@ import SwiftUI
 // MARK: - Shared status lane list
 
 /// One selectable status lane row, shared by the sidebar row's context-menu
-/// Status submenu and the glyph's status popover so both surfaces present
+/// Status submenu and the todo pane's status popover so both surfaces present
 /// identical lanes, titles, and selection through one model, and apply through
-/// the same `WorkspaceTodoActions.applyStatusOverride` path.
+/// the same `WorkspaceTodoActions.applyStatusOverride` path. Sidebar workspace
+/// rows deliberately draw no status glyph (the leading status circles were
+/// removed; see `SidebarWorkspaceRowStatusGlyphRemovalTests`).
 struct WorkspaceTodoStatusLane: Equatable, Identifiable {
     /// The lane to pin, or `nil` for Auto (clear the override) and for None.
     let status: WorkspaceTaskStatus?
@@ -91,11 +93,11 @@ struct SidebarWorkspaceStatusPopoverModel: Equatable {
 
 // MARK: - Popover content
 
-/// The glyph-click status popover: the Auto row, a divider, the five status
-/// lanes (each drawing the real glyph), and — while a lane is pinned — a
-/// footnote explaining the pin auto-clears. Arrow keys move the highlight,
-/// Return or click applies and closes, Esc closes, and a lane's first letter
-/// jumps.
+/// The status popover opened from the todo pane's header glyph: the Auto row,
+/// a divider, the five status lanes (each drawing the real glyph), and —
+/// while a lane is pinned — a footnote explaining the pin auto-clears. Arrow
+/// keys move the highlight, Return or click applies and closes, Esc closes,
+/// and a lane's first letter jumps.
 struct SidebarWorkspaceStatusPopover: View {
     let model: SidebarWorkspaceStatusPopoverModel
     /// Applies a lane (`nil` = Auto) through the shared status action path.
@@ -264,71 +266,3 @@ struct SidebarWorkspaceStatusPopover: View {
     }
 }
 
-// MARK: - Clickable glyph control
-
-/// The clickable status glyph on a sidebar workspace row: a plain click opens
-/// the status popover anchored to the glyph, option-click one-step toggles
-/// Done (pin `.done`, or return an already-done row to Auto). Receives value
-/// snapshots and closures only (snapshot-boundary rule); the ~16pt hit area
-/// comes from an outset content shape so the row layout keeps the glyph's
-/// visual slot width.
-struct SidebarWorkspaceTaskStatusGlyphControl: View {
-    let status: WorkspaceTaskStatus
-    let inferred: WorkspaceTaskStatus
-    let hasOverride: Bool
-    let usesMonochrome: Bool
-    let monochromeColor: Color
-    let neutralColor: Color
-    let fontScale: CGFloat
-    let isPopoverPresented: Bool
-    let onPopoverPresentedChange: @MainActor (Bool) -> Void
-    /// Applies a lane (`nil` = Auto) through the shared status action path.
-    let onSelectLane: @MainActor (WorkspaceTaskStatus?) -> Void
-    /// Opts the workspace out (None): hide the status glyph.
-    let onSelectNone: @MainActor () -> Void
-    let onOptionToggleDone: @MainActor () -> Void
-
-    var body: some View {
-        Button {
-            if NSApp.currentEvent?.modifierFlags.contains(.option) == true {
-                onOptionToggleDone()
-            } else {
-                onPopoverPresentedChange(!isPopoverPresented)
-            }
-        } label: {
-            SidebarWorkspaceTaskStatusGlyph(
-                status: status,
-                hasOverride: hasOverride,
-                usesMonochrome: usesMonochrome,
-                monochromeColor: monochromeColor,
-                neutralColor: neutralColor,
-                fontScale: fontScale
-            )
-            .contentShape(Rectangle().inset(by: -3))
-        }
-        .buttonStyle(.plain)
-        // SwiftUI's native popover (not the NSPopover host). An embedded
-        // NSViewRepresentable inside a `.onHover`-tracked sidebar row
-        // suppresses the row's hover tracking (hover-close "x" never appears),
-        // so any AppKit lifecycle bridge must live inside popover content.
-        .popover(
-            isPresented: Binding(
-                get: { isPopoverPresented },
-                set: { onPopoverPresentedChange($0) }
-            ),
-            arrowEdge: .trailing
-        ) {
-            SidebarWorkspaceStatusPopover(
-                model: SidebarWorkspaceStatusPopoverModel(
-                    inferred: inferred,
-                    activeOverride: hasOverride ? status : nil
-                ),
-                onSelectLane: onSelectLane,
-                onSelectNone: onSelectNone,
-                onClose: { onPopoverPresentedChange(false) }
-            )
-            .frame(minWidth: 200)
-        }
-        .accessibilityIdentifier("SidebarWorkspaceTaskStatusGlyphControl")
-    }
-}

--- a/Sources/SidebarWorkspaceTaskStatusGlyph.swift
+++ b/Sources/SidebarWorkspaceTaskStatusGlyph.swift
@@ -74,8 +74,7 @@ struct SidebarWorkspaceTaskStatusGlyphModel: Equatable {
         }
     }
 
-    /// Localized format strings resolved once, not per row render (the glyph
-    /// sits on every sidebar row's title line, a hot layout path).
+    /// Localized format strings resolved once, not per render.
     private static let manualTooltipFormat = String(
         localized: "sidebar.status.tooltip.manual",
         defaultValue: "%@ — set manually"
@@ -98,11 +97,13 @@ struct SidebarWorkspaceTaskStatusGlyphModel: Equatable {
 
 // MARK: - Glyph view
 
-/// The custom-drawn circular progress-pie status glyph rendered as the
-/// leftmost element of a sidebar workspace row's title line. Drawn in a
-/// fixed-width slot sized like the pin glyph (~9pt, font-scaled). Modeled on
-/// `PullRequestOpenIcon`/`PullRequestMergedIcon` (custom `Path` drawing, row
-/// passes resolved colors; no store access below the snapshot boundary).
+/// The custom-drawn circular progress-pie status glyph shown in the todo
+/// pane's header and the status popover's lane rows. Deliberately NOT drawn
+/// on sidebar workspace rows (the leading status circles were removed; see
+/// `SidebarWorkspaceRowStatusGlyphRemovalTests`). Drawn in a fixed-width slot
+/// (~9pt base, font-scaled). Modeled on `PullRequestOpenIcon`/
+/// `PullRequestMergedIcon` (custom `Path` drawing, caller passes resolved
+/// colors; no store access).
 struct SidebarWorkspaceTaskStatusGlyph: View {
     let status: WorkspaceTaskStatus
     let hasOverride: Bool

--- a/Sources/TabItemView+WorkspaceTodo.swift
+++ b/Sources/TabItemView+WorkspaceTodo.swift
@@ -28,8 +28,8 @@ extension TabItemView {
             : String(localized: "contextMenu.markWorkspaceDone", defaultValue: "Mark Workspace as Done")
         let markWorkspaceDoneShortcut = KeyboardShortcutSettings.shortcut(for: .markWorkspaceDone)
 
-        // The lane list is shared with the glyph's status popover (one model,
-        // one apply path) so both surfaces stay in lockstep.
+        // The lane list is shared with the todo pane's status popover (one
+        // model, one apply path) so both surfaces stay in lockstep.
         let statusLanes = WorkspaceTodoStatusLane.lanes(
             inferred: inferred,
             activeOverride: activeOverride,

--- a/Sources/WorkspaceTodoFeature.swift
+++ b/Sources/WorkspaceTodoFeature.swift
@@ -52,23 +52,13 @@ enum WorkspaceTodoActions {
         WorkspaceTodoFeature.markUsed()
     }
 
-    /// Opts each workspace out of the status feature (None): hide the glyph.
+    /// Opts each workspace out of the status feature (None).
     static func hideStatus(for workspaces: [Workspace]) {
         guard !workspaces.isEmpty else { return }
         for workspace in workspaces {
             workspace.hideTaskStatus()
         }
         WorkspaceTodoFeature.markUsed()
-    }
-
-    /// The glyph's option-click one-step toggle: pin `.done` unless the
-    /// workspace already reads done, in which case return it to automatic.
-    static func toggleDone(for workspace: Workspace) {
-        if workspace.effectiveTaskStatus == .done {
-            applyStatusOverride(nil, to: [workspace])
-        } else {
-            applyStatusOverride(.done, to: [workspace])
-        }
     }
 
     /// Cycles the workspace's status one lane forward (see

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1416,6 +1416,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F7216004000000000000001 /* SidebarWorkspaceRowInteractionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7216004000000000000002 /* SidebarWorkspaceRowInteractionStateTests.swift */; };
 		D35450030000000000000003 /* SidebarWorkspaceRowMenuTrackingReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450030000000000000004 /* SidebarWorkspaceRowMenuTrackingReconciler.swift */; };
 		D35450030000000000000005 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35450030000000000000006 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift */; };
+		2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */; };
 		C9A57505C9A57505C9A57505 /* SidebarWorkspaceScrollLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57506C9A57506C9A57506 /* SidebarWorkspaceScrollLayoutTests.swift */; };
 		C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */; };
 		A6AC73040000000000000001 /* SidebarWorkspaceSnapshotAgentActivityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73040000000000000002 /* SidebarWorkspaceSnapshotAgentActivityTests.swift */; };
@@ -1519,7 +1520,6 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */; };
 		C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
-		2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */; };
 		C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000000001 /* TaskManagerResourcesTests.swift */; };
 		C7A503000000000000000002 /* TaskManagerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A503000000000000000001 /* TaskManagerSnapshot.swift */; };
 		C7A504000000000000000002 /* TaskManagerTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A504000000000000000001 /* TaskManagerTypes.swift */; };
@@ -3263,6 +3263,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F7216004000000000000002 /* SidebarWorkspaceRowInteractionStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInteractionStateTests.swift; sourceTree = "<group>"; };
 		D35450030000000000000004 /* SidebarWorkspaceRowMenuTrackingReconciler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowMenuTrackingReconciler.swift; sourceTree = "<group>"; };
 		D35450030000000000000006 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceRowMenuTrackingReconcilerView.swift; sourceTree = "<group>"; };
+		DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowStatusGlyphRemovalTests.swift; sourceTree = "<group>"; };
 		C9A57506C9A57506C9A57506 /* SidebarWorkspaceScrollLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceScrollLayoutTests.swift; sourceTree = "<group>"; };
 		C0DE56010000000000000002 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSelectionAnchorPolicyTests.swift; sourceTree = "<group>"; };
 		A6AC73040000000000000002 /* SidebarWorkspaceSnapshotAgentActivityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSnapshotAgentActivityTests.swift; sourceTree = "<group>"; };
@@ -3358,7 +3359,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateStalenessTests.swift; sourceTree = "<group>"; };
 		C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
-		DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowStatusGlyphRemovalTests.swift; sourceTree = "<group>"; };
 		C7A507000000000000000001 /* TaskManagerResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerResourcesTests.swift; sourceTree = "<group>"; };
 		C7A503000000000000000001 /* TaskManagerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerSnapshot.swift; sourceTree = "<group>"; };
 		C7A504000000000000000001 /* TaskManagerTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerTypes.swift; sourceTree = "<group>"; };
@@ -7768,6 +7768,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57305C9A57305C9A57305 /* SidebarWorkspaceReorderDropOverlayHitTestingTests.swift in Sources */,
 				A80070010000000000000001 /* SidebarWorkspaceRowHoverReconcilerTests.swift in Sources */,
 					F7216004000000000000001 /* SidebarWorkspaceRowInteractionStateTests.swift in Sources */,
+				2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */,
 				C9A57505C9A57505C9A57505 /* SidebarWorkspaceScrollLayoutTests.swift in Sources */,
 				C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */,
 					A6AC73040000000000000001 /* SidebarWorkspaceSnapshotAgentActivityTests.swift in Sources */,
@@ -7796,7 +7797,6 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */,
 				C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
-				2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */,
 				C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */,
 				C7A507000000000000004529 /* TaskManagerViewSnapshotBoundaryTests.swift in Sources */,
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1519,6 +1519,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */; };
 		C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */; };
 		B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */; };
+		2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */; };
 		C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A507000000000000000001 /* TaskManagerResourcesTests.swift */; };
 		C7A503000000000000000002 /* TaskManagerSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A503000000000000000001 /* TaskManagerSnapshot.swift */; };
 		C7A504000000000000000002 /* TaskManagerTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A504000000000000000001 /* TaskManagerTypes.swift */; };
@@ -3357,6 +3358,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateStalenessTests.swift; sourceTree = "<group>"; };
 		C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerTitleUpdateTests.swift; sourceTree = "<group>"; };
 		42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabManagerUnitTests.swift; sourceTree = "<group>"; };
+		DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowStatusGlyphRemovalTests.swift; sourceTree = "<group>"; };
 		C7A507000000000000000001 /* TaskManagerResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerResourcesTests.swift; sourceTree = "<group>"; };
 		C7A503000000000000000001 /* TaskManagerSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerSnapshot.swift; sourceTree = "<group>"; };
 		C7A504000000000000000001 /* TaskManagerTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TaskManagerTypes.swift; sourceTree = "<group>"; };
@@ -5482,6 +5484,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */,
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */,
 				9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */,
 				9F007352E96022D7EFBE73C9 /* WorkspaceTodoSidebarModelTests.swift */,
 				5B0C00010000000000000004 /* SidebarResizerOcclusionResolverTests.swift */,
@@ -7793,6 +7796,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C06552030000000000000001 /* TabManagerTitleUpdateStalenessTests.swift in Sources */,
 				C06552020000000000000001 /* TabManagerTitleUpdateTests.swift in Sources */,
 				B6BF3DC98DB1495E57900199 /* TabManagerUnitTests.swift in Sources */,
+				2E057C19B76F8034F30969BF /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift in Sources */,
 				C7A507000000000000000002 /* TaskManagerResourcesTests.swift in Sources */,
 				C7A507000000000000004529 /* TaskManagerViewSnapshotBoundaryTests.swift in Sources */,
 				46F6AC15863EC84DCD3770A2 /* TerminalAndGhosttyTests.swift in Sources */,

--- a/cmuxTests/SidebarWorkspaceRowStatusGlyphRemovalTests.swift
+++ b/cmuxTests/SidebarWorkspaceRowStatusGlyphRemovalTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+
+// No app import needed: this guard asserts against the checked-in sources,
+// so it fails red on any tree where the row glyph is present regardless of
+// how the app target compiles.
+
+/// Regression guard: sidebar workspace rows must NOT render the leading
+/// task-status circle glyph (the empty/half-filled "pie" circles).
+///
+/// History this guards against repeating: the circles shipped with
+/// workspaces-as-todos (#7216), were removed by the full revert (#7761,
+/// commit 657248a17), and came back when the feature was restored (#7790,
+/// commit 998e7fb23) — pre-existing persisted workspaces restored to the
+/// visible/Auto state, so the circles reappeared on every old workspace row.
+/// The status feature itself (context-menu Status submenu, command palette,
+/// CLI, todo pane, checklist) stays; only the per-row circle is banned.
+///
+/// The sidebar row is a SwiftUI shape subtree under a lazy list, so there is
+/// no NSView to walk for a mounted-hierarchy assertion; scanning the row's
+/// rendering sources is the repo's established guard pattern for "this must
+/// not silently return" (see the `#filePath` repo-root scans in
+/// `GhosttyConfigTests` / `RemoteShellCWDRelayTests`).
+struct SidebarWorkspaceRowStatusGlyphRemovalTests {
+    private static var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent() // cmuxTests
+            .deletingLastPathComponent() // repo root
+    }
+
+    /// The files that render sidebar workspace rows. The glyph view itself
+    /// legitimately survives for the todo pane header and the status
+    /// popover's lane rows — the ban is on the row rendering path.
+    private static let rowRenderingSources = [
+        "Sources/ContentView.swift",
+        "Sources/TabItemView+WorkspaceTodo.swift",
+    ]
+
+    /// Identifiers that only exist while a status circle is wired into the
+    /// sidebar row: the glyph views, the row-anchored status popover, and the
+    /// container state that drove it.
+    private static let bannedRowTokens = [
+        "SidebarWorkspaceTaskStatusGlyph",
+        "SidebarStatusPieShape",
+        "SidebarWorkspaceStatusPopover",
+        "statusPopoverWorkspaceId",
+        "isStatusPopoverPresented",
+    ]
+
+    private static func sourceText(_ relativePath: String) throws -> String {
+        try String(
+            contentsOf: repoRoot.appendingPathComponent(relativePath),
+            encoding: .utf8
+        )
+    }
+
+    @Test
+    func workspaceRowSourcesRenderNoStatusCircleGlyph() throws {
+        for relativePath in Self.rowRenderingSources {
+            let source = try Self.sourceText(relativePath)
+            for token in Self.bannedRowTokens {
+                #expect(
+                    !source.contains(token),
+                    """
+                    \(relativePath) references \(token). Sidebar workspace rows must not \
+                    render the leading task-status circle glyph (removed by #7761, \
+                    resurrected by the #7790 feature restore, removed again here). If a \
+                    merge or feature restore reintroduced the glyph block on the row's \
+                    title line, delete it: status stays reachable through the context \
+                    menu, command palette, CLI, and the todo pane.
+                    """
+                )
+            }
+        }
+    }
+
+    /// The row files under `Sources/Sidebar/` (slots, snapshot refresh
+    /// policy, hover reconcilers, …) must not grow a status-glyph reference
+    /// either; they are all below the sidebar snapshot boundary.
+    @Test
+    func sidebarRowSupportSourcesRenderNoStatusCircleGlyph() throws {
+        let sidebarDir = Self.repoRoot.appendingPathComponent("Sources/Sidebar")
+        let files = try FileManager.default
+            .contentsOfDirectory(at: sidebarDir, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "swift" }
+            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+        #expect(!files.isEmpty, "Sources/Sidebar contained no Swift files; guard scan is broken.")
+        for file in files {
+            let source = try String(contentsOf: file, encoding: .utf8)
+            for token in Self.bannedRowTokens {
+                #expect(
+                    !source.contains(token),
+                    "Sources/Sidebar/\(file.lastPathComponent) references \(token); sidebar rows must not render the status circle glyph."
+                )
+            }
+        }
+    }
+
+    /// The row snapshot must not carry glyph-only observation fields. Dead
+    /// per-row observation wiring is exactly the class of sidebar perf
+    /// incident tracked by #2586/#8004 — if status state beyond the done-dim
+    /// `taskStatus` reappears in the snapshot, something is rendering status
+    /// on rows again.
+    @Test
+    func workspaceSnapshotCarriesNoGlyphFeedingFields() throws {
+        let source = try Self.sourceText("Sources/SidebarWorkspaceSnapshotBuilder.swift")
+        for field in ["taskStatusHasOverride", "taskStatusInferred"] {
+            #expect(
+                !source.contains(field),
+                "SidebarWorkspaceSnapshotBuilder.Snapshot regained \(field), a status-glyph-only field; sidebar rows must not observe status-glyph state."
+            )
+        }
+    }
+}

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -159,8 +159,6 @@ import Testing
             finderDirectoryPath: finderDirectoryPath,
             mediaActivity: mediaActivity,
             taskStatus: nil,
-            taskStatusHasOverride: false,
-            taskStatusInferred: nil,
             checklistItems: [],
             checklistCompletedCount: 0,
             checklistTotalCount: 0,


### PR DESCRIPTION
## What

Sidebar workspace rows no longer show the leading status circle icons (empty circle = Todo, half-filled pie = Working/Needs Attention). These are the `SidebarWorkspaceTaskStatusGlyph` pies from the workspaces-as-todos feature, rendered as the leftmost element of every row's title line.

## Archaeology (verified with git, not memory)

- **Introduced:** 968bae70e "Workspaces as todos: inferred status lifecycle + per-workspace checklist" (#7216). Not by 8fdc23f62 "Add sidebar agent activity indicators" — that commit added the GPU loading **spinners**, which are untouched here.
- **Removed:** 657248a17 (PR #7761, merge 20c82bdd1) — a full revert of #7216. It removed the whole feature, so it carried no circles-specific regression test that could survive.
- **How they came back:** 998e7fb23 "Restore workspaces-as-todos, default new workspaces to None status" (#7790, merged 2026-07-14). It reverts the #7761 revert, reintroducing the `SidebarWorkspaceTaskStatusGlyphControl` block on the row title line in `Sources/ContentView.swift` (the `if let taskStatus = workspaceSnapshot.taskStatus { SidebarWorkspaceTaskStatusGlyphControl(...) }` hunk). Its mitigation — `WorkspaceTodoState.statusHidden` defaulting `true` — only applies to **newly created** workspaces; every pre-existing persisted workspace restores to its historical visible/Auto state, so the circles reappeared on all existing rows.
- **PR #7901 is exonerated.** `git show 3d2e3f44b` touches no status-glyph file: its `Workspace.swift`/`TabManager.swift`/`AppDelegate.swift`/ghostty-submodule changes are all notification-scroll plumbing. The hypothesis that its broad diff resurrected the sidebar code does not hold; #7790 merged 28 minutes before #7901 on the same day, which is why both looked like candidates.

## The fix (surgical; nothing from #7901 reverted)

- Delete the glyph block from the row title line in `Sources/ContentView.swift`, including its fixed-width slot and `.padding(.top, 2)`.
- Delete the dead per-row observation wiring feeding it (the sidebar's known perf-incident class, #2586/#8004): `statusPopoverWorkspaceId` container state, `isStatusPopoverPresented`/`onStatusPopoverPresentedChange` `TabItemView` parameters and their `Equatable ==` entry, and the glyph-only snapshot fields `taskStatusHasOverride`/`taskStatusInferred` in `SidebarWorkspaceSnapshotBuilder` + the context-menu refresh policy.
- Delete the now-unreachable `SidebarWorkspaceTaskStatusGlyphControl` and `WorkspaceTodoActions.toggleDone` (the glyph's option-click).
- **Kept intact:** the whole status/todo feature via its other entry points — context-menu Status submenu, command palette, CLI, `markWorkspaceDone`/`cycleWorkspaceStatus` shortcuts, checklist, and the todo pane (its header glyph + status popover remain; `SidebarWorkspaceTaskStatusGlyph` and `SidebarWorkspaceStatusPopover` survive for those surfaces). The done-row dim (`taskStatus == .done → opacity 0.6`) also stays; it is not a circle.

## Regression guard (two-commit red/green)

- **Commit 1** adds only `cmuxTests/SidebarWorkspaceRowStatusGlyphRemovalTests` (wired into `project.pbxproj`): it scans the row-rendering sources (`ContentView.swift`, `TabItemView+WorkspaceTodo.swift`, `Sources/Sidebar/*`) for glyph/popover/state tokens and asserts the snapshot carries no glyph-only fields. It fails red on the pre-fix tree.
- **Commit 2** removes the circles; the test goes green.
- Why source-scan and not a mounted-hierarchy assertion: the row is a SwiftUI `Shape` subtree under a lazy list — there is no NSView to walk, and the repo's sidebar-mount harness (`SidebarLazyLayoutScaleTests`) counts row bodies rather than introspecting SwiftUI internals. The `#filePath` repo-root scan is the established guard pattern here (`GhosttyConfigTests`, `RemoteShellCWDRelayTests`), and it directly catches the observed resurrection mode (a merge/feature-restore reintroducing the row hunk).

## Localization audit

Removal-only change: no new user-facing strings. Every remaining `sidebar.status.*` key is still referenced by surviving surfaces (context menu, todo pane, status popover); `Resources/Localizable.xcstrings` untouched.

🤖 Generated with Claude Code (via cmux HQ dispatch)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8052"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786613646&installation_id=133855650&pr_number=8052&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8052&signature=7379a1e2f87b9ce8da8f1603105f84bbd83aec3ae3e07297baf8172e418e6dce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove the status circle glyphs from sidebar workspace rows to fix their accidental return on existing workspaces. Status is still managed via the context menu, command palette, CLI, shortcuts, checklist, and the todo pane header glyph.

- **Bug Fixes**
  - Removed the glyph from the row title and deleted the row-anchored status popover state and snapshot-only fields; also removed the unused `WorkspaceTodoActions.toggleDone`.
  - Kept done-row dimming and all other status surfaces (todo pane glyph + popover, context menu, etc.).
  - Added `SidebarWorkspaceRowStatusGlyphRemovalTests` to scan sources and guard against reintroducing the glyph/popover/state tokens.

- **Refactors**
  - Normalized `project.pbxproj` entries to sort and wire the new tests consistently.

<sup>Written for commit 7c1f614236201e53db9fc43e0ca1f1803b2aceea. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **UI Improvements**
  - Removed task-status glyphs and their popovers from sidebar workspace rows, simplifying the row layout.
  - Consolidated transient popover handling so outside-click/auto-dismiss now closes only the checklist popover.
  - Simplified status data flowing into row visuals so completion/done styling still reflects the resolved task status.
  - Kept access to status details via the todo pane header’s unified status popover.

- **Tests**
  - Added regression tests to ensure the removed sidebar status glyphs never return and related snapshot/status fields stay absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->