### PR TITLE
iOS: smooth large-file artifact scrolling with TextKit 1 + progressive streaming

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Source/ChatEventSource.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Source/ChatEventSource.swift
@@ -97,7 +97,7 @@ public protocol ChatEventSource: Sendable {
     func artifactFetch(
         sessionID: String,
         path: String,
-        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
     ) async throws
 
     /// Fetches a JPEG thumbnail for a referenced image artifact.
@@ -147,7 +147,7 @@ public extension ChatEventSource {
     func artifactFetch(
         sessionID: String,
         path: String,
-        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
     ) async throws {
         let data = try await artifactFetch(sessionID: sessionID, path: path, progress: nil)
         try Task.checkCancellation()

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Source/ChatEventSource.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Source/ChatEventSource.swift
@@ -84,6 +84,22 @@ public protocol ChatEventSource: Sendable {
         progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?
     ) async throws -> Data
 
+    /// Streams raw chunks for a referenced artifact path.
+    ///
+    /// Implementations call `onChunk` in byte-offset order and await it before
+    /// requesting the next chunk, so cancellation and consumer backpressure
+    /// remain part of the fetch task.
+    ///
+    /// - Parameters:
+    ///   - sessionID: The session whose transcript referenced the path.
+    ///   - path: Absolute Mac host path.
+    ///   - onChunk: Structured callback for each fetched chunk.
+    func artifactFetch(
+        sessionID: String,
+        path: String,
+        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws
+
     /// Fetches a JPEG thumbnail for a referenced image artifact.
     ///
     /// - Parameters:
@@ -125,6 +141,24 @@ public extension ChatEventSource {
         progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)? = nil
     ) async throws -> Data {
         throw ChatArtifactError.unsupported
+    }
+
+    /// Whole-file fallback for sources that have not adopted chunk streaming.
+    func artifactFetch(
+        sessionID: String,
+        path: String,
+        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws {
+        let data = try await artifactFetch(sessionID: sessionID, path: path, progress: nil)
+        try Task.checkCancellation()
+        try await onChunk(
+            ChatArtifactChunk(
+                data: data,
+                offset: 0,
+                totalSize: Int64(data.count),
+                eof: true
+            )
+        )
     }
 
     /// Unsupported-by-default artifact thumbnail implementation.

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactDataAccumulator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactDataAccumulator.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Accumulates non-text artifact chunks away from the main actor.
+actor ChatArtifactDataAccumulator {
+    private var data = Data()
+
+    func append(_ chunk: Data, totalSize: Int64) {
+        if data.isEmpty, totalSize > 0, totalSize <= Int64(Int.max) {
+            data.reserveCapacity(Int(totalSize))
+        }
+        data.append(chunk)
+    }
+
+    func value() -> Data {
+        data
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLoader.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLoader.swift
@@ -86,10 +86,27 @@ public struct ChatArtifactLoader: Sendable {
         _ path: String,
         _ progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?
     ) async throws -> Data
+    private let streamHandler: @Sendable (
+        _ path: String,
+        _ onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws -> Void
     private let thumbnailHandler: @Sendable (_ path: String, _ maxDimension: Int) async throws -> ChatArtifactThumbnail
     private let listHandler: @Sendable (_ path: String) async throws -> ChatArtifactDirectoryListing
     private let thumbnailCache: ChatArtifactThumbnailCache
 
+    /// Creates a closure-backed artifact loader.
+    ///
+    /// - Parameters:
+    ///   - supportsArtifacts: Whether artifact operations are available.
+    ///   - supportsDirectoryBrowsing: Whether directory stat results may be listed.
+    ///   - scope: Cache and authorization namespace for this loader.
+    ///   - cache: Thumbnail cache shared by rows and viewers.
+    ///   - stat: Metadata operation for an absolute host path.
+    ///   - fetch: Whole-file operation retained for image and compatibility callers.
+    ///   - stream: Optional structured chunk operation; defaults to one callback
+    ///     containing the result of `fetch`.
+    ///   - thumbnail: Thumbnail operation for image artifacts.
+    ///   - list: Immediate-directory listing operation.
     public init(
         supportsArtifacts: Bool = false,
         supportsDirectoryBrowsing: Bool = false,
@@ -104,6 +121,10 @@ public struct ChatArtifactLoader: Sendable {
         ) async throws -> Data = { _, _ in
             throw ChatArtifactError.unsupported
         },
+        stream: (@Sendable (
+            _ path: String,
+            _ onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+        ) async throws -> Void)? = nil,
         thumbnail: @escaping @Sendable (_ path: String, _ maxDimension: Int) async throws -> ChatArtifactThumbnail = { _, _ in
             throw ChatArtifactError.unsupported
         },
@@ -117,6 +138,18 @@ public struct ChatArtifactLoader: Sendable {
         self.thumbnailCache = cache
         statHandler = stat
         fetchHandler = fetch
+        streamHandler = stream ?? { path, onChunk in
+            let data = try await fetch(path, nil)
+            try Task.checkCancellation()
+            try await onChunk(
+                ChatArtifactChunk(
+                    data: data,
+                    offset: 0,
+                    totalSize: Int64(data.count),
+                    eof: true
+                )
+            )
+        }
         thumbnailHandler = thumbnail
         listHandler = list
     }
@@ -137,6 +170,9 @@ public struct ChatArtifactLoader: Sendable {
             fetch: { path, progress in
                 try await source.artifactFetch(sessionID: sessionID, path: path, progress: progress)
             },
+            stream: { path, onChunk in
+                try await source.artifactFetch(sessionID: sessionID, path: path, onChunk: onChunk)
+            },
             thumbnail: { path, maxDimension in
                 try await source.artifactThumbnail(
                     sessionID: sessionID,
@@ -150,6 +186,19 @@ public struct ChatArtifactLoader: Sendable {
         )
     }
 
+    /// Creates a terminal-scoped closure-backed artifact loader.
+    ///
+    /// - Parameters:
+    ///   - terminalWorkspaceID: Workspace containing the terminal surface.
+    ///   - terminalSurfaceID: Terminal surface authorizing visible paths.
+    ///   - supportsArtifacts: Whether terminal artifact operations are available.
+    ///   - supportsDirectoryBrowsing: Whether terminal directory listing is available.
+    ///   - cache: Thumbnail cache shared by rows and viewers.
+    ///   - stat: Metadata operation for an absolute host path.
+    ///   - fetch: Whole-file compatibility operation.
+    ///   - stream: Optional structured chunk operation.
+    ///   - thumbnail: Thumbnail operation for image artifacts.
+    ///   - list: Immediate-directory listing operation.
     public init(
         terminalWorkspaceID: String,
         terminalSurfaceID: String,
@@ -161,6 +210,10 @@ public struct ChatArtifactLoader: Sendable {
             _ path: String,
             _ progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?
         ) async throws -> Data,
+        stream: (@Sendable (
+            _ path: String,
+            _ onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+        ) async throws -> Void)? = nil,
         thumbnail: @escaping @Sendable (_ path: String, _ maxDimension: Int) async throws -> ChatArtifactThumbnail,
         list: @escaping @Sendable (_ path: String) async throws -> ChatArtifactDirectoryListing = { _ in
             throw ChatArtifactError.unsupported
@@ -173,6 +226,7 @@ public struct ChatArtifactLoader: Sendable {
             cache: cache,
             stat: stat,
             fetch: fetch,
+            stream: stream,
             thumbnail: thumbnail,
             list: list
         )
@@ -191,6 +245,18 @@ public struct ChatArtifactLoader: Sendable {
         progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)? = nil
     ) async throws -> Data {
         try await fetchHandler(path, progress)
+    }
+
+    /// Streams artifact chunks without requiring a contiguous whole-file copy.
+    ///
+    /// - Parameters:
+    ///   - path: Absolute Mac host path.
+    ///   - onChunk: Structured callback awaited for each chunk in byte order.
+    public func stream(
+        path: String,
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws {
+        try await streamHandler(path, onChunk)
     }
 
     public func thumbnail(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -45,7 +45,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
             context.coordinator.handledBottomRequestID = bottomRequestID
         }
 
-        guard context.coordinator.appliedChunkCount <= chunks.count else {
+        if context.coordinator.appliedChunkCount > chunks.count {
             context.coordinator.appliedChunkCount = 0
             textView.textStorage.setAttributedString(NSAttributedString())
         }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -7,7 +7,12 @@ struct ChatArtifactTextView: UIViewRepresentable {
     let text: String
 
     func makeUIView(context: Context) -> UITextView {
-        let textView = UITextView()
+        // A default UITextView uses TextKit 2 on modern iOS. Large artifacts
+        // then synchronously create layout fragments during fast scrolling.
+        // Opt into the TextKit 1 stack so non-contiguous glyph layout remains
+        // genuinely lazy instead of entering TextKit 2 compatibility mode.
+        let textView = UITextView(usingTextLayoutManager: false)
+        textView.layoutManager.allowsNonContiguousLayout = true
         textView.isEditable = false
         textView.isSelectable = true
         textView.isScrollEnabled = true

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -6,6 +6,8 @@ import UIKit
 struct ChatArtifactTextView: UIViewRepresentable {
     let documentID: String
     let chunks: [String]
+    let topRequestID: Int
+    let bottomRequestID: Int
 
     func makeCoordinator() -> ChatArtifactTextViewCoordinator {
         ChatArtifactTextViewCoordinator()
@@ -39,6 +41,8 @@ struct ChatArtifactTextView: UIViewRepresentable {
             textView.selectedRange = NSRange(location: 0, length: 0)
             context.coordinator.documentID = documentID
             context.coordinator.appliedChunkCount = 0
+            context.coordinator.handledTopRequestID = topRequestID
+            context.coordinator.handledBottomRequestID = bottomRequestID
         }
 
         guard context.coordinator.appliedChunkCount <= chunks.count else {
@@ -68,14 +72,29 @@ struct ChatArtifactTextView: UIViewRepresentable {
         }
 
         if isNewDocument {
-            textView.setContentOffset(
-                CGPoint(
-                    x: -textView.adjustedContentInset.left,
-                    y: -textView.adjustedContentInset.top
-                ),
-                animated: false
-            )
+            Self.scrollToTop(textView)
+        } else {
+            if context.coordinator.handledTopRequestID != topRequestID {
+                context.coordinator.handledTopRequestID = topRequestID
+                Self.scrollToTop(textView)
+            }
+            if context.coordinator.handledBottomRequestID != bottomRequestID {
+                context.coordinator.handledBottomRequestID = bottomRequestID
+                textView.scrollRangeToVisible(
+                    NSRange(location: textView.textStorage.length, length: 0)
+                )
+            }
         }
+    }
+
+    private static func scrollToTop(_ textView: UITextView) {
+        textView.setContentOffset(
+            CGPoint(
+                x: -textView.adjustedContentInset.left,
+                y: -textView.adjustedContentInset.top
+            ),
+            animated: false
+        )
     }
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -4,7 +4,12 @@ import UIKit
 
 /// Displays large artifact text without asking SwiftUI to lay out one monolithic `Text` view.
 struct ChatArtifactTextView: UIViewRepresentable {
-    let text: String
+    let documentID: String
+    let chunks: [String]
+
+    func makeCoordinator() -> ChatArtifactTextViewCoordinator {
+        ChatArtifactTextViewCoordinator()
+    }
 
     func makeUIView(context: Context) -> UITextView {
         // A default UITextView uses TextKit 2 on modern iOS. Large artifacts
@@ -24,13 +29,53 @@ struct ChatArtifactTextView: UIViewRepresentable {
         )
         textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         textView.textContainer.lineFragmentPadding = 0
-        textView.text = text
         return textView
     }
 
     func updateUIView(_ textView: UITextView, context: Context) {
-        guard textView.text != text else { return }
-        textView.text = text
+        let isNewDocument = context.coordinator.documentID != documentID
+        if isNewDocument {
+            textView.textStorage.setAttributedString(NSAttributedString())
+            textView.selectedRange = NSRange(location: 0, length: 0)
+            context.coordinator.documentID = documentID
+            context.coordinator.appliedChunkCount = 0
+        }
+
+        guard context.coordinator.appliedChunkCount <= chunks.count else {
+            context.coordinator.appliedChunkCount = 0
+            textView.textStorage.setAttributedString(NSAttributedString())
+        }
+
+        let font = textView.font ?? UIFont.monospacedSystemFont(
+            ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize,
+            weight: .regular
+        )
+        let textColor = textView.textColor ?? UIColor.label
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: textColor,
+        ]
+        while context.coordinator.appliedChunkCount < chunks.count {
+            let chunk = chunks[context.coordinator.appliedChunkCount]
+            let contentOffset = textView.contentOffset
+            let selection = textView.selectedRange
+            textView.textStorage.beginEditing()
+            textView.textStorage.append(NSAttributedString(string: chunk, attributes: attributes))
+            textView.textStorage.endEditing()
+            textView.selectedRange = selection
+            textView.setContentOffset(contentOffset, animated: false)
+            context.coordinator.appliedChunkCount += 1
+        }
+
+        if isNewDocument {
+            textView.setContentOffset(
+                CGPoint(
+                    x: -textView.adjustedContentInset.left,
+                    y: -textView.adjustedContentInset.top
+                ),
+                animated: false
+            )
+        }
     }
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -1,0 +1,9 @@
+#if canImport(UIKit)
+import Foundation
+
+/// Tracks which streamed chunks have been applied to one text-storage instance.
+final class ChatArtifactTextViewCoordinator {
+    var documentID: String?
+    var appliedChunkCount = 0
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -5,5 +5,7 @@ import Foundation
 final class ChatArtifactTextViewCoordinator {
     var documentID: String?
     var appliedChunkCount = 0
+    var handledTopRequestID = 0
+    var handledBottomRequestID = 0
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -1,0 +1,145 @@
+import CmuxAgentChat
+import Foundation
+import Observation
+
+/// Main-actor state machine for one progressively loaded artifact path.
+@Observable
+@MainActor
+final class ChatArtifactViewerModel {
+    private(set) var state: ChatArtifactViewerState = .loading
+    private(set) var textChunks: [String] = []
+    private(set) var fetchedBytes: Int64 = 0
+    private(set) var totalBytes: Int64?
+    private(set) var textReachedEOF = false
+    private(set) var activePath: String?
+
+    var renderedText: String {
+        textChunks.joined()
+    }
+
+    func load(path: String, loader: ChatArtifactLoader) async {
+        reset(for: path)
+        var stat: ChatArtifactStat?
+        do {
+            let loadedStat = try await loader.stat(path: path)
+            try Task.checkCancellation()
+            guard path == activePath else { return }
+            stat = loadedStat
+
+            guard !loadedStat.isDirectory else {
+                state = loadedStat.showsFolder(
+                    supportsDirectoryBrowsing: loader.supportsDirectoryBrowsing
+                ) ? .folder : .binary(stat: loadedStat)
+                return
+            }
+
+            let limit = ChatArtifactTransferPolicy.defaultPolicy.maxPreviewBytes
+            guard loadedStat.size <= limit else {
+                state = .tooLarge(actualSize: loadedStat.size, limit: limit)
+                return
+            }
+
+            switch loadedStat.kind {
+            case .text:
+                try await streamText(path: path, loader: loader)
+            case .image, .binary, .directory:
+                try await loadNonText(path: path, stat: loadedStat, loader: loader)
+            }
+        } catch is CancellationError {
+            return
+        } catch is UTF8ChunkAssemblerError {
+            guard path == activePath, let stat else { return }
+            textChunks = []
+            state = .binary(stat: stat)
+        } catch {
+            guard !Task.isCancelled, path == activePath else { return }
+            state = Self.state(for: error, stat: stat)
+        }
+    }
+
+    private func reset(for path: String) {
+        activePath = path
+        state = .loading
+        textChunks = []
+        fetchedBytes = 0
+        totalBytes = nil
+        textReachedEOF = false
+    }
+
+    private func streamText(path: String, loader: ChatArtifactLoader) async throws {
+        let decoder = UTF8ChunkDecoder()
+        try await loader.stream(path: path) { chunk in
+            try Task.checkCancellation()
+            let decoded = try await decoder.decode(chunk.data, eof: chunk.eof)
+            try Task.checkCancellation()
+            await self.receiveText(decoded, chunk: chunk, path: path)
+        }
+    }
+
+    private func receiveText(_ text: String, chunk: ChatArtifactChunk, path: String) {
+        guard path == activePath else { return }
+        if !text.isEmpty {
+            textChunks.append(text)
+        }
+        updateProgress(for: chunk)
+        textReachedEOF = chunk.eof
+        state = .text
+    }
+
+    private func loadNonText(
+        path: String,
+        stat: ChatArtifactStat,
+        loader: ChatArtifactLoader
+    ) async throws {
+        let accumulator = ChatArtifactDataAccumulator()
+        try await loader.stream(path: path) { chunk in
+            try Task.checkCancellation()
+            await accumulator.append(chunk.data, totalSize: chunk.totalSize)
+            await self.receiveNonTextProgress(chunk: chunk, path: path)
+        }
+        try Task.checkCancellation()
+        guard path == activePath else { return }
+        let data = await accumulator.value()
+        switch stat.kind {
+        case .image:
+            state = .image(data: data)
+        case .text:
+            break
+        case .binary, .directory:
+            state = .binary(stat: stat)
+        }
+    }
+
+    private func receiveNonTextProgress(chunk: ChatArtifactChunk, path: String) {
+        guard path == activePath else { return }
+        updateProgress(for: chunk)
+    }
+
+    private func updateProgress(for chunk: ChatArtifactChunk) {
+        totalBytes = chunk.totalSize
+        fetchedBytes = chunk.eof
+            ? chunk.totalSize
+            : chunk.offset + Int64(chunk.data.count)
+    }
+
+    private static func state(
+        for error: any Error,
+        stat: ChatArtifactStat?
+    ) -> ChatArtifactViewerState {
+        guard let artifactError = error as? ChatArtifactError else {
+            return .macUnreachable
+        }
+        switch artifactError {
+        case .fileNotFound:
+            return .fileMissing
+        case .forbidden:
+            return .forbidden
+        case .macUnreachable, .unavailable, .unsupported, .sessionNotFound, .invalidParams:
+            return .macUnreachable
+        case .unsupportedMedia:
+            return .unsupportedMedia
+        case .tooLarge(let limitBytes):
+            return .tooLarge(actualSize: stat?.size, limit: limitBytes)
+        }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -16,6 +16,8 @@ struct ChatArtifactViewerRouteView: View {
     @Environment(\.chatArtifactLoader) private var loader
     @State private var model = ChatArtifactViewerModel()
     @State private var retryGeneration = 0
+    @State private var topRequestID = 0
+    @State private var bottomRequestID = 0
 
     var body: some View {
         content
@@ -29,6 +31,29 @@ struct ChatArtifactViewerRouteView: View {
                         onDone()
                     }
                 }
+                #if os(iOS)
+                if model.state == .text {
+                    ToolbarItemGroup(placement: .primaryAction) {
+                        Button {
+                            topRequestID += 1
+                        } label: {
+                            Label(
+                                String(
+                                    localized: "chat.artifact.jump.top",
+                                    defaultValue: "Top",
+                                    bundle: .module
+                                ),
+                                systemImage: "arrow.up.to.line"
+                            )
+                        }
+                        Button {
+                            bottomRequestID += 1
+                        } label: {
+                            Label(jumpToBottomTitle, systemImage: "arrow.down.to.line")
+                        }
+                    }
+                }
+                #endif
             }
             .task(id: "\(path)\u{0}\(retryGeneration)") {
                 await model.load(path: path, loader: loader)
@@ -77,7 +102,12 @@ struct ChatArtifactViewerRouteView: View {
                     streamingProgressHeader
                 }
                 #if canImport(UIKit)
-                ChatArtifactTextView(documentID: path, chunks: model.textChunks)
+                ChatArtifactTextView(
+                    documentID: path,
+                    chunks: model.textChunks,
+                    topRequestID: topRequestID,
+                    bottomRequestID: bottomRequestID
+                )
                 #else
                 ScrollView {
                     Text(model.renderedText)
@@ -203,6 +233,21 @@ struct ChatArtifactViewerRouteView: View {
 
     private var displayName: String {
         URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    private var jumpToBottomTitle: String {
+        if model.textReachedEOF {
+            return String(
+                localized: "chat.artifact.jump.end",
+                defaultValue: "End",
+                bundle: .module
+            )
+        }
+        return String(
+            localized: "chat.artifact.jump.bottom",
+            defaultValue: "Bottom",
+            bundle: .module
+        )
     }
 
     private var forbiddenMessage: String {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -14,7 +14,8 @@ struct ChatArtifactViewerRouteView: View {
     let onDone: () -> Void
 
     @Environment(\.chatArtifactLoader) private var loader
-    @State private var state: LoadState = .loading(fetched: 0, total: nil)
+    @State private var model = ChatArtifactViewerModel()
+    @State private var retryGeneration = 0
 
     var body: some View {
         content
@@ -29,26 +30,36 @@ struct ChatArtifactViewerRouteView: View {
                     }
                 }
             }
-            .task(id: path) {
-                await load()
+            .task(id: "\(path)\u{0}\(retryGeneration)") {
+                await model.load(path: path, loader: loader)
             }
     }
 
     @ViewBuilder
     private var content: some View {
-        switch state {
-        case .loading(let fetched, let total):
+        switch model.state {
+        case .loading:
             VStack(spacing: 12) {
-                ProgressView(value: progressValue(fetched: fetched, total: total))
-                    .progressViewStyle(.linear)
-                    .frame(maxWidth: 220)
+                ProgressView(
+                    value: progressValue(
+                        fetched: model.fetchedBytes,
+                        total: model.totalBytes
+                    )
+                )
+                .progressViewStyle(.linear)
+                .frame(maxWidth: 220)
                 Text(String(localized: "chat.artifact.loading", defaultValue: "Loading preview", bundle: .module))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                if fetched > 0 || total != nil {
-                    Text(verbatim: progressText(fetched: fetched, total: total))
-                        .font(.caption.monospacedDigit())
-                        .foregroundStyle(.tertiary)
+                if model.fetchedBytes > 0 || model.totalBytes != nil {
+                    Text(
+                        verbatim: progressText(
+                            fetched: model.fetchedBytes,
+                            total: model.totalBytes
+                        )
+                    )
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.tertiary)
                 }
             }
             .frame(maxWidth: .infinity, maxHeight: .infinity)
@@ -60,28 +71,33 @@ struct ChatArtifactViewerRouteView: View {
                 .scaledToFit()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding()
-        case .text(let text):
-            #if canImport(UIKit)
-            ChatArtifactTextView(text: text)
-            #else
-            ScrollView {
-                Text(text)
-                    .font(.system(.body, design: .monospaced))
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding()
+        case .text:
+            VStack(spacing: 0) {
+                if !model.textReachedEOF {
+                    streamingProgressHeader
+                }
+                #if canImport(UIKit)
+                ChatArtifactTextView(documentID: path, chunks: model.textChunks)
+                #else
+                ScrollView {
+                    Text(model.renderedText)
+                        .font(.system(.body, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .padding()
+                }
+                #endif
             }
-            #endif
         case .binary(let stat):
             unavailableView(
                 title: String(localized: "chat.artifact.preview_unavailable.title", defaultValue: "Preview unavailable", bundle: .module),
                 message: String(localized: "chat.artifact.preview_unavailable.message", defaultValue: "This file can't be previewed.", bundle: .module),
                 detail: formattedSize(stat.size)
             )
-        case .tooLarge(let limit):
+        case .tooLarge(let actualSize, let limit):
             unavailableView(
                 title: String(localized: "chat.artifact.too_large.title", defaultValue: "File too large to preview", bundle: .module),
-                message: tooLargeMessage(limit: limit)
+                message: tooLargeMessage(actualSize: actualSize, limit: limit)
             )
         case .unsupportedMedia:
             unavailableView(
@@ -110,49 +126,23 @@ struct ChatArtifactViewerRouteView: View {
         }
     }
 
-    private func load() async {
-        await MainActor.run {
-            state = .loading(fetched: 0, total: nil)
+    private var streamingProgressHeader: some View {
+        HStack(spacing: 10) {
+            ProgressView(
+                value: progressValue(
+                    fetched: model.fetchedBytes,
+                    total: model.totalBytes
+                )
+            )
+            .progressViewStyle(.linear)
+            Text(verbatim: progressText(fetched: model.fetchedBytes, total: model.totalBytes))
+                .font(.caption2.monospacedDigit())
+                .foregroundStyle(.secondary)
+                .fixedSize()
         }
-        do {
-            let stat = try await loader.stat(path: path)
-            guard !stat.isDirectory else {
-                await MainActor.run {
-                    state = stat.showsFolder(
-                        supportsDirectoryBrowsing: loader.supportsDirectoryBrowsing
-                    ) ? .folder : .binary(stat: stat)
-                }
-                return
-            }
-            guard stat.size <= ChatArtifactTransferPolicy.defaultPolicy.maxPreviewBytes else {
-                await MainActor.run {
-                    state = .tooLarge(limit: ChatArtifactTransferPolicy.defaultPolicy.maxPreviewBytes)
-                }
-                return
-            }
-            let data = try await loader.fetch(path: path) { fetched, total in
-                Task { @MainActor in
-                    state = .loading(fetched: fetched, total: total)
-                }
-            }
-            guard !Task.isCancelled else { return }
-            switch stat.kind {
-            case .image:
-                await MainActor.run { state = .image(data: data) }
-            case .text:
-                if let text = String(data: data, encoding: .utf8) {
-                    await MainActor.run { state = .text(text: text) }
-                } else {
-                    await MainActor.run { state = .binary(stat: stat) }
-                }
-            case .binary, .directory:
-                await MainActor.run { state = .binary(stat: stat) }
-            }
-        } catch {
-            await MainActor.run {
-                state = LoadState(error: error)
-            }
-        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 6)
+        .background(.bar)
     }
 
     private func unavailableView(
@@ -175,7 +165,7 @@ struct ChatArtifactViewerRouteView: View {
             }
             if retry {
                 Button {
-                    Task { await load() }
+                    retryGeneration += 1
                 } label: {
                     Label(
                         String(localized: "chat.artifact.retry", defaultValue: "Retry", bundle: .module),
@@ -248,45 +238,25 @@ struct ChatArtifactViewerRouteView: View {
         ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
     }
 
-    private func tooLargeMessage(limit: Int64) -> String {
+    private func tooLargeMessage(actualSize: Int64?, limit: Int64) -> String {
+        guard let actualSize else {
+            let format = String(
+                localized: "chat.artifact.too_large.limit_message",
+                defaultValue: "This preview is limited to %@.",
+                bundle: .module
+            )
+            return String.localizedStringWithFormat(format, formattedSize(limit))
+        }
         let format = String(
             localized: "chat.artifact.too_large.message",
-            defaultValue: "This preview is limited to %@.",
+            defaultValue: "This file is %@; previews are limited to %@.",
             bundle: .module
         )
-        return String.localizedStringWithFormat(format, formattedSize(limit))
-    }
-
-    private enum LoadState: Equatable {
-        case loading(fetched: Int64, total: Int64?)
-        case folder
-        case image(data: Data)
-        case text(text: String)
-        case binary(stat: ChatArtifactStat)
-        case tooLarge(limit: Int64)
-        case unsupportedMedia
-        case fileMissing
-        case macUnreachable
-        case forbidden
-
-        init(error: any Error) {
-            guard let artifactError = error as? ChatArtifactError else {
-                self = .macUnreachable
-                return
-            }
-            switch artifactError {
-            case .fileNotFound:
-                self = .fileMissing
-            case .forbidden:
-                self = .forbidden
-            case .macUnreachable, .unavailable, .unsupported, .sessionNotFound, .invalidParams:
-                self = .macUnreachable
-            case .unsupportedMedia:
-                self = .unsupportedMedia
-            case .tooLarge(let limitBytes):
-                self = .tooLarge(limit: limitBytes)
-            }
-        }
+        return String.localizedStringWithFormat(
+            format,
+            formattedSize(actualSize),
+            formattedSize(limit)
+        )
     }
 }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
@@ -1,0 +1,16 @@
+import CmuxAgentChat
+import Foundation
+
+/// Renderable states for one stat-driven artifact path.
+enum ChatArtifactViewerState: Equatable {
+    case loading
+    case folder
+    case image(data: Data)
+    case text
+    case binary(stat: ChatArtifactStat)
+    case tooLarge(actualSize: Int64?, limit: Int64)
+    case unsupportedMedia
+    case fileMissing
+    case macUnreachable
+    case forbidden
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkAssembler.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkAssembler.swift
@@ -1,0 +1,121 @@
+import Foundation
+
+/// Incrementally decodes UTF-8 while retaining only an incomplete trailing scalar.
+struct UTF8ChunkAssembler: Sendable {
+    private var pendingBytes = Data()
+
+    /// Appends raw bytes and returns the complete Unicode scalars now available.
+    ///
+    /// - Parameters:
+    ///   - data: The next contiguous bytes in the stream.
+    ///   - eof: Whether these are the final bytes in the stream.
+    /// - Returns: Decoded text excluding any buffered incomplete trailing scalar.
+    /// - Throws: ``UTF8ChunkAssemblerError/invalidEncoding`` for malformed UTF-8
+    ///   or an incomplete scalar at EOF.
+    mutating func append(_ data: Data, eof: Bool) throws -> String {
+        var bytes = [UInt8]()
+        bytes.reserveCapacity(pendingBytes.count + data.count)
+        bytes.append(contentsOf: pendingBytes)
+        bytes.append(contentsOf: data)
+        pendingBytes.removeAll(keepingCapacity: true)
+
+        var index = 0
+        var validEnd = bytes.count
+        while index < bytes.count {
+            let lead = bytes[index]
+            if lead <= 0x7F {
+                index += 1
+                continue
+            }
+
+            let scalarLength = try Self.scalarLength(for: lead)
+            let availableLength = bytes.count - index
+            if availableLength < scalarLength {
+                try Self.validateAvailableScalarPrefix(
+                    bytes,
+                    start: index,
+                    availableLength: availableLength
+                )
+                guard !eof else {
+                    throw UTF8ChunkAssemblerError.invalidEncoding
+                }
+                validEnd = index
+                pendingBytes.append(contentsOf: bytes[index...])
+                break
+            }
+
+            try Self.validateCompleteScalar(bytes, start: index, length: scalarLength)
+            index += scalarLength
+        }
+
+        guard validEnd > 0 else { return "" }
+        return String(decoding: bytes[..<validEnd], as: UTF8.self)
+    }
+
+    private static func scalarLength(for lead: UInt8) throws -> Int {
+        switch lead {
+        case 0xC2...0xDF:
+            return 2
+        case 0xE0...0xEF:
+            return 3
+        case 0xF0...0xF4:
+            return 4
+        default:
+            throw UTF8ChunkAssemblerError.invalidEncoding
+        }
+    }
+
+    private static func validateAvailableScalarPrefix(
+        _ bytes: [UInt8],
+        start: Int,
+        availableLength: Int
+    ) throws {
+        guard availableLength > 1 else { return }
+        try validateSecondByte(bytes[start + 1], lead: bytes[start])
+        if availableLength > 2 {
+            for offset in 2..<availableLength {
+                guard isContinuationByte(bytes[start + offset]) else {
+                    throw UTF8ChunkAssemblerError.invalidEncoding
+                }
+            }
+        }
+    }
+
+    private static func validateCompleteScalar(
+        _ bytes: [UInt8],
+        start: Int,
+        length: Int
+    ) throws {
+        try validateSecondByte(bytes[start + 1], lead: bytes[start])
+        if length > 2 {
+            for offset in 2..<length {
+                guard isContinuationByte(bytes[start + offset]) else {
+                    throw UTF8ChunkAssemblerError.invalidEncoding
+                }
+            }
+        }
+    }
+
+    private static func validateSecondByte(_ byte: UInt8, lead: UInt8) throws {
+        let isValid: Bool
+        switch lead {
+        case 0xE0:
+            isValid = (0xA0...0xBF).contains(byte)
+        case 0xED:
+            isValid = (0x80...0x9F).contains(byte)
+        case 0xF0:
+            isValid = (0x90...0xBF).contains(byte)
+        case 0xF4:
+            isValid = (0x80...0x8F).contains(byte)
+        default:
+            isValid = isContinuationByte(byte)
+        }
+        guard isValid else {
+            throw UTF8ChunkAssemblerError.invalidEncoding
+        }
+    }
+
+    private static func isContinuationByte(_ byte: UInt8) -> Bool {
+        (0x80...0xBF).contains(byte)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkAssemblerError.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkAssemblerError.swift
@@ -1,0 +1,4 @@
+/// A byte stream cannot be assembled into valid UTF-8 text.
+enum UTF8ChunkAssemblerError: Error, Equatable {
+    case invalidEncoding
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkDecoder.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkDecoder.swift
@@ -1,0 +1,11 @@
+import Foundation
+
+/// Owns one UTF-8 assembler while an artifact stream crosses actor boundaries.
+actor UTF8ChunkDecoder {
+    private var assembler = UTF8ChunkAssembler()
+
+    /// Decodes the next raw chunk without moving byte scanning onto the main actor.
+    func decode(_ data: Data, eof: Bool) throws -> String {
+        try assembler.append(data, eof: eof)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -205,6 +205,57 @@
         }
       }
     },
+    "chat.artifact.jump.bottom" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Bottom"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "下端"
+          }
+        }
+      }
+    },
+    "chat.artifact.jump.end" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "End"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "末尾"
+          }
+        }
+      }
+    },
+    "chat.artifact.jump.top" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Top"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "先頭"
+          }
+        }
+      }
+    },
     "chat.artifact.loading" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -324,7 +324,7 @@
         }
       }
     },
-    "chat.artifact.too_large.message" : {
+    "chat.artifact.too_large.limit_message" : {
       "extractionState" : "manual",
       "localizations" : {
         "en" : {
@@ -337,6 +337,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "このプレビューの上限は%@です。"
+          }
+        }
+      }
+    },
+    "chat.artifact.too_large.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This file is %@; previews are limited to %@."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このファイルのサイズは%@です。プレビューの上限は%@です。"
           }
         }
       }

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
@@ -1,0 +1,156 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite
+struct ChatArtifactViewerModelTests {
+    @Test
+    @MainActor
+    func exposesFirstChunkBeforeEOFAndCompletesProgress() async throws {
+        let firstData = Data("first 漢".utf8)
+        let lastData = Data("🙂 last".utf8)
+        let totalSize = Int64(firstData.count + lastData.count)
+        let stream = ControlledArtifactStream(chunks: [
+            ChatArtifactChunk(
+                data: firstData,
+                offset: 0,
+                totalSize: totalSize,
+                eof: false
+            ),
+            ChatArtifactChunk(
+                data: lastData,
+                offset: Int64(firstData.count),
+                totalSize: totalSize,
+                eof: true
+            ),
+        ])
+        let loader = Self.loader(totalSize: totalSize) { _, onChunk in
+            try await stream.fetch(onChunk: onChunk)
+        }
+        let model = ChatArtifactViewerModel()
+
+        let loadTask = Task {
+            await model.load(path: "/tmp/progressive.txt", loader: loader)
+        }
+        await stream.waitUntilFirstChunkDelivered()
+
+        #expect(model.state == .text)
+        #expect(model.renderedText == "first 漢")
+        #expect(!model.textReachedEOF)
+        #expect(model.fetchedBytes == Int64(firstData.count))
+        #expect(model.totalBytes == totalSize)
+
+        await stream.resume()
+        await loadTask.value
+
+        #expect(model.renderedText == "first 漢🙂 last")
+        #expect(model.textReachedEOF)
+        #expect(model.fetchedBytes == totalSize)
+        #expect(model.totalBytes == totalSize)
+    }
+
+    @Test
+    @MainActor
+    func pathChangeCancellationStopsThePreviousStream() async {
+        let firstPathData = Data("old".utf8)
+        let staleData = Data(" stale".utf8)
+        let staleTotalSize = Int64(firstPathData.count + staleData.count)
+        let blockedStream = ControlledArtifactStream(chunks: [
+            ChatArtifactChunk(
+                data: firstPathData,
+                offset: 0,
+                totalSize: staleTotalSize,
+                eof: false
+            ),
+            ChatArtifactChunk(
+                data: staleData,
+                offset: Int64(firstPathData.count),
+                totalSize: staleTotalSize,
+                eof: true
+            ),
+        ])
+        let newData = Data("new path".utf8)
+        let loader = Self.loader(totalSize: Int64(newData.count)) { path, onChunk in
+            if path == "/tmp/old.txt" {
+                try await blockedStream.fetch(onChunk: onChunk)
+                return
+            }
+            try await onChunk(
+                ChatArtifactChunk(
+                    data: newData,
+                    offset: 0,
+                    totalSize: Int64(newData.count),
+                    eof: true
+                )
+            )
+        }
+        let model = ChatArtifactViewerModel()
+
+        let oldTask = Task {
+            await model.load(path: "/tmp/old.txt", loader: loader)
+        }
+        await blockedStream.waitUntilFirstChunkDelivered()
+        oldTask.cancel()
+        let newTask = Task {
+            await model.load(path: "/tmp/new.txt", loader: loader)
+        }
+
+        await blockedStream.waitUntilCancelled()
+        await oldTask.value
+        await newTask.value
+
+        #expect(model.activePath == "/tmp/new.txt")
+        #expect(model.renderedText == "new path")
+        #expect(model.textReachedEOF)
+    }
+
+    @Test
+    @MainActor
+    func tooLargeStateRetainsActualFileSize() async {
+        let limit = ChatArtifactTransferPolicy.defaultPolicy.maxPreviewBytes
+        let actualSize = limit + 42
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: actualSize,
+                    modifiedAt: Date(timeIntervalSince1970: 0),
+                    kind: .text,
+                    mimeType: "text/plain"
+                )
+            }
+        )
+        let model = ChatArtifactViewerModel()
+
+        await model.load(path: "/tmp/too-large.txt", loader: loader)
+
+        #expect(model.state == .tooLarge(actualSize: actualSize, limit: limit))
+    }
+
+    private static func loader(
+        totalSize: Int64,
+        stream: @escaping @Sendable (
+            _ path: String,
+            _ onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+        ) async throws -> Void
+    ) -> ChatArtifactLoader {
+        ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: totalSize,
+                    modifiedAt: Date(timeIntervalSince1970: 0),
+                    kind: .text,
+                    mimeType: "text/plain"
+                )
+            },
+            stream: stream
+        )
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ControlledArtifactStream.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ControlledArtifactStream.swift
@@ -1,0 +1,78 @@
+import CmuxAgentChat
+import Foundation
+
+/// Suspends after its first chunk so viewer tests can inspect and cancel mid-stream.
+actor ControlledArtifactStream {
+    private let chunks: [ChatArtifactChunk]
+    private let resumeStream: AsyncStream<Void>
+    private let resumeContinuation: AsyncStream<Void>.Continuation
+    private var firstChunkDelivered = false
+    private var cancelled = false
+    private var firstChunkWaiters: [CheckedContinuation<Void, Never>] = []
+    private var cancellationWaiters: [CheckedContinuation<Void, Never>] = []
+
+    init(chunks: [ChatArtifactChunk]) {
+        self.chunks = chunks
+        let pair = AsyncStream<Void>.makeStream()
+        resumeStream = pair.stream
+        resumeContinuation = pair.continuation
+    }
+
+    func fetch(
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws {
+        defer {
+            if Task.isCancelled {
+                markCancelled()
+            }
+        }
+
+        for (index, chunk) in chunks.enumerated() {
+            try await onChunk(chunk)
+            if index == chunks.startIndex {
+                markFirstChunkDelivered()
+            }
+            if index == chunks.startIndex, chunks.count > 1 {
+                var iterator = resumeStream.makeAsyncIterator()
+                _ = await iterator.next()
+                try Task.checkCancellation()
+            }
+        }
+    }
+
+    func resume() {
+        resumeContinuation.yield()
+    }
+
+    func waitUntilFirstChunkDelivered() async {
+        guard !firstChunkDelivered else { return }
+        await withCheckedContinuation { continuation in
+            firstChunkWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilCancelled() async {
+        guard !cancelled else { return }
+        await withCheckedContinuation { continuation in
+            cancellationWaiters.append(continuation)
+        }
+    }
+
+    private func markFirstChunkDelivered() {
+        firstChunkDelivered = true
+        let waiters = firstChunkWaiters
+        firstChunkWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+
+    private func markCancelled() {
+        cancelled = true
+        let waiters = cancellationWaiters
+        cancellationWaiters.removeAll()
+        for waiter in waiters {
+            waiter.resume()
+        }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/UTF8ChunkAssemblerTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/UTF8ChunkAssemblerTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite
+struct UTF8ChunkAssemblerTests {
+    @Test
+    func preservesCJKAndEmojiAcrossEveryByteBoundary() throws {
+        let expected = "start 漢字🙂終わり end"
+        let data = Data(expected.utf8)
+
+        for boundary in 1..<data.count {
+            var assembler = UTF8ChunkAssembler()
+            let first = try assembler.append(data.prefix(boundary), eof: false)
+            let second = try assembler.append(data.dropFirst(boundary), eof: true)
+            #expect(first + second == expected, "failed at byte boundary \(boundary)")
+        }
+    }
+
+    @Test
+    func assemblesOneByteChunks() throws {
+        let expected = "漢🙂字"
+        let bytes = Array(expected.utf8)
+        var assembler = UTF8ChunkAssembler()
+        var result = ""
+
+        for (index, byte) in bytes.enumerated() {
+            result += try assembler.append(
+                Data([byte]),
+                eof: index == bytes.index(before: bytes.endIndex)
+            )
+        }
+
+        #expect(result == expected)
+    }
+
+    @Test
+    func rejectsIncompleteScalarAtEOF() {
+        var assembler = UTF8ChunkAssembler()
+
+        #expect(throws: UTF8ChunkAssemblerError.invalidEncoding) {
+            try assembler.append(Data([0xF0, 0x9F, 0x99]), eof: true)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileArtifactChunkFetchLoop.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileArtifactChunkFetchLoop.swift
@@ -1,0 +1,44 @@
+internal import CmuxAgentChat
+internal import Foundation
+
+/// Runs the offset-driven artifact fetch protocol for chat and terminal scopes.
+struct MobileArtifactChunkFetchLoop: Sendable {
+    /// Fetches chunks in sequence until EOF while preserving consumer backpressure.
+    ///
+    /// - Parameters:
+    ///   - collectsData: Whether to return a contiguous copy of all chunk data.
+    ///   - progress: Optional byte-progress callback.
+    ///   - fetchChunk: Fetches the chunk beginning at the requested byte offset.
+    ///   - onChunk: Optionally consumes each response before the next request begins.
+    /// - Returns: All fetched bytes when `collectsData` is true; otherwise empty data.
+    func run(
+        collectsData: Bool,
+        progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?,
+        fetchChunk: @Sendable (_ offset: Int64) async throws -> ChatArtifactChunk,
+        onChunk: (@Sendable (_ chunk: ChatArtifactChunk) async throws -> Void)?
+    ) async throws -> Data {
+        var offset: Int64 = 0
+        var result = Data()
+        while true {
+            try Task.checkCancellation()
+            let chunk = try await fetchChunk(offset)
+            try Task.checkCancellation()
+
+            if collectsData {
+                if result.isEmpty, chunk.totalSize > 0, chunk.totalSize <= Int64(Int.max) {
+                    result.reserveCapacity(Int(chunk.totalSize))
+                }
+                result.append(chunk.data)
+            }
+            offset = chunk.offset + Int64(chunk.data.count)
+            progress?(offset, chunk.totalSize)
+            try await onChunk?(chunk)
+            if chunk.eof {
+                return result
+            }
+            guard !chunk.data.isEmpty else {
+                throw ChatArtifactError.macUnreachable
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileArtifactChunkFetchLoop.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileArtifactChunkFetchLoop.swift
@@ -15,7 +15,7 @@ struct MobileArtifactChunkFetchLoop: Sendable {
         collectsData: Bool,
         progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?,
         fetchChunk: @Sendable (_ offset: Int64) async throws -> ChatArtifactChunk,
-        onChunk: (@Sendable (_ chunk: ChatArtifactChunk) async throws -> Void)?
+        onChunk: @Sendable (_ chunk: ChatArtifactChunk) async throws -> Void
     ) async throws -> Data {
         var offset: Int64 = 0
         var result = Data()
@@ -32,7 +32,7 @@ struct MobileArtifactChunkFetchLoop: Sendable {
             }
             offset = chunk.offset + Int64(chunk.data.count)
             progress?(offset, chunk.totalSize)
-            try await onChunk?(chunk)
+            try await onChunk(chunk)
             if chunk.eof {
                 return result
             }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource+TerminalArtifacts.swift
@@ -69,7 +69,7 @@ extension MobileChatEventSource {
             ],
             collectsData: true,
             progress: progress,
-            onChunk: nil
+            onChunk: { _ in }
         )
     }
 
@@ -84,7 +84,7 @@ extension MobileChatEventSource {
         workspaceID: String,
         surfaceID: String,
         path: String,
-        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
     ) async throws {
         _ = try await fetchArtifactChunks(
             method: "mobile.terminal.artifact.fetch",

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource+TerminalArtifacts.swift
@@ -60,32 +60,43 @@ extension MobileChatEventSource {
         path: String,
         progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?
     ) async throws -> Data {
-        var offset: Int64 = 0
-        var result = Data()
-        while true {
-            let chunk: ChatArtifactChunk = try await artifactCall(
-                method: "mobile.terminal.artifact.fetch",
-                params: [
-                    "workspace_id": workspaceID,
-                    "surface_id": surfaceID,
-                    "path": path,
-                    "offset": offset,
-                    "length": ChatArtifactTransferPolicy.defaultPolicy.maxRawChunkBytes,
-                ]
-            )
-            if result.isEmpty, chunk.totalSize > 0, chunk.totalSize <= Int64(Int.max) {
-                result.reserveCapacity(Int(chunk.totalSize))
-            }
-            result.append(chunk.data)
-            offset = chunk.offset + Int64(chunk.data.count)
-            progress?(offset, chunk.totalSize)
-            if chunk.eof {
-                return result
-            }
-            guard !chunk.data.isEmpty else {
-                throw ChatArtifactError.macUnreachable
-            }
-        }
+        try await fetchArtifactChunks(
+            method: "mobile.terminal.artifact.fetch",
+            stringParams: [
+                "workspace_id": workspaceID,
+                "surface_id": surfaceID,
+                "path": path,
+            ],
+            collectsData: true,
+            progress: progress,
+            onChunk: nil
+        )
+    }
+
+    /// Streams terminal-scoped artifact chunks without accumulating a second copy.
+    ///
+    /// - Parameters:
+    ///   - workspaceID: Workspace containing the terminal surface.
+    ///   - surfaceID: Terminal surface whose visible paths authorize the fetch.
+    ///   - path: Absolute Mac host path.
+    ///   - onChunk: Structured callback for each fetched chunk.
+    public func terminalArtifactFetch(
+        workspaceID: String,
+        surfaceID: String,
+        path: String,
+        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws {
+        _ = try await fetchArtifactChunks(
+            method: "mobile.terminal.artifact.fetch",
+            stringParams: [
+                "workspace_id": workspaceID,
+                "surface_id": surfaceID,
+                "path": path,
+            ],
+            collectsData: false,
+            progress: nil,
+            onChunk: onChunk
+        )
     }
 
     public func terminalArtifactThumbnail(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
@@ -262,31 +262,27 @@ public actor MobileChatEventSource: ChatEventSource {
         path: String,
         progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?
     ) async throws -> Data {
-        var offset: Int64 = 0
-        var result = Data()
-        while true {
-            let chunk: ChatArtifactChunk = try await artifactCall(
-                method: "mobile.chat.artifact.fetch",
-                params: [
-                    "session_id": sessionID,
-                    "path": path,
-                    "offset": offset,
-                    "length": ChatArtifactTransferPolicy.defaultPolicy.maxRawChunkBytes,
-                ]
-            )
-            if result.isEmpty, chunk.totalSize > 0, chunk.totalSize <= Int64(Int.max) {
-                result.reserveCapacity(Int(chunk.totalSize))
-            }
-            result.append(chunk.data)
-            offset = chunk.offset + Int64(chunk.data.count)
-            progress?(offset, chunk.totalSize)
-            if chunk.eof {
-                return result
-            }
-            guard !chunk.data.isEmpty else {
-                throw ChatArtifactError.macUnreachable
-            }
-        }
+        try await fetchArtifactChunks(
+            method: "mobile.chat.artifact.fetch",
+            stringParams: ["session_id": sessionID, "path": path],
+            collectsData: true,
+            progress: progress,
+            onChunk: nil
+        )
+    }
+
+    public func artifactFetch(
+        sessionID: String,
+        path: String,
+        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws {
+        _ = try await fetchArtifactChunks(
+            method: "mobile.chat.artifact.fetch",
+            stringParams: ["session_id": sessionID, "path": path],
+            collectsData: false,
+            progress: nil,
+            onChunk: onChunk
+        )
     }
 
     public func artifactThumbnail(
@@ -361,6 +357,27 @@ public actor MobileChatEventSource: ChatEventSource {
             return try coding.decode(T.self, from: result)
         } catch {
             throw Self.artifactError(from: error)
+        }
+    }
+
+    func fetchArtifactChunks(
+        method: String,
+        stringParams: [String: String],
+        collectsData: Bool,
+        progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?,
+        onChunk: (@Sendable (ChatArtifactChunk) async throws -> Void)?
+    ) async throws -> Data {
+        let loop = MobileArtifactChunkFetchLoop()
+        return try await loop.run(
+            collectsData: collectsData,
+            progress: progress
+        ) { offset in
+            var params: [String: Any] = stringParams
+            params["offset"] = offset
+            params["length"] = ChatArtifactTransferPolicy.defaultPolicy.maxRawChunkBytes
+            return try await self.artifactCall(method: method, params: params)
+        } onChunk: { chunk in
+            try await onChunk?(chunk)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileChatEventSource.swift
@@ -267,14 +267,14 @@ public actor MobileChatEventSource: ChatEventSource {
             stringParams: ["session_id": sessionID, "path": path],
             collectsData: true,
             progress: progress,
-            onChunk: nil
+            onChunk: { _ in }
         )
     }
 
     public func artifactFetch(
         sessionID: String,
         path: String,
-        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
     ) async throws {
         _ = try await fetchArtifactChunks(
             method: "mobile.chat.artifact.fetch",
@@ -365,7 +365,7 @@ public actor MobileChatEventSource: ChatEventSource {
         stringParams: [String: String],
         collectsData: Bool,
         progress: (@Sendable (_ fetchedBytes: Int64, _ totalBytes: Int64) -> Void)?,
-        onChunk: (@Sendable (ChatArtifactChunk) async throws -> Void)?
+        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
     ) async throws -> Data {
         let loop = MobileArtifactChunkFetchLoop()
         return try await loop.run(
@@ -377,7 +377,7 @@ public actor MobileChatEventSource: ChatEventSource {
             params["length"] = ChatArtifactTransferPolicy.defaultPolicy.maxRawChunkBytes
             return try await self.artifactCall(method: method, params: params)
         } onChunk: { chunk in
-            try await onChunk?(chunk)
+            try await onChunk(chunk)
         }
     }
 

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactChunkFetchLoopTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactChunkFetchLoopTests.swift
@@ -1,0 +1,93 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxMobileShell
+
+@Suite
+struct MobileArtifactChunkFetchLoopTests {
+    @Test
+    func sequencesOffsetsAndStopsAtEOF() async throws {
+        let first = ChatArtifactChunk(
+            data: Data("abc".utf8),
+            offset: 0,
+            totalSize: 5,
+            eof: false
+        )
+        let last = ChatArtifactChunk(
+            data: Data("de".utf8),
+            offset: 3,
+            totalSize: 5,
+            eof: true
+        )
+        let script = MobileArtifactChunkScript(chunks: [first, last])
+
+        _ = try await MobileArtifactChunkFetchLoop().run(
+            collectsData: false,
+            progress: nil
+        ) { offset in
+            try await script.fetch(offset: offset)
+        } onChunk: { chunk in
+            await script.record(chunk)
+        }
+
+        let snapshot = await script.snapshot()
+        #expect(snapshot.requestedOffsets == [0, 3])
+        #expect(snapshot.deliveredChunks == [first, last])
+    }
+
+    @Test
+    func acceptsEmptyEOFChunk() async throws {
+        let emptyEOF = ChatArtifactChunk(
+            data: Data(),
+            offset: 0,
+            totalSize: 0,
+            eof: true
+        )
+        let script = MobileArtifactChunkScript(chunks: [emptyEOF])
+
+        _ = try await MobileArtifactChunkFetchLoop().run(
+            collectsData: false,
+            progress: nil
+        ) { offset in
+            try await script.fetch(offset: offset)
+        } onChunk: { chunk in
+            await script.record(chunk)
+        }
+
+        let snapshot = await script.snapshot()
+        #expect(snapshot.requestedOffsets == [0])
+        #expect(snapshot.deliveredChunks == [emptyEOF])
+    }
+
+    @Test
+    func rejectsEmptyNonEOFChunkAsMacUnreachable() async {
+        let stalled = ChatArtifactChunk(
+            data: Data(),
+            offset: 0,
+            totalSize: 8,
+            eof: false
+        )
+        let script = MobileArtifactChunkScript(chunks: [stalled])
+
+        do {
+            _ = try await MobileArtifactChunkFetchLoop().run(
+                collectsData: false,
+                progress: nil
+            ) { offset in
+                try await script.fetch(offset: offset)
+            } onChunk: { chunk in
+                await script.record(chunk)
+            }
+            Issue.record("empty non-EOF chunk should fail")
+        } catch let error as ChatArtifactError {
+            #expect(error == .macUnreachable)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        let snapshot = await script.snapshot()
+        #expect(snapshot.requestedOffsets == [0])
+        #expect(snapshot.deliveredChunks == [stalled])
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactChunkScript.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileArtifactChunkScript.swift
@@ -1,0 +1,29 @@
+import CmuxAgentChat
+import Foundation
+
+/// Deterministic chunk source and delivery recorder for fetch-loop tests.
+actor MobileArtifactChunkScript {
+    private let chunksByOffset: [Int64: ChatArtifactChunk]
+    private var requestedOffsets: [Int64] = []
+    private var deliveredChunks: [ChatArtifactChunk] = []
+
+    init(chunks: [ChatArtifactChunk]) {
+        chunksByOffset = Dictionary(uniqueKeysWithValues: chunks.map { ($0.offset, $0) })
+    }
+
+    func fetch(offset: Int64) throws -> ChatArtifactChunk {
+        requestedOffsets.append(offset)
+        guard let chunk = chunksByOffset[offset] else {
+            throw ChatArtifactError.fileNotFound
+        }
+        return chunk
+    }
+
+    func record(_ chunk: ChatArtifactChunk) {
+        deliveredChunks.append(chunk)
+    }
+
+    func snapshot() -> (requestedOffsets: [Int64], deliveredChunks: [ChatArtifactChunk]) {
+        (requestedOffsets, deliveredChunks)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -310,6 +310,14 @@ struct WorkspaceDetailView: View {
                     progress: progress
                 )
             },
+            stream: { path, onChunk in
+                try await source.terminalArtifactFetch(
+                    workspaceID: workspaceID,
+                    surfaceID: surfaceID,
+                    path: path,
+                    onChunk: onChunk
+                )
+            },
             thumbnail: { path, maxDimension in
                 try await source.terminalArtifactThumbnail(
                     workspaceID: workspaceID,


### PR DESCRIPTION
Scrolling a multi-MB text artifact hitched badly: the viewer wrapped a bare `UITextView` (TextKit 2), assigned the entire file as one string, and only rendered after the whole file had been fetched over chunked RPC, so a 20 MB log meant a long spinner followed by main-thread fragment layout on every fast fling.

The text view now opts into an explicit TextKit 1 stack (`UITextView(usingTextLayoutManager: false)` with `allowsNonContiguousLayout`), porting the fix that resolved the identical hang class in macOS File Preview (https://github.com/manaflow-ai/cmux/issues/4576). The viewer streams: the first 3 MiB chunk renders immediately and later chunks append as bounded `NSTextStorage` edits that restore selection and content offset, so the viewport never moves while loading; a header progress indicator tracks bytes. UTF-8 decoding buffers trailing partial scalars at chunk edges (tested across every byte split of mixed CJK/emoji content). The two duplicated chunked-fetch loops merged into one shared loop with structured cancellation owned by the view lifecycle, replacing the uncancelled progress-tick Tasks from https://github.com/manaflow-ai/cmux/issues/8044. Text files gain jump-to-top/bottom controls; End activates once the tail has streamed. The 64 MiB text cap stays and its message now states the file's actual size.

Tests: CmuxAgentChatUI 51 (first-chunk visibility, EOF progress, path-change cancellation, cap state), CmuxMobileShell 484 (shared loop sequencing/EOF/failure), UTF-8 boundary matrix. Both packages compile clean for the iOS simulator triple (`swift build --sdk <iphonesimulator> --triple arm64-apple-ios18.0-simulator`), which caught a guard fall-through in the UIKit-gated view that host `swift test` cannot compile.

Part 3 of the chip-files-gallery completion stack, based on https://github.com/manaflow-ai/cmux/pull/8086.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8088"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786655522&installation_id=133855650&pr_number=8088&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8088&signature=4ff6ba72b56baed719f1076acbc81dab76faa7043f2f864b36f685065c533a07"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Smooth, fast loading for large text artifacts on iOS by switching to TextKit 1 and streaming file chunks progressively. First bytes render immediately, scrolling stays responsive, and users can jump to top/bottom while a progress header tracks load.

- **New Features**
  - Streamed artifact API: added `artifactFetch(...onChunk:)` to `ChatEventSource` (with whole‑file fallback), terminal `terminalArtifactFetch(...)`, `ChatArtifactLoader.stream(...)` (chat and terminal), and wired terminal streaming in `WorkspaceDetailView`.
  - Progressive text viewing: `ChatArtifactViewerModel` streams UTF‑8 safely, renders the first chunk right away, shows a progress header, and adds Top/Bottom/End controls. Too‑large message now includes the actual file size; 64 MiB cap unchanged. Non‑text artifacts stream without extra copies via an off‑main accumulator.

- **Refactors**
  - Shared chunk fetch loop in `CmuxMobileShell` with backpressure and structured cancellation; used by chat and terminal to replace duplicated loops. Progress now comes from this loop.
  - TextKit 1 rendering: `ChatArtifactTextView` opts into TextKit 1 with `allowsNonContiguousLayout` and preserves selection/offset while appending chunks.
  - Fixed guard fall‑through in iOS text chunk reset; added focused tests for streaming flow, UTF‑8 boundaries, progress/cancellation, and loop behavior across `CmuxAgentChatUI` and `CmuxMobileShell`.

<sup>Written for commit 9b528050a53a22a7a457ca7d0dee3f9ac773a4f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8088?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

