### PR TITLE
iOS: artifact text viewer features and top-anchored files chip

### DIFF
--- a/Packages/iOS/CmuxAgentChatUI/Package.resolved
+++ b/Packages/iOS/CmuxAgentChatUI/Package.resolved
@@ -1,0 +1,15 @@
+{
+  "originHash" : "360573bfc5c7f7a8fdde3df27bac8472e0c3938aa9fb7f8bd43b1def104914e8",
+  "pins" : [
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr.git",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/Packages/iOS/CmuxAgentChatUI/Package.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Package.swift
@@ -18,6 +18,10 @@ let package = Package(
     dependencies: [
         .package(path: "../../Shared/CmuxAgentChat"),
         .package(path: "../CmuxMobileSupport"),
+        .package(
+            url: "https://github.com/raspu/Highlightr.git",
+            exact: "2.3.0"
+        ),
     ],
     targets: [
         .target(
@@ -25,6 +29,7 @@ let package = Package(
             dependencies: [
                 "CmuxAgentChat",
                 "CmuxMobileSupport",
+                .product(name: "Highlightr", package: "Highlightr"),
             ],
             resources: [.process("Resources")],
             swiftSettings: [.swiftLanguageMode(.v6)]

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactGoToLineBar.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactGoToLineBar.swift
@@ -1,0 +1,82 @@
+import SwiftUI
+
+/// Inline numeric controls for jumping to a currently loaded text line.
+struct ChatArtifactGoToLineBar: View {
+    @Binding var lineText: String
+    let onGo: (Int) -> Void
+    let onClose: () -> Void
+
+    @FocusState private var isLineFieldFocused: Bool
+
+    var body: some View {
+        HStack(spacing: 8) {
+            lineField
+
+            Button {
+                submit()
+            } label: {
+                Text(String(
+                    localized: "chat.artifact.line.go",
+                    defaultValue: "Go",
+                    bundle: .module
+                ))
+            }
+            .buttonStyle(.borderedProminent)
+            .disabled(Int(lineText) == nil)
+
+            Button {
+                isLineFieldFocused = false
+                onClose()
+            } label: {
+                Image(systemName: "xmark.circle.fill")
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(String(
+                localized: "chat.artifact.line.close",
+                defaultValue: "Close go to line",
+                bundle: .module
+            ))
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+        .onAppear {
+            isLineFieldFocused = true
+        }
+        .onDisappear {
+            isLineFieldFocused = false
+        }
+    }
+
+    @ViewBuilder
+    private var lineField: some View {
+        #if os(iOS)
+        baseLineField
+            .keyboardType(.numberPad)
+        #else
+        baseLineField
+        #endif
+    }
+
+    private var baseLineField: some View {
+        TextField(
+            String(
+                localized: "chat.artifact.line.placeholder",
+                defaultValue: "Line number",
+                bundle: .module
+            ),
+            text: $lineText
+        )
+        .textFieldStyle(.roundedBorder)
+        .focused($isLineFieldFocused)
+        .onSubmit {
+            submit()
+        }
+    }
+
+    private func submit() {
+        guard let line = Int(lineText) else { return }
+        isLineFieldFocused = false
+        onGo(line)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightDecision.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightDecision.swift
@@ -1,0 +1,11 @@
+/// Describes whether and how a loaded text artifact should be syntax highlighted.
+enum ChatArtifactHighlightDecision: Equatable, Sendable {
+    case highlight(language: String?)
+    case skippedForSize
+    case skippedNoLanguage
+
+    /// Whether the size-threshold explanation belongs in the viewer chrome.
+    var showsHighlightingOffPill: Bool {
+        self == .skippedForSize
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightTheme.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightTheme.swift
@@ -1,0 +1,5 @@
+/// The syntax color palette selected from the viewer's current appearance.
+enum ChatArtifactHighlightTheme: Equatable, Sendable {
+    case light
+    case dark
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightedText.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightedText.swift
@@ -1,0 +1,13 @@
+import Foundation
+
+/// An immutable attributed-string snapshot produced by the background highlighter.
+///
+/// SAFETY: `value` is copied into an immutable `NSAttributedString` before transfer
+/// and is only read after the producing actor has returned it.
+final class ChatArtifactHighlightedText: @unchecked Sendable {
+    let value: NSAttributedString
+
+    init(_ value: NSAttributedString) {
+        self.value = NSAttributedString(attributedString: value)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightingStatusPill.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightingStatusPill.swift
@@ -1,0 +1,58 @@
+import Foundation
+import SwiftUI
+
+/// A compact, expandable explanation for syntax highlighting disabled by file size.
+struct ChatArtifactHighlightingStatusPill: View {
+    let actualBytes: Int64
+    let maximumBytes: Int64
+
+    @State private var isExpanded = false
+
+    var body: some View {
+        Button {
+            isExpanded.toggle()
+        } label: {
+            HStack(alignment: .firstTextBaseline, spacing: 8) {
+                Image(systemName: "paintbrush.slash")
+                    .imageScale(.small)
+                if isExpanded {
+                    Text(explanation)
+                        .font(.caption)
+                        .multilineTextAlignment(.leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    Text(String(
+                        localized: "chat.artifact.highlighting.off",
+                        defaultValue: "Highlighting off",
+                        bundle: .module
+                    ))
+                    .font(.caption.weight(.semibold))
+                }
+                Image(systemName: isExpanded ? "xmark.circle.fill" : "chevron.right")
+                    .imageScale(.small)
+                    .foregroundStyle(.secondary)
+            }
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .frame(maxWidth: isExpanded ? 360 : nil, alignment: .leading)
+            .background(.thinMaterial, in: Capsule())
+            .contentShape(Capsule())
+        }
+        .buttonStyle(.plain)
+        .animation(.snappy, value: isExpanded)
+    }
+
+    private var explanation: String {
+        let format = String(
+            localized: "chat.artifact.highlighting.off.explanation",
+            defaultValue: "This file is %@. Syntax highlighting is off above %@ to keep scrolling smooth.",
+            bundle: .module
+        )
+        return String.localizedStringWithFormat(
+            format,
+            ByteCountFormatter.string(fromByteCount: actualBytes, countStyle: .file),
+            ByteCountFormatter.string(fromByteCount: maximumBytes, countStyle: .file)
+        )
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineIndex.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineIndex.swift
@@ -1,0 +1,48 @@
+/// Incremental UTF-16 line starts for streamed text and constant-time line jumps.
+struct ChatArtifactLineIndex: Equatable, Sendable {
+    private(set) var lineStartOffsets: [Int] = [0]
+    private(set) var loadedUTF16Length = 0
+
+    var lineCount: Int {
+        lineStartOffsets.count
+    }
+
+    /// Adds line starts from one newly decoded streaming chunk.
+    mutating func append(_ text: String) {
+        let baseOffset = loadedUTF16Length
+        var chunkOffset = 0
+        for codeUnit in text.utf16 {
+            chunkOffset += 1
+            if codeUnit == 0x0A {
+                lineStartOffsets.append(baseOffset + chunkOffset)
+            }
+        }
+        loadedUTF16Length += chunkOffset
+    }
+
+    /// Clamps a one-based requested line to the range currently loaded.
+    func clampedLine(_ requestedLine: Int) -> Int {
+        min(max(requestedLine, 1), lineCount)
+    }
+
+    /// Returns the UTF-16 location for a one-based line, clamped to loaded lines.
+    func offset(forLine requestedLine: Int) -> Int {
+        lineStartOffsets[clampedLine(requestedLine) - 1]
+    }
+
+    /// Finds the one-based logical line containing a UTF-16 text location.
+    func lineNumber(containingUTF16Offset requestedOffset: Int) -> Int {
+        let offset = min(max(requestedOffset, 0), loadedUTF16Length)
+        var lowerBound = 0
+        var upperBound = lineStartOffsets.count
+        while lowerBound < upperBound {
+            let midpoint = (lowerBound + upperBound) / 2
+            if lineStartOffsets[midpoint] <= offset {
+                lowerBound = midpoint + 1
+            } else {
+                upperBound = midpoint
+            }
+        }
+        return max(lowerBound, 1)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineNumberGutterView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineNumberGutterView.swift
@@ -1,0 +1,74 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Draws only line numbers whose TextKit 1 fragments intersect the viewport.
+@MainActor
+final class ChatArtifactLineNumberGutterView: UIView {
+    weak var textView: UITextView?
+    var lineIndex = ChatArtifactLineIndex()
+    var textFontPointSize: CGFloat = UIFont.preferredFont(forTextStyle: .body).pointSize
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        backgroundColor = UIColor.secondarySystemBackground.withAlphaComponent(0.45)
+        isOpaque = false
+        contentMode = .redraw
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func draw(_ rect: CGRect) {
+        guard let textView else { return }
+        let textContainer = textView.textContainer
+        let layoutManager = textView.layoutManager
+        let visibleTextRect = CGRect(
+            x: textView.contentOffset.x - textView.textContainerInset.left,
+            y: textView.contentOffset.y - textView.textContainerInset.top,
+            width: textView.bounds.width,
+            height: textView.bounds.height
+        )
+        let glyphRange = layoutManager.glyphRange(
+            forBoundingRect: visibleTextRect,
+            in: textContainer
+        )
+        let font = UIFont.monospacedDigitSystemFont(
+            ofSize: max(9, textFontPointSize * 0.78),
+            weight: .regular
+        )
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .right
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: UIColor.secondaryLabel,
+            .paragraphStyle: paragraphStyle,
+        ]
+
+        layoutManager.enumerateLineFragments(forGlyphRange: glyphRange) {
+            [weak self] _, usedRect, _, fragmentGlyphRange, _ in
+            guard let self else { return }
+            let characterRange = layoutManager.characterRange(
+                forGlyphRange: fragmentGlyphRange,
+                actualGlyphRange: nil
+            )
+            let lineNumber = self.lineIndex.lineNumber(
+                containingUTF16Offset: characterRange.location
+            )
+            guard self.lineIndex.offset(forLine: lineNumber) == characterRange.location else {
+                return
+            }
+            let labelRect = CGRect(
+                x: 4,
+                y: usedRect.minY + textView.textContainerInset.top - textView.contentOffset.y,
+                width: max(0, self.bounds.width - 12),
+                height: max(usedRect.height, font.lineHeight)
+            )
+            String(lineNumber).draw(in: labelRect, withAttributes: attributes)
+        }
+
+        UIColor.separator.setFill()
+        UIBezierPath(rect: CGRect(x: bounds.maxX - 0.5, y: 0, width: 0.5, height: bounds.height)).fill()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSearchBar.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSearchBar.swift
@@ -1,0 +1,113 @@
+import SwiftUI
+
+/// Inline in-file search controls for the currently loaded artifact text.
+struct ChatArtifactSearchBar: View {
+    @Binding var query: String
+    let summary: ChatArtifactSearchSummary
+    let isStillLoading: Bool
+    let onPrevious: () -> Void
+    let onNext: () -> Void
+    let onClose: () -> Void
+
+    @FocusState private var isSearchFieldFocused: Bool
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 8) {
+                searchField
+
+                if !query.isEmpty {
+                    Text(verbatim: "\(summary.currentPosition)/\(summary.matchCount)")
+                        .font(.caption.monospacedDigit())
+                        .foregroundStyle(.secondary)
+                        .fixedSize()
+                }
+
+                Button(action: onPrevious) {
+                    Image(systemName: "chevron.up")
+                }
+                .disabled(query.isEmpty || summary.matchCount == 0)
+                .accessibilityLabel(String(
+                    localized: "chat.artifact.search.previous",
+                    defaultValue: "Previous match",
+                    bundle: .module
+                ))
+
+                Button(action: onNext) {
+                    Image(systemName: "chevron.down")
+                }
+                .disabled(query.isEmpty || summary.matchCount == 0)
+                .accessibilityLabel(String(
+                    localized: "chat.artifact.search.next",
+                    defaultValue: "Next match",
+                    bundle: .module
+                ))
+
+                Button {
+                    isSearchFieldFocused = false
+                    onClose()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                }
+                .accessibilityLabel(String(
+                    localized: "chat.artifact.search.close",
+                    defaultValue: "Close search",
+                    bundle: .module
+                ))
+            }
+            .buttonStyle(.plain)
+
+            if isStillLoading, !query.isEmpty {
+                HStack(spacing: 5) {
+                    ProgressView()
+                        .controlSize(.mini)
+                    Text(String(
+                        localized: "chat.artifact.search.still_loading",
+                        defaultValue: "Still loading",
+                        bundle: .module
+                    ))
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+                }
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(.bar)
+        .onAppear {
+            isSearchFieldFocused = true
+        }
+        .onDisappear {
+            isSearchFieldFocused = false
+        }
+    }
+
+    @ViewBuilder
+    private var searchField: some View {
+        #if os(iOS)
+        baseSearchField
+            .textInputAutocapitalization(.never)
+        #else
+        baseSearchField
+        #endif
+    }
+
+    private var baseSearchField: some View {
+        TextField(
+            String(
+                localized: "chat.artifact.search.placeholder",
+                defaultValue: "Find in file",
+                bundle: .module
+            ),
+            text: $query
+        )
+        .textFieldStyle(.roundedBorder)
+        .autocorrectionDisabled()
+        .submitLabel(.search)
+        .focused($isSearchFieldFocused)
+        .onSubmit {
+            isSearchFieldFocused = false
+            onNext()
+        }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSearchModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSearchModel.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+/// Pure literal-search state over the currently loaded UTF-16 text range.
+struct ChatArtifactSearchModel: Equatable, Sendable {
+    private(set) var query: String
+    private(set) var matchRanges: [NSRange]
+    private(set) var selectedMatchIndex: Int?
+
+    init(query: String = "", text: String = "") {
+        self.query = query
+        matchRanges = Self.ranges(of: query, in: text)
+        selectedMatchIndex = matchRanges.isEmpty ? nil : 0
+    }
+
+    var currentRange: NSRange? {
+        guard let selectedMatchIndex,
+              matchRanges.indices.contains(selectedMatchIndex) else {
+            return nil
+        }
+        return matchRanges[selectedMatchIndex]
+    }
+
+    var summary: ChatArtifactSearchSummary {
+        ChatArtifactSearchSummary(
+            currentPosition: selectedMatchIndex.map { $0 + 1 } ?? 0,
+            matchCount: matchRanges.count
+        )
+    }
+
+    /// Replaces the literal query and starts selection at the first loaded match.
+    mutating func update(query: String, in text: String) {
+        guard query == self.query else {
+            self.query = query
+            matchRanges = Self.ranges(of: query, in: text)
+            selectedMatchIndex = matchRanges.isEmpty ? nil : 0
+            return
+        }
+        recompute(in: text)
+    }
+
+    /// Recomputes after a stream append while preserving the current match when possible.
+    mutating func recompute(in text: String) {
+        let selectedRange = currentRange
+        matchRanges = Self.ranges(of: query, in: text)
+        if let selectedRange,
+           let preservedIndex = matchRanges.firstIndex(of: selectedRange) {
+            selectedMatchIndex = preservedIndex
+        } else {
+            selectedMatchIndex = matchRanges.isEmpty ? nil : 0
+        }
+    }
+
+    /// Advances to the next result, wrapping from the last match to the first.
+    mutating func selectNext() {
+        guard !matchRanges.isEmpty else {
+            selectedMatchIndex = nil
+            return
+        }
+        selectedMatchIndex = ((selectedMatchIndex ?? -1) + 1) % matchRanges.count
+    }
+
+    /// Moves to the previous result, wrapping from the first match to the last.
+    mutating func selectPrevious() {
+        guard !matchRanges.isEmpty else {
+            selectedMatchIndex = nil
+            return
+        }
+        let currentIndex = selectedMatchIndex ?? 0
+        selectedMatchIndex = (currentIndex - 1 + matchRanges.count) % matchRanges.count
+    }
+
+    private static func ranges(of query: String, in text: String) -> [NSRange] {
+        guard !query.isEmpty else { return [] }
+        let source = text as NSString
+        var searchRange = NSRange(location: 0, length: source.length)
+        var results: [NSRange] = []
+
+        while searchRange.length > 0 {
+            let match = source.range(
+                of: query,
+                options: [.caseInsensitive, .literal],
+                range: searchRange
+            )
+            guard match.location != NSNotFound else { break }
+            results.append(match)
+            let nextLocation = NSMaxRange(match)
+            guard nextLocation > searchRange.location else { break }
+            searchRange = NSRange(
+                location: nextLocation,
+                length: source.length - nextLocation
+            )
+        }
+        return results
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSearchSummary.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSearchSummary.swift
@@ -1,0 +1,7 @@
+/// The small search-state snapshot needed by the SwiftUI search chrome.
+struct ChatArtifactSearchSummary: Equatable, Sendable {
+    static let empty = ChatArtifactSearchSummary(currentPosition: 0, matchCount: 0)
+
+    let currentPosition: Int
+    let matchCount: Int
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSyntaxHighlightPolicy.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSyntaxHighlightPolicy.swift
@@ -69,13 +69,18 @@ struct ChatArtifactSyntaxHighlightPolicy: Sendable {
             return .skippedForSize
         }
 
-        let pathExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
-        if let language = Self.languagesByExtension[pathExtension] {
+        if let language = inferredLanguage(path: path) {
             return .highlight(language: language)
         }
         if byteCount < Self.maxAutomaticDetectionBytes {
             return .highlight(language: nil)
         }
         return .skippedNoLanguage
+    }
+
+    /// Returns a highlight.js language inferred strictly from the path extension.
+    func inferredLanguage(path: String) -> String? {
+        let pathExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
+        return Self.languagesByExtension[pathExtension]
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSyntaxHighlightPolicy.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSyntaxHighlightPolicy.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Selects syntax highlighting without spending unbounded work on large artifacts.
+struct ChatArtifactSyntaxHighlightPolicy: Sendable {
+    static let maxHighlightBytes: Int64 = 1_500_000
+    static let maxAutomaticDetectionBytes: Int64 = 256_000
+
+    private static let languagesByExtension: [String: String] = [
+        "bash": "bash",
+        "c": "c",
+        "cc": "cpp",
+        "cjs": "javascript",
+        "clj": "clojure",
+        "cljs": "clojure",
+        "cpp": "cpp",
+        "cs": "csharp",
+        "css": "css",
+        "cxx": "cpp",
+        "dart": "dart",
+        "ex": "elixir",
+        "exs": "elixir",
+        "fs": "fsharp",
+        "fsx": "fsharp",
+        "go": "go",
+        "gradle": "gradle",
+        "groovy": "groovy",
+        "h": "c",
+        "hh": "cpp",
+        "hpp": "cpp",
+        "htm": "html",
+        "html": "html",
+        "java": "java",
+        "js": "javascript",
+        "json": "json",
+        "jsx": "javascript",
+        "kt": "kotlin",
+        "kts": "kotlin",
+        "less": "less",
+        "lua": "lua",
+        "m": "objectivec",
+        "markdown": "markdown",
+        "md": "markdown",
+        "mjs": "javascript",
+        "mm": "objectivec",
+        "php": "php",
+        "pl": "perl",
+        "pm": "perl",
+        "py": "python",
+        "r": "r",
+        "rb": "ruby",
+        "rs": "rust",
+        "sass": "scss",
+        "scala": "scala",
+        "scss": "scss",
+        "sh": "bash",
+        "sql": "sql",
+        "swift": "swift",
+        "ts": "typescript",
+        "tsx": "typescript",
+        "xml": "xml",
+        "yaml": "yaml",
+        "yml": "yaml",
+        "zsh": "bash",
+    ]
+
+    /// Returns the bounded highlighting decision for a path and its real byte size.
+    func decision(path: String, byteCount: Int64) -> ChatArtifactHighlightDecision {
+        guard byteCount <= Self.maxHighlightBytes else {
+            return .skippedForSize
+        }
+
+        let pathExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
+        if let language = Self.languagesByExtension[pathExtension] {
+            return .highlight(language: language)
+        }
+        if byteCount < Self.maxAutomaticDetectionBytes {
+            return .highlight(language: nil)
+        }
+        return .skippedNoLanguage
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSyntaxHighlighter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactSyntaxHighlighter.swift
@@ -1,0 +1,30 @@
+import Foundation
+@preconcurrency import Highlightr
+
+/// Serializes JavaScriptCore-backed highlighting away from the main actor.
+actor ChatArtifactSyntaxHighlighter {
+    private var engine: Highlightr?
+
+    /// Highlights a complete artifact using the palette for the current appearance.
+    func highlight(
+        text: String,
+        language: String?,
+        theme: ChatArtifactHighlightTheme
+    ) -> ChatArtifactHighlightedText? {
+        let highlightr: Highlightr
+        if let engine {
+            highlightr = engine
+        } else {
+            guard let newEngine = Highlightr() else { return nil }
+            engine = newEngine
+            highlightr = newEngine
+        }
+
+        let themeName = theme == .dark ? "xcode-dark" : "xcode"
+        guard highlightr.setTheme(to: themeName),
+              let highlighted = highlightr.highlight(text, as: language) else {
+            return nil
+        }
+        return ChatArtifactHighlightedText(highlighted)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextContainerView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextContainerView.swift
@@ -1,0 +1,80 @@
+#if canImport(UIKit)
+import UIKit
+
+/// Hosts the TextKit 1 text view beside its independently redrawn line gutter.
+@MainActor
+final class ChatArtifactTextContainerView: UIView {
+    let textView: UITextView
+    let gutterView = ChatArtifactLineNumberGutterView()
+
+    private let gutterWidthConstraint: NSLayoutConstraint
+
+    override init(frame: CGRect) {
+        textView = UITextView(usingTextLayoutManager: false)
+        gutterWidthConstraint = gutterView.widthAnchor.constraint(equalToConstant: 0)
+        super.init(frame: frame)
+
+        backgroundColor = .clear
+        textView.layoutManager.allowsNonContiguousLayout = true
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.isScrollEnabled = true
+        textView.backgroundColor = .clear
+        textView.adjustsFontForContentSizeCategory = true
+        textView.font = .monospacedSystemFont(
+            ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize,
+            weight: .regular
+        )
+        textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
+        textView.textContainer.lineFragmentPadding = 0
+
+        gutterView.textView = textView
+        gutterView.translatesAutoresizingMaskIntoConstraints = false
+        textView.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(gutterView)
+        addSubview(textView)
+        NSLayoutConstraint.activate([
+            gutterView.leadingAnchor.constraint(equalTo: leadingAnchor),
+            gutterView.topAnchor.constraint(equalTo: topAnchor),
+            gutterView.bottomAnchor.constraint(equalTo: bottomAnchor),
+            gutterWidthConstraint,
+            textView.leadingAnchor.constraint(equalTo: gutterView.trailingAnchor),
+            textView.trailingAnchor.constraint(equalTo: trailingAnchor),
+            textView.topAnchor.constraint(equalTo: topAnchor),
+            textView.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func layoutSubviews() {
+        super.layoutSubviews()
+        gutterView.setNeedsDisplay()
+    }
+
+    /// Refreshes the immutable line snapshot and the width needed for its largest number.
+    func updateLineNumbers(
+        index: ChatArtifactLineIndex,
+        isVisible: Bool
+    ) {
+        gutterView.lineIndex = index
+        gutterView.textFontPointSize = textView.font?.pointSize
+            ?? UIFont.preferredFont(forTextStyle: .body).pointSize
+        gutterView.isHidden = !isVisible
+        if isVisible {
+            let digitCount = max(2, String(index.lineCount).count)
+            let font = UIFont.monospacedDigitSystemFont(
+                ofSize: max(9, gutterView.textFontPointSize * 0.78),
+                weight: .regular
+            )
+            let digitWidth = ("0" as NSString).size(withAttributes: [.font: font]).width
+            gutterWidthConstraint.constant = ceil(digitWidth * CGFloat(digitCount) + 18)
+        } else {
+            gutterWidthConstraint.constant = 0
+        }
+        gutterView.setNeedsDisplay()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextContainerView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextContainerView.swift
@@ -8,6 +8,7 @@ final class ChatArtifactTextContainerView: UIView {
     let gutterView = ChatArtifactLineNumberGutterView()
 
     private let gutterWidthConstraint: NSLayoutConstraint
+    private var wrapsLines = true
 
     override init(frame: CGRect) {
         textView = UITextView(usingTextLayoutManager: false)
@@ -51,6 +52,54 @@ final class ChatArtifactTextContainerView: UIView {
 
     override func layoutSubviews() {
         super.layoutSubviews()
+        if wrapsLines {
+            textView.textContainer.size = CGSize(
+                width: max(
+                    0,
+                    textView.bounds.width
+                        - textView.textContainerInset.left
+                        - textView.textContainerInset.right
+                ),
+                height: .greatestFiniteMagnitude
+            )
+        }
+        gutterView.setNeedsDisplay()
+    }
+
+    /// Switches between viewport-width wrapping and an unbounded horizontal container.
+    func updateWordWrap(_ wrapsLines: Bool) {
+        guard self.wrapsLines != wrapsLines else { return }
+        self.wrapsLines = wrapsLines
+        let contentOffset = textView.contentOffset
+        textView.textContainer.widthTracksTextView = wrapsLines
+        textView.textContainer.lineBreakMode = wrapsLines ? .byWordWrapping : .byClipping
+        textView.alwaysBounceHorizontal = !wrapsLines
+        textView.showsHorizontalScrollIndicator = !wrapsLines
+        if wrapsLines {
+            textView.textContainer.size = CGSize(
+                width: max(
+                    0,
+                    textView.bounds.width
+                        - textView.textContainerInset.left
+                        - textView.textContainerInset.right
+                ),
+                height: .greatestFiniteMagnitude
+            )
+            textView.setContentOffset(
+                CGPoint(x: -textView.adjustedContentInset.left, y: contentOffset.y),
+                animated: false
+            )
+        } else {
+            textView.textContainer.size = CGSize(
+                width: CGFloat.greatestFiniteMagnitude,
+                height: CGFloat.greatestFiniteMagnitude
+            )
+            textView.setContentOffset(contentOffset, animated: false)
+        }
+        textView.layoutManager.invalidateLayout(
+            forCharacterRange: NSRange(location: 0, length: textView.textStorage.length),
+            actualCharacterRange: nil
+        )
         gutterView.setNeedsDisplay()
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextLayoutKind.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextLayoutKind.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Persistence buckets for artifact text layout choices.
+enum ChatArtifactTextLayoutKind: String, Equatable, Sendable {
+    case code
+    case log
+    case plainText
+
+    init(path: String) {
+        let pathExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
+        if pathExtension == "log" || pathExtension == "out" {
+            self = .log
+        } else if ChatArtifactSyntaxHighlightPolicy().inferredLanguage(path: path) != nil {
+            self = .code
+        } else {
+            self = .plainText
+        }
+    }
+
+    var defaultWrapsLines: Bool {
+        self != .log
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextPreferences.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextPreferences.swift
@@ -1,0 +1,61 @@
+import Foundation
+
+/// Stores independent wrap and font-size choices for each artifact text kind.
+struct ChatArtifactTextPreferences {
+    static let minimumFontSize = 8.0
+    static let maximumFontSize = 28.0
+    static let defaultFontSize = 15.0
+
+    private let defaults: UserDefaults
+    private let keyPrefix: String
+
+    init(
+        defaults: UserDefaults,
+        keyPrefix: String = "cmux.artifactText"
+    ) {
+        self.defaults = defaults
+        self.keyPrefix = keyPrefix
+    }
+
+    /// Returns the saved wrap choice or the kind-specific default.
+    func wrapsLines(for kind: ChatArtifactTextLayoutKind) -> Bool {
+        let key = wrapKey(for: kind)
+        guard defaults.object(forKey: key) != nil else {
+            return kind.defaultWrapsLines
+        }
+        return defaults.bool(forKey: key)
+    }
+
+    /// Saves an explicit wrap choice for one text kind.
+    func setWrapsLines(_ wrapsLines: Bool, for kind: ChatArtifactTextLayoutKind) {
+        defaults.set(wrapsLines, forKey: wrapKey(for: kind))
+    }
+
+    /// Returns the saved, clamped monospaced font size for one text kind.
+    func fontSize(for kind: ChatArtifactTextLayoutKind) -> Double {
+        guard defaults.object(forKey: fontSizeKey(for: kind)) != nil else {
+            return Self.defaultFontSize
+        }
+        return Self.clamped(defaults.double(forKey: fontSizeKey(for: kind)))
+    }
+
+    /// Saves and returns a clamped monospaced font size for one text kind.
+    @discardableResult
+    func setFontSize(_ fontSize: Double, for kind: ChatArtifactTextLayoutKind) -> Double {
+        let clamped = Self.clamped(fontSize)
+        defaults.set(clamped, forKey: fontSizeKey(for: kind))
+        return clamped
+    }
+
+    private func wrapKey(for kind: ChatArtifactTextLayoutKind) -> String {
+        "\(keyPrefix).wrap.\(kind.rawValue)"
+    }
+
+    private func fontSizeKey(for kind: ChatArtifactTextLayoutKind) -> String {
+        "\(keyPrefix).fontSize.\(kind.rawValue)"
+    }
+
+    private static func clamped(_ fontSize: Double) -> Double {
+        min(max(fontSize, minimumFontSize), maximumFontSize)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -9,6 +9,10 @@ struct ChatArtifactTextView: UIViewRepresentable {
     let reachedEOF: Bool
     let highlightDecision: ChatArtifactHighlightDecision
     let highlightTheme: ChatArtifactHighlightTheme
+    let searchQuery: String
+    let previousSearchRequestID: Int
+    let nextSearchRequestID: Int
+    let onSearchSummaryChanged: (ChatArtifactSearchSummary) -> Void
     let topRequestID: Int
     let bottomRequestID: Int
 
@@ -41,6 +45,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
         let isNewDocument = context.coordinator.documentID != documentID
         if isNewDocument {
             context.coordinator.resetHighlighting()
+            context.coordinator.resetSearch()
             textView.textStorage.setAttributedString(NSAttributedString())
             textView.selectedRange = NSRange(location: 0, length: 0)
             context.coordinator.documentID = documentID
@@ -51,6 +56,8 @@ struct ChatArtifactTextView: UIViewRepresentable {
 
         if context.coordinator.appliedChunkCount > chunks.count {
             context.coordinator.appliedChunkCount = 0
+            context.coordinator.resetHighlighting()
+            context.coordinator.resetSearch()
             textView.textStorage.setAttributedString(NSAttributedString())
         }
 
@@ -82,6 +89,16 @@ struct ChatArtifactTextView: UIViewRepresentable {
             reachedEOF: reachedEOF,
             decision: highlightDecision,
             theme: highlightTheme
+        )
+        context.coordinator.updateSearch(
+            in: textView,
+            documentID: documentID,
+            text: textView.textStorage.string,
+            query: searchQuery,
+            reachedEOF: reachedEOF,
+            previousRequestID: previousSearchRequestID,
+            nextRequestID: nextSearchRequestID,
+            onSummaryChanged: onSearchSummaryChanged
         )
 
         if isNewDocument {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -6,6 +6,9 @@ import UIKit
 struct ChatArtifactTextView: UIViewRepresentable {
     let documentID: String
     let chunks: [String]
+    let reachedEOF: Bool
+    let highlightDecision: ChatArtifactHighlightDecision
+    let highlightTheme: ChatArtifactHighlightTheme
     let topRequestID: Int
     let bottomRequestID: Int
 
@@ -37,6 +40,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
     func updateUIView(_ textView: UITextView, context: Context) {
         let isNewDocument = context.coordinator.documentID != documentID
         if isNewDocument {
+            context.coordinator.resetHighlighting()
             textView.textStorage.setAttributedString(NSAttributedString())
             textView.selectedRange = NSRange(location: 0, length: 0)
             context.coordinator.documentID = documentID
@@ -70,6 +74,15 @@ struct ChatArtifactTextView: UIViewRepresentable {
             textView.setContentOffset(contentOffset, animated: false)
             context.coordinator.appliedChunkCount += 1
         }
+
+        context.coordinator.updateHighlighting(
+            in: textView,
+            documentID: documentID,
+            text: textView.textStorage.string,
+            reachedEOF: reachedEOF,
+            decision: highlightDecision,
+            theme: highlightTheme
+        )
 
         if isNewDocument {
             Self.scrollToTop(textView)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -17,6 +17,9 @@ struct ChatArtifactTextView: UIViewRepresentable {
     let showsLineNumbers: Bool
     let goToLineUTF16Offset: Int
     let goToLineRequestID: Int
+    let wrapsLines: Bool
+    let fontPointSize: Double
+    let onFontSizeChanged: (Double) -> Void
     let topRequestID: Int
     let bottomRequestID: Int
 
@@ -30,11 +33,13 @@ struct ChatArtifactTextView: UIViewRepresentable {
         let containerView = ChatArtifactTextContainerView()
         containerView.textView.delegate = context.coordinator
         context.coordinator.attach(containerView)
+        context.coordinator.onFontSizeChanged = onFontSizeChanged
         return containerView
     }
 
     func updateUIView(_ containerView: ChatArtifactTextContainerView, context: Context) {
         let textView = containerView.textView
+        context.coordinator.onFontSizeChanged = onFontSizeChanged
         let isNewDocument = context.coordinator.documentID != documentID
         if isNewDocument {
             context.coordinator.resetHighlighting()
@@ -54,6 +59,9 @@ struct ChatArtifactTextView: UIViewRepresentable {
             context.coordinator.resetSearch()
             textView.textStorage.setAttributedString(NSAttributedString())
         }
+
+        containerView.updateWordWrap(wrapsLines)
+        context.coordinator.updateFontSize(in: textView, pointSize: fontPointSize)
 
         let font = textView.font ?? UIFont.monospacedSystemFont(
             ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize,

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -13,6 +13,10 @@ struct ChatArtifactTextView: UIViewRepresentable {
     let previousSearchRequestID: Int
     let nextSearchRequestID: Int
     let onSearchSummaryChanged: (ChatArtifactSearchSummary) -> Void
+    let lineIndex: ChatArtifactLineIndex
+    let showsLineNumbers: Bool
+    let goToLineUTF16Offset: Int
+    let goToLineRequestID: Int
     let topRequestID: Int
     let bottomRequestID: Int
 
@@ -20,28 +24,17 @@ struct ChatArtifactTextView: UIViewRepresentable {
         ChatArtifactTextViewCoordinator()
     }
 
-    func makeUIView(context: Context) -> UITextView {
-        // A default UITextView uses TextKit 2 on modern iOS. Large artifacts
-        // then synchronously create layout fragments during fast scrolling.
-        // Opt into the TextKit 1 stack so non-contiguous glyph layout remains
-        // genuinely lazy instead of entering TextKit 2 compatibility mode.
-        let textView = UITextView(usingTextLayoutManager: false)
-        textView.layoutManager.allowsNonContiguousLayout = true
-        textView.isEditable = false
-        textView.isSelectable = true
-        textView.isScrollEnabled = true
-        textView.backgroundColor = .clear
-        textView.adjustsFontForContentSizeCategory = true
-        textView.font = .monospacedSystemFont(
-            ofSize: UIFont.preferredFont(forTextStyle: .body).pointSize,
-            weight: .regular
-        )
-        textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
-        textView.textContainer.lineFragmentPadding = 0
-        return textView
+    func makeUIView(context: Context) -> ChatArtifactTextContainerView {
+        // The container constructs `UITextView(usingTextLayoutManager: false)`
+        // so non-contiguous TextKit 1 layout remains genuinely viewport-lazy.
+        let containerView = ChatArtifactTextContainerView()
+        containerView.textView.delegate = context.coordinator
+        context.coordinator.attach(containerView)
+        return containerView
     }
 
-    func updateUIView(_ textView: UITextView, context: Context) {
+    func updateUIView(_ containerView: ChatArtifactTextContainerView, context: Context) {
+        let textView = containerView.textView
         let isNewDocument = context.coordinator.documentID != documentID
         if isNewDocument {
             context.coordinator.resetHighlighting()
@@ -52,6 +45,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
             context.coordinator.appliedChunkCount = 0
             context.coordinator.handledTopRequestID = topRequestID
             context.coordinator.handledBottomRequestID = bottomRequestID
+            context.coordinator.handledGoToLineRequestID = goToLineRequestID
         }
 
         if context.coordinator.appliedChunkCount > chunks.count {
@@ -100,6 +94,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
             nextRequestID: nextSearchRequestID,
             onSummaryChanged: onSearchSummaryChanged
         )
+        containerView.updateLineNumbers(index: lineIndex, isVisible: showsLineNumbers)
 
         if isNewDocument {
             Self.scrollToTop(textView)
@@ -113,6 +108,13 @@ struct ChatArtifactTextView: UIViewRepresentable {
                 textView.scrollRangeToVisible(
                     NSRange(location: textView.textStorage.length, length: 0)
                 )
+            }
+            if context.coordinator.handledGoToLineRequestID != goToLineRequestID {
+                context.coordinator.handledGoToLineRequestID = goToLineRequestID
+                textView.scrollRangeToVisible(NSRange(
+                    location: min(max(goToLineUTF16Offset, 0), textView.textStorage.length),
+                    length: 0
+                ))
             }
         }
     }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -1,11 +1,125 @@
 #if canImport(UIKit)
 import Foundation
+import UIKit
 
 /// Tracks which streamed chunks have been applied to one text-storage instance.
+@MainActor
 final class ChatArtifactTextViewCoordinator {
     var documentID: String?
     var appliedChunkCount = 0
     var handledTopRequestID = 0
     var handledBottomRequestID = 0
+    private let syntaxHighlighter = ChatArtifactSyntaxHighlighter()
+    private var highlightTask: Task<Void, Never>?
+    private var highlightGeneration = 0
+    private var highlightedDocumentID: String?
+    private var highlightedTextLength = 0
+    private var highlightedLanguage: String?
+    private var highlightedTheme: ChatArtifactHighlightTheme?
+
+    func resetHighlighting() {
+        highlightTask?.cancel()
+        highlightTask = nil
+        highlightGeneration += 1
+        highlightedDocumentID = nil
+        highlightedTextLength = 0
+        highlightedLanguage = nil
+        highlightedTheme = nil
+    }
+
+    func updateHighlighting(
+        in textView: UITextView,
+        documentID: String,
+        text: String,
+        reachedEOF: Bool,
+        decision: ChatArtifactHighlightDecision,
+        theme: ChatArtifactHighlightTheme
+    ) {
+        guard reachedEOF,
+              case .highlight(let language) = decision,
+              !text.isEmpty else {
+            highlightTask?.cancel()
+            highlightTask = nil
+            return
+        }
+        guard highlightedDocumentID != documentID
+                || highlightedTextLength != text.utf16.count
+                || highlightedLanguage != language
+                || highlightedTheme != theme else {
+            return
+        }
+
+        highlightTask?.cancel()
+        highlightGeneration += 1
+        let generation = highlightGeneration
+        let highlighter = syntaxHighlighter
+        highlightTask = Task { @MainActor [weak self, weak textView] in
+            let result = await highlighter.highlight(
+                text: text,
+                language: language,
+                theme: theme
+            )
+            guard let self,
+                  !Task.isCancelled,
+                  generation == self.highlightGeneration,
+                  let textView,
+                  let result,
+                  result.value.string == text,
+                  textView.textStorage.string == text else {
+                return
+            }
+
+            self.apply(result.value, to: textView)
+            self.highlightedDocumentID = documentID
+            self.highlightedTextLength = text.utf16.count
+            self.highlightedLanguage = language
+            self.highlightedTheme = theme
+            self.highlightTask = nil
+        }
+    }
+
+    private func apply(_ highlighted: NSAttributedString, to textView: UITextView) {
+        let contentOffset = textView.contentOffset
+        let selection = textView.selectedRange
+        let pointSize = textView.font?.pointSize
+            ?? UIFont.preferredFont(forTextStyle: .body).pointSize
+        let fullRange = NSRange(location: 0, length: highlighted.length)
+
+        textView.textStorage.beginEditing()
+        highlighted.enumerateAttributes(in: fullRange) { attributes, range, _ in
+            textView.textStorage.setAttributes(
+                normalized(attributes, pointSize: pointSize),
+                range: range
+            )
+        }
+        textView.textStorage.endEditing()
+        textView.selectedRange = selection
+        textView.setContentOffset(contentOffset, animated: false)
+    }
+
+    private func normalized(
+        _ attributes: [NSAttributedString.Key: Any],
+        pointSize: CGFloat
+    ) -> [NSAttributedString.Key: Any] {
+        var normalized = attributes
+        normalized.removeValue(forKey: .backgroundColor)
+        guard let highlightedFont = attributes[.font] as? UIFont else {
+            normalized[.font] = UIFont.monospacedSystemFont(ofSize: pointSize, weight: .regular)
+            return normalized
+        }
+
+        let traits = highlightedFont.fontDescriptor.symbolicTraits
+        let weight: UIFont.Weight = traits.contains(.traitBold) ? .bold : .regular
+        let baseFont = UIFont.monospacedSystemFont(ofSize: pointSize, weight: weight)
+        if traits.contains(.traitItalic),
+           let descriptor = baseFont.fontDescriptor.withSymbolicTraits(
+               baseFont.fontDescriptor.symbolicTraits.union(.traitItalic)
+           ) {
+            normalized[.font] = UIFont(descriptor: descriptor, size: pointSize)
+        } else {
+            normalized[.font] = baseFont
+        }
+        return normalized
+    }
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -16,6 +16,29 @@ final class ChatArtifactTextViewCoordinator {
     private var highlightedTextLength = 0
     private var highlightedLanguage: String?
     private var highlightedTheme: ChatArtifactHighlightTheme?
+    private var pendingHighlightDocumentID: String?
+    private var pendingHighlightTextLength = 0
+    private var pendingHighlightLanguage: String?
+    private var pendingHighlightTheme: ChatArtifactHighlightTheme?
+    private var searchModel = ChatArtifactSearchModel()
+    private var searchTask: Task<Void, Never>?
+    private var searchGeneration = 0
+    private var searchedDocumentID: String?
+    private var searchedTextLength = 0
+    private var pendingSearchDocumentID: String?
+    private var pendingSearchTextLength = 0
+    private var pendingSearchQuery = ""
+    private var handledPreviousSearchRequestID = 0
+    private var handledNextSearchRequestID = 0
+    private var appliedSearchRange: NSRange?
+    private var onSearchSummaryChanged: ((ChatArtifactSearchSummary) -> Void)?
+    private var publishedSearchSummary = ChatArtifactSearchSummary.empty
+    private var summaryPublishGeneration = 0
+    private let searchDebounce: Duration
+
+    init(searchDebounce: Duration = .milliseconds(160)) {
+        self.searchDebounce = searchDebounce
+    }
 
     func resetHighlighting() {
         highlightTask?.cancel()
@@ -25,6 +48,26 @@ final class ChatArtifactTextViewCoordinator {
         highlightedTextLength = 0
         highlightedLanguage = nil
         highlightedTheme = nil
+        pendingHighlightDocumentID = nil
+        pendingHighlightTextLength = 0
+        pendingHighlightLanguage = nil
+        pendingHighlightTheme = nil
+    }
+
+    func resetSearch() {
+        searchTask?.cancel()
+        searchTask = nil
+        searchGeneration += 1
+        searchModel = ChatArtifactSearchModel()
+        searchedDocumentID = nil
+        searchedTextLength = 0
+        pendingSearchDocumentID = nil
+        pendingSearchTextLength = 0
+        pendingSearchQuery = ""
+        handledPreviousSearchRequestID = 0
+        handledNextSearchRequestID = 0
+        appliedSearchRange = nil
+        publishSearchSummary(.empty)
     }
 
     func updateHighlighting(
@@ -48,11 +91,21 @@ final class ChatArtifactTextViewCoordinator {
                 || highlightedTheme != theme else {
             return
         }
+        guard pendingHighlightDocumentID != documentID
+                || pendingHighlightTextLength != text.utf16.count
+                || pendingHighlightLanguage != language
+                || pendingHighlightTheme != theme else {
+            return
+        }
 
         highlightTask?.cancel()
         highlightGeneration += 1
         let generation = highlightGeneration
         let highlighter = syntaxHighlighter
+        pendingHighlightDocumentID = documentID
+        pendingHighlightTextLength = text.utf16.count
+        pendingHighlightLanguage = language
+        pendingHighlightTheme = theme
         highlightTask = Task { @MainActor [weak self, weak textView] in
             let result = await highlighter.highlight(
                 text: text,
@@ -74,8 +127,148 @@ final class ChatArtifactTextViewCoordinator {
             self.highlightedTextLength = text.utf16.count
             self.highlightedLanguage = language
             self.highlightedTheme = theme
+            self.pendingHighlightDocumentID = nil
+            self.pendingHighlightTextLength = 0
+            self.pendingHighlightLanguage = nil
+            self.pendingHighlightTheme = nil
             self.highlightTask = nil
         }
+    }
+
+    func updateSearch(
+        in textView: UITextView,
+        documentID: String,
+        text: String,
+        query: String,
+        reachedEOF: Bool,
+        previousRequestID: Int,
+        nextRequestID: Int,
+        onSummaryChanged: @escaping (ChatArtifactSearchSummary) -> Void
+    ) {
+        self.onSearchSummaryChanged = onSummaryChanged
+        guard !query.isEmpty else {
+            searchTask?.cancel()
+            searchTask = nil
+            searchGeneration += 1
+            clearSearchHighlight(in: textView)
+            searchModel = ChatArtifactSearchModel()
+            searchedDocumentID = documentID
+            searchedTextLength = text.utf16.count
+            pendingSearchDocumentID = nil
+            pendingSearchTextLength = 0
+            pendingSearchQuery = ""
+            handledPreviousSearchRequestID = previousRequestID
+            handledNextSearchRequestID = nextRequestID
+            publishSearchSummary(.empty)
+            return
+        }
+
+        let textLength = text.utf16.count
+        let hasCurrentResults = searchedDocumentID == documentID
+            && searchedTextLength == textLength
+            && searchModel.query == query
+        let hasPendingResults = pendingSearchDocumentID == documentID
+            && pendingSearchTextLength == textLength
+            && pendingSearchQuery == query
+        if !hasCurrentResults, !hasPendingResults {
+            scheduleSearch(
+                in: textView,
+                documentID: documentID,
+                text: text,
+                query: query,
+                reachedEOF: reachedEOF,
+                previousRequestID: previousRequestID,
+                nextRequestID: nextRequestID
+            )
+            return
+        }
+        guard hasCurrentResults else { return }
+        applySearchNavigation(
+            in: textView,
+            previousRequestID: previousRequestID,
+            nextRequestID: nextRequestID
+        )
+    }
+
+    private func scheduleSearch(
+        in textView: UITextView,
+        documentID: String,
+        text: String,
+        query: String,
+        reachedEOF: Bool,
+        previousRequestID: Int,
+        nextRequestID: Int
+    ) {
+        searchTask?.cancel()
+        searchGeneration += 1
+        let generation = searchGeneration
+        let previousModel = searchModel
+        let debounce = searchDebounce
+        let shouldDebounce = !reachedEOF
+        pendingSearchDocumentID = documentID
+        pendingSearchTextLength = text.utf16.count
+        pendingSearchQuery = query
+        if previousModel.query != query {
+            clearSearchHighlight(in: textView)
+            publishSearchSummary(.empty)
+        }
+
+        searchTask = Task { @MainActor [weak self, weak textView] in
+            if shouldDebounce {
+                do {
+                    // A bounded, cancellable debounce coalesces streamed append bursts.
+                    try await Task.sleep(for: debounce)
+                } catch {
+                    return
+                }
+            }
+            let nextModel = await Task.detached(priority: .userInitiated) {
+                var model = previousModel
+                model.update(query: query, in: text)
+                return model
+            }.value
+            guard let self,
+                  !Task.isCancelled,
+                  generation == self.searchGeneration,
+                  let textView,
+                  textView.textStorage.string == text else {
+                return
+            }
+
+            let shouldScroll = previousModel.query != query
+            self.searchModel = nextModel
+            self.searchedDocumentID = documentID
+            self.searchedTextLength = text.utf16.count
+            self.pendingSearchDocumentID = nil
+            self.pendingSearchTextLength = 0
+            self.pendingSearchQuery = ""
+            self.handledPreviousSearchRequestID = previousRequestID
+            self.handledNextSearchRequestID = nextRequestID
+            self.applyCurrentSearchHighlight(in: textView, scrollToMatch: shouldScroll)
+            self.publishSearchSummary(nextModel.summary)
+            self.searchTask = nil
+        }
+    }
+
+    private func applySearchNavigation(
+        in textView: UITextView,
+        previousRequestID: Int,
+        nextRequestID: Int
+    ) {
+        var didNavigate = false
+        if handledPreviousSearchRequestID != previousRequestID {
+            handledPreviousSearchRequestID = previousRequestID
+            searchModel.selectPrevious()
+            didNavigate = true
+        }
+        if handledNextSearchRequestID != nextRequestID {
+            handledNextSearchRequestID = nextRequestID
+            searchModel.selectNext()
+            didNavigate = true
+        }
+        guard didNavigate else { return }
+        applyCurrentSearchHighlight(in: textView, scrollToMatch: true)
+        publishSearchSummary(searchModel.summary)
     }
 
     private func apply(_ highlighted: NSAttributedString, to textView: UITextView) {
@@ -95,6 +288,51 @@ final class ChatArtifactTextViewCoordinator {
         textView.textStorage.endEditing()
         textView.selectedRange = selection
         textView.setContentOffset(contentOffset, animated: false)
+        applyCurrentSearchHighlight(in: textView, scrollToMatch: false)
+    }
+
+    private func applyCurrentSearchHighlight(
+        in textView: UITextView,
+        scrollToMatch: Bool
+    ) {
+        clearSearchHighlight(in: textView)
+        guard let currentRange = searchModel.currentRange,
+              NSMaxRange(currentRange) <= textView.textStorage.length else {
+            return
+        }
+        textView.textStorage.addAttribute(
+            .backgroundColor,
+            value: UIColor.systemYellow.withAlphaComponent(0.38),
+            range: currentRange
+        )
+        appliedSearchRange = currentRange
+        if scrollToMatch {
+            textView.scrollRangeToVisible(currentRange)
+        }
+    }
+
+    private func clearSearchHighlight(in textView: UITextView) {
+        guard let appliedSearchRange,
+              NSMaxRange(appliedSearchRange) <= textView.textStorage.length else {
+            self.appliedSearchRange = nil
+            return
+        }
+        textView.textStorage.removeAttribute(.backgroundColor, range: appliedSearchRange)
+        self.appliedSearchRange = nil
+    }
+
+    private func publishSearchSummary(_ summary: ChatArtifactSearchSummary) {
+        guard publishedSearchSummary != summary else { return }
+        publishedSearchSummary = summary
+        summaryPublishGeneration += 1
+        let generation = summaryPublishGeneration
+        let handler = onSearchSummaryChanged
+        Task { @MainActor [weak self] in
+            await Task.yield()
+            guard let self,
+                  generation == self.summaryPublishGeneration else { return }
+            handler?(summary)
+        }
     }
 
     private func normalized(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -4,11 +4,13 @@ import UIKit
 
 /// Tracks which streamed chunks have been applied to one text-storage instance.
 @MainActor
-final class ChatArtifactTextViewCoordinator {
+final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     var documentID: String?
     var appliedChunkCount = 0
     var handledTopRequestID = 0
     var handledBottomRequestID = 0
+    var handledGoToLineRequestID = 0
+    private weak var containerView: ChatArtifactTextContainerView?
     private let syntaxHighlighter = ChatArtifactSyntaxHighlighter()
     private var highlightTask: Task<Void, Never>?
     private var highlightGeneration = 0
@@ -38,6 +40,15 @@ final class ChatArtifactTextViewCoordinator {
 
     init(searchDebounce: Duration = .milliseconds(160)) {
         self.searchDebounce = searchDebounce
+        super.init()
+    }
+
+    func attach(_ containerView: ChatArtifactTextContainerView) {
+        self.containerView = containerView
+    }
+
+    func scrollViewDidScroll(_ scrollView: UIScrollView) {
+        containerView?.gutterView.setNeedsDisplay()
     }
 
     func resetHighlighting() {
@@ -289,6 +300,7 @@ final class ChatArtifactTextViewCoordinator {
         textView.selectedRange = selection
         textView.setContentOffset(contentOffset, animated: false)
         applyCurrentSearchHighlight(in: textView, scrollToMatch: false)
+        containerView?.gutterView.setNeedsDisplay()
     }
 
     private func applyCurrentSearchHighlight(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -10,6 +10,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     var handledTopRequestID = 0
     var handledBottomRequestID = 0
     var handledGoToLineRequestID = 0
+    var onFontSizeChanged: ((Double) -> Void)?
     private weak var containerView: ChatArtifactTextContainerView?
     private let syntaxHighlighter = ChatArtifactSyntaxHighlighter()
     private var highlightTask: Task<Void, Never>?
@@ -37,6 +38,13 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     private var publishedSearchSummary = ChatArtifactSearchSummary.empty
     private var summaryPublishGeneration = 0
     private let searchDebounce: Duration
+    private var appliedFontPointSize = 0.0
+    private var pinchStartFontPointSize = 0.0
+    private lazy var fontPinchGestureRecognizer: UIPinchGestureRecognizer = {
+        let recognizer = UIPinchGestureRecognizer(target: self, action: #selector(handleFontPinch(_:)))
+        recognizer.cancelsTouchesInView = false
+        return recognizer
+    }()
 
     init(searchDebounce: Duration = .milliseconds(160)) {
         self.searchDebounce = searchDebounce
@@ -45,10 +53,74 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
 
     func attach(_ containerView: ChatArtifactTextContainerView) {
         self.containerView = containerView
+        containerView.textView.addGestureRecognizer(fontPinchGestureRecognizer)
     }
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         containerView?.gutterView.setNeedsDisplay()
+    }
+
+    func updateFontSize(in textView: UITextView, pointSize: Double) {
+        let clamped = min(
+            max(pointSize, ChatArtifactTextPreferences.minimumFontSize),
+            ChatArtifactTextPreferences.maximumFontSize
+        )
+        guard abs(appliedFontPointSize - clamped) > 0.001 else { return }
+        applyFontSize(clamped, to: textView)
+    }
+
+    @objc
+    private func handleFontPinch(_ recognizer: UIPinchGestureRecognizer) {
+        guard let textView = containerView?.textView else { return }
+        switch recognizer.state {
+        case .began:
+            pinchStartFontPointSize = appliedFontPointSize > 0
+                ? appliedFontPointSize
+                : Double(textView.font?.pointSize ?? 15)
+        case .changed, .ended:
+            let scaled = pinchStartFontPointSize * Double(recognizer.scale)
+            let quantized = (scaled * 2).rounded() / 2
+            let clamped = min(
+                max(quantized, ChatArtifactTextPreferences.minimumFontSize),
+                ChatArtifactTextPreferences.maximumFontSize
+            )
+            if abs(clamped - appliedFontPointSize) > 0.001 {
+                applyFontSize(clamped, to: textView)
+            }
+            if recognizer.state == .ended {
+                onFontSizeChanged?(clamped)
+            }
+        case .cancelled, .failed:
+            applyFontSize(pinchStartFontPointSize, to: textView)
+        default:
+            break
+        }
+    }
+
+    private func applyFontSize(_ pointSize: Double, to textView: UITextView) {
+        let font = UIFont.monospacedSystemFont(
+            ofSize: CGFloat(pointSize),
+            weight: .regular
+        )
+        let contentOffset = textView.contentOffset
+        let selection = textView.selectedRange
+        textView.font = font
+        if textView.textStorage.length > 0 {
+            textView.textStorage.addAttribute(
+                .font,
+                value: font,
+                range: NSRange(location: 0, length: textView.textStorage.length)
+            )
+        }
+        textView.selectedRange = selection
+        textView.setContentOffset(contentOffset, animated: false)
+        appliedFontPointSize = pointSize
+        if let containerView {
+            containerView.updateLineNumbers(
+                index: containerView.gutterView.lineIndex,
+                isVisible: !containerView.gutterView.isHidden
+            )
+        }
     }
 
     func resetHighlighting() {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -14,6 +14,7 @@ final class ChatArtifactViewerModel {
     private(set) var activePath: String?
     private(set) var markdownPresentation = ChatArtifactMarkdownPresentation(byteCount: 0)
     private(set) var textHighlightDecision: ChatArtifactHighlightDecision = .skippedNoLanguage
+    private(set) var textLineIndex = ChatArtifactLineIndex()
     private let temporaryFileStore: ChatArtifactTemporaryFileStore
     private var temporaryFileURL: URL?
 
@@ -142,6 +143,7 @@ final class ChatArtifactViewerModel {
         textReachedEOF = false
         markdownPresentation = ChatArtifactMarkdownPresentation(byteCount: 0)
         textHighlightDecision = .skippedNoLanguage
+        textLineIndex = ChatArtifactLineIndex()
     }
 
     private func streamText(
@@ -172,6 +174,7 @@ final class ChatArtifactViewerModel {
         guard path == activePath else { return }
         if !text.isEmpty {
             textChunks.append(text)
+            textLineIndex.append(text)
         }
         updateProgress(for: chunk)
         textReachedEOF = chunk.eof

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -13,6 +13,7 @@ final class ChatArtifactViewerModel {
     private(set) var textReachedEOF = false
     private(set) var activePath: String?
     private(set) var markdownPresentation = ChatArtifactMarkdownPresentation(byteCount: 0)
+    private(set) var textHighlightDecision: ChatArtifactHighlightDecision = .skippedNoLanguage
     private let temporaryFileStore: ChatArtifactTemporaryFileStore
     private var temporaryFileURL: URL?
 
@@ -40,6 +41,10 @@ final class ChatArtifactViewerModel {
             guard path == activePath else { return }
             stat = loadedStat
             totalBytes = loadedStat.size
+            textHighlightDecision = ChatArtifactSyntaxHighlightPolicy().decision(
+                path: path,
+                byteCount: loadedStat.size
+            )
 
             let route = ChatArtifactPreviewRouter().route(stat: loadedStat, path: path)
             guard route != .folder else {
@@ -136,6 +141,7 @@ final class ChatArtifactViewerModel {
         totalBytes = nil
         textReachedEOF = false
         markdownPresentation = ChatArtifactMarkdownPresentation(byteCount: 0)
+        textHighlightDecision = .skippedNoLanguage
     }
 
     private func streamText(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -27,6 +27,11 @@ struct ChatArtifactViewerRouteView: View {
     @State private var searchSummary = ChatArtifactSearchSummary.empty
     @State private var previousSearchRequestID = 0
     @State private var nextSearchRequestID = 0
+    @State private var showsLineNumbers = true
+    @State private var isGoToLinePresented = false
+    @State private var goToLineText = ""
+    @State private var goToLineUTF16Offset = 0
+    @State private var goToLineRequestID = 0
 
     var body: some View {
         content
@@ -48,6 +53,7 @@ struct ChatArtifactViewerRouteView: View {
                                 if isSearchPresented {
                                     dismissSearch()
                                 } else {
+                                    dismissGoToLine()
                                     isSearchPresented = true
                                 }
                             }
@@ -59,6 +65,48 @@ struct ChatArtifactViewerRouteView: View {
                                     bundle: .module
                                 ),
                                 systemImage: "magnifyingglass"
+                            )
+                        }
+                        Menu {
+                            Button {
+                                withAnimation(.snappy) {
+                                    if isGoToLinePresented {
+                                        dismissGoToLine()
+                                    } else {
+                                        dismissSearch()
+                                        isGoToLinePresented = true
+                                    }
+                                }
+                            } label: {
+                                Label(
+                                    String(
+                                        localized: "chat.artifact.line.goto",
+                                        defaultValue: "Go to line",
+                                        bundle: .module
+                                    ),
+                                    systemImage: "text.line.first.and.arrowtriangle.forward"
+                                )
+                            }
+                            Button {
+                                showsLineNumbers.toggle()
+                            } label: {
+                                Label(
+                                    String(
+                                        localized: "chat.artifact.line.numbers",
+                                        defaultValue: "Line numbers",
+                                        bundle: .module
+                                    ),
+                                    systemImage: showsLineNumbers ? "checkmark" : "number"
+                                )
+                            }
+                        } label: {
+                            Label(
+                                String(
+                                    localized: "chat.artifact.text_options",
+                                    defaultValue: "Text options",
+                                    bundle: .module
+                                ),
+                                systemImage: "textformat"
                             )
                         }
                         Button {
@@ -197,6 +245,7 @@ struct ChatArtifactViewerRouteView: View {
                     streamingProgressHeader
                 }
                 searchBar
+                goToLineBar
                 highlightingStatusPill
                 rawTextView
             }
@@ -209,6 +258,7 @@ struct ChatArtifactViewerRouteView: View {
                     ChatArtifactMarkdownView(markdown: model.renderedText)
                 } else {
                     searchBar
+                    goToLineBar
                     highlightingStatusPill
                     rawTextView
                 }
@@ -285,6 +335,10 @@ struct ChatArtifactViewerRouteView: View {
             onSearchSummaryChanged: { summary in
                 searchSummary = summary
             },
+            lineIndex: model.textLineIndex,
+            showsLineNumbers: showsLineNumbers,
+            goToLineUTF16Offset: goToLineUTF16Offset,
+            goToLineRequestID: goToLineRequestID,
             topRequestID: topRequestID,
             bottomRequestID: bottomRequestID
         )
@@ -297,6 +351,22 @@ struct ChatArtifactViewerRouteView: View {
                 .padding()
         }
         #endif
+    }
+
+    @ViewBuilder
+    private var goToLineBar: some View {
+        if isGoToLinePresented {
+            ChatArtifactGoToLineBar(
+                lineText: $goToLineText,
+                onGo: goToLine,
+                onClose: {
+                    withAnimation(.snappy) {
+                        dismissGoToLine()
+                    }
+                }
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
     }
 
     @ViewBuilder
@@ -400,6 +470,7 @@ struct ChatArtifactViewerRouteView: View {
             set: { mode in
                 if mode == .rendered {
                     dismissSearch()
+                    dismissGoToLine()
                 }
                 model.selectMarkdownMode(mode)
             }
@@ -410,6 +481,18 @@ struct ChatArtifactViewerRouteView: View {
         isSearchPresented = false
         searchQuery = ""
         searchSummary = .empty
+    }
+
+    private func dismissGoToLine() {
+        isGoToLinePresented = false
+        goToLineText = ""
+    }
+
+    private func goToLine(_ requestedLine: Int) {
+        let line = model.textLineIndex.clampedLine(requestedLine)
+        goToLineText = String(line)
+        goToLineUTF16Offset = model.textLineIndex.offset(forLine: line)
+        goToLineRequestID += 1
     }
 
     private var shouldShowTextJumpControls: Bool {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -17,6 +17,7 @@ struct ChatArtifactViewerRouteView: View {
     let onDone: () -> Void
 
     @Environment(\.chatArtifactLoader) private var loader
+    @Environment(\.colorScheme) private var colorScheme
     @State private var model = ChatArtifactViewerModel()
     @State private var retryGeneration = 0
     @State private var topRequestID = 0
@@ -172,6 +173,7 @@ struct ChatArtifactViewerRouteView: View {
                 if !model.textReachedEOF {
                     streamingProgressHeader
                 }
+                highlightingStatusPill
                 rawTextView
             }
         case .markdown:
@@ -182,6 +184,7 @@ struct ChatArtifactViewerRouteView: View {
                 if model.markdownPresentation.mode == .rendered {
                     ChatArtifactMarkdownView(markdown: model.renderedText)
                 } else {
+                    highlightingStatusPill
                     rawTextView
                 }
             }
@@ -248,6 +251,9 @@ struct ChatArtifactViewerRouteView: View {
         ChatArtifactTextView(
             documentID: path,
             chunks: model.textChunks,
+            reachedEOF: model.textReachedEOF,
+            highlightDecision: model.textHighlightDecision,
+            highlightTheme: colorScheme == .dark ? .dark : .light,
             topRequestID: topRequestID,
             bottomRequestID: bottomRequestID
         )
@@ -260,6 +266,22 @@ struct ChatArtifactViewerRouteView: View {
                 .padding()
         }
         #endif
+    }
+
+    @ViewBuilder
+    private var highlightingStatusPill: some View {
+        if model.textHighlightDecision.showsHighlightingOffPill,
+           let totalBytes = model.totalBytes {
+            HStack {
+                Spacer(minLength: 16)
+                ChatArtifactHighlightingStatusPill(
+                    actualBytes: totalBytes,
+                    maximumBytes: ChatArtifactSyntaxHighlightPolicy.maxHighlightBytes
+                )
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+        }
     }
 
     private func unavailableView(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -15,6 +15,8 @@ struct ChatArtifactViewerRouteView: View {
     let path: String
     let scope: ChatArtifactViewerScope
     let onDone: () -> Void
+    private let textPreferences: ChatArtifactTextPreferences
+    private let textLayoutKind: ChatArtifactTextLayoutKind
 
     @Environment(\.chatArtifactLoader) private var loader
     @Environment(\.colorScheme) private var colorScheme
@@ -32,6 +34,26 @@ struct ChatArtifactViewerRouteView: View {
     @State private var goToLineText = ""
     @State private var goToLineUTF16Offset = 0
     @State private var goToLineRequestID = 0
+    @State private var wrapsLines: Bool
+    @State private var textFontSize: Double
+
+    init(
+        path: String,
+        scope: ChatArtifactViewerScope,
+        textPreferences: ChatArtifactTextPreferences = ChatArtifactTextPreferences(
+            defaults: .standard
+        ),
+        onDone: @escaping () -> Void
+    ) {
+        self.path = path
+        self.scope = scope
+        self.onDone = onDone
+        self.textPreferences = textPreferences
+        let layoutKind = ChatArtifactTextLayoutKind(path: path)
+        textLayoutKind = layoutKind
+        _wrapsLines = State(initialValue: textPreferences.wrapsLines(for: layoutKind))
+        _textFontSize = State(initialValue: textPreferences.fontSize(for: layoutKind))
+    }
 
     var body: some View {
         content
@@ -97,6 +119,22 @@ struct ChatArtifactViewerRouteView: View {
                                         bundle: .module
                                     ),
                                     systemImage: showsLineNumbers ? "checkmark" : "number"
+                                )
+                            }
+                            Button {
+                                wrapsLines.toggle()
+                                textPreferences.setWrapsLines(
+                                    wrapsLines,
+                                    for: textLayoutKind
+                                )
+                            } label: {
+                                Label(
+                                    String(
+                                        localized: "chat.artifact.wrap",
+                                        defaultValue: "Word wrap",
+                                        bundle: .module
+                                    ),
+                                    systemImage: wrapsLines ? "checkmark" : "text.justify.left"
                                 )
                             }
                         } label: {
@@ -339,6 +377,14 @@ struct ChatArtifactViewerRouteView: View {
             showsLineNumbers: showsLineNumbers,
             goToLineUTF16Offset: goToLineUTF16Offset,
             goToLineRequestID: goToLineRequestID,
+            wrapsLines: wrapsLines,
+            fontPointSize: textFontSize,
+            onFontSizeChanged: { fontSize in
+                textFontSize = textPreferences.setFontSize(
+                    fontSize,
+                    for: textLayoutKind
+                )
+            },
             topRequestID: topRequestID,
             bottomRequestID: bottomRequestID
         )

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -22,6 +22,11 @@ struct ChatArtifactViewerRouteView: View {
     @State private var retryGeneration = 0
     @State private var topRequestID = 0
     @State private var bottomRequestID = 0
+    @State private var isSearchPresented = false
+    @State private var searchQuery = ""
+    @State private var searchSummary = ChatArtifactSearchSummary.empty
+    @State private var previousSearchRequestID = 0
+    @State private var nextSearchRequestID = 0
 
     var body: some View {
         content
@@ -38,6 +43,24 @@ struct ChatArtifactViewerRouteView: View {
                 #if os(iOS)
                 if shouldShowTextJumpControls {
                     ToolbarItemGroup(placement: .primaryAction) {
+                        Button {
+                            withAnimation(.snappy) {
+                                if isSearchPresented {
+                                    dismissSearch()
+                                } else {
+                                    isSearchPresented = true
+                                }
+                            }
+                        } label: {
+                            Label(
+                                String(
+                                    localized: "chat.artifact.search.title",
+                                    defaultValue: "Search",
+                                    bundle: .module
+                                ),
+                                systemImage: "magnifyingglass"
+                            )
+                        }
                         Button {
                             topRequestID += 1
                         } label: {
@@ -173,6 +196,7 @@ struct ChatArtifactViewerRouteView: View {
                 if !model.textReachedEOF {
                     streamingProgressHeader
                 }
+                searchBar
                 highlightingStatusPill
                 rawTextView
             }
@@ -184,6 +208,7 @@ struct ChatArtifactViewerRouteView: View {
                 if model.markdownPresentation.mode == .rendered {
                     ChatArtifactMarkdownView(markdown: model.renderedText)
                 } else {
+                    searchBar
                     highlightingStatusPill
                     rawTextView
                 }
@@ -254,6 +279,12 @@ struct ChatArtifactViewerRouteView: View {
             reachedEOF: model.textReachedEOF,
             highlightDecision: model.textHighlightDecision,
             highlightTheme: colorScheme == .dark ? .dark : .light,
+            searchQuery: searchQuery,
+            previousSearchRequestID: previousSearchRequestID,
+            nextSearchRequestID: nextSearchRequestID,
+            onSearchSummaryChanged: { summary in
+                searchSummary = summary
+            },
             topRequestID: topRequestID,
             bottomRequestID: bottomRequestID
         )
@@ -266,6 +297,25 @@ struct ChatArtifactViewerRouteView: View {
                 .padding()
         }
         #endif
+    }
+
+    @ViewBuilder
+    private var searchBar: some View {
+        if isSearchPresented {
+            ChatArtifactSearchBar(
+                query: $searchQuery,
+                summary: searchSummary,
+                isStillLoading: !model.textReachedEOF,
+                onPrevious: { previousSearchRequestID += 1 },
+                onNext: { nextSearchRequestID += 1 },
+                onClose: {
+                    withAnimation(.snappy) {
+                        dismissSearch()
+                    }
+                }
+            )
+            .transition(.move(edge: .top).combined(with: .opacity))
+        }
     }
 
     @ViewBuilder
@@ -347,8 +397,19 @@ struct ChatArtifactViewerRouteView: View {
     private var markdownModeBinding: Binding<ChatArtifactMarkdownMode> {
         Binding(
             get: { model.markdownPresentation.mode },
-            set: { model.selectMarkdownMode($0) }
+            set: { mode in
+                if mode == .rendered {
+                    dismissSearch()
+                }
+                model.selectMarkdownMode(mode)
+            }
         )
+    }
+
+    private func dismissSearch() {
+        isSearchPresented = false
+        searchQuery = ""
+        searchSummary = .empty
     }
 
     private var shouldShowTextJumpControls: Bool {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -290,6 +290,91 @@
         }
       }
     },
+    "chat.artifact.line.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close go to line"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行へ移動を閉じる"
+          }
+        }
+      }
+    },
+    "chat.artifact.line.go" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "移動"
+          }
+        }
+      }
+    },
+    "chat.artifact.line.goto" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Go to line"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行へ移動"
+          }
+        }
+      }
+    },
+    "chat.artifact.line.numbers" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line numbers"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行番号"
+          }
+        }
+      }
+    },
+    "chat.artifact.line.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Line number"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行番号"
+          }
+        }
+      }
+    },
     "chat.artifact.loading" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -609,6 +694,23 @@
           "stringUnit" : {
             "state" : "translated",
             "value" : "ファイルが大きすぎてプレビューできません"
+          }
+        }
+      }
+    },
+    "chat.artifact.text_options" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Text options"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "テキストオプション"
           }
         }
       }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -2380,6 +2380,23 @@
           }
         }
       }
+    },
+    "chat.artifact.wrap" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Word wrap"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "行を折り返す"
+          }
+        }
+      }
     }
   },
   "version" : "1.0"

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -460,6 +460,108 @@
         }
       }
     },
+    "chat.artifact.search.close" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Close search"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索を閉じる"
+          }
+        }
+      }
+    },
+    "chat.artifact.search.next" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Next match"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "次の一致"
+          }
+        }
+      }
+    },
+    "chat.artifact.search.placeholder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Find in file"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ファイル内を検索"
+          }
+        }
+      }
+    },
+    "chat.artifact.search.previous" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Previous match"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "前の一致"
+          }
+        }
+      }
+    },
+    "chat.artifact.search.still_loading" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Still loading"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "読み込み中"
+          }
+        }
+      }
+    },
+    "chat.artifact.search.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Search"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "検索"
+          }
+        }
+      }
+    },
     "chat.artifact.too_large.limit_message" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -205,6 +205,40 @@
         }
       }
     },
+    "chat.artifact.highlighting.off" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Highlighting off"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ハイライトはオフ"
+          }
+        }
+      }
+    },
+    "chat.artifact.highlighting.off.explanation" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "This file is %@. Syntax highlighting is off above %@ to keep scrolling smooth."
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "このファイルは%@です。スクロールを滑らかに保つため、%@を超えるファイルでは構文ハイライトがオフになります。"
+          }
+        }
+      }
+    },
     "chat.artifact.jump.bottom" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactLineIndexTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactLineIndexTests.swift
@@ -1,0 +1,36 @@
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact line index")
+struct ChatArtifactLineIndexTests {
+    @Test("line starts accumulate incrementally in UTF-16 offsets")
+    func appendsLineStarts() {
+        var index = ChatArtifactLineIndex()
+
+        index.append("one\n🙂")
+        #expect(index.lineStartOffsets == [0, 4])
+        #expect(index.loadedUTF16Length == 6)
+        index.append("\nthree\n")
+
+        #expect(index.lineStartOffsets == [0, 4, 7, 13])
+        #expect(index.loadedUTF16Length == 13)
+        #expect(index.lineCount == 4)
+        #expect(index.lineNumber(containingUTF16Offset: 8) == 3)
+    }
+
+    @Test("go to line clamps against lines loaded so far")
+    func clampsDuringStreaming() {
+        var index = ChatArtifactLineIndex()
+        index.append("first\nsecond")
+
+        #expect(index.clampedLine(-4) == 1)
+        #expect(index.offset(forLine: -4) == 0)
+        #expect(index.clampedLine(200) == 2)
+        #expect(index.offset(forLine: 200) == 6)
+
+        index.append("\nthird")
+        #expect(index.clampedLine(3) == 3)
+        #expect(index.offset(forLine: 3) == 13)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactSearchModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactSearchModelTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact text search")
+struct ChatArtifactSearchModelTests {
+    @Test("literal case-insensitive search returns UTF-16 ranges")
+    func findsLiteralRanges() {
+        let model = ChatArtifactSearchModel(
+            query: "A.B",
+            text: "a.b A-B A.B a.b"
+        )
+
+        #expect(model.matchRanges == [
+            NSRange(location: 0, length: 3),
+            NSRange(location: 8, length: 3),
+            NSRange(location: 12, length: 3),
+        ])
+        #expect(model.summary == ChatArtifactSearchSummary(currentPosition: 1, matchCount: 3))
+    }
+
+    @Test("next and previous wrap around")
+    func navigationWraps() {
+        var model = ChatArtifactSearchModel(query: "hit", text: "hit no hit")
+
+        model.selectPrevious()
+        #expect(model.summary.currentPosition == 2)
+        model.selectNext()
+        #expect(model.summary.currentPosition == 1)
+        model.selectNext()
+        #expect(model.summary.currentPosition == 2)
+        model.selectNext()
+        #expect(model.summary.currentPosition == 1)
+    }
+
+    @Test("stream append recomputes matches and preserves selection")
+    func recomputesAfterAppend() {
+        var model = ChatArtifactSearchModel(query: "line", text: "line one\nline two")
+        model.selectNext()
+        let selectedRange = model.currentRange
+
+        model.recompute(in: "line one\nline two\nLINE three")
+
+        #expect(model.matchRanges.count == 3)
+        #expect(model.currentRange == selectedRange)
+        #expect(model.summary == ChatArtifactSearchSummary(currentPosition: 2, matchCount: 3))
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactSyntaxHighlightPolicyTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactSyntaxHighlightPolicyTests.swift
@@ -1,0 +1,44 @@
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact syntax highlighting policy")
+struct ChatArtifactSyntaxHighlightPolicyTests {
+    private let policy = ChatArtifactSyntaxHighlightPolicy()
+
+    @Test("known languages highlight through the exact size limit")
+    func highlightsAtThreshold() {
+        #expect(policy.decision(
+            path: "/tmp/example.swift",
+            byteCount: ChatArtifactSyntaxHighlightPolicy.maxHighlightBytes
+        ) == .highlight(language: "swift"))
+    }
+
+    @Test("files over the limit skip for size and show the pill")
+    func skipsOverThreshold() {
+        let decision = policy.decision(
+            path: "/tmp/example.swift",
+            byteCount: ChatArtifactSyntaxHighlightPolicy.maxHighlightBytes + 1
+        )
+
+        #expect(decision == .skippedForSize)
+        #expect(decision.showsHighlightingOffPill)
+    }
+
+    @Test("unknown small files use detection without showing the pill")
+    func detectsOnlySmallUnknownFiles() {
+        let small = policy.decision(
+            path: "/tmp/extensionless",
+            byteCount: ChatArtifactSyntaxHighlightPolicy.maxAutomaticDetectionBytes - 1
+        )
+        let larger = policy.decision(
+            path: "/tmp/server.log",
+            byteCount: ChatArtifactSyntaxHighlightPolicy.maxAutomaticDetectionBytes
+        )
+
+        #expect(small == .highlight(language: nil))
+        #expect(!small.showsHighlightingOffPill)
+        #expect(larger == .skippedNoLanguage)
+        #expect(!larger.showsHighlightingOffPill)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTextPreferencesTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTextPreferencesTests.swift
@@ -1,0 +1,51 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact text preferences", .serialized)
+struct ChatArtifactTextPreferencesTests {
+    @Test("log defaults differ and explicit wrap choices persist per kind")
+    func wrapPersistence() throws {
+        let suiteName = "ChatArtifactTextPreferencesTests.wrap.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let preferences = ChatArtifactTextPreferences(defaults: defaults, keyPrefix: "test")
+
+        #expect(!preferences.wrapsLines(for: .log))
+        #expect(preferences.wrapsLines(for: .code))
+        #expect(preferences.wrapsLines(for: .plainText))
+
+        preferences.setWrapsLines(true, for: .log)
+        preferences.setWrapsLines(false, for: .code)
+        let reloaded = ChatArtifactTextPreferences(defaults: defaults, keyPrefix: "test")
+        #expect(reloaded.wrapsLines(for: .log))
+        #expect(!reloaded.wrapsLines(for: .code))
+        #expect(reloaded.wrapsLines(for: .plainText))
+    }
+
+    @Test("font sizes persist independently and clamp to the supported range")
+    func fontPersistence() throws {
+        let suiteName = "ChatArtifactTextPreferencesTests.font.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let preferences = ChatArtifactTextPreferences(defaults: defaults, keyPrefix: "test")
+
+        #expect(preferences.fontSize(for: .code) == ChatArtifactTextPreferences.defaultFontSize)
+        #expect(preferences.setFontSize(40, for: .code) == 28)
+        #expect(preferences.setFontSize(6, for: .log) == 8)
+
+        let reloaded = ChatArtifactTextPreferences(defaults: defaults, keyPrefix: "test")
+        #expect(reloaded.fontSize(for: .code) == 28)
+        #expect(reloaded.fontSize(for: .log) == 8)
+        #expect(reloaded.fontSize(for: .plainText) == ChatArtifactTextPreferences.defaultFontSize)
+    }
+
+    @Test("paths resolve to stable preference kinds")
+    func kindResolution() {
+        #expect(ChatArtifactTextLayoutKind(path: "/tmp/build.log") == .log)
+        #expect(ChatArtifactTextLayoutKind(path: "/tmp/process.OUT") == .log)
+        #expect(ChatArtifactTextLayoutKind(path: "/tmp/main.swift") == .code)
+        #expect(ChatArtifactTextLayoutKind(path: "/tmp/README") == .plainText)
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Package.resolved
+++ b/Packages/iOS/CmuxMobileShellUI/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "680f016588d1919fc59e09829d71907c229c473ea64dcd38f9013a99e7c9560e",
+  "originHash" : "8e4d600dd748d7cf440352cd9cd6219c40b399f51b2f821c0c4ddf4fae27d332",
   "pins" : [
+    {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr.git",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    },
     {
       "identity" : "swift-asn1",
       "kind" : "remoteSourceControl",

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
@@ -28,7 +28,10 @@ final class GhosttySurfaceArtifactChipHost {
         container.addSubview(view)
     }
 
-    func layout(in bounds: CGRect, toolbarTop: CGFloat) {
+    // Anchored to the terminal's top edge: pinned above the toolbar it covered
+    // the input row, which users type into far more often than they read the
+    // first terminal line.
+    func layout(in bounds: CGRect, topInset: CGFloat) {
         guard let content = container.subviews.first else {
             container.frame = .zero
             return
@@ -43,7 +46,7 @@ final class GhosttySurfaceArtifactChipHost {
         let height = max(44, fitting.height)
         container.frame = CGRect(
             x: (bounds.width - width) / 2,
-            y: max(8, toolbarTop - height - 8),
+            y: max(8, topInset + 8),
             width: width,
             height: height
         ).integral
@@ -61,7 +64,7 @@ final class GhosttySurfaceArtifactChipHost {
             }
             if animated {
                 if container.alpha < 0.01 {
-                    container.transform = CGAffineTransform(translationX: 0, y: 8)
+                    container.transform = CGAffineTransform(translationX: 0, y: -8)
                 }
                 UIView.animate(
                     withDuration: 0.2,
@@ -79,7 +82,7 @@ final class GhosttySurfaceArtifactChipHost {
         container.accessibilityElementsHidden = true
         let changes = { [weak self] in
             self?.container.alpha = 0
-            self?.container.transform = CGAffineTransform(translationX: 0, y: 8)
+            self?.container.transform = CGAffineTransform(translationX: 0, y: -8)
         }
         let completion: (Bool) -> Void = { [weak self] _ in
             guard let self, !self.visibilityRequested else { return }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1358,7 +1358,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     private func layoutArtifactChip(using snapshot: TerminalViewportSnapshot) {
-        artifactChipHost.layout(in: bounds, toolbarTop: snapshot.toolbarFrame.minY)
+        artifactChipHost.layout(in: bounds, topInset: safeAreaInsets.top)
     }
 
     private var artifactChipShouldBeVisible: Bool {

--- a/ios/cmuxPackage/Package.resolved
+++ b/ios/cmuxPackage/Package.resolved
@@ -2,6 +2,15 @@
   "originHash" : "eef9bc2175179405e8193eed1f1b9d34d3c35c477aa28a24697f47e4458ecd12",
   "pins" : [
     {
+      "identity" : "highlightr",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/raspu/Highlightr.git",
+      "state" : {
+        "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
+        "version" : "2.3.0"
+      }
+    },
+    {
       "identity" : "sentry-cocoa",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/getsentry/sentry-cocoa.git",


### PR DESCRIPTION
The artifact text viewer was plain monospaced text with no navigation, and the files chip sat directly above the terminal's bottom toolbar where it covered the input row (a direct user complaint).

Syntax highlighting lands via Highlightr 2.3.0 (MIT; bundled highlight.js assets BSD-3-Clause), pinned exactly: language from the extension, computed off the main actor, applied as in-place attribute runs on the existing text storage so the scroll position never moves when colors arrive, active only for files at or under 1.5 MB and only after streaming reaches EOF. Above the threshold a compact "Highlighting off" pill appears; tapping expands it inline to the real numbers ("This file is 18.2 MB…") and collapses again. In-file search gets a match counter with next/previous and temporary match highlighting, recomputing (debounced) while content streams. A line-number gutter renders lazily from visible line fragments (O(viewport), no full-document passes), with go-to-line clamped to loaded lines. Word wrap toggles (off = horizontal scroll; .log/.out default off) and pinch adjusts the monospaced font size; both persist per kind. The files chip now anchors at the terminal's top safe-area inset and slides in from the top edge, so it no longer covers the input row.

Tests: CmuxAgentChatUI 72 across 16 suites (threshold/pill decisions, search model, incremental line index, preferences); iOS simulator-triple builds pass for CmuxAgentChatUI, CmuxMobileShellUI, CmuxMobileTerminal, and ios/cmuxPackage. EN+JA localization audited. Note: Highlightr upstream marks itself unmaintained; it is the deliberately chosen engine (attributed-string output fits the TextKit 1 stack) and is pinned exactly.

Part 5 of the chip-files-gallery completion stack, based on https://github.com/manaflow-ai/cmux/pull/8090.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8103"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786661768&installation_id=133855650&pr_number=8103&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8103&signature=48d16ec9ce622d86c973c6f8c713119b3b49839eb527188afba00b07557a0e24"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds syntax highlighting, search, line numbers with go-to-line, word wrap, and pinch-to-zoom to the iOS artifact text viewer. Moves the files chip to the terminal’s top safe-area inset so it no longer covers the input.

- New Features
  - Syntax highlighting with `Highlightr` 2.3.0; extension-based language or auto-detect for small files; applied at EOF; off above 1.5 MB with an inline “Highlighting off” pill; light/dark themes; preserves scroll.
  - Find-in-file with case-insensitive matches, counter, and next/previous; highlights current match; recomputes during streaming with debounce.
  - Line numbers gutter renders only visible lines and can be toggled; go-to-line clamps to loaded lines.
  - Word wrap toggle (logs default off) and pinch to change monospaced font size; both persist per kind (`code`, `log`, `plainText`).
  - Files chip anchored to the top safe-area and slides in; no longer overlaps the terminal input row.

- Dependencies
  - Added `Highlightr` at exact version `2.3.0`.

<sup>Written for commit c00c18e08359a2070e015649a50a99e92f913797. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8103?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

