### PR TITLE
terminal: replay occlusion after surface creation

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Debug.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Debug.swift
@@ -213,14 +213,12 @@ extension TerminalSurface {
         callbackContext?.release()
     }
 
-    /// Test-only helper to install a runtime surface pointer and simulate the
-    /// creation-time visibility synchronization.
+    /// Test-only helper to install a runtime surface pointer directly.
     @MainActor
     public func installRuntimeSurfaceForTesting(_ runtimeSurface: ghostty_surface_t) {
         surface = runtimeSurface
         portalLifecycleState = .live
         runtimeSurfaceFreedOutOfBandForTesting = false
-        applyDesiredOcclusionState(to: runtimeSurface)
     }
 #endif
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Debug.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Debug.swift
@@ -213,12 +213,14 @@ extension TerminalSurface {
         callbackContext?.release()
     }
 
-    /// Test-only helper to install a runtime surface pointer directly.
+    /// Test-only helper to install a runtime surface pointer and simulate the
+    /// creation-time visibility synchronization.
     @MainActor
     public func installRuntimeSurfaceForTesting(_ runtimeSurface: ghostty_surface_t) {
         surface = runtimeSurface
         portalLifecycleState = .live
         runtimeSurfaceFreedOutOfBandForTesting = false
+        applyDesiredOcclusionState(to: runtimeSurface)
     }
 #endif
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+Renderer.swift
@@ -43,10 +43,20 @@ extension TerminalSurface {
         }
     }
 
-    /// Applies the occlusion state to the runtime surface.
+    /// Records and applies the occlusion state to the runtime surface.
+    ///
+    /// The host can determine that a surface is hidden before Ghostty's native
+    /// surface has been created. Keep the desired state in that case so the
+    /// creation path can apply it before the initial refresh.
     public func setOcclusion(_ visible: Bool) {
+        desiredOcclusionVisible = visible
         guard let surface = surface else { return }
         ghostty_surface_set_occlusion(surface, visible)
+    }
+
+    /// Replays the latest host visibility after a native surface is installed.
+    func applyDesiredOcclusionState(to surface: ghostty_surface_t) {
+        ghostty_surface_set_occlusion(surface, desiredOcclusionVisible)
     }
 
     /// Whether this surface currently holds realized GPU renderer resources.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -542,6 +542,10 @@ extension TerminalSurface {
             return
         }
         guard let createdSurface = surface else { return }
+        // Workspace visibility can settle before background startup creates the
+        // native surface. Apply that state immediately so a hidden terminal's
+        // renderer never starts processing its continuous output as visible.
+        applyDesiredOcclusionState(to: createdSurface)
         if source == .scheduledRestore || source == .inputDemand {
             requiresRestoreSpawnPacing = false
         }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -259,6 +259,13 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// state unless the workspace focus path requests it.
     var desiredFocusState: Bool = false
 
+    /// The desired visibility state for the Ghostty C surface. Visibility can
+    /// be decided before the native surface exists (for example, when a
+    /// background workspace starts headlessly), so creation must replay it.
+    /// Default to visible to preserve Ghostty's behavior until a host supplies
+    /// an explicit occlusion state.
+    var desiredOcclusionVisible: Bool = true
+
     /// Bumped after every completed runtime clipboard read.
     public internal(set) var clipboardReadGeneration = 0
 #if DEBUG

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceOcclusionTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceOcclusionTests.swift
@@ -1,0 +1,81 @@
+import AppKit
+import GhosttyKit
+import Testing
+@testable import CmuxTerminal
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_reset")
+private func resetGhosttyRuntimeStubs()
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_occlusion_call_count")
+private func occlusionCallCount() -> UInt64
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_last_occlusion_surface")
+private func lastOcclusionSurface() -> UInt
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_last_occlusion_visible")
+private func lastOcclusionVisible() -> Bool
+
+@MainActor
+@Suite(.serialized) struct TerminalSurfaceOcclusionTests {
+    @Test func hiddenStateRequestedBeforeRuntimeCreationIsReplayedAfterCreation() {
+        let surface = makeSurface()
+        let runtimeSurface = fakeRuntimeSurface()
+        resetGhosttyRuntimeStubs()
+        defer {
+            resetGhosttyRuntimeStubs()
+            surface.releaseSurfaceForTesting()
+        }
+
+        surface.setOcclusion(false)
+        #expect(occlusionCallCount() == 0)
+
+        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+
+        #expect(occlusionCallCount() == 1)
+        #expect(lastOcclusionSurface() == UInt(bitPattern: runtimeSurface))
+        #expect(!lastOcclusionVisible())
+    }
+
+    private func makeSurface() -> TerminalSurface {
+        let nativeView = FakeTerminalSurfaceNativeView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
+        )
+        let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
+        return TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            dependencies: TerminalSurfaceRuntimeDependencies(
+                registry: FakeSurfaceRegistry(),
+                engine: FakeTerminalEngine(),
+                viewProvider: FakeTerminalSurfaceViewProvider(
+                    surfaceView: nativeView,
+                    paneHost: paneHost
+                ),
+                spawnPolicy: FakeSpawnPolicyProvider(),
+                byteTee: FakeTerminalByteTee(),
+                rendererRealization: FakeRendererRealizationScheduler(),
+                hibernationRecorder: FakeHibernationRecorder(),
+                runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
+                restoreSpawnScheduler: TerminalSurfaceRestoreSpawnScheduler(
+                    interSpawnDelay: .zero
+                ),
+                runtimeFilesystem: TerminalSurfaceRuntimeFilesystem(
+                    claudeCommandShimTemporaryDirectory: URL(
+                        fileURLWithPath: "/tmp/cmux-terminal-tests",
+                        isDirectory: true
+                    ),
+                    installClaudeCommandShim: { _, _, _ in nil },
+                    isExecutableFile: { _ in false }
+                ),
+                sessionPortBase: 40_000,
+                sessionPortRangeSize: 100,
+                scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"
+            )
+        )
+    }
+
+    private func fakeRuntimeSurface() -> ghostty_surface_t {
+        UnsafeMutableRawPointer(bitPattern: 0x0CC1_0510)!
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceOcclusionTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceOcclusionTests.swift
@@ -1,10 +1,11 @@
 import AppKit
+import CmuxTerminalCore
 import GhosttyKit
 import Testing
 @testable import CmuxTerminal
 
-@_silgen_name("cmux_test_ghostty_runtime_stubs_reset")
-private func resetGhosttyRuntimeStubs()
+@_silgen_name("cmux_test_ghostty_runtime_stubs_reset_occlusion")
+private func resetOcclusionStubs()
 
 @_silgen_name("cmux_test_ghostty_runtime_stubs_occlusion_call_count")
 private func occlusionCallCount() -> UInt64
@@ -15,39 +16,53 @@ private func lastOcclusionSurface() -> UInt
 @_silgen_name("cmux_test_ghostty_runtime_stubs_last_occlusion_visible")
 private func lastOcclusionVisible() -> Bool
 
+@_silgen_name("cmux_test_ghostty_runtime_stubs_last_occlusion_sequence")
+private func lastOcclusionSequence() -> UInt64
+
+@_silgen_name("cmux_test_ghostty_runtime_stubs_last_refresh_sequence")
+private func lastRefreshSequence() -> UInt64
+
 @MainActor
 @Suite(.serialized) struct TerminalSurfaceOcclusionTests {
-    @Test func hiddenStateRequestedBeforeRuntimeCreationIsReplayedAfterCreation() {
-        let surface = makeSurface()
-        let runtimeSurface = fakeRuntimeSurface()
-        resetGhosttyRuntimeStubs()
+    @Test func hiddenStateRequestedBeforeRuntimeCreationIsReplayedBeforeRefresh() throws {
+        let surfaceID = UUID()
+        let nativeView = FakeTerminalSurfaceNativeView(
+            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
+        )
+        let surface = makeSurface(id: surfaceID, nativeView: nativeView)
+        resetOcclusionStubs()
         defer {
-            resetGhosttyRuntimeStubs()
             surface.releaseSurfaceForTesting()
+            resetOcclusionStubs()
         }
 
         surface.setOcclusion(false)
         #expect(occlusionCallCount() == 0)
 
-        surface.installRuntimeSurfaceForTesting(runtimeSurface)
+        surface.claudeCommandShimInstallCompleted = true
+        surface.createSurface(for: nativeView, source: .normal)
+        let runtimeSurface = try #require(surface.surface)
 
         #expect(occlusionCallCount() == 1)
         #expect(lastOcclusionSurface() == UInt(bitPattern: runtimeSurface))
         #expect(!lastOcclusionVisible())
+        #expect(lastOcclusionSequence() > 0)
+        #expect(lastRefreshSequence() > lastOcclusionSequence())
     }
 
-    private func makeSurface() -> TerminalSurface {
-        let nativeView = FakeTerminalSurfaceNativeView(
-            frame: NSRect(x: 0, y: 0, width: 800, height: 600)
-        )
+    private func makeSurface(
+        id: UUID,
+        nativeView: FakeTerminalSurfaceNativeView
+    ) -> TerminalSurface {
         let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
         return TerminalSurface(
+            id: id,
             tabId: UUID(),
             context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
             configTemplate: nil,
             dependencies: TerminalSurfaceRuntimeDependencies(
-                registry: FakeSurfaceRegistry(),
-                engine: FakeTerminalEngine(),
+                registry: OcclusionTestSurfaceRegistry(ownerID: id),
+                engine: OcclusionTestTerminalEngine(),
                 viewProvider: FakeTerminalSurfaceViewProvider(
                     surfaceView: nativeView,
                     paneHost: paneHost
@@ -74,8 +89,29 @@ private func lastOcclusionVisible() -> Bool
             )
         )
     }
+}
 
-    private func fakeRuntimeSurface() -> ghostty_surface_t {
-        UnsafeMutableRawPointer(bitPattern: 0x0CC1_0510)!
+@MainActor
+private final class OcclusionTestTerminalEngine: TerminalEngineHosting {
+    let runtimeApp: ghostty_app_t? = UnsafeMutableRawPointer(bitPattern: 0x0CC1_0510)
+    let runtimeConfig: ghostty_config_t? = nil
+    let userGhosttyShellIntegrationMode = "none"
+}
+
+private final class OcclusionTestSurfaceRegistry: TerminalSurfaceRegistering {
+    let ownerID: UUID
+
+    init(ownerID: UUID) {
+        self.ownerID = ownerID
     }
+
+    func register(_ surface: any TerminalSurfacing) {}
+    func unregister(_ surface: any TerminalSurfacing) {}
+    func registerRuntimeSurface(_ surface: ghostty_surface_t, ownerId: UUID) {}
+    func unregisterRuntimeSurface(_ surface: ghostty_surface_t, ownerId: UUID) {}
+    func runtimeSurfaceOwnerId(_ surface: ghostty_surface_t) -> UUID? { ownerID }
+    func surface(id: UUID) -> (any TerminalSurfacing)? { nil }
+    func isRightSidebarDockSurface(id: UUID) -> Bool { false }
+    func updateFocusPlacement(id: UUID, _ placement: TerminalSurfaceFocusPlacement) {}
+    func allSurfaces() -> [any TerminalSurfacing] { [] }
 }

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -4,17 +4,35 @@
 static bool cmux_test_needs_confirm_quit = false;
 static uint64_t cmux_test_foreground_pid = 0;
 static const char* cmux_test_tty_name = NULL;
+static uint64_t cmux_test_occlusion_call_count = 0;
+static uintptr_t cmux_test_last_occlusion_surface = 0;
+static bool cmux_test_last_occlusion_visible = true;
 
 void cmux_test_ghostty_runtime_stubs_reset(void) {
     cmux_test_needs_confirm_quit = false;
     cmux_test_foreground_pid = 0;
     cmux_test_tty_name = NULL;
+    cmux_test_occlusion_call_count = 0;
+    cmux_test_last_occlusion_surface = 0;
+    cmux_test_last_occlusion_visible = true;
 }
 
 void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name) {
     cmux_test_needs_confirm_quit = needs_confirm;
     cmux_test_foreground_pid = foreground_pid;
     cmux_test_tty_name = tty_name;
+}
+
+uint64_t cmux_test_ghostty_runtime_stubs_occlusion_call_count(void) {
+    return cmux_test_occlusion_call_count;
+}
+
+uintptr_t cmux_test_ghostty_runtime_stubs_last_occlusion_surface(void) {
+    return cmux_test_last_occlusion_surface;
+}
+
+bool cmux_test_ghostty_runtime_stubs_last_occlusion_visible(void) {
+    return cmux_test_last_occlusion_visible;
 }
 
 bool ghostty_surface_clear_selection(void *surface) {
@@ -58,7 +76,11 @@ void ghostty_surface_render_grid_json(void) {}
 void ghostty_surface_set_content_scale(void) {}
 void ghostty_surface_set_display_id(void) {}
 void ghostty_surface_set_focus(void) {}
-void ghostty_surface_set_occlusion(void) {}
+void ghostty_surface_set_occlusion(void *surface, bool visible) {
+    cmux_test_occlusion_call_count += 1;
+    cmux_test_last_occlusion_surface = (uintptr_t)surface;
+    cmux_test_last_occlusion_visible = visible;
+}
 void ghostty_surface_set_renderer_realized(void) {}
 void ghostty_surface_set_size(void) {}
 void ghostty_surface_size(void) {}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -1,4 +1,5 @@
 #include "include/GhosttyRuntimeTestStubs.h"
+#include <stdlib.h>
 #include <string.h>
 
 static bool cmux_test_needs_confirm_quit = false;
@@ -7,14 +8,15 @@ static const char* cmux_test_tty_name = NULL;
 static uint64_t cmux_test_occlusion_call_count = 0;
 static uintptr_t cmux_test_last_occlusion_surface = 0;
 static bool cmux_test_last_occlusion_visible = true;
+static uint64_t cmux_test_call_sequence = 0;
+static uint64_t cmux_test_last_occlusion_sequence = 0;
+static uint64_t cmux_test_last_refresh_sequence = 0;
+static ghostty_surface_t cmux_test_created_surface = NULL;
 
 void cmux_test_ghostty_runtime_stubs_reset(void) {
     cmux_test_needs_confirm_quit = false;
     cmux_test_foreground_pid = 0;
     cmux_test_tty_name = NULL;
-    cmux_test_occlusion_call_count = 0;
-    cmux_test_last_occlusion_surface = 0;
-    cmux_test_last_occlusion_visible = true;
 }
 
 void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name) {
@@ -35,6 +37,14 @@ bool cmux_test_ghostty_runtime_stubs_last_occlusion_visible(void) {
     return cmux_test_last_occlusion_visible;
 }
 
+uint64_t cmux_test_ghostty_runtime_stubs_last_occlusion_sequence(void) {
+    return cmux_test_last_occlusion_sequence;
+}
+
+uint64_t cmux_test_ghostty_runtime_stubs_last_refresh_sequence(void) {
+    return cmux_test_last_refresh_sequence;
+}
+
 bool ghostty_surface_clear_selection(void *surface) {
     (void)surface;
     return false;
@@ -46,8 +56,15 @@ void ghostty_string_free(ghostty_string_s string) {
     (void)string;
 }
 void ghostty_surface_binding_action(void) {}
-void ghostty_surface_config_new(void) {}
-void ghostty_surface_free(void) {}
+ghostty_surface_config_s ghostty_surface_config_new(void) {
+    return (ghostty_surface_config_s){0};
+}
+void ghostty_surface_free(ghostty_surface_t surface) {
+    if (surface == cmux_test_created_surface) {
+        free(surface);
+        cmux_test_created_surface = NULL;
+    }
+}
 void ghostty_surface_free_text(void) {}
 uint64_t ghostty_surface_foreground_pid(void *surface) {
     (void)surface;
@@ -62,24 +79,40 @@ bool ghostty_surface_needs_confirm_quit(void *surface) {
     (void)surface;
     return cmux_test_needs_confirm_quit;
 }
-void ghostty_surface_new(void) {}
+ghostty_surface_t ghostty_surface_new(ghostty_app_t app, const ghostty_surface_config_s* config) {
+    (void)app;
+    (void)config;
+    cmux_test_created_surface = malloc(1);
+    return cmux_test_created_surface;
+}
 bool ghostty_surface_process_exited(void *surface) {
     (void)surface;
     return false;
 }
 void ghostty_surface_process_output(void) {}
-void ghostty_surface_quicklook_font(void) {}
+void* ghostty_surface_quicklook_font(ghostty_surface_t surface) {
+    (void)surface;
+    return NULL;
+}
 void ghostty_surface_read_screen_tail_vt(void) {}
 void ghostty_surface_read_text(void) {}
-void ghostty_surface_refresh(void) {}
+void ghostty_surface_refresh(ghostty_surface_t surface) {
+    if (surface == cmux_test_created_surface) {
+        cmux_test_last_refresh_sequence = ++cmux_test_call_sequence;
+    }
+}
 void ghostty_surface_render_grid_json(void) {}
 void ghostty_surface_set_content_scale(void) {}
 void ghostty_surface_set_display_id(void) {}
 void ghostty_surface_set_focus(void) {}
 void ghostty_surface_set_occlusion(void *surface, bool visible) {
+    if (surface != cmux_test_created_surface) {
+        return;
+    }
     cmux_test_occlusion_call_count += 1;
     cmux_test_last_occlusion_surface = (uintptr_t)surface;
     cmux_test_last_occlusion_visible = visible;
+    cmux_test_last_occlusion_sequence = ++cmux_test_call_sequence;
 }
 void ghostty_surface_set_renderer_realized(void) {}
 void ghostty_surface_set_size(void) {}
@@ -92,4 +125,12 @@ ghostty_string_s ghostty_surface_tty_name(void *surface) {
         return (ghostty_string_s){0};
     }
     return (ghostty_string_s){.ptr = cmux_test_tty_name, .len = strlen(cmux_test_tty_name), .sentinel = false};
+}
+void cmux_test_ghostty_runtime_stubs_reset_occlusion(void) {
+    cmux_test_occlusion_call_count = 0;
+    cmux_test_last_occlusion_surface = 0;
+    cmux_test_last_occlusion_visible = true;
+    cmux_test_call_sequence = 0;
+    cmux_test_last_occlusion_sequence = 0;
+    cmux_test_last_refresh_sequence = 0;
 }

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -2,6 +2,7 @@
 #define GHOSTTY_RUNTIME_TEST_STUBS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 #include <stdint.h>
 
 // Test-only stand-ins for the libghostty symbols referenced by CmuxTerminal
@@ -15,14 +16,46 @@ typedef struct {
   bool sentinel;
 } ghostty_string_s;
 
+typedef void* ghostty_app_t;
+typedef void* ghostty_surface_t;
+typedef int32_t ghostty_platform_e;
+typedef int32_t ghostty_surface_context_e;
+typedef int32_t ghostty_surface_io_mode_e;
+typedef void (*ghostty_io_write_cb)(void*, const char*, uintptr_t);
+
+typedef union {
+  struct { void* nsview; } macos;
+  struct { void* uiview; } ios;
+} ghostty_platform_u;
+
+// Matches ghostty_surface_config_s so the test stub can execute the real
+// CmuxTerminal surface-creation path without linking libghostty.
+typedef struct {
+  ghostty_platform_e platform_tag;
+  ghostty_platform_u platform;
+  void* userdata;
+  double scale_factor;
+  float font_size;
+  const char* working_directory;
+  const char* command;
+  void* env_vars;
+  size_t env_var_count;
+  const char* initial_input;
+  bool wait_after_command;
+  ghostty_surface_context_e context;
+  ghostty_surface_io_mode_e io_mode;
+  ghostty_io_write_cb io_write_cb;
+  void* io_write_userdata;
+} ghostty_surface_config_s;
+
 bool ghostty_surface_clear_selection(void *surface);
 
 void ghostty_config_diagnostics_count(void);
 void ghostty_config_get_diagnostic(void);
 void ghostty_string_free(ghostty_string_s string);
 void ghostty_surface_binding_action(void);
-void ghostty_surface_config_new(void);
-void ghostty_surface_free(void);
+ghostty_surface_config_s ghostty_surface_config_new(void);
+void ghostty_surface_free(ghostty_surface_t surface);
 void ghostty_surface_free_text(void);
 uint64_t ghostty_surface_foreground_pid(void *surface);
 void ghostty_surface_has_selection(void);
@@ -31,13 +64,13 @@ void ghostty_surface_mouse_button(void);
 void ghostty_surface_mouse_pos(void);
 void ghostty_surface_mouse_scroll(void);
 bool ghostty_surface_needs_confirm_quit(void *surface);
-void ghostty_surface_new(void);
+ghostty_surface_t ghostty_surface_new(ghostty_app_t app, const ghostty_surface_config_s* config);
 bool ghostty_surface_process_exited(void *surface);
 void ghostty_surface_process_output(void);
-void ghostty_surface_quicklook_font(void);
+void* ghostty_surface_quicklook_font(ghostty_surface_t surface);
 void ghostty_surface_read_screen_tail_vt(void);
 void ghostty_surface_read_text(void);
-void ghostty_surface_refresh(void);
+void ghostty_surface_refresh(ghostty_surface_t surface);
 void ghostty_surface_render_grid_json(void);
 void ghostty_surface_set_content_scale(void);
 void ghostty_surface_set_display_id(void);
@@ -52,8 +85,11 @@ ghostty_string_s ghostty_surface_tty_name(void *surface);
 
 void cmux_test_ghostty_runtime_stubs_reset(void);
 void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name);
+void cmux_test_ghostty_runtime_stubs_reset_occlusion(void);
 uint64_t cmux_test_ghostty_runtime_stubs_occlusion_call_count(void);
 uintptr_t cmux_test_ghostty_runtime_stubs_last_occlusion_surface(void);
 bool cmux_test_ghostty_runtime_stubs_last_occlusion_visible(void);
+uint64_t cmux_test_ghostty_runtime_stubs_last_occlusion_sequence(void);
+uint64_t cmux_test_ghostty_runtime_stubs_last_refresh_sequence(void);
 
 #endif

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -42,7 +42,7 @@ void ghostty_surface_render_grid_json(void);
 void ghostty_surface_set_content_scale(void);
 void ghostty_surface_set_display_id(void);
 void ghostty_surface_set_focus(void);
-void ghostty_surface_set_occlusion(void);
+void ghostty_surface_set_occlusion(void *surface, bool visible);
 void ghostty_surface_set_renderer_realized(void);
 void ghostty_surface_set_size(void);
 void ghostty_surface_size(void);
@@ -52,5 +52,8 @@ ghostty_string_s ghostty_surface_tty_name(void *surface);
 
 void cmux_test_ghostty_runtime_stubs_reset(void);
 void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_t foreground_pid, const char* tty_name);
+uint64_t cmux_test_ghostty_runtime_stubs_occlusion_call_count(void);
+uintptr_t cmux_test_ghostty_runtime_stubs_last_occlusion_surface(void);
+bool cmux_test_ghostty_runtime_stubs_last_occlusion_visible(void);
 
 #endif


### PR DESCRIPTION
## Summary

- Persist the latest requested occlusion state even when the native Ghostty surface has not been created yet.
- Replay that state immediately after `ghostty_surface_new`, before the initial refresh, so headless/background terminals do not start life as visible renderers.
- Add a serialized regression test with Ghostty C-stub call capture. The test-only commit fails before the fix and passes after it.
- This is a narrow, rebased, tested successor to #2485. It relates to the high-CPU report in #7186 and overlaps only the surface-creation replay part of the broader #7621.

## Testing

### Regression proof

- Test-only commit `492a1da`: `swift test --package-path Packages/macOS/CmuxTerminal --filter TerminalSurfaceOcclusionTests` fails all three replay assertions (0 occlusion calls; no surface/visibility forwarded).
- Fix commit `f47682a`: the same command passes 1 test in 1 suite.
- Full package: `swift test --package-path Packages/macOS/CmuxTerminal` passes 78 Swift Testing tests plus 11 XCTest tests.
- Repository guards: `python3 scripts/check-package-resolved-policy.py`, `git diff --check origin/main...HEAD`, and `./tests/test_ci_swift_file_length_budget.sh` pass.
- Tagged Debug build: `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag pr-occ-after` succeeds.

### Time Profiler evidence

Captured with the repository profiling wrapper:

```sh
Resources/bin/start-cmux-profiling \
  --pid <pid> --duration 15 --template "Time Profiler" \
  --no-submit --out <directory>
```

Repro workload: 12 background workspaces, each continuously writing 100 lines/second. All 12 reported `runtime=1 visible=0 inWindow=0`; `read-screen` confirmed their counters kept advancing while the foreground workspace stayed selected.

| Metric (15 s profile) | Test-only baseline `492a1da` | Fixed `f47682a` | Reduction |
| --- | ---: | ---: | ---: |
| Average process CPU from running samples | 214.12% | 6.00% | 97.20% |
| Ghostty renderer-thread CPU | 186.38% | 1.24% | 99.33% |
| CPU samples containing `updateFrame` / `rebuildRow` / `addGlyph` / `renderGlyph` | 9,903 ms | 0 ms | 100% |

A separate 5-second `sample` capture showed the same direction: the baseline was dominated by `Renderer.rebuildRow`, `addGlyph`, and `SharedGrid.renderGlyph`; the fixed run had zero hits for those target symbols.

Raw `.trace` bundles are intentionally not attached because Instruments records the target process environment. I exported and inspected sanitized Time Profiler tables locally; they contain no environment section or common secret-key markers.

### Manual verification

- Background streaming output continued to advance after occlusion.
- The foreground workspace remained selected throughout profiling.
- The final tagged app compiled successfully from the pushed HEAD.
- No user-facing strings changed; localization catalogs are unaffected.

## Demo Video

This changes renderer lifecycle behavior without a visible UI change. The Time Profiler comparison above is the relevant demo.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed (not needed for this internal lifecycle fix)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8057"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786620932&installation_id=133855650&pr_number=8057&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8057&signature=71b41188f653228b4487b39ef72e5f55ebbf76d94120cfa2c4e903cf9d0962d5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal surfaces now preserve requested visibility settings before the surface is created.
  * Newly created terminal surfaces immediately apply the correct hidden or visible state.
  * Prevents unnecessary terminal output processing when a surface should be hidden.

* **Tests**
  * Added coverage verifying occlusion state and refresh ordering during surface creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->