### PR TITLE
feat: honour app.preferredEditor for Ghostty-detected file-path links

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3064,7 +3064,11 @@ class GhosttyApp {
                         return (false, nil)
                     }
                     guard CommandClickFileOpenRouter.shouldRouteInCmux(path: resolvedPath) else {
-                        return (false, resolvedPath)
+                        // Not a cmux-supported file type; open directly in the preferred editor
+                        // so that app.preferredEditor is honoured for .tsx, .py, .go etc.
+                        let fileURL = URL(fileURLWithPath: resolvedPath)
+                        PreferredEditorService(defaults: .standard).open(fileURL)
+                        return (true, resolvedPath)
                     }
                     #if DEBUG
                     cmuxDebugLog("link.openURL resolvedAsFilePath=\(resolvedPath)")
@@ -3076,7 +3080,7 @@ class GhosttyApp {
                         surfaceId: termSurface.id,
                         filePath: resolvedPath
                     ) {
-                        NSWorkspace.shared.open(fileURL)
+                        PreferredEditorService(defaults: .standard).open(fileURL)
                     }
                     return (true, resolvedPath)
                 }
@@ -3124,7 +3128,7 @@ class GhosttyApp {
                         surfaceId: termSurface.id,
                         filePath: fileURL.path
                     ) {
-                        NSWorkspace.shared.open(fileURL)
+                        PreferredEditorService(defaults: .standard).open(fileURL)
                     }
                     return true
                 }


### PR DESCRIPTION
## Summary

Fixes #1678 — file paths that Ghostty's built-in hyperlink scanner detects (i.e. paths surfaced via `GHOSTTY_ACTION_OPEN_URL`) now open in the user's configured editor rather than the system default.

- When a resolved path is **not** a cmux-supported type (`.tsx`, `.py`, `.go`, etc.): opens directly via `PreferredEditorService` instead of falling through to the URL-routing path and `NSWorkspace.shared.open`.
- When a cmux-routed file **fails** to open in the internal viewer: the `deferredOpenFileInCmux` fallback now calls `PreferredEditorService` instead of `NSWorkspace.shared.open`.

The cmd-click word-under-cursor paths (`tryOpenWordAsPath`, `handleCommandClickRelease`) already used `PreferredEditorService`; this change brings the Ghostty hyperlink-detection code path into line with them.

## How to use

Settings → App → **Open Files With** — set to `code`, `zed`, `subl`, `cursor`, etc.  
Leave empty to keep the system default (no behaviour change).

## Test plan

- [ ] With `app.preferredEditor = code`, cmd-click a `.tsx` path in terminal output — VS Code opens at that file
- [ ] With `app.preferredEditor` empty, same click still opens with the system default
- [ ] With "Open Supported Files in cmux" ON, cmd-clicking a Markdown file still opens the cmux viewer
- [ ] With "Open Supported Files in cmux" ON but cmux split creation fails, the preferred editor catches the fallback

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8058"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786624346&installation_id=133855650&pr_number=8058&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8058&signature=9ec95161fa1b28ffa4ee2bbe9b2a73cce6c5362b0816dd799c47deff54b3d0f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ghostty-detected file-path links now honor the `app.preferredEditor` setting, opening files in your chosen editor instead of the system default. Non-cmux types and cmux fallbacks now use `PreferredEditorService` consistently. Closes #1678.

- **New Features**
  - For `GHOSTTY_ACTION_OPEN_URL`, non-cmux-supported paths open via `PreferredEditorService`.
  - If a cmux-routed file fails to open, fallback now uses `PreferredEditorService` instead of `NSWorkspace.shared.open`.

<sup>Written for commit d12d2931d8950815d9577e3e73d6a836401cbdc5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

