### PR TITLE
Preserve Claude permission mode across session restore

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -134,6 +134,9 @@ struct ClaudeHookSessionRecord: Codable {
     var transcriptPath: String?
     var pid: Int?
     var launchCommand: AgentHookLaunchCommandRecord?
+    /// Last hook-observed `permission_mode`, re-applied as `--permission-mode`
+    /// on user-owned session restore (https://github.com/manaflow-ai/cmux/issues/8066).
+    var lastPermissionMode: String?
     var isRestorable: Bool?
     var agentLifecycle: AgentHibernationLifecycleState?
     var lastSubtitle: String?
@@ -269,6 +272,23 @@ final class ClaudeHookSessionStore {
         guard !normalized.isEmpty else { return nil }
         return try withLockedState { state in
             state.sessions[normalized]
+        }
+    }
+
+    /// Records the hook-observed permission mode on an existing session record.
+    /// Hooks fire on every tool use and the mode rarely changes, so an unlocked
+    /// pre-check skips the lock+rewrite cycle when the stored value already
+    /// matches. Unknown sessions are left alone (the session-start upsert owns
+    /// record creation).
+    func updateLastPermissionMode(sessionId: String, permissionMode: String) throws {
+        let normalized = normalizeSessionId(sessionId)
+        let mode = permissionMode.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalized.isEmpty, !mode.isEmpty else { return }
+        guard loadUnlocked().sessions[normalized]?.lastPermissionMode != mode else { return }
+        try withLockedState { state in
+            guard var record = state.sessions[normalized] else { return }
+            record.lastPermissionMode = mode
+            state.sessions[normalized] = record
         }
     }
 
@@ -23943,6 +23963,21 @@ struct CMUXCLI {
         let rawInput = String(data: FileHandle.standardInput.readDataToEndOfFile(), encoding: .utf8) ?? ""
         let parsedInput = parseClaudeHookInput(rawInput: rawInput)
         let sessionStore = ClaudeHookSessionStore()
+        // Record the hook-observed permission mode (shift+tab auto-accept, plan
+        // mode, bypass toggle): it is runtime state that never appears in the
+        // captured launch argv, and session restore re-applies it as
+        // `--permission-mode`. Read from rawObject — the compacted hook object
+        // keeps only an allowlist of keys and does not retain permission_mode.
+        // https://github.com/manaflow-ai/cmux/issues/8066
+        let observedHookPermissionMode = (parsedInput.rawObject?["permission_mode"] as? String)
+            ?? (parsedInput.rawObject?["permissionMode"] as? String)
+        if let hookSessionId = parsedInput.sessionId,
+           let observedHookPermissionMode {
+            try? sessionStore.updateLastPermissionMode(
+                sessionId: hookSessionId,
+                permissionMode: observedHookPermissionMode
+            )
+        }
         telemetry.breadcrumb(
             "claude-hook.input",
             data: [
@@ -24044,7 +24079,8 @@ struct CMUXCLI {
                         displayName: String(localized: "cli.claude-hook.notification.title", defaultValue: "Claude Code"),
                         sessionId: sessionId,
                         cwd: parsedInput.cwd,
-                        launchCommand: launchCommand
+                        launchCommand: launchCommand,
+                        observedPermissionMode: observedHookPermissionMode
                     )
                 }
             }
@@ -24176,7 +24212,9 @@ struct CMUXCLI {
                         displayName: String(localized: "cli.claude-hook.notification.title", defaultValue: "Claude Code"),
                         sessionId: sessionId,
                         cwd: parsedInput.cwd ?? mappedSession?.cwd,
-                        launchCommand: mappedSession?.launchCommand
+                        launchCommand: mappedSession?.launchCommand,
+                        observedPermissionMode: observedHookPermissionMode
+                            ?? mappedSession?.lastPermissionMode
                     )
                 }
 
@@ -24316,7 +24354,9 @@ struct CMUXCLI {
                     displayName: String(localized: "cli.claude-hook.notification.title", defaultValue: "Claude Code"),
                     sessionId: sessionId,
                     cwd: parsedInput.cwd ?? mappedSession?.cwd,
-                    launchCommand: mappedSession?.launchCommand ?? firstSightingLaunchCommand
+                    launchCommand: mappedSession?.launchCommand ?? firstSightingLaunchCommand,
+                    observedPermissionMode: observedHookPermissionMode
+                        ?? mappedSession?.lastPermissionMode
                 )
             }
             _ = try sendV1Command("clear_notifications --tab=\(workspaceId)\(socketPanelOption(surfaceId))", client: client)
@@ -27687,7 +27727,8 @@ struct CMUXCLI {
         displayName: String,
         sessionId: String,
         cwd: String?,
-        launchCommand: AgentHookLaunchCommandRecord?
+        launchCommand: AgentHookLaunchCommandRecord?,
+        observedPermissionMode: String? = nil
     ) {
         if !agentHookSessionHasDurableResumeEvidence(kind: kind, launchCommand: launchCommand) {
             clearAgentSurfaceResumeBinding(client: client, workspaceId: workspaceId, surfaceId: surfaceId, sessionId: sessionId)
@@ -27705,7 +27746,8 @@ struct CMUXCLI {
             sessionId: sessionId,
             launchCommand: launchCommand,
             workingDirectory: resumeWorkingDirectory,
-            environment: resumeEnvironment
+            environment: resumeEnvironment,
+            observedPermissionMode: observedPermissionMode
         ) else {
             clearAgentSurfaceResumeBinding(
                 client: client,
@@ -27756,7 +27798,8 @@ struct CMUXCLI {
         sessionId: String,
         launchCommand: AgentHookLaunchCommandRecord?,
         workingDirectory: String?,
-        environment: [String: String]?
+        environment: [String: String]?,
+        observedPermissionMode: String? = nil
     ) -> String? {
         let normalizedSessionId = normalizedHookValue(sessionId)
         guard let normalizedSessionId else { return nil }
@@ -27769,13 +27812,17 @@ struct CMUXCLI {
             arguments: launchCommand?.arguments ?? []
         ) {
         case .resolved(let resolved):
+            // Wrapper launchers include the claude-teams orphan-respawn path,
+            // which must never regain permission state a restored teammate did
+            // not explicitly opt into; observed mode applies only below.
             argv = resolved
         case .passthrough:
             argv = AgentResumeArgv().builtInKind(
                 kind: kind,
                 sessionId: normalizedSessionId,
                 executablePath: launchCommand?.executablePath,
-                arguments: launchCommand?.arguments ?? []
+                arguments: launchCommand?.arguments ?? [],
+                observedPermissionMode: observedPermissionMode
             )
         }
 

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -276,17 +276,17 @@ final class ClaudeHookSessionStore {
     }
 
     /// Records the hook-observed permission mode on an existing session record.
-    /// Hooks fire on every tool use and the mode rarely changes, so an unlocked
-    /// pre-check skips the lock+rewrite cycle when the stored value already
-    /// matches. Unknown sessions are left alone (the session-start upsert owns
-    /// record creation).
+    /// The already-current check happens INSIDE the lock: an unlocked pre-check
+    /// can race an overlapping hook's write and skip persisting the newest mode,
+    /// leaving restore on a stale (possibly more permissive) mode. Unknown
+    /// sessions are left alone (the session-start upsert owns record creation).
     func updateLastPermissionMode(sessionId: String, permissionMode: String) throws {
         let normalized = normalizeSessionId(sessionId)
         let mode = permissionMode.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !normalized.isEmpty, !mode.isEmpty else { return }
-        guard loadUnlocked().sessions[normalized]?.lastPermissionMode != mode else { return }
         try withLockedState { state in
-            guard var record = state.sessions[normalized] else { return }
+            guard var record = state.sessions[normalized],
+                  record.lastPermissionMode != mode else { return }
             record.lastPermissionMode = mode
             state.sessions[normalized] = record
         }

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentForkArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentForkArgv.swift
@@ -62,12 +62,17 @@ public struct AgentForkArgv: Sendable, Equatable {
     ///   - sessionId: The session/thread id to fork.
     ///   - executablePath: The captured executable path, if any.
     ///   - arguments: The captured launch argv, including the executable as element zero.
+    ///   - observedPermissionMode: The hook-observed Claude permission mode the session last ran
+    ///     in, re-applied via
+    ///     ``AgentResumeArgv/claudeArgvApplyingObservedPermissionMode(_:observedPermissionMode:)``
+    ///     for user-owned claude forks; ignored for every other kind.
     /// - Returns: The fork argv when the kind has a sanitizer-approved fork form, or `nil`.
     public func builtInKind(
         kind: String,
         sessionId: String,
         executablePath: String?,
-        arguments: [String]
+        arguments: [String],
+        observedPermissionMode: String? = nil
     ) -> [String]? {
         switch kind {
         case "claude":
@@ -75,7 +80,10 @@ public struct AgentForkArgv: Sendable, Equatable {
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "claude", args: parts.tail) else {
                 return nil
             }
-            return ["claude", "--resume", sessionId, "--fork-session"] + preserved
+            return AgentResumeArgv.claudeArgvApplyingObservedPermissionMode(
+                ["claude", "--resume", sessionId, "--fork-session"] + preserved,
+                observedPermissionMode: observedPermissionMode
+            )
         case "codex":
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "codex")
             guard let preserved = preservedCodexForkArguments(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchPositionalScanning.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchPositionalScanning.swift
@@ -129,6 +129,9 @@ extension AgentLaunchSanitizer {
         if arg.contains("=") {
             return 1
         }
+        if policy.booleanOptions.contains(arg) {
+            return 1
+        }
         if policy.optionalValueOptions.contains(arg) {
             guard index + 1 < args.count else { return 1 }
             let value = args[index + 1]

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizer.swift
@@ -19,6 +19,10 @@ public enum AgentLaunchSanitizer {
     struct Policy {
         var valueOptions: Set<String>
         var optionalValueOptions: Set<String> = []; var optionalValueChoices: [String: Set<String>] = [:]; var greedyOptionalValueOptions: Set<String> = []
+        /// Flags known to never consume a value. Exactly one token wide, so the
+        /// unknown-option value heuristic can never promote a following prompt
+        /// positional to the flag's "value" and replay it on resume.
+        var booleanOptions: Set<String> = []
         var variadicOptions: Set<String> = []
         var nonRestorableCommands: Set<String>
         var droppedOptions: Set<String>

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentLaunchSanitizerPrimaryPolicies.swift
@@ -29,6 +29,7 @@ extension AgentLaunchSanitizer {
             "--output-format",
             "--permission-mode",
             "--plugin-dir",
+            "--plugin-url",
             "--remote-control-session-name-prefix",
             "--resume",
             "-r",
@@ -44,7 +45,38 @@ extension AgentLaunchSanitizer {
             "-w"
         ],
         optionalValueOptions: [
-            "--debug"
+            "--debug",
+            "-d"
+        ],
+        // Claude booleans (from `claude --help`) pinned to width 1 so a following
+        // one-word prompt is never inferred as the flag's value and replayed on
+        // resume. Permission booleans are deliberately preserved for user-owned
+        // restore: resuming your own session continues the original explicit
+        // opt-in (https://github.com/manaflow-ai/cmux/issues/8066). Session-identity
+        // and lifecycle booleans (--continue/-c, --fork-session, --bg) stay listed
+        // in droppedOptions; being width-pinned here only keeps their drop exact.
+        booleanOptions: [
+            "--allow-dangerously-skip-permissions",
+            "--ax-screen-reader",
+            "--background",
+            "--bare",
+            "--bg",
+            "--brief",
+            "--chrome",
+            "--continue",
+            "-c",
+            "--dangerously-skip-permissions",
+            "--disable-slash-commands",
+            "--exclude-dynamic-system-prompt-sections",
+            "--fork-session",
+            "--ide",
+            "--include-hook-events",
+            "--include-partial-messages",
+            "--no-chrome",
+            "--replay-user-messages",
+            "--safe-mode",
+            "--strict-mcp-config",
+            "--verbose"
         ],
         variadicOptions: [
             "--add-dir",
@@ -76,6 +108,10 @@ extension AgentLaunchSanitizer {
             "upgrade"
         ],
         droppedOptions: [
+            // Replaying --bg/--background would turn an interactive pane restore
+            // into a detached background-agent launch.
+            "--background",
+            "--bg",
             "--continue",
             "-c",
             "--file",

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -303,15 +303,27 @@ public struct AgentResumeArgv: Sendable, Equatable {
     ///   - sessionId: the session/thread id to resume.
     ///   - executablePath: the captured executable path, if any.
     ///   - arguments: the captured launch arguments (argv, including the executable as element 0).
+    ///   - observedPermissionMode: the hook-observed Claude permission mode the session last ran
+    ///     in, re-applied via ``claudeArgvApplyingObservedPermissionMode(_:observedPermissionMode:)``
+    ///     for user-owned claude restore; ignored for every other kind.
     public func builtInKind(
         kind: String,
         sessionId: String,
         executablePath: String?,
-        arguments: [String]
+        arguments: [String],
+        observedPermissionMode: String? = nil
     ) -> [String]? {
         switch kind {
         case "claude":
-            return claudeResumeArgv(sessionId: sessionId, executablePath: executablePath, arguments: arguments)
+            guard let argv = claudeResumeArgv(
+                sessionId: sessionId,
+                executablePath: executablePath,
+                arguments: arguments
+            ) else { return nil }
+            return Self.claudeArgvApplyingObservedPermissionMode(
+                argv,
+                observedPermissionMode: observedPermissionMode
+            )
         case "codex":
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "codex")
             guard let preserved = preservedCodexForkArguments(

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeObservedPermissionMode.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/ClaudeObservedPermissionMode.swift
@@ -1,0 +1,80 @@
+import Foundation
+
+/// Re-applies a hook-observed Claude permission mode to a rebuilt resume/fork argv.
+///
+/// A mode selected in-session (shift+tab auto-accept, plan mode, bypass toggle) is
+/// runtime state, not argv, so no amount of launch-argument preservation can recover
+/// it. cmux already observes the live mode from Claude hook payloads
+/// (`permission_mode`); the restore builders feed the last-known value back as
+/// `--permission-mode <mode>` so a user-owned resume continues in the mode the
+/// session actually ended in.
+///
+/// Trust boundary: this applies ONLY to user-owned session resume/fork — a user
+/// restoring their own session is a continuation of their original explicit opt-in.
+/// The claude-teams orphan-respawn path (`launcherResolution`) deliberately has no
+/// observed-mode input: an orphaned teammate pane whose parent session is gone is
+/// not a fresh permission opt-in and must fall back to Claude's own prompts
+/// (see `CMUXCLI+TmuxCompatSupport.tmuxClaudeTeamsRespawnEnvironment`).
+/// https://github.com/manaflow-ai/cmux/issues/8066
+extension AgentResumeArgv {
+    /// The `--permission-mode` values the Claude CLI accepts. Observed state is
+    /// persisted on disk and rendered into a shell command, so only these exact
+    /// values are ever re-emitted; `default` (the hook payload's name for the
+    /// normal mode, not a CLI choice) and anything unrecognized are ignored.
+    public static let restorableClaudePermissionModes: Set<String> = [
+        "acceptEdits",
+        "auto",
+        "bypassPermissions",
+        "dontAsk",
+        "manual",
+        "plan"
+    ]
+
+    /// Returns `argv` with `--permission-mode <observedPermissionMode>` appended
+    /// when the observed mode is a recognized non-default mode and the argv does
+    /// not already carry an explicit permission flag. Explicit flags preserved
+    /// from the original launch (`--permission-mode`, `--permission-mode=…`, or
+    /// `--dangerously-skip-permissions`) always win over observed state, so the
+    /// two are never emitted together.
+    public static func claudeArgvApplyingObservedPermissionMode(
+        _ argv: [String],
+        observedPermissionMode: String?
+    ) -> [String] {
+        guard let mode = observedPermissionMode?.trimmingCharacters(in: .whitespacesAndNewlines),
+              restorableClaudePermissionModes.contains(mode) else {
+            return argv
+        }
+        let tail = Array(argv.dropFirst())
+        guard !AgentLaunchSanitizer.claudeLaunchHasOption("--permission-mode", args: tail),
+              !AgentLaunchSanitizer.claudeLaunchHasOption("--dangerously-skip-permissions", args: tail) else {
+            return argv
+        }
+        return argv + ["--permission-mode", mode]
+    }
+}
+
+extension AgentLaunchSanitizer {
+    /// Whether `option` appears as a real option token in a direct-claude argv.
+    ///
+    /// Mirror of ``claudeTeamsLaunchHasOption(_:args:)`` for the direct claude
+    /// policy: value slots are skipped via the policy's option widths, so a
+    /// flag-shaped token inside another option's value (e.g.
+    /// `--append-system-prompt "--permission-mode"`) is never promoted to an
+    /// option. Positionals are skipped, matching the policy's
+    /// scan-past-positionals replay boundary.
+    static func claudeLaunchHasOption(_ option: String, args: [String]) -> Bool {
+        let policy = claudePolicy
+        var index = 0
+        while index < args.count {
+            let arg = args[index]
+            if arg == "--" { return false }
+            if !arg.hasPrefix("-") || arg == "-" {
+                index += 1
+                continue
+            }
+            if arg == option || arg.hasPrefix(option + "=") { return true }
+            index += max(optionWidth(args, index: index, policy: policy), 1)
+        }
+        return false
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeBooleanLaunchFlagTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudeBooleanLaunchFlagTests.swift
@@ -1,0 +1,109 @@
+import CMUXAgentLaunch
+import Testing
+
+/// Claude's permission-affecting launch flags are booleans (`--dangerously-skip-permissions`,
+/// `--verbose`, …). The sanitizer must treat them as exactly one token wide: when it instead
+/// infers a value for them, a one-word prompt positional that follows gets promoted to the
+/// flag's "value" and is replayed verbatim on every resume/fork of the session.
+/// https://github.com/manaflow-ai/cmux/issues/8066
+@Suite("Claude boolean launch flags")
+struct ClaudeBooleanLaunchFlagTests {
+    @Test("Bypass flag does not swallow a one-word prompt bounded by a later flag")
+    func bypassFlagDoesNotSwallowBoundedOneWordPrompt() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["claude", "--dangerously-skip-permissions", "build", "--model", "opus"],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == ["claude", "--dangerously-skip-permissions", "--model", "opus"]
+        )
+    }
+
+    @Test("Bypass flag does not swallow a trailing comma-containing prompt word")
+    func bypassFlagDoesNotSwallowTrailingCommaPromptWord() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["claude", "--dangerously-skip-permissions", "fix,polish"],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == ["claude", "--dangerously-skip-permissions"]
+        )
+    }
+
+    @Test("Verbose flag does not swallow a one-word prompt bounded by a later flag")
+    func verboseFlagDoesNotSwallowBoundedOneWordPrompt() {
+        #expect(
+            AgentLaunchSanitizer.sanitizedLaunchArguments(
+                ["claude", "--verbose", "lint", "--model", "opus"],
+                launcher: "claude",
+                fallbackKind: "claude"
+            ) == ["claude", "--verbose", "--model", "opus"]
+        )
+    }
+
+    @Test("Resume argv keeps bypass without replaying a one-word prompt")
+    func resumeArgvKeepsBypassWithoutReplayingOneWordPrompt() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--dangerously-skip-permissions", "ship", "--model", "opus"]
+            ) == ["claude", "--resume", "SID", "--dangerously-skip-permissions", "--model", "opus"]
+        )
+    }
+
+    @Test("Fork argv keeps boolean flags without replaying a one-word prompt")
+    func forkArgvKeepsBooleanFlagsWithoutReplayingOneWordPrompt() {
+        #expect(
+            AgentForkArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--verbose", "ship", "--model", "opus"]
+            ) == ["claude", "--resume", "SID", "--fork-session", "--verbose", "--model", "opus"]
+        )
+    }
+
+    // MARK: - Guards that must keep passing
+
+    @Test("Bare bypass flag is preserved through resume argv preservation")
+    func bareBypassFlagIsPreserved() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--dangerously-skip-permissions"]
+            ) == ["claude", "--resume", "SID", "--dangerously-skip-permissions"]
+        )
+    }
+
+    @Test("Multi-word prompt after bypass flag stays dropped")
+    func multiWordPromptAfterBypassFlagStaysDropped() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--dangerously-skip-permissions", "fix the flaky test"]
+            ) == ["claude", "--resume", "SID", "--dangerously-skip-permissions"]
+        )
+    }
+
+    @Test("Teams prompt payload never promotes a flag-shaped token to an option")
+    func teamsPromptPayloadNeverPromotesFlagShapedToken() {
+        #expect(
+            !AgentLaunchSanitizer.claudeTeamsLaunchHasOption(
+                "--dangerously-skip-permissions",
+                args: ["--tmux", "--dangerously-skip-permissions"]
+            )
+        )
+        #expect(
+            AgentLaunchSanitizer.claudeTeamsLaunchHasOption(
+                "--dangerously-skip-permissions",
+                args: ["--dangerously-skip-permissions", "--tmux", "please do the thing"]
+            )
+        )
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudePermissionModeRestoreTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/ClaudePermissionModeRestoreTests.swift
@@ -1,0 +1,175 @@
+import CMUXAgentLaunch
+import Testing
+
+/// A Claude permission mode selected in-session (shift+tab auto-accept, plan mode,
+/// bypass toggle) is runtime state, not argv, so replay-based restore can never
+/// recover it from the captured launch command. cmux observes the live mode from
+/// hook payloads; the resume/fork argv builders re-apply it as `--permission-mode`
+/// on user-owned restore. Explicit launch flags always win over observed state,
+/// and the claude-teams launcher path never gains observed state (an orphaned
+/// teammate respawn is not a fresh permission opt-in).
+/// https://github.com/manaflow-ai/cmux/issues/8066
+@Suite("Claude permission mode restore")
+struct ClaudePermissionModeRestoreTests {
+    @Test("Resume argv appends observed non-default permission mode")
+    func resumeArgvAppendsObservedMode() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude"],
+                observedPermissionMode: "acceptEdits"
+            ) == ["claude", "--resume", "SID", "--permission-mode", "acceptEdits"]
+        )
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--model", "opus"],
+                observedPermissionMode: "plan"
+            ) == ["claude", "--resume", "SID", "--model", "opus", "--permission-mode", "plan"]
+        )
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude"],
+                observedPermissionMode: "bypassPermissions"
+            ) == ["claude", "--resume", "SID", "--permission-mode", "bypassPermissions"]
+        )
+    }
+
+    @Test("Default, empty, and unrecognized observed modes are not emitted")
+    func defaultEmptyAndUnrecognizedModesAreNotEmitted() {
+        let plain = ["claude", "--resume", "SID"]
+        for mode in ["default", "  ", "yolo; rm -rf /", ""] {
+            #expect(
+                AgentResumeArgv().builtInKind(
+                    kind: "claude",
+                    sessionId: "SID",
+                    executablePath: nil,
+                    arguments: ["claude"],
+                    observedPermissionMode: mode
+                ) == plain
+            )
+        }
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude"],
+                observedPermissionMode: nil
+            ) == plain
+        )
+    }
+
+    @Test("Explicit --permission-mode launch flag wins over observed state")
+    func explicitPermissionModeFlagWins() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--permission-mode", "plan"],
+                observedPermissionMode: "acceptEdits"
+            ) == ["claude", "--resume", "SID", "--permission-mode", "plan"]
+        )
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--permission-mode=plan"],
+                observedPermissionMode: "acceptEdits"
+            ) == ["claude", "--resume", "SID", "--permission-mode=plan"]
+        )
+    }
+
+    @Test("Explicit bypass launch flag wins over observed state")
+    func explicitBypassFlagWins() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--dangerously-skip-permissions"],
+                observedPermissionMode: "plan"
+            ) == ["claude", "--resume", "SID", "--dangerously-skip-permissions"]
+        )
+    }
+
+    @Test("Flag-shaped token inside a value slot is not an explicit permission flag")
+    func flagShapedValueSlotTokenIsNotExplicit() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--append-system-prompt", "--permission-mode"],
+                observedPermissionMode: "plan"
+            ) == [
+                "claude",
+                "--resume",
+                "SID",
+                "--append-system-prompt",
+                "--permission-mode",
+                "--permission-mode",
+                "plan"
+            ]
+        )
+    }
+
+    @Test("Fork argv appends observed non-default permission mode")
+    func forkArgvAppendsObservedMode() {
+        #expect(
+            AgentForkArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude"],
+                observedPermissionMode: "acceptEdits"
+            ) == ["claude", "--resume", "SID", "--fork-session", "--permission-mode", "acceptEdits"]
+        )
+        #expect(
+            AgentForkArgv().builtInKind(
+                kind: "claude",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["claude", "--dangerously-skip-permissions"],
+                observedPermissionMode: "plan"
+            ) == ["claude", "--resume", "SID", "--fork-session", "--dangerously-skip-permissions"]
+        )
+    }
+
+    @Test("Non-claude kinds ignore observed permission mode")
+    func nonClaudeKindsIgnoreObservedMode() {
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "codex",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["codex"],
+                observedPermissionMode: "plan"
+            ) == ["codex", "resume", "SID", "-c", "check_for_update_on_startup=false"]
+        )
+    }
+
+    @Test("Teams orphan respawn path never gains observed permission state")
+    func teamsLauncherResolutionNeverGainsObservedMode() {
+        // launcherResolution deliberately has no observed-mode input: an orphaned
+        // teammate pane restored after the parent session is gone must fall back
+        // to Claude's own trust/permission prompts, exactly as before.
+        #expect(
+            AgentResumeArgv().launcherResolution(
+                launcher: "claudeTeams",
+                sessionId: "SID",
+                executablePath: nil,
+                arguments: ["cmux", "claude-teams", "--model", "sonnet"]
+            ) == .resolved(["cmux", "claude-teams", "--resume", "SID", "--model", "sonnet"])
+        )
+    }
+}

--- a/Sources/RestorableAgentHookSessionRecord.swift
+++ b/Sources/RestorableAgentHookSessionRecord.swift
@@ -8,6 +8,8 @@ struct RestorableAgentHookSessionRecord: Codable, Sendable {
     var transcriptPath: String?
     var pid: Int?
     var launchCommand: AgentLaunchCommandSnapshot?
+    /// Last hook-observed agent permission mode (e.g. Claude's `permission_mode`).
+    var lastPermissionMode: String?
     var isRestorable: Bool?
     var agentLifecycle: AgentHibernationLifecycleState?
     var updatedAt: TimeInterval

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -317,7 +317,8 @@ enum AgentResumeCommandBuilder {
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
         registrationOverride: CmuxVaultAgentRegistration? = nil,
-        includeWorkingDirectoryPrefix: Bool = true
+        includeWorkingDirectoryPrefix: Bool = true,
+        observedPermissionMode: String? = nil
     ) -> String? {
         let customRegistration = registrationOverride
         guard !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -326,7 +327,8 @@ enum AgentResumeCommandBuilder {
                   sessionId: sessionId,
                   launchCommand: launchCommand,
                   workingDirectory: workingDirectory,
-                  customRegistration: customRegistration
+                  customRegistration: customRegistration,
+                  observedPermissionMode: observedPermissionMode
               ),
               !argv.isEmpty else {
             return nil
@@ -348,7 +350,8 @@ enum AgentResumeCommandBuilder {
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
         registrationOverride: CmuxVaultAgentRegistration? = nil,
-        includeWorkingDirectoryPrefix: Bool = true
+        includeWorkingDirectoryPrefix: Bool = true,
+        observedPermissionMode: String? = nil
     ) -> String? {
         let customRegistration = registrationOverride
         guard !sessionId.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
@@ -357,7 +360,8 @@ enum AgentResumeCommandBuilder {
                   sessionId: sessionId,
                   launchCommand: launchCommand,
                   workingDirectory: workingDirectory,
-                  customRegistration: customRegistration
+                  customRegistration: customRegistration,
+                  observedPermissionMode: observedPermissionMode
               ),
               !argv.isEmpty else {
             return nil
@@ -476,7 +480,8 @@ enum AgentResumeCommandBuilder {
         sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
-        customRegistration: CmuxVaultAgentRegistration?
+        customRegistration: CmuxVaultAgentRegistration?,
+        observedPermissionMode: String? = nil
     ) -> [String]? {
         switch AgentResumeArgv().launcherResolution(
             launcher: launchCommand?.launcher,
@@ -514,7 +519,8 @@ enum AgentResumeCommandBuilder {
             kind: kind.rawValue,
             sessionId: sessionId,
             executablePath: launchCommand?.executablePath,
-            arguments: launchCommand?.arguments ?? []
+            arguments: launchCommand?.arguments ?? [],
+            observedPermissionMode: observedPermissionMode
         )
     }
 
@@ -523,7 +529,8 @@ enum AgentResumeCommandBuilder {
         sessionId: String,
         launchCommand: AgentLaunchCommandSnapshot?,
         workingDirectory: String?,
-        customRegistration: CmuxVaultAgentRegistration?
+        customRegistration: CmuxVaultAgentRegistration?,
+        observedPermissionMode: String? = nil
     ) -> [String]? {
         let forkArgv = AgentForkArgv()
         switch forkArgv.launcherResolution(
@@ -553,7 +560,8 @@ enum AgentResumeCommandBuilder {
             kind: kind.rawValue,
             sessionId: sessionId,
             executablePath: launchCommand?.executablePath,
-            arguments: launchCommand?.arguments ?? []
+            arguments: launchCommand?.arguments ?? [],
+            observedPermissionMode: observedPermissionMode
         )
     }
 
@@ -738,6 +746,9 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
     var workingDirectory: String?
     var launchCommand: AgentLaunchCommandSnapshot?
     var registration: CmuxVaultAgentRegistration? = nil
+    /// Last hook-observed permission mode; re-applied as `--permission-mode` on
+    /// user-owned claude resume/fork when no explicit launch flag covers it.
+    var permissionMode: String? = nil
 
     func resumeStartupInput(
         fileManager: FileManager = .default,
@@ -1112,7 +1123,8 @@ struct RestorableAgentSessionIndex: Sendable {
                         codexCwdLookup: codexCwdLookup
                     ),
                     launchCommand: effectiveRecord.launchCommand,
-                    registration: registration
+                    registration: registration,
+                    permissionMode: effectiveRecord.lastPermissionMode
                 )
                 let key = PanelKey(workspaceId: workspaceId, panelId: panelId)
                 let sessionKey = SessionKey(kind: kind, sessionId: normalizedSessionId)

--- a/Sources/SessionRestorableAgentSnapshot+Commands.swift
+++ b/Sources/SessionRestorableAgentSnapshot+Commands.swift
@@ -7,6 +7,7 @@ extension SessionRestorableAgentSnapshot {
         case workingDirectory
         case launchCommand
         case registration
+        case permissionMode
     }
 
     init(from decoder: Decoder) throws {
@@ -34,7 +35,9 @@ extension SessionRestorableAgentSnapshot {
                 AgentLaunchCommandSnapshot.self,
                 forKey: .launchCommand
             ),
-            registration: registration
+            registration: registration,
+            // Optional so snapshots persisted before the field decode unchanged.
+            permissionMode: try container.decodeIfPresent(String.self, forKey: .permissionMode)
         )
     }
 
@@ -51,7 +54,8 @@ extension SessionRestorableAgentSnapshot {
             sessionId: sessionId,
             launchCommand: launchCommand,
             workingDirectory: workingDirectory,
-            registrationOverride: registration
+            registrationOverride: registration,
+            observedPermissionMode: permissionMode
         )
     }
 
@@ -62,7 +66,8 @@ extension SessionRestorableAgentSnapshot {
             sessionId: sessionId,
             launchCommand: launchCommand,
             workingDirectory: workingDirectory,
-            registrationOverride: registration
+            registrationOverride: registration,
+            observedPermissionMode: permissionMode
         )
     }
 

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1299,6 +1299,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */; };
 		E30780000000000000000014 /* SessionRemoteWorkspaceSnapshot+Restore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */; };
 		0A1107110000000000000022 /* SessionRestorableAgentSnapshot+Commands.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1107110000000000000023 /* SessionRestorableAgentSnapshot+Commands.swift */; };
+		806600000000000000000002 /* SessionRestorableAgentSnapshotPermissionModeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 806600000000000000000001 /* SessionRestorableAgentSnapshotPermissionModeTests.swift */; };
 		A5001670 /* SessionRestoredTerminalCommandStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001671 /* SessionRestoredTerminalCommandStore.swift */; };
 		C54860090000000000000001 /* SessionRestoreIdentityExclusions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C54860090000000000000002 /* SessionRestoreIdentityExclusions.swift */; };
 		A50016B1A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift in Sources */ = {isa = PBXBuildFile; fileRef = A50016B0A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift */; };
@@ -3146,6 +3147,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionPersistenceTests.swift; sourceTree = "<group>"; };
 		E30780000000000000000013 /* SessionRemoteWorkspaceSnapshot+Restore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionRemoteWorkspaceSnapshot+Restore.swift"; sourceTree = "<group>"; };
 		0A1107110000000000000023 /* SessionRestorableAgentSnapshot+Commands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionRestorableAgentSnapshot+Commands.swift"; sourceTree = "<group>"; };
+		806600000000000000000001 /* SessionRestorableAgentSnapshotPermissionModeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestorableAgentSnapshotPermissionModeTests.swift; sourceTree = "<group>"; };
 		A5001671 /* SessionRestoredTerminalCommandStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestoredTerminalCommandStore.swift; sourceTree = "<group>"; };
 		C54860090000000000000002 /* SessionRestoreIdentityExclusions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionRestoreIdentityExclusions.swift; sourceTree = "<group>"; };
 		A50016B0A1B2C3D4E5F60718 /* SessionSnapshotDebugBenchmark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/SessionSnapshotDebugBenchmark.swift; sourceTree = "<group>"; };
@@ -5206,6 +5208,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					F6572003A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift */,
 					F6572013A1B2C3D4E5F60718 /* SurfaceResumeBindingCodexUpdateCheckTests.swift */,
 					F5000001A1B2C3D4E5F60718 /* SessionPersistenceTests.swift */,
+					806600000000000000000001 /* SessionRestorableAgentSnapshotPermissionModeTests.swift */,
 					F17F00000000000000000002 /* FullWidthTabPersistenceTests.swift */,
 					FD21AD844E5D4D50A6DFC442 /* AppDelegateWindowFrameReconcileTests.swift */,
 					A1B2C3D4E5F600000000CF02 /* AppDelegateDisplayConfigRestoreTests.swift */,
@@ -7735,6 +7738,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8A3392FE64E0605D942213D1 /* SessionIndexViewTests.swift in Sources */,
 				F6572002A1B2C3D4E5F60718 /* SessionPersistenceResumeBindingTests.swift in Sources */,
 				F5000000A1B2C3D4E5F60718 /* SessionPersistenceTests.swift in Sources */,
+				806600000000000000000002 /* SessionRestorableAgentSnapshotPermissionModeTests.swift in Sources */,
 				583A675AA1224E8D82A44883 /* SetAutoTitleSocketTests.swift in Sources */,
 				A50019B2 /* SettingsSearchIndexTests.swift in Sources */,
 				D80100010000000000000001 /* SettingsWindowChromeTests.swift in Sources */,

--- a/cmuxTests/SessionRestorableAgentSnapshotPermissionModeTests.swift
+++ b/cmuxTests/SessionRestorableAgentSnapshotPermissionModeTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Restore must keep the permission mode a Claude session actually ended in:
+/// explicit launch flags are preserved through the sanitizer, and a mode selected
+/// in-session (shift+tab auto-accept, plan mode) is persisted from hook
+/// observation and re-applied as `--permission-mode` on user-owned resume/fork.
+/// https://github.com/manaflow-ai/cmux/issues/8066
+final class SessionRestorableAgentSnapshotPermissionModeTests: XCTestCase {
+    private func claudeSnapshot(
+        arguments: [String] = ["claude"],
+        permissionMode: String?
+    ) -> SessionRestorableAgentSnapshot {
+        SessionRestorableAgentSnapshot(
+            kind: .claude,
+            sessionId: "24ec0052-450c-4914-b1dd-2ee80d4bc84b",
+            workingDirectory: nil,
+            launchCommand: AgentLaunchCommandSnapshot(
+                launcher: "claude",
+                executablePath: "/usr/local/bin/claude",
+                arguments: arguments,
+                workingDirectory: nil,
+                environment: nil,
+                capturedAt: 123,
+                source: "environment"
+            ),
+            permissionMode: permissionMode
+        )
+    }
+
+    private func occurrences(of needle: String, in haystack: String) -> Int {
+        haystack.components(separatedBy: needle).count - 1
+    }
+
+    func testResumeCommandAppendsObservedPermissionMode() throws {
+        let command = try XCTUnwrap(
+            claudeSnapshot(permissionMode: "acceptEdits").resumeCommand
+        )
+        XCTAssertTrue(command.contains("--permission-mode"), command)
+        XCTAssertTrue(command.contains("acceptEdits"), command)
+    }
+
+    func testForkCommandAppendsObservedPermissionMode() throws {
+        let command = try XCTUnwrap(
+            claudeSnapshot(permissionMode: "plan").forkCommand
+        )
+        XCTAssertTrue(command.contains("--fork-session"), command)
+        XCTAssertTrue(command.contains("--permission-mode"), command)
+        XCTAssertTrue(command.contains("plan"), command)
+    }
+
+    func testExplicitPermissionModeLaunchFlagWinsOverObservedMode() throws {
+        let command = try XCTUnwrap(
+            claudeSnapshot(
+                arguments: ["claude", "--permission-mode", "plan"],
+                permissionMode: "acceptEdits"
+            ).resumeCommand
+        )
+        XCTAssertEqual(occurrences(of: "--permission-mode", in: command), 1, command)
+        XCTAssertTrue(command.contains("plan"), command)
+        XCTAssertFalse(command.contains("acceptEdits"), command)
+    }
+
+    func testExplicitBypassLaunchFlagSuppressesObservedMode() throws {
+        let command = try XCTUnwrap(
+            claudeSnapshot(
+                arguments: ["claude", "--dangerously-skip-permissions"],
+                permissionMode: "plan"
+            ).resumeCommand
+        )
+        XCTAssertTrue(command.contains("--dangerously-skip-permissions"), command)
+        XCTAssertFalse(command.contains("--permission-mode"), command)
+    }
+
+    func testDefaultObservedModeIsNotEmitted() throws {
+        let command = try XCTUnwrap(
+            claudeSnapshot(permissionMode: "default").resumeCommand
+        )
+        XCTAssertFalse(command.contains("--permission-mode"), command)
+    }
+
+    func testDecodingToleratesSnapshotsWithoutPermissionMode() throws {
+        let legacyJSON = """
+        {
+            "kind": "claude",
+            "sessionId": "24ec0052-450c-4914-b1dd-2ee80d4bc84b"
+        }
+        """
+        let snapshot = try JSONDecoder().decode(
+            SessionRestorableAgentSnapshot.self,
+            from: Data(legacyJSON.utf8)
+        )
+        XCTAssertNil(snapshot.permissionMode)
+        let command = try XCTUnwrap(snapshot.resumeCommand)
+        XCTAssertFalse(command.contains("--permission-mode"), command)
+    }
+
+    func testSnapshotRoundTripsPermissionMode() throws {
+        let encoded = try JSONEncoder().encode(claudeSnapshot(permissionMode: "acceptEdits"))
+        let decoded = try JSONDecoder().decode(SessionRestorableAgentSnapshot.self, from: encoded)
+        XCTAssertEqual(decoded.permissionMode, "acceptEdits")
+    }
+}


### PR DESCRIPTION
Addresses #8066

Restoring/resuming a Claude Code session lost its permission mode two ways. This PR fixes both with two-commit red/green pairs in the `CMUXAgentLaunch` package suite.

## 1. Boolean launch flags could swallow (and replay) a prompt word

Re-verifying the issue's diagnosis against current main: `--dangerously-skip-permissions` is no longer dropped outright (#7602 fixed the allowlist truncation), but Claude's boolean flags were still *unknown* to `claudePolicy`, so `unknownOptionWidth` could infer a "value" for them — a one-word prompt positional after the flag was promoted to the flag's value and **replayed verbatim on every resume/fork** (`claude --dangerously-skip-permissions build --model opus` resumed as `claude --resume <id> --dangerously-skip-permissions build --model opus`).

Fix: new `Policy.booleanOptions` pins Claude's boolean flags (audited from `claude --help`) to exactly one token. While in there: `--plugin-url` joins `valueOptions`, `-d` (alias of `--debug`) joins `optionalValueOptions`, and `--bg`/`--background` are dropped on restore (replaying them would turn an interactive pane resume into a detached background-agent launch). Session-identity flags (`--fork-session`, `--continue`, `--session-id`, `--from-pr`) stay dropped.

- Red commit: ae217cb3 (5 behavior-failing tests) → green: 451145e8

## 2. Interactively selected mode was never restored

A mode chosen in-session (shift+tab auto-accept, plan mode, bypass toggle) is runtime state, not argv, so no argv preservation can recover it. Now:

- **CLI**: every claude hook records the payload's `permission_mode` on the session record (`lastPermissionMode`), skipping the lock+rewrite when unchanged; the surface-resume binding publisher threads it into the rebuilt command.
- **App**: `SessionRestorableAgentSnapshot` persists `permissionMode` (optional — old snapshots decode unchanged) and feeds it to both `resumeCommand` and `forkCommand`.
- **Package**: `AgentResumeArgv`/`AgentForkArgv.builtInKind` gain `observedPermissionMode`, applied only to the direct-claude kind, appending `--permission-mode <mode>` when the mode is one of the CLI's documented choices. **Explicit launch flags always win**: if the preserved argv already carries `--permission-mode` or `--dangerously-skip-permissions`, observed state is never emitted (the two can't appear together). The check scans with the policy's option widths, so a flag-shaped token inside a value slot is never treated as an explicit flag.

- Red commit: ba00e325 (test target fails to build — the API is the contract) → green: aa04daf1

## Trust-boundary reasoning

**User-owned resume keeps the mode.** A user resuming their own session after an app restart is a *continuation of their original explicit opt-in* — today's behavior silently downgrades a bypass/auto-accept session to default mode, which is the bug, not the boundary.

**The claude-teams orphan respawn keeps NOT regaining bypass.** `CLI/CMUXCLI+TmuxCompatSupport.swift` deliberately treats a restored teammate pane (whose parent session is gone) as *not* a fresh opt-in; that decision is made from `CMUX_CLAUDE_TEAMS_SANDBOXED` launcher env, never from replayed argv, and is untouched here. Structurally, observed-mode injection exists only on the direct-claude `builtInKind` path — the wrapper-launcher path (`launcherResolution`, which owns claude-teams restore) has no observed-mode input at all, and tests pin that.

## Restore-path audit

- `snapshot.resumeCommand` / `snapshot.forkCommand` (app restore + fork UI): both carry the mode.
- CLI surface-resume binding publisher (`publishAgentSurfaceResumeBinding`): carries the mode on the three claude hook sites.
- Sessions panel manual resume (`SessionIndexModels`): already mode-aware via transcript parsing (pre-existing); unchanged.
- `SurfaceResumeCommandCanonicalizer*`: approval matching/tokenization only, builds no agent commands — no change.
- `TerminalSurface+RuntimeSurfaceCreation`: wrapper-shim env exports only — no change.

## Verification

- `swift test --package-path Packages/macOS/CMUXAgentLaunch`: 235 tests, 34 suites, green (219 on main).
- New app-level tests in `cmuxTests/SessionRestorableAgentSnapshotPermissionModeTests.swift` (wired into project.pbxproj; `lint-pbxproj-test-wiring.sh` ok) cover snapshot round-trip, legacy decode without the field, and explicit-flag precedence — they run on CI.
- `python3 scripts/swift_file_length_budget.py`: every touched file within budget (the 5 reported overruns are byte-identical to origin/main).
- Localization audit: no user-facing strings added or changed (code comments and CLI-internal plumbing only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8070"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786645179&installation_id=133855650&pr_number=8070&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8070&signature=e46bab24578d44c952257705480903d1f23232cbb005d9e5e6239c2fc822f1ad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep Claude Code’s permission mode when resuming or forking a session, and fix boolean flag parsing that could capture a one‑word prompt. Resolves #8066 by preserving user‑chosen permissions and preventing prompt replay on restore.

- **Bug Fixes**
  - Pin Claude boolean flags (`--dangerously-skip-permissions`, `--verbose`, etc.) to width 1 in `CMUXAgentLaunch` so a following prompt word isn’t inferred as a value and replayed; also treat `--plugin-url` as a value option, `-d` as optional‑value, and drop `--bg`/`--background` on restore.
  - Avoid stale permission modes by moving the unchanged‑mode no‑op check inside the `ClaudeHookSessionStore` lock, preventing races when multiple hooks update `permission_mode`.

- **New Features**
  - Persist and reapply the last observed Claude `permission_mode`: CLI hooks store it on the session record; app snapshots keep it; direct `claude` resume/fork appends `--permission-mode <mode>` for known modes when no explicit permission flag is present. Explicit `--permission-mode` or `--dangerously-skip-permissions` always win; non‑`claude` kinds and claude‑teams orphan respawn ignore observed mode.

<sup>Written for commit 992137babfc16b0d79be68ab6eae1b549a4c2e3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Claude sessions now remember and reapply supported `--permission-mode` settings when resumed or forked.
  - Session snapshots preserve permission-mode state across restarts.
- **Bug Fixes**
  - Improved command-line parsing so boolean, debug, and flag-style options are no longer misread as consuming a prompt or swallowing following tokens.
  - Restore behavior now more reliably retains or suppresses permission-related options based on observed state and explicit launch flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->