### PR TITLE
Replace sidebar workspace list with an AppKit NSTableView (issue 8004 alternative)

### DIFF
--- a/Sources/App/WorkspaceRuntimeSettings.swift
+++ b/Sources/App/WorkspaceRuntimeSettings.swift
@@ -1,6 +1,5 @@
 import Darwin
 import Foundation
-
 enum WorkspaceTitlebarSettings {
     static let showTitlebarKey = "workspaceTitlebarVisible"
     static let defaultShowTitlebar = true
@@ -14,7 +13,6 @@ enum WorkspaceTitlebarSettings {
 }
 enum WorkspacePresentationModeSettings {
     static let modeKey = "workspacePresentationMode"
-
     enum Mode: String {
         case standard
         case minimal

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -9901,17 +9901,13 @@ struct VerticalTabsSidebar: View {
     // Bonsplit tab drags arrive through AppKit pasteboard callbacks, not
     // `SidebarDragState`, so they need a separate transient collection flag.
     @State private var isBonsplitWorkspaceDropTargetCollectionActive = false
-    @State private var bonsplitWorkspaceDropTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()
     @State private var isWorkspaceReorderDropTargetCollectionActive = false
-    @State private var workspaceReorderDropTargetBridge = SidebarWorkspaceReorderDropOverlay.TargetBridge()
     // Freezes `showsModifierShortcutHints` for the workspace whose context menu
     // is open. Set on the row's contextMenu.onAppear and cleared on
     // .onDisappear so modifier-key transitions don't flip the badges on the
     // row sitting behind the open menu. See `SidebarShortcutHintFreezePolicy`.
     @State private var frozenShortcutHintsTabId: UUID?
     @State private var frozenShortcutHintsValue: Bool = false
-    @State private var pendingSelectedWorkspaceScrollId: UUID?
-    @State private var workspaceScrollContentMinHeight: CGFloat = 0
     @State private var collapsedExtensionSidebarSectionIds: Set<String> = []
     @State private var extensionSidebarWorktreeCreationInFlightSectionIds: Set<String> = []
     @State private var extensionSidebarUpdateToken: UInt64 = 0
@@ -9943,7 +9939,10 @@ struct VerticalTabsSidebar: View {
     @LiveSetting(\.sidebar.showAgentActivity) private var showAgentActivity
 #if DEBUG
     @Environment(\.minimalModeInvalidationProbe) private var minimalModeInvalidationProbe
+    @Environment(\.sidebarLazyContractProbe) private var sidebarLazyContractProbe
 #endif
+    @Environment(\.colorScheme) private var sidebarColorScheme
+    @Environment(\.cmuxGlobalFontMagnificationPercent) private var sidebarGlobalFontMagnificationPercent
 
     // The provider to actually render. Built-in views are always honored; only
     // the hosted-extension selection falls back to the default workspaces
@@ -10162,65 +10161,8 @@ struct VerticalTabsSidebar: View {
         )
     }
 
-    private func requestSelectedWorkspaceScroll(
-        _ proxy: ScrollViewProxy,
-        renderContext: WorkspaceListRenderContext
-    ) {
-        guard let selectedWorkspaceId = tabManager.selectedTabId,
-              renderContext.workspaceIds.contains(selectedWorkspaceId) else {
-            pendingSelectedWorkspaceScrollId = nil
-            return
-        }
-
-        pendingSelectedWorkspaceScrollId = selectedWorkspaceId
-        flushPendingSelectedWorkspaceScroll(proxy, renderContext: renderContext)
-    }
-
-    private func flushPendingSelectedWorkspaceScroll(
-        _ proxy: ScrollViewProxy,
-        renderContext: WorkspaceListRenderContext
-    ) {
-        guard let selectedWorkspaceId = pendingSelectedWorkspaceScrollId else { return }
-
-        // Scroll unconditionally: ScrollViewProxy resolves `.id(_:)` values in
-        // lazy containers without requiring the row to be realized, and an
-        // unknown id is a harmless no-op. The previous design gated this on a
-        // per-row "laid-out row ids" PreferenceKey whose sidebar-wide reduce
-        // fed `@State` writes from inside the layout/preference update cycle,
-        // the cmux-owned edge in the sidebar layout livelock
-        // (https://github.com/manaflow-ai/cmux/issues/2586). No anchor means
-        // SwiftUI scrolls the minimum needed to reveal the row.
-        let group = renderContext.workspaceById[selectedWorkspaceId]?.groupId
-            .flatMap { renderContext.workspaceGroupById[$0] }
-        proxy.scrollTo(SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId(
-            selectedWorkspaceId: selectedWorkspaceId,
-            group: group
-        ))
-        pendingSelectedWorkspaceScrollId = nil
-    }
-
-    private func shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(
-        from oldWorkspaceIds: [UUID],
-        to newWorkspaceIds: [UUID]
-    ) -> Bool {
-        SidebarSelectedWorkspaceScrollPolicy.shouldScrollSelectedWorkspace(
-            selectedWorkspaceId: tabManager.selectedTabId,
-            oldWorkspaceIds: oldWorkspaceIds,
-            newWorkspaceIds: newWorkspaceIds
-        )
-    }
-
-    private func requestSelectedWorkspaceScrollAfterWorkspaceOrderChange(_ notification: Notification) {
-        guard let manager = notification.object as? TabManager, manager === tabManager else {
-            return
-        }
-        guard let selectedWorkspaceId = tabManager.selectedTabId else { return }
-        let movedWorkspaceIds = notification.userInfo?[WorkspaceOrderChangeNotificationKey.movedWorkspaceIds] as? [UUID] ?? []
-        guard movedWorkspaceIds.contains(selectedWorkspaceId) else { return }
-        pendingSelectedWorkspaceScrollId = selectedWorkspaceId
-    }
-
     struct WorkspaceListRenderContext {
+        let environment: SidebarWorkspaceTableEnvironmentSnapshot
         let tabs: [Workspace]
         /// Stored `tabs.map(\.id)` snapshot so row predicates avoid O(n) work.
         let tabIds: [UUID]
@@ -10301,7 +10243,20 @@ struct VerticalTabsSidebar: View {
                 visibleWorkspaceRowIds: visibleWorkspaceRowIds
             )
         } ?? []
+#if DEBUG
+        let tableEnvironment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: sidebarColorScheme,
+            globalFontMagnificationPercent: sidebarGlobalFontMagnificationPercent,
+            lazyContractProbe: sidebarLazyContractProbe
+        )
+#else
+        let tableEnvironment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: sidebarColorScheme,
+            globalFontMagnificationPercent: sidebarGlobalFontMagnificationPercent
+        )
+#endif
         let renderContext = WorkspaceListRenderContext(
+            environment: tableEnvironment,
             tabs: tabs,
             tabIds: tabIds,
             sidebarReorderIds: sidebarReorderIds,
@@ -10442,25 +10397,35 @@ struct VerticalTabsSidebar: View {
     }
 
     private func workspaceScrollArea(renderContext: WorkspaceListRenderContext) -> some View {
-        let scrollInsets = SidebarWorkspaceScrollInsets.workspaceList
-        return ScrollViewReader { scrollProxy in
-            ScrollView(.vertical) {
-                workspaceScrollContent(renderContext: renderContext, minHeight: workspaceScrollContentMinHeight)
+        let tableRows = renderContext.workspaceRenderItems.map { item in
+            switch item {
+            case .groupHeader(let group, let memberWorkspaceIds):
+                sidebarWorkspaceGroupTableConfiguration(
+                    group: group,
+                    memberWorkspaceIds: memberWorkspaceIds,
+                    renderContext: renderContext,
+                    showModifierHoldHints: showModifierHoldHints
+                )
+            case .workspace(let workspace):
+                workspaceTableRowConfiguration(workspace, renderContext: renderContext)
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
-            .background(
-                SidebarScrollViewResolver { scrollView in
-                    configureSidebarScrollView(scrollView)
-                    dragAutoScrollController.attach(scrollView: scrollView)
-                }
-                .frame(width: 0, height: 0)
+        }
+        let selectedScrollTargetWorkspaceId: UUID? = tabManager.selectedTabId.map { selectedId in
+            let group = renderContext.workspaceById[selectedId]?.groupId
+                .flatMap { renderContext.workspaceGroupById[$0] }
+            return SidebarSelectedWorkspaceScrollPolicy.scrollTargetWorkspaceId(
+                selectedWorkspaceId: selectedId,
+                group: group
             )
-            .safeAreaInset(edge: .top, spacing: 0) {
-                Color.clear.frame(height: scrollInsets.top).allowsHitTesting(false)
-            }
-            .safeAreaInset(edge: .bottom, spacing: 0) {
-                Color.clear.frame(height: scrollInsets.bottom).allowsHitTesting(false)
-            }
+        }
+        return SidebarWorkspaceTableView(
+            rows: tableRows,
+            actions: workspaceTableActions(renderContext: renderContext),
+            workspaceIds: renderContext.workspaceIds,
+            selectedWorkspaceId: tabManager.selectedTabId,
+            selectedScrollTargetWorkspaceId: selectedScrollTargetWorkspaceId
+        )
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
             .mask(
                 SidebarWorkspaceScrollEdgeFadeMask(
                     topHeight: sidebarTopScrimHeight,
@@ -10477,38 +10442,7 @@ struct VerticalTabsSidebar: View {
             .overlay(alignment: .topLeading) {
                 minimalModeSidebarTitlebarControlsOverlay()
             }
-            .overlay(alignment: .top) {
-                workspaceReorderDropOverlay(
-                    renderContext: renderContext,
-                    pointOffset: CGSize(width: 0, height: -scrollInsets.top)
-                )
-                .frame(maxWidth: .infinity)
-                .frame(height: scrollInsets.top)
-            }
             .background(Color.clear)
-            .modifier(ClearScrollBackground())
-            .onGeometryChange(for: CGFloat.self) {
-                SidebarWorkspaceScrollLayout.contentMinHeight(viewportHeight: $0.size.height, insets: scrollInsets)
-            } action: { updateWorkspaceScrollContentMinHeight($0) }
-            .onAppear {
-                requestSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
-            }
-            .onChange(of: tabManager.selectedTabId) { _, _ in
-                requestSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
-            }
-            .onChange(of: renderContext.workspaceIds) { oldWorkspaceIds, newWorkspaceIds in
-                guard shouldRequestSelectedWorkspaceScrollAfterWorkspaceIdsChange(
-                    from: oldWorkspaceIds,
-                    to: newWorkspaceIds
-                ) else {
-                    flushPendingSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
-                    return
-                }
-                requestSelectedWorkspaceScroll(scrollProxy, renderContext: renderContext)
-            }
-            .onReceive(NotificationCenter.default.publisher(for: .workspaceOrderDidChange)) { notification in
-                requestSelectedWorkspaceScrollAfterWorkspaceOrderChange(notification)
-            }
             .onReceive(NotificationCenter.default.publisher(for: .workspaceCurrentDirectoryDidChange)) { _ in
                 // Drive a revision counter that the group-header resolver
                 // reads. Forces SwiftUI to re-invoke `cmuxConfigStore.resolveWorkspaceGroupConfig(forCwd:)`
@@ -10555,12 +10489,124 @@ struct VerticalTabsSidebar: View {
                     lastSidebarSelectionIndex = index
                 }
             }
-        }
     }
-    private func updateWorkspaceScrollContentMinHeight(_ contentMinHeight: CGFloat) {
-        guard workspaceScrollContentMinHeight != contentMinHeight else { return }
-        var transaction = Transaction(animation: nil); transaction.disablesAnimations = true
-        withTransaction(transaction) { workspaceScrollContentMinHeight = contentMinHeight }
+
+    private func workspaceTableActions(
+        renderContext: WorkspaceListRenderContext
+    ) -> SidebarWorkspaceTableActions {
+        SidebarWorkspaceTableActions(
+            attachScrollView: { scrollView in
+                dragAutoScrollController.attach(scrollView: scrollView)
+            },
+            closeWorkspace: { workspaceId in
+                guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) else { return }
+#if DEBUG
+                cmuxDebugLog("sidebar.close workspace=\(workspaceId.uuidString.prefix(5)) method=middleClick")
+#endif
+                tabManager.closeWorkspaceWithConfirmation(workspace)
+            },
+            createWorkspaceAtEnd: {
+                if tabManager.selectedTab?.isRemoteTmuxMirror == true {
+                    _ = AppDelegate.shared?.performNewWorkspaceAction(
+                        tabManager: tabManager,
+                        debugSource: "sidebar.emptyArea.remoteTmux"
+                    )
+                } else {
+                    tabManager.addWorkspace(placementOverride: .end)
+                }
+                if let selectedId = tabManager.selectedTabId {
+                    selectedTabIds = [selectedId]
+                    lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+                }
+                selection = .tabs
+            },
+            createEmptyWorkspaceGroup: {
+                _ = AppDelegate.shared?.createEmptyWorkspaceGroup(tabManager: tabManager)
+            },
+            beginWorkspaceDrag: { workspaceId in
+                dragState.beginDragging(tabId: workspaceId)
+            },
+            endWorkspaceDrag: {
+                dragState.clearDrag()
+                dragAutoScrollController.stop()
+            },
+            isValidWorkspaceDrag: {
+                activateSidebarWorkspaceDragIfNeeded()
+            },
+            updateWorkspaceDrag: { point, targets in
+                updateWorkspaceReorderDrop(point: point, targets: targets, renderContext: renderContext)
+            },
+            performWorkspaceDrop: { point, targets in
+                performWorkspaceReorderDrop(point: point, targets: targets, renderContext: renderContext)
+            },
+            clearWorkspaceDropIndicator: {
+                dragState.clearDropIndicator()
+                dragAutoScrollController.stop()
+            },
+            currentDropIndicator: {
+                dragState.dropIndicator
+            },
+            currentDropIndicatorScope: {
+                dragState.dropIndicatorScope
+            },
+            setWorkspaceDropTargetCollectionActive: { isActive in
+                guard isWorkspaceReorderDropTargetCollectionActive != isActive else { return }
+                isWorkspaceReorderDropTargetCollectionActive = isActive
+            },
+            canPerformBonsplitAction: { action, transfer in
+                guard let app = AppDelegate.shared else { return false }
+                switch action {
+                case .existingWorkspace(let workspaceId):
+                    if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
+                       source.workspaceId == workspaceId {
+                        return true
+                    }
+                    return app.canMoveBonsplitTab(tabId: transfer.tab.id, toWorkspace: workspaceId)
+                case .newWorkspace:
+                    return app.canMoveBonsplitTabToNewWorkspace(tabId: transfer.tab.id)
+                }
+            },
+            moveBonsplitToExistingWorkspace: { workspaceId, transfer in
+                guard let app = AppDelegate.shared else { return false }
+                if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
+                   source.workspaceId == workspaceId {
+                    return true
+                }
+                return app.moveBonsplitTab(
+                    tabId: transfer.tab.id,
+                    toWorkspace: workspaceId,
+                    focus: true,
+                    focusWindow: true
+                )
+            },
+            moveBonsplitToNewWorkspace: { insertionIndex, transfer in
+                guard let app = AppDelegate.shared,
+                      let result = app.moveBonsplitTabToNewWorkspace(
+                        tabId: transfer.tab.id,
+                        destinationManager: tabManager,
+                        focus: true,
+                        focusWindow: true,
+                        insertionIndexOverride: insertionIndex
+                      ) else {
+                    return nil
+                }
+                return result.destinationWorkspaceId
+            },
+            didMoveBonsplitToWorkspace: { workspaceId in
+                selectedTabIds = [workspaceId]
+                lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == workspaceId }
+            },
+            updateDragAutoscroll: {
+                dragAutoScrollController.updateFromDragLocation()
+            },
+            setBonsplitDropTargetCollectionActive: { isActive in
+                guard isBonsplitWorkspaceDropTargetCollectionActive != isActive else { return }
+                isBonsplitWorkspaceDropTargetCollectionActive = isActive
+            },
+            setBonsplitDropIndicator: { indicator in
+                dragState.setDropIndicator(indicator)
+            }
+        )
     }
 
     // Applies one stable overlay/autohide scroller config and never toggles it.
@@ -11657,249 +11703,6 @@ struct VerticalTabsSidebar: View {
         }
     }
 
-    private func workspaceScrollContent(
-        renderContext: WorkspaceListRenderContext,
-        minHeight: CGFloat
-    ) -> some View {
-        let signpost = SidebarProfilingSignposts.begin("sidebar-scroll-content", "workspaces=\(renderContext.workspaceCount) renderItems=\(renderContext.workspaceRenderItems.count) minHeight=\(minHeight)"); defer { SidebarProfilingSignposts.end(signpost) }
-        let shouldCollectWorkspaceDropTargets = SidebarDropPlanner().shouldCollectWorkspaceDropTargets(
-            draggedTabId: dragState.draggedTabId,
-            isBonsplitWorkspaceDropActive: isBonsplitWorkspaceDropTargetCollectionActive ||
-                isWorkspaceReorderDropTargetCollectionActive
-        )
-        // Rows stay lazy + pinned top; `.frame(minHeight:)` fills the viewport
-        // (#3241) or scrolls without measuring the LazyVStack. The prior
-        // SidebarRowsFillLayout measured it (`sizeThatFits(height: nil)`) every
-        // pass, realizing all rows and re-livelocking at scale (#2586 / #5764 /
-        // #5845; regressed by #6033). Drop/tap = background; indicator on rows.
-        let content = workspaceRows(
-            renderContext: renderContext,
-            shouldCollectWorkspaceDropTargets: shouldCollectWorkspaceDropTargets
-        )
-            .overlay(alignment: .bottom) {
-                if emptyAreaTopDropIndicatorVisible() {
-                    Rectangle()
-                        .fill(cmuxAccentColor())
-                        .frame(height: 2)
-                        .padding(.horizontal, 8)
-                        .offset(y: tabRowSpacing / 2)
-                }
-            }
-            // Neutralize ALL end-of-list empty-area interactions over the rows
-            // block (2pt gaps, row padding, and the entire list when it
-            // overflows) so none fall through to SidebarEmptyArea behind:
-            // workspace-reorder drops, Bonsplit new-workspace drops, and the
-            // double-tap-to-create gesture. Sized to the rows, so only the
-            // genuine blank area below the last row stays interactive. This is
-            // the measurement-free equivalent of physically placing the empty
-            // area below the rows; doing that requires asking the LazyVStack for
-            // its height, which realizes every row each layout pass and is the
-            // livelock this change removes. Per-row delegates render in front
-            // and still win over their own rows.
-            .background {
-                Color.clear
-                    .contentShape(Rectangle())
-                    .onTapGesture(count: 2) {}
-                    .onDrop(of: SidebarTabDragPayload.dropContentTypes, isTargeted: nil) { _ in false }
-                    .onDrop(of: BonsplitTabDragPayload.dropContentTypes, isTargeted: nil) { _ in false }
-            }
-            .frame(minHeight: minHeight, alignment: .top)
-            .background(alignment: .top) {
-                SidebarEmptyArea(
-                    rowSpacing: tabRowSpacing,
-                    selection: $selection,
-                    selectedTabIds: $selectedTabIds,
-                    lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-                    dragAutoScrollController: dragAutoScrollController,
-                    topDropIndicatorVisible: false,
-                    bonsplitDropIndicator: dropIndicatorBinding,
-                    expandsVertically: true
-                )
-            }
-
-        return rowsWithGatedDropTargetReader(
-            rows: content,
-            renderContext: renderContext,
-            shouldCollect: shouldCollectWorkspaceDropTargets
-        )
-        .overlay {
-            workspaceReorderDropOverlay(renderContext: renderContext)
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-        .overlay {
-            bonsplitWorkspaceDropOverlay()
-                .frame(maxWidth: .infinity, maxHeight: .infinity)
-        }
-    }
-
-    @ViewBuilder
-    private func workspaceRows(
-        renderContext: WorkspaceListRenderContext,
-        shouldCollectWorkspaceDropTargets: Bool
-    ) -> some View {
-        let signpost = SidebarProfilingSignposts.begin("sidebar-workspace-rows", "renderItems=\(renderContext.workspaceRenderItems.count) collectDropTargets=\(shouldCollectWorkspaceDropTargets)")
-        let renderItems = renderContext.workspaceRenderItems
-        // LazyVStack is safe here because `dragState` is @Observable:
-        // drag mutations at 60fps invalidate only the rows/overlays that
-        // read them, never this sidebar body. See SidebarDragState and
-        // https://github.com/manaflow-ai/cmux/issues/2586.
-        let rows = LazyVStack(spacing: tabRowSpacing) {
-            ForEach(renderItems, id: \.id) { item in
-                switch item {
-                case .groupHeader(let group, let memberWorkspaceIds):
-                    sidebarWorkspaceGroupHeader(
-                        group: group,
-                        memberWorkspaceIds: memberWorkspaceIds,
-                        renderContext: renderContext,
-                        shouldCollectWorkspaceDropTargets: shouldCollectWorkspaceDropTargets, showModifierHoldHints: showModifierHoldHints
-                    )
-                case .workspace(let tab):
-                    workspaceRow(
-                        tab,
-                        renderContext: renderContext,
-                        shouldCollectWorkspaceDropTargets: shouldCollectWorkspaceDropTargets
-                    )
-                }
-            }
-        }
-        .padding(.vertical, SidebarWorkspaceListMetrics.rowVerticalPadding)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        // No whole-content height measurement here: reading the LazyVStack's
-        // total height (GeometryReader, or a custom Layout's sizeThatFits) fed a
-        // non-converging relayout loop (#2586 / #5764 / #5845). Fill is handled
-        // by `.frame(minHeight:)` in workspaceScrollContent.
-        let _ = SidebarProfilingSignposts.end(signpost)
-        rows
-    }
-    /// Conditionally installs the row-frame `overlayPreferenceValue` reader (the part
-    /// that defeats `LazyVStack` virtualization) only while a drag is collecting drop
-    /// targets. Kept separate from the always-mounted drop-capture overlay so the gate
-    /// flip never changes the drop NSView's identity. (#5325 review)
-    @ViewBuilder
-    private func rowsWithGatedDropTargetReader<Rows: View>(
-        rows: Rows,
-        renderContext: WorkspaceListRenderContext,
-        shouldCollect: Bool
-    ) -> some View {
-        if shouldCollect {
-            rows
-                .overlayPreferenceValue(SidebarWorkspaceRowFramePreferenceKey.self) { anchors in
-                    GeometryReader { proxy in
-                        let workspaceGroupsByAnchor = Dictionary(
-                            uniqueKeysWithValues: renderContext.workspaceGroups.map { ($0.anchorWorkspaceId, $0) }
-                        )
-                        SidebarWorkspaceDropTargetWriters(
-                            bonsplitTargetBridge: bonsplitWorkspaceDropTargetBridge,
-                            bonsplitTargets: renderContext.tabs.compactMap { tab in
-                                guard let anchor = anchors[tab.id] else { return nil }
-                                return SidebarDropPlanner.WorkspaceDropTarget(
-                                    workspaceId: tab.id,
-                                    isPinned: tab.isPinned,
-                                    frame: proxy[anchor]
-                                )
-                            },
-                            reorderTargetBridge: workspaceReorderDropTargetBridge,
-                            reorderTargets: renderContext.visibleWorkspaceRowIds.compactMap { workspaceId in
-                                guard let anchor = anchors[workspaceId],
-                                      renderContext.workspaceById[workspaceId] != nil else {
-                                    return nil
-                                }
-                                let group = workspaceGroupsByAnchor[workspaceId]
-                                let targetGroupId = group?.id ??
-                                    (renderContext.workspaceGroupIdByWorkspaceId[workspaceId] ?? nil)
-                                return SidebarWorkspaceReorderDropOverlay.Target(
-                                    workspaceId: workspaceId,
-                                    groupId: targetGroupId,
-                                    isGroupHeader: group != nil,
-                                    frame: proxy[anchor]
-                                )
-                            }
-                        )
-                    }
-                }
-        } else {
-            rows
-        }
-    }
-
-    private func bonsplitWorkspaceDropOverlay() -> some View {
-        SidebarBonsplitTabWorkspaceDropOverlay(
-            currentSelectedTabId: {
-                tabManager.selectedTabId
-            },
-            sidebarIndexForTabId: { workspaceId in
-                tabManager.tabs.firstIndex { $0.id == workspaceId }
-            },
-            moveToExistingWorkspace: { workspaceId, transfer in
-                guard let app = AppDelegate.shared else {
-                    return false
-                }
-                if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
-                   source.workspaceId == workspaceId {
-                    return true
-                }
-                return app.moveBonsplitTab(
-                    tabId: transfer.tab.id,
-                    toWorkspace: workspaceId,
-                    focus: true,
-                    focusWindow: true
-                )
-            },
-            moveToNewWorkspace: { insertionIndex, transfer in
-                guard let app = AppDelegate.shared,
-                      let result = app.moveBonsplitTabToNewWorkspace(
-                        tabId: transfer.tab.id,
-                        destinationManager: tabManager,
-                        focus: true,
-                        focusWindow: true,
-                        insertionIndexOverride: insertionIndex
-                      ) else {
-                    return nil
-                }
-                return result.destinationWorkspaceId
-            },
-            selectedTabIds: $selectedTabIds,
-            lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
-            dropIndicator: dropIndicatorBinding,
-            updateAutoscroll: {
-                dragAutoScrollController.updateFromDragLocation()
-            },
-            setWorkspaceDropTargetCollectionActive: { isActive in
-                guard isBonsplitWorkspaceDropTargetCollectionActive != isActive else { return }
-                isBonsplitWorkspaceDropTargetCollectionActive = isActive
-            },
-            isWorkspaceDropTargetCollectionActive: isBonsplitWorkspaceDropTargetCollectionActive,
-            targetBridge: bonsplitWorkspaceDropTargetBridge
-        )
-    }
-
-    private func workspaceReorderDropOverlay(
-        renderContext: WorkspaceListRenderContext,
-        pointOffset: CGSize = .zero
-    ) -> some View {
-        SidebarWorkspaceReorderDropOverlay(
-            targetBridge: workspaceReorderDropTargetBridge,
-            isValidDrag: {
-                activateSidebarWorkspaceDragIfNeeded()
-            },
-            updateDrag: { point, targets in
-                updateWorkspaceReorderDrop(point: point, targets: targets, renderContext: renderContext)
-            },
-            performDrop: { point, targets in
-                performWorkspaceReorderDrop(point: point, targets: targets, renderContext: renderContext)
-            },
-            clearDropIndicator: {
-                dragState.clearDropIndicator()
-                dragAutoScrollController.stop()
-            },
-            setWorkspaceDropTargetCollectionActive: { isActive in
-                guard isWorkspaceReorderDropTargetCollectionActive != isActive else { return }
-                isWorkspaceReorderDropTargetCollectionActive = isActive
-            },
-            pointOffset: pointOffset
-        )
-    }
-
     private func activateSidebarWorkspaceDragIfNeeded() -> Bool {
         if dragState.draggedTabId != nil {
             return true
@@ -12131,13 +11934,12 @@ struct VerticalTabsSidebar: View {
         )
     }
 
-    @ViewBuilder
-    private func workspaceRow(
+    private func workspaceTableRowConfiguration(
         _ tab: Workspace,
-        renderContext: WorkspaceListRenderContext,
-        shouldCollectWorkspaceDropTargets: Bool
-    ) -> some View {
+        renderContext: WorkspaceListRenderContext
+    ) -> SidebarWorkspaceTableRowConfiguration {
         let signpost = SidebarProfilingSignposts.begin("sidebar-workspace-row", "index=\(renderContext.tabIndexById[tab.id] ?? -1) workspace=\(sidebarShortTabId(tab.id)) selected=\(tabManager.selectedTabId == tab.id)")
+        defer { SidebarProfilingSignposts.end(signpost) }
         let index = renderContext.tabIndexById[tab.id] ?? 0
         let usesSelectedContextMenuTargets = selectedTabIds.contains(tab.id)
         let contextMenuWorkspaceIds = usesSelectedContextMenuTargets
@@ -12232,7 +12034,10 @@ struct VerticalTabsSidebar: View {
                 lastSidebarSelectionIndex = nil
             }
         }
-        let row = TabItemView(
+        let makeRow: (Bool, SidebarWorkspaceTableContextMenuActions) -> TabItemView = {
+            isPointerHovering,
+            contextMenuActions in
+            TabItemView(
             tabManager: tabManager,
             notificationStore: notificationStore,
             tab: tab,
@@ -12252,6 +12057,7 @@ struct VerticalTabsSidebar: View {
             selectedTabIds: $selectedTabIds,
             lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
             showsModifierShortcutHints: resolvedShowsModifierShortcutHints,
+            appKitPointerHovering: isPointerHovering,
             dragAutoScrollController: dragAutoScrollController,
             isBeingDragged: isBeingDragged,
             topDropIndicatorVisible: topDropIndicatorVisible,
@@ -12268,51 +12074,43 @@ struct VerticalTabsSidebar: View {
             contextMenuPinState: contextMenuPinState,
             workspaceGroupMenuSnapshot: renderContext.workspaceGroupMenuSnapshot,
             settings: renderContext.tabItemSettings,
-            onContextMenuAppear: onContextMenuAppear,
-            onContextMenuDisappear: onContextMenuDisappear
+            onContextMenuAppear: {
+                onContextMenuAppear()
+                contextMenuActions.didOpen()
+            },
+            onContextMenuDisappear: {
+                onContextMenuDisappear()
+                contextMenuActions.didClose()
+            }
         )
-        .equatable()
-        .id(tab.id)
-        .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
-
-        let _ = SidebarProfilingSignposts.end(signpost)
-        row
-            .sidebarWorkspaceFrameAnchor(id: tab.id, isEnabled: shouldCollectWorkspaceDropTargets)
-            .padding(.leading, tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0)
-            .frame(maxWidth: .infinity, alignment: .leading)
-            .contentShape(Rectangle())
-    }
-
-}
-
-struct SidebarWorkspaceFrameAnchorModifier: ViewModifier {
-    let id: UUID
-    let isEnabled: Bool
-
-    func body(content: Content) -> some View {
-        // Branchless: always apply anchorPreference, emit [:] when disabled. An
-        // if/else gives `content` distinct identity per state, so flipping
-        // isEnabled at drag start/end recreated every visible row's subtree
-        // (lost @State, fresh snapshot builds + relayout mid-drag). The frame
-        // *reader* stays gated on the drag (#5325), so an empty emit costs nothing.
-        content.anchorPreference(key: SidebarWorkspaceRowFramePreferenceKey.self, value: .bounds) { anchor in
-            isEnabled ? [id: anchor] : [:]
+        }
+        let equivalenceValue = makeRow(
+            false,
+            SidebarWorkspaceTableContextMenuActions(didOpen: {}, didClose: {})
+        )
+        return SidebarWorkspaceTableRowConfiguration(
+            id: .workspace(tab.id),
+            workspaceId: tab.id,
+            groupId: tab.groupId,
+            isGroupHeader: false,
+            isPinned: tab.isPinned,
+            environment: renderContext.environment,
+            equivalenceValue: equivalenceValue
+        ) { isPointerHovering, contextMenuActions in
+            AnyView(
+                renderContext.environment.apply(
+                    to: makeRow(isPointerHovering, contextMenuActions)
+                        .equatable()
+                        .id(tab.id)
+                        .accessibilityIdentifier("sidebarWorkspace.\(tab.id.uuidString)")
+                        .padding(.leading, tab.groupId != nil ? SidebarWorkspaceGroupingMetrics.memberIndent : 0)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .contentShape(Rectangle())
+                )
+            )
         }
     }
-}
 
-extension View {
-    func sidebarWorkspaceFrameAnchor(id: UUID, isEnabled: Bool) -> some View {
-        modifier(SidebarWorkspaceFrameAnchorModifier(id: id, isEnabled: isEnabled))
-    }
-}
-
-struct SidebarWorkspaceRowFramePreferenceKey: PreferenceKey {
-    static let defaultValue: [UUID: Anchor<CGRect>] = [:]
-
-    static func reduce(value: inout [UUID: Anchor<CGRect>], nextValue: () -> [UUID: Anchor<CGRect>]) {
-        value.merge(nextValue()) { _, next in next }
-    }
 }
 
 @MainActor
@@ -13089,6 +12887,7 @@ struct TabItemView: View, Equatable {
         lhs.showsAgentActivity == rhs.showsAgentActivity &&
         lhs.rowSpacing == rhs.rowSpacing &&
         lhs.showsModifierShortcutHints == rhs.showsModifierShortcutHints &&
+        lhs.appKitPointerHovering == rhs.appKitPointerHovering &&
         lhs.contextMenuWorkspaceIds == rhs.contextMenuWorkspaceIds &&
         lhs.remoteContextMenuWorkspaceIds == rhs.remoteContextMenuWorkspaceIds &&
         lhs.allRemoteContextMenuTargetsConnecting == rhs.allRemoteContextMenuTargetsConnecting &&
@@ -13137,6 +12936,9 @@ struct TabItemView: View, Equatable {
     @Binding var selectedTabIds: Set<UUID>
     @Binding var lastSidebarSelectionIndex: Int?
     let showsModifierShortcutHints: Bool
+    /// Table-owned hover snapshot. The default sidebar always supplies this;
+    /// `nil` remains available to isolated row previews.
+    let appKitPointerHovering: Bool?
     let dragAutoScrollController: SidebarDragAutoScrollController
     // Row receives precomputed drag/drop snapshot values + action closures
     // instead of an `@Observable` store reference. This keeps TabItemView in
@@ -13379,10 +13181,11 @@ struct TabItemView: View, Equatable {
     }
 
     private var showCloseButton: Bool {
-        rowInteractionState.shouldShowCloseButton(
-            canCloseWorkspace: canCloseWorkspace,
-            shortcutHintModeActive: showsModifierShortcutHints || alwaysShowShortcutHints
-        )
+        let pointerHovering = appKitPointerHovering ?? rowInteractionState.isPointerHovering
+        return pointerHovering
+            && !rowInteractionState.contextMenuVisible
+            && canCloseWorkspace
+            && !(showsModifierShortcutHints || alwaysShowShortcutHints)
     }
 
     private var workspaceShortcutLabel: String? {
@@ -13904,30 +13707,7 @@ struct TabItemView: View, Equatable {
         .shortcutHintVisibilityAnimation(value: showsWorkspaceShortcutHint)
         .padding(.horizontal, SidebarWorkspaceListMetrics.rowOuterHorizontalPadding)
         .contentShape(Rectangle())
-        .sidebarWorkspaceRowHoverTracking($rowInteractionState)
         .opacity(isBeingDragged ? 0.6 : 1)
-        .overlay {
-            MiddleClickCapture {
-                #if DEBUG
-                cmuxDebugLog("sidebar.close workspace=\(tab.id.uuidString.prefix(5)) method=middleClick")
-                #endif
-                tabManager.closeWorkspaceWithConfirmation(tab)
-            }
-        }
-        .overlay {
-            if rowInteractionState.contextMenuVisible {
-                SidebarWorkspaceRowMenuTrackingReconciler { pointerInsideRow in
-                    guard rowInteractionState.contextMenuTrackingDidEnd(pointerInsideRow: pointerInsideRow) else {
-                        return
-                    }
-                    onContextMenuDisappear()
-                    flushDeferredWorkspaceObservationInvalidation()
-                }
-                .onAppear {
-                    rowInteractionState.contextMenuTrackingObserverDidInstall()
-                }
-            }
-        }
         .overlay(alignment: .top) {
             SidebarWorkspaceTopDropIndicator(
                 isVisible: topDropIndicatorVisible,
@@ -14001,16 +13781,6 @@ struct TabItemView: View, Equatable {
         .onChange(of: settings) { _ in
             refreshWorkspaceSnapshot(force: true)
         }
-        .sidebarRowDragGate(isEditing: isEditing, onDragStart)
-        .internalOnlyTabDrag()
-        .modifier(SidebarBonsplitWorkspaceRowDropModifier(
-            isEnabled: isBonsplitWorkspaceDropActive,
-            targetWorkspaceId: tab.id,
-            bonsplitSourceWorkspaceId: bonsplitSourceWorkspaceId,
-            moveBonsplitTabToWorkspace: moveBonsplitTabToWorkspace,
-            syncSidebarSelectionAfterDrop: syncSidebarSelectionAfterBonsplitDrop,
-            selectedTabIds: $selectedTabIds
-        ))
         .onTapGesture {
             if !isEditing { updateSelection() }
         }

--- a/Sources/Debug/SidebarLazyContractProbe.swift
+++ b/Sources/Debug/SidebarLazyContractProbe.swift
@@ -1,14 +1,10 @@
 import SwiftUI
 
 #if DEBUG
-/// Test-only body-evaluation probe for the workspace sidebar's lazy-layout
-/// contract: sidebar layout/diff work must stay O(visible rows), never
-/// O(all workspaces). The contract has regressed five times through five
-/// different mechanisms (#2586, #5764, #5845, #6210, #6556), each shipping to
-/// stable before being detected at scale. `SidebarLazyLayoutScaleTests` mounts
-/// the sidebar with hundreds of workspaces, injects these closures, and fails
-/// if row bodies are realized without bound or keep re-evaluating after
-/// updates settle — regardless of which mechanism defeats laziness next.
+/// Test-only probe for the workspace sidebar virtualization contract: AppKit
+/// must materialize viewport-many cells and reconfigure only changed hosted
+/// roots, never all workspaces. `SidebarLazyLayoutScaleTests` mounts hundreds
+/// of workspaces and fails on realization or reconfiguration churn.
 ///
 /// Same pattern as `MinimalModeInvalidationProbe`; compiled out of Release.
 struct SidebarLazyContractProbe {
@@ -16,5 +12,6 @@ struct SidebarLazyContractProbe {
     var workspaceRowBodyEnd: (() -> Void)?
     var groupHeaderRowBody: (() -> Void)?
     var workspaceSnapshotBuild: (() -> Void)?
+    var tableRootViewReconfigure: (() -> Void)?
 }
 #endif

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableActions.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableActions.swift
@@ -1,0 +1,29 @@
+import Bonsplit
+import AppKit
+import CmuxFoundation
+import Foundation
+
+/// Closure bundle routing table input and drag operations to existing sidebar actions.
+@MainActor
+struct SidebarWorkspaceTableActions {
+    let attachScrollView: (NSScrollView) -> Void
+    let closeWorkspace: (UUID) -> Void
+    let createWorkspaceAtEnd: () -> Void
+    let createEmptyWorkspaceGroup: () -> Void
+    let beginWorkspaceDrag: (UUID) -> Void
+    let endWorkspaceDrag: () -> Void
+    let isValidWorkspaceDrag: () -> Bool
+    let updateWorkspaceDrag: (CGPoint, [SidebarWorkspaceReorderDropOverlay.Target]) -> Bool
+    let performWorkspaceDrop: (CGPoint, [SidebarWorkspaceReorderDropOverlay.Target]) -> Bool
+    let clearWorkspaceDropIndicator: () -> Void
+    let currentDropIndicator: () -> SidebarDropIndicator?
+    let currentDropIndicatorScope: () -> SidebarWorkspaceReorderDropIndicatorScope
+    let setWorkspaceDropTargetCollectionActive: (Bool) -> Void
+    let canPerformBonsplitAction: (SidebarDropPlanner.WorkspaceDropAction, BonsplitTabDragPayload.Transfer) -> Bool
+    let moveBonsplitToExistingWorkspace: (UUID, BonsplitTabDragPayload.Transfer) -> Bool
+    let moveBonsplitToNewWorkspace: (Int, BonsplitTabDragPayload.Transfer) -> UUID?
+    let didMoveBonsplitToWorkspace: (UUID) -> Void
+    let updateDragAutoscroll: () -> Void
+    let setBonsplitDropTargetCollectionActive: (Bool) -> Void
+    let setBonsplitDropIndicator: (SidebarDropIndicator?) -> Void
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellModel.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellModel.swift
@@ -1,0 +1,28 @@
+import Observation
+
+/// Cell-owned observable state that never reaches into a shared sidebar store.
+@MainActor
+@Observable
+final class SidebarWorkspaceTableCellModel {
+    private(set) var state: SidebarWorkspaceTableCellState?
+
+    @discardableResult
+    func configure(
+        row: SidebarWorkspaceTableRowConfiguration,
+        isPointerHovering: Bool,
+        contextMenuActions: SidebarWorkspaceTableContextMenuActions
+    ) -> Bool {
+        if let state,
+           state.row.id == row.id,
+           state.row.hasEquivalentContent(to: row),
+           state.isPointerHovering == isPointerHovering {
+            return false
+        }
+        state = SidebarWorkspaceTableCellState(
+            row: row,
+            isPointerHovering: isPointerHovering,
+            contextMenuActions: contextMenuActions
+        )
+        return true
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellRootView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellRootView.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftUI
+
+/// Stable SwiftUI root installed once for a reusable sidebar table cell.
+@MainActor
+struct SidebarWorkspaceTableCellRootView: View {
+    let identity: UUID
+    let model: SidebarWorkspaceTableCellModel
+
+    var body: some View {
+        Group {
+            if let state = model.state {
+                state.row.makeContent(
+                    state.isPointerHovering,
+                    state.contextMenuActions
+                )
+            } else {
+                EmptyView()
+            }
+        }
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellState.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellState.swift
@@ -1,0 +1,7 @@
+/// Immutable input rendered by one stable sidebar table-cell root.
+@MainActor
+struct SidebarWorkspaceTableCellState {
+    let row: SidebarWorkspaceTableRowConfiguration
+    let isPointerHovering: Bool
+    let contextMenuActions: SidebarWorkspaceTableContextMenuActions
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
@@ -1,0 +1,46 @@
+import AppKit
+import SwiftUI
+
+/// Reusable table cell containing exactly one SwiftUI hosting view.
+@MainActor
+final class SidebarWorkspaceTableCellView: NSTableCellView {
+    static let reuseIdentifier = NSUserInterfaceItemIdentifier("SidebarWorkspaceTableCellView")
+
+    private let hostingView = NSHostingView(rootView: AnyView(EmptyView()))
+    private(set) var representedRowId: SidebarWorkspaceRenderItemID?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        identifier = Self.reuseIdentifier
+        hostingView.translatesAutoresizingMaskIntoConstraints = false
+        hostingView.setContentHuggingPriority(.required, for: .vertical)
+        hostingView.setContentCompressionResistancePriority(.required, for: .vertical)
+        addSubview(hostingView)
+        NSLayoutConstraint.activate([
+            hostingView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            hostingView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            hostingView.topAnchor.constraint(equalTo: topAnchor),
+            hostingView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func configure(
+        row: SidebarWorkspaceTableRowConfiguration,
+        isPointerHovering: Bool,
+        contextMenuDidOpen: @escaping () -> Void,
+        contextMenuDidClose: @escaping () -> Void
+    ) {
+        representedRowId = row.id
+        hostingView.rootView = row.makeContent(
+            isPointerHovering,
+            SidebarWorkspaceTableContextMenuActions(
+                didOpen: contextMenuDidOpen,
+                didClose: contextMenuDidClose
+            )
+        )
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
@@ -33,6 +33,14 @@ final class SidebarWorkspaceTableCellView: NSTableCellView {
         wantsLayer = true
         hostingView.wantsLayer = true
         hostingView.translatesAutoresizingMaskIntoConstraints = false
+        // Row heights are owned by the controller's explicit height cache, so
+        // this hosting view must never negotiate sizing with Auto Layout.
+        // Every window-wide layout pass (e.g. the terminal portal's
+        // synchronizeLayoutHierarchy) otherwise re-runs SwiftUI size
+        // negotiation in NSHostingView.layout() for every visible cell, which
+        // profiling showed dominating main-thread time during workspace
+        // switching at 200 rows.
+        hostingView.sizingOptions = []
         hostingView.setContentHuggingPriority(.required, for: .vertical)
         hostingView.setContentCompressionResistancePriority(.required, for: .vertical)
         addSubview(hostingView)

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
@@ -8,10 +8,14 @@ final class SidebarWorkspaceTableCellView: NSTableCellView {
 
     private let hostingView = NSHostingView(rootView: AnyView(EmptyView()))
     private(set) var representedRowId: SidebarWorkspaceRenderItemID?
+    private var representedRow: SidebarWorkspaceTableRowConfiguration?
+    private var representedPointerHovering = false
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
         identifier = Self.reuseIdentifier
+        wantsLayer = true
+        hostingView.wantsLayer = true
         hostingView.translatesAutoresizingMaskIntoConstraints = false
         hostingView.setContentHuggingPriority(.required, for: .vertical)
         hostingView.setContentCompressionResistancePriority(.required, for: .vertical)
@@ -28,13 +32,22 @@ final class SidebarWorkspaceTableCellView: NSTableCellView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    @discardableResult
     func configure(
         row: SidebarWorkspaceTableRowConfiguration,
         isPointerHovering: Bool,
         contextMenuDidOpen: @escaping () -> Void,
         contextMenuDidClose: @escaping () -> Void
-    ) {
+    ) -> Bool {
+        if let representedRow,
+           representedRow.id == row.id,
+           representedRow.hasEquivalentContent(to: row),
+           representedPointerHovering == isPointerHovering {
+            return false
+        }
         representedRowId = row.id
+        representedRow = row
+        representedPointerHovering = isPointerHovering
         hostingView.rootView = row.makeContent(
             isPointerHovering,
             SidebarWorkspaceTableContextMenuActions(
@@ -42,5 +55,6 @@ final class SidebarWorkspaceTableCellView: NSTableCellView {
                 didClose: contextMenuDidClose
             )
         )
+        return true
     }
 }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift
@@ -6,12 +6,28 @@ import SwiftUI
 final class SidebarWorkspaceTableCellView: NSTableCellView {
     static let reuseIdentifier = NSUserInterfaceItemIdentifier("SidebarWorkspaceTableCellView")
 
-    private let hostingView = NSHostingView(rootView: AnyView(EmptyView()))
-    private(set) var representedRowId: SidebarWorkspaceRenderItemID?
-    private var representedRow: SidebarWorkspaceTableRowConfiguration?
-    private var representedPointerHovering = false
+    private let model: SidebarWorkspaceTableCellModel
+    private let hostingView: NSHostingView<SidebarWorkspaceTableCellRootView>
+
+#if DEBUG
+    var reconfigurationProbe: (() -> Void)?
+    var hostingViewIdentity: ObjectIdentifier { ObjectIdentifier(hostingView) }
+    var hostedRootIdentity: UUID { hostingView.rootView.identity }
+#endif
+
+    var representedRowId: SidebarWorkspaceRenderItemID? {
+        model.state?.row.id
+    }
 
     override init(frame frameRect: NSRect) {
+        let model = SidebarWorkspaceTableCellModel()
+        self.model = model
+        self.hostingView = NSHostingView(
+            rootView: SidebarWorkspaceTableCellRootView(
+                identity: UUID(),
+                model: model
+            )
+        )
         super.init(frame: frameRect)
         identifier = Self.reuseIdentifier
         wantsLayer = true
@@ -39,22 +55,19 @@ final class SidebarWorkspaceTableCellView: NSTableCellView {
         contextMenuDidOpen: @escaping () -> Void,
         contextMenuDidClose: @escaping () -> Void
     ) -> Bool {
-        if let representedRow,
-           representedRow.id == row.id,
-           representedRow.hasEquivalentContent(to: row),
-           representedPointerHovering == isPointerHovering {
-            return false
-        }
-        representedRowId = row.id
-        representedRow = row
-        representedPointerHovering = isPointerHovering
-        hostingView.rootView = row.makeContent(
-            isPointerHovering,
-            SidebarWorkspaceTableContextMenuActions(
+        let didReconfigure = model.configure(
+            row: row,
+            isPointerHovering: isPointerHovering,
+            contextMenuActions: SidebarWorkspaceTableContextMenuActions(
                 didOpen: contextMenuDidOpen,
                 didClose: contextMenuDidClose
             )
         )
-        return true
+#if DEBUG
+        if didReconfigure {
+            reconfigurationProbe?()
+        }
+#endif
+        return didReconfigure
     }
 }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableClipView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableClipView.swift
@@ -1,0 +1,18 @@
+import AppKit
+
+/// Scroll viewport that preserves empty-area double-click and context-menu behavior.
+@MainActor
+final class SidebarWorkspaceTableClipView: NSClipView {
+    weak var workspaceController: SidebarWorkspaceTableController?
+
+    override func mouseDown(with event: NSEvent) {
+        super.mouseDown(with: event)
+        if event.clickCount == 2 {
+            workspaceController?.doubleClickEmptyArea()
+        }
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        workspaceController?.emptyAreaMenu()
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift
@@ -1,0 +1,45 @@
+import AppKit
+
+/// AppKit container stacking drag destinations above the virtualized table.
+@MainActor
+final class SidebarWorkspaceTableContainerView: NSView {
+    let scrollView = NSScrollView()
+    let clipView = SidebarWorkspaceTableClipView()
+    let tableView = SidebarWorkspaceTableViewImpl()
+    let reorderDropView = SidebarWorkspaceReorderDropView()
+    let bonsplitDropView = SidebarBonsplitTabWorkspaceDropView()
+    let emptyDropIndicatorView = SidebarWorkspaceTableEmptyDropIndicatorView()
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = false
+        scrollView.contentView = clipView
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        reorderDropView.translatesAutoresizingMaskIntoConstraints = false
+        bonsplitDropView.translatesAutoresizingMaskIntoConstraints = false
+        emptyDropIndicatorView.translatesAutoresizingMaskIntoConstraints = true
+        addSubview(scrollView)
+        addSubview(reorderDropView)
+        addSubview(bonsplitDropView)
+        addSubview(emptyDropIndicatorView)
+        NSLayoutConstraint.activate([
+            scrollView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            scrollView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            scrollView.topAnchor.constraint(equalTo: topAnchor),
+            scrollView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            reorderDropView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            reorderDropView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            reorderDropView.topAnchor.constraint(equalTo: topAnchor),
+            reorderDropView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bonsplitDropView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bonsplitDropView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bonsplitDropView.topAnchor.constraint(equalTo: topAnchor),
+            bonsplitDropView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift
@@ -12,7 +12,9 @@ final class SidebarWorkspaceTableContainerView: NSView {
 
     override init(frame frameRect: NSRect) {
         super.init(frame: frameRect)
-        wantsLayer = false
+        // One layer-backed subtree keeps recycled hosted rows on AppKit's
+        // accelerated scroll path without per-cell layer topology changes.
+        wantsLayer = true
         scrollView.contentView = clipView
 
         scrollView.translatesAutoresizingMaskIntoConstraints = false

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -18,6 +18,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var appKitDropIndicatorScope: SidebarWorkspaceReorderDropIndicatorScope = .raw
     private var appKitDropIndicatorIncludesRowTargets = false
     private var clipBoundsObserver: NSObjectProtocol?
+    private let rowHeightCache = SidebarWorkspaceTableRowHeightCache()
     private let bonsplitTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()
 
 #if DEBUG
@@ -29,7 +30,6 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             NotificationCenter.default.removeObserver(clipBoundsObserver)
         }
     }
-
     func makeContainerView() -> SidebarWorkspaceTableContainerView {
         let container = SidebarWorkspaceTableContainerView()
         containerView = container
@@ -51,12 +51,8 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         table.allowsMultipleSelection = false
         table.allowsTypeSelect = false
         table.intercellSpacing = NSSize(width: 0, height: 2)
-        table.usesAutomaticRowHeights = true
-        table.rowHeight = SidebarWorkspaceTableRowHeightCalculator().estimatedWorkspaceHeight(
-            fontScale: 1,
-            titleLineCount: 1,
-            auxiliaryLineCount: 0
-        )
+        table.usesAutomaticRowHeights = false
+        table.rowHeight = SidebarWorkspaceTableRowHeightCalculator().defaultWorkspaceHeight
         table.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
         table.setDraggingSourceOperationMask(.move, forLocal: true)
         table.setDraggingSourceOperationMask(.move, forLocal: false)
@@ -114,17 +110,19 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
         let previousRows = rows
         let hasStructuralChanges = previousRows.map(\.id) != nextRows.map(\.id)
+        let contentChanges = IndexSet(nextRows.indices.filter { index in
+            previousRows.indices.contains(index)
+                && !previousRows[index].hasEquivalentContent(to: nextRows[index])
+        })
+        let heightChanges = rowHeightCache.prepareHostedRows(nextRows, columnWidth: currentColumnWidth())
         rows = nextRows
 
         if hasStructuralChanges {
             containerView.tableView.reloadData()
         } else {
-            let changed = IndexSet(nextRows.indices.filter { index in
-                !previousRows[index].hasEquivalentContent(to: nextRows[index])
-            })
-            reconfigureVisibleRows(changed)
-            if !changed.isEmpty {
-                containerView.tableView.noteHeightOfRows(withIndexesChanged: changed)
+            reconfigureVisibleRows(contentChanges)
+            if !heightChanges.isEmpty {
+                containerView.tableView.noteHeightOfRows(withIndexesChanged: heightChanges)
             }
         }
 
@@ -147,6 +145,16 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 
     func numberOfRows(in tableView: NSTableView) -> Int {
         rows.count
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+        guard rows.indices.contains(row) else { return tableView.rowHeight }
+        let configuration = rows[row]
+        let columnWidth = currentColumnWidth()
+        return rowHeightCache.height(
+            for: configuration,
+            columnWidth: columnWidth
+        ) ?? configuration.estimatedHeight
     }
 
     func tableView(
@@ -245,8 +253,19 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     }
 
     private func viewportDidChange() {
+        if let changed = rowHeightCache.prepareHostedRowsIfWidthChanged(
+            rows,
+            columnWidth: currentColumnWidth()
+        ), !changed.isEmpty {
+            containerView?.tableView.noteHeightOfRows(withIndexesChanged: changed)
+        }
         recomputeHoveredRow()
         updateDropTargets()
+    }
+
+    private func currentColumnWidth() -> CGFloat {
+        guard let containerView else { return 0 }
+        return containerView.clipView.bounds.width
     }
 
     private func setHoveredRowId(_ next: SidebarWorkspaceRenderItemID?) {
@@ -286,7 +305,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private func configure(cell: SidebarWorkspaceTableCellView, at row: Int) {
         let configuration = rows[row]
         let rowId = configuration.id
-        cell.configure(
+        let didReconfigure = cell.configure(
             row: configuration,
             isPointerHovering: hoveredRowId == rowId && contextMenuRowId != rowId,
             contextMenuDidOpen: { [weak self] in
@@ -297,7 +316,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             }
         )
 #if DEBUG
-        reconfigurationProbe?()
+        if didReconfigure {
+            reconfigurationProbe?()
+        }
 #endif
     }
 

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -40,6 +40,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         table.dataSource = self
         table.delegate = self
         table.headerView = nil
+        table.style = .fullWidth
         table.backgroundColor = .clear
         table.enclosingScrollView?.backgroundColor = .clear
         table.focusRingType = .none

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -19,10 +19,14 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private var appKitDropIndicatorIncludesRowTargets = false
     private var clipBoundsObserver: NSObjectProtocol?
     private let rowHeightCache = SidebarWorkspaceTableRowHeightCache()
-    private let bonsplitTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()
+    private let dropTargetGeometry = SidebarWorkspaceTableDropTargetGeometryGate()
 
 #if DEBUG
     var reconfigurationProbe: (() -> Void)?
+    var dropTargetComputationProbe: (() -> Void)? {
+        get { dropTargetGeometry.computationProbe }
+        set { dropTargetGeometry.computationProbe = newValue }
+    }
 #endif
 
     deinit {
@@ -81,7 +85,8 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         container.reorderDropView.registerForDraggedTypes([
             NSPasteboard.PasteboardType(SidebarTabDragPayload.typeIdentifier),
         ])
-        container.bonsplitDropView.targetBridge = bonsplitTargetBridge
+        dropTargetGeometry.attach(containerView: container)
+        container.bonsplitDropView.targetBridge = dropTargetGeometry.bonsplitTargetBridge
 
         clipBoundsObserver = NotificationCenter.default.addObserver(
             forName: NSView.boundsDidChangeNotification,
@@ -179,6 +184,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         guard rows.indices.contains(row), let actions else { return nil }
         let workspaceId = rows[row].workspaceId
         actions.beginWorkspaceDrag(workspaceId)
+        workspaceDragSessionDidBegin()
         let item = NSPasteboardItem()
         item.setString(
             "\(SidebarTabDragPayload.prefix)\(workspaceId.uuidString)",
@@ -194,6 +200,18 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         operation: NSDragOperation
     ) {
         actions?.endWorkspaceDrag()
+        workspaceDragSessionDidEnd()
+    }
+
+    func workspaceDragSessionDidBegin() {
+        if dropTargetGeometry.setWorkspaceDragSessionActive(true, rows: rows) {
+            positionAppKitDropIndicator()
+        }
+    }
+
+    func workspaceDragSessionDidEnd() {
+        dropTargetGeometry.setWorkspaceDragSessionActive(false, rows: rows)
+        dropTargetGeometry.setReorderTargetCollectionActive(false, rows: rows)
     }
 
     func middleClick(row: Int) {
@@ -252,7 +270,7 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         setHoveredRowId(row.map { rows[$0].id })
     }
 
-    private func viewportDidChange() {
+    func viewportDidChange() {
         if let changed = rowHeightCache.prepareHostedRowsIfWidthChanged(
             rows,
             columnWidth: currentColumnWidth()
@@ -355,12 +373,24 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
             actions.clearWorkspaceDropIndicator()
             self?.setAppKitDropIndicator(nil, scope: .raw, includeRowTargets: false)
         }
-        reorder.setWorkspaceDropTargetCollectionActive = actions.setWorkspaceDropTargetCollectionActive
+        reorder.setWorkspaceDropTargetCollectionActive = { [weak self] isActive in
+            actions.setWorkspaceDropTargetCollectionActive(isActive)
+            guard let self else { return }
+            if self.dropTargetGeometry.setReorderTargetCollectionActive(isActive, rows: self.rows) {
+                self.positionAppKitDropIndicator()
+            }
+        }
 
         let bonsplit = container.bonsplitDropView
         bonsplit.canPerformAction = actions.canPerformBonsplitAction
         bonsplit.updateAutoscroll = actions.updateDragAutoscroll
-        bonsplit.setWorkspaceDropTargetCollectionActive = actions.setBonsplitDropTargetCollectionActive
+        bonsplit.setWorkspaceDropTargetCollectionActive = { [weak self] isActive in
+            actions.setBonsplitDropTargetCollectionActive(isActive)
+            guard let self else { return }
+            if self.dropTargetGeometry.setBonsplitTargetCollectionActive(isActive, rows: self.rows) {
+                self.positionAppKitDropIndicator()
+            }
+        }
         bonsplit.setDropIndicator = { [weak self] indicator in
             actions.setBonsplitDropIndicator(indicator)
             self?.setAppKitDropIndicator(indicator, scope: .raw, includeRowTargets: true)
@@ -380,40 +410,9 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     }
 
     private func updateDropTargets() {
-        guard let container = containerView else { return }
-        let table = container.tableView
-        let visibleRange = table.rows(in: table.visibleRect)
-        guard visibleRange.location != NSNotFound, visibleRange.length > 0 else {
-            container.reorderDropView.targets = []
-            container.reorderDropView.targetsDidUpdate()
-            bonsplitTargetBridge.updateTargets([])
-            return
+        if dropTargetGeometry.refreshIfActive(rows: rows) {
+            positionAppKitDropIndicator()
         }
-
-        let lower = max(0, visibleRange.location)
-        let upper = min(rows.count, visibleRange.location + visibleRange.length)
-        let visibleIndexes = lower..<upper
-        let reorderTargets = visibleIndexes.map { row -> SidebarWorkspaceReorderDropOverlay.Target in
-            let configuration = rows[row]
-            return SidebarWorkspaceReorderDropOverlay.Target(
-                workspaceId: configuration.workspaceId,
-                groupId: configuration.groupId,
-                isGroupHeader: configuration.isGroupHeader,
-                frame: table.convert(table.rect(ofRow: row), to: container.reorderDropView)
-            )
-        }
-        container.reorderDropView.targets = reorderTargets
-        container.reorderDropView.targetsDidUpdate()
-
-        bonsplitTargetBridge.updateTargets(visibleIndexes.map { row in
-            let configuration = rows[row]
-            return SidebarDropPlanner.WorkspaceDropTarget(
-                workspaceId: configuration.workspaceId,
-                isPinned: configuration.isPinned,
-                frame: table.convert(table.rect(ofRow: row), to: container.bonsplitDropView)
-            )
-        })
-        positionAppKitDropIndicator()
     }
 
     private func synchronizeAppKitDropIndicator(actions: SidebarWorkspaceTableActions) {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -305,7 +305,10 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
     private func configure(cell: SidebarWorkspaceTableCellView, at row: Int) {
         let configuration = rows[row]
         let rowId = configuration.id
-        let didReconfigure = cell.configure(
+#if DEBUG
+        cell.reconfigurationProbe = reconfigurationProbe
+#endif
+        cell.configure(
             row: configuration,
             isPointerHovering: hoveredRowId == rowId && contextMenuRowId != rowId,
             contextMenuDidOpen: { [weak self] in
@@ -315,11 +318,6 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
                 self?.contextMenuDidClose(rowId: rowId)
             }
         )
-#if DEBUG
-        if didReconfigure {
-            reconfigurationProbe?()
-        }
-#endif
     }
 
     private func scrollSelectedRowToVisibleIfNeeded() {

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -1,0 +1,477 @@
+import AppKit
+import Bonsplit
+import CmuxAppKitSupportUI
+import CmuxFoundation
+import SwiftUI
+
+/// Main-actor owner of the default sidebar table lifecycle and its AppKit interactions.
+@MainActor
+final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NSTableViewDelegate {
+    private weak var containerView: SidebarWorkspaceTableContainerView?
+    private var rows: [SidebarWorkspaceTableRowConfiguration] = []
+    private var actions: SidebarWorkspaceTableActions?
+    private var hoveredRowId: SidebarWorkspaceRenderItemID?
+    private var contextMenuRowId: SidebarWorkspaceRenderItemID?
+    private var workspaceIds: [UUID] = []
+    private var selectedScrollTargetWorkspaceId: UUID?
+    private var appKitDropIndicator: SidebarDropIndicator?
+    private var appKitDropIndicatorScope: SidebarWorkspaceReorderDropIndicatorScope = .raw
+    private var appKitDropIndicatorIncludesRowTargets = false
+    private var clipBoundsObserver: NSObjectProtocol?
+    private let bonsplitTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()
+
+#if DEBUG
+    var reconfigurationProbe: (() -> Void)?
+#endif
+
+    deinit {
+        if let clipBoundsObserver {
+            NotificationCenter.default.removeObserver(clipBoundsObserver)
+        }
+    }
+
+    func makeContainerView() -> SidebarWorkspaceTableContainerView {
+        let container = SidebarWorkspaceTableContainerView()
+        containerView = container
+
+        let table = container.tableView
+        table.workspaceController = self
+        container.clipView.workspaceController = self
+        table.dataSource = self
+        table.delegate = self
+        table.headerView = nil
+        table.backgroundColor = .clear
+        table.enclosingScrollView?.backgroundColor = .clear
+        table.focusRingType = .none
+        table.gridStyleMask = []
+        table.usesAlternatingRowBackgroundColors = false
+        table.selectionHighlightStyle = .none
+        table.allowsEmptySelection = true
+        table.allowsMultipleSelection = false
+        table.allowsTypeSelect = false
+        table.intercellSpacing = NSSize(width: 0, height: 2)
+        table.usesAutomaticRowHeights = true
+        table.rowHeight = SidebarWorkspaceTableRowHeightCalculator().estimatedWorkspaceHeight(
+            fontScale: 1,
+            titleLineCount: 1,
+            auxiliaryLineCount: 0
+        )
+        table.columnAutoresizingStyle = .uniformColumnAutoresizingStyle
+        table.setDraggingSourceOperationMask(.move, forLocal: true)
+        table.setDraggingSourceOperationMask(.move, forLocal: false)
+
+        let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier("workspace"))
+        column.resizingMask = .autoresizingMask
+        table.addTableColumn(column)
+
+        let scrollView = container.scrollView
+        scrollView.documentView = table
+        scrollView.drawsBackground = false
+        scrollView.hasHorizontalScroller = false
+        scrollView.automaticallyAdjustsContentInsets = false
+        scrollView.contentView.drawsBackground = false
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        scrollView.contentInsets = NSEdgeInsets(
+            top: SidebarWorkspaceScrollInsets.workspaceList.top
+                + SidebarWorkspaceListMetrics.rowVerticalPadding,
+            left: 0,
+            bottom: SidebarWorkspaceScrollInsets.workspaceList.bottom
+                + SidebarWorkspaceListMetrics.rowVerticalPadding,
+            right: 0
+        )
+        scrollView.applySidebarOverlayScrollerConfiguration()
+
+        container.reorderDropView.registerForDraggedTypes([
+            NSPasteboard.PasteboardType(SidebarTabDragPayload.typeIdentifier),
+        ])
+        container.bonsplitDropView.targetBridge = bonsplitTargetBridge
+
+        clipBoundsObserver = NotificationCenter.default.addObserver(
+            forName: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.viewportDidChange()
+            }
+        }
+
+        return container
+    }
+
+    func apply(
+        rows nextRows: [SidebarWorkspaceTableRowConfiguration],
+        actions: SidebarWorkspaceTableActions,
+        workspaceIds nextWorkspaceIds: [UUID],
+        selectedWorkspaceId: UUID?,
+        selectedScrollTargetWorkspaceId: UUID?
+    ) {
+        guard let containerView else { return }
+        self.actions = actions
+        actions.attachScrollView(containerView.scrollView)
+        configureDropViews(in: containerView, actions: actions)
+
+        let previousRows = rows
+        let hasStructuralChanges = previousRows.map(\.id) != nextRows.map(\.id)
+        rows = nextRows
+
+        if hasStructuralChanges {
+            containerView.tableView.reloadData()
+        } else {
+            let changed = IndexSet(nextRows.indices.filter { index in
+                !previousRows[index].hasEquivalentContent(to: nextRows[index])
+            })
+            reconfigureVisibleRows(changed)
+            if !changed.isEmpty {
+                containerView.tableView.noteHeightOfRows(withIndexesChanged: changed)
+            }
+        }
+
+        let shouldScrollAfterWorkspaceChange = SidebarSelectedWorkspaceScrollPolicy
+            .shouldScrollSelectedWorkspace(
+                selectedWorkspaceId: selectedWorkspaceId,
+                oldWorkspaceIds: workspaceIds,
+                newWorkspaceIds: nextWorkspaceIds
+            )
+        workspaceIds = nextWorkspaceIds
+        let selectionTargetChanged = self.selectedScrollTargetWorkspaceId != selectedScrollTargetWorkspaceId
+        self.selectedScrollTargetWorkspaceId = selectedScrollTargetWorkspaceId
+        if selectionTargetChanged || shouldScrollAfterWorkspaceChange {
+            scrollSelectedRowToVisibleIfNeeded()
+        }
+        synchronizeAppKitDropIndicator(actions: actions)
+        recomputeHoveredRow()
+        updateDropTargets()
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        rows.count
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        viewFor tableColumn: NSTableColumn?,
+        row: Int
+    ) -> NSView? {
+        guard rows.indices.contains(row) else { return nil }
+        let cell = tableView.makeView(
+            withIdentifier: SidebarWorkspaceTableCellView.reuseIdentifier,
+            owner: self
+        ) as? SidebarWorkspaceTableCellView ?? SidebarWorkspaceTableCellView()
+        configure(cell: cell, at: row)
+        return cell
+    }
+
+    func tableView(_ tableView: NSTableView, shouldSelectRow row: Int) -> Bool {
+        false
+    }
+
+    func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> (any NSPasteboardWriting)? {
+        guard rows.indices.contains(row), let actions else { return nil }
+        let workspaceId = rows[row].workspaceId
+        actions.beginWorkspaceDrag(workspaceId)
+        let item = NSPasteboardItem()
+        item.setString(
+            "\(SidebarTabDragPayload.prefix)\(workspaceId.uuidString)",
+            forType: NSPasteboard.PasteboardType(SidebarTabDragPayload.typeIdentifier)
+        )
+        return item
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        draggingSession session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        actions?.endWorkspaceDrag()
+    }
+
+    func middleClick(row: Int) {
+        guard rows.indices.contains(row) else { return }
+        actions?.closeWorkspace(rows[row].workspaceId)
+    }
+
+    func doubleClickEmptyArea() {
+        actions?.createWorkspaceAtEnd()
+    }
+
+    func createEmptyWorkspaceGroup() {
+        actions?.createEmptyWorkspaceGroup()
+    }
+
+    func emptyAreaMenu() -> NSMenu {
+        let menu = NSMenu()
+        let item = NSMenuItem(
+            title: String(
+                localized: "contextMenu.workspaceGroup.newEmpty",
+                defaultValue: "New Empty Workspace Group"
+            ),
+            action: #selector(createEmptyWorkspaceGroupFromMenu),
+            keyEquivalent: ""
+        )
+        item.target = self
+        let shortcut = KeyboardShortcutSettings.shortcut(for: .newWorkspaceGroup)
+        if let keyEquivalent = shortcut.menuItemKeyEquivalent {
+            item.keyEquivalent = keyEquivalent
+            item.keyEquivalentModifierMask = shortcut.modifierFlags
+        }
+        menu.addItem(item)
+        return menu
+    }
+
+    @objc private func createEmptyWorkspaceGroupFromMenu() {
+        createEmptyWorkspaceGroup()
+    }
+
+    func pointerDidLeaveTable() {
+        guard contextMenuRowId == nil else { return }
+        setHoveredRowId(nil)
+    }
+
+    func recomputeHoveredRow() {
+        guard contextMenuRowId == nil,
+              let table = containerView?.tableView else {
+            return
+        }
+        let row = SidebarWorkspaceTableHoverResolver().hoveredRow(
+            windowPoint: table.lastPointerWindowLocation,
+            convertToTable: { table.convert($0, from: nil) },
+            rowAtPoint: { table.row(at: $0) },
+            rowCount: rows.count
+        )
+        setHoveredRowId(row.map { rows[$0].id })
+    }
+
+    private func viewportDidChange() {
+        recomputeHoveredRow()
+        updateDropTargets()
+    }
+
+    private func setHoveredRowId(_ next: SidebarWorkspaceRenderItemID?) {
+        guard hoveredRowId != next else { return }
+        let previous = hoveredRowId
+        hoveredRowId = next
+        reconfigureRows(withIds: [previous, next].compactMap { $0 })
+    }
+
+    private func contextMenuDidOpen(rowId: SidebarWorkspaceRenderItemID) {
+        contextMenuRowId = rowId
+    }
+
+    private func contextMenuDidClose(rowId: SidebarWorkspaceRenderItemID) {
+        guard contextMenuRowId == rowId else { return }
+        contextMenuRowId = nil
+        recomputeHoveredRow()
+    }
+
+    private func reconfigureRows(withIds ids: [SidebarWorkspaceRenderItemID]) {
+        let idSet = Set(ids)
+        let indexes = IndexSet(rows.indices.filter { idSet.contains(rows[$0].id) })
+        reconfigureVisibleRows(indexes)
+    }
+
+    private func reconfigureVisibleRows(_ indexes: IndexSet) {
+        guard let table = containerView?.tableView else { return }
+        for row in indexes where rows.indices.contains(row) {
+            guard let cell = table.view(atColumn: 0, row: row, makeIfNecessary: false)
+                    as? SidebarWorkspaceTableCellView else {
+                continue
+            }
+            configure(cell: cell, at: row)
+        }
+    }
+
+    private func configure(cell: SidebarWorkspaceTableCellView, at row: Int) {
+        let configuration = rows[row]
+        let rowId = configuration.id
+        cell.configure(
+            row: configuration,
+            isPointerHovering: hoveredRowId == rowId && contextMenuRowId != rowId,
+            contextMenuDidOpen: { [weak self] in
+                self?.contextMenuDidOpen(rowId: rowId)
+            },
+            contextMenuDidClose: { [weak self] in
+                self?.contextMenuDidClose(rowId: rowId)
+            }
+        )
+#if DEBUG
+        reconfigurationProbe?()
+#endif
+    }
+
+    private func scrollSelectedRowToVisibleIfNeeded() {
+        guard let table = containerView?.tableView,
+              let selectedScrollTargetWorkspaceId,
+              let row = rows.firstIndex(where: { $0.workspaceId == selectedScrollTargetWorkspaceId }) else {
+            return
+        }
+        let visibleRect = table.visibleRect
+        guard !visibleRect.contains(table.rect(ofRow: row)) else { return }
+        table.scrollRowToVisible(row)
+    }
+
+    private func configureDropViews(
+        in container: SidebarWorkspaceTableContainerView,
+        actions: SidebarWorkspaceTableActions
+    ) {
+        let reorder = container.reorderDropView
+        reorder.isValidDrag = actions.isValidWorkspaceDrag
+        reorder.updateDrag = { [weak self] point, targets in
+            let accepted = actions.updateWorkspaceDrag(point, targets)
+            self?.setAppKitDropIndicator(
+                actions.currentDropIndicator(),
+                scope: actions.currentDropIndicatorScope(),
+                includeRowTargets: false
+            )
+            return accepted
+        }
+        reorder.performDropAtPoint = { [weak self] point, targets in
+            let performed = actions.performWorkspaceDrop(point, targets)
+            self?.setAppKitDropIndicator(nil, scope: .raw, includeRowTargets: false)
+            return performed
+        }
+        reorder.clearDropIndicator = { [weak self] in
+            actions.clearWorkspaceDropIndicator()
+            self?.setAppKitDropIndicator(nil, scope: .raw, includeRowTargets: false)
+        }
+        reorder.setWorkspaceDropTargetCollectionActive = actions.setWorkspaceDropTargetCollectionActive
+
+        let bonsplit = container.bonsplitDropView
+        bonsplit.canPerformAction = actions.canPerformBonsplitAction
+        bonsplit.updateAutoscroll = actions.updateDragAutoscroll
+        bonsplit.setWorkspaceDropTargetCollectionActive = actions.setBonsplitDropTargetCollectionActive
+        bonsplit.setDropIndicator = { [weak self] indicator in
+            actions.setBonsplitDropIndicator(indicator)
+            self?.setAppKitDropIndicator(indicator, scope: .raw, includeRowTargets: true)
+        }
+        bonsplit.performExistingWorkspaceMove = { workspaceId, transfer in
+            guard actions.moveBonsplitToExistingWorkspace(workspaceId, transfer) else { return false }
+            actions.didMoveBonsplitToWorkspace(workspaceId)
+            return true
+        }
+        bonsplit.performNewWorkspaceMove = { insertionIndex, _, transfer in
+            guard let workspaceId = actions.moveBonsplitToNewWorkspace(insertionIndex, transfer) else {
+                return false
+            }
+            actions.didMoveBonsplitToWorkspace(workspaceId)
+            return true
+        }
+    }
+
+    private func updateDropTargets() {
+        guard let container = containerView else { return }
+        let table = container.tableView
+        let visibleRange = table.rows(in: table.visibleRect)
+        guard visibleRange.location != NSNotFound, visibleRange.length > 0 else {
+            container.reorderDropView.targets = []
+            container.reorderDropView.targetsDidUpdate()
+            bonsplitTargetBridge.updateTargets([])
+            return
+        }
+
+        let lower = max(0, visibleRange.location)
+        let upper = min(rows.count, visibleRange.location + visibleRange.length)
+        let visibleIndexes = lower..<upper
+        let reorderTargets = visibleIndexes.map { row -> SidebarWorkspaceReorderDropOverlay.Target in
+            let configuration = rows[row]
+            return SidebarWorkspaceReorderDropOverlay.Target(
+                workspaceId: configuration.workspaceId,
+                groupId: configuration.groupId,
+                isGroupHeader: configuration.isGroupHeader,
+                frame: table.convert(table.rect(ofRow: row), to: container.reorderDropView)
+            )
+        }
+        container.reorderDropView.targets = reorderTargets
+        container.reorderDropView.targetsDidUpdate()
+
+        bonsplitTargetBridge.updateTargets(visibleIndexes.map { row in
+            let configuration = rows[row]
+            return SidebarDropPlanner.WorkspaceDropTarget(
+                workspaceId: configuration.workspaceId,
+                isPinned: configuration.isPinned,
+                frame: table.convert(table.rect(ofRow: row), to: container.bonsplitDropView)
+            )
+        })
+        positionAppKitDropIndicator()
+    }
+
+    private func synchronizeAppKitDropIndicator(actions: SidebarWorkspaceTableActions) {
+        let current = actions.currentDropIndicator()
+        let currentScope = actions.currentDropIndicatorScope()
+        if current == nil {
+            setAppKitDropIndicator(nil, scope: .raw, includeRowTargets: false)
+        } else if current == appKitDropIndicator && currentScope == appKitDropIndicatorScope {
+            positionAppKitDropIndicator()
+        } else {
+            setAppKitDropIndicator(
+                current,
+                scope: currentScope,
+                includeRowTargets: false
+            )
+        }
+    }
+
+    private func setAppKitDropIndicator(
+        _ indicator: SidebarDropIndicator?,
+        scope: SidebarWorkspaceReorderDropIndicatorScope,
+        includeRowTargets: Bool
+    ) {
+        let shouldDisplay: Bool = {
+            guard let indicator else { return false }
+            if includeRowTargets { return true }
+            guard !scope.isGroup else { return false }
+            if indicator.tabId == nil { return true }
+            return indicator.edge == .bottom && rows.last?.workspaceId == indicator.tabId
+        }()
+        appKitDropIndicator = shouldDisplay ? indicator : nil
+        appKitDropIndicatorScope = scope
+        appKitDropIndicatorIncludesRowTargets = includeRowTargets
+        containerView?.emptyDropIndicatorView.isHidden = !shouldDisplay
+        positionAppKitDropIndicator()
+    }
+
+    private func positionAppKitDropIndicator() {
+        guard let indicator = appKitDropIndicator, let container = containerView else { return }
+        let targetRow = indicator.tabId.flatMap { tabId in
+            rows.firstIndex { $0.workspaceId == tabId }
+        }
+        if indicator.tabId != nil, targetRow == nil {
+            container.emptyDropIndicatorView.isHidden = true
+            return
+        }
+        container.emptyDropIndicatorView.isHidden = false
+        let y: CGFloat
+        if let targetRow {
+            let rowFrame = container.tableView.convert(
+                container.tableView.rect(ofRow: targetRow),
+                to: container
+            )
+            y = (indicator.edge == .top ? rowFrame.maxY : rowFrame.minY) - 1
+        } else if let lastRow = rows.indices.last {
+            y = container.tableView.convert(
+                container.tableView.rect(ofRow: lastRow),
+                to: container
+            ).minY - 1
+        } else {
+            y = container.bounds.height
+                - SidebarWorkspaceScrollInsets.workspaceList.top
+                - SidebarWorkspaceListMetrics.rowVerticalPadding
+        }
+        let leadingIndent: CGFloat = {
+            guard appKitDropIndicatorIncludesRowTargets,
+                  let targetRow,
+                  rows[targetRow].groupId != nil,
+                  !rows[targetRow].isGroupHeader else {
+                return 0
+            }
+            return SidebarWorkspaceGroupingMetrics.memberIndent
+        }()
+        container.emptyDropIndicatorView.frame = NSRect(
+            x: 8 + leadingIndent,
+            y: y,
+            width: max(0, container.bounds.width - 16 - leadingIndent),
+            height: 2
+        )
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableDropTargetGeometryGate.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableDropTargetGeometryGate.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxFoundation
 
 /// Builds sidebar drop geometry only while an AppKit drag requests it.
 @MainActor

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableDropTargetGeometryGate.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableDropTargetGeometryGate.swift
@@ -1,0 +1,112 @@
+import AppKit
+
+/// Builds sidebar drop geometry only while an AppKit drag requests it.
+@MainActor
+final class SidebarWorkspaceTableDropTargetGeometryGate {
+    let bonsplitTargetBridge = SidebarBonsplitTabWorkspaceDropOverlay.TargetBridge()
+
+    private weak var containerView: SidebarWorkspaceTableContainerView?
+    private var isWorkspaceDragSessionActive = false
+    private var isReorderTargetCollectionActive = false
+    private var isBonsplitTargetCollectionActive = false
+
+#if DEBUG
+    var computationProbe: (() -> Void)?
+#endif
+
+    func attach(containerView: SidebarWorkspaceTableContainerView) {
+        self.containerView = containerView
+    }
+
+    @discardableResult
+    func setWorkspaceDragSessionActive(
+        _ isActive: Bool,
+        rows: [SidebarWorkspaceTableRowConfiguration]
+    ) -> Bool {
+        let wasActive = hasActiveDrag
+        isWorkspaceDragSessionActive = isActive
+        return handleActivityChange(wasActive: wasActive, rows: rows)
+    }
+
+    @discardableResult
+    func setReorderTargetCollectionActive(
+        _ isActive: Bool,
+        rows: [SidebarWorkspaceTableRowConfiguration]
+    ) -> Bool {
+        let wasActive = hasActiveDrag
+        isReorderTargetCollectionActive = isActive
+        return handleActivityChange(wasActive: wasActive, rows: rows)
+    }
+
+    @discardableResult
+    func setBonsplitTargetCollectionActive(
+        _ isActive: Bool,
+        rows: [SidebarWorkspaceTableRowConfiguration]
+    ) -> Bool {
+        let wasActive = hasActiveDrag
+        isBonsplitTargetCollectionActive = isActive
+        return handleActivityChange(wasActive: wasActive, rows: rows)
+    }
+
+    @discardableResult
+    func refreshIfActive(rows: [SidebarWorkspaceTableRowConfiguration]) -> Bool {
+        guard hasActiveDrag, let container = containerView else { return false }
+#if DEBUG
+        computationProbe?()
+#endif
+        let table = container.tableView
+        let visibleRange = table.rows(in: table.visibleRect)
+        guard visibleRange.location != NSNotFound, visibleRange.length > 0 else {
+            clearTargets()
+            return true
+        }
+
+        let lower = max(0, visibleRange.location)
+        let upper = min(rows.count, visibleRange.location + visibleRange.length)
+        let visibleIndexes = lower..<upper
+        container.reorderDropView.targets = visibleIndexes.map { row in
+            let configuration = rows[row]
+            return SidebarWorkspaceReorderDropOverlay.Target(
+                workspaceId: configuration.workspaceId,
+                groupId: configuration.groupId,
+                isGroupHeader: configuration.isGroupHeader,
+                frame: table.convert(table.rect(ofRow: row), to: container.reorderDropView)
+            )
+        }
+        container.reorderDropView.targetsDidUpdate()
+        bonsplitTargetBridge.updateTargets(visibleIndexes.map { row in
+            let configuration = rows[row]
+            return SidebarDropPlanner.WorkspaceDropTarget(
+                workspaceId: configuration.workspaceId,
+                isPinned: configuration.isPinned,
+                frame: table.convert(table.rect(ofRow: row), to: container.bonsplitDropView)
+            )
+        })
+        return true
+    }
+
+    private var hasActiveDrag: Bool {
+        isWorkspaceDragSessionActive
+            || isReorderTargetCollectionActive
+            || isBonsplitTargetCollectionActive
+    }
+
+    private func handleActivityChange(
+        wasActive: Bool,
+        rows: [SidebarWorkspaceTableRowConfiguration]
+    ) -> Bool {
+        guard wasActive != hasActiveDrag else { return false }
+        if hasActiveDrag {
+            return refreshIfActive(rows: rows)
+        }
+        clearTargets()
+        return false
+    }
+
+    private func clearTargets() {
+        guard let container = containerView else { return }
+        container.reorderDropView.targets = []
+        container.reorderDropView.targetsDidUpdate()
+        bonsplitTargetBridge.updateTargets([])
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableEmptyDropIndicatorView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableEmptyDropIndicatorView.swift
@@ -1,0 +1,30 @@
+import AppKit
+
+/// AppKit counterpart of the existing two-point accent drop indicator.
+@MainActor
+final class SidebarWorkspaceTableEmptyDropIndicatorView: NSView {
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        wantsLayer = true
+        layer?.cornerRadius = 1
+        updateAccentColor()
+        isHidden = true
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        updateAccentColor()
+    }
+
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+
+    private func updateAccentColor() {
+        layer?.backgroundColor = cmuxAccentNSColor(for: effectiveAppearance).cgColor
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableEnvironmentSnapshot.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableEnvironmentSnapshot.swift
@@ -1,0 +1,30 @@
+import CmuxFoundation
+import SwiftUI
+
+/// Value-only SwiftUI environment forwarded into each independently hosted table cell.
+struct SidebarWorkspaceTableEnvironmentSnapshot {
+    let colorScheme: ColorScheme
+    let globalFontMagnificationPercent: Int
+#if DEBUG
+    let lazyContractProbe: SidebarLazyContractProbe
+#endif
+
+    func hasEquivalentPresentation(to other: Self) -> Bool {
+        colorScheme == other.colorScheme
+            && globalFontMagnificationPercent == other.globalFontMagnificationPercent
+    }
+
+    @ViewBuilder
+    func apply<Content: View>(to content: Content) -> some View {
+#if DEBUG
+        content
+            .environment(\.colorScheme, colorScheme)
+            .environment(\.cmuxGlobalFontMagnificationPercent, globalFontMagnificationPercent)
+            .environment(\.sidebarLazyContractProbe, lazyContractProbe)
+#else
+        content
+            .environment(\.colorScheme, colorScheme)
+            .environment(\.cmuxGlobalFontMagnificationPercent, globalFontMagnificationPercent)
+#endif
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableHoverResolver.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableHoverResolver.swift
@@ -1,0 +1,16 @@
+import AppKit
+
+/// Pure hovered-row resolution shared by the table controller and unit tests.
+struct SidebarWorkspaceTableHoverResolver {
+    func hoveredRow(
+        windowPoint: NSPoint?,
+        convertToTable: (NSPoint) -> NSPoint,
+        rowAtPoint: (NSPoint) -> Int,
+        rowCount: Int
+    ) -> Int? {
+        guard let windowPoint else { return nil }
+        let row = rowAtPoint(convertToTable(windowPoint))
+        guard row >= 0, row < rowCount else { return nil }
+        return row
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
@@ -52,4 +52,17 @@ struct SidebarWorkspaceTableRowConfiguration {
         environment.hasEquivalentPresentation(to: other.environment)
             && isEquivalentValue(other.equivalenceValue)
     }
+
+    var estimatedHeight: CGFloat {
+        let fontScale = CGFloat(environment.globalFontMagnificationPercent) / 100
+        let calculator = SidebarWorkspaceTableRowHeightCalculator()
+        if isGroupHeader {
+            return calculator.estimatedGroupHeaderHeight(fontScale: fontScale)
+        }
+        return calculator.estimatedWorkspaceHeight(
+            fontScale: fontScale,
+            titleLineCount: 1,
+            auxiliaryLineCount: 0
+        )
+    }
 }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift
@@ -1,0 +1,55 @@
+import SwiftUI
+
+struct SidebarWorkspaceTableContextMenuActions {
+    let didOpen: () -> Void
+    let didClose: () -> Void
+}
+
+/// Immutable description of one AppKit-owned sidebar row.
+@MainActor
+struct SidebarWorkspaceTableRowConfiguration {
+    typealias ContentFactory = (
+        _ isPointerHovering: Bool,
+        _ contextMenuActions: SidebarWorkspaceTableContextMenuActions
+    ) -> AnyView
+
+    let id: SidebarWorkspaceRenderItemID
+    let workspaceId: UUID
+    let groupId: UUID?
+    let isGroupHeader: Bool
+    let isPinned: Bool
+    let makeContent: ContentFactory
+
+    private let environment: SidebarWorkspaceTableEnvironmentSnapshot
+    private let equivalenceValue: Any
+    private let isEquivalentValue: (Any) -> Bool
+
+    init<Content: View & Equatable>(
+        id: SidebarWorkspaceRenderItemID,
+        workspaceId: UUID,
+        groupId: UUID?,
+        isGroupHeader: Bool,
+        isPinned: Bool,
+        environment: SidebarWorkspaceTableEnvironmentSnapshot,
+        equivalenceValue: Content,
+        makeContent: @escaping ContentFactory
+    ) {
+        self.id = id
+        self.workspaceId = workspaceId
+        self.groupId = groupId
+        self.isGroupHeader = isGroupHeader
+        self.isPinned = isPinned
+        self.environment = environment
+        self.makeContent = makeContent
+        self.equivalenceValue = equivalenceValue
+        self.isEquivalentValue = { value in
+            guard let value = value as? Content else { return false }
+            return value == equivalenceValue
+        }
+    }
+
+    func hasEquivalentContent(to other: Self) -> Bool {
+        environment.hasEquivalentPresentation(to: other.environment)
+            && isEquivalentValue(other.equivalenceValue)
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCache.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCache.swift
@@ -1,0 +1,120 @@
+import AppKit
+import Foundation
+import SwiftUI
+
+/// Stores exact hosted-row heights without measuring from AppKit's layout callbacks.
+@MainActor
+final class SidebarWorkspaceTableRowHeightCache {
+    typealias Measurement = (
+        _ row: SidebarWorkspaceTableRowConfiguration,
+        _ columnWidth: CGFloat
+    ) -> CGFloat
+
+    @MainActor
+    private struct Entry {
+        let row: SidebarWorkspaceTableRowConfiguration
+        let columnWidth: CGFloat
+        let height: CGFloat
+
+        func matches(
+            row candidate: SidebarWorkspaceTableRowConfiguration,
+            columnWidth candidateWidth: CGFloat
+        ) -> Bool {
+            columnWidth == candidateWidth && row.hasEquivalentContent(to: candidate)
+        }
+    }
+
+    private var entries: [SidebarWorkspaceRenderItemID: Entry] = [:]
+    private let prototypeView = NSHostingView(rootView: AnyView(EmptyView()))
+    private var preparedColumnWidth: CGFloat?
+
+    func prepareHostedRows(
+        _ rows: [SidebarWorkspaceTableRowConfiguration],
+        columnWidth: CGFloat
+    ) -> IndexSet {
+        return prepare(rows: rows, columnWidth: columnWidth, measure: measureHostedRow)
+    }
+
+    func prepareHostedRowsIfWidthChanged(
+        _ rows: [SidebarWorkspaceTableRowConfiguration],
+        columnWidth: CGFloat
+    ) -> IndexSet? {
+        guard columnWidth > 0, preparedColumnWidth != columnWidth else { return nil }
+        return prepareHostedRows(rows, columnWidth: columnWidth)
+    }
+
+    /// Measures only missing or invalid entries. Call from render updates or
+    /// viewport-width notifications, never from `heightOfRow`.
+    func prepare(
+        rows: [SidebarWorkspaceTableRowConfiguration],
+        columnWidth: CGFloat,
+        measure: Measurement
+    ) -> IndexSet {
+        guard columnWidth > 0 else {
+            entries.removeAll(keepingCapacity: true)
+            preparedColumnWidth = nil
+            return []
+        }
+        preparedColumnWidth = columnWidth
+
+        var nextEntries: [SidebarWorkspaceRenderItemID: Entry] = [:]
+        nextEntries.reserveCapacity(rows.count)
+        var changedHeights = IndexSet()
+
+        for (index, row) in rows.enumerated() {
+            let previous = entries[row.id]
+            if let previous, previous.matches(row: row, columnWidth: columnWidth) {
+                nextEntries[row.id] = previous
+                continue
+            }
+
+            let measuredHeight = Self.normalizedHeight(measure(row, columnWidth))
+            let previousHeight = previous?.height ?? row.estimatedHeight
+            if previousHeight != measuredHeight {
+                changedHeights.insert(index)
+            }
+            nextEntries[row.id] = Entry(
+                row: row,
+                columnWidth: columnWidth,
+                height: measuredHeight
+            )
+        }
+
+        entries = nextEntries
+        return changedHeights
+    }
+
+    /// A pure cache read used by `tableView(_:heightOfRow:)` during layout.
+    func height(
+        for row: SidebarWorkspaceTableRowConfiguration,
+        columnWidth: CGFloat
+    ) -> CGFloat? {
+        guard let entry = entries[row.id],
+              entry.matches(row: row, columnWidth: columnWidth) else {
+            return nil
+        }
+        return entry.height
+    }
+
+    private static func normalizedHeight(_ height: CGFloat) -> CGFloat {
+        ceil(max(1, height))
+    }
+
+    private func measureHostedRow(
+        row: SidebarWorkspaceTableRowConfiguration,
+        columnWidth: CGFloat
+    ) -> CGFloat {
+        let contextMenuActions = SidebarWorkspaceTableContextMenuActions(
+            didOpen: {},
+            didClose: {}
+        )
+        prototypeView.rootView = AnyView(
+            row.makeContent(false, contextMenuActions)
+                .frame(width: columnWidth, alignment: .leading)
+                .fixedSize(horizontal: false, vertical: true)
+        )
+        prototypeView.frame = NSRect(x: 0, y: 0, width: columnWidth, height: 1)
+        prototypeView.layoutSubtreeIfNeeded()
+        return prototypeView.fittingSize.height
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCalculator.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCalculator.swift
@@ -1,0 +1,22 @@
+import CoreGraphics
+
+/// Supplies deterministic estimates while AppKit resolves exact hosted SwiftUI row heights.
+struct SidebarWorkspaceTableRowHeightCalculator {
+    func estimatedWorkspaceHeight(
+        fontScale: CGFloat,
+        titleLineCount: Int,
+        auxiliaryLineCount: Int
+    ) -> CGFloat {
+        let scale = max(0.5, fontScale)
+        let titleLines = max(1, titleLineCount)
+        let auxiliaryLines = max(0, auxiliaryLineCount)
+        let titleHeight = CGFloat(titleLines) * 15 * scale
+        let auxiliaryHeight = CGFloat(auxiliaryLines) * 12 * scale
+        let interlineSpacing = auxiliaryLines > 0 ? CGFloat(auxiliaryLines) * 4 : 0
+        return ceil(16 + titleHeight + auxiliaryHeight + interlineSpacing)
+    }
+
+    func estimatedGroupHeaderHeight(fontScale: CGFloat) -> CGFloat {
+        ceil(26 * max(0.5, fontScale) + 10)
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCalculator.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCalculator.swift
@@ -2,6 +2,10 @@ import CoreGraphics
 
 /// Supplies deterministic estimates while AppKit resolves exact hosted SwiftUI row heights.
 struct SidebarWorkspaceTableRowHeightCalculator {
+    var defaultWorkspaceHeight: CGFloat {
+        estimatedWorkspaceHeight(fontScale: 1, titleLineCount: 1, auxiliaryLineCount: 0)
+    }
+
     func estimatedWorkspaceHeight(
         fontScale: CGFloat,
         titleLineCount: Int,

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
@@ -1,0 +1,35 @@
+import SwiftUI
+
+/// Container-level bridge mounting the AppKit-owned default workspace list once.
+struct SidebarWorkspaceTableView: NSViewRepresentable {
+    let rows: [SidebarWorkspaceTableRowConfiguration]
+    let actions: SidebarWorkspaceTableActions
+    let workspaceIds: [UUID]
+    let selectedWorkspaceId: UUID?
+    let selectedScrollTargetWorkspaceId: UUID?
+
+#if DEBUG
+    @Environment(\.sidebarLazyContractProbe) private var sidebarLazyContractProbe
+#endif
+
+    func makeCoordinator() -> SidebarWorkspaceTableController {
+        SidebarWorkspaceTableController()
+    }
+
+    func makeNSView(context: Context) -> SidebarWorkspaceTableContainerView {
+        context.coordinator.makeContainerView()
+    }
+
+    func updateNSView(_ nsView: SidebarWorkspaceTableContainerView, context: Context) {
+#if DEBUG
+        context.coordinator.reconfigurationProbe = sidebarLazyContractProbe.tableRootViewReconfigure
+#endif
+        context.coordinator.apply(
+            rows: rows,
+            actions: actions,
+            workspaceIds: workspaceIds,
+            selectedWorkspaceId: selectedWorkspaceId,
+            selectedScrollTargetWorkspaceId: selectedScrollTargetWorkspaceId
+        )
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
@@ -1,0 +1,77 @@
+import AppKit
+
+/// Event-owning NSTableView for the default workspace sidebar.
+@MainActor
+final class SidebarWorkspaceTableViewImpl: NSTableView {
+    weak var workspaceController: SidebarWorkspaceTableController?
+    private var pointerTrackingArea: NSTrackingArea?
+    private(set) var lastPointerWindowLocation: NSPoint?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let pointerTrackingArea {
+            removeTrackingArea(pointerTrackingArea)
+        }
+        let next = NSTrackingArea(
+            rect: bounds,
+            options: [.activeInKeyWindow, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(next)
+        pointerTrackingArea = next
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        updatePointer(with: event)
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        updatePointer(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        setPointerWindowLocation(nil)
+    }
+
+    override func otherMouseDown(with event: NSEvent) {
+        guard event.buttonNumber == 2 else {
+            super.otherMouseDown(with: event)
+            return
+        }
+        let row = row(at: convert(event.locationInWindow, from: nil))
+        guard row >= 0 else {
+            super.otherMouseDown(with: event)
+            return
+        }
+        workspaceController?.middleClick(row: row)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        let point = convert(event.locationInWindow, from: nil)
+        let clickedRow = row(at: point)
+        super.mouseDown(with: event)
+        if event.clickCount == 2, clickedRow < 0 {
+            workspaceController?.doubleClickEmptyArea()
+        }
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let row = row(at: convert(event.locationInWindow, from: nil))
+        guard row < 0 else { return super.menu(for: event) }
+        return workspaceController?.emptyAreaMenu()
+    }
+
+    private func updatePointer(with event: NSEvent) {
+        setPointerWindowLocation(event.locationInWindow)
+    }
+
+    func setPointerWindowLocation(_ point: NSPoint?) {
+        lastPointerWindowLocation = point
+        if point == nil {
+            workspaceController?.pointerDidLeaveTable()
+        } else {
+            workspaceController?.recomputeHoveredRow()
+        }
+    }
+}

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
@@ -14,7 +14,7 @@ final class SidebarWorkspaceTableViewImpl: NSTableView {
         }
         let next = NSTrackingArea(
             rect: bounds,
-            options: [.activeInKeyWindow, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
+            options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
             owner: self,
             userInfo: nil
         )

--- a/Sources/SidebarWorkspaceGroupHeaderView.swift
+++ b/Sources/SidebarWorkspaceGroupHeaderView.swift
@@ -35,6 +35,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             lhs.cwdContextMenuItems == rhs.cwdContextMenuItems &&
             lhs.newWorkspacePlacement == rhs.newWorkspacePlacement &&
             lhs.rowSpacing == rhs.rowSpacing &&
+            lhs.isPointerHovering == rhs.isPointerHovering &&
             lhs.isFirstRow == rhs.isFirstRow &&
             lhs.isBeingDragged == rhs.isBeingDragged &&
             lhs.topDropIndicatorVisible == rhs.topDropIndicatorVisible &&
@@ -65,6 +66,7 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let cwdContextMenuItems: [CmuxResolvedConfigContextMenuItem]
     let newWorkspacePlacement: WorkspaceGroupNewPlacement?
     let rowSpacing: CGFloat
+    let isPointerHovering: Bool
     let isFirstRow: Bool
     let isBeingDragged: Bool
     let topDropIndicatorVisible: Bool
@@ -85,6 +87,8 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
     let onDelete: () -> Void
     let onEditConfig: () -> Void
     let onOpenDocs: () -> Void
+    let onContextMenuAppear: () -> Void
+    let onContextMenuDisappear: () -> Void
 
     @State private var rowInteractionState = SidebarWorkspaceRowInteractionState()
 
@@ -193,10 +197,9 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 defaultValue: "Focus the group's anchor workspace"
             )))
 
-            let plusVisible = rowInteractionState.shouldShowCloseButton(
-                canCloseWorkspace: true,
-                shortcutHintModeActive: showsShortcutHint
-            )
+            let plusVisible = isPointerHovering
+                && !rowInteractionState.contextMenuVisible
+                && !showsShortcutHint
             Button(action: onTapPlus) {
                 CmuxSystemSymbolImage(
                     systemName: "plus",
@@ -227,9 +230,11 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 )
                 .onAppear {
                     rowInteractionState.contextMenuDidAppear()
+                    onContextMenuAppear()
                 }
                 .onDisappear {
                     rowInteractionState.contextMenuDidDisappear()
+                    onContextMenuDisappear()
                 }
                 if !cwdContextMenuItems.isEmpty {
                     Divider()
@@ -278,7 +283,6 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
         )
         .padding(.horizontal, SidebarWorkspaceListMetrics.rowOuterHorizontalPadding)
         .shortcutHintVisibilityAnimation(value: showsShortcutHint)
-        .sidebarWorkspaceRowHoverTracking($rowInteractionState)
         .opacity(isBeingDragged ? 0.6 : 1)
         .overlay(alignment: .top) {
             SidebarWorkspaceTopDropIndicator(
@@ -296,18 +300,6 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
                 leadingInset: metrics.groupScopedBottomDropIndicatorLeadingInset
             )
         }
-        .onDrag(onDragStart)
-        .internalOnlyTabDrag()
-        .overlay {
-            if rowInteractionState.contextMenuVisible {
-                SidebarWorkspaceRowMenuTrackingReconciler { pointerInsideRow in
-                    rowInteractionState.contextMenuTrackingDidEnd(pointerInsideRow: pointerInsideRow)
-                }
-                .onAppear {
-                    rowInteractionState.contextMenuTrackingObserverDidInstall()
-                }
-            }
-        }
         .contextMenu {
             Button(
                 String(
@@ -318,9 +310,11 @@ struct SidebarWorkspaceGroupHeaderView: View, Equatable {
             )
             .onAppear {
                 rowInteractionState.contextMenuDidAppear()
+                onContextMenuAppear()
             }
             .onDisappear {
                 rowInteractionState.contextMenuDidDisappear()
+                onContextMenuDisappear()
             }
             Divider()
             Button(

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -5,14 +5,12 @@ import CmuxSettings
 import CmuxWorkspaces
 
 extension VerticalTabsSidebar {
-    @ViewBuilder
-    func sidebarWorkspaceGroupHeader(
+    func sidebarWorkspaceGroupTableConfiguration(
         group: WorkspaceGroup,
         memberWorkspaceIds: [UUID],
         renderContext: WorkspaceListRenderContext,
-        shouldCollectWorkspaceDropTargets: Bool,
         showModifierHoldHints: Bool
-    ) -> some View {
+    ) -> SidebarWorkspaceTableRowConfiguration {
         let settings = renderContext.tabItemSettings
         let isAnchorActive = tabManager.selectedTabId == group.anchorWorkspaceId
         let anchorCwd = renderContext.workspaceById[group.anchorWorkspaceId]?.currentDirectory
@@ -69,7 +67,10 @@ extension VerticalTabsSidebar {
             dragState.beginDragging(tabId: anchorId)
             return SidebarTabDragPayload(tabId: anchorId).provider()
         }
-        let header = SidebarWorkspaceGroupHeaderView(
+        let makeHeader: (Bool, SidebarWorkspaceTableContextMenuActions) -> SidebarWorkspaceGroupHeaderView = {
+            isPointerHovering,
+            contextMenuActions in
+            SidebarWorkspaceGroupHeaderView(
             groupId: group.id,
             anchorWorkspaceId: group.anchorWorkspaceId,
             name: group.name,
@@ -94,6 +95,7 @@ extension VerticalTabsSidebar {
             cwdContextMenuItems: cwdContextMenuItems,
             newWorkspacePlacement: newWorkspacePlacement,
             rowSpacing: tabRowSpacing,
+            isPointerHovering: isPointerHovering,
             isFirstRow: renderContext.sidebarReorderIds.first == group.anchorWorkspaceId,
             isBeingDragged: dragState.draggedTabId == group.anchorWorkspaceId,
             topDropIndicatorVisible: topDropIndicatorVisible,
@@ -193,16 +195,32 @@ extension VerticalTabsSidebar {
             },
             onOpenDocs: {
                 SidebarWorkspaceGroupConfigOpener.openWorkspaceGroupsDocs()
-            }
+            },
+            onContextMenuAppear: contextMenuActions.didOpen,
+            onContextMenuDisappear: contextMenuActions.didClose
         )
-        .equatable()
-        .id(group.anchorWorkspaceId)
-        .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
-
-        header
-            .sidebarWorkspaceFrameAnchor(
-                id: group.anchorWorkspaceId,
-                isEnabled: shouldCollectWorkspaceDropTargets
+        }
+        let equivalenceValue = makeHeader(
+            false,
+            SidebarWorkspaceTableContextMenuActions(didOpen: {}, didClose: {})
+        )
+        return SidebarWorkspaceTableRowConfiguration(
+            id: .group(group.id),
+            workspaceId: group.anchorWorkspaceId,
+            groupId: group.id,
+            isGroupHeader: true,
+            isPinned: group.isPinned,
+            environment: renderContext.environment,
+            equivalenceValue: equivalenceValue
+        ) { isPointerHovering, contextMenuActions in
+            AnyView(
+                renderContext.environment.apply(
+                    to: makeHeader(isPointerHovering, contextMenuActions)
+                        .equatable()
+                        .id(group.anchorWorkspaceId)
+                        .accessibilityIdentifier("sidebarWorkspaceGroup.\(group.id.uuidString)")
+                )
             )
+        }
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1400,6 +1400,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B804A00B000000000000000B /* SidebarWorkspaceTableClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */; };
 		B804A0030000000000000003 /* SidebarWorkspaceTableContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */; };
 		B804A0040000000000000004 /* SidebarWorkspaceTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */; };
+		B804A0110000000000000011 /* SidebarWorkspaceTableDropTargetGeometryGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0110000000000000011 /* SidebarWorkspaceTableDropTargetGeometryGate.swift */; };
 		B804A00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */; };
 		B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */; };
 		B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */; };
@@ -3210,6 +3211,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableClipView.swift; sourceTree = "<group>"; };
 		B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift; sourceTree = "<group>"; };
 		B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableController.swift; sourceTree = "<group>"; };
+		B804B0110000000000000011 /* SidebarWorkspaceTableDropTargetGeometryGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableDropTargetGeometryGate.swift; sourceTree = "<group>"; };
 		B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableEmptyDropIndicatorView.swift; sourceTree = "<group>"; };
 		B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableEnvironmentSnapshot.swift; sourceTree = "<group>"; };
 		B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableHoverResolver.swift; sourceTree = "<group>"; };
@@ -4072,6 +4074,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */,
 				B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */,
 				B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */,
+				B804B0110000000000000011 /* SidebarWorkspaceTableDropTargetGeometryGate.swift */,
 				B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */,
 				B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */,
 				B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */,
@@ -6791,6 +6794,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804A00B000000000000000B /* SidebarWorkspaceTableClipView.swift in Sources */,
 				B804A0030000000000000003 /* SidebarWorkspaceTableContainerView.swift in Sources */,
 				B804A0040000000000000004 /* SidebarWorkspaceTableController.swift in Sources */,
+				B804A0110000000000000011 /* SidebarWorkspaceTableDropTargetGeometryGate.swift in Sources */,
 				B804A00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift in Sources */,
 				B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */,
 				B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1393,6 +1393,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 			62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */; };
 			A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */; };
 		B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */; };
+		B804A00E000000000000000E /* SidebarWorkspaceTableCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00E000000000000000E /* SidebarWorkspaceTableCellModel.swift */; };
+		B804A00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift */; };
+		B804A0100000000000000010 /* SidebarWorkspaceTableCellState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0100000000000000010 /* SidebarWorkspaceTableCellState.swift */; };
 		B804A0020000000000000002 /* SidebarWorkspaceTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0020000000000000002 /* SidebarWorkspaceTableCellView.swift */; };
 		B804A00B000000000000000B /* SidebarWorkspaceTableClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */; };
 		B804A0030000000000000003 /* SidebarWorkspaceTableContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */; };
@@ -3200,6 +3203,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSnapshotRefreshPolicyTests.swift; sourceTree = "<group>"; };
 			A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceStatusSlots.swift; sourceTree = "<group>"; };
 		B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableActions.swift; sourceTree = "<group>"; };
+		B804B00E000000000000000E /* SidebarWorkspaceTableCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellModel.swift; sourceTree = "<group>"; };
+		B804B00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellRootView.swift; sourceTree = "<group>"; };
+		B804B0100000000000000010 /* SidebarWorkspaceTableCellState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellState.swift; sourceTree = "<group>"; };
 		B804B0020000000000000002 /* SidebarWorkspaceTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift; sourceTree = "<group>"; };
 		B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableClipView.swift; sourceTree = "<group>"; };
 		B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift; sourceTree = "<group>"; };
@@ -4058,6 +4064,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57606C9A57606C9A57606 /* SidebarWorkspaceDropTargetWriters.swift */,
 				C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */,
 				B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */,
+				B804B00E000000000000000E /* SidebarWorkspaceTableCellModel.swift */,
+				B804B00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift */,
+				B804B0100000000000000010 /* SidebarWorkspaceTableCellState.swift */,
 				B804B0020000000000000002 /* SidebarWorkspaceTableCellView.swift */,
 				B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */,
 				B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */,
@@ -6775,6 +6784,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */,
 					A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */,
 				B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */,
+				B804A00E000000000000000E /* SidebarWorkspaceTableCellModel.swift in Sources */,
+				B804A00F000000000000000F /* SidebarWorkspaceTableCellRootView.swift in Sources */,
+				B804A0100000000000000010 /* SidebarWorkspaceTableCellState.swift in Sources */,
 				B804A0020000000000000002 /* SidebarWorkspaceTableCellView.swift in Sources */,
 				B804A00B000000000000000B /* SidebarWorkspaceTableClipView.swift in Sources */,
 				B804A0030000000000000003 /* SidebarWorkspaceTableContainerView.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1401,6 +1401,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */; };
 		B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */; };
 		B804A0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */; };
+		B804A00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift */; };
 		B804A0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */; };
 		B804C0010000000000000001 /* SidebarWorkspaceTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */; };
 		B804A0070000000000000007 /* SidebarWorkspaceTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0070000000000000007 /* SidebarWorkspaceTableView.swift */; };
@@ -3207,6 +3208,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableEnvironmentSnapshot.swift; sourceTree = "<group>"; };
 		B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableHoverResolver.swift; sourceTree = "<group>"; };
 		B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift; sourceTree = "<group>"; };
+		B804B00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCache.swift; sourceTree = "<group>"; };
 		B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCalculator.swift; sourceTree = "<group>"; };
 		B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceTableTests.swift; sourceTree = "<group>"; };
 		B804B0070000000000000007 /* SidebarWorkspaceTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableView.swift; sourceTree = "<group>"; };
@@ -4064,6 +4066,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */,
 				B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */,
 				B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */,
+				B804B00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift */,
 				B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */,
 				B804B0070000000000000007 /* SidebarWorkspaceTableView.swift */,
 				B804B0080000000000000008 /* SidebarWorkspaceTableViewImpl.swift */,
@@ -6780,6 +6783,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */,
 				B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */,
 				B804A0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift in Sources */,
+				B804A00D000000000000000D /* SidebarWorkspaceTableRowHeightCache.swift in Sources */,
 				B804A0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift in Sources */,
 				B804A0070000000000000007 /* SidebarWorkspaceTableView.swift in Sources */,
 				B804A0080000000000000008 /* SidebarWorkspaceTableViewImpl.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1392,6 +1392,19 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 			988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */; };
 			62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */; };
 			A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */; };
+		B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */; };
+		B804A0020000000000000002 /* SidebarWorkspaceTableCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0020000000000000002 /* SidebarWorkspaceTableCellView.swift */; };
+		B804A00B000000000000000B /* SidebarWorkspaceTableClipView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */; };
+		B804A0030000000000000003 /* SidebarWorkspaceTableContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */; };
+		B804A0040000000000000004 /* SidebarWorkspaceTableController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */; };
+		B804A00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */; };
+		B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */; };
+		B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */; };
+		B804A0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */; };
+		B804A0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */; };
+		B804C0010000000000000001 /* SidebarWorkspaceTableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */; };
+		B804A0070000000000000007 /* SidebarWorkspaceTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0070000000000000007 /* SidebarWorkspaceTableView.swift */; };
+		B804A0080000000000000008 /* SidebarWorkspaceTableViewImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0080000000000000008 /* SidebarWorkspaceTableViewImpl.swift */; };
 			C9A57601C9A57601C9A57601 /* SidebarWorkspaceTopDropIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57602C9A57602C9A57602 /* SidebarWorkspaceTopDropIndicator.swift */; };
 			A6AC73330000000000000001 /* SidebarWorkspaceTrailingStatusSlot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73330000000000000002 /* SidebarWorkspaceTrailingStatusSlot.swift */; };
 			A6AC73340000000000000001 /* SidebarWorkspaceUnreadBadge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73340000000000000002 /* SidebarWorkspaceUnreadBadge.swift */; };
@@ -3185,6 +3198,19 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift; sourceTree = "<group>"; };
 			F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSnapshotRefreshPolicyTests.swift; sourceTree = "<group>"; };
 			A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceStatusSlots.swift; sourceTree = "<group>"; };
+		B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableActions.swift; sourceTree = "<group>"; };
+		B804B0020000000000000002 /* SidebarWorkspaceTableCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellView.swift; sourceTree = "<group>"; };
+		B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableClipView.swift; sourceTree = "<group>"; };
+		B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableContainerView.swift; sourceTree = "<group>"; };
+		B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableController.swift; sourceTree = "<group>"; };
+		B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableEmptyDropIndicatorView.swift; sourceTree = "<group>"; };
+		B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableEnvironmentSnapshot.swift; sourceTree = "<group>"; };
+		B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableHoverResolver.swift; sourceTree = "<group>"; };
+		B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowConfiguration.swift; sourceTree = "<group>"; };
+		B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableRowHeightCalculator.swift; sourceTree = "<group>"; };
+		B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceTableTests.swift; sourceTree = "<group>"; };
+		B804B0070000000000000007 /* SidebarWorkspaceTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableView.swift; sourceTree = "<group>"; };
+		B804B0080000000000000008 /* SidebarWorkspaceTableViewImpl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift; sourceTree = "<group>"; };
 			C9A57602C9A57602C9A57602 /* SidebarWorkspaceTopDropIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceTopDropIndicator.swift; sourceTree = "<group>"; };
 			A6AC73330000000000000002 /* SidebarWorkspaceTrailingStatusSlot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceTrailingStatusSlot.swift; sourceTree = "<group>"; };
 			A6AC73340000000000000002 /* SidebarWorkspaceUnreadBadge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceUnreadBadge.swift; sourceTree = "<group>"; };
@@ -4029,6 +4055,18 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				CA1F0A02CA1F0A02CA1F0A02 /* CmuxModalAlertPresentation.swift */,
 				C9A57606C9A57606C9A57606 /* SidebarWorkspaceDropTargetWriters.swift */,
 				C9A57102C9A57102C9A57102 /* SidebarWorkspaceGroupHeaderView.swift */,
+				B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */,
+				B804B0020000000000000002 /* SidebarWorkspaceTableCellView.swift */,
+				B804B00B000000000000000B /* SidebarWorkspaceTableClipView.swift */,
+				B804B0030000000000000003 /* SidebarWorkspaceTableContainerView.swift */,
+				B804B00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift */,
+				B804B0040000000000000004 /* SidebarWorkspaceTableController.swift */,
+				B804B00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift */,
+				B804B0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift */,
+				B804B0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift */,
+				B804B0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift */,
+				B804B0070000000000000007 /* SidebarWorkspaceTableView.swift */,
+				B804B0080000000000000008 /* SidebarWorkspaceTableViewImpl.swift */,
 				C9A57302C9A57302C9A57302 /* SidebarWorkspaceGroupHeaderMetrics.swift */,
 				C9A5710AC9A5710AC9A5710A /* SidebarWorkspaceGroupingMetrics.swift */,
 				D5037010000000000000002 /* RenderableSystemSymbol.swift */,
@@ -5402,6 +5440,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7A50C000000000000000001 /* CmuxTopProcessCPUTests.swift */,
 				C7A50C000000000000000004 /* CmuxTopProcessArgumentsTests.swift */,
 				D7AB34300000000000000006 /* SidebarWorkspaceDropPlannerTests.swift */,
+				B804D0010000000000000001 /* SidebarWorkspaceTableTests.swift */,
 				D7AB34300000000000000106 /* SidebarTabDropIndicatorPredicateTests.swift */,
 				D73440010000000000000002 /* SidebarTabDragPayloadProviderTests.swift */,
 				AABBCC000000000000000205 /* SidebarInlineRenameKeyResolverTests.swift */,
@@ -6732,6 +6771,18 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					D35450030000000000000005 /* SidebarWorkspaceRowMenuTrackingReconcilerView.swift in Sources */,
 					988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */,
 					A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */,
+				B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */,
+				B804A0020000000000000002 /* SidebarWorkspaceTableCellView.swift in Sources */,
+				B804A00B000000000000000B /* SidebarWorkspaceTableClipView.swift in Sources */,
+				B804A0030000000000000003 /* SidebarWorkspaceTableContainerView.swift in Sources */,
+				B804A0040000000000000004 /* SidebarWorkspaceTableController.swift in Sources */,
+				B804A00C000000000000000C /* SidebarWorkspaceTableEmptyDropIndicatorView.swift in Sources */,
+				B804A00A000000000000000A /* SidebarWorkspaceTableEnvironmentSnapshot.swift in Sources */,
+				B804A0050000000000000005 /* SidebarWorkspaceTableHoverResolver.swift in Sources */,
+				B804A0060000000000000006 /* SidebarWorkspaceTableRowConfiguration.swift in Sources */,
+				B804A0090000000000000009 /* SidebarWorkspaceTableRowHeightCalculator.swift in Sources */,
+				B804A0070000000000000007 /* SidebarWorkspaceTableView.swift in Sources */,
+				B804A0080000000000000008 /* SidebarWorkspaceTableViewImpl.swift in Sources */,
 					C9A57601C9A57601C9A57601 /* SidebarWorkspaceTopDropIndicator.swift in Sources */,
 					A6AC73330000000000000001 /* SidebarWorkspaceTrailingStatusSlot.swift in Sources */,
 					A6AC73340000000000000001 /* SidebarWorkspaceUnreadBadge.swift in Sources */,
@@ -7559,6 +7610,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE56010000000000000001 /* SidebarWorkspaceSelectionAnchorPolicyTests.swift in Sources */,
 					A6AC73040000000000000001 /* SidebarWorkspaceSnapshotAgentActivityTests.swift in Sources */,
 					62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */,
+				B804C0010000000000000001 /* SidebarWorkspaceTableTests.swift in Sources */,
 				5830CA11BAC0000000000002 /* SocketCallbackAwaiterMainThreadTests.swift in Sources */,
 						F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */,

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -1,40 +1,24 @@
 import Testing
 import AppKit
 import CmuxUpdater
+import OSLog
 import SwiftUI
-
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
 @testable import cmux
 #endif
-
-/// Behavioral gate for the workspace sidebar's lazy-layout contract: layout
-/// and diff work must stay O(visible rows) no matter how many workspaces are
-/// open, and updates must converge (no self-sustaining invalidation).
-///
-/// The contract has regressed five times through five different mechanisms —
-/// per-row anchorPreference aggregation (#5323), per-row String ids (#5764),
-/// animated row-height interpolation (#5845), a force-measuring custom Layout
-/// (#6210), and GeometryReader → @State row-height feedback (#6556) — and each
-/// shipped to stable before being detected, because nothing exercised the
-/// sidebar at the 100+ workspace scale where O(N) per pass becomes a
-/// main-thread livelock (issue #2586). These tests mount the real
-/// `VerticalTabsSidebar` at that scale and count actual row body evaluations
-/// through `SidebarLazyContractProbe`, so ANY future mechanism that realizes
-/// the whole list or loops the AttributeGraph fails here instead of on a
-/// user's machine. `scripts/check-sidebar-lazy-layout.py` bans the known
-/// source shapes; this is the mechanism-independent backstop.
+/// Behavioral gate for the workspace sidebar's AppKit virtualization contract.
+/// Mounts the production `VerticalTabsSidebar` at 300 workspaces and verifies
+/// viewport-scale materialization, row-scoped updates, convergence, and clean
+/// SwiftUI/AppKit runtime logs. The source-topology companion is
+/// `scripts/check-sidebar-lazy-layout.py`.
 @Suite(.serialized)
 final class SidebarLazyLayoutScaleTests {
     private static let workspaceCount = 300
-    /// Generous ceiling for "how many rows may be realized for one viewport".
-    /// A 640pt window shows ~20 rows; LazyVStack prefetch and a second layout
-    /// pass can multiply that, but a virtualization defeat realizes all 300.
-    private static let realizedRowCeiling = 150
-
-    // Plain class (not @MainActor) so the probe's nonisolated `() -> Void`
-    // closures can mutate it; bodies only run on the main thread. Same shape
+    /// A 640pt window shows ~20 rows; allow a small AppKit reuse buffer.
+    private static let realizedRowCeiling = 80
+    // Plain class so the probe's nonisolated closures can mutate it on main. Same shape
     // as MinimalModeBodyProbeCounts in WorkspaceContentViewVisibilityTests.
     private final class RowBodyCounter {
         var workspaceRowBodies = 0
@@ -47,6 +31,7 @@ final class SidebarLazyLayoutScaleTests {
         var insideWorkspaceRowBody = false
         var snapshotBuildsInCurrentRowBody = 0
         var maxSnapshotBuildsInOneRowBody = 0
+        var tableRootViewReconfigures = 0
         func reset() {
             workspaceRowBodies = 0
             groupHeaderBodies = 0
@@ -54,6 +39,7 @@ final class SidebarLazyLayoutScaleTests {
             insideWorkspaceRowBody = false
             snapshotBuildsInCurrentRowBody = 0
             maxSnapshotBuildsInOneRowBody = 0
+            tableRootViewReconfigures = 0
         }
     }
 
@@ -114,7 +100,7 @@ final class SidebarLazyLayoutScaleTests {
         }
 
         // Group the first workspaces (top of the list, inside the viewport) so
-        // group-header rows — assembled by sidebarWorkspaceGroupHeader(...) in
+        // group-header rows — assembled by sidebarWorkspaceGroupTableConfiguration(...) in
         // VerticalTabsSidebar+WorkspaceGroups.swift, a historical regression
         // site (#4385) — are exercised by the same realization bounds.
         let groupCandidates = Array(tabManager.tabs.prefix(20).map(\.id))
@@ -172,7 +158,8 @@ final class SidebarLazyLayoutScaleTests {
                         counter.maxSnapshotBuildsInOneRowBody,
                         counter.snapshotBuildsInCurrentRowBody
                     )
-                }
+                },
+                tableRootViewReconfigure: { counter.tableRootViewReconfigures += 1 }
             )
         )
         .defaultAppStorage(defaults)
@@ -221,13 +208,21 @@ final class SidebarLazyLayoutScaleTests {
     }
 
     @MainActor
-    private static func hoverReconcilerViews(in rootView: NSView) -> [SidebarWorkspaceRowHoverReconcilerView] {
-        var result: [SidebarWorkspaceRowHoverReconcilerView] = []
+    private static func tableView(in rootView: NSView) -> SidebarWorkspaceTableViewImpl? {
         var pendingViews = [rootView]
         while let view = pendingViews.popLast() {
-            if let reconciler = view as? SidebarWorkspaceRowHoverReconcilerView {
-                result.append(reconciler)
-            }
+            if let table = view as? SidebarWorkspaceTableViewImpl { return table }
+            pendingViews.append(contentsOf: view.subviews)
+        }
+        return nil
+    }
+
+    @MainActor
+    private static func materializedCells(in rootView: NSView) -> [SidebarWorkspaceTableCellView] {
+        var result: [SidebarWorkspaceTableCellView] = []
+        var pendingViews = [rootView]
+        while let view = pendingViews.popLast() {
+            result.append(contentsOf: view.subviews.compactMap { $0 as? SidebarWorkspaceTableCellView })
             pendingViews.append(contentsOf: view.subviews)
         }
         return result
@@ -245,16 +240,23 @@ final class SidebarLazyLayoutScaleTests {
 
         await Self.drainMainRunLoop(for: harness.window)
 
+        let rootView = try #require(harness.window.contentView)
+        let cells = Self.materializedCells(in: rootView)
+        #expect(!cells.isEmpty, "The production NSTableView mounted no reusable row cells.")
+        #expect(
+            cells.count < Self.realizedRowCeiling,
+            "NSTableView materialized \(cells.count) cells for a single viewport of \(Self.workspaceCount) rows."
+        )
+
         let realized = harness.counter.workspaceRowBodies
         #expect(realized > 0, "Sidebar mounted but no workspace row body ran; harness is broken.")
         #expect(
             realized < Self.realizedRowCeiling,
             """
             \(realized) workspace row bodies evaluated for a single ~20-row viewport with \
-            \(Self.workspaceCount) workspaces. The LazyVStack is being defeated (all rows \
-            realized per pass) — the #2586 sidebar livelock class. Look for per-row geometry \
-            feedback (GeometryReader/@State height, anchorPreference aggregation) or a \
-            force-measuring Layout; see scripts/check-sidebar-lazy-layout.py.
+            \(Self.workspaceCount) workspaces. NSTableView virtualization is being defeated \
+            (all rows realized per pass), recreating the #2586 sidebar livelock class; see \
+            scripts/check-sidebar-lazy-layout.py.
             """
         )
 
@@ -270,7 +272,7 @@ final class SidebarLazyLayoutScaleTests {
             headerRealized < Self.realizedRowCeiling,
             """
             \(headerRealized) group-header bodies evaluated for 5 groups in one viewport. \
-            The group-header row wrapper (sidebarWorkspaceGroupHeader) is defeating \
+            The group-header row factory (sidebarWorkspaceGroupTableConfiguration) is defeating \
             virtualization or re-evaluating without bound — the #4385 regression site.
             """
         )
@@ -352,6 +354,10 @@ final class SidebarLazyLayoutScaleTests {
             \(storms) updates re-realizing per pass is the #2586 livelock at scale.
             """
         )
+        #expect(
+            harness.counter.tableRootViewReconfigures < storms * 10,
+            "Unread storm replaced \(harness.counter.tableRootViewReconfigures) hosted roots; only changed visible rows may reconfigure."
+        )
 
         harness.counter.reset()
         await Self.drainMainRunLoop(for: harness.window, iterations: 30)
@@ -364,50 +370,62 @@ final class SidebarLazyLayoutScaleTests {
             loop (the #6556 signature). This livelocks the main thread at scale.
             """
         )
+        #expect(
+            harness.counter.tableRootViewReconfigures == 0,
+            "The table reconfigured \(harness.counter.tableRootViewReconfigures) roots during a quiet period."
+        )
     }
 
-    /// AppKit may invoke `updateTrackingAreas` repeatedly while SwiftUI is
-    /// reconciling a lazy row's platform children. A burst must collapse to a
-    /// bounded asynchronous delivery and then settle; calling row bindings on
-    /// this stack is the #8004 AttributeGraph/NSHostingView livelock.
+    /// Churn variable-height content, scroll, and synthetic table-owned hover.
     @Test
     @MainActor
-    func testTrackingAreaStormStaysBoundedAndConverges() async throws {
+    func testTableChurnScrollAndHoverEmitNoRuntimeFaults() async throws {
         let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
         defer { harness.tearDown() }
 
         await Self.drainMainRunLoop(for: harness.window)
         let rootView = try #require(harness.window.contentView)
-        let reconcilers = Self.hoverReconcilerViews(in: rootView)
-        #expect(!reconcilers.isEmpty, "The mounted viewport has no hover reconcilers; the stress path is not covered.")
+        let table = try #require(Self.tableView(in: rootView))
+        let logStore = try OSLogStore(scope: .currentProcessIdentifier)
+        let start = logStore.position(date: Date())
 
-        harness.counter.reset()
-        for _ in 0..<100 {
-            for reconciler in reconcilers {
-                reconciler.updateTrackingAreas()
-            }
+        for index in 0..<40 {
+            let workspace = harness.tabManager.tabs[index % 8]
+            harness.tabManager.setCustomTitle(
+                tabId: workspace.id,
+                title: String(repeating: "variable title \(index) ", count: (index % 5) + 1)
+            )
+            harness.unread.apply(
+                totalUnreadCount: index + 1,
+                summaries: [
+                    workspace.id: SidebarWorkspaceUnreadSummary(
+                        unreadCount: index + 1,
+                        latestNotificationText: String(repeating: "update ", count: (index % 4) + 1)
+                    )
+                ],
+                unreadSurfaceKeys: [],
+                focusedReadIndicatorByWorkspaceId: [:],
+                manualUnreadWorkspaceIds: []
+            )
+            table.scrollRowToVisible((index * 17) % Self.workspaceCount)
+            table.setPointerWindowLocation(table.convert(
+                NSPoint(x: 20, y: table.visibleRect.midY),
+                to: nil
+            ))
+            await Self.drainMainRunLoop(for: harness.window, iterations: 2)
         }
-        await Self.drainMainRunLoop(for: harness.window)
-
-        let stormEvals = harness.counter.workspaceRowBodies + harness.counter.groupHeaderBodies
-        #expect(
-            stormEvals < reconcilers.count * 4,
-            """
-            \(stormEvals) row bodies evaluated after 100 tracking-area passes across \
-            \(reconcilers.count) visible rows. AppKit lifecycle events must be coalesced before they update SwiftUI.
-            """
-        )
-
-        harness.counter.reset()
+        table.setPointerWindowLocation(nil)
         await Self.drainMainRunLoop(for: harness.window, iterations: 30)
-        let quietEvals = harness.counter.workspaceRowBodies + harness.counter.groupHeaderBodies
-        #expect(
-            quietEvals < 20,
-            """
-            \(quietEvals) row bodies evaluated after the tracking-area burst ended. The sidebar failed to converge \
-            and is still feeding SwiftUI state changes back into AppKit layout.
-            """
-        )
+
+        let faultNeedles = ["Modifying state during view update",
+                            "Publishing changes from within view updates",
+                            "laid out reentrantly"]
+        let faults = try logStore.getEntries(at: start).compactMap { entry -> String? in
+            guard let log = entry as? OSLogEntryLog else { return nil }
+            return faultNeedles.contains { log.composedMessage.localizedCaseInsensitiveContains($0) }
+                ? log.composedMessage : nil
+        }
+        #expect(faults.isEmpty, "Sidebar churn emitted runtime faults: \(faults)")
     }
 
     /// Harness self-test: prove the drain loop + body counter actually detect

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -11,9 +11,15 @@ import Testing
 struct SidebarWorkspaceTableTests {
     @Test
     @MainActor
-    func containerHasNoStructuralHorizontalRowInset() throws {
+    func containerHasNoStructuralHorizontalRowInsetAndAlwaysActiveHoverTracking() throws {
         let container = SidebarWorkspaceTableController().makeContainerView()
         let column = try #require(container.tableView.tableColumns.first)
+        container.tableView.updateTrackingAreas()
+        let hoverTrackingArea = try #require(container.tableView.trackingAreas.first { area in
+            area.options.contains(.mouseEnteredAndExited)
+                && area.options.contains(.mouseMoved)
+                && area.options.contains(.inVisibleRect)
+        })
 
         #expect(container.tableView.style == .fullWidth)
         #expect(container.scrollView.contentInsets.left == 0)
@@ -21,6 +27,8 @@ struct SidebarWorkspaceTableTests {
         #expect(container.tableView.intercellSpacing.width == 0)
         #expect(container.tableView.columnAutoresizingStyle == .uniformColumnAutoresizingStyle)
         #expect(column.resizingMask.contains(.autoresizingMask))
+        #expect(hoverTrackingArea.options.contains(.activeAlways))
+        #expect(!hoverTrackingArea.options.contains(.activeInKeyWindow))
     }
 
     @Test

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -1,0 +1,55 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite
+struct SidebarWorkspaceTableTests {
+    @Test
+    func rowHeightEstimateAccountsForScaleWrappingAndDetails() {
+        let calculator = SidebarWorkspaceTableRowHeightCalculator()
+        let compact = calculator.estimatedWorkspaceHeight(
+            fontScale: 1,
+            titleLineCount: 1,
+            auxiliaryLineCount: 0
+        )
+        let detailed = calculator.estimatedWorkspaceHeight(
+            fontScale: 1.2,
+            titleLineCount: 3,
+            auxiliaryLineCount: 4
+        )
+
+        #expect(compact == 31)
+        #expect(detailed == 144)
+        #expect(calculator.estimatedGroupHeaderHeight(fontScale: 1) == 36)
+        #expect(detailed > compact)
+    }
+
+    @Test
+    func hoverRecomputesFromStationaryWindowPointAfterScrollAndReorder() throws {
+        let resolver = SidebarWorkspaceTableHoverResolver()
+        let pointer = NSPoint(x: 20, y: 15)
+        var scrollOffset: CGFloat = 0
+        var orderedIds = ["a", "b", "c", "d"]
+
+        func resolvedId() -> String? {
+            let row = resolver.hoveredRow(
+                windowPoint: pointer,
+                convertToTable: { NSPoint(x: $0.x, y: $0.y + scrollOffset) },
+                rowAtPoint: { Int(floor($0.y / 20)) },
+                rowCount: orderedIds.count
+            )
+            return row.map { orderedIds[$0] }
+        }
+
+        #expect(resolvedId() == "a")
+        scrollOffset = 20
+        #expect(resolvedId() == "b")
+        orderedIds = ["a", "c", "b", "d"]
+        #expect(resolvedId() == "c")
+    }
+}

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import SwiftUI
 import Testing
 
 #if canImport(cmux_DEV)
@@ -25,6 +26,7 @@ struct SidebarWorkspaceTableTests {
         #expect(container.scrollView.contentInsets.left == 0)
         #expect(container.scrollView.contentInsets.right == 0)
         #expect(container.tableView.intercellSpacing.width == 0)
+        #expect(!container.tableView.usesAutomaticRowHeights)
         #expect(container.tableView.columnAutoresizingStyle == .uniformColumnAutoresizingStyle)
         #expect(column.resizingMask.contains(.autoresizingMask))
         #expect(hoverTrackingArea.options.contains(.activeAlways))
@@ -52,6 +54,100 @@ struct SidebarWorkspaceTableTests {
     }
 
     @Test
+    @MainActor
+    func rowHeightCacheMeasuresOnceForEquivalentRepeatedQueries() {
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        let row = makeRowConfiguration()
+        var measurementCount = 0
+
+        let initialChanges = cache.prepare(rows: [row], columnWidth: 200) { _, _ in
+            measurementCount += 1
+            return 44
+        }
+        let repeatedChanges = cache.prepare(rows: [row], columnWidth: 200) { _, _ in
+            measurementCount += 1
+            return 99
+        }
+
+        #expect(measurementCount == 1)
+        #expect(initialChanges == IndexSet(integer: 0))
+        #expect(repeatedChanges.isEmpty)
+        #expect(cache.height(for: row, columnWidth: 200) == 44)
+    }
+
+    @Test
+    @MainActor
+    func rowHeightCacheInvalidatesWhenColumnWidthChanges() {
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        let row = makeRowConfiguration()
+        var measurementCount = 0
+        let measure: SidebarWorkspaceTableRowHeightCache.Measurement = { _, width in
+            measurementCount += 1
+            return width / 4
+        }
+
+        _ = cache.prepare(rows: [row], columnWidth: 200, measure: measure)
+        let changed = cache.prepare(rows: [row], columnWidth: 240, measure: measure)
+
+        #expect(measurementCount == 2)
+        #expect(changed == IndexSet(integer: 0))
+        #expect(cache.height(for: row, columnWidth: 200) == nil)
+        #expect(cache.height(for: row, columnWidth: 240) == 60)
+    }
+
+    @Test
+    @MainActor
+    func rowHeightCacheInvalidatesContentFontAndAppearanceChanges() {
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        let workspaceId = UUID()
+        var measurementCount = 0
+        let measure: SidebarWorkspaceTableRowHeightCache.Measurement = { _, _ in
+            measurementCount += 1
+            return CGFloat(40 + measurementCount)
+        }
+        let original = makeRowConfiguration(workspaceId: workspaceId)
+        let changedContent = makeRowConfiguration(workspaceId: workspaceId, contentToken: 1)
+        let changedFont = makeRowConfiguration(
+            workspaceId: workspaceId,
+            contentToken: 1,
+            fontMagnificationPercent: 120
+        )
+        let changedAppearance = makeRowConfiguration(
+            workspaceId: workspaceId,
+            contentToken: 1,
+            fontMagnificationPercent: 120,
+            colorScheme: .dark
+        )
+
+        _ = cache.prepare(rows: [original], columnWidth: 200, measure: measure)
+        _ = cache.prepare(rows: [changedContent], columnWidth: 200, measure: measure)
+        _ = cache.prepare(rows: [changedFont], columnWidth: 200, measure: measure)
+        _ = cache.prepare(rows: [changedAppearance], columnWidth: 200, measure: measure)
+
+        #expect(measurementCount == 4)
+        #expect(cache.height(for: changedAppearance, columnWidth: 200) == 44)
+    }
+
+    @Test
+    @MainActor
+    func cachedHeightQueriesDuringScrollNeverMeasure() {
+        let cache = SidebarWorkspaceTableRowHeightCache()
+        let row = makeRowConfiguration()
+        var measurementCount = 0
+        _ = cache.prepare(rows: [row], columnWidth: 200) { _, _ in
+            measurementCount += 1
+            return 44
+        }
+
+        for _ in 0..<500 {
+            #expect(cache.prepareHostedRowsIfWidthChanged([row], columnWidth: 200) == nil)
+            #expect(cache.height(for: row, columnWidth: 200) == 44)
+        }
+
+        #expect(measurementCount == 1)
+    }
+
+    @Test
     func hoverRecomputesFromStationaryWindowPointAfterScrollAndReorder() throws {
         let resolver = SidebarWorkspaceTableHoverResolver()
         let pointer = NSPoint(x: 20, y: 15)
@@ -73,5 +169,45 @@ struct SidebarWorkspaceTableTests {
         #expect(resolvedId() == "b")
         orderedIds = ["a", "c", "b", "d"]
         #expect(resolvedId() == "c")
+    }
+
+    @MainActor
+    private func makeRowConfiguration(
+        workspaceId: UUID = UUID(),
+        contentToken: Int = 0,
+        fontMagnificationPercent: Int = 100,
+        colorScheme: ColorScheme = .light
+    ) -> SidebarWorkspaceTableRowConfiguration {
+#if DEBUG
+        let environment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: colorScheme,
+            globalFontMagnificationPercent: fontMagnificationPercent,
+            lazyContractProbe: SidebarLazyContractProbe()
+        )
+#else
+        let environment = SidebarWorkspaceTableEnvironmentSnapshot(
+            colorScheme: colorScheme,
+            globalFontMagnificationPercent: fontMagnificationPercent
+        )
+#endif
+        return SidebarWorkspaceTableRowConfiguration(
+            id: .workspace(workspaceId),
+            workspaceId: workspaceId,
+            groupId: nil,
+            isGroupHeader: false,
+            isPinned: false,
+            environment: environment,
+            equivalenceValue: TestRowContent(token: contentToken)
+        ) { _, _ in
+            AnyView(TestRowContent(token: contentToken))
+        }
+    }
+
+    private struct TestRowContent: View, Equatable {
+        let token: Int
+
+        var body: some View {
+            EmptyView()
+        }
     }
 }

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -10,6 +10,20 @@ import Testing
 @Suite
 struct SidebarWorkspaceTableTests {
     @Test
+    @MainActor
+    func containerHasNoStructuralHorizontalRowInset() throws {
+        let container = SidebarWorkspaceTableController().makeContainerView()
+        let column = try #require(container.tableView.tableColumns.first)
+
+        #expect(container.tableView.style == .fullWidth)
+        #expect(container.scrollView.contentInsets.left == 0)
+        #expect(container.scrollView.contentInsets.right == 0)
+        #expect(container.tableView.intercellSpacing.width == 0)
+        #expect(container.tableView.columnAutoresizingStyle == .uniformColumnAutoresizingStyle)
+        #expect(column.resizingMask.contains(.autoresizingMask))
+    }
+
+    @Test
     func rowHeightEstimateAccountsForScaleWrappingAndDetails() {
         let calculator = SidebarWorkspaceTableRowHeightCalculator()
         let compact = calculator.estimatedWorkspaceHeight(

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -147,6 +147,60 @@ struct SidebarWorkspaceTableTests {
         #expect(measurementCount == 1)
     }
 
+#if DEBUG
+    @Test
+    @MainActor
+    func equivalentCellConfigurationDoesNotRenderAgain() {
+        let cell = SidebarWorkspaceTableCellView()
+        let workspaceId = UUID()
+        var renders = 0
+        cell.reconfigurationProbe = { renders += 1 }
+
+        configure(cell, row: makeRowConfiguration(workspaceId: workspaceId))
+        configure(cell, row: makeRowConfiguration(workspaceId: workspaceId))
+
+        #expect(renders == 1)
+    }
+
+    @Test
+    @MainActor
+    func hoverFlipRendersOnlyTheAffectedCell() {
+        let firstCell = SidebarWorkspaceTableCellView()
+        let secondCell = SidebarWorkspaceTableCellView()
+        let firstRow = makeRowConfiguration()
+        let secondRow = makeRowConfiguration()
+        var firstRenders = 0
+        var secondRenders = 0
+        firstCell.reconfigurationProbe = { firstRenders += 1 }
+        secondCell.reconfigurationProbe = { secondRenders += 1 }
+
+        configure(firstCell, row: firstRow)
+        configure(secondCell, row: secondRow)
+        configure(firstCell, row: firstRow, isPointerHovering: true)
+        configure(firstCell, row: firstRow, isPointerHovering: true)
+
+        #expect(firstRenders == 2)
+        #expect(secondRenders == 1)
+    }
+
+    @Test
+    @MainActor
+    func cellReusePreservesOneHostingViewAndStableRootIdentity() {
+        let cell = SidebarWorkspaceTableCellView()
+        let hostingIdentity = cell.hostingViewIdentity
+        let rootIdentity = cell.hostedRootIdentity
+        let reusedWorkspaceId = UUID()
+
+        configure(cell, row: makeRowConfiguration())
+        configure(cell, row: makeRowConfiguration(workspaceId: reusedWorkspaceId))
+
+        #expect(cell.subviews.count == 1)
+        #expect(cell.hostingViewIdentity == hostingIdentity)
+        #expect(cell.hostedRootIdentity == rootIdentity)
+        #expect(cell.representedRowId == .workspace(reusedWorkspaceId))
+    }
+#endif
+
     @Test
     func hoverRecomputesFromStationaryWindowPointAfterScrollAndReorder() throws {
         let resolver = SidebarWorkspaceTableHoverResolver()
@@ -202,6 +256,22 @@ struct SidebarWorkspaceTableTests {
             AnyView(TestRowContent(token: contentToken))
         }
     }
+
+#if DEBUG
+    @MainActor
+    private func configure(
+        _ cell: SidebarWorkspaceTableCellView,
+        row: SidebarWorkspaceTableRowConfiguration,
+        isPointerHovering: Bool = false
+    ) {
+        cell.configure(
+            row: row,
+            isPointerHovering: isPointerHovering,
+            contextMenuDidOpen: {},
+            contextMenuDidClose: {}
+        )
+    }
+#endif
 
     private struct TestRowContent: View, Equatable {
         let token: Int

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -199,6 +199,48 @@ struct SidebarWorkspaceTableTests {
         #expect(cell.hostedRootIdentity == rootIdentity)
         #expect(cell.representedRowId == .workspace(reusedWorkspaceId))
     }
+
+    @Test
+    @MainActor
+    func dropTargetGeometryIsIdleDuringScrollAndTracksDragLifecycle() {
+        let controller = SidebarWorkspaceTableController()
+        let container = controller.makeContainerView()
+        let workspaceId = UUID()
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = container
+        controller.apply(
+            rows: [makeRowConfiguration(workspaceId: workspaceId)],
+            actions: makeTableActions(),
+            workspaceIds: [workspaceId],
+            selectedWorkspaceId: nil,
+            selectedScrollTargetWorkspaceId: nil
+        )
+        container.layoutSubtreeIfNeeded()
+        container.tableView.layoutSubtreeIfNeeded()
+        var computations = 0
+        controller.dropTargetComputationProbe = { computations += 1 }
+
+        controller.viewportDidChange()
+        controller.viewportDidChange()
+        #expect(computations == 0)
+
+        controller.workspaceDragSessionDidBegin()
+        #expect(computations == 1)
+        #expect(container.reorderDropView.targets.map(\.workspaceId) == [workspaceId])
+
+        controller.viewportDidChange()
+        #expect(computations == 2)
+
+        controller.workspaceDragSessionDidEnd()
+        #expect(container.reorderDropView.targets.isEmpty)
+        controller.viewportDidChange()
+        #expect(computations == 2)
+    }
 #endif
 
     @Test
@@ -269,6 +311,32 @@ struct SidebarWorkspaceTableTests {
             isPointerHovering: isPointerHovering,
             contextMenuDidOpen: {},
             contextMenuDidClose: {}
+        )
+    }
+
+    @MainActor
+    private func makeTableActions() -> SidebarWorkspaceTableActions {
+        SidebarWorkspaceTableActions(
+            attachScrollView: { _ in },
+            closeWorkspace: { _ in },
+            createWorkspaceAtEnd: {},
+            createEmptyWorkspaceGroup: {},
+            beginWorkspaceDrag: { _ in },
+            endWorkspaceDrag: {},
+            isValidWorkspaceDrag: { true },
+            updateWorkspaceDrag: { _, _ in false },
+            performWorkspaceDrop: { _, _ in false },
+            clearWorkspaceDropIndicator: {},
+            currentDropIndicator: { nil },
+            currentDropIndicatorScope: { .raw },
+            setWorkspaceDropTargetCollectionActive: { _ in },
+            canPerformBonsplitAction: { _, _ in false },
+            moveBonsplitToExistingWorkspace: { _, _ in false },
+            moveBonsplitToNewWorkspace: { _, _ in nil },
+            didMoveBonsplitToWorkspace: { _ in },
+            updateDragAutoscroll: {},
+            setBonsplitDropTargetCollectionActive: { _ in },
+            setBonsplitDropIndicator: { _ in }
         )
     }
 #endif

--- a/scripts/check-sidebar-lazy-layout.py
+++ b/scripts/check-sidebar-lazy-layout.py
@@ -1,67 +1,15 @@
 #!/usr/bin/env python3
-"""Regression guard for the workspace-sidebar lazy-layout contract.
+"""Guard the AppKit-owned default sidebar list boundary.
 
-The workspace sidebar renders its rows as a `LazyVStack` inside a vertical
-`ScrollView`. Keeping that stack lazy at *measure time* is load-bearing: the
-sidebar is re-diffed on every workspace/telemetry update, so any code that
-forces SwiftUI to realize and measure the whole row list on each layout pass
-turns a routine update into a multi-second `GraphHost.flushTransactions()`
-main-thread livelock once enough workspaces/surfaces are open.
+The default workspace list must remain one container-level NSViewRepresentable
+wrapping NSTableView. SwiftUI row content may be hosted in reusable cells, but
+must not mount additional platform representables except the established inline
+rename field and GPU spinner. Table reload/reconfiguration is forbidden from
+AppKit layout lifecycle callbacks; mutations enter through render-context
+updates, input events, or scroll notifications.
 
-This exact class of bug has regressed four times:
-
-  * #2586  GeometryReader + PreferenceKey -> @State height feedback loop
-  * #5764  per-row String id allocation in the ForEach diff
-  * #5845  same livelock family, reintroduced
-  * #6033 -> #6210  `SidebarRowsFillLayout`, a custom `Layout` that called
-           `subview.sizeThatFits(ProposedViewSize(width:, height: nil))` on the
-           `LazyVStack` in both `sizeThatFits` and `placeSubviews`, realizing
-           every row each pass. Removed in #6188.
-
-  * #6384  the user-reported ~1s beachball that #6188 fixed.
-
-Until now the contract was defended only by inline comments, which CI cannot
-enforce. This guard scans the two functions that define the sidebar's
-steady-state scroll layout in `Sources/ContentView.swift`
-(`workspaceScrollContent` and `workspaceRows`) and fails if either:
-
-  1. reintroduces a whole-list measurement signature
-     (`GeometryReader`, `ProposedViewSize(... nil ...)`, `.sizeThatFits(`, the
-     deleted `SidebarRowsFillLayout`, or ANY custom `Layout`-conforming type
-     discovered in the codebase being applied to the rows -- so renaming the
-     force-measuring layout does not dodge the guard), or
-  2. drops one of the lazy-fill primitives the fix relies on
-     (`LazyVStack(` in `workspaceRows`, `.frame(minHeight:` in
-     `workspaceScrollContent`).
-
-Comments and string literals are neutralized before scanning, so the historical
-explanatory comments in those functions (which deliberately name the very
-anti-patterns this guard forbids) do not trip it.
-
-The drag-only drop-target reader (`rowsWithGatedDropTargetReader`) is *not*
-scanned: it intentionally uses a `GeometryReader` to resolve per-row drop
-anchors and is gated behind an active drag (#5325), so it never runs during the
-steady-state layout this guard protects.
-
-Scope: the guard protects the rows layout *as expressed in*
-`workspaceScrollContent` / `workspaceRows`. It deliberately does not chase a
-force-measure that a future refactor relocates into some other
-transitively-called helper function: tracking arbitrary call graphs in a
-source-pattern lint is fragile, and extracting the rows layout into a new helper
-is a large enough change that it should re-review this guard directly (the
-"could not locate function" failure already trips on the most common such
-rename). Custom `Layout` types are the exception that *is* chased across files,
-because a renamed force-measuring layout is the concrete historical regression
-(#6033).
-
-Usage:
-    scripts/check-sidebar-lazy-layout.py [--file PATH]
-
-Exit codes:
-    0  the scanned file satisfies the lazy-layout contract
-    1  an anti-pattern was found, a required primitive is missing, or one of the
-       guarded functions could not be located (treated as a failure so the guard
-       cannot silently rot into a no-op when the code is renamed).
+The guard fails loudly when a required type/function/file is renamed so it
+cannot silently become a no-op.
 """
 
 import argparse
@@ -69,448 +17,204 @@ import os
 import re
 import sys
 
-# Functions that define the sidebar's steady-state scroll layout. Both must
-# exist; a rename should fail the guard loudly rather than silently skip.
-GUARDED_FUNCTIONS = ("workspaceScrollContent", "workspaceRows")
 
-# Tokens that mean "the whole row list is being measured/realized on every
-# layout pass" if they appear in the guarded functions' code (not comments).
-FORBIDDEN_PATTERNS = (
-    (re.compile(r"\bGeometryReader\b"),
-     "GeometryReader (reading the rows' size feeds the #2586 layout feedback "
-     "loop / forces row realization at measure time)"),
-    (re.compile(r"\bSidebarRowsFillLayout\b"),
-     "SidebarRowsFillLayout (the custom Layout removed in #6188 that "
-     "force-measured the LazyVStack every pass; do not reintroduce it)"),
-    (re.compile(r"\.sizeThatFits\s*\("),
-     "manual .sizeThatFits( call (measuring a subview by hand realizes the "
-     "lazy rows; let SwiftUI size the stack)"),
-    (re.compile(r"\bProposedViewSize\s*\([^)]*\bnil\b"),
-     "ProposedViewSize(..., nil) (proposing nil on an axis asks the LazyVStack "
-     "for its natural size, realizing every row -- the #6210 force-measure)"),
+OLD_DEFAULT_LIST_FUNCTIONS = (
+    "workspaceScrollContent",
+    "workspaceRows",
+    "rowsWithGatedDropTargetReader",
 )
-
-# Declaration of a type conforming to SwiftUI's `Layout` protocol. A custom
-# Layout applied to the sidebar rows is the #6033/#6210 force-measure shape no
-# matter what the type is named, so the guard discovers every such type in the
-# codebase and bans ALL of their names from the guarded functions -- not just the
-# literal `SidebarRowsFillLayout`. This closes the "rename the layout to dodge the
-# guard" bypass (#6870 review).
-CUSTOM_LAYOUT_DECL = re.compile(
-    r"\b(?:struct|final\s+class|class|enum|extension)\s+([A-Z]\w*)\b[^{]*?\bLayout\b[^{]*?\{",
-    re.DOTALL,
-)
-
-# Row-view regions guarded against per-row geometry feedback. Four of the five
-# historical regressions in this class entered through the row views, not the
-# container functions above: the #2586/#6556 GeometryReader -> @State row-height
-# probes lived in `TabItemView` and `SidebarWorkspaceGroupHeaderView` (deleted
-# by #6111, reintroduced by #4385, deleted by #7117 -- and the reintroduction
-# shipped in stable v0.64.17, which livelocked in the wild on 2026-07-02). The
-# per-row `.anchorPreference` aggregation of #5323 is the same shape: a row
-# publishing its own geometry forces SwiftUI to realize every row per pass.
-#
-# Rows must not measure themselves, period. Row heights are implicit; the ONLY
-# sanctioned geometry path is the container's drag-gated reader
-# (`rowsWithGatedDropTargetReader` + `SidebarWorkspaceFrameAnchorModifier`),
-# which lives outside these regions. A future legitimate need must extend this
-# guard consciously rather than slip past it.
-GUARDED_ROW_TYPES = ("TabItemView", "SidebarWorkspaceGroupHeaderView")
-
-ROW_FORBIDDEN_PATTERNS = (
-    (re.compile(r"\bGeometryReader\b"),
-     "GeometryReader (a row measuring itself feeds the #2586/#6556 "
-     "GeometryReader -> @State row-height livelock; row heights are implicit)"),
-    (re.compile(r"\bonGeometryChange\b"),
-     "onGeometryChange (geometry-driven state writes in a row re-trigger "
-     "layout the same way the #6556 GeometryReader probes did)"),
-    (re.compile(r"\.sizeThatFits\s*\("),
-     "manual .sizeThatFits( call (measuring from a row realizes lazy "
-     "siblings; let SwiftUI size the row)"),
-    (re.compile(r"\bProposedViewSize\s*\([^)]*\bnil\b"),
-     "ProposedViewSize(..., nil) (natural-size measurement realizes the lazy "
-     "list -- the #6210 force-measure)"),
-    (re.compile(r"\.anchorPreference\s*\("),
-     ".anchorPreference( in a row (per-row frame publication aggregated by an "
-     "ancestor is the #5323 virtualization defeat; only the container's "
-     "drag-gated SidebarWorkspaceFrameAnchorModifier may collect row frames)"),
-    (re.compile(r"\.overlayPreferenceValue\s*\("),
-     ".overlayPreferenceValue( in a row (consuming aggregated row geometry "
-     "inside a row is the #5323 feedback shape)"),
-)
-
-# Lazy-fill primitives the #6188 fix depends on. Each must remain present in the
-# named function (after comments/strings are stripped).
-REQUIRED_PRIMITIVES = (
-    ("workspaceRows", re.compile(r"\bLazyVStack\s*\("),
-     "LazyVStack( -- the rows must stay lazy; a plain VStack realizes every "
-     "row on each pass and re-livelocks at scale"),
-    ("workspaceScrollContent", re.compile(r"\.frame\s*\(\s*minHeight:"),
-     ".frame(minHeight:) -- the measurement-free fill primitive that replaced "
-     "SidebarRowsFillLayout; do not remove it"),
+ROW_TYPES = ("TabItemView", "SidebarWorkspaceGroupHeaderView")
+REPRESENTABLE_ALLOWLIST = {"SidebarInlineRenameField", "GPUSpinner"}
+LAYOUT_CALLBACKS = ("layout", "updateTrackingAreas", "viewDidMoveToWindow")
+LAYOUT_MUTATION_PATTERNS = (
+    re.compile(r"\breloadData\s*\("),
+    re.compile(r"\bnoteHeightOfRows\s*\("),
+    re.compile(r"\breconfigure(?:Visible)?Rows\s*\("),
+    re.compile(r"\.rootView\s*="),
 )
 
 
 def neutralize_swift(source):
-    """Return ``source`` with comment and string-literal *contents* replaced by
-    spaces, preserving every character's position and all newlines.
-
-    Token and brace scanning runs on this neutralized text so that tokens which
-    appear only inside the explanatory comments (e.g. the words
-    ``SidebarRowsFillLayout`` or ``sizeThatFits(height: nil)``) are invisible to
-    the guard, and so braces/parens inside comments or strings never corrupt the
-    function-body matching.
-    """
+    """Blank comments and string contents while preserving source positions."""
     out = []
     i = 0
-    n = len(source)
-    LINE_COMMENT, BLOCK_COMMENT, STRING, MULTILINE_STRING = 1, 2, 3, 4
-    state = 0
-    while i < n:
+    state = "code"
+    block_depth = 0
+    while i < len(source):
         ch = source[i]
-        nxt = source[i + 1] if i + 1 < n else ""
-        if state == 0:
-            if ch == "/" and nxt == "/":
-                out.append("  ")
+        pair = source[i:i + 2]
+        triple = source[i:i + 3]
+        if state == "code":
+            if pair == "//":
+                out.extend("  ")
                 i += 2
-                state = LINE_COMMENT
-                continue
-            if ch == "/" and nxt == "*":
-                out.append("  ")
+                state = "line"
+            elif pair == "/*":
+                out.extend("  ")
                 i += 2
-                state = BLOCK_COMMENT
-                continue
-            if source[i:i + 3] == '"""':
-                # Swift multi-line string literal: only a closing `"""` ends it,
-                # so a bare `"` inside must NOT toggle string state -- otherwise
-                # the inner quote would close the literal early and expose the
-                # rest (e.g. a forbidden token named in prose) as apparent code,
-                # tripping the guard with a false positive. (#6870 review)
-                out.append('"""')
+                state = "block"
+                block_depth = 1
+            elif triple == '\"\"\"':
+                out.extend('\"\"\"')
                 i += 3
-                state = MULTILINE_STRING
-                continue
-            if ch == '"':
-                out.append('"')
+                state = "multiline"
+            elif ch == '\"':
+                out.append(ch)
                 i += 1
-                state = STRING
-                continue
-            out.append(ch)
-            i += 1
-            continue
-        if state == LINE_COMMENT:
-            if ch == "\n":
-                out.append("\n")
-                state = 0
+                state = "string"
             else:
-                out.append(" ")
+                out.append(ch)
+                i += 1
+        elif state == "line":
+            out.append("\n" if ch == "\n" else " ")
             i += 1
-            continue
-        if state == BLOCK_COMMENT:
-            if ch == "*" and nxt == "/":
-                out.append("  ")
+            if ch == "\n":
+                state = "code"
+        elif state == "block":
+            if pair == "/*":
+                out.extend("  ")
+                block_depth += 1
                 i += 2
-                state = 0
+            elif pair == "*/":
+                out.extend("  ")
+                block_depth -= 1
+                i += 2
+                if block_depth == 0:
+                    state = "code"
             else:
                 out.append("\n" if ch == "\n" else " ")
                 i += 1
-            continue
-        if state == STRING:
-            if ch == "\\" and nxt != "":
-                # Preserve the escape pair as spaces so positions stay aligned.
-                out.append("  ")
+        elif state == "string":
+            if ch == "\\" and i + 1 < len(source):
+                out.extend("  ")
                 i += 2
-                continue
-            if ch == '"':
-                out.append('"')
+            elif ch == '\"':
+                out.append(ch)
                 i += 1
-                state = 0
-                continue
-            out.append("\n" if ch == "\n" else " ")
-            i += 1
-            continue
-        if state == MULTILINE_STRING:
-            if source[i:i + 3] == '"""':
-                out.append('"""')
+                state = "code"
+            else:
+                out.append("\n" if ch == "\n" else " ")
+                i += 1
+        else:
+            if triple == '\"\"\"':
+                out.extend('\"\"\"')
                 i += 3
-                state = 0
-                continue
-            # A lone `"` does not close a multi-line string; only `"""` does.
-            out.append("\n" if ch == "\n" else " ")
-            i += 1
-            continue
+                state = "code"
+            else:
+                out.append("\n" if ch == "\n" else " ")
+                i += 1
     return "".join(out)
 
 
-def extract_function_body(neutralized, func_name):
-    """Return the brace-matched body text of ``func <func_name>(`` in the
-    neutralized source, or ``None`` if the function is not found.
-
-    Handles multi-line signatures by walking parenthesis depth until the
-    parameter list closes, then brace-matching from the body's opening ``{``.
-    """
-    match = re.search(r"\bfunc\s+" + re.escape(func_name) + r"\s*\(", neutralized)
+def extract_braced_declaration(source, pattern):
+    match = re.search(pattern, source)
     if not match:
         return None
-    i = match.end() - 1  # at the opening '(' of the parameter list
-    n = len(neutralized)
-    paren_depth = 0
-    # Walk until the parameter-list parens balance back to zero.
-    while i < n:
-        ch = neutralized[i]
-        if ch == "(":
-            paren_depth += 1
-        elif ch == ")":
-            paren_depth -= 1
-            if paren_depth == 0:
-                i += 1
-                break
-        i += 1
-    else:
+    opening = source.find("{", match.end())
+    if opening < 0:
         return None
-    # Find the body's opening brace (skip the `-> some View` return clause).
-    while i < n and neutralized[i] != "{":
-        # A premature ';' or top-level '}' means there was no body.
-        if neutralized[i] == "}":
-            return None
-        i += 1
-    if i >= n:
-        return None
-    brace_depth = 0
-    start = i
-    while i < n:
-        ch = neutralized[i]
-        if ch == "{":
-            brace_depth += 1
-        elif ch == "}":
-            brace_depth -= 1
-            if brace_depth == 0:
-                return neutralized[start:i + 1]
-        i += 1
+    depth = 0
+    for index in range(opening, len(source)):
+        if source[index] == "{":
+            depth += 1
+        elif source[index] == "}":
+            depth -= 1
+            if depth == 0:
+                return source[opening:index + 1]
     return None
 
 
-def extract_type_body(neutralized, type_name):
-    """Return the brace-matched body text of ``struct/class <type_name>`` in the
-    neutralized source, or ``None`` if the declaration is not found.
-
-    Walks from the declaration keyword to the body's opening ``{`` (skipping
-    generic parameters and the conformance list), then brace-matches.
-    """
-    match = re.search(
-        r"\b(?:struct|final\s+class|class)\s+" + re.escape(type_name) + r"\b",
-        neutralized,
+def extract_function_body(source, name):
+    return extract_braced_declaration(
+        source,
+        r"\bfunc\s+" + re.escape(name) + r"\s*\(",
     )
-    if not match:
-        return None
-    i = match.end()
-    n = len(neutralized)
-    while i < n and neutralized[i] != "{":
-        if neutralized[i] == ";":
-            return None
-        i += 1
-    if i >= n:
-        return None
-    brace_depth = 0
-    start = i
-    while i < n:
-        ch = neutralized[i]
-        if ch == "{":
-            brace_depth += 1
-        elif ch == "}":
-            brace_depth -= 1
-            if brace_depth == 0:
-                return neutralized[start:i + 1]
-        i += 1
-    return None
 
 
-# Directory names that hold build artifacts, VCS data, or vendored third-party
-# code. Pruned from the repo-owned Swift walk: a Layout pulled from an external
-# dependency is out of scope (you would have to import it), and SwiftPM checkout
-# trees under `.build` are huge.
-EXCLUDED_DIR_NAMES = frozenset({
-    ".build", ".git", "DerivedData", "Vendor", "vendor", "ThirdParty",
-    "third_party", "Pods", "Carthage", "node_modules",
-})
+def extract_type_body(source, name):
+    return extract_braced_declaration(
+        source,
+        r"\b(?:struct|class|final\s+class)\s+" + re.escape(name) + r"\b",
+    )
 
 
-def repo_owned_swift_files(repo_root):
-    """Yield every repo-owned Swift source path under ``Sources/`` and
-    ``Packages/`` (where cmux migrates app code), pruning build/VCS/vendored
-    directories. Scanning both keeps the custom-Layout discovery from being
-    bypassed by defining the force-measuring layout in a package. (#6870 review)
-    """
-    for top in ("Sources", "Packages"):
-        root = os.path.join(repo_root, top)
-        if not os.path.isdir(root):
-            continue
-        for dirpath, dirnames, filenames in os.walk(root):
-            dirnames[:] = [d for d in dirnames if d not in EXCLUDED_DIR_NAMES]
-            for filename in filenames:
-                if filename.endswith(".swift"):
-                    yield os.path.join(dirpath, filename)
-
-
-def find_custom_layout_type_names(paths):
-    """Return the set of type names conforming to SwiftUI's `Layout` protocol
-    across ``paths`` (comment/string-neutralized so a `: Layout` in prose is not
-    counted). Cheap-filtered to files that mention ``Layout`` at all.
-    """
+def discovered_representables(swift_sources):
     names = set()
-    seen = set()
-    for path in paths:
-        try:
-            real = os.path.realpath(path)
-        except OSError:
-            continue
-        if real in seen:
-            continue
-        seen.add(real)
-        try:
-            with open(path, "r", encoding="utf-8") as handle:
-                text = handle.read()
-        except OSError:
-            continue
-        if "Layout" not in text:
-            continue
-        for match in CUSTOM_LAYOUT_DECL.finditer(neutralize_swift(text)):
-            names.add(match.group(1))
+    pattern = re.compile(
+        r"\b(?:struct|class|final\s+class)\s+([A-Za-z_]\w*)[^\{\n]*:\s*[^\{\n]*\bNSViewRepresentable\b"
+    )
+    for source in swift_sources:
+        names.update(pattern.findall(neutralize_swift(source)))
     return names
 
 
-def check_source(
-    source,
-    custom_layout_names=None,
-    require_functions=True,
-    required_row_types=(),
-    scan_all_rows=False,
-    required_markers=(),
-):
-    """Return a list of human-readable violation strings (empty == clean).
-
-    ``require_functions`` controls whether the two container functions must be
-    present: True for ContentView.swift, False for row-view files like
-    SidebarWorkspaceGroupHeaderView.swift (which do not contain them), or
-    "auto" for ad-hoc ``--file`` runs -- container checks then apply only when
-    at least one guarded function exists in the source, so a row-view file
-    scans cleanly while a fixture that renamed ONE function still fails loudly.
-    ``required_row_types`` names GUARDED_ROW_TYPES that must exist in this
-    source -- a rename fails loudly instead of silently skipping the region.
-    Row types that are merely present are always scanned.
-
-    ``scan_all_rows`` applies the row-forbidden patterns to the ENTIRE
-    neutralized source instead of extracted type regions. Used for row-wrapper
-    files (e.g. VerticalTabsSidebar+WorkspaceGroups.swift) whose modifier
-    sites wrap a row before it enters the LazyVStack: a GeometryReader or
-    anchorPreference added around the header there defeats laziness exactly
-    like one inside the row view. ``required_markers`` are substrings that
-    must appear in the source so a rename/move fails loudly.
-    """
-    custom_layout_names = custom_layout_names or set()
-    neutralized = neutralize_swift(source)
+def check_content_view(source):
+    clean = neutralize_swift(source)
     violations = []
-    bodies = {}
-    if require_functions == "auto":
-        require_functions = any(
-            re.search(r"\bfunc\s+" + re.escape(name) + r"\s*\(", neutralized)
-            for name in GUARDED_FUNCTIONS
-        )
-    if require_functions:
-        for func_name in GUARDED_FUNCTIONS:
-            body = extract_function_body(neutralized, func_name)
-            if body is None:
-                violations.append(
-                    "could not locate func {0}(...) in the source. The sidebar "
-                    "lazy-layout guard must be updated to track the renamed "
-                    "function (refusing to pass as a no-op).".format(func_name)
-                )
-                continue
-            bodies[func_name] = body
+    body = extract_function_body(clean, "workspaceScrollArea")
+    if body is None:
+        return ["could not locate func workspaceScrollArea(...); update this guard for the renamed boundary"]
+    if "SidebarWorkspaceTableView" not in body:
+        violations.append("workspaceScrollArea does not mount SidebarWorkspaceTableView")
+    for token in ("ScrollView", "LazyVStack", "LazyHStack", "List"):
+        if re.search(r"\b" + token + r"\b", body):
+            violations.append("workspaceScrollArea reintroduces SwiftUI list container: " + token)
+    for name in OLD_DEFAULT_LIST_FUNCTIONS:
+        if extract_function_body(clean, name) is not None:
+            violations.append("obsolete default-list function still exists: " + name)
+    return violations
 
-    for func_name, body in bodies.items():
-        for pattern, description in FORBIDDEN_PATTERNS:
-            if pattern.search(body):
-                violations.append(
-                    "{0}(...) reintroduces a forbidden whole-list measurement: "
-                    "{1}".format(func_name, description)
-                )
-        # A custom Layout (under ANY name) applied to the rows wraps the
-        # LazyVStack and measures it every pass -- the #6210 shape. Banning the
-        # whole discovered set, not just the deleted name, blocks the rename
-        # dodge (#6870 review).
-        for name in sorted(custom_layout_names):
-            if re.search(r"\b" + re.escape(name) + r"\b", body):
-                violations.append(
-                    "{0}(...) applies the custom Layout `{1}` to the sidebar rows. "
-                    "A custom Layout wrapping the LazyVStack measures it on every "
-                    "pass (the #6210 force-measure shape, regardless of the type's "
-                    "name); size the rows with .frame(minHeight:) instead.".format(
-                        func_name, name
-                    )
-                )
 
-    for func_name, pattern, description in REQUIRED_PRIMITIVES:
-        body = bodies.get(func_name)
-        if body is None:
-            continue  # already reported as a missing-function violation
-        if not pattern.search(body):
-            violations.append(
-                "{0}(...) is missing a required lazy-fill primitive: {1}".format(
-                    func_name, description
-                )
-            )
+def check_row_source(source, required_type, representable_names):
+    clean = neutralize_swift(source)
+    body = extract_type_body(clean, required_type)
+    if body is None:
+        return [f"could not locate row type {required_type}; update this guard for the rename"]
+    violations = []
+    forbidden = representable_names - REPRESENTABLE_ALLOWLIST - {"SidebarWorkspaceTableView"}
+    for name in sorted(forbidden):
+        if re.search(r"\b" + re.escape(name) + r"\b", body):
+            violations.append(f"{required_type} mounts forbidden per-row NSViewRepresentable {name}")
+    return violations
 
-    for marker in required_markers:
-        if marker not in neutralized:
-            violations.append(
-                "could not locate `{0}` in the source. The sidebar lazy-layout "
-                "guard must be updated to track the renamed/moved row wrapper "
-                "(refusing to pass as a no-op).".format(marker)
-            )
 
-    if scan_all_rows:
-        for pattern, description in ROW_FORBIDDEN_PATTERNS:
-            if pattern.search(neutralized):
-                violations.append(
-                    "row-wrapper file contains forbidden per-row geometry "
-                    "feedback: {0}".format(description)
-                )
-        for name in sorted(custom_layout_names):
-            if re.search(r"\b" + re.escape(name) + r"\b", neutralized):
-                violations.append(
-                    "row-wrapper file applies the custom Layout `{0}` (the "
-                    "#6210 force-measure shape); row wrappers must stay "
-                    "measurement-free.".format(name)
-                )
-
-    # Row-view regions: rows must never measure or publish their own geometry.
-    for type_name in GUARDED_ROW_TYPES:
-        body = extract_type_body(neutralized, type_name)
-        if body is None:
-            if type_name in required_row_types:
-                violations.append(
-                    "could not locate type {0} in the source. The sidebar "
-                    "lazy-layout guard must be updated to track the renamed "
-                    "row view (refusing to pass as a no-op).".format(type_name)
-                )
+def check_appkit_sources(sources_by_name):
+    violations = []
+    required = {
+        "SidebarWorkspaceTableView.swift": ("NSViewRepresentable", "makeNSView", "updateNSView"),
+        "SidebarWorkspaceTableController.swift": ("@MainActor", "NSTableViewDataSource", "NSTableViewDelegate"),
+        "SidebarWorkspaceTableCellView.swift": ("NSTableCellView", "NSHostingView", "rootView"),
+        "SidebarWorkspaceTableViewImpl.swift": ("NSTableView", "updateTrackingAreas", "otherMouseDown"),
+    }
+    for filename, markers in required.items():
+        source = sources_by_name.get(filename)
+        if source is None:
+            violations.append(f"missing required AppKit-list file {filename}")
             continue
-        for pattern, description in ROW_FORBIDDEN_PATTERNS:
-            if pattern.search(body):
-                violations.append(
-                    "{0} contains forbidden per-row geometry feedback: "
-                    "{1}".format(type_name, description)
-                )
-        for name in sorted(custom_layout_names):
-            if re.search(r"\b" + re.escape(name) + r"\b", body):
-                violations.append(
-                    "{0} applies the custom Layout `{1}`. A custom Layout in a "
-                    "sidebar row measures its subtree every pass (the #6210 "
-                    "force-measure shape); rows must stay measurement-free.".format(
-                        type_name, name
-                    )
-                )
+        clean = neutralize_swift(source)
+        for marker in markers:
+            if marker not in clean:
+                violations.append(f"{filename} is missing required marker {marker}")
 
+    for filename, source in sources_by_name.items():
+        clean = neutralize_swift(source)
+        for callback in LAYOUT_CALLBACKS:
+            body = extract_function_body(clean, callback)
+            if body is None:
+                continue
+            for pattern in LAYOUT_MUTATION_PATTERNS:
+                if pattern.search(body):
+                    violations.append(
+                        f"{filename}.{callback} mutates/reconfigures the table from a layout callback"
+                    )
+        for pattern, label in (
+            (r"\bObservableObject\b", "ObservableObject"),
+            (r"@Published\b", "@Published"),
+            (r"DispatchQueue\.main\.async", "DispatchQueue.main.async"),
+            (r"DispatchQueue\.asyncAfter", "DispatchQueue.asyncAfter"),
+        ):
+            if re.search(pattern, clean):
+                violations.append(f"{filename} introduces forbidden {label}")
     return violations
 
 
@@ -518,104 +222,59 @@ def repo_root_dir():
     return os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 
-def default_targets():
-    """(path, require_functions, required_row_types, scan_all_rows,
-    required_markers) per scanned file.
+def read(path):
+    with open(path, "r", encoding="utf-8") as handle:
+        return handle.read()
 
-    ContentView.swift holds the container functions and TabItemView; the group
-    header row view lives in its own file with neither container function; the
-    group-header ROW WRAPPER (`sidebarWorkspaceGroupHeader(...)`) lives in a
-    third file whose modifier sites wrap the header before it enters the
-    LazyVStack, so the whole file is scanned for the row-forbidden shapes.
-    """
-    root = repo_root_dir()
+
+def default_violations(root):
+    appkit_dir = os.path.join(root, "Sources", "Sidebar", "AppKitList")
+    try:
+        appkit_sources = {
+            name: read(os.path.join(appkit_dir, name))
+            for name in os.listdir(appkit_dir)
+            if name.endswith(".swift")
+        }
+        content = read(os.path.join(root, "Sources", "ContentView.swift"))
+        group = read(os.path.join(root, "Sources", "SidebarWorkspaceGroupHeaderView.swift"))
+    except OSError as error:
+        return [f"cannot read required sidebar source: {error}"]
+
+    all_sources = list(appkit_sources.values())
+    for directory, _, filenames in os.walk(os.path.join(root, "Sources")):
+        for filename in filenames:
+            if filename.endswith(".swift"):
+                try:
+                    all_sources.append(read(os.path.join(directory, filename)))
+                except OSError:
+                    pass
+    representables = discovered_representables(all_sources)
     return (
-        (
-            os.path.join(root, "Sources", "ContentView.swift"),
-            True,
-            ("TabItemView",),
-            False,
-            (),
-        ),
-        (
-            os.path.join(root, "Sources", "SidebarWorkspaceGroupHeaderView.swift"),
-            False,
-            ("SidebarWorkspaceGroupHeaderView",),
-            False,
-            (),
-        ),
-        (
-            os.path.join(root, "Sources", "VerticalTabsSidebar+WorkspaceGroups.swift"),
-            False,
-            (),
-            True,
-            ("sidebarWorkspaceGroupHeader",),
-        ),
+        check_content_view(content)
+        + check_row_source(content, "TabItemView", representables)
+        + check_row_source(group, "SidebarWorkspaceGroupHeaderView", representables)
+        + check_appkit_sources(appkit_sources)
     )
 
 
 def main(argv=None):
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--file",
-        default=None,
-        help="Swift source file to scan (defaults to Sources/ContentView.swift "
-             "+ Sources/SidebarWorkspaceGroupHeaderView.swift).",
-    )
+    parser.add_argument("--file", help="scan one AppKit-list Swift file for layout-callback mutations")
     args = parser.parse_args(argv)
-
     if args.file:
-        # "auto": ad-hoc scans of a row-view file (no container functions)
-        # skip the container checks instead of failing on their absence; a
-        # source containing any guarded function still has both enforced.
-        targets = ((args.file, "auto", (), False, ()),)
-    else:
-        targets = default_targets()
-
-    # Discover custom Layout type names from the target files plus every
-    # repo-owned Swift source (Sources/ and Packages/), so a renamed
-    # force-measuring layout defined in any app file or package is still banned
-    # from the guarded regions.
-    layout_scan_paths = [target[0] for target in targets]
-    layout_scan_paths.extend(sorted(repo_owned_swift_files(repo_root_dir())))
-    custom_layout_names = find_custom_layout_type_names(layout_scan_paths)
-
-    exit_code = 0
-    for target, require_functions, required_row_types, scan_all_rows, required_markers in targets:
         try:
-            with open(target, "r", encoding="utf-8") as handle:
-                source = handle.read()
+            violations = check_appkit_sources({os.path.basename(args.file): read(args.file)})
         except OSError as error:
-            print("check-sidebar-lazy-layout: cannot read {0}: {1}".format(target, error),
-                  file=sys.stderr)
-            exit_code = 1
-            continue
-
-        violations = check_source(
-            source,
-            custom_layout_names,
-            require_functions=require_functions,
-            required_row_types=required_row_types,
-            scan_all_rows=scan_all_rows,
-            required_markers=required_markers,
-        )
-        if violations:
-            print("check-sidebar-lazy-layout: FAILED for {0}".format(target),
-                  file=sys.stderr)
-            for violation in violations:
-                print("  - {0}".format(violation), file=sys.stderr)
-            print(
-                "\nThe workspace sidebar must keep its rows lazy at measure time "
-                "and its rows measurement-free. See #6188 / #6210 / #6384 / #6556 "
-                "and the comments in workspaceScrollContent / workspaceRows.",
-                file=sys.stderr,
-            )
-            exit_code = 1
-            continue
-
-        print("check-sidebar-lazy-layout: ok ({0})".format(target))
-
-    return exit_code
+            violations = [f"cannot read {args.file}: {error}"]
+    else:
+        violations = default_violations(repo_root_dir())
+    if violations:
+        print("check-sidebar-lazy-layout: FAILED", file=sys.stderr)
+        for violation in violations:
+            print("  - " + violation, file=sys.stderr)
+        return 1
+    print("check-sidebar-lazy-layout: ok (AppKit NSTableView boundary)")
+    return 0
 
 
 if __name__ == "__main__":

--- a/tests/test_ci_sidebar_lazy_layout_guard.py
+++ b/tests/test_ci_sidebar_lazy_layout_guard.py
@@ -1,427 +1,127 @@
 #!/usr/bin/env python3
-"""CI guard for ./scripts/check-sidebar-lazy-layout.py.
-
-Verifies the guard reports "ok" on the real cmux repo and correctly *fails* on
-every way the workspace-sidebar lazy-layout contract can be broken. The negative
-cases are what keep the guard from rotting into a no-op.
-
-Cases:
-  (a) Real cmux repo passes (Sources/ContentView.swift).
-  (b) A fixture whose guarded functions are clean code but whose comments and
-      string literals deliberately name every forbidden token still passes
-      (comment/string neutralization works -- this mirrors the real source,
-      which documents the anti-patterns it forbids).
-  (c) Reintroducing the #6210 force-measure (`.sizeThatFits(ProposedViewSize(
-      width:, height: nil))`) fails.
-  (d) Reintroducing the deleted `SidebarRowsFillLayout` custom Layout fails.
-  (e) A `GeometryReader` in the steady-state scroll content fails.
-  (f) Downgrading the rows from `LazyVStack` to a plain eager `VStack` fails.
-  (g) Dropping `.frame(minHeight:)` from `workspaceScrollContent` fails.
-  (h) Renaming/removing a guarded function fails loudly (no silent skip).
-  (j) A clean TabItemView row region passes.
-  (k) The #6556 rowHeightProbe shape (GeometryReader + @State height in a row)
-      fails — this exact code shipped in stable v0.64.17 and livelocked in the
-      wild on 2026-07-02.
-  (l) Per-row `.anchorPreference` (the #5323 virtualization defeat) fails.
-  (m) A required row type missing from its file fails loudly (no silent skip).
-"""
+"""Negative coverage for the AppKit sidebar topology guard."""
 
 import importlib.util
 import os
-import subprocess
 import sys
-import tempfile
-
-ROOT_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-GUARD = os.path.join(ROOT_DIR, "scripts", "check-sidebar-lazy-layout.py")
 
 
-def load_guard_module():
-    spec = importlib.util.spec_from_file_location("sidebar_lazy_layout_guard", GUARD)
+ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+GUARD_PATH = os.path.join(ROOT, "scripts", "check-sidebar-lazy-layout.py")
+
+
+def load_guard():
+    spec = importlib.util.spec_from_file_location("sidebar_guard", GUARD_PATH)
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
 
 
-def write_text(path, contents):
-    os.makedirs(os.path.dirname(path), exist_ok=True)
-    with open(path, "w", encoding="utf-8") as handle:
-        handle.write(contents)
+def expect(condition, label):
+    print(f"[{'PASS' if condition else 'FAIL'}] {label}")
+    return 0 if condition else 1
 
 
-def run_guard(path):
-    return subprocess.run(
-        [sys.executable, GUARD, "--file", path],
-        cwd=ROOT_DIR,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-
-
-def run_guard_default():
-    return subprocess.run(
-        [sys.executable, GUARD],
-        cwd=ROOT_DIR,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-
-
-def fixture(scroll_body, rows_body):
-    """Assemble a minimal ContentView-shaped Swift source with the two guarded
-    functions. ``scroll_body`` / ``rows_body`` are the function-body statements.
-    """
-    return (
-        "import SwiftUI\n"
-        "struct ContentBody {\n"
-        "    private func workspaceScrollContent(\n"
-        "        renderContext: WorkspaceListRenderContext,\n"
-        "        minHeight: CGFloat\n"
-        "    ) -> some View {\n"
-        "        // History: SidebarRowsFillLayout measured it via\n"
-        "        // sizeThatFits(ProposedViewSize(width: width, height: nil)) and a\n"
-        "        // GeometryReader feedback loop. Those tokens live only in this\n"
-        "        // comment and must not trip the guard.\n"
-        + scroll_body
-        + "\n    }\n"
-        "    @ViewBuilder\n"
-        "    private func workspaceRows(renderContext: WorkspaceListRenderContext) -> some View {\n"
-        + rows_body
-        + "\n    }\n"
-        "}\n"
-    )
-
-
-# A clean scroll body and rows body that satisfy the contract.
-GOOD_SCROLL = (
-    "        workspaceRows(renderContext: renderContext)\n"
-    "            .frame(minHeight: minHeight, alignment: .top)"
-)
-GOOD_ROWS = (
-    "        let rows = LazyVStack(spacing: tabRowSpacing) {\n"
-    "            ForEach(renderItems, id: \\.id) { item in workspaceRow(item) }\n"
-    "        }\n"
-    "        return rows"
-)
-
-
-def write_fixture(directory, name, contents):
-    path = os.path.join(directory, name)
-    with open(path, "w", encoding="utf-8") as handle:
-        handle.write(contents)
-    return path
-
-
-def expect(result, should_pass, label):
-    ok = (result.returncode == 0) if should_pass else (result.returncode != 0)
-    state = "PASS" if ok else "FAIL"
-    print("[{0}] {1} (exit={2}, expected {3})".format(
-        state, label, result.returncode, "0" if should_pass else "non-zero"))
-    if not ok:
-        print("---- guard output ----")
-        print(result.stdout.rstrip())
-        print("----------------------")
-    return ok
+def content_fixture(body):
+    return f"""
+import SwiftUI
+struct Sidebar {{
+    func workspaceScrollArea(renderContext: Context) -> some View {{
+        {body}
+    }}
+}}
+struct TabItemView: View {{
+    var body: some View {{ Text(\"row\") }}
+}}
+"""
 
 
 def main():
+    guard = load_guard()
     failures = 0
 
-    # (a) Real repo must pass.
-    failures += 0 if expect(run_guard_default(), True, "real repo passes") else 1
+    failures += expect(not guard.default_violations(ROOT), "real repository passes")
 
-    with tempfile.TemporaryDirectory() as workdir:
-        # (b) Clean code + forbidden tokens only in comments/strings still passes.
-        good_with_string = fixture(
-            GOOD_SCROLL + "\n            .accessibilityLabel(\"GeometryReader sizeThatFits\")",
-            GOOD_ROWS,
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "Good.swift", good_with_string)),
-            True, "clean body, anti-patterns only in comments/strings",
-        ) else 1
+    clean = content_fixture("SidebarWorkspaceTableView()")
+    failures += expect(not guard.check_content_view(clean), "table boundary passes")
 
-        # (b2) A Swift multi-line string literal that contains a bare `"` and
-        # forbidden tokens must not trip the guard. A naive tokenizer closes the
-        # literal at the inner quote and exposes `GeometryReader` as code. (#6870)
-        good_multiline = fixture(
-            GOOD_SCROLL
-            + "\n            .help(\"\"\"\n"
-            + "            Layout note: he said \"GeometryReader\" plus\n"
-            + "            sizeThatFits(ProposedViewSize(width: w, height: nil)) and\n"
-            + "            SidebarRowsFillLayout are all forbidden here.\n"
-            + "            \"\"\")",
-            GOOD_ROWS,
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "GoodMultiline.swift", good_multiline)),
-            True, "multi-line string with bare quote + forbidden tokens passes",
-        ) else 1
+    missing = "struct Sidebar { func renamed() {} }"
+    failures += expect(
+        any("could not locate" in item for item in guard.check_content_view(missing)),
+        "renamed boundary fails loudly",
+    )
 
-        # (c) Force-measure reintroduced.
-        bad_force = fixture(
-            "        let h = subviews.first?.sizeThatFits(\n"
-            "            ProposedViewSize(width: width, height: nil)).height ?? 0\n"
-            "        return workspaceRows(renderContext: renderContext)\n"
-            "            .frame(minHeight: max(h, minHeight), alignment: .top)",
-            GOOD_ROWS,
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "Force.swift", bad_force)),
-            False, "force-measure sizeThatFits(ProposedViewSize(height: nil)) fails",
-        ) else 1
+    swiftui_list = content_fixture("ScrollView { LazyVStack { Text(\"x\") } }")
+    failures += expect(
+        any("SwiftUI list container" in item for item in guard.check_content_view(swiftui_list)),
+        "SwiftUI ScrollView/LazyVStack regression fails",
+    )
 
-        # (d) SidebarRowsFillLayout reintroduced.
-        bad_layout = fixture(
-            "        SidebarRowsFillLayout(minHeight: minHeight) {\n"
-            "            workspaceRows(renderContext: renderContext)\n"
-            "        }",
-            GOOD_ROWS,
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "Layout.swift", bad_layout)),
-            False, "reintroduced SidebarRowsFillLayout fails",
-        ) else 1
+    obsolete = clean + "\nextension Sidebar { func workspaceRows() {} }\n"
+    failures += expect(
+        any("obsolete" in item for item in guard.check_content_view(obsolete)),
+        "obsolete workspaceRows seam fails",
+    )
 
-        # (d2) A *renamed* custom Layout (not the literal old name) applied to the
-        # rows must fail, even when the force-measure lives in the layout type
-        # outside the two guarded functions. The guard discovers Layout-conforming
-        # types and bans all their names from the functions. (#6870 review)
-        renamed_layout = (
-            "import SwiftUI\n"
-            "struct RowsFillLayout: Layout {\n"
-            "    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {\n"
-            "        subviews.first?.sizeThatFits(ProposedViewSize(width: 10, height: nil)) ?? .zero\n"
-            "    }\n"
-            "    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {}\n"
-            "}\n"
-            + fixture(
-                "        RowsFillLayout {\n"
-                "            workspaceRows(renderContext: renderContext)\n"
-                "        }\n"
-                "        .frame(minHeight: minHeight, alignment: .top)",
-                GOOD_ROWS,
-            )
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "RenamedLayout.swift", renamed_layout)),
-            False, "renamed custom Layout applied to rows fails",
-        ) else 1
+    representables = {"BadRowPortal", "SidebarInlineRenameField", "GPUSpinner"}
+    bad_row = """
+struct TabItemView: View {
+    var body: some View { BadRowPortal() }
+}
+"""
+    failures += expect(
+        any("BadRowPortal" in item for item in guard.check_row_source(
+            bad_row, "TabItemView", representables
+        )),
+        "per-row NSViewRepresentable fails",
+    )
 
-        # (e) GeometryReader in steady-state scroll content.
-        bad_geo = fixture(
-            "        GeometryReader { proxy in\n"
-            "            workspaceRows(renderContext: renderContext)\n"
-            "                .frame(minHeight: proxy.size.height, alignment: .top)\n"
-            "        }",
-            GOOD_ROWS,
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "Geo.swift", bad_geo)),
-            False, "GeometryReader in scroll content fails",
-        ) else 1
+    allowed_row = """
+struct TabItemView: View {
+    var body: some View { SidebarInlineRenameField() }
+}
+"""
+    failures += expect(
+        not guard.check_row_source(allowed_row, "TabItemView", representables),
+        "inline rename allowlist passes",
+    )
 
-        # (f) Eager VStack instead of LazyVStack.
-        bad_eager = fixture(
-            GOOD_SCROLL,
-            "        let rows = VStack(spacing: tabRowSpacing) {\n"
-            "            ForEach(renderItems, id: \\.id) { item in workspaceRow(item) }\n"
-            "        }\n"
-            "        return rows",
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "Eager.swift", bad_eager)),
-            False, "eager VStack (no LazyVStack) fails",
-        ) else 1
+    bad_lifecycle = """
+final class SidebarWorkspaceTableViewImpl: NSTableView {
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        reloadData()
+    }
+}
+"""
+    failures += expect(
+        any("layout callback" in item for item in guard.check_appkit_sources({
+            "SidebarWorkspaceTableViewImpl.swift": bad_lifecycle,
+        })),
+        "reload from updateTrackingAreas fails",
+    )
 
-        # (g) Missing .frame(minHeight:).
-        bad_nominheight = fixture(
-            "        workspaceRows(renderContext: renderContext)\n"
-            "            .frame(maxWidth: .infinity, alignment: .top)",
-            GOOD_ROWS,
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "NoMinHeight.swift", bad_nominheight)),
-            False, "missing .frame(minHeight:) fails",
-        ) else 1
-
-        # (h) A guarded function renamed away -> guard must fail loudly.
-        renamed = (
-            "import SwiftUI\n"
-            "struct ContentBody {\n"
-            "    private func workspaceScrollContent(\n"
-            "        renderContext: WorkspaceListRenderContext, minHeight: CGFloat\n"
-            "    ) -> some View {\n"
-            + GOOD_SCROLL
-            + "\n    }\n"
-            "    @ViewBuilder\n"
-            "    private func workspaceRowsRenamed(renderContext: WorkspaceListRenderContext) -> some View {\n"
-            + GOOD_ROWS
-            + "\n    }\n"
-            "}\n"
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "Renamed.swift", renamed)),
-            False, "renamed guarded function fails (no silent skip)",
-        ) else 1
-
-        # (j) Clean TabItemView row region passes.
-        def row_fixture(row_body):
-            return fixture(GOOD_SCROLL, GOOD_ROWS) + (
-                "struct TabItemView: View, Equatable {\n"
-                "    let tab: Tab\n"
-                "    var body: some View {\n"
-                + row_body
-                + "\n    }\n"
-                "}\n"
-            )
-
-        clean_row = row_fixture(
-            "        HStack { Text(tab.title) }\n"
-            "            .contentShape(Rectangle())"
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "CleanRow.swift", clean_row)),
-            True, "clean TabItemView row region passes",
-        ) else 1
-
-        # (k) The #6556 rowHeightProbe shape: GeometryReader writing @State row
-        # height from inside a row. This exact code shipped in stable v0.64.17
-        # and livelocked in the wild (issue #2586, 2026-07-02 spindump).
-        probe_row = row_fixture(
-            "        HStack { Text(tab.title) }\n"
-            "            .background {\n"
-            "                GeometryReader { proxy in\n"
-            "                    Color.clear.onAppear { rowHeight = proxy.size.height }\n"
-            "                }\n"
-            "            }"
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "ProbeRow.swift", probe_row)),
-            False, "#6556 rowHeightProbe (GeometryReader in row) fails",
-        ) else 1
-
-        # (l) Per-row anchorPreference publication (the #5323 defeat).
-        anchor_row = row_fixture(
-            "        HStack { Text(tab.title) }\n"
-            "            .anchorPreference(key: RowFrameKey.self, value: .bounds) { [tab.id: $0] }"
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "AnchorRow.swift", anchor_row)),
-            False, "per-row .anchorPreference (#5323 shape) fails",
-        ) else 1
-
-        # (n) --file on a row-view source (no container functions) must not
-        # emit false "could not locate func" violations; row scanning still
-        # applies. (Greptile P2 on #7221.)
-        header_like = (
-            "import SwiftUI\n"
-            "struct SidebarWorkspaceGroupHeaderView: View, Equatable {\n"
-            "    var body: some View {\n"
-            "        HStack { Text(\"group\") }\n"
-            "    }\n"
-            "}\n"
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "HeaderLike.swift", header_like)),
-            True, "--file on row-view source without container functions passes",
-        ) else 1
-
-        header_like_bad = header_like.replace(
-            "        HStack { Text(\"group\") }\n",
-            "        HStack { Text(\"group\") }\n"
-            "            .background { GeometryReader { p in Color.clear } }\n",
-        )
-        failures += 0 if expect(
-            run_guard(write_fixture(workdir, "HeaderLikeBad.swift", header_like_bad)),
-            False, "--file row-view source with GeometryReader still fails",
-        ) else 1
-
-        # (o) Whole-file row-wrapper scan (VerticalTabsSidebar+WorkspaceGroups):
-        # clean passes, GeometryReader at the wrapper site fails, and a missing
-        # required marker fails loudly. (Codex review on #7221.)
-        guard_mod_rows = load_guard_module()
-        wrapper_clean = (
-            "import SwiftUI\nextension VerticalTabsSidebar {\n"
-            "    func sidebarWorkspaceGroupHeader(item: Item) -> some View {\n"
-            "        SidebarWorkspaceGroupHeaderView(item: item)\n"
-            "            .contentShape(Rectangle())\n"
-            "    }\n}\n"
-        )
-        v = guard_mod_rows.check_source(
-            wrapper_clean, set(), require_functions=False,
-            scan_all_rows=True, required_markers=("sidebarWorkspaceGroupHeader",),
-        )
-        ok = not v
-        print("[{0}] clean row-wrapper file passes whole-file scan".format(
-            "PASS" if ok else "FAIL"))
-        failures += 0 if ok else 1
-
-        v = guard_mod_rows.check_source(
-            wrapper_clean.replace(
-                ".contentShape(Rectangle())",
-                ".background { GeometryReader { p in Color.clear } }",
-            ),
-            set(), require_functions=False,
-            scan_all_rows=True, required_markers=("sidebarWorkspaceGroupHeader",),
-        )
-        ok = any("GeometryReader" in x for x in v)
-        print("[{0}] GeometryReader at wrapper site fails whole-file scan".format(
-            "PASS" if ok else "FAIL"))
-        failures += 0 if ok else 1
-
-        v = guard_mod_rows.check_source(
-            "import SwiftUI\n", set(), require_functions=False,
-            scan_all_rows=True, required_markers=("sidebarWorkspaceGroupHeader",),
-        )
-        ok = any("could not locate" in x for x in v)
-        print("[{0}] missing wrapper marker fails loudly".format(
-            "PASS" if ok else "FAIL"))
-        failures += 0 if ok else 1
-
-        # (m) A required row type missing from its file must fail loudly.
-        guard_mod = load_guard_module()
-        missing_row_violations = guard_mod.check_source(
-            "import SwiftUI\nstruct SomethingElse: View { var body: some View { Text(\"x\") } }\n",
-            set(),
-            require_functions=False,
-            required_row_types=("SidebarWorkspaceGroupHeaderView",),
-        )
-        row_rename_ok = any("could not locate type" in v for v in missing_row_violations)
-        print("[{0}] missing required row type fails loudly".format(
-            "PASS" if row_rename_ok else "FAIL"))
-        failures += 0 if row_rename_ok else 1
-
-        # (i) Custom-Layout discovery must cover repo-owned Packages/ (where cmux
-        # migrates app code) and exclude build/vendor trees. (#6870 review)
-        guard = load_guard_module()
-        fake_root = os.path.join(workdir, "fakerepo")
-        write_text(os.path.join(fake_root, "Sources", "Z.swift"),
-                   "struct SourcesLayout: Layout {}\n")
-        write_text(os.path.join(fake_root, "Packages", "macOS", "CmuxSidebar",
-                                "Sources", "X.swift"),
-                   "struct PackagedRowsLayout: Layout {}\n")
-        write_text(os.path.join(fake_root, "Packages", "macOS", "Dep", ".build",
-                                "checkouts", "ext", "Y.swift"),
-                   "struct VendoredLayout: Layout {}\n")
-        scanned = list(guard.repo_owned_swift_files(fake_root))
-        discovered = guard.find_custom_layout_type_names(scanned)
-        cov_ok = (
-            "SourcesLayout" in discovered
-            and "PackagedRowsLayout" in discovered
-            and "VendoredLayout" not in discovered
-        )
-        print("[{0}] discovery covers Sources/ + Packages/, excludes .build "
-              "(found {1})".format("PASS" if cov_ok else "FAIL", sorted(discovered)))
-        failures += 0 if cov_ok else 1
+    comments_only = """
+final class SidebarWorkspaceTableViewImpl: NSTableView {
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        // reloadData() and rootView = are forbidden, but this is prose.
+        let note = \"noteHeightOfRows()\"
+    }
+}
+"""
+    lifecycle_violations = guard.check_appkit_sources({
+        "SidebarWorkspaceTableViewImpl.swift": comments_only,
+    })
+    failures += expect(
+        not any("layout callback" in item for item in lifecycle_violations),
+        "comments and strings are neutralized",
+    )
 
     if failures:
-        print("\ntest_ci_sidebar_lazy_layout_guard: {0} case(s) FAILED".format(failures),
-              file=sys.stderr)
+        print(f"test_ci_sidebar_lazy_layout_guard: {failures} case(s) failed", file=sys.stderr)
         return 1
-    print("\ntest_ci_sidebar_lazy_layout_guard: all cases passed")
+    print("test_ci_sidebar_lazy_layout_guard: all cases passed")
     return 0
 
 


### PR DESCRIPTION
Alternative architecture for https://github.com/manaflow-ai/cmux/issues/8004 (see the pointer-owner fix in https://github.com/manaflow-ai/cmux/pull/8067; one of the two will merge).

## What this does

Replaces the default sidebar workspace list's SwiftUI `ScrollView`/`LazyVStack`/`ForEach` container with a view-based `NSTableView` that owns virtualization, cell recycling, hover tracking, middle-click, drag sourcing/destinations, and scroll-to-selected. Row content stays SwiftUI: each recycled cell hosts one `NSHostingView` rendering the existing `TabItemView` / `SidebarWorkspaceGroupHeaderView` from immutable row configurations plus closure action bundles, so visuals and context menus are unchanged. The SwiftUI lazy-layout boundary that admitted the issue-8004 livelock (per-row platform views publishing state mid-update inside `GraphHost.flushTransactions`) no longer exists in the sidebar.

Diffing is a minimal hand-rolled differ: identical ID order reconfigures only changed visible cells (unread/title storms stay O(changed rows)); structural changes reload. Hover is one table-level tracking area; the hovered row is recomputed from the last pointer position on scroll-bounds changes and after every render-context application, so the close affordance stays correct under a stationary pointer. Reorder and Bonsplit drops reuse `SidebarWorkspaceDropPlanner` and the existing overlays, with target frames taken from visible table row rects; the cmux accent drop indicator is preserved.

## Tests and guard

`SidebarLazyLayoutScaleTests` was adapted to the table architecture: 300-workspace mount realizes only viewport-many cells, unread storms reconfigure O(changed rows), quiet-period convergence holds, and a unified-log fault detector asserts zero state-during-update, publishing-during-update, or reentrant-layout faults while churning titles/unread, scrolling programmatically, and moving a synthetic hover. `scripts/check-sidebar-lazy-layout.py` was rewritten for the new topology (bans per-row representables inside hosted row content except the gated rename-field/spinner allowlist, and bans table reload/reconfigure calls from layout callbacks), with its own positive/negative guard tests.

## Known risks for review/dogfood

Row heights use `usesAutomaticRowHeights` with hosted SwiftUI for exact visual parity; the CI fault/convergence test is the evidence gate for that choice. SwiftUI `.contextMenu` inside recycled hosting views, click-vs-drag arbitration, drag preview appearance, and inline-rename focus need interactive dogfood. Structural list changes use `reloadData()` so insert/remove/reorder animations may differ from the SwiftUI container.

## Verification

`swift_file_length_budget.py`, `check-pbxproj.sh`, `lint-pbxproj-test-wiring.sh`, the rewritten `check-sidebar-lazy-layout.py`, and its guard self-tests all pass. Tagged build `sblst` succeeded on this head, and the unit-test target compile-verified. No new user-facing strings beyond one AppKit menu item reusing the existing localized `contextMenu.workspaceGroup.newEmpty` key. Tests run on CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Refactored the workspace sidebar to use a virtualized, table-based layout for smoother rendering and more responsive interactions.
  * Improved drag-and-drop visuals, including a new empty-area drop indicator, plus refined hover and context-menu behavior.
  * Preserved double-click-to-create on empty sidebar space.
* **Bug Fixes**
  * Reduced unnecessary row reconfiguration and improved hover/selection/scroll stability during workspace updates and drag/drop.
* **Tests**
  * Expanded sidebar table coverage (sizing/height caching, hover/virtualization contract, drag/drop churn) and strengthened the CI guard for the AppKit list boundary.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->