### PR TITLE
Fix Ghostty SSH wrapper path in embedded app bundles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -890,6 +890,7 @@ jobs:
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omx_fallback_path.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_cli_omc_fallback_path.py
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
+          python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py

--- a/tests/test_issue_8093_ghostty_ssh_binary_path.py
+++ b/tests/test_issue_8093_ghostty_ssh_binary_path.py
@@ -1,0 +1,95 @@
+#!/usr/bin/env python3
+"""Regression coverage for Ghostty SSH wrappers in embedded app bundles.
+
+The terminal host owns the exact CLI executable path. Shell integration must
+invoke that path directly instead of rebuilding ``<gui executable dir>/ghostty``.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+import subprocess
+import tempfile
+
+
+ROOT = Path(__file__).resolve().parents[1]
+ZSH_INTEGRATION = ROOT / "ghostty/src/shell-integration/zsh/ghostty-integration"
+BASH_INTEGRATION = ROOT / "ghostty/src/shell-integration/bash/ghostty.bash"
+EXPECTED_ARGUMENTS = ["+ssh", "--", "user@example.com"]
+
+
+def _run_wrapper(shell: str, integration: Path, helper: Path, log: Path) -> None:
+    env = os.environ.copy()
+    env.update(
+        {
+            "GHOSTTY_BIN": str(helper),
+            # Reproduce cmux's GUI executable directory. No `ghostty` binary
+            # exists here because cmux embeds GhosttyKit in its own executable.
+            "GHOSTTY_BIN_DIR": str(helper.parents[2] / "MacOS"),
+            "GHOSTTY_SHELL_FEATURES": "ssh-env,ssh-terminfo",
+            "GHOSTTY_TEST_LOG": str(log),
+        }
+    )
+
+    if shell == "zsh":
+        command = [
+            "zsh",
+            "-dfc",
+            (
+                "typeset -gi _ghostty_fd=1; "
+                'source "$1"; '
+                "_ghostty_deferred_init; "
+                "ssh user@example.com"
+            ),
+            "zsh",
+            str(integration),
+        ]
+    else:
+        command = [
+            "bash",
+            "--noprofile",
+            "--norc",
+            "-ic",
+            'source "$1"; ssh user@example.com',
+            "bash",
+            str(integration),
+        ]
+
+    result = subprocess.run(command, env=env, text=True, capture_output=True)
+    if result.returncode != 0:
+        raise AssertionError(
+            f"{shell} SSH wrapper failed with exit {result.returncode}\n"
+            f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+
+    actual = log.read_text().splitlines() if log.exists() else []
+    if actual != EXPECTED_ARGUMENTS:
+        raise AssertionError(
+            f"{shell} SSH wrapper invoked the wrong executable or arguments: "
+            f"expected {EXPECTED_ARGUMENTS!r}, got {actual!r}"
+        )
+
+
+def main() -> None:
+    with tempfile.TemporaryDirectory(prefix="cmux-issue-8093-") as raw_tmp:
+        tmp = Path(raw_tmp)
+        contents = tmp / "cmux.app/Contents"
+        helper = contents / "Resources/bin/cmux-ghostty-cli"
+        helper.parent.mkdir(parents=True)
+        (contents / "MacOS").mkdir(parents=True)
+        helper.write_text('#!/bin/sh\nprintf "%s\\n" "$@" > "$GHOSTTY_TEST_LOG"\n')
+        helper.chmod(0o755)
+
+        for shell, integration in (
+            ("zsh", ZSH_INTEGRATION),
+            ("bash", BASH_INTEGRATION),
+        ):
+            log = tmp / f"{shell}-argv.log"
+            _run_wrapper(shell, integration, helper, log)
+
+    print("PASS: Ghostty SSH wrappers invoke the host-provided executable path")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a deterministic regression for Ghostty SSH wrappers in embedded app bundles
- export the exact bundled Ghostty CLI helper path from cmux and protect it from inherited/user environment overrides
- teach Ghostty core and its zsh, bash, fish, nushell, and elvish integrations to invoke that full path instead of reconstructing `<GUI executable dir>/ghostty`
- publish and checksum-pin the matching universal ReleaseFast GhosttyKit

## Root cause

Ghostty derived `GHOSTTY_BIN_DIR` from `selfExePath()` and every SSH shell wrapper appended `/ghostty`. In a GhosttyKit host, `selfExePath()` is cmux, so the wrapper constructed `/Applications/cmux.app/Contents/MacOS/ghostty`. cmux actually ships the Ghostty CLI helper at `Contents/Resources/bin/ghostty`.

The fix introduces one full executable-path contract, `GHOSTTY_BIN`. Native Ghostty resolves it to its own executable; cmux sets it to its bundled helper. `GHOSTTY_BIN_DIR` remains only the directory used by the independent PATH feature. Embedded hosts without a helper do not install a broken SSH wrapper.

## Affected users

Ghostty defaults `ssh-env` and `ssh-terminfo` to off, so ordinary sessions without either feature do not define the wrapper and will not reproduce the bug. It affects sessions where either feature is enabled by Ghostty config or cmux remote/bootstrap behavior. A separately installed Ghostty does not determine the outcome because the old wrapper directly executed the derived bundle path instead of searching `PATH`.

## Regression proof

Commit `d08653b7d4` contains the failing test only. Against the old submodule it invokes the actual zsh integration and fails with exit 127 and `ssh:4: no such file or directory: .../cmux.app/Contents/MacOS/ghostty`, matching #8093. Against the fixed head the same zsh and bash behavior checks invoke the host-provided helper as `+ssh -- user@example.com` and pass.

## Verification

- `python3 tests/test_issue_8093_ghostty_ssh_binary_path.py`
- zsh, bash, and fish syntax checks
- Ghostty fork required test workflow: green (manaflow-ai/ghostty#115)
- universal ReleaseFast GhosttyKit built from `b4b6d69c8`, archive validator passed, GitHub asset digest pinned as `89a2d738fc566c9c91e2c0ed7c2c9fa9f6ac18d9f0541fd9ff58e41bb8b8caa9`
- `./tests/test_ci_ghosttykit_checksum_present.sh`
- `./tests/test_ci_ghosttykit_checksum_verification.sh`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- global Swift budget script run; current main baseline fails in unrelated files, while the only touched Swift file is 315 lines and neither budget TSV changes
- no local xcodebuild or app dogfood build run, per task instructions

Closes #8093