### PR TITLE
iOS: preview PDFs, media, documents, and Markdown artifacts

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactByteReader.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ArtifactByteReader.swift
@@ -9,6 +9,7 @@ import UniformTypeIdentifiers
 public struct ArtifactByteReader: Sendable {
     /// Maximum immediate children returned by one directory-list request.
     public static let maximumDirectoryEntryCount = 500
+    private static let utf8SniffByteCount = 8 * 1024
 
     /// Filesystem/decoder failures surfaced by artifact RPC handlers.
     public enum Error: Swift.Error, Sendable {
@@ -131,17 +132,93 @@ public struct ArtifactByteReader: Sendable {
         )
     }
 
-    /// Infers preview category from a path extension and directory flag.
+    /// Infers preview category from a path extension and a bounded UTF-8 sniff.
     public func kind(path: String, isDirectory: Bool) -> ChatArtifactKind {
         if isDirectory { return .directory }
-        guard let type = UTType(filenameExtension: URL(fileURLWithPath: path).pathExtension) else {
-            return .binary
+        let fileExtension = URL(fileURLWithPath: path).pathExtension
+        let type = fileExtension.isEmpty ? nil : UTType(filenameExtension: fileExtension)
+        guard let type, !type.isDynamic else {
+            return isUTF8Text(path: path) ? .text : .binary
         }
         if type.conforms(to: .image) { return .image }
         if type.conforms(to: .text) || type.conforms(to: .sourceCode) || type.conforms(to: .json) {
             return .text
         }
         return .binary
+    }
+
+    private func isUTF8Text(path: String) -> Bool {
+        guard let handle = FileHandle(forReadingAtPath: path) else {
+            return false
+        }
+        defer { try? handle.close() }
+        let bytes: Data
+        do {
+            bytes = try handle.read(upToCount: Self.utf8SniffByteCount + 1) ?? Data()
+        } catch {
+            return false
+        }
+        let sample = Data(bytes.prefix(Self.utf8SniffByteCount))
+        if String(data: sample, encoding: .utf8) != nil {
+            return true
+        }
+        guard bytes.count > Self.utf8SniffByteCount else {
+            return false
+        }
+        return hasValidUTF8PrefixEndingInPartialScalar(sample)
+    }
+
+    private func hasValidUTF8PrefixEndingInPartialScalar(_ data: Data) -> Bool {
+        let bytes = Array(data)
+        guard !bytes.isEmpty else { return false }
+        let earliestCandidate = max(0, bytes.count - 4)
+        for start in stride(from: bytes.count - 1, through: earliestCandidate, by: -1) {
+            guard let expectedLength = utf8ScalarLength(leadingByte: bytes[start]) else {
+                continue
+            }
+            let actualLength = bytes.count - start
+            guard actualLength < expectedLength,
+                  utf8PartialScalarBytesAreValid(Array(bytes[start...])) else {
+                continue
+            }
+            let prefix = Data(bytes[..<start])
+            return String(data: prefix, encoding: .utf8) != nil
+        }
+        return false
+    }
+
+    private func utf8ScalarLength(leadingByte: UInt8) -> Int? {
+        switch leadingByte {
+        case 0xC2...0xDF:
+            return 2
+        case 0xE0...0xEF:
+            return 3
+        case 0xF0...0xF4:
+            return 4
+        default:
+            return nil
+        }
+    }
+
+    private func utf8PartialScalarBytesAreValid(_ bytes: [UInt8]) -> Bool {
+        guard let leadingByte = bytes.first else { return false }
+        for byte in bytes.dropFirst() where byte & 0xC0 != 0x80 {
+            return false
+        }
+        guard bytes.count > 1 else { return true }
+        let firstContinuation = bytes[1]
+        switch leadingByte {
+        case 0xE0:
+            return firstContinuation >= 0xA0
+        case 0xED:
+            return firstContinuation <= 0x9F
+        case 0xF0:
+            return firstContinuation >= 0x90
+        case 0xF4:
+            return firstContinuation <= 0x8F
+        default:
+            return true
+        }
     }
 
     private func attributes(path: String) throws -> [FileAttributeKey: Any] {

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactTransferPolicy.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactTransferPolicy.swift
@@ -9,6 +9,8 @@ public struct ChatArtifactTransferPolicy: Sendable, Equatable {
     public let mobileSyncFrameLimitBytes: Int
     /// Maximum file size the iOS viewer previews inline.
     public let maxPreviewBytes: Int64
+    /// Maximum movie or audio size streamed to an iOS temporary file.
+    public let maxMediaPreviewBytes: Int64
 
     /// Creates an artifact transfer policy.
     ///
@@ -16,14 +18,17 @@ public struct ChatArtifactTransferPolicy: Sendable, Equatable {
     ///   - maxRawChunkBytes: Maximum raw bytes returned by one fetch chunk.
     ///   - mobileSyncFrameLimitBytes: Maximum mobile-sync frame size.
     ///   - maxPreviewBytes: Maximum inline preview file size.
+    ///   - maxMediaPreviewBytes: Maximum temporary-file media preview size.
     public init(
         maxRawChunkBytes: Int = 3 * 1024 * 1024,
         mobileSyncFrameLimitBytes: Int = 8 * 1024 * 1024,
-        maxPreviewBytes: Int64 = 64 * 1024 * 1024
+        maxPreviewBytes: Int64 = 64 * 1024 * 1024,
+        maxMediaPreviewBytes: Int64 = 512 * 1024 * 1024
     ) {
         self.maxRawChunkBytes = maxRawChunkBytes
         self.mobileSyncFrameLimitBytes = mobileSyncFrameLimitBytes
         self.maxPreviewBytes = maxPreviewBytes
+        self.maxMediaPreviewBytes = maxMediaPreviewBytes
     }
 
     /// Clamps a requested chunk length to the policy's raw-byte maximum.

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ArtifactByteReaderTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ArtifactByteReaderTests.swift
@@ -3,7 +3,7 @@ import Testing
 
 @testable import CmuxAgentChat
 
-@Suite("ArtifactByteReader directory listing")
+@Suite("ArtifactByteReader")
 struct ArtifactByteReaderTests {
     @Test("directory listings cap at 500 and report truncation")
     func listCap() throws {
@@ -36,6 +36,68 @@ struct ArtifactByteReaderTests {
             } catch {
                 Issue.record("unexpected error: \(error)")
             }
+        }
+    }
+
+    @Test("extensionless UTF-8 text is classified as text")
+    func extensionlessUTF8Text() throws {
+        try withTemporaryDirectory { directory in
+            let file = directory.appendingPathComponent("output")
+            try Data("hello, 漢字 and 🙂".utf8).write(to: file)
+
+            #expect(ArtifactByteReader().kind(path: file.path, isDirectory: false) == .text)
+        }
+    }
+
+    @Test("unknown-extension UTF-8 text is classified as text")
+    func unknownExtensionUTF8Text() throws {
+        try withTemporaryDirectory { directory in
+            let file = directory.appendingPathComponent("output.cmux-unknown-text-kind")
+            try Data("plain text".utf8).write(to: file)
+
+            #expect(ArtifactByteReader().kind(path: file.path, isDirectory: false) == .text)
+        }
+    }
+
+    @Test("binary junk remains binary")
+    func binaryJunk() throws {
+        try withTemporaryDirectory { directory in
+            let file = directory.appendingPathComponent("output")
+            try Data([0x00, 0xFF, 0xFE, 0x80]).write(to: file)
+
+            #expect(ArtifactByteReader().kind(path: file.path, isDirectory: false) == .binary)
+        }
+    }
+
+    @Test("empty extensionless files are valid UTF-8 text")
+    func emptyFile() throws {
+        try withTemporaryDirectory { directory in
+            let file = directory.appendingPathComponent("output")
+            try Data().write(to: file)
+
+            #expect(ArtifactByteReader().kind(path: file.path, isDirectory: false) == .text)
+        }
+    }
+
+    @Test("files smaller than the sniff budget are classified from all bytes")
+    func smallerThanSniffBudget() throws {
+        try withTemporaryDirectory { directory in
+            let file = directory.appendingPathComponent("output")
+            try Data(repeating: 0x61, count: 8 * 1024 - 1).write(to: file)
+
+            #expect(ArtifactByteReader().kind(path: file.path, isDirectory: false) == .text)
+        }
+    }
+
+    @Test("a multibyte scalar split at the 8 KiB edge is accepted")
+    func multibyteScalarSplitAtSniffEdge() throws {
+        try withTemporaryDirectory { directory in
+            let file = directory.appendingPathComponent("output")
+            var bytes = Data(repeating: 0x61, count: 8 * 1024 - 1)
+            bytes.append(contentsOf: "🙂".utf8)
+            try bytes.write(to: file)
+
+            #expect(ArtifactByteReader().kind(path: file.path, isDirectory: false) == .text)
         }
     }
 

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactTransferPolicyTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactTransferPolicyTests.swift
@@ -8,6 +8,8 @@ struct ChatArtifactTransferPolicyTests {
     func defaultChunkFitsFrame() {
         let policy = ChatArtifactTransferPolicy.defaultPolicy
         #expect(policy.maxRawChunkBytes == 3 * 1024 * 1024)
+        #expect(policy.maxPreviewBytes == 64 * 1024 * 1024)
+        #expect(policy.maxMediaPreviewBytes == 512 * 1024 * 1024)
         #expect(policy.estimatedEnvelopeByteCount(rawByteCount: policy.maxRawChunkBytes) < policy.mobileSyncFrameLimitBytes)
         #expect(policy.clampedChunkLength(10 * 1024 * 1024) == policy.maxRawChunkBytes)
     }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownMode.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownMode.swift
@@ -1,0 +1,5 @@
+/// User-selectable Markdown presentation modes.
+enum ChatArtifactMarkdownMode: Hashable, Sendable {
+    case raw
+    case rendered
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownPresentation.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownPresentation.swift
@@ -1,0 +1,20 @@
+/// Enforces the rendered-Markdown size threshold and selected mode.
+struct ChatArtifactMarkdownPresentation: Equatable, Sendable {
+    static let maximumRenderedByteCount: Int64 = 1_500_000
+
+    let isRenderedAvailable: Bool
+    private(set) var mode: ChatArtifactMarkdownMode
+
+    init(byteCount: Int64) {
+        isRenderedAvailable = byteCount <= Self.maximumRenderedByteCount
+        mode = isRenderedAvailable ? .rendered : .raw
+    }
+
+    mutating func select(_ requestedMode: ChatArtifactMarkdownMode) {
+        if requestedMode == .rendered, !isRenderedAvailable {
+            mode = .raw
+        } else {
+            mode = requestedMode
+        }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftUI
+
+/// Renders document-level Markdown with Foundation's native syntax support.
+struct ChatArtifactMarkdownView: View {
+    let markdown: String
+
+    var body: some View {
+        ScrollView {
+            Text(renderedMarkdown)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+    }
+
+    private var renderedMarkdown: AttributedString {
+        let options = AttributedString.MarkdownParsingOptions(interpretedSyntax: .full)
+        return (try? AttributedString(markdown: markdown, options: options))
+            ?? AttributedString(markdown)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMediaView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMediaView.swift
@@ -1,0 +1,32 @@
+#if os(iOS)
+import AVKit
+import SwiftUI
+
+/// Hosts AVKit's system playback controls for a local movie or audio artifact.
+struct ChatArtifactMediaView: UIViewControllerRepresentable {
+    let fileURL: URL
+
+    func makeUIViewController(context: Context) -> AVPlayerViewController {
+        let controller = AVPlayerViewController()
+        controller.player = AVPlayer(url: fileURL)
+        controller.videoGravity = .resizeAspect
+        return controller
+    }
+
+    func updateUIViewController(_ controller: AVPlayerViewController, context: Context) {
+        let currentURL = (controller.player?.currentItem?.asset as? AVURLAsset)?.url
+        if currentURL != fileURL {
+            controller.player?.pause()
+            controller.player = AVPlayer(url: fileURL)
+        }
+    }
+
+    static func dismantleUIViewController(
+        _ controller: AVPlayerViewController,
+        coordinator: Void
+    ) {
+        controller.player?.pause()
+        controller.player = nil
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPDFView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPDFView.swift
@@ -1,0 +1,25 @@
+#if os(iOS)
+import PDFKit
+import SwiftUI
+
+/// Hosts PDFKit's zoomable, scrollable document viewer for a local artifact.
+struct ChatArtifactPDFView: UIViewRepresentable {
+    let fileURL: URL
+
+    func makeUIView(context: Context) -> PDFView {
+        let pdfView = PDFView()
+        pdfView.autoScales = true
+        pdfView.displayMode = .singlePageContinuous
+        pdfView.displayDirection = .vertical
+        pdfView.document = PDFDocument(url: fileURL)
+        return pdfView
+    }
+
+    func updateUIView(_ pdfView: PDFView, context: Context) {
+        if pdfView.document?.documentURL != fileURL {
+            pdfView.document = PDFDocument(url: fileURL)
+        }
+        pdfView.autoScales = true
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRoute.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRoute.swift
@@ -1,0 +1,11 @@
+/// Client-side viewer routes derived without expanding the artifact wire kind.
+enum ChatArtifactPreviewRoute: Equatable, Sendable {
+    case folder
+    case image
+    case pdf
+    case media
+    case markdown
+    case text
+    case quickLook
+    case binary
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRouter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRouter.swift
@@ -27,7 +27,7 @@ struct ChatArtifactPreviewRouter: Sendable {
         }
 
         let type = fileExtension.isEmpty ? nil : UTType(filenameExtension: fileExtension)
-        if let type, type.conforms(to: .movie) || type.conforms(to: .audio) {
+        if isMedia(type) || isMedia(mimeType.flatMap { UTType(mimeType: $0) }) {
             return .media
         }
         if fileExtension == "md" || fileExtension == "markdown" {
@@ -40,5 +40,10 @@ struct ChatArtifactPreviewRouter: Sendable {
             return .quickLook
         }
         return .binary
+    }
+
+    private func isMedia(_ type: UTType?) -> Bool {
+        guard let type else { return false }
+        return type.conforms(to: .movie) || type.conforms(to: .audio)
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRouter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRouter.swift
@@ -17,11 +17,7 @@ struct ChatArtifactPreviewRouter: Sendable {
         }
 
         let fileExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
-        let mimeType = stat.mimeType?
-            .split(separator: ";", maxSplits: 1)
-            .first?
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .lowercased()
+        let mimeType = Self.normalizedMIMEType(stat.mimeType)
         if mimeType == "application/pdf" || fileExtension == "pdf" {
             return .pdf
         }
@@ -42,8 +38,30 @@ struct ChatArtifactPreviewRouter: Sendable {
         return .binary
     }
 
+    /// Preferred filename extension for a wire MIME type, used to type
+    /// extensionless temporary files for preview frameworks.
+    func preferredExtension(forMIMEType rawMIMEType: String?) -> String? {
+        guard let mimeType = Self.normalizedMIMEType(rawMIMEType),
+              let type = UTType(mimeType: mimeType) else {
+            return nil
+        }
+        return type.preferredFilenameExtension
+    }
+
     private func isMedia(_ type: UTType?) -> Bool {
         guard let type else { return false }
         return type.conforms(to: .movie) || type.conforms(to: .audio)
+    }
+
+    private static func normalizedMIMEType(_ rawValue: String?) -> String? {
+        guard let normalized = rawValue?
+            .split(separator: ";", maxSplits: 1)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+            !normalized.isEmpty else {
+            return nil
+        }
+        return normalized
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRouter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPreviewRouter.swift
@@ -1,0 +1,44 @@
+import CmuxAgentChat
+import Foundation
+import UniformTypeIdentifiers
+
+/// Resolves rich client preview routes from wire metadata and the filename.
+struct ChatArtifactPreviewRouter: Sendable {
+    /// Chooses the viewer route while preserving the four-case wire kind.
+    ///
+    /// Quick Look candidates still require a local
+    /// `QLPreviewController.canPreview(_:)` check after download.
+    func route(stat: ChatArtifactStat, path: String) -> ChatArtifactPreviewRoute {
+        if stat.isDirectory {
+            return .folder
+        }
+        if stat.kind == .image {
+            return .image
+        }
+
+        let fileExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
+        let mimeType = stat.mimeType?
+            .split(separator: ";", maxSplits: 1)
+            .first?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        if mimeType == "application/pdf" || fileExtension == "pdf" {
+            return .pdf
+        }
+
+        let type = fileExtension.isEmpty ? nil : UTType(filenameExtension: fileExtension)
+        if let type, type.conforms(to: .movie) || type.conforms(to: .audio) {
+            return .media
+        }
+        if fileExtension == "md" || fileExtension == "markdown" {
+            return .markdown
+        }
+        if stat.kind == .text {
+            return .text
+        }
+        if let type, !type.isDynamic, type.conforms(to: .content) {
+            return .quickLook
+        }
+        return .binary
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactQuickLookCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactQuickLookCoordinator.swift
@@ -1,0 +1,28 @@
+#if os(iOS)
+import QuickLook
+
+/// Retains and supplies the current artifact item to a Quick Look controller.
+@MainActor
+final class ChatArtifactQuickLookCoordinator: NSObject, QLPreviewControllerDataSource {
+    private(set) var item: ChatArtifactQuickLookItem
+
+    init(item: ChatArtifactQuickLookItem) {
+        self.item = item
+    }
+
+    func update(item: ChatArtifactQuickLookItem) {
+        self.item = item
+    }
+
+    func numberOfPreviewItems(in controller: QLPreviewController) -> Int {
+        1
+    }
+
+    func previewController(
+        _ controller: QLPreviewController,
+        previewItemAt index: Int
+    ) -> any QLPreviewItem {
+        item
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactQuickLookItem.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactQuickLookItem.swift
@@ -1,0 +1,15 @@
+#if os(iOS)
+import Foundation
+import QuickLook
+
+/// Supplies a local artifact URL and original display name to Quick Look.
+final class ChatArtifactQuickLookItem: NSObject, QLPreviewItem {
+    let previewItemURL: URL?
+    let previewItemTitle: String?
+
+    init(fileURL: URL, title: String?) {
+        previewItemURL = fileURL
+        previewItemTitle = title
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactQuickLookView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactQuickLookView.swift
@@ -1,0 +1,29 @@
+#if os(iOS)
+import QuickLook
+import SwiftUI
+
+/// Hosts the system Quick Look document preview for one local artifact file.
+struct ChatArtifactQuickLookView: UIViewControllerRepresentable {
+    let fileURL: URL
+    let title: String
+
+    func makeCoordinator() -> ChatArtifactQuickLookCoordinator {
+        ChatArtifactQuickLookCoordinator(
+            item: ChatArtifactQuickLookItem(fileURL: fileURL, title: title)
+        )
+    }
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {
+        context.coordinator.update(
+            item: ChatArtifactQuickLookItem(fileURL: fileURL, title: title)
+        )
+        controller.reloadData()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileStore.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileStore.swift
@@ -1,0 +1,60 @@
+import CmuxAgentChat
+import Foundation
+
+/// Fetches streamed artifacts into a dedicated purgeable caches directory.
+actor ChatArtifactTemporaryFileStore {
+    private let directory: URL
+
+    init(directory: URL? = nil) {
+        if let directory {
+            self.directory = directory
+        } else {
+            let cachesDirectory = FileManager.default.urls(
+                for: .cachesDirectory,
+                in: .userDomainMask
+            ).first ?? FileManager.default.temporaryDirectory
+            self.directory = cachesDirectory.appendingPathComponent(
+                "cmux-artifact-previews",
+                isDirectory: true
+            )
+        }
+    }
+
+    /// Streams a bounded artifact to disk without accumulating its bytes in memory.
+    func fetch(
+        path: String,
+        expectedSize: Int64,
+        limit: Int64,
+        fallbackExtension: String? = nil,
+        loader: ChatArtifactLoader,
+        progress: @escaping @Sendable (ChatArtifactChunk) async -> Void
+    ) async throws -> URL {
+        guard expectedSize <= limit else {
+            throw ChatArtifactError.tooLarge(limitBytes: limit)
+        }
+        let originalExtension = URL(fileURLWithPath: path).pathExtension
+        let fileExtension = originalExtension.isEmpty
+            ? (fallbackExtension ?? "")
+            : originalExtension
+        let writer = try ChatArtifactTemporaryFileWriter(
+            directory: directory,
+            fileExtension: fileExtension
+        )
+        do {
+            try await loader.stream(path: path) { chunk in
+                try Task.checkCancellation()
+                try await writer.append(chunk, limit: limit)
+                await progress(chunk)
+            }
+            try Task.checkCancellation()
+            return try await writer.finish()
+        } catch {
+            await writer.discard()
+            throw error
+        }
+    }
+
+    func remove(_ fileURL: URL) {
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileWriter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileWriter.swift
@@ -1,0 +1,57 @@
+import CmuxAgentChat
+import Foundation
+
+/// Serializes one streamed artifact into an ordered temporary file.
+actor ChatArtifactTemporaryFileWriter {
+    let fileURL: URL
+
+    private var fileHandle: FileHandle?
+    private var nextOffset: Int64 = 0
+
+    init(directory: URL, fileExtension: String) throws {
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        var fileURL = directory.appendingPathComponent(UUID().uuidString)
+        if !fileExtension.isEmpty {
+            fileURL.appendPathExtension(fileExtension)
+        }
+        guard FileManager.default.createFile(atPath: fileURL.path, contents: nil) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        self.fileURL = fileURL
+        do {
+            fileHandle = try FileHandle(forWritingTo: fileURL)
+        } catch {
+            try? FileManager.default.removeItem(at: fileURL)
+            throw error
+        }
+    }
+
+    func append(_ chunk: ChatArtifactChunk, limit: Int64) throws {
+        guard chunk.offset == nextOffset,
+              chunk.totalSize <= limit,
+              nextOffset <= limit - Int64(chunk.data.count),
+              let fileHandle else {
+            throw ChatArtifactError.macUnreachable
+        }
+        try fileHandle.write(contentsOf: chunk.data)
+        nextOffset += Int64(chunk.data.count)
+    }
+
+    func finish() throws -> URL {
+        guard let fileHandle else {
+            throw ChatArtifactError.macUnreachable
+        }
+        try fileHandle.close()
+        self.fileHandle = nil
+        return fileURL
+    }
+
+    func discard() {
+        try? fileHandle?.close()
+        fileHandle = nil
+        try? FileManager.default.removeItem(at: fileURL)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -12,12 +12,21 @@ final class ChatArtifactViewerModel {
     private(set) var totalBytes: Int64?
     private(set) var textReachedEOF = false
     private(set) var activePath: String?
+    private let temporaryFileStore: ChatArtifactTemporaryFileStore
+    private var temporaryFileURL: URL?
+
+    init(
+        temporaryFileStore: ChatArtifactTemporaryFileStore = ChatArtifactTemporaryFileStore()
+    ) {
+        self.temporaryFileStore = temporaryFileStore
+    }
 
     var renderedText: String {
         textChunks.joined()
     }
 
     func load(path: String, loader: ChatArtifactLoader) async {
+        await removeTemporaryFile()
         reset(for: path)
         var stat: ChatArtifactStat?
         do {
@@ -25,8 +34,10 @@ final class ChatArtifactViewerModel {
             try Task.checkCancellation()
             guard path == activePath else { return }
             stat = loadedStat
+            totalBytes = loadedStat.size
 
-            guard !loadedStat.isDirectory else {
+            let route = ChatArtifactPreviewRouter().route(stat: loadedStat, path: path)
+            guard route != .folder else {
                 state = loadedStat.showsFolder(
                     supportsDirectoryBrowsing: loader.supportsDirectoryBrowsing
                 ) ? .folder : .binary(stat: loadedStat)
@@ -39,11 +50,22 @@ final class ChatArtifactViewerModel {
                 return
             }
 
-            switch loadedStat.kind {
-            case .text:
+            switch route {
+            case .text, .markdown:
                 try await streamText(path: path, loader: loader)
-            case .image, .binary, .directory:
-                try await loadNonText(path: path, stat: loadedStat, loader: loader)
+            case .image:
+                try await loadImage(path: path, loader: loader)
+            case .pdf:
+                try await loadPDF(
+                    path: path,
+                    expectedSize: loadedStat.size,
+                    limit: limit,
+                    loader: loader
+                )
+            case .media, .quickLook, .binary:
+                state = .binary(stat: loadedStat)
+            case .folder:
+                break
             }
         } catch is CancellationError {
             return
@@ -55,6 +77,10 @@ final class ChatArtifactViewerModel {
             guard !Task.isCancelled, path == activePath else { return }
             state = Self.state(for: error, stat: stat)
         }
+    }
+
+    func cleanup() async {
+        await removeTemporaryFile()
     }
 
     private func reset(for path: String) {
@@ -86,11 +112,7 @@ final class ChatArtifactViewerModel {
         state = .text
     }
 
-    private func loadNonText(
-        path: String,
-        stat: ChatArtifactStat,
-        loader: ChatArtifactLoader
-    ) async throws {
+    private func loadImage(path: String, loader: ChatArtifactLoader) async throws {
         let accumulator = ChatArtifactDataAccumulator()
         try await loader.stream(path: path) { chunk in
             try Task.checkCancellation()
@@ -100,14 +122,30 @@ final class ChatArtifactViewerModel {
         try Task.checkCancellation()
         guard path == activePath else { return }
         let data = await accumulator.value()
-        switch stat.kind {
-        case .image:
-            state = .image(data: data)
-        case .text:
-            break
-        case .binary, .directory:
-            state = .binary(stat: stat)
+        state = .image(data: data)
+    }
+
+    private func loadPDF(
+        path: String,
+        expectedSize: Int64,
+        limit: Int64,
+        loader: ChatArtifactLoader
+    ) async throws {
+        let fileURL = try await temporaryFileStore.fetch(
+            path: path,
+            expectedSize: expectedSize,
+            limit: limit,
+            fallbackExtension: "pdf",
+            loader: loader
+        ) { chunk in
+            await self.receiveNonTextProgress(chunk: chunk, path: path)
         }
+        guard path == activePath else {
+            await temporaryFileStore.remove(fileURL)
+            return
+        }
+        temporaryFileURL = fileURL
+        state = .pdf(fileURL: fileURL)
     }
 
     private func receiveNonTextProgress(chunk: ChatArtifactChunk, path: String) {
@@ -120,6 +158,12 @@ final class ChatArtifactViewerModel {
         fetchedBytes = chunk.eof
             ? chunk.totalSize
             : chunk.offset + Int64(chunk.data.count)
+    }
+
+    private func removeTemporaryFile() async {
+        guard let temporaryFileURL else { return }
+        self.temporaryFileURL = nil
+        await temporaryFileStore.remove(temporaryFileURL)
     }
 
     private static func state(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -83,7 +83,8 @@ final class ChatArtifactViewerModel {
                     path: path,
                     expectedSize: loadedStat.size,
                     limit: limit,
-                    fallbackExtension: nil,
+                    fallbackExtension: ChatArtifactPreviewRouter()
+                        .preferredExtension(forMIMEType: loadedStat.mimeType),
                     loader: loader
                 ) {
                     state = .media(fileURL: fileURL)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -25,7 +25,11 @@ final class ChatArtifactViewerModel {
         textChunks.joined()
     }
 
-    func load(path: String, loader: ChatArtifactLoader) async {
+    func load(
+        path: String,
+        loader: ChatArtifactLoader,
+        quickLookCanPreview: @MainActor (URL) -> Bool = { _ in false }
+    ) async {
         await removeTemporaryFile()
         reset(for: path)
         var stat: ChatArtifactStat?
@@ -78,7 +82,22 @@ final class ChatArtifactViewerModel {
                 ) {
                     state = .media(fileURL: fileURL)
                 }
-            case .quickLook, .binary:
+            case .quickLook:
+                if let fileURL = try await loadTemporaryFile(
+                    path: path,
+                    expectedSize: loadedStat.size,
+                    limit: limit,
+                    fallbackExtension: nil,
+                    loader: loader
+                ) {
+                    if quickLookCanPreview(fileURL) {
+                        state = .quickLook(fileURL: fileURL)
+                    } else {
+                        await removeTemporaryFile()
+                        state = .binary(stat: loadedStat)
+                    }
+                }
+            case .binary:
                 state = .binary(stat: loadedStat)
             case .folder:
                 break

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -12,6 +12,7 @@ final class ChatArtifactViewerModel {
     private(set) var totalBytes: Int64?
     private(set) var textReachedEOF = false
     private(set) var activePath: String?
+    private(set) var markdownPresentation = ChatArtifactMarkdownPresentation(byteCount: 0)
     private let temporaryFileStore: ChatArtifactTemporaryFileStore
     private var temporaryFileURL: URL?
 
@@ -58,8 +59,13 @@ final class ChatArtifactViewerModel {
             }
 
             switch route {
-            case .text, .markdown:
-                try await streamText(path: path, loader: loader)
+            case .text:
+                try await streamText(path: path, isMarkdown: false, loader: loader)
+            case .markdown:
+                markdownPresentation = ChatArtifactMarkdownPresentation(
+                    byteCount: loadedStat.size
+                )
+                try await streamText(path: path, isMarkdown: true, loader: loader)
             case .image:
                 try await loadImage(path: path, loader: loader)
             case .pdf:
@@ -118,6 +124,10 @@ final class ChatArtifactViewerModel {
         await removeTemporaryFile()
     }
 
+    func selectMarkdownMode(_ mode: ChatArtifactMarkdownMode) {
+        markdownPresentation.select(mode)
+    }
+
     private func reset(for path: String) {
         activePath = path
         state = .loading
@@ -125,26 +135,41 @@ final class ChatArtifactViewerModel {
         fetchedBytes = 0
         totalBytes = nil
         textReachedEOF = false
+        markdownPresentation = ChatArtifactMarkdownPresentation(byteCount: 0)
     }
 
-    private func streamText(path: String, loader: ChatArtifactLoader) async throws {
+    private func streamText(
+        path: String,
+        isMarkdown: Bool,
+        loader: ChatArtifactLoader
+    ) async throws {
         let decoder = UTF8ChunkDecoder()
         try await loader.stream(path: path) { chunk in
             try Task.checkCancellation()
             let decoded = try await decoder.decode(chunk.data, eof: chunk.eof)
             try Task.checkCancellation()
-            await self.receiveText(decoded, chunk: chunk, path: path)
+            await self.receiveText(
+                decoded,
+                chunk: chunk,
+                path: path,
+                isMarkdown: isMarkdown
+            )
         }
     }
 
-    private func receiveText(_ text: String, chunk: ChatArtifactChunk, path: String) {
+    private func receiveText(
+        _ text: String,
+        chunk: ChatArtifactChunk,
+        path: String,
+        isMarkdown: Bool
+    ) {
         guard path == activePath else { return }
         if !text.isEmpty {
             textChunks.append(text)
         }
         updateProgress(for: chunk)
         textReachedEOF = chunk.eof
-        state = .text
+        state = isMarkdown ? .markdown : .text
     }
 
     private func loadImage(path: String, loader: ChatArtifactLoader) async throws {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -44,7 +44,10 @@ final class ChatArtifactViewerModel {
                 return
             }
 
-            let limit = ChatArtifactTransferPolicy.defaultPolicy.maxPreviewBytes
+            let policy = ChatArtifactTransferPolicy.defaultPolicy
+            let limit = route == .media
+                ? policy.maxMediaPreviewBytes
+                : policy.maxPreviewBytes
             guard loadedStat.size <= limit else {
                 state = .tooLarge(actualSize: loadedStat.size, limit: limit)
                 return
@@ -56,13 +59,26 @@ final class ChatArtifactViewerModel {
             case .image:
                 try await loadImage(path: path, loader: loader)
             case .pdf:
-                try await loadPDF(
+                if let fileURL = try await loadTemporaryFile(
                     path: path,
                     expectedSize: loadedStat.size,
                     limit: limit,
+                    fallbackExtension: "pdf",
                     loader: loader
-                )
-            case .media, .quickLook, .binary:
+                ) {
+                    state = .pdf(fileURL: fileURL)
+                }
+            case .media:
+                if let fileURL = try await loadTemporaryFile(
+                    path: path,
+                    expectedSize: loadedStat.size,
+                    limit: limit,
+                    fallbackExtension: nil,
+                    loader: loader
+                ) {
+                    state = .media(fileURL: fileURL)
+                }
+            case .quickLook, .binary:
                 state = .binary(stat: loadedStat)
             case .folder:
                 break
@@ -125,27 +141,28 @@ final class ChatArtifactViewerModel {
         state = .image(data: data)
     }
 
-    private func loadPDF(
+    private func loadTemporaryFile(
         path: String,
         expectedSize: Int64,
         limit: Int64,
+        fallbackExtension: String?,
         loader: ChatArtifactLoader
-    ) async throws {
+    ) async throws -> URL? {
         let fileURL = try await temporaryFileStore.fetch(
             path: path,
             expectedSize: expectedSize,
             limit: limit,
-            fallbackExtension: "pdf",
+            fallbackExtension: fallbackExtension,
             loader: loader
         ) { chunk in
             await self.receiveNonTextProgress(chunk: chunk, path: path)
         }
         guard path == activePath else {
             await temporaryFileStore.remove(fileURL)
-            return
+            return nil
         }
         temporaryFileURL = fileURL
-        state = .pdf(fileURL: fileURL)
+        return fileURL
     }
 
     private func receiveNonTextProgress(chunk: ChatArtifactChunk, path: String) {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -109,6 +109,16 @@ struct ChatArtifactViewerRouteView: View {
                 message: String(localized: "chat.artifact.preview_unavailable.message", defaultValue: "This file can't be previewed.", bundle: .module)
             )
             #endif
+        case .media(let fileURL):
+            #if os(iOS)
+            ChatArtifactMediaView(fileURL: fileURL)
+                .ignoresSafeArea(.container, edges: .bottom)
+            #else
+            unavailableView(
+                title: String(localized: "chat.artifact.preview_unavailable.title", defaultValue: "Preview unavailable", bundle: .module),
+                message: String(localized: "chat.artifact.preview_unavailable.message", defaultValue: "This file can't be previewed.", bundle: .module)
+            )
+            #endif
         case .text:
             VStack(spacing: 0) {
                 if !model.textReachedEOF {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -3,6 +3,9 @@ import SwiftUI
 
 #if canImport(UIKit)
 import UIKit
+#if os(iOS)
+import QuickLook
+#endif
 #elseif canImport(AppKit)
 import AppKit
 #endif
@@ -56,7 +59,15 @@ struct ChatArtifactViewerRouteView: View {
                 #endif
             }
             .task(id: "\(path)\u{0}\(retryGeneration)") {
+                #if os(iOS)
+                await model.load(
+                    path: path,
+                    loader: loader,
+                    quickLookCanPreview: canQuickLookPreview
+                )
+                #else
                 await model.load(path: path, loader: loader)
+                #endif
             }
             .onDisappear {
                 Task { await model.cleanup() }
@@ -112,6 +123,16 @@ struct ChatArtifactViewerRouteView: View {
         case .media(let fileURL):
             #if os(iOS)
             ChatArtifactMediaView(fileURL: fileURL)
+                .ignoresSafeArea(.container, edges: .bottom)
+            #else
+            unavailableView(
+                title: String(localized: "chat.artifact.preview_unavailable.title", defaultValue: "Preview unavailable", bundle: .module),
+                message: String(localized: "chat.artifact.preview_unavailable.message", defaultValue: "This file can't be previewed.", bundle: .module)
+            )
+            #endif
+        case .quickLook(let fileURL):
+            #if os(iOS)
+            ChatArtifactQuickLookView(fileURL: fileURL, title: displayName)
                 .ignoresSafeArea(.container, edges: .bottom)
             #else
             unavailableView(
@@ -257,6 +278,14 @@ struct ChatArtifactViewerRouteView: View {
     private var displayName: String {
         URL(fileURLWithPath: path).lastPathComponent
     }
+
+    #if os(iOS)
+    private func canQuickLookPreview(_ fileURL: URL) -> Bool {
+        QLPreviewController.canPreview(
+            ChatArtifactQuickLookItem(fileURL: fileURL, title: displayName)
+        )
+    }
+    #endif
 
     private var jumpToBottomTitle: String {
         if model.textReachedEOF {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -58,6 +58,9 @@ struct ChatArtifactViewerRouteView: View {
             .task(id: "\(path)\u{0}\(retryGeneration)") {
                 await model.load(path: path, loader: loader)
             }
+            .onDisappear {
+                Task { await model.cleanup() }
+            }
     }
 
     @ViewBuilder
@@ -96,6 +99,16 @@ struct ChatArtifactViewerRouteView: View {
                 .scaledToFit()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding()
+        case .pdf(let fileURL):
+            #if os(iOS)
+            ChatArtifactPDFView(fileURL: fileURL)
+                .ignoresSafeArea(.container, edges: .bottom)
+            #else
+            unavailableView(
+                title: String(localized: "chat.artifact.preview_unavailable.title", defaultValue: "Preview unavailable", bundle: .module),
+                message: String(localized: "chat.artifact.preview_unavailable.message", defaultValue: "This file can't be previewed.", bundle: .module)
+            )
+            #endif
         case .text:
             VStack(spacing: 0) {
                 if !model.textReachedEOF {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -35,7 +35,7 @@ struct ChatArtifactViewerRouteView: View {
                     }
                 }
                 #if os(iOS)
-                if model.state == .text {
+                if shouldShowTextJumpControls {
                     ToolbarItemGroup(placement: .primaryAction) {
                         Button {
                             topRequestID += 1
@@ -54,6 +54,33 @@ struct ChatArtifactViewerRouteView: View {
                         } label: {
                             Label(jumpToBottomTitle, systemImage: "arrow.down.to.line")
                         }
+                    }
+                }
+                if model.state == .markdown,
+                   model.markdownPresentation.isRenderedAvailable {
+                    ToolbarItem(placement: .primaryAction) {
+                        Picker(
+                            String(
+                                localized: "chat.artifact.markdown.view",
+                                defaultValue: "Markdown view",
+                                bundle: .module
+                            ),
+                            selection: markdownModeBinding
+                        ) {
+                            Text(String(
+                                localized: "chat.artifact.markdown.raw",
+                                defaultValue: "Raw",
+                                bundle: .module
+                            ))
+                            .tag(ChatArtifactMarkdownMode.raw)
+                            Text(String(
+                                localized: "chat.artifact.markdown.rendered",
+                                defaultValue: "Rendered",
+                                bundle: .module
+                            ))
+                            .tag(ChatArtifactMarkdownMode.rendered)
+                        }
+                        .pickerStyle(.segmented)
                     }
                 }
                 #endif
@@ -145,22 +172,18 @@ struct ChatArtifactViewerRouteView: View {
                 if !model.textReachedEOF {
                     streamingProgressHeader
                 }
-                #if canImport(UIKit)
-                ChatArtifactTextView(
-                    documentID: path,
-                    chunks: model.textChunks,
-                    topRequestID: topRequestID,
-                    bottomRequestID: bottomRequestID
-                )
-                #else
-                ScrollView {
-                    Text(model.renderedText)
-                        .font(.system(.body, design: .monospaced))
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .padding()
+                rawTextView
+            }
+        case .markdown:
+            VStack(spacing: 0) {
+                if !model.textReachedEOF {
+                    streamingProgressHeader
                 }
-                #endif
+                if model.markdownPresentation.mode == .rendered {
+                    ChatArtifactMarkdownView(markdown: model.renderedText)
+                } else {
+                    rawTextView
+                }
             }
         case .binary(let stat):
             unavailableView(
@@ -217,6 +240,26 @@ struct ChatArtifactViewerRouteView: View {
         .padding(.horizontal, 16)
         .padding(.vertical, 6)
         .background(.bar)
+    }
+
+    @ViewBuilder
+    private var rawTextView: some View {
+        #if canImport(UIKit)
+        ChatArtifactTextView(
+            documentID: path,
+            chunks: model.textChunks,
+            topRequestID: topRequestID,
+            bottomRequestID: bottomRequestID
+        )
+        #else
+        ScrollView {
+            Text(model.renderedText)
+                .font(.system(.body, design: .monospaced))
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+        }
+        #endif
     }
 
     private func unavailableView(
@@ -277,6 +320,18 @@ struct ChatArtifactViewerRouteView: View {
 
     private var displayName: String {
         URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    private var markdownModeBinding: Binding<ChatArtifactMarkdownMode> {
+        Binding(
+            get: { model.markdownPresentation.mode },
+            set: { model.selectMarkdownMode($0) }
+        )
+    }
+
+    private var shouldShowTextJumpControls: Bool {
+        model.state == .text
+            || (model.state == .markdown && model.markdownPresentation.mode == .raw)
     }
 
     #if os(iOS)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
@@ -8,6 +8,7 @@ enum ChatArtifactViewerState: Equatable {
     case image(data: Data)
     case pdf(fileURL: URL)
     case media(fileURL: URL)
+    case quickLook(fileURL: URL)
     case text
     case binary(stat: ChatArtifactStat)
     case tooLarge(actualSize: Int64?, limit: Int64)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
@@ -6,6 +6,7 @@ enum ChatArtifactViewerState: Equatable {
     case loading
     case folder
     case image(data: Data)
+    case pdf(fileURL: URL)
     case text
     case binary(stat: ChatArtifactStat)
     case tooLarge(actualSize: Int64?, limit: Int64)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
@@ -7,6 +7,7 @@ enum ChatArtifactViewerState: Equatable {
     case folder
     case image(data: Data)
     case pdf(fileURL: URL)
+    case media(fileURL: URL)
     case text
     case binary(stat: ChatArtifactStat)
     case tooLarge(actualSize: Int64?, limit: Int64)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerState.swift
@@ -10,6 +10,7 @@ enum ChatArtifactViewerState: Equatable {
     case media(fileURL: URL)
     case quickLook(fileURL: URL)
     case text
+    case markdown
     case binary(stat: ChatArtifactStat)
     case tooLarge(actualSize: Int64?, limit: Int64)
     case unsupportedMedia

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -273,6 +273,57 @@
         }
       }
     },
+    "chat.artifact.markdown.raw" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Raw"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ソース"
+          }
+        }
+      }
+    },
+    "chat.artifact.markdown.rendered" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Rendered"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "プレビュー"
+          }
+        }
+      }
+    },
+    "chat.artifact.markdown.view" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Markdown view"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Markdown表示"
+          }
+        }
+      }
+    },
     "chat.artifact.open_item" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ArtifactStreamCallCounter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ArtifactStreamCallCounter.swift
@@ -1,0 +1,12 @@
+/// Records whether an artifact stream was invoked without shared test globals.
+actor ArtifactStreamCallCounter {
+    private var count = 0
+
+    func recordCall() {
+        count += 1
+    }
+
+    func callCount() -> Int {
+        count
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactMarkdownPresentationTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactMarkdownPresentationTests.swift
@@ -1,0 +1,28 @@
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact Markdown presentation")
+struct ChatArtifactMarkdownPresentationTests {
+    @Test("small files toggle between rendered and raw")
+    func togglesSmallFile() {
+        var presentation = ChatArtifactMarkdownPresentation(byteCount: 1_500_000)
+
+        #expect(presentation.isRenderedAvailable)
+        #expect(presentation.mode == .rendered)
+        presentation.select(.raw)
+        #expect(presentation.mode == .raw)
+        presentation.select(.rendered)
+        #expect(presentation.mode == .rendered)
+    }
+
+    @Test("oversize files remain raw")
+    func oversizeFallsBackToRaw() {
+        var presentation = ChatArtifactMarkdownPresentation(byteCount: 1_500_001)
+
+        #expect(!presentation.isRenderedAvailable)
+        #expect(presentation.mode == .raw)
+        presentation.select(.rendered)
+        #expect(presentation.mode == .raw)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPreviewRouterTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPreviewRouterTests.swift
@@ -1,0 +1,47 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact preview routing")
+struct ChatArtifactPreviewRouterTests {
+    @Test
+    func routesMimeAndExtensionMatrix() {
+        let fixtures: [(String, ChatArtifactKind, String?, Bool, ChatArtifactPreviewRoute)] = [
+            ("/tmp/photo.png", .image, "image/png", false, .image),
+            ("/tmp/image-with-pdf-name.pdf", .image, "application/pdf", false, .image),
+            ("/tmp/report", .binary, "application/pdf; charset=binary", false, .pdf),
+            ("/tmp/report.PDF", .binary, "application/octet-stream", false, .pdf),
+            ("/tmp/movie.mp4", .binary, "video/mp4", false, .media),
+            ("/tmp/sound.m4a", .binary, "audio/mp4", false, .media),
+            ("/tmp/README.md", .text, "text/markdown", false, .markdown),
+            ("/tmp/notes.MARKDOWN", .text, "text/plain", false, .markdown),
+            ("/tmp/plain.txt", .text, "text/plain", false, .text),
+            ("/tmp/output", .text, nil, false, .text),
+            ("/tmp/report.docx", .binary, nil, false, .quickLook),
+            ("/tmp/sheet.xlsx", .binary, nil, false, .quickLook),
+            ("/tmp/slides.pptx", .binary, nil, false, .quickLook),
+            ("/tmp/document.pages", .binary, nil, false, .quickLook),
+            ("/tmp/deck.key", .binary, nil, false, .quickLook),
+            ("/tmp/table.numbers", .binary, nil, false, .quickLook),
+            ("/tmp/archive.zip", .binary, nil, false, .binary),
+            ("/tmp/blob.bin", .binary, nil, false, .binary),
+            ("/tmp/folder", .directory, nil, true, .folder),
+        ]
+        let router = ChatArtifactPreviewRouter()
+
+        for (path, kind, mimeType, isDirectory, expected) in fixtures {
+            let stat = ChatArtifactStat(
+                exists: true,
+                isDirectory: isDirectory,
+                size: 12,
+                modifiedAt: Date(timeIntervalSince1970: 0),
+                kind: kind,
+                mimeType: mimeType
+            )
+
+            #expect(router.route(stat: stat, path: path) == expected, "Unexpected route for \(path)")
+        }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPreviewRouterTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPreviewRouterTests.swift
@@ -46,4 +46,14 @@ struct ChatArtifactPreviewRouterTests {
             #expect(router.route(stat: stat, path: path) == expected, "Unexpected route for \(path)")
         }
     }
+
+    @Test
+    func mimeFallbackExtensionTypesExtensionlessTempFiles() {
+        let router = ChatArtifactPreviewRouter()
+
+        #expect(router.preferredExtension(forMIMEType: "video/mp4") == "mp4")
+        #expect(router.preferredExtension(forMIMEType: "application/pdf; charset=binary") == "pdf")
+        #expect(router.preferredExtension(forMIMEType: "not a mime") == nil)
+        #expect(router.preferredExtension(forMIMEType: nil) == nil)
+    }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPreviewRouterTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPreviewRouterTests.swift
@@ -15,6 +15,8 @@ struct ChatArtifactPreviewRouterTests {
             ("/tmp/report.PDF", .binary, "application/octet-stream", false, .pdf),
             ("/tmp/movie.mp4", .binary, "video/mp4", false, .media),
             ("/tmp/sound.m4a", .binary, "audio/mp4", false, .media),
+            ("/tmp/recording", .binary, "video/mp4", false, .media),
+            ("/tmp/voice-note", .binary, "audio/mp4; charset=binary", false, .media),
             ("/tmp/README.md", .text, "text/markdown", false, .markdown),
             ("/tmp/notes.MARKDOWN", .text, "text/plain", false, .markdown),
             ("/tmp/plain.txt", .text, "text/plain", false, .text),

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTemporaryFileStoreTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTemporaryFileStoreTests.swift
@@ -1,0 +1,50 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact temporary files")
+struct ChatArtifactTemporaryFileStoreTests {
+    @Test("writes streamed chunks to a file with the requested extension")
+    func writesChunks() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-artifact-temp-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = Data("PDF".utf8)
+        let second = Data(" bytes".utf8)
+        let totalSize = Int64(first.count + second.count)
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stream: { _, onChunk in
+                try await onChunk(ChatArtifactChunk(
+                    data: first,
+                    offset: 0,
+                    totalSize: totalSize,
+                    eof: false
+                ))
+                try await onChunk(ChatArtifactChunk(
+                    data: second,
+                    offset: Int64(first.count),
+                    totalSize: totalSize,
+                    eof: true
+                ))
+            }
+        )
+        let store = ChatArtifactTemporaryFileStore(directory: directory)
+
+        let fileURL = try await store.fetch(
+            path: "/remote/report",
+            expectedSize: totalSize,
+            limit: 1024,
+            fallbackExtension: "pdf",
+            loader: loader,
+            progress: { _ in }
+        )
+
+        #expect(fileURL.pathExtension == "pdf")
+        #expect(try Data(contentsOf: fileURL) == first + second)
+        await store.remove(fileURL)
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTemporaryFileStoreTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTemporaryFileStoreTests.swift
@@ -47,4 +47,53 @@ struct ChatArtifactTemporaryFileStoreTests {
         await store.remove(fileURL)
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
     }
+
+    @Test("cancellation removes a partially written file")
+    func cancellationRemovesPartialFile() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-artifact-cancel-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = Data("partial".utf8)
+        let second = Data(" remainder".utf8)
+        let totalSize = Int64(first.count + second.count)
+        let stream = ControlledArtifactStream(chunks: [
+            ChatArtifactChunk(data: first, offset: 0, totalSize: totalSize, eof: false),
+            ChatArtifactChunk(
+                data: second,
+                offset: Int64(first.count),
+                totalSize: totalSize,
+                eof: true
+            ),
+        ])
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stream: { _, onChunk in
+                try await stream.fetch(onChunk: onChunk)
+            }
+        )
+        let store = ChatArtifactTemporaryFileStore(directory: directory)
+        let fetchTask = Task {
+            try await store.fetch(
+                path: "/remote/movie.mp4",
+                expectedSize: totalSize,
+                limit: 512 * 1024 * 1024,
+                loader: loader,
+                progress: { _ in }
+            )
+        }
+
+        await stream.waitUntilFirstChunkDelivered()
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).count == 1)
+        fetchTask.cancel()
+        await stream.waitUntilCancelled()
+        do {
+            _ = try await fetchTask.value
+            Issue.record("cancelled fetch should throw")
+        } catch is CancellationError {
+            // Expected structured cancellation.
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+    }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
@@ -248,6 +248,52 @@ struct ChatArtifactViewerModelTests {
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
     }
 
+    @Test
+    @MainActor
+    func quickLookRequiresCapabilityAcceptance() async throws {
+        let acceptedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-artifact-ql-accepted-\(UUID().uuidString)", isDirectory: true)
+        let rejectedDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-artifact-ql-rejected-\(UUID().uuidString)", isDirectory: true)
+        defer {
+            try? FileManager.default.removeItem(at: acceptedDirectory)
+            try? FileManager.default.removeItem(at: rejectedDirectory)
+        }
+        let data = Data("document bytes".utf8)
+        let loader = Self.quickLookLoader(data: data)
+        let acceptedModel = ChatArtifactViewerModel(
+            temporaryFileStore: ChatArtifactTemporaryFileStore(directory: acceptedDirectory)
+        )
+        let rejectedModel = ChatArtifactViewerModel(
+            temporaryFileStore: ChatArtifactTemporaryFileStore(directory: rejectedDirectory)
+        )
+
+        await acceptedModel.load(
+            path: "/remote/report.docx",
+            loader: loader,
+            quickLookCanPreview: { _ in true }
+        )
+        await rejectedModel.load(
+            path: "/remote/report.docx",
+            loader: loader,
+            quickLookCanPreview: { _ in false }
+        )
+
+        guard case .quickLook(let acceptedURL) = acceptedModel.state else {
+            Issue.record("accepted document should route to Quick Look")
+            return
+        }
+        #expect(acceptedURL.pathExtension == "docx")
+        #expect(try Data(contentsOf: acceptedURL) == data)
+        guard case .binary = rejectedModel.state else {
+            Issue.record("rejected document should retain the binary state")
+            return
+        }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: rejectedDirectory.path).isEmpty)
+        await acceptedModel.cleanup()
+        #expect(!FileManager.default.fileExists(atPath: acceptedURL.path))
+    }
+
     private static func loader(
         totalSize: Int64,
         stream: @escaping @Sendable (
@@ -268,6 +314,30 @@ struct ChatArtifactViewerModelTests {
                 )
             },
             stream: stream
+        )
+    }
+
+    private static func quickLookLoader(data: Data) -> ChatArtifactLoader {
+        ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: Int64(data.count),
+                    modifiedAt: Date(timeIntervalSince1970: 0),
+                    kind: .binary,
+                    mimeType: "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+                )
+            },
+            stream: { _, onChunk in
+                try await onChunk(ChatArtifactChunk(
+                    data: data,
+                    offset: 0,
+                    totalSize: Int64(data.count),
+                    eof: true
+                ))
+            }
         )
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
@@ -131,6 +131,50 @@ struct ChatArtifactViewerModelTests {
         #expect(model.state == .tooLarge(actualSize: actualSize, limit: limit))
     }
 
+    @Test
+    @MainActor
+    func pdfStreamsToTemporaryFileAndCleansUp() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-artifact-pdf-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let data = Data("%PDF-test".utf8)
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: Int64(data.count),
+                    modifiedAt: Date(timeIntervalSince1970: 0),
+                    kind: .binary,
+                    mimeType: "application/pdf"
+                )
+            },
+            stream: { _, onChunk in
+                try await onChunk(ChatArtifactChunk(
+                    data: data,
+                    offset: 0,
+                    totalSize: Int64(data.count),
+                    eof: true
+                ))
+            }
+        )
+        let model = ChatArtifactViewerModel(
+            temporaryFileStore: ChatArtifactTemporaryFileStore(directory: directory)
+        )
+
+        await model.load(path: "/remote/report", loader: loader)
+
+        guard case .pdf(let fileURL) = model.state else {
+            Issue.record("PDF metadata should route to the PDF file state")
+            return
+        }
+        #expect(fileURL.pathExtension == "pdf")
+        #expect(try Data(contentsOf: fileURL) == data)
+        await model.cleanup()
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
     private static func loader(
         totalSize: Int64,
         stream: @escaping @Sendable (

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
@@ -294,6 +294,41 @@ struct ChatArtifactViewerModelTests {
         #expect(!FileManager.default.fileExists(atPath: acceptedURL.path))
     }
 
+    @Test
+    @MainActor
+    func markdownStreamsAsTextAndAppliesRawOnlyThreshold() async {
+        let markdown = Data("# Heading\n\nBody".utf8)
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: ChatArtifactMarkdownPresentation.maximumRenderedByteCount + 1,
+                    modifiedAt: Date(timeIntervalSince1970: 0),
+                    kind: .text,
+                    mimeType: "text/markdown"
+                )
+            },
+            stream: { _, onChunk in
+                try await onChunk(ChatArtifactChunk(
+                    data: markdown,
+                    offset: 0,
+                    totalSize: Int64(markdown.count),
+                    eof: true
+                ))
+            }
+        )
+        let model = ChatArtifactViewerModel()
+
+        await model.load(path: "/remote/README.md", loader: loader)
+
+        #expect(model.state == .markdown)
+        #expect(model.renderedText == "# Heading\n\nBody")
+        #expect(model.markdownPresentation.mode == .raw)
+        #expect(!model.markdownPresentation.isRenderedAvailable)
+    }
+
     private static func loader(
         totalSize: Int64,
         stream: @escaping @Sendable (

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
@@ -175,6 +175,79 @@ struct ChatArtifactViewerModelTests {
         #expect(!FileManager.default.fileExists(atPath: fileURL.path))
     }
 
+    @Test
+    @MainActor
+    func mediaUsesMediaCapAndRejectsFromStatBeforeFetch() async {
+        let limit = ChatArtifactTransferPolicy.defaultPolicy.maxMediaPreviewBytes
+        let streamCalls = ArtifactStreamCallCounter()
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: limit + 1,
+                    modifiedAt: Date(timeIntervalSince1970: 0),
+                    kind: .binary,
+                    mimeType: "video/mp4"
+                )
+            },
+            stream: { _, _ in
+                await streamCalls.recordCall()
+            }
+        )
+        let model = ChatArtifactViewerModel()
+
+        await model.load(path: "/remote/movie.mp4", loader: loader)
+
+        #expect(model.state == .tooLarge(actualSize: limit + 1, limit: limit))
+        #expect(await streamCalls.callCount() == 0)
+    }
+
+    @Test
+    @MainActor
+    func mediaStreamsToExtensionPreservingFile() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-artifact-media-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let data = Data("media bytes".utf8)
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: Int64(data.count),
+                    modifiedAt: Date(timeIntervalSince1970: 0),
+                    kind: .binary,
+                    mimeType: "video/mp4"
+                )
+            },
+            stream: { _, onChunk in
+                try await onChunk(ChatArtifactChunk(
+                    data: data,
+                    offset: 0,
+                    totalSize: Int64(data.count),
+                    eof: true
+                ))
+            }
+        )
+        let model = ChatArtifactViewerModel(
+            temporaryFileStore: ChatArtifactTemporaryFileStore(directory: directory)
+        )
+
+        await model.load(path: "/remote/movie.mp4", loader: loader)
+
+        guard case .media(let fileURL) = model.state else {
+            Issue.record("movie metadata should route to the media file state")
+            return
+        }
+        #expect(fileURL.pathExtension == "mp4")
+        #expect(try Data(contentsOf: fileURL) == data)
+        await model.cleanup()
+        #expect(!FileManager.default.fileExists(atPath: fileURL.path))
+    }
+
     private static func loader(
         totalSize: Int64,
         stream: @escaping @Sendable (


### PR DESCRIPTION
Only images and plain text previewed; PDFs, screen recordings, audio, and office documents all landed on "Preview unavailable", and extensionless text artifacts classified as binary.

Preview dispatch now happens client-side from stat mimeType plus filename UTType through a single tested router, so the four-case wire kind enum is untouched and no capability bump is needed. PDFs render in PDFKit (zoom and page navigation built in). Video and audio stream to a properly-named temp file via the shared chunk loop (never fully in memory, new 512 MiB media cap beside the 64 MiB text cap, cancellation removes partial files) and play in AVPlayer. Office/iWork and the QuickLook long tail go through QLPreviewController when it accepts the item. Markdown gets a raw/rendered toolbar toggle (native attributed-string rendering; files over 1.5 MB stay raw). On the Mac, extensionless files are sniffed: if the first 8 KiB decodes as UTF-8 (allowing a trailing partial scalar) they classify as text, so bare `output`-style files preview normally on old and new phones alike.

Tests: CmuxAgentChat 303 (sniff matrix), CmuxAgentChatUI 61 (router matrix, temp-file streaming and cancellation, markdown presentation, QuickLook gating); both packages compile for the iOS simulator triple. EN+JA localization audited.

Part 4 of the chip-files-gallery completion stack, based on https://github.com/manaflow-ai/cmux/pull/8088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8090"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786657278&installation_id=133855650&pr_number=8090&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8090&signature=8cdc3af3ed1c4f60c09a876e363b8da3bad1f8496ec08ff71ee83825707feba0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds rich previews for PDFs, media, documents, and Markdown on iOS via client-side routing and streamed temp files. Extensionless UTF‑8 files render as text; MIME‑typed media without extensions route and play correctly.

- **New Features**
  - Client-side preview routing from stat `mimeType` and filename `UTType`; wire enum unchanged.
  - PDF previews with PDFKit.
  - Stream video/audio to temp files for AVPlayer; 512 MiB cap; cancellation removes partial files; files cleaned up on dismiss; never fully buffered in memory.
  - Quick Look for accepted Office/iWork and other document types, with acceptance check after download.
  - Markdown viewer with Raw/Rendered toggle; render up to 1.5 MB, else show raw.
  - UTF‑8 sniff for extensionless/unknown-extension files (8 KiB, partial‑scalar safe) to classify as text.
  - 64 MiB inline cap for text/images; tests cover sniffing, routing, temp-file streaming/cancellation/cleanup, Markdown, and Quick Look; EN+JA strings added.

- **Bug Fixes**
  - Route MIME-only audio/video artifacts to the media player (no extension required).
  - Type extensionless media temp files from the wire `mimeType` so AVPlayer can open them.

<sup>Written for commit 2ea7162dbff27034e985d4700cdc2bb58c793656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8090?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

