### PR TITLE
Fix: cmux browser eval prints "false" for numeric 0

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -13106,10 +13106,10 @@ struct CMUXCLI {
             if let string = value as? String {
                 return string
             }
-            if let bool = value as? Bool {
-                return bool ? "true" : "false"
-            }
             if let number = value as? NSNumber {
+                if CFGetTypeID(number) == CFBooleanGetTypeID() {
+                    return number.boolValue ? "true" : "false"
+                }
                 return number.stringValue
             }
             if JSONSerialization.isValidJSONObject(value),

--- a/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
+++ b/cmuxTests/CLIExplicitSurfaceRoutingTests.swift
@@ -39,6 +39,14 @@ struct CLIExplicitSurfaceRoutingTests {
         )
     }
 
+    @Test func browserEvalPlainOutputPreservesNumericZero() throws {
+        try assertExplicitSurfaceCommand(
+            arguments: ["browser", Self.targetSurfaceRef, "eval", "0"],
+            expectedMethod: "browser.eval",
+            expectedStdout: "0\n"
+        )
+    }
+
     @Test func numericSurfaceHandleStillInheritsCallerWorkspaceForIndexResolution() throws {
         let socketPath = Self.makeSocketPath("numeric")
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
@@ -100,7 +108,8 @@ struct CLIExplicitSurfaceRoutingTests {
         arguments: [String],
         expectedMethod: String,
         expectedText: String? = nil,
-        expectedKey: String? = nil
+        expectedKey: String? = nil,
+        expectedStdout: String? = nil
     ) throws {
         let socketPath = Self.makeSocketPath(expectedMethod)
         let listenerFD = try Self.bindUnixSocket(at: socketPath)
@@ -121,6 +130,8 @@ struct CLIExplicitSurfaceRoutingTests {
                 return Self.v2Response(id: id, ok: true, result: ["text": "agent screen\n"])
             case "surface.send_text", "surface.send_key":
                 return Self.v2Response(id: id, ok: true, result: ["surface_id": Self.targetSurfaceRef])
+            case "browser.eval":
+                return Self.v2Response(id: id, ok: true, result: ["value": 0])
             default:
                 return Self.v2Response(
                     id: id,
@@ -141,6 +152,9 @@ struct CLIExplicitSurfaceRoutingTests {
         #expect(state.errorsSnapshot().isEmpty, Comment(rawValue: state.errorsSnapshot().joined(separator: "\n")))
         #expect(!result.timedOut, Comment(rawValue: result.stderr))
         #expect(result.status == 0, Comment(rawValue: result.stderr + result.stdout))
+        if let expectedStdout {
+            #expect(result.stdout == expectedStdout, Comment(rawValue: result.stdout))
+        }
 
         let requests = try state.requestObjects()
         #expect(requests.compactMap { $0["method"] as? String } == [expectedMethod])


### PR DESCRIPTION
`cmux browser eval '<js>'` printed `"false"` instead of `"0"` when the JS expression evaluated to the number `0` (e.g. `document.querySelectorAll(...).length` on an empty NodeList), making falsy numeric results look like boolean failures.

**Root cause:** the wire JSON was always correct — the bug was in the CLI's plain-text renderer (`displayBrowserValue`). Swift's `value as? Bool` succeeds for JSON-bridged `NSNumber` `0`/`1`, so the boolean branch swallowed numeric results before the `NSNumber` branch could render them.

**Fix:** distinguish booleans via `CFGetTypeID(number) == CFBooleanGetTypeID()` (the established idiom in this codebase, e.g. `safeV2DetailValue`, `JSONValue.swift`) instead of `as? Bool`.

| Wire value | Before | After |
|---|---|---|
| `0` | `false` | `0` |
| `1` | `true` | `1` |
| `false` / `true` | correct | unchanged |
| strings, null, arrays, dicts, undefined envelope | correct | unchanged |

## Testing

- Verified renderer behavior against real `JSONSerialization` wire values for `0`, `1`, `-1`, `0.5`, `false`, `true`, `null`, strings, nested containers, and the `__cmux_t: undefined` envelope
- No user-facing strings introduced (no localization impact)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8076"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786650797&installation_id=133855650&pr_number=8076&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8076&signature=9e702f46bab2755d22e3c9b2a6e5c4efab1ac3c82fd38429c8f1d512abe607eb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `cmux browser eval` printing "false" for numeric `0`. Numeric results now print as numbers (e.g., `0`, `1`), while booleans still print as `true`/`false`.

- **Bug Fixes**
  - Update plain-text renderer to detect `CFBoolean` via `CFGetTypeID` and render other `NSNumber` values with `stringValue`.
  - Add test to assert `browser eval` prints `0` when the wire value is `{"value": 0}`.

<sup>Written for commit 63fee0d29697ba5477bfecc4a900193e41637bba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8076?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected CLI handling of boolean values so they are consistently displayed as `true` or `false`.
  * Preserved numeric zero output for browser evaluation commands instead of converting it incorrectly.

* **Tests**
  * Added coverage to verify browser evaluation returns numeric zero exactly as expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->