### PR TITLE
Fix Subrouter Codex session resume credentials

### DIFF
--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv+SubrouterCodex.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv+SubrouterCodex.swift
@@ -1,0 +1,71 @@
+import Foundation
+
+extension AgentResumeArgv {
+    /// The non-secret credential assignment required by Subrouter's custom Codex provider.
+    public static let subrouterCodexDummyAPIKeyEnvironmentAssignment =
+        "SUBROUTER_CODEX_DUMMY_API_KEY=subrouter"
+
+    /// Returns Subrouter's dummy credential assignment when captured Codex config selects its env key.
+    ///
+    /// `subrouter codex` uses a custom provider whenever it needs request headers for account or model
+    /// routing. The provider names a dummy environment variable because Codex requires custom providers
+    /// to resolve an authentication source, while Subrouter replaces the outbound credential itself.
+    /// Resume commands preserve the provider config arguments but cannot recover the launcher's process
+    /// environment, so callers must restore this non-secret assignment alongside the preserved argv.
+    ///
+    /// - Parameter arguments: Captured or rendered Codex arguments containing `-c`/`--config` options.
+    /// - Returns: The environment assignment when the effective Subrouter env-key config needs it.
+    public func subrouterCodexDummyAPIKeyEnvironmentAssignment(
+        in arguments: [String]
+    ) -> String? {
+        guard codexConfigValue(
+            for: "model_providers.subrouter.env_key",
+            in: arguments
+        ) == "SUBROUTER_CODEX_DUMMY_API_KEY" else {
+            return nil
+        }
+        return Self.subrouterCodexDummyAPIKeyEnvironmentAssignment
+    }
+
+    private func codexConfigValue(for key: String, in arguments: [String]) -> String? {
+        var effectiveValue: String?
+        for (index, argument) in arguments.enumerated() {
+            let config: String?
+            if argument == "-c" || argument == "--config" {
+                config = index + 1 < arguments.count ? arguments[index + 1] : nil
+            } else if argument.hasPrefix("-c=") {
+                config = String(argument.dropFirst(3))
+            } else if argument.hasPrefix("--config=") {
+                config = String(argument.dropFirst(9))
+            } else {
+                config = nil
+            }
+            guard let config,
+                  let assignment = codexConfigAssignment(config),
+                  assignment.key == key else {
+                continue
+            }
+            effectiveValue = unquotedCodexConfigValue(assignment.value)
+        }
+        return effectiveValue
+    }
+
+    private func codexConfigAssignment(_ config: String) -> (key: String, value: String)? {
+        guard let separator = config.firstIndex(of: "=") else { return nil }
+        let key = config[..<separator].trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !key.isEmpty else { return nil }
+        let valueStart = config.index(after: separator)
+        let value = config[valueStart...].trimmingCharacters(in: .whitespacesAndNewlines)
+        return (key, value)
+    }
+
+    private func unquotedCodexConfigValue(_ value: String) -> String {
+        guard value.count >= 2,
+              let first = value.first,
+              first == value.last,
+              first == "\"" || first == "'" else {
+            return value
+        }
+        return String(value.dropFirst().dropLast())
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/AgentResumeArgv.swift
@@ -276,10 +276,9 @@ public struct AgentResumeArgv: Sendable, Equatable {
             guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: "codex-fork-restore", args: tail) else {
                 return .resolved(nil)
             }
-            return .resolved(
-                [parts.executable, "codex-teams", "resume", sessionId]
-                    + codexResumeConfigOverrides(preserved: preserved) + preserved
-            )
+            let resume = [parts.executable, "codex-teams", "resume", sessionId]
+                + codexResumeConfigOverrides(preserved: preserved) + preserved
+            return .resolved(codexResumeEnvironmentPrefix(preserved: preserved) + resume)
         case "omo":
             let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: "cmux")
             var tail = parts.tail
@@ -323,8 +322,9 @@ public struct AgentResumeArgv: Sendable, Equatable {
                 capturedExecutable: parts.executable,
                 launchTail: parts.tail
             )
-            return [replayExecutable, "resume", sessionId]
+            let resume = [replayExecutable, "resume", sessionId]
                 + codexResumeConfigOverrides(preserved: preserved) + preserved
+            return codexResumeEnvironmentPrefix(preserved: preserved) + resume
         case "grok":
             return withOption("grok", executable: "grok", option: "-r", sessionId: sessionId, executablePath: executablePath, arguments: arguments)
         case "pi":
@@ -414,6 +414,13 @@ public struct AgentResumeArgv: Sendable, Equatable {
         let parts = commandParts(executablePath: executablePath, arguments: arguments, fallbackExecutable: fallbackExecutable)
         guard let preserved = AgentLaunchSanitizer.preservedArguments(kind: kind, args: parts.tail) else { return nil }
         return [parts.executable, option, sessionId] + preserved
+    }
+
+    private func codexResumeEnvironmentPrefix(preserved: [String]) -> [String] {
+        guard let assignment = subrouterCodexDummyAPIKeyEnvironmentAssignment(in: preserved) else {
+            return []
+        }
+        return ["env", assignment]
     }
 
     private func commandParts(

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/AgentResumeArgvTests.swift
@@ -149,6 +149,55 @@ struct AgentResumeArgvTests {
         )
     }
 
+    @Test("Codex resume restores Subrouter's dummy provider credential")
+    func codexResumeRestoresSubrouterDummyProviderCredential() {
+        let subrouterConfig = [
+            "-c", "model_provider=\"subrouter\"",
+            "-c", "model_providers.subrouter.env_key=\"SUBROUTER_CODEX_DUMMY_API_KEY\"",
+            "-c", "model_providers.subrouter.base_url=\"http://subrouter.example/v1\"",
+        ]
+
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "codex",
+                sessionId: "SUBROUTER-SID",
+                executablePath: "/opt/bin/codex",
+                arguments: ["/opt/bin/codex"] + subrouterConfig
+            ) == [
+                "env",
+                "SUBROUTER_CODEX_DUMMY_API_KEY=subrouter",
+                "/opt/bin/codex",
+                "resume",
+                "SUBROUTER-SID",
+                "-c",
+                "check_for_update_on_startup=false",
+            ] + subrouterConfig
+        )
+    }
+
+    @Test("Codex resume does not invent credentials for unrelated providers")
+    func codexResumeDoesNotInventUnrelatedProviderCredentials() {
+        let unrelatedConfig = [
+            "-c", "model_provider=\"company\"",
+            "-c", "model_providers.company.env_key=\"COMPANY_API_KEY\"",
+        ]
+
+        #expect(
+            AgentResumeArgv().builtInKind(
+                kind: "codex",
+                sessionId: "COMPANY-SID",
+                executablePath: "/opt/bin/codex",
+                arguments: ["/opt/bin/codex"] + unrelatedConfig
+            ) == [
+                "/opt/bin/codex",
+                "resume",
+                "COMPANY-SID",
+                "-c",
+                "check_for_update_on_startup=false",
+            ] + unrelatedConfig
+        )
+    }
+
     @Test("Codex resume respects an explicit captured check_for_update_on_startup setting")
     func codexResumeRespectsExplicitUpdateCheckSetting() {
         // The codex sanitizer policy preserves `-c key=value` pairs, so a captured

--- a/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+CodexUpdateCheck.swift
@@ -2,6 +2,147 @@ import CMUXAgentLaunch
 import Foundation
 
 extension SurfaceResumeCommandCanonicalizer {
+    /// Restores the non-secret environment assignment required by Subrouter's custom Codex provider.
+    static func insertingSubrouterCodexDummyAPIKey(
+        in command: String,
+        kind: String?
+    ) -> String {
+        let normalizedKind = kind?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard normalizedKind == nil || normalizedKind == "codex" else { return command }
+        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
+        guard let executableIndex = commandExecutableWordIndex(in: words, command: command) else {
+            return command
+        }
+        if let updated = insertingSubrouterCodexDummyAPIKey(
+            in: command,
+            words: words,
+            executableIndex: executableIndex,
+            normalizedKind: normalizedKind
+        ) {
+            return updated
+        }
+        if let updated = insertingSubrouterCodexDummyAPIKeyIntoShellWrapper(
+            in: command,
+            words: words,
+            executableIndex: executableIndex,
+            normalizedKind: normalizedKind
+        ) {
+            return updated
+        }
+        return command
+    }
+
+    private static func insertingSubrouterCodexDummyAPIKey(
+        in command: String,
+        words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange],
+        executableIndex: Int,
+        normalizedKind: String?
+    ) -> String? {
+        let executableBasename = (words[executableIndex].value as NSString).lastPathComponent
+        let commandIndex = executableIndex + 1
+        let isCodexExecutable = executableBasename == "codex"
+        let isCodexTeamsCommand = commandIndex < words.count && words[commandIndex].value == "codex-teams"
+        guard normalizedKind == "codex" || isCodexExecutable || isCodexTeamsCommand else {
+            return nil
+        }
+        let resumeIndex = isCodexTeamsCommand ? commandIndex + 1 : commandIndex
+        guard resumeIndex < words.count, words[resumeIndex].value == "resume" else {
+            return nil
+        }
+        let arguments = words[(executableIndex + 1)...].map(\.value)
+        guard let assignment = AgentResumeArgv()
+            .subrouterCodexDummyAPIKeyEnvironmentAssignment(in: arguments),
+              !hasEnvironmentAssignment(named: "SUBROUTER_CODEX_DUMMY_API_KEY", before: executableIndex, words: words) else {
+            return nil
+        }
+
+        let hasEnvUtility = words[..<executableIndex].contains {
+            $0.value == "env" || $0.value == "/usr/bin/env"
+        }
+        let prefix = hasEnvUtility ? "\(assignment) " : "env \(assignment) "
+        var updated = command
+        updated.insert(contentsOf: prefix, at: words[executableIndex].range.lowerBound)
+        return updated
+    }
+
+    private static func insertingSubrouterCodexDummyAPIKeyIntoShellWrapper(
+        in command: String,
+        words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange],
+        executableIndex: Int,
+        normalizedKind: String?
+    ) -> String? {
+        let executableBasename = (words[executableIndex].value as NSString).lastPathComponent
+        guard executableBasename == "sh" || executableBasename == "zsh" || executableBasename == "bash" else {
+            return nil
+        }
+        let optionIndex = executableIndex + 1
+        let commandIndex = executableIndex + 2
+        guard commandIndex < words.count,
+              words[optionIndex].value == "-c" || words[optionIndex].value == "-lc" else {
+            return nil
+        }
+        let innerCommand = words[commandIndex].value
+        guard let updatedInner = insertingSubrouterCodexDummyAPIKeyInShellWrapperBody(
+            innerCommand,
+            normalizedKind: normalizedKind
+        ), updatedInner != innerCommand else {
+            return nil
+        }
+        var updated = command
+        updated.replaceSubrange(words[commandIndex].range, with: shellQuoted(updatedInner))
+        return updated
+    }
+
+    private static func insertingSubrouterCodexDummyAPIKeyInShellWrapperBody(
+        _ command: String,
+        normalizedKind: String?
+    ) -> String? {
+        let words = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(command)
+        if let executableIndex = commandExecutableWordIndex(in: words, command: command),
+           let updated = insertingSubrouterCodexDummyAPIKey(
+               in: command,
+               words: words,
+               executableIndex: executableIndex,
+               normalizedKind: normalizedKind
+           ) {
+            return updated
+        }
+
+        let wrapperToken = AgentResumeArgv.codexWrapperShellExecutableToken
+        guard let wrapperRange = command.range(of: wrapperToken) else { return nil }
+        let tail = String(command[wrapperRange.upperBound...])
+        let tailWords = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(tail)
+        guard tailWords.first?.value == "resume",
+              AgentResumeArgv().subrouterCodexDummyAPIKeyEnvironmentAssignment(
+                  in: tailWords.map(\.value)
+              ) != nil else {
+            return nil
+        }
+        let prefix = String(command[..<wrapperRange.lowerBound])
+        let prefixWords = TerminalStartupWorkingDirectoryPrefix.shellWordRanges(prefix)
+        guard !prefixWords.contains(where: {
+            $0.value.hasPrefix("SUBROUTER_CODEX_DUMMY_API_KEY=")
+        }) else {
+            return nil
+        }
+        let hasEnvUtility = prefixWords.contains {
+            $0.value == "env" || $0.value == "/usr/bin/env"
+        }
+        let assignment = AgentResumeArgv.subrouterCodexDummyAPIKeyEnvironmentAssignment
+        let insertion = hasEnvUtility ? "\(assignment) " : "env \(assignment) "
+        var updated = command
+        updated.insert(contentsOf: insertion, at: wrapperRange.lowerBound)
+        return updated
+    }
+
+    private static func hasEnvironmentAssignment(
+        named name: String,
+        before index: Int,
+        words: [TerminalStartupWorkingDirectoryPrefix.ShellWordRange]
+    ) -> Bool {
+        words[..<index].contains { $0.value.hasPrefix(name + "=") }
+    }
+
     /// Inserts codex's per-invocation update-check suppression override into a
     /// persisted codex resume binding command that predates the override.
     ///

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -95,14 +95,18 @@ extension SurfaceResumeBindingSnapshot {
             in: startupCommand,
             kind: kind
         )
+        let credentialed = SurfaceResumeCommandCanonicalizer.insertingSubrouterCodexDummyAPIKey(
+            in: suppressed,
+            kind: kind
+        )
         guard repairPortableAgentExecutable else {
-            return suppressed
+            return credentialed
         }
         // Suppression insertion runs before executable repair: repair can wrap a
         // stale-executable command in `/bin/sh -c '…'`, whose single-word body no
         // longer parses as a codex resume argv.
         return SurfaceResumeCommandCanonicalizer.replacingPortableAgentExecutable(
-            in: suppressed,
+            in: credentialed,
             kind: kind
         )
     }

--- a/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
+++ b/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
@@ -49,6 +49,43 @@ import Testing
         )
     }
 
+    @Test func persistedSubrouterCodexBindingGainsDummyProviderCredentialOnReplay() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ] && '/opt/company/bin/codex' 'resume' 'subrouter-session' '-c' 'model_provider=\"subrouter\"' '-c' 'model_providers.subrouter.env_key=\"SUBROUTER_CODEX_DUMMY_API_KEY\"'",
+            cwd: "/tmp/repo",
+            checkpointId: "subrouter-session",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("&& env SUBROUTER_CODEX_DUMMY_API_KEY=subrouter '/opt/company/bin/codex' 'resume' 'subrouter-session'"),
+            "\(startupInput)"
+        )
+    }
+
+    @Test func persistedSubrouterCodexBindingKeepsExistingDummyProviderCredential() throws {
+        let command = "'env' 'SUBROUTER_CODEX_DUMMY_API_KEY=custom-value' '/opt/company/bin/codex' 'resume' 'subrouter-session' '-c' 'model_providers.subrouter.env_key=\"SUBROUTER_CODEX_DUMMY_API_KEY\"'"
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: command,
+            checkpointId: "subrouter-session",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("'env' 'SUBROUTER_CODEX_DUMMY_API_KEY=custom-value' '/opt/company/bin/codex'"),
+            "\(startupInput)"
+        )
+        #expect(!startupInput.contains("SUBROUTER_CODEX_DUMMY_API_KEY=subrouter"), "\(startupInput)")
+    }
+
     @Test func codexBindingWithExistingUpdateCheckSettingReplaysUnchanged() throws {
         let command = "'/opt/company/bin/codex' 'resume' 'session-explicit' '-c' 'check_for_update_on_startup=true'"
         let binding = SurfaceResumeBindingSnapshot(

--- a/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
+++ b/cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests.swift
@@ -86,6 +86,31 @@ import Testing
         #expect(!startupInput.contains("SUBROUTER_CODEX_DUMMY_API_KEY=subrouter"), "\(startupInput)")
     }
 
+    @Test func persistedWrappedSubrouterCodexBindingGainsDummyProviderCredential() throws {
+        let wrapped = AgentResumeArgv.portableCodexResumeShellCommand(
+            posixCommand: "\(AgentResumeArgv.codexWrapperShellExecutableToken) resume wrapped-subrouter-session -c 'model_providers.subrouter.env_key=\"SUBROUTER_CODEX_DUMMY_API_KEY\"'"
+        )
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "codex",
+            command: "cd -- '/tmp/repo' 2>/dev/null || [ ! -d '/tmp/repo' ] && \(wrapped)",
+            cwd: "/tmp/repo",
+            checkpointId: "wrapped-subrouter-session",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let startupInput = try #require(binding.startupInput)
+
+        #expect(
+            startupInput.contains("/bin/sh -c 'env SUBROUTER_CODEX_DUMMY_API_KEY=subrouter"),
+            "\(startupInput)"
+        )
+        #expect(
+            startupInput.contains("resume wrapped-subrouter-session"),
+            "\(startupInput)"
+        )
+    }
+
     @Test func codexBindingWithExistingUpdateCheckSettingReplaysUnchanged() throws {
         let command = "'/opt/company/bin/codex' 'resume' 'session-explicit' '-c' 'check_for_update_on_startup=true'"
         let binding = SurfaceResumeBindingSnapshot(


### PR DESCRIPTION
## Summary

- restore the non-secret Subrouter dummy provider credential when cmux generates a Codex resume command
- upgrade already-persisted direct, Codex Teams, and portable shell resume commands at replay time
- preserve explicit custom values and leave unrelated providers unchanged
- keep the regression proof in a test-only red commit followed by the green fix commit

## Testing

- `arch -arm64 swift test --package-path Packages/macOS/CMUXAgentLaunch --filter AgentResumeArgvTests`
- `arch -arm64 xcodebuild -project cmux.xcodeproj -scheme cmux-unit -configuration Debug -destination platform=macOS -derivedDataPath /tmp/cmux-subrouter-resume-tests test -only-testing:cmuxTests/SurfaceResumeBindingCodexUpdateCheckTests`
- `arch -arm64 /bin/bash ./scripts/reload.sh --tag fix-subrouter-codex-resume`
- package resolution policy, workspace package grouping, test wiring, and diff whitespace checks

## Demo Video

No visible UI change. The behavior is covered at the generated argv and persisted replay-command boundaries.

- Video URL or attachment: N/A

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally
- [x] I added or updated tests for behavior changes
- [x] I updated docs/changelog if needed
- [ ] I requested bot reviews after my latest commit
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved