### PR TITLE
Pause automatic iOS screenshot CI

### DIFF
--- a/.github/workflows/ios-screenshots.yml
+++ b/.github/workflows/ios-screenshots.yml
@@ -6,9 +6,8 @@ name: iOS App Store screenshots
 # the CMUX_UITEST_MOCK_DATA hook, so no Apple signing is needed to shoot; only
 # the optional upload-to-ASC step needs the App Store Connect API key.
 #
-# On PRs touching the screenshot tooling it runs capture-only (validates the
-# snapshot test + Snapfile). Upload to App Store Connect is workflow_dispatch +
-# upload=true only.
+# During the CI pause this runs only on explicit dispatch. Upload to App Store
+# Connect additionally requires upload=true.
 
 on:
   workflow_dispatch:
@@ -26,19 +25,6 @@ on:
         required: false
         default: false
         type: boolean
-  pull_request:
-    paths:
-      - "ios/fastlane/**"
-      - "ios/cmuxUITests/SnapshotUITests.swift"
-      - "ios/cmuxUITests/SnapshotHelper.swift"
-      - "ios/Gemfile"
-      - ".github/workflows/ios-screenshots.yml"
-      # Screenshot fixtures: changing what the preview screens render should
-      # re-capture.
-      - "Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/*PreviewView.swift"
-      # The recorded agent terminal sessions replayed in the screenshots.
-      - "Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalPreviewTranscripts.swift"
-
 permissions:
   contents: read
   actions: write

--- a/.github/workflows/ios-streamed-validate.yml
+++ b/.github/workflows/ios-streamed-validate.yml
@@ -1,6 +1,6 @@
 name: iOS streamed-screenshot CI validation
 
-# Validates the REAL Mac-streamed screenshot pipeline headless on a Blacksmith
+# Validates the REAL Mac-streamed screenshot pipeline headless on a WarpBuild
 # macOS runner: stand up the dev web backend (local Postgres + Next.js), build +
 # run the desktop cmux Mac app, pair an iOS simulator to it, and capture the live
 # streamed terminal. Proves the pipeline works in CI before wiring it into the
@@ -12,21 +12,17 @@ name: iOS streamed-screenshot CI validation
 # test account) is provided as CMUXTERM_DEV_ENV_B64.
 on:
   workflow_dispatch:
-  push:
-    branches: [main]
-    paths: [".github/workflows/ios-streamed-validate.yml"]
 
 permissions:
   contents: read
 
 jobs:
   validate:
-    # Blacksmith macOS-26 (Xcode 26 / iOS 26 sims). Pinned directly rather than
-    # via vars.MACOS_RUNNER_IOS: that repo var currently routes the iOS lane to a
-    # Depot macOS image whose default Xcode is 16.4, under which cmux's iOS
-    # targets fail to compile (Swift 6 actor-isolation + interpolation errors)
-    # and the iPhone 17 sim does not exist. Blacksmith macos-26 ships Xcode 26.
-    runs-on: blacksmith-6vcpu-macos-26
+    # This end-to-end validation is expensive and is run only on explicit
+    # dispatch. Default to the isolated WarpBuild ARM lane; the selector below
+    # chooses its installed Xcode 26 toolchain and simulator runtime. Keep an
+    # override for a future isolated runner migration.
+    runs-on: ${{ vars.MACOS_RUNNER_STREAMED_VALIDATION || 'warp-macos-15-arm64-6x' }}
     timeout-minutes: 120
     env:
       CMUX_PORT: "3000"


### PR DESCRIPTION
## Summary

- make App Store screenshot capture manual-only during the CI pause
- make streamed screenshot validation manual-only
- route manually dispatched streamed validation to WarpBuild by default

## Testing

- parsed both workflow YAML files
- ran actionlint (only pre-existing shell warnings in the streamed validator)
- ran `git diff --check`
- canonical `$autoreview` and cmux policy checks passed

## Demo Video

Not applicable, workflow-only change.

## Checklist

- [x] No automatic GitHub Actions job is added by this PR
- [x] Expensive screenshot workflows require explicit dispatch
- [x] No app/runtime code changed