### PR TITLE
Fix sidebar Running/Needs-input pills attaching to wrong workspace on cold load (#7519)

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13015,6 +13015,16 @@ private struct ExtensionSidebarBrowserStackEmptyArea: View {
 // Do NOT remove .equatable() from the ForEach call site in VerticalTabsSidebar.
 struct SidebarWorkspaceSnapshotBuilder {
     struct PresentationKey: Equatable {
+        /// Identity of the workspace this snapshot was built for. Included in the
+        /// cache-validity key so a `TabItemView`'s memoized snapshot
+        /// (`workspaceSnapshotStorage` / `workspaceSnapshotScratch`) can never be
+        /// served for a *different* workspace after SwiftUI recycles the row's
+        /// `@State` across an identity change — the LazyVStack recycling hazard
+        /// behind #7519, where sidebar "Running" / "Needs input" pills attached to
+        /// neighbouring workspaces on cold load. The rest of the key is global
+        /// presentation settings, so without this field every row's key compared
+        /// equal and a recycled snapshot passed the guard silently.
+        let workspaceId: UUID
         let showsWorkspaceDescription: Bool
         let usesVerticalBranchLayout: Bool
         let showsGitBranch: Bool
@@ -13514,6 +13524,7 @@ struct TabItemView: View, Equatable {
 
     private var workspaceSnapshotPresentationKey: SidebarWorkspaceSnapshotBuilder.PresentationKey {
         SidebarWorkspaceSnapshotBuilder.PresentationKey(
+            workspaceId: tab.id,
             showsWorkspaceDescription: settings.showsWorkspaceDescription,
             usesVerticalBranchLayout: sidebarBranchVerticalLayout,
             showsGitBranch: sidebarShowGitBranch,

--- a/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
+++ b/cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift
@@ -119,6 +119,63 @@ import Testing
         #expect(!decision.hasDeferredWorkspaceObservationInvalidation)
     }
 
+    // MARK: - #7519 cold-load pill mis-attribution
+
+    /// `TabItemView.workspaceSnapshot` serves a memoized snapshot when its
+    /// `presentationKey` matches the row's current key
+    /// (`Sources/ContentView.swift`). This mirrors that guard so the cache
+    /// contract can be tested without a live SwiftUI hierarchy.
+    private static func servedSnapshot(
+        cached: SidebarWorkspaceSnapshotBuilder.Snapshot?,
+        currentKey: SidebarWorkspaceSnapshotBuilder.PresentationKey
+    ) -> SidebarWorkspaceSnapshotBuilder.Snapshot? {
+        guard let cached, cached.presentationKey == currentKey else { return nil }
+        return cached
+    }
+
+    /// Two rows that differ only by which workspace they render must produce
+    /// distinct presentation keys. Before #7519 the key held only global
+    /// presentation settings, so every row's key compared equal and a recycled
+    /// snapshot silently passed the cache guard.
+    @Test func presentationKeyDistinguishesWorkspaces() {
+        let workspaceA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000001")!
+        let workspaceB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000002")!
+        let keyA = Self.presentationKey(workspaceId: workspaceA)
+        let keyB = Self.presentationKey(workspaceId: workspaceB)
+        #expect(keyA != keyB)
+        #expect(Self.presentationKey(workspaceId: workspaceA) == keyA)
+    }
+
+    /// Regression for #7519: a workspace's memoized snapshot (carrying its
+    /// "Running" / "Needs input" pills) must never be served for a *different*
+    /// workspace after the `LazyVStack` recycles the row's `@State` across an
+    /// identity change. The recycled snapshot must fail the cache guard so the
+    /// row rebuilds from its own workspace instead of showing a neighbour's.
+    @Test func memoizedSnapshotIsNotServedForADifferentWorkspace() {
+        let workspaceA = UUID(uuidString: "AAAAAAAA-0000-0000-0000-000000000001")!
+        let workspaceB = UUID(uuidString: "BBBBBBBB-0000-0000-0000-000000000002")!
+
+        // Workspace A has three running coding agents (its "Running" pill).
+        let cachedForA = Self.snapshot(
+            presentationKey: Self.presentationKey(workspaceId: workspaceA),
+            title: "workspace-a",
+            activeCodingAgentCount: 3
+        )
+
+        // The row is now bound to workspace B (idle) under identical global
+        // presentation settings — exactly the recycled-row state.
+        let currentKeyForB = Self.presentationKey(workspaceId: workspaceB)
+
+        let served = Self.servedSnapshot(cached: cachedForA, currentKey: currentKeyForB)
+
+        // Cache must MISS: B never inherits A's running-agent pill.
+        #expect(served == nil)
+
+        // And A's own row still serves its cached snapshot.
+        let currentKeyForA = Self.presentationKey(workspaceId: workspaceA)
+        #expect(Self.servedSnapshot(cached: cachedForA, currentKey: currentKeyForA) == cachedForA)
+    }
+
     static func snapshot(
         presentationKey: SidebarWorkspaceSnapshotBuilder.PresentationKey? = nil,
         title: String = "workspace",
@@ -161,7 +218,14 @@ import Testing
         )
     }
 
+    /// Stable default identity so `snapshot()` / `presentationKey()` calls model
+    /// successive snapshots of ONE workspace (the common same-workspace case).
+    /// Cross-workspace tests pass distinct ids explicitly; keeping the default
+    /// random would make key-difference assertions pass on unrelated UUIDs.
+    static let defaultWorkspaceId = UUID(uuidString: "00000000-0000-0000-0000-000000000001")!
+
     static func presentationKey(
+        workspaceId: UUID = SidebarWorkspaceSnapshotRefreshPolicyTests.defaultWorkspaceId,
         showsWorkspaceDescription: Bool = true,
         usesVerticalBranchLayout: Bool = true,
         showsGitBranch: Bool = true,
@@ -177,6 +241,7 @@ import Testing
         )
     ) -> SidebarWorkspaceSnapshotBuilder.PresentationKey {
         SidebarWorkspaceSnapshotBuilder.PresentationKey(
+            workspaceId: workspaceId,
             showsWorkspaceDescription: showsWorkspaceDescription,
             usesVerticalBranchLayout: usesVerticalBranchLayout,
             showsGitBranch: showsGitBranch,


### PR DESCRIPTION
## Summary

**What changed?** `SidebarWorkspaceSnapshotBuilder.PresentationKey` now includes the workspace identity (`workspaceId: tab.id`). This key guards `TabItemView`'s per-row snapshot memo (`workspaceSnapshotStorage` / `workspaceSnapshotScratch`).

**Why?** Fixes #7519 — on cold app load the sidebar **Running** / **Needs input** status pills attach to the wrong workspaces (a neighbour's pill renders on the wrong tile; selecting the tile shows a different state than the pill claims).

Root cause: `TabItemView` memoizes its per-row sidebar snapshot — which carries the pill data (`metadataEntries` = `statusEntries`, and `activeCodingAgentCount`) — and serves the cached value whenever the current `PresentationKey` matches the stored one:

```swift
if let workspaceSnapshotStorage,
   workspaceSnapshotStorage.presentationKey == presentationKey {
    return workspaceSnapshotStorage
}
```

But `PresentationKey` was built from **global presentation settings only** (`showsAgentActivity`, `visibleAuxiliaryDetails`, …) with **nothing identifying the workspace**, so every row's key compared equal. The sidebar list is a `LazyVStack` (enforced by `scripts/check-sidebar-lazy-layout.py`). On cold load, `TabManager.restoreSessionSnapshot` replaces the entire `tabs` array with workspaces that all receive **fresh UUIDs**. When SwiftUI recycles a row's `@State` across that identity change, the memo returns the *previously bound* workspace's cached snapshot, and the presentation-key guard cannot detect that it belongs to a different workspace — so the neighbour's pills render on the wrong tile until an observation-driven refresh happens to correct it.

The data layer is not at fault: `statusEntries` / `agentLifecycleStatesByPanelId` are cleared on restore and re-seeded by UUID-resolved events (verified via a trace of the restore + hook-resolution paths). The mis-attribution is purely in the render-layer memo.

The fix makes the cache correct-by-construction: a snapshot built for workspace A can never satisfy workspace B's cache guard, so a recycled row falls through to `makeWorkspaceSnapshot()` and rebuilds from its own `tab`.

Two commits:
1. the fix (`Sources/ContentView.swift`)
2. the regression test (`cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests.swift`)

> Note on the repo's two-commit red/green convention: because the fix is *adding a field* to `PresentationKey`, a test-first commit cannot compile against the buggy API (the test must reference `workspaceId`), so a literal in-target runtime-red is not achievable for this defect class. The red/green is demonstrated instead by an isolated harness that models the exact cache guard with and without the field: `beforeFix` → serves A's pills for B (bug reproduced); `afterFix` → cache miss, rebuilds from B. Happy to restructure if a maintainer prefers a different arrangement.

## Testing

- **Unit test (in-target, `cmux-unit` scheme):** added `presentationKeyDistinguishesWorkspaces` and `memoizedSnapshotIsNotServedForADifferentWorkspace` to `SidebarWorkspaceSnapshotRefreshPolicyTests` (already wired into the pbxproj). Both pass compiled into the real `cmux` module:
  ```
  ✔ Test presentationKeyDistinguishesWorkspaces() passed
  ✔ Test memoizedSnapshotIsNotServedForADifferentWorkspace() passed
  ✔ Suite SidebarWorkspaceSnapshotRefreshPolicyTests passed  (10 tests, 0 failures)
  ** TEST SUCCEEDED **
  ```
  Run: `xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination 'platform=macOS' -only-testing:cmuxTests/SidebarWorkspaceSnapshotRefreshPolicyTests CMUX_SKIP_ZIG_BUILD=1 test`
- **Isolated harness (red/green):** models the getter's cache guard with/without `workspaceId` — reproduces the bug before the fix and confirms the cache miss after.
- **Build:** tagged Debug app builds and signs cleanly with the change.

**Manual repro (matches the report):** launch the app, shrink the window so the sidebar scrolls (forces `LazyVStack` row recycling), create ~10–12 workspaces (a couple with nested cwds, e.g. `~/tmp/repro/elastic` and `~/tmp/repro/elastic/kiriver`), put several `claude` sessions into distinct states (Running / Needs input / idle), `Cmd-Q`, and cold-relaunch. Compare each tile's pill against the pane's real state.

## Demo Video

- Video URL or attachment: _N/A — the visual manifestation depends on SwiftUI's `LazyVStack` `@State` recycling (timing-dependent). Deterministic coverage is provided by the unit test above; can add a screen recording of the manual repro on request._

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed (N/A — internal render fix, no user-facing string/API change)
- [ ] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

## Related (not addressed here)

While tracing this I found two adjacent issues worth separate follow-up:
- `SessionIndexStore.swift:418` (`filteredEntriesForCurrentScope`) uses a cwd prefix match with no longest-prefix / nearest-workspace ownership, so a parent workspace (`~/projects/elastic`) absorbs a nested child's (`~/projects/elastic/kiriver`) sessions in the **Sessions** panel. This is the nested-cwd pattern noted in the issue, but on a different surface than the sidebar pills.
- `RestorableAgentSession.entry(workspaceId:panelId:)` falls back to a panel-id-only key on cold load (workspace UUIDs are regenerated); safe while panel ids are unique, but fragile if a panel has moved workspaces.

Fixes #7519

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8062"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786631380&installation_id=133855650&pr_number=8062&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8062&signature=cf40e03d5ac178f87da1303f5beb8f9f1a52acecc79f6d5907f8649d5ceea361"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sidebar "Running"/"Needs input" pills attaching to the wrong workspace on cold launch by scoping snapshot caching per workspace. We now include the workspace ID in the snapshot `PresentationKey` so memoized snapshots are never reused across workspaces. Fixes #7519.

- **Bug Fixes**
  - Add `workspaceId` (`tab.id`) to `SidebarWorkspaceSnapshotBuilder.PresentationKey` and pass it from `TabItemView`.
  - Ensure recycled `LazyVStack` rows miss the cache and rebuild from their own `tab`.
  - Add regression tests in `SidebarWorkspaceSnapshotRefreshPolicyTests` to verify keys differ per workspace and prevent serving another workspace’s snapshot.

<sup>Written for commit 8ab8ea9264432e15aec2b43a2ce3c5aa0997add5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed workspace snapshot caching to avoid showing stale content when switching between workspaces.
  * Improved cache validation so snapshot reuse is correctly scoped to the active workspace, including safe behavior during row identity recycling.

* **Tests**
  * Added regression coverage to ensure snapshot presentation keys differ across workspaces and remain stable within the same workspace, preventing cross-workspace cache hits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->