### PR TITLE
Add nushell support: wrapper shim routing, resume envelope, fish-parity shell integration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -907,6 +907,41 @@ jobs:
         with:
           node-version: "20"
 
+      - name: Install pinned nushell (shell-integration tests)
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        run: |
+          set -euo pipefail
+
+          # tests/test_nushell_*.py drive the bundled nushell shell
+          # integration through a real `nu`. Pin the release binary (no brew:
+          # deterministic, fast, checksum-verified) and match the version the
+          # integration was verified against.
+          NU_VERSION="0.113.1"
+          case "$(uname -m)" in
+            arm64|aarch64)
+              NU_ARCH="aarch64-apple-darwin"
+              NU_SHA256="458aa21674221b2e8adbd784f9ba8113288b78f3c352465cef37b114ff3dffd5"
+              ;;
+            x86_64)
+              NU_ARCH="x86_64-apple-darwin"
+              NU_SHA256="18ec6448cd8562b4f94ba24bace6164c5d8b8d634c8105751ec45e17d34549b2"
+              ;;
+            *)
+              echo "unsupported runner arch for pinned nushell: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          NU_DIR="$RUNNER_TEMP/cmux-nushell"
+          mkdir -p "$NU_DIR"
+          curl -fsSL --retry 3 -o "$NU_DIR/nu.tar.gz" \
+            "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/nu-${NU_VERSION}-${NU_ARCH}.tar.gz"
+          echo "$NU_SHA256  $NU_DIR/nu.tar.gz" | shasum -a 256 -c -
+          tar -xzf "$NU_DIR/nu.tar.gz" -C "$NU_DIR" --strip-components=1
+          test -x "$NU_DIR/nu"
+          "$NU_DIR/nu" --version
+          echo "$NU_DIR" >> "$GITHUB_PATH"
+
       - name: Run CLI no-socket regressions
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
@@ -942,6 +977,9 @@ jobs:
           python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py
           python3 tests/test_issue_8093_ghostty_ssh_binary_path.py
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
+          python3 tests/test_nushell_shim_path_refront.py
+          python3 tests/test_nushell_resume_command_dialect.py
+          python3 tests/test_nushell_integration_hooks.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py
           CMUX_CLI_BIN="$CLI_BIN" python3 tests/test_claude_hook_stop_last_assistant.py

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1137,6 +1137,41 @@ jobs:
         with:
           bun-version: "1.3.6"
 
+      - name: Install pinned nushell (shell-integration tests)
+        if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
+        run: |
+          set -euo pipefail
+
+          # tests/test_nushell_*.py drive the bundled nushell shell
+          # integration through a real `nu`. Pin the release binary (no brew:
+          # deterministic, fast, checksum-verified) and match the version the
+          # integration was verified against.
+          NU_VERSION="0.113.1"
+          case "$(uname -m)" in
+            arm64|aarch64)
+              NU_ARCH="aarch64-apple-darwin"
+              NU_SHA256="458aa21674221b2e8adbd784f9ba8113288b78f3c352465cef37b114ff3dffd5"
+              ;;
+            x86_64)
+              NU_ARCH="x86_64-apple-darwin"
+              NU_SHA256="18ec6448cd8562b4f94ba24bace6164c5d8b8d634c8105751ec45e17d34549b2"
+              ;;
+            *)
+              echo "unsupported runner arch for pinned nushell: $(uname -m)" >&2
+              exit 1
+              ;;
+          esac
+
+          NU_DIR="$RUNNER_TEMP/cmux-nushell"
+          mkdir -p "$NU_DIR"
+          curl -fsSL --retry 3 -o "$NU_DIR/nu.tar.gz" \
+            "https://github.com/nushell/nushell/releases/download/${NU_VERSION}/nu-${NU_VERSION}-${NU_ARCH}.tar.gz"
+          echo "$NU_SHA256  $NU_DIR/nu.tar.gz" | shasum -a 256 -c -
+          tar -xzf "$NU_DIR/nu.tar.gz" -C "$NU_DIR" --strip-components=1
+          test -x "$NU_DIR/nu"
+          "$NU_DIR/nu" --version
+          echo "$NU_DIR" >> "$GITHUB_PATH"
+
       - name: Run CLI no-socket regressions
         if: ${{ matrix.shard == fromJSON(env.CMUX_APP_HOST_FOCUSED_REGRESSION_SHARD) }}
         run: |
@@ -1186,6 +1221,9 @@ jobs:
           python3 tests/test_issue_6714_zsh_shim_noclobber.py
           python3 tests/test_issue_9356_bash_shim_noclobber.py
           python3 tests/test_issue_8953_zsh_prompt_wrap_guard.py
+          python3 tests/test_nushell_shim_path_refront.py
+          python3 tests/test_nushell_resume_command_dialect.py
+          python3 tests/test_nushell_integration_hooks.py
           python3 tests/test_shell_git_branch_stale_cwd.py
           python3 tests/test_shell_git_config_remote_url_parsing.py
           if ! command -v fish >/dev/null 2>&1; then

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-/// Rendering of cmux-generated POSIX one-liners for shells that cannot parse
+/// Renders cmux-generated POSIX one-liners for shells that cannot parse
 /// POSIX syntax.
 ///
 /// cmux builds resume/relaunch commands as POSIX strings (AND-OR lists,
@@ -14,14 +14,16 @@ import Foundation
 /// boundary — the same portable-envelope approach as
 /// ``AgentResumeArgv/portableClaudeResumeShellCommand(posixCommand:)``
 /// (issue #5639) and the `/bin/zsh <launcher-script>` startup inputs.
-public enum NushellTypedShellCommand {
+public struct NushellTypedShellCommand {
+    public init() {}
+
     /// A nushell-parseable line that runs `posixCommand` through `/bin/sh`.
     ///
     /// `^` forces external-command resolution for the absolute-path head and
     /// the body rides in a nushell double-quoted string (no interpolation;
     /// only `\` and `"` need escaping). Verified against real nu by
     /// `tests/test_nushell_resume_command_dialect.py`.
-    public static func wrapping(posixCommand: String) -> String {
+    public func wrapping(posixCommand: String) -> String {
         "^/bin/sh -c " + doubleQuoted(posixCommand)
     }
 
@@ -29,7 +31,7 @@ public enum NushellTypedShellCommand {
     /// single-quoted strings cannot contain single quotes at all, so double
     /// quotes are the safe general form; escaping every backslash first
     /// guarantees no invalid escape sequence remains.
-    public static func doubleQuoted(_ value: String) -> String {
+    public func doubleQuoted(_ value: String) -> String {
         "\"" + value
             .replacingOccurrences(of: "\\", with: "\\\\")
             .replacingOccurrences(of: "\"", with: "\\\"")

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Rendering of cmux-generated POSIX one-liners for shells that cannot parse
+/// POSIX syntax.
+///
+/// cmux builds resume/relaunch commands as POSIX strings (AND-OR lists,
+/// `[ … ]` tests, single-quote escaping, `"$(printf …)"` substitutions) and
+/// either types them into the user's interactive shell or dispatches them via
+/// `"$SHELL" -c`. Nushell parses none of that: `&&`/`||` are dedicated parse
+/// errors, `[ … ]` is a list literal, POSIX `'…'\''…'` concatenation does not
+/// exist, and even a quoted command head (`'claude' …`) is rejected. Instead
+/// of teaching every command builder a second dialect, the POSIX body is kept
+/// as-is and delegated through `/bin/sh` at the final typed/dispatched
+/// boundary — the same portable-envelope approach as
+/// ``AgentResumeArgv/portableClaudeResumeShellCommand(posixCommand:)``
+/// (issue #5639) and the `/bin/zsh <launcher-script>` startup inputs.
+public enum NushellTypedShellCommand {
+    /// A nushell-parseable line that runs `posixCommand` through `/bin/sh`.
+    ///
+    /// `^` forces external-command resolution for the absolute-path head and
+    /// the body rides in a nushell double-quoted string (no interpolation;
+    /// only `\` and `"` need escaping). Verified against real nu by
+    /// `tests/test_nushell_resume_command_dialect.py`.
+    public static func wrapping(posixCommand: String) -> String {
+        "^/bin/sh -c " + doubleQuoted(posixCommand)
+    }
+
+    /// Double-quotes a value for generated nushell source. Nushell
+    /// single-quoted strings cannot contain single quotes at all, so double
+    /// quotes are the safe general form; escaping every backslash first
+    /// guarantees no invalid escape sequence remains.
+    public static func doubleQuoted(_ value: String) -> String {
+        "\"" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            + "\""
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
@@ -14,7 +14,7 @@ import Foundation
 /// boundary — the same portable-envelope approach as
 /// ``AgentResumeArgv/portableClaudeResumeShellCommand(posixCommand:)``
 /// (issue #5639) and the `/bin/zsh <launcher-script>` startup inputs.
-public struct NushellTypedShellCommand {
+nonisolated public struct NushellTypedShellCommand: Sendable {
     /// The renderer is stateless; construct at the call site.
     public init() {}
 

--- a/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Sources/CMUXAgentLaunch/NushellTypedShellCommand.swift
@@ -15,6 +15,7 @@ import Foundation
 /// ``AgentResumeArgv/portableClaudeResumeShellCommand(posixCommand:)``
 /// (issue #5639) and the `/bin/zsh <launcher-script>` startup inputs.
 public struct NushellTypedShellCommand {
+    /// The renderer is stateless; construct at the call site.
     public init() {}
 
     /// A nushell-parseable line that runs `posixCommand` through `/bin/sh`.

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/NushellTypedShellCommandTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/NushellTypedShellCommandTests.swift
@@ -1,0 +1,41 @@
+import CMUXAgentLaunch
+import Testing
+
+@Suite("NushellTypedShellCommand")
+struct NushellTypedShellCommandTests {
+    @Test("Wraps a POSIX one-liner for nushell via /bin/sh")
+    func wrapsPosixCommand() {
+        let posix = "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'"
+        #expect(
+            NushellTypedShellCommand.wrapping(posixCommand: posix)
+                == #"^/bin/sh -c "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'""#
+        )
+    }
+
+    @Test("Escapes double quotes and backslashes, backslashes first")
+    func escapesQuotesAndBackslashes() {
+        #expect(
+            NushellTypedShellCommand.doubleQuoted(#"say "hi" \ bye"#)
+                == #""say \"hi\" \\ bye""#
+        )
+        // A pre-escaped sequence must not collapse: \" becomes \\\" so no
+        // invalid nushell escape can be formed.
+        #expect(
+            NushellTypedShellCommand.doubleQuoted(#"\""#) == #""\\\"""#
+        )
+    }
+
+    @Test("POSIX printf substitutions ride through untouched")
+    func printfSubstitutionSurvives() {
+        let posix = #"'claude' "$(printf '\303\251')""#
+        #expect(
+            NushellTypedShellCommand.wrapping(posixCommand: posix)
+                == #"^/bin/sh -c "'claude' \"$(printf '\\303\\251')\"""#
+        )
+    }
+
+    @Test("Empty command still renders a valid wrapper")
+    func emptyCommand() {
+        #expect(NushellTypedShellCommand.wrapping(posixCommand: "") == #"^/bin/sh -c """#)
+    }
+}

--- a/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/NushellTypedShellCommandTests.swift
+++ b/Packages/macOS/CMUXAgentLaunch/Tests/CMUXAgentLaunchTests/NushellTypedShellCommandTests.swift
@@ -7,7 +7,7 @@ struct NushellTypedShellCommandTests {
     func wrapsPosixCommand() {
         let posix = "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'"
         #expect(
-            NushellTypedShellCommand.wrapping(posixCommand: posix)
+            NushellTypedShellCommand().wrapping(posixCommand: posix)
                 == #"^/bin/sh -c "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'""#
         )
     }
@@ -15,13 +15,13 @@ struct NushellTypedShellCommandTests {
     @Test("Escapes double quotes and backslashes, backslashes first")
     func escapesQuotesAndBackslashes() {
         #expect(
-            NushellTypedShellCommand.doubleQuoted(#"say "hi" \ bye"#)
+            NushellTypedShellCommand().doubleQuoted(#"say "hi" \ bye"#)
                 == #""say \"hi\" \\ bye""#
         )
         // A pre-escaped sequence must not collapse: \" becomes \\\" so no
         // invalid nushell escape can be formed.
         #expect(
-            NushellTypedShellCommand.doubleQuoted(#"\""#) == #""\\\"""#
+            NushellTypedShellCommand().doubleQuoted(#"\""#) == #""\\\"""#
         )
     }
 
@@ -29,13 +29,13 @@ struct NushellTypedShellCommandTests {
     func printfSubstitutionSurvives() {
         let posix = #"'claude' "$(printf '\303\251')""#
         #expect(
-            NushellTypedShellCommand.wrapping(posixCommand: posix)
+            NushellTypedShellCommand().wrapping(posixCommand: posix)
                 == #"^/bin/sh -c "'claude' \"$(printf '\\303\\251')\"""#
         )
     }
 
     @Test("Empty command still renders a valid wrapper")
     func emptyCommand() {
-        #expect(NushellTypedShellCommand.wrapping(posixCommand: "") == #"^/bin/sh -c """#)
+        #expect(NushellTypedShellCommand().wrapping(posixCommand: "") == #"^/bin/sh -c """#)
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
@@ -378,8 +378,9 @@ extension TerminalSurface {
         return false
     }
 
-    /// Applies the shell-specific startup redirection (zsh/bash/fish) and
-    /// returns a replacement launch command when one is required (fish).
+    /// Applies the shell-specific startup redirection (zsh/bash/fish/nushell)
+    /// and returns a replacement launch command when one is required
+    /// (fish, nushell).
     public static func applyManagedShellSpecificStartupEnvironment(
         shell: String,
         integrationDir: String,
@@ -444,10 +445,66 @@ extension TerminalSurface {
             guard bundledBootstrapIsReadable("fish/config.fish") else { return nil }
             applyManagedFishStartupEnvironment(integrationDir: integrationDir, to: &environment, protectedKeys: &protectedKeys)
             return managedFishShellCommand(shell: shell)
+        case "nu":
+            guard bundledBootstrapIsReadable("nushell/cmux-nushell-bootstrap.nu") else { return nil }
+            let bootstrapPath = (integrationDir as NSString)
+                .appendingPathComponent("nushell/cmux-nushell-bootstrap.nu")
+            do {
+                let payload = nushellStartupPayload(
+                    bootstrapContents: try readFile(bootstrapPath),
+                    integrationDir: integrationDir
+                )
+                guard !payload.isEmpty else { return nil }
+                return managedNushellShellCommand(shell: shell, startupPayload: payload)
+            } catch {
+                Logger(subsystem: "com.cmuxterm.app", category: "ghostty.initialization")
+                    .error("cmux nushell bootstrap unreadable at \(bootstrapPath, privacy: .private): \(error.localizedDescription, privacy: .public); nushell shell integration will not load")
+                return nil
+            }
         default:
             break
         }
         return nil
+    }
+
+    /// Builds the nushell `-e` payload: the bootstrap squashed to one line
+    /// (comments and blank lines dropped, statements joined with `; `), plus a
+    /// `source` of the bundled integration file when it is present. The
+    /// integration path is baked in as a literal because nushell's `source`
+    /// requires a parse-time constant.
+    public static func nushellStartupPayload(
+        bootstrapContents: String,
+        integrationDir: String,
+        integrationFileIsReadable: (String) -> Bool = { FileManager.default.isReadableFile(atPath: $0) }
+    ) -> String {
+        var statements = bootstrapContents
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        let integrationPath = (integrationDir as NSString)
+            .appendingPathComponent("nushell/cmux-nushell-integration.nu")
+        if integrationFileIsReadable(integrationPath) {
+            statements.append("source \(nushellDoubleQuoted(integrationPath))")
+        }
+        return statements.joined(separator: "; ")
+    }
+
+    /// The managed nushell launch command: a login shell that evaluates the
+    /// cmux payload after the user's env.nu/config.nu/login.nu, then enters
+    /// the interactive REPL (`--execute` semantics).
+    public static func managedNushellShellCommand(shell: String, startupPayload: String) -> String {
+        "\(shellSingleQuoted(shell)) -l -e \(shellSingleQuoted(startupPayload))"
+    }
+
+    /// Double-quotes a value for nushell (`\` and `"` escaped). Used for
+    /// literals embedded in generated nushell source; nushell single-quoted
+    /// strings cannot contain single quotes at all, so double quotes are the
+    /// safe general form.
+    public static func nushellDoubleQuoted(_ value: String) -> String {
+        "\"" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            + "\""
     }
 
     /// The managed fish launch command sourcing the cmux integration file.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Spawn/TerminalSurface+StartupEnvironment.swift
@@ -219,8 +219,9 @@ extension TerminalSurface {
         return false
     }
 
-    /// Applies the shell-specific startup redirection (zsh/bash/fish) and
-    /// returns a replacement launch command when one is required (fish).
+    /// Applies the shell-specific startup redirection (zsh/bash/fish/nushell)
+    /// and returns a replacement launch command when one is required
+    /// (fish, nushell).
     public static func applyManagedShellSpecificStartupEnvironment(
         shell: String,
         integrationDir: String,
@@ -285,10 +286,66 @@ extension TerminalSurface {
             guard bundledBootstrapIsReadable("fish/config.fish") else { return nil }
             applyManagedFishStartupEnvironment(integrationDir: integrationDir, to: &environment, protectedKeys: &protectedKeys)
             return managedFishShellCommand(shell: shell)
+        case "nu":
+            guard bundledBootstrapIsReadable("nushell/cmux-nushell-bootstrap.nu") else { return nil }
+            let bootstrapPath = (integrationDir as NSString)
+                .appendingPathComponent("nushell/cmux-nushell-bootstrap.nu")
+            do {
+                let payload = nushellStartupPayload(
+                    bootstrapContents: try readFile(bootstrapPath),
+                    integrationDir: integrationDir
+                )
+                guard !payload.isEmpty else { return nil }
+                return managedNushellShellCommand(shell: shell, startupPayload: payload)
+            } catch {
+                Logger(subsystem: "com.cmuxterm.app", category: "ghostty.initialization")
+                    .error("cmux nushell bootstrap unreadable at \(bootstrapPath, privacy: .private): \(error.localizedDescription, privacy: .public); nushell shell integration will not load")
+                return nil
+            }
         default:
             break
         }
         return nil
+    }
+
+    /// Builds the nushell `-e` payload: the bootstrap squashed to one line
+    /// (comments and blank lines dropped, statements joined with `; `), plus a
+    /// `source` of the bundled integration file when it is present. The
+    /// integration path is baked in as a literal because nushell's `source`
+    /// requires a parse-time constant.
+    public static func nushellStartupPayload(
+        bootstrapContents: String,
+        integrationDir: String,
+        integrationFileIsReadable: (String) -> Bool = { FileManager.default.isReadableFile(atPath: $0) }
+    ) -> String {
+        var statements = bootstrapContents
+            .components(separatedBy: "\n")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        let integrationPath = (integrationDir as NSString)
+            .appendingPathComponent("nushell/cmux-nushell-integration.nu")
+        if integrationFileIsReadable(integrationPath) {
+            statements.append("source \(nushellDoubleQuoted(integrationPath))")
+        }
+        return statements.joined(separator: "; ")
+    }
+
+    /// The managed nushell launch command: a login shell that evaluates the
+    /// cmux payload after the user's env.nu/config.nu/login.nu, then enters
+    /// the interactive REPL (`--execute` semantics).
+    public static func managedNushellShellCommand(shell: String, startupPayload: String) -> String {
+        "\(shellSingleQuoted(shell)) -l -e \(shellSingleQuoted(startupPayload))"
+    }
+
+    /// Double-quotes a value for nushell (`\` and `"` escaped). Used for
+    /// literals embedded in generated nushell source; nushell single-quoted
+    /// strings cannot contain single quotes at all, so double quotes are the
+    /// safe general form.
+    public static func nushellDoubleQuoted(_ value: String) -> String {
+        "\"" + value
+            .replacingOccurrences(of: "\\", with: "\\\\")
+            .replacingOccurrences(of: "\"", with: "\\\"")
+            + "\""
     }
 
     /// The managed fish launch command sourcing the cmux integration file.

--- a/Resources/shell-integration/nushell/cmux-nushell-bootstrap.nu
+++ b/Resources/shell-integration/nushell/cmux-nushell-bootstrap.nu
@@ -1,0 +1,16 @@
+# cmux nushell bootstrap
+# Injected by cmux as the `-e` payload of the spawned login shell, which runs
+# after the user's env.nu/config.nu/login.nu. Keep every non-comment line a
+# self-contained statement: the Swift spawn path strips comments and blank
+# lines and joins the rest with '; ' into a single line (and appends a
+# `source` of cmux-nushell-integration.nu with the bundle path baked in).
+#
+# User config commonly rebuilds PATH with its own prepends, which shadows the
+# per-surface cmux-cli-shims directory cmux front-loaded at spawn (the claude
+# wrapper that injects session tracking + notification hooks). Re-front every
+# shim entry, preserving the relative order of everything else — nushell's
+# equivalent of the zsh integration's "keep the bundled wrapper ahead of later
+# PATH mutations". Also normalizes PATH back to a list when user config left
+# it a colon-joined string.
+def --env _cmux_refront_cli_shims [] { if ($env.CMUX_SURFACE_ID? | default "") == "" { return }; let raw = ($env.PATH? | default []); let entries = if ($raw | describe | str starts-with "list") { $raw } else { $raw | split row (char esep) }; let shims = ($entries | where {|p| $p | str contains "cmux-cli-shims" }); $env.PATH = ($shims ++ ($entries | where {|p| not ($p | str contains "cmux-cli-shims") })) }
+_cmux_refront_cli_shims

--- a/Resources/shell-integration/nushell/cmux-nushell-integration.nu
+++ b/Resources/shell-integration/nushell/cmux-nushell-integration.nu
@@ -12,10 +12,12 @@
 # cannot mutate the environment; cmux registers string hooks that call the
 # `def --env` entry points below, so mutations persist across prompts.
 
+# Whether the cmux integration is active (CMUX_SHELL_INTEGRATION=0 disables it).
 def _cmux_integration_enabled [] {
     ($env.CMUX_SHELL_INTEGRATION? | default "1") != "0"
 }
 
+# Picks the socket transport once at source time: ncat, socat, or nc.
 def _cmux_pick_send_tool [] {
     if (which ncat | is-not-empty) {
         "ncat"
@@ -28,6 +30,8 @@ def _cmux_pick_send_tool [] {
     }
 }
 
+# Whether CMUX_SOCKET_PATH points at a live unix socket; positive results are
+# cached for the session because the probe forks /bin/test.
 def --env _cmux_socket_is_unix [] {
     let sock = ($env.CMUX_SOCKET_PATH? | default "")
     if ($sock | is-empty) { return false }
@@ -41,12 +45,14 @@ def --env _cmux_socket_is_unix [] {
     $live
 }
 
+# Resolves the cmux CLI used for remote-relay RPCs, preferring the bundled binary.
 def _cmux_relay_cli_path [] {
     let bundled = ($env.CMUX_BUNDLED_CLI_PATH? | default "")
     if ($bundled != "") and ($bundled | path exists) { return $bundled }
     which cmux | get -o 0.path | default ""
 }
 
+# Whether CMUX_SOCKET_PATH is a host:port relay address reachable through the cmux CLI.
 def _cmux_socket_uses_remote_relay [] {
     let sock = ($env.CMUX_SOCKET_PATH? | default "")
     if ($sock | is-empty) { return false }
@@ -55,6 +61,7 @@ def _cmux_socket_uses_remote_relay [] {
     (_cmux_relay_cli_path) != ""
 }
 
+# Sends one payload line to the cmux socket, synchronously.
 def _cmux_send [payload: string] {
     if ($payload | is-empty) { return }
     let sock = ($env.CMUX_SOCKET_PATH? | default "")
@@ -73,6 +80,9 @@ def _cmux_send [payload: string] {
     }
 }
 
+# Sends a payload without blocking the prompt (job spawn). CMUX_TEST_SYNC_SEND=1
+# forces the synchronous path so tests are deterministic (nushell kills jobs at
+# shell exit, which a -c script would race).
 def _cmux_send_bg [payload: string] {
     if ($env.CMUX_TEST_SYNC_SEND? | default "") == "1" {
         _cmux_send $payload
@@ -81,6 +91,8 @@ def _cmux_send_bg [payload: string] {
     job spawn { _cmux_send $payload } | ignore
 }
 
+# Escapes a value for the quoted field of a socket payload, mirroring the fish
+# integration's escaping so the app-side parser sees identical wire format.
 def _cmux_json_escape [value: string] {
     $value
     | str replace -a "\\" "\\\\"
@@ -90,12 +102,14 @@ def _cmux_json_escape [value: string] {
     | str replace -a "\t" "\\t"
 }
 
+# Workspace id for relay RPC params, falling back to the tab id.
 def _cmux_relay_workspace_id [] {
     let workspace = ($env.CMUX_WORKSPACE_ID? | default "")
     if $workspace != "" { return $workspace }
     $env.CMUX_TAB_ID? | default ""
 }
 
+# Fires a cmux relay RPC without blocking the prompt.
 def _cmux_relay_rpc_bg [method: string, params: string] {
     let cli = (_cmux_relay_cli_path)
     if ($cli | is-empty) { return }
@@ -106,11 +120,7 @@ def _cmux_relay_rpc_bg [method: string, params: string] {
     job spawn { ^$cli rpc $method $params | complete | ignore } | ignore
 }
 
-def _cmux_relay_params [pairs: record] {
-    mut params = ($pairs | to json --raw)
-    $params
-}
-
+# Reports the tty name through the remote relay.
 def _cmux_report_tty_via_relay [] {
     if not (_cmux_socket_uses_remote_relay) { return }
     let name = ($env._CMUX_TTY_NAME? | default "")
@@ -123,6 +133,7 @@ def _cmux_report_tty_via_relay [] {
     _cmux_relay_rpc_bg surface.report_tty ($payload | to json --raw)
 }
 
+# Reports a cwd change through the remote relay; returns true when dispatched.
 def _cmux_report_pwd_via_relay [pwd: string] {
     if not (_cmux_socket_uses_remote_relay) { return false }
     if ($pwd | is-empty) { return false }
@@ -135,6 +146,7 @@ def _cmux_report_pwd_via_relay [pwd: string] {
     true
 }
 
+# Requests a port scan through the remote relay.
 def _cmux_ports_kick_via_relay [reason: string] {
     if not (_cmux_socket_uses_remote_relay) { return }
     let workspace = (_cmux_relay_workspace_id)
@@ -145,6 +157,8 @@ def _cmux_ports_kick_via_relay [reason: string] {
     _cmux_relay_rpc_bg surface.ports_kick ($payload | to json --raw)
 }
 
+# Reports the surface tty once per session so cmux can map this shell to its
+# panel. Honors a preset _CMUX_TTY_NAME (tests have no tty to probe).
 def --env _cmux_report_tty_once [] {
     if ($env._CMUX_TTY_REPORTED? | default "") == "1" { return }
     mut name = ($env._CMUX_TTY_NAME? | default "")
@@ -169,6 +183,7 @@ def --env _cmux_report_tty_once [] {
     }
 }
 
+# Reports busy/idle transitions (running/prompt), deduped across repeated prompts.
 def --env _cmux_report_shell_activity_state [state: string] {
     if ($state | is-empty) { return }
     # Dedupe before the socket probe: this runs on every prompt and the
@@ -183,6 +198,8 @@ def --env _cmux_report_shell_activity_state [state: string] {
     _cmux_send_bg $"report_shell_state ($state) --tab=($tab) --panel=($panel)"
 }
 
+# Reports the cwd when it changed since the last prompt; feeds cmux's
+# workspace current-directory tracking.
 def --env _cmux_report_pwd_if_changed [] {
     let pwd = $env.PWD
     if $pwd == ($env._CMUX_PWD_LAST_PWD? | default "") { return }
@@ -199,6 +216,7 @@ def --env _cmux_report_pwd_if_changed [] {
     }
 }
 
+# Requests a cmux port scan (reason: command or refresh).
 def --env _cmux_ports_kick [reason: string] {
     mut why = $reason
     if ($why | is-empty) { $why = "command" }
@@ -214,12 +232,15 @@ def --env _cmux_ports_kick [reason: string] {
     }
 }
 
+# Resets modifyOtherKeys/kitty keyboard protocols a crashed TUI can leave enabled.
 def _cmux_reset_terminal_keyboard_protocols [] {
     let forced = ($env.CMUX_TEST_FORCE_KEYBOARD_RESET? | default "") + ($env.CMUX_TEST_FORCE_KITTY_RESET? | default "")
     if ($forced | is-empty) and not (is-terminal --stdout) { return }
     print -n "\e[>m\e[<8u"
 }
 
+# Replays saved scrollback into a restored surface, bracketed by the OSC 1337
+# markers cmux recognizes, then deletes the replay file.
 def --env _cmux_restore_scrollback_once [] {
     let path = ($env.CMUX_RESTORE_SCROLLBACK_FILE? | default "")
     if ($path | is-empty) { return }
@@ -235,6 +256,7 @@ def --env _cmux_restore_scrollback_once [] {
     print -n $"\e]1337;CurrentDir=kitty-shell-cwd://($host)($env.PWD)\u{07}"
 }
 
+# Locates a bundled cmux CLI wrapper relative to CMUX_SHELL_INTEGRATION_DIR.
 def _cmux_wrapper_path [wrapper_file: string] {
     let dir = ($env.CMUX_SHELL_INTEGRATION_DIR? | default "")
     if ($dir | is-empty) { return "" }
@@ -260,6 +282,7 @@ def --wrapped claude [...args: string] {
     }
 }
 
+# Routes grok through the bundled cmux wrapper when present.
 def --wrapped grok [...args: string] {
     let wrapper = (_cmux_wrapper_path "grok")
     if ($wrapper != "") {
@@ -269,6 +292,8 @@ def --wrapped grok [...args: string] {
     }
 }
 
+# pre_execution hook: report tty + busy state and kick a port scan before a
+# command runs.
 def --env _cmux_pre_execution [] {
     if not (_cmux_integration_enabled) { return }
     _cmux_report_tty_once
@@ -276,6 +301,8 @@ def --env _cmux_pre_execution [] {
     _cmux_ports_kick command
 }
 
+# pre_prompt hook: keyboard reset, tty/idle/cwd reports, and a port-scan
+# refresh at most every 5 seconds.
 def --env _cmux_pre_prompt [] {
     if not (_cmux_integration_enabled) { return }
     _cmux_reset_terminal_keyboard_protocols

--- a/Resources/shell-integration/nushell/cmux-nushell-integration.nu
+++ b/Resources/shell-integration/nushell/cmux-nushell-integration.nu
@@ -28,11 +28,17 @@ def _cmux_pick_send_tool [] {
     }
 }
 
-def _cmux_socket_is_unix [] {
+def --env _cmux_socket_is_unix [] {
     let sock = ($env.CMUX_SOCKET_PATH? | default "")
     if ($sock | is-empty) { return false }
     if not ($sock | str starts-with "/") { return false }
-    (^/bin/test -S $sock | complete | get exit_code) == 0
+    # The probe forks /bin/test and this runs from every prompt hook, so cache
+    # the positive result for the session (the socket path is session-stable).
+    # A negative result is not cached: the socket may come up moments later.
+    if ($env._CMUX_SOCKET_IS_UNIX? | default "") == $"yes:($sock)" { return true }
+    let live = ((^/bin/test -S $sock | complete | get exit_code) == 0)
+    if $live { $env._CMUX_SOCKET_IS_UNIX = $"yes:($sock)" }
+    $live
 }
 
 def _cmux_relay_cli_path [] {
@@ -165,12 +171,14 @@ def --env _cmux_report_tty_once [] {
 
 def --env _cmux_report_shell_activity_state [state: string] {
     if ($state | is-empty) { return }
+    # Dedupe before the socket probe: this runs on every prompt and the
+    # state is unchanged almost every time.
+    if ($env._CMUX_SHELL_ACTIVITY_LAST? | default "") == $state { return }
     if not (_cmux_socket_is_unix) { return }
     let tab = ($env.CMUX_TAB_ID? | default "")
     if ($tab | is-empty) { return }
     let panel = ($env.CMUX_PANEL_ID? | default "")
     if ($panel | is-empty) { return }
-    if ($env._CMUX_SHELL_ACTIVITY_LAST? | default "") == $state { return }
     $env._CMUX_SHELL_ACTIVITY_LAST = $state
     _cmux_send_bg $"report_shell_state ($state) --tab=($tab) --panel=($panel)"
 }

--- a/Resources/shell-integration/nushell/cmux-nushell-integration.nu
+++ b/Resources/shell-integration/nushell/cmux-nushell-integration.nu
@@ -1,0 +1,293 @@
+# cmux shell integration for nushell
+# Sourced automatically by the cmux nushell bootstrap; do not source manually.
+#
+# Feature parity target is the fish integration
+# (Resources/shell-integration/fish/config.fish): socket reporting of tty,
+# shell activity state, pwd changes, and port-scan kicks, plus the claude/grok
+# CLI wrappers, scrollback restore, and the keyboard-protocol reset. The
+# zsh-only extras (git-branch probes, PR polling, Ghostty job-table patching)
+# are intentionally not replicated here.
+#
+# State lives in _CMUX_* environment variables because nushell hook closures
+# cannot mutate the environment; cmux registers string hooks that call the
+# `def --env` entry points below, so mutations persist across prompts.
+
+def _cmux_integration_enabled [] {
+    ($env.CMUX_SHELL_INTEGRATION? | default "1") != "0"
+}
+
+def _cmux_pick_send_tool [] {
+    if (which ncat | is-not-empty) {
+        "ncat"
+    } else if (which socat | is-not-empty) {
+        "socat"
+    } else if (which nc | is-not-empty) {
+        "nc"
+    } else {
+        ""
+    }
+}
+
+def _cmux_socket_is_unix [] {
+    let sock = ($env.CMUX_SOCKET_PATH? | default "")
+    if ($sock | is-empty) { return false }
+    if not ($sock | str starts-with "/") { return false }
+    (^/bin/test -S $sock | complete | get exit_code) == 0
+}
+
+def _cmux_relay_cli_path [] {
+    let bundled = ($env.CMUX_BUNDLED_CLI_PATH? | default "")
+    if ($bundled != "") and ($bundled | path exists) { return $bundled }
+    which cmux | get -o 0.path | default ""
+}
+
+def _cmux_socket_uses_remote_relay [] {
+    let sock = ($env.CMUX_SOCKET_PATH? | default "")
+    if ($sock | is-empty) { return false }
+    if ($sock | str starts-with "/") { return false }
+    if not ($sock | str contains ":") { return false }
+    (_cmux_relay_cli_path) != ""
+}
+
+def _cmux_send [payload: string] {
+    if ($payload | is-empty) { return }
+    let sock = ($env.CMUX_SOCKET_PATH? | default "")
+    if ($sock | is-empty) { return }
+    let tool = ($env._CMUX_SEND_TOOL? | default "")
+    let line = $"($payload)(char nl)"
+    if $tool == "ncat" {
+        $line | ^ncat -w 1 -U $sock --send-only | complete | ignore
+    } else if $tool == "socat" {
+        $line | ^socat -T 1 - $"UNIX-CONNECT:($sock)" | complete | ignore
+    } else if $tool == "nc" {
+        let first = ($line | ^nc -N -U $sock | complete)
+        if $first.exit_code != 0 {
+            $line | ^nc -w 1 -U $sock | complete | ignore
+        }
+    }
+}
+
+def _cmux_send_bg [payload: string] {
+    if ($env.CMUX_TEST_SYNC_SEND? | default "") == "1" {
+        _cmux_send $payload
+        return
+    }
+    job spawn { _cmux_send $payload } | ignore
+}
+
+def _cmux_json_escape [value: string] {
+    $value
+    | str replace -a "\\" "\\\\"
+    | str replace -a '"' '\"'
+    | str replace -a "\n" "\\n"
+    | str replace -a "\r" "\\r"
+    | str replace -a "\t" "\\t"
+}
+
+def _cmux_relay_workspace_id [] {
+    let workspace = ($env.CMUX_WORKSPACE_ID? | default "")
+    if $workspace != "" { return $workspace }
+    $env.CMUX_TAB_ID? | default ""
+}
+
+def _cmux_relay_rpc_bg [method: string, params: string] {
+    let cli = (_cmux_relay_cli_path)
+    if ($cli | is-empty) { return }
+    if ($env.CMUX_TEST_SYNC_SEND? | default "") == "1" {
+        ^$cli rpc $method $params | complete | ignore
+        return
+    }
+    job spawn { ^$cli rpc $method $params | complete | ignore } | ignore
+}
+
+def _cmux_relay_params [pairs: record] {
+    mut params = ($pairs | to json --raw)
+    $params
+}
+
+def _cmux_report_tty_via_relay [] {
+    if not (_cmux_socket_uses_remote_relay) { return }
+    let name = ($env._CMUX_TTY_NAME? | default "")
+    if ($name | is-empty) { return }
+    let workspace = (_cmux_relay_workspace_id)
+    if ($workspace | is-empty) { return }
+    mut payload = {workspace_id: $workspace, tty_name: $name}
+    let panel = ($env.CMUX_PANEL_ID? | default "")
+    if $panel != "" { $payload = ($payload | insert surface_id $panel) }
+    _cmux_relay_rpc_bg surface.report_tty ($payload | to json --raw)
+}
+
+def _cmux_report_pwd_via_relay [pwd: string] {
+    if not (_cmux_socket_uses_remote_relay) { return false }
+    if ($pwd | is-empty) { return false }
+    let workspace = (_cmux_relay_workspace_id)
+    if ($workspace | is-empty) { return false }
+    mut payload = {workspace_id: $workspace, path: $pwd}
+    let panel = ($env.CMUX_PANEL_ID? | default "")
+    if $panel != "" { $payload = ($payload | insert surface_id $panel) }
+    _cmux_relay_rpc_bg surface.report_pwd ($payload | to json --raw)
+    true
+}
+
+def _cmux_ports_kick_via_relay [reason: string] {
+    if not (_cmux_socket_uses_remote_relay) { return }
+    let workspace = (_cmux_relay_workspace_id)
+    if ($workspace | is-empty) { return }
+    mut payload = {workspace_id: $workspace, reason: $reason}
+    let panel = ($env.CMUX_PANEL_ID? | default "")
+    if $panel != "" { $payload = ($payload | insert surface_id $panel) }
+    _cmux_relay_rpc_bg surface.ports_kick ($payload | to json --raw)
+}
+
+def --env _cmux_report_tty_once [] {
+    if ($env._CMUX_TTY_REPORTED? | default "") == "1" { return }
+    mut name = ($env._CMUX_TTY_NAME? | default "")
+    if ($name | is-empty) {
+        let probe = (^tty | complete)
+        if $probe.exit_code == 0 {
+            $name = ($probe.stdout | str trim | str replace -r '^.*/' '')
+        }
+    }
+    if ($name | is-empty) or ($name == "not a tty") { return }
+    $env._CMUX_TTY_NAME = $name
+    if (_cmux_socket_is_unix) {
+        let tab = ($env.CMUX_TAB_ID? | default "")
+        if ($tab | is-empty) { return }
+        let panel = ($env.CMUX_PANEL_ID? | default "")
+        if ($panel | is-empty) { return }
+        $env._CMUX_TTY_REPORTED = "1"
+        _cmux_send_bg $"report_tty ($name) --tab=($tab) --panel=($panel)"
+    } else if (_cmux_socket_uses_remote_relay) {
+        $env._CMUX_TTY_REPORTED = "1"
+        _cmux_report_tty_via_relay
+    }
+}
+
+def --env _cmux_report_shell_activity_state [state: string] {
+    if ($state | is-empty) { return }
+    if not (_cmux_socket_is_unix) { return }
+    let tab = ($env.CMUX_TAB_ID? | default "")
+    if ($tab | is-empty) { return }
+    let panel = ($env.CMUX_PANEL_ID? | default "")
+    if ($panel | is-empty) { return }
+    if ($env._CMUX_SHELL_ACTIVITY_LAST? | default "") == $state { return }
+    $env._CMUX_SHELL_ACTIVITY_LAST = $state
+    _cmux_send_bg $"report_shell_state ($state) --tab=($tab) --panel=($panel)"
+}
+
+def --env _cmux_report_pwd_if_changed [] {
+    let pwd = $env.PWD
+    if $pwd == ($env._CMUX_PWD_LAST_PWD? | default "") { return }
+    if (_cmux_socket_is_unix) {
+        let tab = ($env.CMUX_TAB_ID? | default "")
+        if ($tab | is-empty) { return }
+        let panel = ($env.CMUX_PANEL_ID? | default "")
+        if ($panel | is-empty) { return }
+        let qpwd = (_cmux_json_escape $pwd)
+        _cmux_send_bg $"report_pwd \"($qpwd)\" --tab=($tab) --panel=($panel)"
+        $env._CMUX_PWD_LAST_PWD = $pwd
+    } else if (_cmux_report_pwd_via_relay $pwd) {
+        $env._CMUX_PWD_LAST_PWD = $pwd
+    }
+}
+
+def --env _cmux_ports_kick [reason: string] {
+    mut why = $reason
+    if ($why | is-empty) { $why = "command" }
+    let tab = ($env.CMUX_TAB_ID? | default "")
+    if ($tab | is-empty) { return }
+    $env._CMUX_PORTS_LAST_RUN = (date now | format date "%s")
+    if (_cmux_socket_is_unix) {
+        let panel = ($env.CMUX_PANEL_ID? | default "")
+        if ($panel | is-empty) { return }
+        _cmux_send_bg $"ports_kick --tab=($tab) --panel=($panel) --reason=($why)"
+    } else {
+        _cmux_ports_kick_via_relay $why
+    }
+}
+
+def _cmux_reset_terminal_keyboard_protocols [] {
+    let forced = ($env.CMUX_TEST_FORCE_KEYBOARD_RESET? | default "") + ($env.CMUX_TEST_FORCE_KITTY_RESET? | default "")
+    if ($forced | is-empty) and not (is-terminal --stdout) { return }
+    print -n "\e[>m\e[<8u"
+}
+
+def --env _cmux_restore_scrollback_once [] {
+    let path = ($env.CMUX_RESTORE_SCROLLBACK_FILE? | default "")
+    if ($path | is-empty) { return }
+    hide-env CMUX_RESTORE_SCROLLBACK_FILE
+    let token = ($path | str replace -r '^.*/' '')
+    let host = (^/bin/hostname | complete | get stdout | str trim)
+    print -n $"\e]1337;CurrentDir=kitty-shell-cwd://($host)/.cmux/session-scrollback-replay/($token)/start\u{07}"
+    if ($path | path exists) {
+        try { ^/bin/cat -- $path }
+        ^/bin/rm -f -- $path | complete | ignore
+    }
+    print -n $"\e]1337;CurrentDir=kitty-shell-cwd://($host)/.cmux/session-scrollback-replay/($token)/end\u{07}"
+    print -n $"\e]1337;CurrentDir=kitty-shell-cwd://($host)($env.PWD)\u{07}"
+}
+
+def _cmux_wrapper_path [wrapper_file: string] {
+    let dir = ($env.CMUX_SHELL_INTEGRATION_DIR? | default "")
+    if ($dir | is-empty) { return "" }
+    let bundle = ($dir | str replace -r '/shell-integration/?$' '')
+    let candidate = ($bundle | path join "bin" $wrapper_file)
+    if ($candidate | path exists) { $candidate } else { "" }
+}
+
+# Route `claude` through the cmux wrapper so session tracking and
+# notification hooks are injected even if later PATH edits shadow the
+# per-surface shim. `^claude` resolves the real external through PATH.
+def --wrapped claude [...args: string] {
+    let shim = ($env.CMUX_CLAUDE_WRAPPER_SHIM? | default "")
+    if ($shim != "") and ($shim | path exists) {
+        ^$shim ...$args
+    } else {
+        let wrapper = (_cmux_wrapper_path "cmux-claude-wrapper")
+        if ($wrapper != "") {
+            ^$wrapper ...$args
+        } else {
+            ^claude ...$args
+        }
+    }
+}
+
+def --wrapped grok [...args: string] {
+    let wrapper = (_cmux_wrapper_path "grok")
+    if ($wrapper != "") {
+        ^$wrapper ...$args
+    } else {
+        ^grok ...$args
+    }
+}
+
+def --env _cmux_pre_execution [] {
+    if not (_cmux_integration_enabled) { return }
+    _cmux_report_tty_once
+    _cmux_report_shell_activity_state running
+    _cmux_ports_kick command
+}
+
+def --env _cmux_pre_prompt [] {
+    if not (_cmux_integration_enabled) { return }
+    _cmux_reset_terminal_keyboard_protocols
+    _cmux_report_tty_once
+    _cmux_report_shell_activity_state prompt
+    _cmux_report_pwd_if_changed
+    let now = (date now | format date "%s" | into int)
+    let last = (($env._CMUX_PORTS_LAST_RUN? | default "0") | into int)
+    if ($now - $last) >= 5 { _cmux_ports_kick refresh }
+}
+
+if (_cmux_integration_enabled) {
+    $env._CMUX_SEND_TOOL = (_cmux_pick_send_tool)
+    _cmux_restore_scrollback_once
+    # String hooks (not closures) so the def --env entry points can persist
+    # their dedupe state into the REPL environment.
+    $env.config = ($env.config | upsert hooks.pre_execution (
+        ($env.config.hooks.pre_execution? | default []) | append "_cmux_pre_execution"
+    ))
+    $env.config = ($env.config | upsert hooks.pre_prompt (
+        ($env.config.hooks.pre_prompt? | default []) | append "_cmux_pre_prompt"
+    ))
+}

--- a/Sources/OneShotTerminalLauncherStore.swift
+++ b/Sources/OneShotTerminalLauncherStore.swift
@@ -100,9 +100,15 @@ struct OneShotTerminalLauncherStore {
                 lines.append(trimmedCommand)
             case .userLoginShell:
                 lines.append("[[ -n \"${SHELL:-}\" ]] || exit 127")
-                lines.append(
-                    "exec \"$SHELL\" -lc \(TerminalStartupShellQuoting.singleQuoted(trimmedCommand))"
-                )
+                // Nushell cannot parse the POSIX command (`nu -lc` has no such
+                // flags and `nu -c` would be a parse error); run it through
+                // /bin/sh with the same run-command-then-exit lifecycle.
+                lines.append(contentsOf: [
+                    #"case "${SHELL:t}" in"#,
+                    "  nu) exec /bin/sh -c \(TerminalStartupShellQuoting.singleQuoted(trimmedCommand)) ;;",
+                    "  *) exec \"$SHELL\" -lc \(TerminalStartupShellQuoting.singleQuoted(trimmedCommand)) ;;",
+                    "esac",
+                ])
             }
 
             try (lines.joined(separator: "\n") + "\n").write(

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -42,6 +42,10 @@ enum TerminalStartupShellDialect: Equatable {
     case posix
     case nushell
 
+    /// Maps a shell executable path to its dialect by basename. Everything
+    /// except `nu` is treated as POSIX: every other login shell cmux supports
+    /// (zsh/bash/fish/csh/dash/ksh) parses the POSIX command strings cmux
+    /// generates.
     static func forShellPath(_ shell: String?) -> TerminalStartupShellDialect {
         guard let shell = shell?.trimmingCharacters(in: .whitespacesAndNewlines),
               !shell.isEmpty else {
@@ -71,12 +75,18 @@ enum TerminalStartupShellDialect: Equatable {
 /// Launcher-script inputs (`/bin/zsh '<script>'`) parse in every supported
 /// shell and do not need this.
 struct TerminalStartupTypedShellCommand {
+    /// Dialect of the shell that will parse the rendered input.
     let dialect: TerminalStartupShellDialect
 
+    /// Defaults to the login shell cmux spawns local surfaces with; pass
+    /// ``TerminalStartupShellDialect/remoteHost`` when the input is typed
+    /// into a remote host's shell instead.
     init(dialect: TerminalStartupShellDialect = .loginShell) {
         self.dialect = dialect
     }
 
+    /// Renders `posixCommand` for typing: verbatim for POSIX shells,
+    /// delegated through `/bin/sh` for nushell (which cannot parse POSIX).
     func typedInput(posixCommand: String) -> String {
         switch dialect {
         case .posix:
@@ -802,6 +812,9 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
     /// user-owned claude resume/fork when no explicit launch flag covers it.
     var permissionMode: String? = nil
 
+    /// Input that resumes this agent session when typed into a shell.
+    /// `dialect` must match the shell that will parse it (see
+    /// ``startupInput(command:fileManager:temporaryDirectory:allowLauncherScript:allowOversizedInlineInput:dialect:)``).
     func resumeStartupInput(
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,
@@ -842,6 +855,9 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         return "/bin/zsh \(shellSingleQuoted(scriptURL.path))"
     }
 
+    /// Input that forks this agent conversation when typed into a shell.
+    /// `dialect` must match the shell that will parse it — `.remoteHost` for
+    /// remote forks.
     func forkStartupInput(
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -35,6 +35,47 @@ fileprivate func shellSingleQuoted(_ value: String) -> String {
     TerminalStartupShellQuoting.singleQuoted(value)
 }
 
+/// Which syntax family the user's interactive shell parses. Everything cmux
+/// generates is POSIX; nushell is the one supported login shell that cannot
+/// parse it (see ``NushellTypedShellCommand``).
+enum TerminalStartupShellDialect: Equatable {
+    case posix
+    case nushell
+
+    static func forShellPath(_ shell: String?) -> TerminalStartupShellDialect {
+        guard let shell = shell?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !shell.isEmpty else {
+            return .posix
+        }
+        return URL(fileURLWithPath: shell).lastPathComponent == "nu" ? .nushell : .posix
+    }
+
+    /// Dialect of the login shell cmux spawns terminal surfaces with — the
+    /// same `$SHELL` fallback chain the spawn path uses.
+    static var loginShell: TerminalStartupShellDialect {
+        forShellPath(ProcessInfo.processInfo.environment["SHELL"])
+    }
+}
+
+/// Final rendering step for cmux-generated POSIX one-liners that get typed
+/// into (or pasted into) the user's interactive shell. POSIX shells receive
+/// the command verbatim; nushell receives it delegated through `/bin/sh`.
+/// Launcher-script inputs (`/bin/zsh '<script>'`) parse in every supported
+/// shell and do not need this.
+enum TerminalStartupTypedShellCommand {
+    static func typedInput(
+        posixCommand: String,
+        dialect: TerminalStartupShellDialect = .loginShell
+    ) -> String {
+        switch dialect {
+        case .posix:
+            return posixCommand
+        case .nushell:
+            return NushellTypedShellCommand.wrapping(posixCommand: posixCommand)
+        }
+    }
+}
+
 enum TerminalStartupWorkingDirectoryPrefix {
     static func optionalChangeDirectoryPrefix(for workingDirectory: String?) -> String? {
         guard let workingDirectory = normalized(workingDirectory) else { return nil }
@@ -809,7 +850,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         allowOversizedInlineInput: Bool = false
     ) -> String? {
         guard let command else { return nil }
-        let inlineInput = command + "\n"
+        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command) + "\n"
         guard inlineInput.utf8.count > Self.maxInlineStartupInputBytes else {
             return inlineInput
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -795,14 +795,16 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,
         allowLauncherScript: Bool = true,
-        allowOversizedInlineInput: Bool = false
+        allowOversizedInlineInput: Bool = false,
+        dialect: TerminalStartupShellDialect = .loginShell
     ) -> String? {
         startupInput(
             command: resumeCommand,
             fileManager: fileManager,
             temporaryDirectory: temporaryDirectory,
             allowLauncherScript: allowLauncherScript,
-            allowOversizedInlineInput: allowOversizedInlineInput
+            allowOversizedInlineInput: allowOversizedInlineInput,
+            dialect: dialect
         )
     }
 
@@ -832,25 +834,34 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
     func forkStartupInput(
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,
-        allowLauncherScript: Bool = true
+        allowLauncherScript: Bool = true,
+        dialect: TerminalStartupShellDialect = .loginShell
     ) -> String? {
         startupInput(
             command: forkCommand,
             fileManager: fileManager,
             temporaryDirectory: temporaryDirectory,
-            allowLauncherScript: allowLauncherScript
+            allowLauncherScript: allowLauncherScript,
+            dialect: dialect
         )
     }
 
+    /// `dialect` describes the shell that will parse the returned input. Local
+    /// surfaces type into the user's login shell (`.loginShell` default);
+    /// remote workspaces type into the remote host's shell after attach, which
+    /// cmux treats as POSIX regardless of the local `$SHELL` — pass `.posix`
+    /// there so a local nushell login never leaks `^/bin/sh -c "…"` to a
+    /// remote zsh/bash.
     private func startupInput(
         command: String?,
         fileManager: FileManager,
         temporaryDirectory: URL,
         allowLauncherScript: Bool = true,
-        allowOversizedInlineInput: Bool = false
+        allowOversizedInlineInput: Bool = false,
+        dialect: TerminalStartupShellDialect = .loginShell
     ) -> String? {
         guard let command else { return nil }
-        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command) + "\n"
+        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command, dialect: dialect) + "\n"
         guard inlineInput.utf8.count > Self.maxInlineStartupInputBytes else {
             return inlineInput
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -55,6 +55,14 @@ enum TerminalStartupShellDialect: Equatable {
     static var loginShell: TerminalStartupShellDialect {
         forShellPath(ProcessInfo.processInfo.environment["SHELL"])
     }
+
+    /// Dialect for input typed into a remote host's shell after attach.
+    /// cmux does not (yet) know the remote login shell — the SSH bootstrap
+    /// resolves `$SHELL` on the host at runtime and nothing reports it back —
+    /// so remote input stays POSIX, which is what cmux has always sent to
+    /// remotes. If the bootstrap ever reports the remote shell, this is the
+    /// single seam to replace with real detection.
+    static let remoteHost: TerminalStartupShellDialect = .posix
 }
 
 /// Final rendering step for cmux-generated POSIX one-liners that get typed
@@ -62,16 +70,19 @@ enum TerminalStartupShellDialect: Equatable {
 /// the command verbatim; nushell receives it delegated through `/bin/sh`.
 /// Launcher-script inputs (`/bin/zsh '<script>'`) parse in every supported
 /// shell and do not need this.
-enum TerminalStartupTypedShellCommand {
-    static func typedInput(
-        posixCommand: String,
-        dialect: TerminalStartupShellDialect = .loginShell
-    ) -> String {
+struct TerminalStartupTypedShellCommand {
+    let dialect: TerminalStartupShellDialect
+
+    init(dialect: TerminalStartupShellDialect = .loginShell) {
+        self.dialect = dialect
+    }
+
+    func typedInput(posixCommand: String) -> String {
         switch dialect {
         case .posix:
             return posixCommand
         case .nushell:
-            return NushellTypedShellCommand.wrapping(posixCommand: posixCommand)
+            return NushellTypedShellCommand().wrapping(posixCommand: posixCommand)
         }
     }
 }
@@ -861,7 +872,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         dialect: TerminalStartupShellDialect = .loginShell
     ) -> String? {
         guard let command else { return nil }
-        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command, dialect: dialect) + "\n"
+        let inlineInput = TerminalStartupTypedShellCommand(dialect: dialect).typedInput(posixCommand: command) + "\n"
         guard inlineInput.utf8.count > Self.maxInlineStartupInputBytes else {
             return inlineInput
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -52,6 +52,14 @@ enum TerminalStartupShellDialect: Equatable {
     static var loginShell: TerminalStartupShellDialect {
         forShellPath(ProcessInfo.processInfo.environment["SHELL"])
     }
+
+    /// Dialect for input typed into a remote host's shell after attach.
+    /// cmux does not (yet) know the remote login shell — the SSH bootstrap
+    /// resolves `$SHELL` on the host at runtime and nothing reports it back —
+    /// so remote input stays POSIX, which is what cmux has always sent to
+    /// remotes. If the bootstrap ever reports the remote shell, this is the
+    /// single seam to replace with real detection.
+    static let remoteHost: TerminalStartupShellDialect = .posix
 }
 
 /// Final rendering step for cmux-generated POSIX one-liners that get typed
@@ -59,16 +67,19 @@ enum TerminalStartupShellDialect: Equatable {
 /// the command verbatim; nushell receives it delegated through `/bin/sh`.
 /// Launcher-script inputs (`/bin/zsh '<script>'`) parse in every supported
 /// shell and do not need this.
-enum TerminalStartupTypedShellCommand {
-    static func typedInput(
-        posixCommand: String,
-        dialect: TerminalStartupShellDialect = .loginShell
-    ) -> String {
+struct TerminalStartupTypedShellCommand {
+    let dialect: TerminalStartupShellDialect
+
+    init(dialect: TerminalStartupShellDialect = .loginShell) {
+        self.dialect = dialect
+    }
+
+    func typedInput(posixCommand: String) -> String {
         switch dialect {
         case .posix:
             return posixCommand
         case .nushell:
-            return NushellTypedShellCommand.wrapping(posixCommand: posixCommand)
+            return NushellTypedShellCommand().wrapping(posixCommand: posixCommand)
         }
     }
 }
@@ -896,7 +907,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         dialect: TerminalStartupShellDialect = .loginShell
     ) -> String? {
         guard let command else { return nil }
-        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command, dialect: dialect) + "\n"
+        let inlineInput = TerminalStartupTypedShellCommand(dialect: dialect).typedInput(posixCommand: command) + "\n"
         guard inlineInput.utf8.count > Self.maxInlineForkInputBytes else {
             return inlineInput
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -32,6 +32,47 @@ enum TerminalStartupShellQuoting {
     }
 }
 
+/// Which syntax family the user's interactive shell parses. Everything cmux
+/// generates is POSIX; nushell is the one supported login shell that cannot
+/// parse it (see ``NushellTypedShellCommand``).
+enum TerminalStartupShellDialect: Equatable {
+    case posix
+    case nushell
+
+    static func forShellPath(_ shell: String?) -> TerminalStartupShellDialect {
+        guard let shell = shell?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !shell.isEmpty else {
+            return .posix
+        }
+        return URL(fileURLWithPath: shell).lastPathComponent == "nu" ? .nushell : .posix
+    }
+
+    /// Dialect of the login shell cmux spawns terminal surfaces with — the
+    /// same `$SHELL` fallback chain the spawn path uses.
+    static var loginShell: TerminalStartupShellDialect {
+        forShellPath(ProcessInfo.processInfo.environment["SHELL"])
+    }
+}
+
+/// Final rendering step for cmux-generated POSIX one-liners that get typed
+/// into (or pasted into) the user's interactive shell. POSIX shells receive
+/// the command verbatim; nushell receives it delegated through `/bin/sh`.
+/// Launcher-script inputs (`/bin/zsh '<script>'`) parse in every supported
+/// shell and do not need this.
+enum TerminalStartupTypedShellCommand {
+    static func typedInput(
+        posixCommand: String,
+        dialect: TerminalStartupShellDialect = .loginShell
+    ) -> String {
+        switch dialect {
+        case .posix:
+            return posixCommand
+        case .nushell:
+            return NushellTypedShellCommand.wrapping(posixCommand: posixCommand)
+        }
+    }
+}
+
 enum TerminalStartupWorkingDirectoryPrefix {
     static func optionalChangeDirectoryPrefix(for workingDirectory: String?) -> String? {
         guard let workingDirectory = normalized(workingDirectory) else { return nil }
@@ -846,7 +887,7 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         allowLauncherScript: Bool = true
     ) -> String? {
         guard let command else { return nil }
-        let inlineInput = command + "\n"
+        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command) + "\n"
         guard inlineInput.utf8.count > Self.maxInlineForkInputBytes else {
             return inlineInput
         }

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -39,6 +39,10 @@ enum TerminalStartupShellDialect: Equatable {
     case posix
     case nushell
 
+    /// Maps a shell executable path to its dialect by basename. Everything
+    /// except `nu` is treated as POSIX: every other login shell cmux supports
+    /// (zsh/bash/fish/csh/dash/ksh) parses the POSIX command strings cmux
+    /// generates.
     static func forShellPath(_ shell: String?) -> TerminalStartupShellDialect {
         guard let shell = shell?.trimmingCharacters(in: .whitespacesAndNewlines),
               !shell.isEmpty else {
@@ -68,12 +72,18 @@ enum TerminalStartupShellDialect: Equatable {
 /// Launcher-script inputs (`/bin/zsh '<script>'`) parse in every supported
 /// shell and do not need this.
 struct TerminalStartupTypedShellCommand {
+    /// Dialect of the shell that will parse the rendered input.
     let dialect: TerminalStartupShellDialect
 
+    /// Defaults to the login shell cmux spawns local surfaces with; pass
+    /// ``TerminalStartupShellDialect/remoteHost`` when the input is typed
+    /// into a remote host's shell instead.
     init(dialect: TerminalStartupShellDialect = .loginShell) {
         self.dialect = dialect
     }
 
+    /// Renders `posixCommand` for typing: verbatim for POSIX shells,
+    /// delegated through `/bin/sh` for nushell (which cannot parse POSIX).
     func typedInput(posixCommand: String) -> String {
         switch dialect {
         case .posix:
@@ -876,6 +886,9 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
         return restoreCommand.map { $0 + "\n" }
     }
 
+    /// Input that forks this agent conversation when typed into a shell.
+    /// `dialect` must match the shell that will parse it — `.remoteHost` for
+    /// remote forks.
     func forkStartupInput(
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,

--- a/Sources/RestorableAgentSession.swift
+++ b/Sources/RestorableAgentSession.swift
@@ -868,26 +868,35 @@ struct SessionRestorableAgentSnapshot: Codable, Sendable {
     func forkStartupInput(
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,
-        allowLauncherScript: Bool = true
+        allowLauncherScript: Bool = true,
+        dialect: TerminalStartupShellDialect = .loginShell
     ) -> String? {
         startupInput(
             command: forkCommand,
             workingDirectory: nil,
             fileManager: fileManager,
             temporaryDirectory: temporaryDirectory,
-            allowLauncherScript: allowLauncherScript
+            allowLauncherScript: allowLauncherScript,
+            dialect: dialect
         )
     }
 
+    /// `dialect` describes the shell that will parse the returned input. Local
+    /// surfaces type into the user's login shell (`.loginShell` default);
+    /// remote workspaces type into the remote host's shell after attach, which
+    /// cmux treats as POSIX regardless of the local `$SHELL` — pass `.posix`
+    /// there so a local nushell login never leaks `^/bin/sh -c "…"` to a
+    /// remote zsh/bash.
     private func startupInput(
         command: String?,
         workingDirectory: String?,
         fileManager: FileManager,
         temporaryDirectory: URL,
-        allowLauncherScript: Bool = true
+        allowLauncherScript: Bool = true,
+        dialect: TerminalStartupShellDialect = .loginShell
     ) -> String? {
         guard let command else { return nil }
-        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command) + "\n"
+        let inlineInput = TerminalStartupTypedShellCommand.typedInput(posixCommand: command, dialect: dialect) + "\n"
         guard inlineInput.utf8.count > Self.maxInlineForkInputBytes else {
             return inlineInput
         }

--- a/Sources/SessionEntryResumeLaunch.swift
+++ b/Sources/SessionEntryResumeLaunch.swift
@@ -60,11 +60,14 @@ extension SessionEntry {
     }
 
     /// Builds the explicit compatibility launch for an unsupported registration.
+    /// The legacy command is a POSIX one-liner typed into the user's shell, so
+    /// it goes through the typed-boundary dialect wrap (nushell cannot parse
+    /// POSIX; the `restoreVerb` strategy types only bare words and needs none).
     private var legacyResumeLaunch: SessionEntryResumeLaunch? {
         guard let legacyCommand = copyResumeCommand else { return nil }
         return SessionEntryResumeLaunch(
             strategy: .legacyCommand,
-            initialInput: legacyCommand + "\n",
+            initialInput: TerminalStartupTypedShellCommand.typedInput(posixCommand: legacyCommand) + "\n",
             workingDirectory: resumeWorkingDirectory,
             startupRestoreAgent: nil
         )

--- a/Sources/SessionEntryResumeLaunch.swift
+++ b/Sources/SessionEntryResumeLaunch.swift
@@ -67,7 +67,7 @@ extension SessionEntry {
         guard let legacyCommand = copyResumeCommand else { return nil }
         return SessionEntryResumeLaunch(
             strategy: .legacyCommand,
-            initialInput: TerminalStartupTypedShellCommand.typedInput(posixCommand: legacyCommand) + "\n",
+            initialInput: TerminalStartupTypedShellCommand().typedInput(posixCommand: legacyCommand) + "\n",
             workingDirectory: resumeWorkingDirectory,
             startupRestoreAgent: nil
         )

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 enum SessionEntryResumeCoordinator {
     static func resume(_ entry: SessionEntry, tabManager: TabManager) {
         guard let resumeCommand = entry.resumeCommandWithCwd else { return }
-        let inputWithReturn = TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand) + "\n"
+        let inputWithReturn = TerminalStartupTypedShellCommand().typedInput(posixCommand: resumeCommand) + "\n"
         let targetCwd = entry.resumeWorkingDirectory
 
         let selected = tabManager.selectedWorkspace
@@ -698,7 +698,7 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
             pb.clearContents()
             // Match the user's shell so the copied command pastes cleanly.
             pb.setString(
-                TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand),
+                TerminalStartupTypedShellCommand().typedInput(posixCommand: resumeCommand),
                 forType: .string
             )
         } label: {

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -11,7 +11,7 @@ import UniformTypeIdentifiers
 enum SessionEntryResumeCoordinator {
     static func resume(_ entry: SessionEntry, tabManager: TabManager) {
         guard let resumeCommand = entry.resumeCommandWithCwd else { return }
-        let inputWithReturn = resumeCommand + "\n"
+        let inputWithReturn = TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand) + "\n"
         let targetCwd = entry.resumeWorkingDirectory
 
         let selected = tabManager.selectedWorkspace
@@ -696,7 +696,11 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
         Button {
             let pb = NSPasteboard.general
             pb.clearContents()
-            pb.setString(resumeCommand, forType: .string)
+            // Match the user's shell so the copied command pastes cleanly.
+            pb.setString(
+                TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand),
+                forType: .string
+            )
         } label: {
             Text(String(localized: "sessionIndex.row.copyResume", defaultValue: "Copy Resume Command"))
         }

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -695,7 +695,7 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
         Button {
             // Match the user's shell so the copied command pastes cleanly.
             GhosttyApp.terminalPasteboard.writeString(
-                TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand),
+                TerminalStartupTypedShellCommand().typedInput(posixCommand: resumeCommand),
                 to: .general
             )
         } label: {

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -693,8 +693,9 @@ private func sessionRowMenuItems(entry: SessionEntry, onResume: ((SessionEntry) 
     }
     if let resumeCommand = entry.copyResumeCommand {
         Button {
+            // Match the user's shell so the copied command pastes cleanly.
             GhosttyApp.terminalPasteboard.writeString(
-                resumeCommand,
+                TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand),
                 to: .general
             )
         } label: {

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -388,6 +388,9 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         inlineStartupInput(repairPortableAgentExecutable: true)
     }
 
+    /// ``WorkspaceSurfaceResumeBinding`` conformance shim: local restores
+    /// type into the login shell, so the protocol shape resolves the dialect
+    /// implicitly.
     func startupInputWithLauncherScript(
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,
@@ -401,6 +404,9 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         )
     }
 
+    /// Startup input for typing into an interactive shell of the given
+    /// dialect, falling back to a `/bin/zsh '<script>'` launcher line when the
+    /// inline form exceeds the paste budget.
     func startupInputWithLauncherScript(
         fileManager: FileManager = .default,
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1345,7 +1345,12 @@ enum TerminalStartupReturnShellScript {
             #"  _cmux_nu_bootstrap="$(/usr/bin/grep -v '^[[:space:]]*#' "$CMUX_SHELL_INTEGRATION_DIR/nushell/cmux-nushell-bootstrap.nu" | /usr/bin/grep -v '^[[:space:]]*$' | /usr/bin/paste -sd ';' -)""#,
             #"  if [ -n "$_cmux_nu_bootstrap" ]; then"#,
             #"    if [ -r "$CMUX_SHELL_INTEGRATION_DIR/nushell/cmux-nushell-integration.nu" ]; then"#,
-            #"      _cmux_nu_bootstrap="$_cmux_nu_bootstrap; source \"$CMUX_SHELL_INTEGRATION_DIR/nushell/cmux-nushell-integration.nu\"""#,
+            // The path lands inside a nushell double-quoted string: escape
+            // backslashes then double quotes so an unusual bundle path cannot
+            // break the payload.
+            #"      _cmux_nu_integration_dir="${CMUX_SHELL_INTEGRATION_DIR//\\/\\\\}""#,
+            #"      _cmux_nu_integration_dir="${_cmux_nu_integration_dir//\"/\\\"}""#,
+            #"      _cmux_nu_bootstrap="$_cmux_nu_bootstrap; source \"$_cmux_nu_integration_dir/nushell/cmux-nushell-integration.nu\"""#,
             #"    fi"#,
             #"    exec "$_cmux_resume_shell" -l -e "$_cmux_nu_bootstrap""#,
             #"  fi"#,

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -393,11 +393,30 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         temporaryDirectory: URL = FileManager.default.temporaryDirectory,
         allowLauncherScript: Bool = true
     ) -> String? {
+        startupInputWithLauncherScript(
+            fileManager: fileManager,
+            temporaryDirectory: temporaryDirectory,
+            allowLauncherScript: allowLauncherScript,
+            dialect: .loginShell
+        )
+    }
+
+    func startupInputWithLauncherScript(
+        fileManager: FileManager = .default,
+        temporaryDirectory: URL = FileManager.default.temporaryDirectory,
+        allowLauncherScript: Bool = true,
+        dialect: TerminalStartupShellDialect
+    ) -> String? {
         guard let inlineInput = inlineStartupInput else { return nil }
-        guard inlineInput.utf8.count > Self.maxInlineStartupInputBytes else {
-            return inlineInput
+        // This return value is typed into the user's interactive shell, so it
+        // is the dialect boundary: nushell logins get the POSIX command
+        // delegated through /bin/sh. The launcher-script fallback below stays
+        // unwrapped — `/bin/zsh '<script>'` parses in every supported shell.
+        let typedInline = Self.typedStartupInput(inlineInput, dialect: dialect)
+        guard typedInline.utf8.count > Self.maxInlineStartupInputBytes else {
+            return typedInline
         }
-        guard allowLauncherScript else { return inlineInput }
+        guard allowLauncherScript else { return typedInline }
         guard let scriptURL = SurfaceResumeBindingScriptStore.writeLauncherScript(
             inlineInput: inlineInput,
             binding: self,
@@ -426,6 +445,17 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
             return nil
         }
         return "/bin/zsh \(Self.shellSingleQuoted(scriptURL.path))"
+    }
+
+    /// Renders an inline startup input for typing into the user's interactive
+    /// shell, applying the nushell `/bin/sh` envelope when the login shell is
+    /// nushell (the trailing newline stays outside the wrap).
+    private static func typedStartupInput(
+        _ inlineInput: String,
+        dialect: TerminalStartupShellDialect = .loginShell
+    ) -> String {
+        let command = inlineInput.hasSuffix("\n") ? String(inlineInput.dropLast()) : inlineInput
+        return TerminalStartupTypedShellCommand.typedInput(posixCommand: command, dialect: dialect) + "\n"
     }
 
     private static func normalized(_ rawValue: String?) -> String? {
@@ -1288,6 +1318,10 @@ enum TerminalStartupReturnShellScript {
             #"case "${_cmux_resume_shell:t}" in"#,
             #"  zsh|bash) "$_cmux_resume_shell" -lic \#(quotedCommand) ;;"#,
             #"  csh|tcsh) "$_cmux_resume_shell" -c \#(quotedCommand) ;;"#,
+            // The command is POSIX; nushell cannot parse it (`nu -c` would be
+            // a parse error), so run it through /bin/sh. The trailing
+            // `exec -l "$_cmux_resume_shell"` below still lands the user in nu.
+            #"  nu) /bin/sh -c \#(quotedCommand) ;;"#,
             #"  *) "$_cmux_resume_shell" -c \#(quotedCommand) ;;"#,
             #"esac"#,
         ] + zshIntegrationReentryLines
@@ -1298,6 +1332,25 @@ enum TerminalStartupReturnShellScript {
             let quotedDirectory = TerminalStartupShellQuoting.singleQuoted(workingDirectory)
             lines.append(#"{ cd -- \#(quotedDirectory) 2>/dev/null || true; }"#)
         }
+        // Nushell logins must re-enter through the cmux bootstrap payload
+        // (`-e`), otherwise the resumed surface's shell loses the
+        // cmux-cli-shims PATH re-front and the fish-parity integration (the
+        // spawn-time replacement command is skipped for script-command
+        // surfaces). The payload is rebuilt at runtime from
+        // CMUX_SHELL_INTEGRATION_DIR — same squash rule as the Swift spawn
+        // path — so a persisted script keeps working after the app bundle
+        // moves.
+        lines.append(contentsOf: [
+            #"if [ "${_cmux_resume_shell:t}" = "nu" ] && [ -n "${CMUX_SHELL_INTEGRATION_DIR:-}" ] && [ -r "$CMUX_SHELL_INTEGRATION_DIR/nushell/cmux-nushell-bootstrap.nu" ]; then"#,
+            #"  _cmux_nu_bootstrap="$(/usr/bin/grep -v '^[[:space:]]*#' "$CMUX_SHELL_INTEGRATION_DIR/nushell/cmux-nushell-bootstrap.nu" | /usr/bin/grep -v '^[[:space:]]*$' | /usr/bin/paste -sd ';' -)""#,
+            #"  if [ -n "$_cmux_nu_bootstrap" ]; then"#,
+            #"    if [ -r "$CMUX_SHELL_INTEGRATION_DIR/nushell/cmux-nushell-integration.nu" ]; then"#,
+            #"      _cmux_nu_bootstrap="$_cmux_nu_bootstrap; source \"$CMUX_SHELL_INTEGRATION_DIR/nushell/cmux-nushell-integration.nu\"""#,
+            #"    fi"#,
+            #"    exec "$_cmux_resume_shell" -l -e "$_cmux_nu_bootstrap""#,
+            #"  fi"#,
+            #"fi"#,
+        ])
         lines.append(#"exec -l "$_cmux_resume_shell""#)
         return lines
     }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -455,7 +455,7 @@ struct SurfaceResumeBindingSnapshot: Codable, Equatable, Sendable {
         dialect: TerminalStartupShellDialect = .loginShell
     ) -> String {
         let command = inlineInput.hasSuffix("\n") ? String(inlineInput.dropLast()) : inlineInput
-        return TerminalStartupTypedShellCommand.typedInput(posixCommand: command, dialect: dialect) + "\n"
+        return TerminalStartupTypedShellCommand(dialect: dialect).typedInput(posixCommand: command) + "\n"
     }
 
     private static func normalized(_ rawValue: String?) -> String? {

--- a/Sources/SessionRestoredTerminalCommandStore.swift
+++ b/Sources/SessionRestoredTerminalCommandStore.swift
@@ -29,7 +29,13 @@ enum SessionRestoredTerminalCommandStore {
                 let quotedDirectory = shellSingleQuoted(workingDirectory)
                 lines.append("{ cd -- \(quotedDirectory) 2>/dev/null || [ ! -d \(quotedDirectory) ]; } || exit $?")
             }
-            lines.append("exec \"${SHELL:-/bin/zsh}\" -lc \(shellSingleQuoted(trimmedCommand))")
+            // Nushell cannot parse the POSIX command (`nu -lc` has no such
+            // flags and `nu -c` would be a parse error); run it through
+            // /bin/sh with the same run-command-then-exit lifecycle.
+            lines.append(#"case "${SHELL:t}" in"#)
+            lines.append("  nu) exec /bin/sh -c \(shellSingleQuoted(trimmedCommand)) ;;")
+            lines.append("  *) exec \"${SHELL:-/bin/zsh}\" -lc \(shellSingleQuoted(trimmedCommand)) ;;")
+            lines.append("esac")
 
             try (lines.joined(separator: "\n") + "\n").write(
                 to: scriptURL,

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -25,6 +25,12 @@ extension SurfaceResumeBindingSnapshot {
             repairPortableAgentExecutable: repairPortableAgentExecutable
         ).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
+        // Stays raw POSIX: this string is embedded verbatim into the zsh
+        // launcher scripts (SurfaceResumeBindingScriptStore) as well as typed
+        // into shells. Dialect wrapping for nushell happens only at the typed
+        // boundary (startupInputWithLauncherScript) — wrapping here made the
+        // launcher script's `nu) /bin/sh -c '<cmd>'` dispatch execute
+        // `^/bin/sh …` under /bin/sh, which cannot parse it.
         guard let environment, !environment.isEmpty else {
             return trimmed + "\n"
         }

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -68,7 +68,7 @@ extension SurfaceResumeBindingSnapshot {
         // newline stays outside the wrap). Remote hosts keep raw POSIX via
         // remoteStartupInput().
         let command = inline.hasSuffix("\n") ? String(inline.dropLast()) : inline
-        return TerminalStartupTypedShellCommand.typedInput(posixCommand: command) + "\n"
+        return TerminalStartupTypedShellCommand().typedInput(posixCommand: command) + "\n"
     }
 
     func remoteStartupInput() -> String? {

--- a/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
+++ b/Sources/SurfaceResumeCommandCanonicalizer+PortableAgentExecutable.swift
@@ -35,6 +35,10 @@ extension SurfaceResumeBindingSnapshot {
             )
         let trimmed = command.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return nil }
+        // Stays raw POSIX: remote restores (remoteStartupInput) hand this to
+        // the remote host's shell, and local callers apply the nushell dialect
+        // envelope at their own typed boundary (restoreStartupInput). Wrapping
+        // here would leak `^/bin/sh …` into contexts that parse POSIX.
         guard let environment, !environment.isEmpty else {
             return trimmed + "\n"
         }
@@ -50,11 +54,21 @@ extension SurfaceResumeBindingSnapshot {
         repairPortableAgentExecutable: Bool
     ) -> String? {
         if usesLocalRestoreVerb {
+            // Bare words (` cmux restore <kind> <id>`): parses identically in
+            // POSIX shells and nushell, no dialect handling needed.
             return localRestoreCLIInput
         }
-        return inlineStartupInput(
+        guard let inline = inlineStartupInput(
             repairPortableAgentExecutable: repairPortableAgentExecutable
-        )
+        ) else {
+            return nil
+        }
+        // The compatibility fallback is a POSIX one-liner typed into the local
+        // login shell, so it is the nushell dialect boundary (the trailing
+        // newline stays outside the wrap). Remote hosts keep raw POSIX via
+        // remoteStartupInput().
+        let command = inline.hasSuffix("\n") ? String(inline.dropLast()) : inline
+        return TerminalStartupTypedShellCommand.typedInput(posixCommand: command) + "\n"
     }
 
     func remoteStartupInput() -> String? {

--- a/Sources/Workspace+ForkConversationContextMenu.swift
+++ b/Sources/Workspace+ForkConversationContextMenu.swift
@@ -188,7 +188,9 @@ extension Workspace {
         guard let owningTabManager,
               let host = remoteTmuxSessionMirror?.host,
               let startupInput = snapshot.forkStartupInput(
-                allowLauncherScript: false
+                allowLauncherScript: false,
+                // Typed into the remote host's shell after attach: keep POSIX.
+                dialect: .remoteHost
               ),
               let remoteConfiguration = SessionRemoteWorkspaceSnapshot(
                 transport: .ssh,

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -10701,7 +10701,7 @@ final class Workspace: Identifiable, ObservableObject {
         destination: BonsplitController.ExternalTabDropRequest.Destination
     ) -> Bool {
         guard let resumeCommand = entry.resumeCommand else { return false }
-        let inputWithReturn = resumeCommand + "\n"
+        let inputWithReturn = TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand) + "\n"
         switch destination {
         case .insert(let paneId, _):
             let panel = newTerminalSurface(

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1331,7 +1331,9 @@ extension Workspace {
             let restoredAgentResumeLaunch: SurfaceResumeStartupLaunch? =
                 if shouldAutoResumeAgent && restoredHibernation == nil && restoredBindingLaunch == nil {
                     if restoresRemoteWorkspaceTerminalSnapshot {
-                        restorableAgent?.resumeStartupInput(allowLauncherScript: false, allowOversizedInlineInput: true)
+                        // Typed into the remote host's shell after attach, not
+                        // the local login shell: keep POSIX.
+                        restorableAgent?.resumeStartupInput(allowLauncherScript: false, allowOversizedInlineInput: true, dialect: .posix)
                             .map(SurfaceResumeStartupLaunch.input)
                     } else {
                         restorableAgent?.resumeStartupCommand()
@@ -10906,7 +10908,9 @@ final class Workspace: Identifiable, ObservableObject {
               let startupInput = launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
-                  allowLauncherScript: !isRemoteFork
+                  allowLauncherScript: !isRemoteFork,
+                  // Remote forks type into the remote host's shell: keep POSIX.
+                  dialect: isRemoteFork ? .posix : .loginShell
               ) else {
             return nil
         }
@@ -10939,7 +10943,9 @@ final class Workspace: Identifiable, ObservableObject {
               let startupInput = launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
-                  allowLauncherScript: remoteStartupCommand == nil
+                  allowLauncherScript: remoteStartupCommand == nil,
+                  // Remote forks type into the remote host's shell: keep POSIX.
+                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
               ) else {
             return nil
         }
@@ -11006,7 +11012,9 @@ final class Workspace: Identifiable, ObservableObject {
               let startupInput = launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
-                  allowLauncherScript: remoteStartupCommand == nil
+                  allowLauncherScript: remoteStartupCommand == nil,
+                  // Remote forks type into the remote host's shell: keep POSIX.
+                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
               ) else {
             return nil
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -1333,7 +1333,7 @@ extension Workspace {
                     if restoresRemoteWorkspaceTerminalSnapshot {
                         // Typed into the remote host's shell after attach, not
                         // the local login shell: keep POSIX.
-                        restorableAgent?.resumeStartupInput(allowLauncherScript: false, allowOversizedInlineInput: true, dialect: .posix)
+                        restorableAgent?.resumeStartupInput(allowLauncherScript: false, allowOversizedInlineInput: true, dialect: .remoteHost)
                             .map(SurfaceResumeStartupLaunch.input)
                     } else {
                         restorableAgent?.resumeStartupCommand()
@@ -10703,7 +10703,7 @@ final class Workspace: Identifiable, ObservableObject {
         destination: BonsplitController.ExternalTabDropRequest.Destination
     ) -> Bool {
         guard let resumeCommand = entry.resumeCommand else { return false }
-        let inputWithReturn = TerminalStartupTypedShellCommand.typedInput(posixCommand: resumeCommand) + "\n"
+        let inputWithReturn = TerminalStartupTypedShellCommand().typedInput(posixCommand: resumeCommand) + "\n"
         switch destination {
         case .insert(let paneId, _):
             let panel = newTerminalSurface(
@@ -10910,7 +10910,7 @@ final class Workspace: Identifiable, ObservableObject {
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: !isRemoteFork,
                   // Remote forks type into the remote host's shell: keep POSIX.
-                  dialect: isRemoteFork ? .posix : .loginShell
+                  dialect: isRemoteFork ? .remoteHost : .loginShell
               ) else {
             return nil
         }
@@ -10945,7 +10945,7 @@ final class Workspace: Identifiable, ObservableObject {
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: remoteStartupCommand == nil,
                   // Remote forks type into the remote host's shell: keep POSIX.
-                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
+                  dialect: remoteStartupCommand == nil ? .loginShell : .remoteHost
               ) else {
             return nil
         }
@@ -11014,7 +11014,7 @@ final class Workspace: Identifiable, ObservableObject {
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: remoteStartupCommand == nil,
                   // Remote forks type into the remote host's shell: keep POSIX.
-                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
+                  dialect: remoteStartupCommand == nil ? .loginShell : .remoteHost
               ) else {
             return nil
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11645,7 +11645,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
               let startupInput = launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
-                  allowLauncherScript: !isRemoteFork
+                  allowLauncherScript: !isRemoteFork,
+                  // Remote forks type into the remote host's shell: keep POSIX.
+                  dialect: isRemoteFork ? .posix : .loginShell
               ) else {
             return nil
         }
@@ -11678,7 +11680,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
               let startupInput = launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
-                  allowLauncherScript: remoteStartupCommand == nil
+                  allowLauncherScript: remoteStartupCommand == nil,
+                  // Remote forks type into the remote host's shell: keep POSIX.
+                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
               ) else {
             return nil
         }
@@ -11745,7 +11749,9 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
               let startupInput = launchSnapshot.forkStartupInput(
                   fileManager: fileManager,
                   temporaryDirectory: temporaryDirectory,
-                  allowLauncherScript: remoteStartupCommand == nil
+                  allowLauncherScript: remoteStartupCommand == nil,
+                  // Remote forks type into the remote host's shell: keep POSIX.
+                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
               ) else {
             return nil
         }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -11647,7 +11647,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: !isRemoteFork,
                   // Remote forks type into the remote host's shell: keep POSIX.
-                  dialect: isRemoteFork ? .posix : .loginShell
+                  dialect: isRemoteFork ? .remoteHost : .loginShell
               ) else {
             return nil
         }
@@ -11682,7 +11682,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: remoteStartupCommand == nil,
                   // Remote forks type into the remote host's shell: keep POSIX.
-                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
+                  dialect: remoteStartupCommand == nil ? .loginShell : .remoteHost
               ) else {
             return nil
         }
@@ -11751,7 +11751,7 @@ final class Workspace: Identifiable, ObservableObject, FilePreviewTabMetadataHos
                   temporaryDirectory: temporaryDirectory,
                   allowLauncherScript: remoteStartupCommand == nil,
                   // Remote forks type into the remote host's shell: keep POSIX.
-                  dialect: remoteStartupCommand == nil ? .loginShell : .posix
+                  dialect: remoteStartupCommand == nil ? .loginShell : .remoteHost
               ) else {
             return nil
         }

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -9,6 +9,38 @@ import Testing
 #endif
 
 @Suite struct SessionPersistenceResumeBindingTests {
+    /// Regression for the first nushell dogfood round: the inline startup input
+    /// is embedded verbatim into zsh launcher scripts, so it must stay raw
+    /// POSIX; the nushell `^/bin/sh -c "…"` envelope may be applied only at the
+    /// typed boundary (`startupInputWithLauncherScript`), per explicit dialect.
+    /// Wrapping the inline input made the launcher's `nu) /bin/sh -c '<cmd>'`
+    /// dispatch fail with "/bin/sh: ^/bin/sh: No such file or directory".
+    @Test func nushellTypingEnvelopeAppliesOnlyAtTheTypedBoundary() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "'claude' '--resume' 'session-nu-envelope'",
+            checkpointId: "session-nu-envelope",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let raw = try #require(binding.inlineStartupInput)
+        #expect(!raw.contains("^/bin/sh"), "inline input must stay raw POSIX: \(raw)")
+
+        let typedNu = try #require(binding.startupInputWithLauncherScript(
+            allowLauncherScript: false,
+            dialect: .nushell
+        ))
+        #expect(typedNu.hasPrefix(#"^/bin/sh -c ""#), "\(typedNu)")
+        #expect(typedNu.hasSuffix("\"\n"), "trailing newline must stay outside the wrap: \(typedNu)")
+
+        let typedPosix = try #require(binding.startupInputWithLauncherScript(
+            allowLauncherScript: false,
+            dialect: .posix
+        ))
+        #expect(typedPosix == raw, "POSIX dialect must pass the inline input through unchanged")
+    }
+
     @Test func agentHookSurfaceResumeStartupInputPreservesCustomAbsoluteAgentExecutable() throws {
         let binding = SurfaceResumeBindingSnapshot(
             kind: "codex",

--- a/cmuxTests/SessionPersistenceResumeBindingTests.swift
+++ b/cmuxTests/SessionPersistenceResumeBindingTests.swift
@@ -80,6 +80,8 @@ import Testing
 
     @Test func localRestoreUsesOneShortCLICommandRegardlessOfBindingSize() throws {
         let sessionId = "a22293b7-bcef-4707-8439-2f538c8517a4"
+
+
         let binding = SurfaceResumeBindingSnapshot(
             kind: "codex",
             command: "codex resume \(sessionId) " + String(repeating: "--config model_provider=subrouter ", count: 80),
@@ -93,6 +95,32 @@ import Testing
         #expect(
             startupInput
                 == " \(AgentRestoreLaunch.cliStartupExecutableToken) restore codex \(sessionId)\n"
+        )
+    }
+
+    /// Regression for the first nushell dogfood round: the compatibility
+    /// inline startup input stays raw POSIX (local callers apply the nushell
+    /// `^/bin/sh -c "…"` envelope only at their typed boundary,
+    /// `restoreStartupInput`), and the local restore verb stays bare words,
+    /// which parse identically in POSIX shells and nushell.
+    @Test func nushellTypingEnvelopeAppliesOnlyAtTheTypedBoundary() throws {
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "'claude' '--resume' 'session-nu-envelope'",
+            checkpointId: "session-nu-envelope",
+            source: "agent-hook",
+            autoResume: true
+        )
+
+        let raw = try #require(binding.inlineStartupInput)
+        #expect(!raw.contains("^/bin/sh"), "inline input must stay raw POSIX: \(raw)")
+
+        let restore = try #require(binding.restoreStartupInput())
+        #expect(restore.hasPrefix(" \(AgentRestoreLaunch.cliStartupExecutableToken) restore"), "\(restore)")
+        #expect(!restore.contains("^/bin/sh"), "the bare-word restore verb needs no dialect envelope: \(restore)")
+        #expect(
+            !restore.contains("&&") && !restore.contains("||") && !restore.contains("'"),
+            "restore input must stay nushell-parseable bare words: \(restore)"
         )
     }
 

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2215,10 +2215,8 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         let snapshot = Self.makeClaudeRestorableSnapshot(workingDirectory: sandbox.sandboxURL.path)
         let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
-        let typedForNushell = TerminalStartupTypedShellCommand.typedInput(
-            posixCommand: resumeCommand,
-            dialect: .nushell
-        )
+        let typedForNushell = TerminalStartupTypedShellCommand(dialect: .nushell)
+            .typedInput(posixCommand: resumeCommand)
 
         let recorded = try runClaudeResumeCommand(
             typedForNushell,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2176,6 +2176,212 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
+    /// Regression: nushell parses none of the POSIX resume command (`&&`/`||` are
+    /// dedicated parse errors, `[ … ]` is a list literal, and even a POSIX-quoted
+    /// command head like `'claude' '--resume'` is rejected), so both the typed
+    /// sessions-panel resume and the restore launcher hard-failed for nushell login
+    /// shells. The typed path now renders through
+    /// `TerminalStartupTypedShellCommand.typedInput` which wraps the POSIX command as
+    /// `^/bin/sh -c "…"` for the nushell dialect; this drives that exact string
+    /// through a real `nu -c` with a hostile user config (PATH rebuilt, shim dir
+    /// dropped) and asserts the cmux wrapper still runs and re-injects hooks.
+    /// (The restore launcher's zsh script gained a matching `nu)` branch that
+    /// dispatches `/bin/sh -c` directly; same envelope, exercised by
+    /// `testResumeLauncherScriptDispatchesNushellThroughBinSh`.)
+    func testClaudeResumeCommandExecutesThroughWrapperInsideNushellTypedInput() throws {
+        let nuURL = [
+            ProcessInfo.processInfo.environment["CMUX_TEST_NU_BIN"],
+            "/opt/homebrew/bin/nu",
+            "/usr/local/bin/nu",
+            "/usr/bin/nu",
+        ]
+        .compactMap { $0 }
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) }
+        guard let nuURL else {
+            throw XCTSkip("nushell is not installed; install nu to exercise the nushell typed-resume dispatch")
+        }
+
+        let sandbox = try makeClaudeResumeWrapperShimSandbox()
+        defer { sandbox.removeSandbox() }
+        let nuConfigDir = sandbox.homeURL.appendingPathComponent(".config/nushell", isDirectory: true)
+        try FileManager.default.createDirectory(at: nuConfigDir, withIntermediateDirectories: true)
+        // Hostile nushell config: rebuild PATH with the user's real claude first —
+        // the exact shadowing that breaks the shim for nushell users.
+        try (
+            "$env.PATH = [\"\(sandbox.realBinDirectoryURL.path)\", \"/usr/bin\", \"/bin\"]\n"
+        ).write(to: nuConfigDir.appendingPathComponent("env.nu"), atomically: true, encoding: .utf8)
+        try "".write(to: nuConfigDir.appendingPathComponent("config.nu"), atomically: true, encoding: .utf8)
+
+        let snapshot = Self.makeClaudeRestorableSnapshot(workingDirectory: sandbox.sandboxURL.path)
+        let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
+        let typedForNushell = TerminalStartupTypedShellCommand.typedInput(
+            posixCommand: resumeCommand,
+            dialect: .nushell
+        )
+
+        let recorded = try runClaudeResumeCommand(
+            typedForNushell,
+            shellURL: nuURL,
+            arguments: ["-c"],
+            sandbox: sandbox,
+            environmentOverrides: [
+                "XDG_CONFIG_HOME": sandbox.homeURL.appendingPathComponent(".config").path
+            ]
+        )
+        XCTAssertTrue(
+            recorded.hasPrefix("wrapper "),
+            "nushell-typed resume must parse and exec the cmux wrapper. Recorded invocation: \(recorded.isEmpty ? "<none>" : recorded)"
+        )
+        XCTAssertTrue(
+            recorded.contains("--settings"),
+            "nushell-typed resume must re-inject the hook --settings via the wrapper. Recorded invocation: \(recorded.isEmpty ? "<none>" : recorded)"
+        )
+    }
+
+    /// The restore launcher script's shell dispatch must route nushell logins through
+    /// `/bin/sh -c` (nushell cannot parse the POSIX command that `*)`'s
+    /// `"$_cmux_resume_shell" -c` would hand it) while leaving the POSIX branches
+    /// untouched, and must still `exec -l` back into the user's nushell afterwards —
+    /// re-entering through the cmux `-e` bootstrap payload so the resumed surface's
+    /// shell keeps the cmux-cli-shims PATH re-front (a plain `exec -l nu` left the
+    /// resumed terminal shim-less because script-command surfaces skip the spawn-time
+    /// replacement command).
+    func testResumeLauncherScriptDispatchesNushellThroughBinSh() {
+        let lines = TerminalStartupReturnShellScript.commandThenReturnLines(
+            command: "cd -- '/tmp/p' && 'claude' '--resume' 'SID'",
+            workingDirectory: "/tmp/p"
+        )
+        let script = lines.joined(separator: "\n")
+        XCTAssertTrue(
+            script.contains("nu) /bin/sh -c "),
+            "launcher script must dispatch nushell logins through /bin/sh: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains(#"zsh|bash) "$_cmux_resume_shell" -lic "#),
+            "posix dispatch branches must stay untouched: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains(#"exec "$_cmux_resume_shell" -l -e "$_cmux_nu_bootstrap""#),
+            "launcher must exec nushell with the cmux bootstrap payload: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains("cmux-nushell-bootstrap.nu"),
+            "launcher must rebuild the nushell payload from CMUX_SHELL_INTEGRATION_DIR: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains(#"exec -l "$_cmux_resume_shell""#),
+            "launcher must keep the plain login-shell exec for POSIX shells: \(script)"
+        )
+    }
+
+    /// Regression for the first nushell dogfood round: the surface auto-resume
+    /// launcher (`startupCommandWithLauncherScript` → zsh script → `nu)` branch)
+    /// received an inline input that had already been wrapped for nushell typing
+    /// (`^/bin/sh -c "…"`), so `/bin/sh` printed
+    /// `"/bin/sh: ^/bin/sh: No such file or directory"`, the agent never resumed,
+    /// and the follow-up `exec -l nu` produced a shim-less shell. The inline input
+    /// must stay raw POSIX for script embedding; this drives the *actual generated
+    /// launcher script* through real zsh with a fake `nu` login shell and asserts
+    /// (a) the resume command reaches the cmux wrapper and (b) nushell is exec'd
+    /// with the cmux bootstrap payload.
+    func testSurfaceResumeLauncherScriptResumesAndReentersBootstrappedNushell() throws {
+        let sandbox = try makeClaudeResumeWrapperShimSandbox()
+        defer { sandbox.removeSandbox() }
+
+        // Fake nu login shell that records its argv instead of exec'ing.
+        let fakeNuURL = sandbox.sandboxURL.appendingPathComponent("nu", isDirectory: false)
+        let nuArgsURL = sandbox.sandboxURL.appendingPathComponent("nu-args.txt", isDirectory: false)
+        try (
+            "#!/bin/sh\n"
+                + "printf '%s\\n' \"$@\" > \(shellQuotedForTest(nuArgsURL.path))\n"
+        ).write(to: fakeNuURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeNuURL.path)
+
+        // Stub bundle shell-integration dir with the nushell bootstrap +
+        // integration shape (content mechanics are covered by the Python tests
+        // against the real files).
+        let integrationDir = sandbox.sandboxURL.appendingPathComponent("shell-integration", isDirectory: true)
+        let nushellDir = integrationDir.appendingPathComponent("nushell", isDirectory: true)
+        try FileManager.default.createDirectory(at: nushellDir, withIntermediateDirectories: true)
+        try "# comment\n_cmux_bootstrap_marker\n".write(
+            to: nushellDir.appendingPathComponent("cmux-nushell-bootstrap.nu"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "# integration stub\n".write(
+            to: nushellDir.appendingPathComponent("cmux-nushell-integration.nu"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "'claude' '--resume' 'claude-session-123'",
+            checkpointId: "claude-session-123",
+            source: "agent-hook",
+            autoResume: true
+        )
+        let launchCommand = try XCTUnwrap(binding.startupCommandWithLauncherScript(
+            temporaryDirectory: sandbox.sandboxURL
+        ))
+        XCTAssertTrue(launchCommand.hasPrefix("/bin/zsh "), launchCommand)
+        XCTAssertFalse(
+            launchCommand.contains("^/bin/sh"),
+            "surface command must not carry the nushell typing envelope: \(launchCommand)"
+        )
+        let scriptPath = launchCommand
+            .replacingOccurrences(of: "/bin/zsh ", with: "")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'"))
+        let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
+        XCTAssertFalse(
+            scriptContents.contains("^/bin/sh"),
+            "launcher script must embed raw POSIX, not the nushell typing envelope: \(scriptContents)"
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [scriptPath]
+        process.environment = [
+            "HOME": sandbox.homeURL.path,
+            "SHELL": fakeNuURL.path,
+            // The recording "real" claude is PATH-resolvable so the embedded
+            // command executes whether or not the binding rewrote it to the
+            // wrapper resolver token.
+            "PATH": "\(sandbox.realBinDirectoryURL.path):/usr/bin:/bin",
+            "CMUX_CLAUDE_WRAPPER_SHIM": sandbox.shimURL.path,
+            "CMUX_SHELL_INTEGRATION_DIR": integrationDir.path,
+        ]
+        let scriptStderr = Pipe()
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = scriptStderr
+        try runWithBoundedWait(process, shellDescription: "/bin/zsh \(scriptPath)")
+
+        let stderrText = String(
+            data: scriptStderr.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        XCTAssertFalse(
+            stderrText.contains("^/bin/sh"),
+            "the dogfood symptom: /bin/sh received the nushell typing envelope. stderr: \(stderrText)"
+        )
+        let recorded = (try? String(contentsOf: sandbox.recordURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(
+            recorded.contains("--resume claude-session-123"),
+            "the resume command must execute through /bin/sh. Recorded: \(recorded.isEmpty ? "<none>" : recorded), stderr: \(stderrText)"
+        )
+        let nuArgs = (try? String(contentsOf: nuArgsURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(
+            nuArgs.contains("_cmux_bootstrap_marker"),
+            "the launcher must exec nushell with the cmux bootstrap payload. nu argv: \(nuArgs.isEmpty ? "<none>" : nuArgs)"
+        )
+        XCTAssertTrue(
+            nuArgs.contains("cmux-nushell-integration.nu"),
+            "the payload must source the bundled integration. nu argv: \(nuArgs)"
+        )
+    }
+
     /// Regression for the stale-shim fallback: `CMUX_CLAUDE_WRAPPER_SHIM` can outlive
     /// its file (macOS reaps idle temporary-directory contents after ~3 days), and bare
     /// `${VAR:-claude}` parameter expansion would exec the dead path and hard-fail

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2256,57 +2256,42 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
-    /// The restore launcher script's shell dispatch must route nushell logins through
-    /// `/bin/sh -c` (nushell cannot parse the POSIX command that `*)`'s
-    /// `"$_cmux_resume_shell" -c` would hand it) while leaving the POSIX branches
-    /// untouched, and must still `exec -l` back into the user's nushell afterwards —
-    /// re-entering through the cmux `-e` bootstrap payload so the resumed surface's
-    /// shell keeps the cmux-cli-shims PATH re-front (a plain `exec -l nu` left the
-    /// resumed terminal shim-less because script-command surfaces skip the spawn-time
-    /// replacement command).
-    func testResumeLauncherScriptDispatchesNushellThroughBinSh() {
-        let lines = TerminalStartupReturnShellScript.commandThenReturnLines(
+    /// The one-shot launcher's user-login-shell execution must route nushell
+    /// logins through `/bin/sh -c` (nushell has no `-lc` flags and cannot parse
+    /// the POSIX command) while leaving the POSIX branch untouched.
+    func testOneShotUserLoginShellLauncherDispatchesNushellThroughBinSh() throws {
+        let tmp = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-oneshot-nu-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: tmp) }
+        let scriptURL = try XCTUnwrap(OneShotTerminalLauncherStore(
+            fileManager: .default,
+            temporaryDirectory: tmp
+        ).writeLauncherScript(
             command: "cd -- '/tmp/p' && 'claude' '--resume' 'SID'",
-            workingDirectory: "/tmp/p"
-        )
-        let script = lines.joined(separator: "\n")
+            workingDirectory: nil,
+            execution: .userLoginShell
+        ))
+        let script = try String(contentsOf: scriptURL, encoding: .utf8)
         XCTAssertTrue(
-            script.contains("nu) /bin/sh -c "),
-            "launcher script must dispatch nushell logins through /bin/sh: \(script)"
-        )
-        XCTAssertTrue(
-            script.contains(#"zsh|bash) "$_cmux_resume_shell" -lic "#),
-            "posix dispatch branches must stay untouched: \(script)"
+            script.contains("nu) exec /bin/sh -c "),
+            "launcher must dispatch nushell logins through /bin/sh: \(script)"
         )
         XCTAssertTrue(
-            script.contains(#"exec "$_cmux_resume_shell" -l -e "$_cmux_nu_bootstrap""#),
-            "launcher must exec nushell with the cmux bootstrap payload: \(script)"
-        )
-        XCTAssertTrue(
-            script.contains("cmux-nushell-bootstrap.nu"),
-            "launcher must rebuild the nushell payload from CMUX_SHELL_INTEGRATION_DIR: \(script)"
-        )
-        XCTAssertTrue(
-            script.contains(#"exec -l "$_cmux_resume_shell""#),
-            "launcher must keep the plain login-shell exec for POSIX shells: \(script)"
+            script.contains(#"*) exec "$SHELL" -lc "#),
+            "the POSIX dispatch branch must stay untouched: \(script)"
         )
     }
 
-    /// Regression for the first nushell dogfood round: the surface auto-resume
-    /// launcher (`startupCommandWithLauncherScript` → zsh script → `nu)` branch)
-    /// received an inline input that had already been wrapped for nushell typing
-    /// (`^/bin/sh -c "…"`), so `/bin/sh` printed
-    /// `"/bin/sh: ^/bin/sh: No such file or directory"`, the agent never resumed,
-    /// and the follow-up `exec -l nu` produced a shim-less shell. The inline input
-    /// must stay raw POSIX for script embedding; this drives the *actual generated
-    /// launcher script* through real zsh with a fake `nu` login shell and asserts
-    /// (a) the resume command reaches the cmux wrapper and (b) nushell is exec'd
-    /// with the cmux bootstrap payload.
-    func testSurfaceResumeLauncherScriptResumesAndReentersBootstrappedNushell() throws {
+    /// Regression for the first nushell dogfood round, adapted to the unified
+    /// one-shot launcher: a `.userLoginShell` script executed with a nushell
+    /// login shell must still run its POSIX payload (via /bin/sh) instead of
+    /// handing it to `nu -lc`, which would fail before the agent launches.
+    func testOneShotUserLoginShellLauncherRunsPosixPayloadUnderNushell() throws {
         let sandbox = try makeClaudeResumeWrapperShimSandbox()
         defer { sandbox.removeSandbox() }
 
-        // Fake nu login shell that records its argv instead of exec'ing.
+        // Fake nu login shell that records its argv; reaching it would mean
+        // the POSIX payload was (wrongly) handed to nushell.
         let fakeNuURL = sandbox.sandboxURL.appendingPathComponent("nu", isDirectory: false)
         let nuArgsURL = sandbox.sandboxURL.appendingPathComponent("nu-args.txt", isDirectory: false)
         try (
@@ -2315,87 +2300,44 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         ).write(to: fakeNuURL, atomically: true, encoding: .utf8)
         try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeNuURL.path)
 
-        // Stub bundle shell-integration dir with the nushell bootstrap +
-        // integration shape (content mechanics are covered by the Python tests
-        // against the real files).
-        let integrationDir = sandbox.sandboxURL.appendingPathComponent("shell-integration", isDirectory: true)
-        let nushellDir = integrationDir.appendingPathComponent("nushell", isDirectory: true)
-        try FileManager.default.createDirectory(at: nushellDir, withIntermediateDirectories: true)
-        try "# comment\n_cmux_bootstrap_marker\n".write(
-            to: nushellDir.appendingPathComponent("cmux-nushell-bootstrap.nu"),
-            atomically: true,
-            encoding: .utf8
-        )
-        try "# integration stub\n".write(
-            to: nushellDir.appendingPathComponent("cmux-nushell-integration.nu"),
-            atomically: true,
-            encoding: .utf8
-        )
-
-        let binding = SurfaceResumeBindingSnapshot(
-            kind: "claude",
-            command: "'claude' '--resume' 'claude-session-123'",
-            checkpointId: "claude-session-123",
-            source: "agent-hook",
-            autoResume: true
-        )
-        let launchCommand = try XCTUnwrap(binding.startupCommandWithLauncherScript(
+        let scriptURL = try XCTUnwrap(OneShotTerminalLauncherStore(
+            fileManager: .default,
             temporaryDirectory: sandbox.sandboxURL
+        ).writeLauncherScript(
+            command: "'claude' '--resume' 'claude-session-123'",
+            workingDirectory: nil,
+            execution: .userLoginShell
         ))
-        XCTAssertTrue(launchCommand.hasPrefix("/bin/zsh "), launchCommand)
-        XCTAssertFalse(
-            launchCommand.contains("^/bin/sh"),
-            "surface command must not carry the nushell typing envelope: \(launchCommand)"
-        )
-        let scriptPath = launchCommand
-            .replacingOccurrences(of: "/bin/zsh ", with: "")
-            .trimmingCharacters(in: CharacterSet(charactersIn: "'"))
-        let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
-        XCTAssertFalse(
-            scriptContents.contains("^/bin/sh"),
-            "launcher script must embed raw POSIX, not the nushell typing envelope: \(scriptContents)"
-        )
 
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/zsh")
-        process.arguments = [scriptPath]
+        process.arguments = [scriptURL.path]
         process.environment = [
             "HOME": sandbox.homeURL.path,
             "SHELL": fakeNuURL.path,
-            // The recording "real" claude is PATH-resolvable so the embedded
-            // command executes whether or not the binding rewrote it to the
-            // wrapper resolver token.
             "PATH": "\(sandbox.realBinDirectoryURL.path):/usr/bin:/bin",
             "CMUX_CLAUDE_WRAPPER_SHIM": sandbox.shimURL.path,
-            "CMUX_SHELL_INTEGRATION_DIR": integrationDir.path,
         ]
         let scriptStderr = Pipe()
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = FileHandle.nullDevice
         process.standardError = scriptStderr
-        try runWithBoundedWait(process, shellDescription: "/bin/zsh \(scriptPath)")
+        try runWithBoundedWait(process, shellDescription: "/bin/zsh \(scriptURL.path)")
 
         let stderrText = String(
             data: scriptStderr.fileHandleForReading.readDataToEndOfFile(),
             encoding: .utf8
         ) ?? ""
-        XCTAssertFalse(
-            stderrText.contains("^/bin/sh"),
-            "the dogfood symptom: /bin/sh received the nushell typing envelope. stderr: \(stderrText)"
-        )
         let recorded = (try? String(contentsOf: sandbox.recordURL, encoding: .utf8)) ?? ""
         XCTAssertTrue(
             recorded.contains("--resume claude-session-123"),
-            "the resume command must execute through /bin/sh. Recorded: \(recorded.isEmpty ? "<none>" : recorded), stderr: \(stderrText)"
+            "the POSIX payload must execute through /bin/sh under a nushell login. "
+                + "Recorded: \(recorded.isEmpty ? "<none>" : recorded), stderr: \(stderrText)"
         )
         let nuArgs = (try? String(contentsOf: nuArgsURL, encoding: .utf8)) ?? ""
         XCTAssertTrue(
-            nuArgs.contains("_cmux_bootstrap_marker"),
-            "the launcher must exec nushell with the cmux bootstrap payload. nu argv: \(nuArgs.isEmpty ? "<none>" : nuArgs)"
-        )
-        XCTAssertTrue(
-            nuArgs.contains("cmux-nushell-integration.nu"),
-            "the payload must source the bundled integration. nu argv: \(nuArgs)"
+            nuArgs.isEmpty,
+            "the POSIX payload must not be handed to the nushell binary: \(nuArgs)"
         )
     }
 

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2232,10 +2232,8 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
 
         let snapshot = Self.makeClaudeRestorableSnapshot(workingDirectory: sandbox.sandboxURL.path)
         let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
-        let typedForNushell = TerminalStartupTypedShellCommand.typedInput(
-            posixCommand: resumeCommand,
-            dialect: .nushell
-        )
+        let typedForNushell = TerminalStartupTypedShellCommand(dialect: .nushell)
+            .typedInput(posixCommand: resumeCommand)
 
         let recorded = try runClaudeResumeCommand(
             typedForNushell,

--- a/cmuxTests/SessionPersistenceTests.swift
+++ b/cmuxTests/SessionPersistenceTests.swift
@@ -2193,6 +2193,212 @@ final class SocketListenerAcceptPolicyTests: XCTestCase {
         )
     }
 
+    /// Regression: nushell parses none of the POSIX resume command (`&&`/`||` are
+    /// dedicated parse errors, `[ … ]` is a list literal, and even a POSIX-quoted
+    /// command head like `'claude' '--resume'` is rejected), so both the typed
+    /// sessions-panel resume and the restore launcher hard-failed for nushell login
+    /// shells. The typed path now renders through
+    /// `TerminalStartupTypedShellCommand.typedInput` which wraps the POSIX command as
+    /// `^/bin/sh -c "…"` for the nushell dialect; this drives that exact string
+    /// through a real `nu -c` with a hostile user config (PATH rebuilt, shim dir
+    /// dropped) and asserts the cmux wrapper still runs and re-injects hooks.
+    /// (The restore launcher's zsh script gained a matching `nu)` branch that
+    /// dispatches `/bin/sh -c` directly; same envelope, exercised by
+    /// `testResumeLauncherScriptDispatchesNushellThroughBinSh`.)
+    func testClaudeResumeCommandExecutesThroughWrapperInsideNushellTypedInput() throws {
+        let nuURL = [
+            ProcessInfo.processInfo.environment["CMUX_TEST_NU_BIN"],
+            "/opt/homebrew/bin/nu",
+            "/usr/local/bin/nu",
+            "/usr/bin/nu",
+        ]
+        .compactMap { $0 }
+        .map { URL(fileURLWithPath: $0) }
+        .first { FileManager.default.isExecutableFile(atPath: $0.path) }
+        guard let nuURL else {
+            throw XCTSkip("nushell is not installed; install nu to exercise the nushell typed-resume dispatch")
+        }
+
+        let sandbox = try makeClaudeResumeWrapperShimSandbox()
+        defer { sandbox.removeSandbox() }
+        let nuConfigDir = sandbox.homeURL.appendingPathComponent(".config/nushell", isDirectory: true)
+        try FileManager.default.createDirectory(at: nuConfigDir, withIntermediateDirectories: true)
+        // Hostile nushell config: rebuild PATH with the user's real claude first —
+        // the exact shadowing that breaks the shim for nushell users.
+        try (
+            "$env.PATH = [\"\(sandbox.realBinDirectoryURL.path)\", \"/usr/bin\", \"/bin\"]\n"
+        ).write(to: nuConfigDir.appendingPathComponent("env.nu"), atomically: true, encoding: .utf8)
+        try "".write(to: nuConfigDir.appendingPathComponent("config.nu"), atomically: true, encoding: .utf8)
+
+        let snapshot = Self.makeClaudeRestorableSnapshot(workingDirectory: sandbox.sandboxURL.path)
+        let resumeCommand = try XCTUnwrap(snapshot.resumeCommand)
+        let typedForNushell = TerminalStartupTypedShellCommand.typedInput(
+            posixCommand: resumeCommand,
+            dialect: .nushell
+        )
+
+        let recorded = try runClaudeResumeCommand(
+            typedForNushell,
+            shellURL: nuURL,
+            arguments: ["-c"],
+            sandbox: sandbox,
+            environmentOverrides: [
+                "XDG_CONFIG_HOME": sandbox.homeURL.appendingPathComponent(".config").path
+            ]
+        )
+        XCTAssertTrue(
+            recorded.hasPrefix("wrapper "),
+            "nushell-typed resume must parse and exec the cmux wrapper. Recorded invocation: \(recorded.isEmpty ? "<none>" : recorded)"
+        )
+        XCTAssertTrue(
+            recorded.contains("--settings"),
+            "nushell-typed resume must re-inject the hook --settings via the wrapper. Recorded invocation: \(recorded.isEmpty ? "<none>" : recorded)"
+        )
+    }
+
+    /// The restore launcher script's shell dispatch must route nushell logins through
+    /// `/bin/sh -c` (nushell cannot parse the POSIX command that `*)`'s
+    /// `"$_cmux_resume_shell" -c` would hand it) while leaving the POSIX branches
+    /// untouched, and must still `exec -l` back into the user's nushell afterwards —
+    /// re-entering through the cmux `-e` bootstrap payload so the resumed surface's
+    /// shell keeps the cmux-cli-shims PATH re-front (a plain `exec -l nu` left the
+    /// resumed terminal shim-less because script-command surfaces skip the spawn-time
+    /// replacement command).
+    func testResumeLauncherScriptDispatchesNushellThroughBinSh() {
+        let lines = TerminalStartupReturnShellScript.commandThenReturnLines(
+            command: "cd -- '/tmp/p' && 'claude' '--resume' 'SID'",
+            workingDirectory: "/tmp/p"
+        )
+        let script = lines.joined(separator: "\n")
+        XCTAssertTrue(
+            script.contains("nu) /bin/sh -c "),
+            "launcher script must dispatch nushell logins through /bin/sh: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains(#"zsh|bash) "$_cmux_resume_shell" -lic "#),
+            "posix dispatch branches must stay untouched: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains(#"exec "$_cmux_resume_shell" -l -e "$_cmux_nu_bootstrap""#),
+            "launcher must exec nushell with the cmux bootstrap payload: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains("cmux-nushell-bootstrap.nu"),
+            "launcher must rebuild the nushell payload from CMUX_SHELL_INTEGRATION_DIR: \(script)"
+        )
+        XCTAssertTrue(
+            script.contains(#"exec -l "$_cmux_resume_shell""#),
+            "launcher must keep the plain login-shell exec for POSIX shells: \(script)"
+        )
+    }
+
+    /// Regression for the first nushell dogfood round: the surface auto-resume
+    /// launcher (`startupCommandWithLauncherScript` → zsh script → `nu)` branch)
+    /// received an inline input that had already been wrapped for nushell typing
+    /// (`^/bin/sh -c "…"`), so `/bin/sh` printed
+    /// `"/bin/sh: ^/bin/sh: No such file or directory"`, the agent never resumed,
+    /// and the follow-up `exec -l nu` produced a shim-less shell. The inline input
+    /// must stay raw POSIX for script embedding; this drives the *actual generated
+    /// launcher script* through real zsh with a fake `nu` login shell and asserts
+    /// (a) the resume command reaches the cmux wrapper and (b) nushell is exec'd
+    /// with the cmux bootstrap payload.
+    func testSurfaceResumeLauncherScriptResumesAndReentersBootstrappedNushell() throws {
+        let sandbox = try makeClaudeResumeWrapperShimSandbox()
+        defer { sandbox.removeSandbox() }
+
+        // Fake nu login shell that records its argv instead of exec'ing.
+        let fakeNuURL = sandbox.sandboxURL.appendingPathComponent("nu", isDirectory: false)
+        let nuArgsURL = sandbox.sandboxURL.appendingPathComponent("nu-args.txt", isDirectory: false)
+        try (
+            "#!/bin/sh\n"
+                + "printf '%s\\n' \"$@\" > \(shellQuotedForTest(nuArgsURL.path))\n"
+        ).write(to: fakeNuURL, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: fakeNuURL.path)
+
+        // Stub bundle shell-integration dir with the nushell bootstrap +
+        // integration shape (content mechanics are covered by the Python tests
+        // against the real files).
+        let integrationDir = sandbox.sandboxURL.appendingPathComponent("shell-integration", isDirectory: true)
+        let nushellDir = integrationDir.appendingPathComponent("nushell", isDirectory: true)
+        try FileManager.default.createDirectory(at: nushellDir, withIntermediateDirectories: true)
+        try "# comment\n_cmux_bootstrap_marker\n".write(
+            to: nushellDir.appendingPathComponent("cmux-nushell-bootstrap.nu"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "# integration stub\n".write(
+            to: nushellDir.appendingPathComponent("cmux-nushell-integration.nu"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let binding = SurfaceResumeBindingSnapshot(
+            kind: "claude",
+            command: "'claude' '--resume' 'claude-session-123'",
+            checkpointId: "claude-session-123",
+            source: "agent-hook",
+            autoResume: true
+        )
+        let launchCommand = try XCTUnwrap(binding.startupCommandWithLauncherScript(
+            temporaryDirectory: sandbox.sandboxURL
+        ))
+        XCTAssertTrue(launchCommand.hasPrefix("/bin/zsh "), launchCommand)
+        XCTAssertFalse(
+            launchCommand.contains("^/bin/sh"),
+            "surface command must not carry the nushell typing envelope: \(launchCommand)"
+        )
+        let scriptPath = launchCommand
+            .replacingOccurrences(of: "/bin/zsh ", with: "")
+            .trimmingCharacters(in: CharacterSet(charactersIn: "'"))
+        let scriptContents = try String(contentsOfFile: scriptPath, encoding: .utf8)
+        XCTAssertFalse(
+            scriptContents.contains("^/bin/sh"),
+            "launcher script must embed raw POSIX, not the nushell typing envelope: \(scriptContents)"
+        )
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.arguments = [scriptPath]
+        process.environment = [
+            "HOME": sandbox.homeURL.path,
+            "SHELL": fakeNuURL.path,
+            // The recording "real" claude is PATH-resolvable so the embedded
+            // command executes whether or not the binding rewrote it to the
+            // wrapper resolver token.
+            "PATH": "\(sandbox.realBinDirectoryURL.path):/usr/bin:/bin",
+            "CMUX_CLAUDE_WRAPPER_SHIM": sandbox.shimURL.path,
+            "CMUX_SHELL_INTEGRATION_DIR": integrationDir.path,
+        ]
+        let scriptStderr = Pipe()
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = scriptStderr
+        try runWithBoundedWait(process, shellDescription: "/bin/zsh \(scriptPath)")
+
+        let stderrText = String(
+            data: scriptStderr.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        XCTAssertFalse(
+            stderrText.contains("^/bin/sh"),
+            "the dogfood symptom: /bin/sh received the nushell typing envelope. stderr: \(stderrText)"
+        )
+        let recorded = (try? String(contentsOf: sandbox.recordURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(
+            recorded.contains("--resume claude-session-123"),
+            "the resume command must execute through /bin/sh. Recorded: \(recorded.isEmpty ? "<none>" : recorded), stderr: \(stderrText)"
+        )
+        let nuArgs = (try? String(contentsOf: nuArgsURL, encoding: .utf8)) ?? ""
+        XCTAssertTrue(
+            nuArgs.contains("_cmux_bootstrap_marker"),
+            "the launcher must exec nushell with the cmux bootstrap payload. nu argv: \(nuArgs.isEmpty ? "<none>" : nuArgs)"
+        )
+        XCTAssertTrue(
+            nuArgs.contains("cmux-nushell-integration.nu"),
+            "the payload must source the bundled integration. nu argv: \(nuArgs)"
+        )
+    }
+
     /// Regression for the stale-shim fallback: `CMUX_CLAUDE_WRAPPER_SHIM` can outlive
     /// its file (macOS reaps idle temporary-directory contents after ~3 days), and bare
     /// `${VAR:-claude}` parameter expansion would exec the dead path and hard-fail

--- a/cmuxTests/ShellStartupMatrixTests.swift
+++ b/cmuxTests/ShellStartupMatrixTests.swift
@@ -224,11 +224,11 @@ struct ShellStartupMatrixTests {
     func typedShellCommandWrapsPosixForNushellOnly() {
         let posix = "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'"
         expectEqual(
-            TerminalStartupTypedShellCommand.typedInput(posixCommand: posix, dialect: .posix),
+            TerminalStartupTypedShellCommand(dialect: .posix).typedInput(posixCommand: posix),
             posix
         )
         expectEqual(
-            TerminalStartupTypedShellCommand.typedInput(posixCommand: posix, dialect: .nushell),
+            TerminalStartupTypedShellCommand(dialect: .nushell).typedInput(posixCommand: posix),
             #"^/bin/sh -c "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'""#
         )
     }

--- a/cmuxTests/ShellStartupMatrixTests.swift
+++ b/cmuxTests/ShellStartupMatrixTests.swift
@@ -120,7 +120,120 @@ struct ShellStartupMatrixTests {
         expectEqual(environment["CMUX_FISH_USER_CONFIG_ALREADY_LOADED"], "1")
     }
 
-    @Test(arguments: ["/bin/sh", "/bin/dash", "/bin/ksh", "/bin/tcsh", "/bin/csh", "/usr/local/bin/nu", "/usr/local/bin/pwsh"])
+    @Test
+    func nushellStartupReturnsManagedCommandEmbeddingBootstrapAndIntegration() throws {
+        let bundled = try makeBundledIntegrationDir(files: [
+            "nushell/cmux-nushell-bootstrap.nu": """
+            # cmux nushell bootstrap stub
+            def --env _cmux_refront_cli_shims [] { $env._CMUX_TEST = "1" }
+
+            _cmux_refront_cli_shims
+            """,
+            "nushell/cmux-nushell-integration.nu": "# cmux nushell integration stub\n",
+        ])
+        defer { try? FileManager.default.removeItem(at: bundled.root) }
+        let integrationDir = bundled.integrationDir
+        let shell = "/opt/homebrew/bin/nu"
+        let originalEnvironment = ["CUSTOM": "1"]
+        var environment = originalEnvironment
+        var protectedKeys: Set<String> = []
+
+        let command = TerminalSurface.applyManagedShellSpecificStartupEnvironment(
+            shell: shell,
+            integrationDir: integrationDir,
+            userGhosttyShellIntegrationMode: "detect",
+            to: &environment,
+            protectedKeys: &protectedKeys
+        )
+
+        let expectedPayload = "def --env _cmux_refront_cli_shims [] { $env._CMUX_TEST = \"1\" }; "
+            + "_cmux_refront_cli_shims; "
+            + "source \"\(integrationDir)/nushell/cmux-nushell-integration.nu\""
+        expectEqual(command, "'\(shell)' -l -e '\(expectedPayload)'")
+        // Nushell startup is command-only: no env redirection like ZDOTDIR or
+        // PROMPT_COMMAND.
+        expectEqual(environment, originalEnvironment)
+        expectTrue(protectedKeys.isEmpty)
+    }
+
+    @Test
+    func nushellStartupOmitsIntegrationSourceWhenIntegrationFileIsMissing() throws {
+        let bundled = try makeBundledIntegrationDir(files: [
+            "nushell/cmux-nushell-bootstrap.nu": "_cmux_stub_statement\n",
+        ])
+        defer { try? FileManager.default.removeItem(at: bundled.root) }
+        var environment: [String: String] = [:]
+        var protectedKeys: Set<String> = []
+
+        let command = TerminalSurface.applyManagedShellSpecificStartupEnvironment(
+            shell: "/usr/local/bin/nu",
+            integrationDir: bundled.integrationDir,
+            userGhosttyShellIntegrationMode: "detect",
+            to: &environment,
+            protectedKeys: &protectedKeys
+        )
+
+        expectEqual(command, "'/usr/local/bin/nu' -l -e '_cmux_stub_statement'")
+    }
+
+    @Test
+    func nushellManagedCommandQuotesShellPathWithSpaces() {
+        let command = TerminalSurface.managedNushellShellCommand(
+            shell: "/Applications/cmux DEV nush.app/Contents/nu",
+            startupPayload: "print 1"
+        )
+        expectEqual(command, "'/Applications/cmux DEV nush.app/Contents/nu' -l -e 'print 1'")
+    }
+
+    @Test
+    func nushellStartupPayloadStripsCommentsAndBlankLinesAndStaysSingleLine() {
+        let payload = TerminalSurface.nushellStartupPayload(
+            bootstrapContents: """
+            # comment
+
+            statement-one
+               # indented comment
+            statement-two
+            """,
+            integrationDir: "/nonexistent",
+            integrationFileIsReadable: { _ in false }
+        )
+        expectEqual(payload, "statement-one; statement-two")
+        expectFalse(payload.contains("\n"))
+    }
+
+    @Test
+    func nushellDoubleQuotedEscapesQuotesAndBackslashes() {
+        expectEqual(
+            TerminalSurface.nushellDoubleQuoted(#"/Apps/we"ird\dir"#),
+            #""/Apps/we\"ird\\dir""#
+        )
+    }
+
+    @Test
+    func shellDialectDetectsNushellFromLoginShellPath() {
+        expectEqual(TerminalStartupShellDialect.forShellPath("/opt/homebrew/bin/nu"), .nushell)
+        expectEqual(TerminalStartupShellDialect.forShellPath("/usr/local/bin/nu"), .nushell)
+        expectEqual(TerminalStartupShellDialect.forShellPath("/bin/zsh"), .posix)
+        expectEqual(TerminalStartupShellDialect.forShellPath("/opt/homebrew/bin/nushell"), .posix)
+        expectEqual(TerminalStartupShellDialect.forShellPath(nil), .posix)
+        expectEqual(TerminalStartupShellDialect.forShellPath(""), .posix)
+    }
+
+    @Test
+    func typedShellCommandWrapsPosixForNushellOnly() {
+        let posix = "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'"
+        expectEqual(
+            TerminalStartupTypedShellCommand.typedInput(posixCommand: posix, dialect: .posix),
+            posix
+        )
+        expectEqual(
+            TerminalStartupTypedShellCommand.typedInput(posixCommand: posix, dialect: .nushell),
+            #"^/bin/sh -c "cd -- '/tmp/p' 2>/dev/null || [ ! -d '/tmp/p' ] && 'claude' '--resume' 'SID'""#
+        )
+    }
+
+    @Test(arguments: ["/bin/sh", "/bin/dash", "/bin/ksh", "/bin/tcsh", "/bin/csh", "/usr/local/bin/pwsh"])
     func unsupportedLocalShellsKeepEnvironmentUnchanged(shell: String) {
         let originalEnvironment = ["CUSTOM": "1"]
         var environment = originalEnvironment

--- a/cmuxTests/ShellStartupMissingBundleTests.swift
+++ b/cmuxTests/ShellStartupMissingBundleTests.swift
@@ -72,6 +72,29 @@ struct ShellStartupMissingBundleTests {
     }
 
     @Test
+    func nushellStartupFallsBackToVanillaStartupWhenBundledBootstrapIsMissing() {
+        let missingIntegrationDir = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-tests-deleted-bundle-\(UUID().uuidString)")
+            .appendingPathComponent("shell-integration")
+            .path
+        let originalEnvironment = ["CUSTOM": "1"]
+        var environment = originalEnvironment
+        var protectedKeys: Set<String> = []
+
+        let command = TerminalSurface.applyManagedShellSpecificStartupEnvironment(
+            shell: "/opt/homebrew/bin/nu",
+            integrationDir: missingIntegrationDir,
+            userGhosttyShellIntegrationMode: "detect",
+            to: &environment,
+            protectedKeys: &protectedKeys
+        )
+
+        expectEqual(command, nil)
+        expectEqual(environment, originalEnvironment)
+        expectTrue(protectedKeys.isEmpty)
+    }
+
+    @Test
     func fishStartupFallsBackToVanillaStartupWhenBundledConfigIsMissing() {
         let missingIntegrationDir = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-tests-deleted-bundle-\(UUID().uuidString)")

--- a/tests/test_nushell_integration_hooks.py
+++ b/tests/test_nushell_integration_hooks.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""
+Behavior coverage for the cmux nushell shell integration
+(``Resources/shell-integration/nushell/cmux-nushell-integration.nu``).
+
+The integration brings nushell to fish parity (see
+``Resources/shell-integration/fish/config.fish``): socket reporting of tty,
+shell activity state (running/prompt), pwd changes, and port-scan kicks,
+driven from nushell ``pre_execution`` / ``pre_prompt`` hooks. This test
+sources the *actual* bundled integration file in real ``nu``, simulates the
+hook entry points, and asserts the exact payloads cmux's app side consumes
+(``report_tty`` / ``report_shell_state`` / ``report_pwd`` / ``ports_kick``,
+same wire format as the fish integration) arrive on a fake unix socket.
+
+Covered:
+
+1. Hook registration: sourcing appends cmux entries to
+   ``$env.config.hooks.pre_prompt`` and ``pre_execution``.
+2. ``report_tty`` is sent once (deduped), honoring a preset ``_CMUX_TTY_NAME``
+   (subprocesses have no tty; the preset mirrors the zsh/fish globals).
+3. ``report_shell_state running`` then ``prompt``, deduped across repeated
+   prompts.
+4. ``report_pwd`` fires on first prompt and again only after ``cd``.
+5. ``ports_kick --reason=command`` fires from pre-execution.
+6. The keyboard-protocol reset escape is emitted under
+   ``CMUX_TEST_FORCE_KEYBOARD_RESET`` (same test knob as fish/zsh).
+7. The integration stays silent on stderr and exits 0.
+
+``CMUX_TEST_SYNC_SEND=1`` makes sends synchronous (the interactive path uses
+``job spawn`` background sends, which nushell kills at shell exit — real
+prompts outlive them, a ``-c`` script does not).
+
+Deterministic: no PTY, no network beyond the local unix socket, no sleeps in
+the shell. Skips loudly without ``nu`` locally; fails when ``CI`` is set so
+CI can never silently skip.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+from pathlib import Path
+from typing import List, Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+INTEGRATION = (
+    REPO_ROOT / "Resources/shell-integration/nushell/cmux-nushell-integration.nu"
+)
+
+TAB_ID = "tab-nu-hooks"
+PANEL_ID = "panel-nu-hooks"
+TTY_NAME = "ttys042"
+
+
+def _find_nu() -> Optional[str]:
+    override = os.environ.get("CMUX_TEST_NU_BIN")
+    candidates = [
+        override,
+        shutil.which("nu"),
+        "/opt/homebrew/bin/nu",
+        "/usr/local/bin/nu",
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _require_nu() -> Optional[str]:
+    nu = _find_nu()
+    if nu is None:
+        if os.environ.get("CI"):
+            raise AssertionError(
+                "nushell (nu) is required on CI for this test but was not found; "
+                "the CI workflow must install a pinned nushell before running it"
+            )
+        print("SKIP: nushell (nu) not found; install nushell to run this test")
+    return nu
+
+
+class _SocketCollector:
+    """Accepts unix-socket connections and collects newline-terminated lines."""
+
+    def __init__(self, path: Path) -> None:
+        self.path = path
+        self.lines: List[str] = []
+        self._lock = threading.Lock()
+        self._server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        self._server.bind(str(path))
+        self._server.listen(16)
+        self._server.settimeout(0.2)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._loop, daemon=True)
+        self._thread.start()
+
+    def _loop(self) -> None:
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            with conn:
+                conn.settimeout(2)
+                chunks = []
+                try:
+                    while True:
+                        data = conn.recv(4096)
+                        if not data:
+                            break
+                        chunks.append(data)
+                except socket.timeout:
+                    pass
+            text = b"".join(chunks).decode("utf-8", errors="replace")
+            with self._lock:
+                for line in text.splitlines():
+                    if line.strip():
+                        self.lines.append(line.strip())
+
+    def stop(self) -> List[str]:
+        self._stop.set()
+        self._thread.join(timeout=5)
+        self._server.close()
+        with self._lock:
+            return list(self.lines)
+
+
+def _short_tmpdir() -> str:
+    # AF_UNIX paths are length-limited; keep the socket dir short.
+    return tempfile.mkdtemp(prefix="cmux-nu-", dir="/tmp")
+
+
+def _debug(proc: subprocess.CompletedProcess, lines: List[str]) -> str:
+    return (
+        f"\nexit={proc.returncode}"
+        f"\n--- nu stdout ---\n{proc.stdout}"
+        f"\n--- nu stderr ---\n{proc.stderr}"
+        f"\n--- socket lines ---\n" + "\n".join(lines)
+    )
+
+
+def test_nushell_integration_hook_reports() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    assert INTEGRATION.exists(), f"missing bundled nushell integration: {INTEGRATION}"
+
+    td = _short_tmpdir()
+    try:
+        # Resolve /tmp's /private/tmp symlink so payload assertions match
+        # nushell's resolved $env.PWD.
+        tmp = Path(td).resolve()
+        sock_path = tmp / "cmux.sock"
+        collector = _SocketCollector(sock_path)
+
+        home = tmp / "home"
+        other_dir = tmp / "elsewhere"
+        home.mkdir()
+        other_dir.mkdir()
+
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("CMUX")
+        }
+        env.update(
+            {
+                "LC_ALL": "C",
+                "LANG": "C",
+                "TERM": "xterm-256color",
+                "HOME": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": str(sock_path),
+                "CMUX_TAB_ID": TAB_ID,
+                "CMUX_PANEL_ID": PANEL_ID,
+                "CMUX_SURFACE_ID": "surface-nu-hooks",
+                "CMUX_TEST_SYNC_SEND": "1",
+                # Subprocesses have no tty; preset the name like the zsh/fish
+                # integrations' globals allow.
+                "_CMUX_TTY_NAME": TTY_NAME,
+            }
+        )
+
+        script = "; ".join(
+            [
+                f'source "{INTEGRATION}"',
+                "_cmux_pre_execution",
+                "_cmux_pre_prompt",
+                "_cmux_pre_prompt",
+                f'cd "{other_dir}"',
+                "_cmux_pre_prompt",
+                "print ($env.config.hooks.pre_prompt | length)",
+                "print ($env.config.hooks.pre_execution | length)",
+            ]
+        )
+        proc = subprocess.run(
+            [nu, "-n", "-c", script],
+            env=env,
+            cwd=str(home),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        lines = collector.stop()
+        debug = _debug(proc, lines)
+
+        assert proc.returncode == 0, "integration errored" + debug
+        assert proc.stderr.strip() == "", (
+            "integration must stay silent on stderr" + debug
+        )
+
+        hook_lengths = [line for line in proc.stdout.splitlines() if line.strip()]
+        assert len(hook_lengths) >= 2, "hook length probes missing" + debug
+        assert int(hook_lengths[-2]) >= 1, "pre_prompt hook not registered" + debug
+        assert int(hook_lengths[-1]) >= 1, "pre_execution hook not registered" + debug
+
+        suffix = f"--tab={TAB_ID} --panel={PANEL_ID}"
+        expected_once = [
+            f"report_tty {TTY_NAME} {suffix}",
+            f"report_shell_state running {suffix}",
+            f"report_shell_state prompt {suffix}",
+            f'report_pwd "{home}" {suffix}',
+            f'report_pwd "{other_dir}" {suffix}',
+        ]
+        for payload in expected_once:
+            count = lines.count(payload)
+            assert count == 1, (
+                f"expected exactly one {payload!r}, saw {count}" + debug
+            )
+
+        kick = f"ports_kick {suffix} --reason=command"
+        assert lines.count(kick) == 1, (
+            f"expected exactly one {kick!r} from pre-execution" + debug
+        )
+
+        for line in lines:
+            assert line.startswith(
+                ("report_tty ", "report_shell_state ", "report_pwd ", "ports_kick ")
+            ), f"unexpected socket payload {line!r}" + debug
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+
+
+def test_nushell_integration_keyboard_reset_test_knob() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    assert INTEGRATION.exists(), f"missing bundled nushell integration: {INTEGRATION}"
+
+    td = _short_tmpdir()
+    try:
+        tmp = Path(td)
+        home = tmp / "home"
+        home.mkdir()
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("CMUX")
+        }
+        env.update(
+            {
+                "LC_ALL": "C",
+                "LANG": "C",
+                "TERM": "xterm-256color",
+                "HOME": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                # No socket: reporting no-ops, only the terminal reset runs.
+                "CMUX_SOCKET_PATH": "",
+                "CMUX_TEST_FORCE_KEYBOARD_RESET": "1",
+            }
+        )
+        proc = subprocess.run(
+            [nu, "-n", "-c", f'source "{INTEGRATION}"; _cmux_pre_prompt'],
+            env=env,
+            cwd=str(home),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        assert proc.returncode == 0, (
+            f"pre-prompt errored without a socket\n{proc.stdout}\n{proc.stderr}"
+        )
+        assert "\x1b[>m\x1b[<8u" in proc.stdout, (
+            "keyboard-protocol reset escape missing under "
+            f"CMUX_TEST_FORCE_KEYBOARD_RESET\n{proc.stdout!r}\n{proc.stderr}"
+        )
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    test_nushell_integration_hook_reports()
+    test_nushell_integration_keyboard_reset_test_knob()
+    if _find_nu() is None:
+        print("SKIP: nushell (nu) not found; nothing was verified")
+    else:
+        print("PASS: cmux nushell integration reports tty/state/pwd/ports like fish")

--- a/tests/test_nushell_integration_hooks.py
+++ b/tests/test_nushell_integration_hooks.py
@@ -248,6 +248,80 @@ def test_nushell_integration_hook_reports() -> None:
         shutil.rmtree(td, ignore_errors=True)
 
 
+def test_nushell_integration_background_sends_deliver() -> None:
+    """Without CMUX_TEST_SYNC_SEND, reports go through `job spawn` — the
+    spawned job must still resolve the sourced `_cmux_send` def and deliver.
+    (The interactive path always uses background sends, so this cannot be
+    covered only by the sync-mode test above.)"""
+    nu = _require_nu()
+    if nu is None:
+        return
+    assert INTEGRATION.exists(), f"missing bundled nushell integration: {INTEGRATION}"
+
+    td = _short_tmpdir()
+    try:
+        tmp = Path(td).resolve()
+        sock_path = tmp / "cmux.sock"
+        collector = _SocketCollector(sock_path)
+        home = tmp / "home"
+        home.mkdir()
+
+        env = {
+            key: value
+            for key, value in os.environ.items()
+            if not key.startswith("CMUX")
+        }
+        env.update(
+            {
+                "LC_ALL": "C",
+                "LANG": "C",
+                "TERM": "xterm-256color",
+                "HOME": str(home),
+                "XDG_CONFIG_HOME": str(home / ".config"),
+                "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+                "CMUX_SOCKET_PATH": str(sock_path),
+                "CMUX_TAB_ID": TAB_ID,
+                "CMUX_PANEL_ID": PANEL_ID,
+                "CMUX_SURFACE_ID": "surface-nu-bg",
+                "_CMUX_TTY_NAME": TTY_NAME,
+                # No CMUX_TEST_SYNC_SEND: exercise the job spawn path. The
+                # trailing sleep keeps the shell alive long enough for the
+                # background job to flush (nushell kills jobs at exit; real
+                # prompts outlive them).
+            }
+        )
+        script = "; ".join(
+            [
+                f'source "{INTEGRATION}"',
+                "_cmux_pre_execution",
+                "sleep 800ms",
+            ]
+        )
+        proc = subprocess.run(
+            [nu, "-n", "-c", script],
+            env=env,
+            cwd=str(home),
+            capture_output=True,
+            text=True,
+            timeout=30,
+            check=False,
+        )
+        lines = collector.stop()
+        debug = _debug(proc, lines)
+
+        assert proc.returncode == 0, "integration errored on background sends" + debug
+        suffix = f"--tab={TAB_ID} --panel={PANEL_ID}"
+        assert f"report_shell_state running {suffix}" in lines, (
+            "background (job spawn) send did not deliver report_shell_state"
+            + debug
+        )
+        assert f"report_tty {TTY_NAME} {suffix}" in lines, (
+            "background (job spawn) send did not deliver report_tty" + debug
+        )
+    finally:
+        shutil.rmtree(td, ignore_errors=True)
+
+
 def test_nushell_integration_keyboard_reset_test_knob() -> None:
     nu = _require_nu()
     if nu is None:
@@ -299,6 +373,7 @@ def test_nushell_integration_keyboard_reset_test_knob() -> None:
 
 if __name__ == "__main__":
     test_nushell_integration_hook_reports()
+    test_nushell_integration_background_sends_deliver()
     test_nushell_integration_keyboard_reset_test_knob()
     if _find_nu() is None:
         print("SKIP: nushell (nu) not found; nothing was verified")

--- a/tests/test_nushell_integration_hooks.py
+++ b/tests/test_nushell_integration_hooks.py
@@ -57,6 +57,7 @@ TTY_NAME = "ttys042"
 
 
 def _find_nu() -> Optional[str]:
+    """Locate a nu binary: CMUX_TEST_NU_BIN override, PATH, then Homebrew paths."""
     override = os.environ.get("CMUX_TEST_NU_BIN")
     candidates = [
         override,
@@ -71,6 +72,7 @@ def _find_nu() -> Optional[str]:
 
 
 def _require_nu() -> Optional[str]:
+    """Return a nu path, skip loudly when absent locally, fail when CI is set."""
     nu = _find_nu()
     if nu is None:
         if os.environ.get("CI"):
@@ -131,11 +133,12 @@ class _SocketCollector:
 
 
 def _short_tmpdir() -> str:
-    # AF_UNIX paths are length-limited; keep the socket dir short.
+    """Create a short-prefix temp dir under /tmp (AF_UNIX socket paths are length-limited)."""
     return tempfile.mkdtemp(prefix="cmux-nu-", dir="/tmp")
 
 
 def _debug(proc: subprocess.CompletedProcess, lines: List[str]) -> str:
+    """Render process (and socket) state for assertion failure messages."""
     return (
         f"\nexit={proc.returncode}"
         f"\n--- nu stdout ---\n{proc.stdout}"

--- a/tests/test_nushell_resume_command_dialect.py
+++ b/tests/test_nushell_resume_command_dialect.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""
+Pin the nushell typed-command envelope against real ``nu``.
+
+cmux resume/relaunch commands are POSIX one-liners executed either by
+``"$_cmux_resume_shell" -c '<cmd>'`` (auto-resume startup script,
+``Sources/SessionPersistence.swift``) or typed into the user's interactive
+shell (sessions panel, session drag-drop, hibernation resume, clipboard):
+
+    cd -- '<dir>' 2>/dev/null || [ ! -d '<dir>' ] && 'claude' '--resume' '<id>'
+
+Every construct in that line is a parse error in nushell: ``&&``, ``||``,
+``[ … ]``, ``2>/dev/null``, POSIX quote concatenation, and even a POSIX-quoted
+command head (``'claude' 'arg'`` is "expected operator"). Rather than teach
+every builder a second dialect, cmux keeps the body POSIX and delegates it
+through ``/bin/sh`` at the final typed boundary
+(``NushellTypedShellCommand.wrapping(posixCommand:)`` in CMUXAgentLaunch —
+the same portable-envelope precedent as issue #5639's ``/bin/sh -c`` wrap and
+the ``/bin/zsh <launcher-script>`` startup inputs):
+
+    ^/bin/sh -c "<posix command, \\ and \" escaped>"
+
+This test replicates that envelope (``nu_wrap`` mirrors the Swift
+implementation as a golden) and drives it through real ``nu`` with a fake
+``claude`` recording argv/cwd/env, asserting:
+
+1. The wrapped legacy resume command runs the agent with argv intact from the
+   session's working directory.
+2. A missing working directory still launches the agent (the POSIX
+   ``|| [ ! -d … ]`` fallback survives the wrap).
+3. Quoting edges survive both layers: dirs/args with spaces, single quotes,
+   double quotes, and backslashes.
+4. Non-ASCII arguments survive via the POSIX ``"$(printf …)"`` substitution
+   that cmux emits for them (needs a real sh — exactly why the wrap exists).
+5. An ``env K=V`` prefix reaches the agent's environment.
+6. The UNwrapped POSIX string is (still) a nushell parse error — the reason
+   this envelope exists.
+
+Deterministic: no PTY, no sleeps, no network. Skips loudly without ``nu``
+locally; fails when ``CI`` is set so CI can never silently skip.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+
+def _find_nu() -> Optional[str]:
+    override = os.environ.get("CMUX_TEST_NU_BIN")
+    candidates = [
+        override,
+        shutil.which("nu"),
+        "/opt/homebrew/bin/nu",
+        "/usr/local/bin/nu",
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _require_nu() -> Optional[str]:
+    nu = _find_nu()
+    if nu is None:
+        if os.environ.get("CI"):
+            raise AssertionError(
+                "nushell (nu) is required on CI for this test but was not found; "
+                "the CI workflow must install a pinned nushell before running it"
+            )
+        print("SKIP: nushell (nu) not found; install nushell to run this test")
+    return nu
+
+
+def nu_double_quote(value: str) -> str:
+    """Golden mirror of NushellTypedShellCommand.doubleQuoted."""
+    return '"' + value.replace("\\", "\\\\").replace('"', '\\"') + '"'
+
+
+def nu_wrap(posix_command: str) -> str:
+    """Golden mirror of NushellTypedShellCommand.wrapping(posixCommand:)."""
+    return "^/bin/sh -c " + nu_double_quote(posix_command)
+
+
+def posix_quote(value: str) -> str:
+    """POSIX single-quoting as TerminalStartupShellQuoting.singleQuoted."""
+    return "'" + value.replace("'", "'\\''") + "'"
+
+
+def posix_printf_substitution(value: str) -> str:
+    """The ASCII printf substitution cmux emits for non-ASCII values."""
+    octal = "".join(f"\\{byte:03o}" for byte in value.encode("utf-8"))
+    return '"$(printf \'' + octal + "')\""
+
+
+def legacy_resume_command(workdir: str, argv_tail: str) -> str:
+    quoted = posix_quote(workdir)
+    return f"cd -- {quoted} 2>/dev/null || [ ! -d {quoted} ] && {argv_tail}"
+
+
+def _sandbox(tmp: Path) -> dict:
+    record_dir = tmp / "record"
+    record_dir.mkdir()
+    bin_dir = tmp / "bin"
+    bin_dir.mkdir()
+    fake_claude = bin_dir / "claude"
+    fake_claude.write_text(
+        "#!/bin/sh\n"
+        'pwd > "$CMUX_TEST_RECORD_DIR/cwd"\n'
+        'printf \'%s\\n\' "$@" > "$CMUX_TEST_RECORD_DIR/args"\n'
+        'printf \'%s\\n\' "${CMUX_TEST_MARKER:-}" > "$CMUX_TEST_RECORD_DIR/marker"\n',
+        encoding="utf-8",
+    )
+    fake_claude.chmod(0o755)
+
+    home = tmp / "home"
+    home.mkdir()
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CMUX")}
+    env.update(
+        {
+            "LC_ALL": "C",
+            "LANG": "C",
+            "TERM": "xterm-256color",
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(home / ".config"),
+            "PATH": os.pathsep.join([str(bin_dir), "/usr/bin", "/bin"]),
+            "CMUX_TEST_RECORD_DIR": str(record_dir),
+        }
+    )
+    return {"env": env, "record_dir": record_dir}
+
+
+def _run_nu_c(nu: str, env: dict, command: str, cwd: Path) -> subprocess.CompletedProcess:
+    # Matches the auto-resume dispatch and typed input: plain `nu -c '<cmd>'`.
+    return subprocess.run(
+        [nu, "-c", command],
+        env=env,
+        cwd=str(cwd),
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+def _read(record_dir: Path, name: str) -> str:
+    path = record_dir / name
+    assert path.exists(), f"agent never wrote {name} (was it launched?)"
+    return path.read_text(encoding="utf-8").rstrip("\n")
+
+
+def _debug(proc: subprocess.CompletedProcess) -> str:
+    return (
+        f"\nexit={proc.returncode}"
+        f"\n--- nu stdout ---\n{proc.stdout}"
+        f"\n--- nu stderr ---\n{proc.stderr}"
+    )
+
+
+SESSION_ID = "01234567-89ab-cdef-0123-456789abcdef"
+
+
+def test_wrapped_legacy_resume_runs_agent_in_working_directory() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-envelope-") as td:
+        tmp = Path(td)
+        sandbox = _sandbox(tmp)
+        workdir = tmp / "project"
+        workdir.mkdir()
+
+        posix = legacy_resume_command(
+            str(workdir), f"'claude' '--resume' '{SESSION_ID}'"
+        )
+        proc = _run_nu_c(nu, sandbox["env"], nu_wrap(posix), cwd=tmp)
+        assert proc.returncode == 0, "wrapped resume command failed" + _debug(proc)
+        assert _read(sandbox["record_dir"], "args") == f"--resume\n{SESSION_ID}", (
+            "agent argv corrupted" + _debug(proc)
+        )
+        recorded_cwd = _read(sandbox["record_dir"], "cwd")
+        assert Path(recorded_cwd).resolve() == workdir.resolve(), (
+            f"agent ran in {recorded_cwd!r}, expected {workdir}" + _debug(proc)
+        )
+
+
+def test_wrapped_resume_survives_missing_working_directory() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-envelope-") as td:
+        tmp = Path(td)
+        sandbox = _sandbox(tmp)
+        missing = tmp / "deleted-project"
+
+        posix = legacy_resume_command(
+            str(missing), f"'claude' '--resume' '{SESSION_ID}'"
+        )
+        proc = _run_nu_c(nu, sandbox["env"], nu_wrap(posix), cwd=tmp)
+        assert proc.returncode == 0, (
+            "resume must still launch the agent when the saved directory is "
+            "gone (POSIX fallback must survive the wrap)" + _debug(proc)
+        )
+        assert _read(sandbox["record_dir"], "args") == f"--resume\n{SESSION_ID}", (
+            "agent argv corrupted for missing-dir resume" + _debug(proc)
+        )
+        recorded_cwd = _read(sandbox["record_dir"], "cwd")
+        assert Path(recorded_cwd).resolve() == tmp.resolve(), (
+            f"agent should run from the launch cwd, got {recorded_cwd!r}"
+            + _debug(proc)
+        )
+
+
+def test_wrapped_resume_quoting_edges() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-envelope-") as td:
+        tmp = Path(td)
+        sandbox = _sandbox(tmp)
+        workdir = tmp / 'dir with "quotes", \'apostrophes\' and spaces'
+        workdir.mkdir()
+
+        tricky_arg = 'value with spaces, "double", \'single\' and back\\slash'
+        argv_tail = " ".join(
+            [
+                posix_quote("claude"),
+                posix_quote("--resume"),
+                posix_quote(SESSION_ID),
+                posix_quote("--append-system-prompt"),
+                posix_quote(tricky_arg),
+            ]
+        )
+        posix = legacy_resume_command(str(workdir), argv_tail)
+        proc = _run_nu_c(nu, sandbox["env"], nu_wrap(posix), cwd=tmp)
+        assert proc.returncode == 0, "quoted resume command failed" + _debug(proc)
+        assert _read(sandbox["record_dir"], "args") == (
+            f"--resume\n{SESSION_ID}\n--append-system-prompt\n{tricky_arg}"
+        ), "quoting mangled agent argv" + _debug(proc)
+        recorded_cwd = _read(sandbox["record_dir"], "cwd")
+        assert Path(recorded_cwd).resolve() == workdir.resolve(), (
+            f"agent ran in {recorded_cwd!r}, expected quoted dir {workdir}"
+            + _debug(proc)
+        )
+
+
+def test_wrapped_resume_non_ascii_printf_substitution() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-envelope-") as td:
+        tmp = Path(td)
+        sandbox = _sandbox(tmp)
+
+        fancy = "résumé — προφίλ"
+        argv_tail = (
+            f"'claude' '--resume' '{SESSION_ID}' "
+            f"'--append-system-prompt' {posix_printf_substitution(fancy)}"
+        )
+        proc = _run_nu_c(nu, sandbox["env"], nu_wrap(argv_tail), cwd=tmp)
+        assert proc.returncode == 0, (
+            "printf-substituted argument failed under the wrap" + _debug(proc)
+        )
+        assert _read(sandbox["record_dir"], "args") == (
+            f"--resume\n{SESSION_ID}\n--append-system-prompt\n{fancy}"
+        ), "non-ASCII argument corrupted" + _debug(proc)
+
+
+def test_wrapped_env_prefix_reaches_agent() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-envelope-") as td:
+        tmp = Path(td)
+        sandbox = _sandbox(tmp)
+
+        posix = (
+            f"env {posix_quote('CMUX_TEST_MARKER=hello nu')} "
+            f"'claude' '--resume' '{SESSION_ID}'"
+        )
+        proc = _run_nu_c(nu, sandbox["env"], nu_wrap(posix), cwd=tmp)
+        assert proc.returncode == 0, "env-prefixed relaunch failed" + _debug(proc)
+        assert _read(sandbox["record_dir"], "marker") == "hello nu", (
+            "env prefix did not reach the agent environment" + _debug(proc)
+        )
+
+
+def test_legacy_posix_resume_string_is_a_nushell_parse_error() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-envelope-") as td:
+        tmp = Path(td)
+        sandbox = _sandbox(tmp)
+        workdir = tmp / "project"
+        workdir.mkdir()
+
+        legacy = legacy_resume_command(
+            str(workdir), f"'claude' '--resume' '{SESSION_ID}'"
+        )
+        proc = _run_nu_c(nu, sandbox["env"], legacy, cwd=tmp)
+        assert proc.returncode != 0, (
+            "expected the unwrapped POSIX resume string to fail under nushell; "
+            "if nushell learned POSIX and-or lists, revisit the envelope"
+            + _debug(proc)
+        )
+        assert not (sandbox["record_dir"] / "args").exists(), (
+            "the agent must not launch off the unwrapped POSIX string under "
+            "nushell" + _debug(proc)
+        )
+
+
+if __name__ == "__main__":
+    test_wrapped_legacy_resume_runs_agent_in_working_directory()
+    test_wrapped_resume_survives_missing_working_directory()
+    test_wrapped_resume_quoting_edges()
+    test_wrapped_resume_non_ascii_printf_substitution()
+    test_wrapped_env_prefix_reaches_agent()
+    test_legacy_posix_resume_string_is_a_nushell_parse_error()
+    if _find_nu() is None:
+        print("SKIP: nushell (nu) not found; nothing was verified")
+    else:
+        print("PASS: nushell typed-command envelope semantics hold on real nu")

--- a/tests/test_nushell_resume_command_dialect.py
+++ b/tests/test_nushell_resume_command_dialect.py
@@ -51,6 +51,7 @@ from typing import Optional
 
 
 def _find_nu() -> Optional[str]:
+    """Locate a nu binary: CMUX_TEST_NU_BIN override, PATH, then Homebrew paths."""
     override = os.environ.get("CMUX_TEST_NU_BIN")
     candidates = [
         override,
@@ -65,6 +66,7 @@ def _find_nu() -> Optional[str]:
 
 
 def _require_nu() -> Optional[str]:
+    """Return a nu path, skip loudly when absent locally, fail when CI is set."""
     nu = _find_nu()
     if nu is None:
         if os.environ.get("CI"):
@@ -98,11 +100,13 @@ def posix_printf_substitution(value: str) -> str:
 
 
 def legacy_resume_command(workdir: str, argv_tail: str) -> str:
+    """The historical POSIX resume one-liner shape for `workdir` + agent argv."""
     quoted = posix_quote(workdir)
     return f"cd -- {quoted} 2>/dev/null || [ ! -d {quoted} ] && {argv_tail}"
 
 
 def _sandbox(tmp: Path) -> dict:
+    """Build an isolated env whose PATH resolves `claude` to an argv/cwd/env recorder."""
     record_dir = tmp / "record"
     record_dir.mkdir()
     bin_dir = tmp / "bin"
@@ -135,6 +139,7 @@ def _sandbox(tmp: Path) -> dict:
 
 
 def _run_nu_c(nu: str, env: dict, command: str, cwd: Path) -> subprocess.CompletedProcess:
+    """Run `command` through plain `nu -c`, matching the auto-resume dispatch and typed input."""
     # Matches the auto-resume dispatch and typed input: plain `nu -c '<cmd>'`.
     return subprocess.run(
         [nu, "-c", command],
@@ -148,12 +153,14 @@ def _run_nu_c(nu: str, env: dict, command: str, cwd: Path) -> subprocess.Complet
 
 
 def _read(record_dir: Path, name: str) -> str:
+    """Read a file the fake agent recorded, failing if the agent never ran."""
     path = record_dir / name
     assert path.exists(), f"agent never wrote {name} (was it launched?)"
     return path.read_text(encoding="utf-8").rstrip("\n")
 
 
 def _debug(proc: subprocess.CompletedProcess) -> str:
+    """Render process (and socket) state for assertion failure messages."""
     return (
         f"\nexit={proc.returncode}"
         f"\n--- nu stdout ---\n{proc.stdout}"

--- a/tests/test_nushell_shim_path_refront.py
+++ b/tests/test_nushell_shim_path_refront.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""
+Regression coverage for nushell wrapper-shim shadowing.
+
+cmux routes ``claude`` through a per-surface shim in ``$TMPDIR/cmux-cli-shims/
+<surface-id>/`` so ``cmux-claude-wrapper`` can inject session tracking and
+notification hooks. The shim directory is prepended to ``PATH`` when the
+terminal spawns, but a nushell user's ``env.nu`` typically re-prepends their
+own directories (``~/.local/bin`` and friends) on top of the inherited
+``PATH``, shadowing the shim. zsh/bash/fish recover via cmux shell
+integration that re-fronts the shim after user config runs; nushell had no
+integration at all, so the wrapper never ran, sessions were never captured
+into ``~/.cmuxterm/claude-hook-sessions.json``, and Claude session resume
+never worked.
+
+This test drives the *actual* bundled nushell bootstrap
+(``Resources/shell-integration/nushell/cmux-nushell-bootstrap.nu``) through
+real ``nu``, launched the same way cmux launches it (``nu -l`` with the
+squashed bootstrap; the test appends its probe where cmux's ``-e`` payload
+would sit, which shares the same post-config execution point). It asserts:
+
+1. Control: with a user ``env.nu`` that prepends a decoy ``claude`` dir, plain
+   ``nu -l`` resolves the decoy (the bug bites; the sandbox is faithful).
+2. With the bootstrap applied, ``which claude`` resolves to the shim again.
+3. Actually running ``claude`` executes the shim, arguments intact.
+4. The bootstrap normalizes a user config that left ``PATH`` a string.
+
+It is deterministic: no PTY, no sleeps, no network. Skips loudly when ``nu``
+is not installed locally, but fails when ``CI`` is set so the suite can never
+silently skip on CI (see the repo pitfall about silently-skipping tests).
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+BOOTSTRAP = REPO_ROOT / "Resources/shell-integration/nushell/cmux-nushell-bootstrap.nu"
+
+SURFACE_ID = "nushell-refront-test"
+
+
+def _find_nu() -> Optional[str]:
+    override = os.environ.get("CMUX_TEST_NU_BIN")
+    candidates = [
+        override,
+        shutil.which("nu"),
+        "/opt/homebrew/bin/nu",
+        "/usr/local/bin/nu",
+    ]
+    for candidate in candidates:
+        if candidate and Path(candidate).is_file() and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _require_nu() -> Optional[str]:
+    nu = _find_nu()
+    if nu is None:
+        if os.environ.get("CI"):
+            raise AssertionError(
+                "nushell (nu) is required on CI for this test but was not found; "
+                "the CI workflow must install a pinned nushell before running it"
+            )
+        print("SKIP: nushell (nu) not found; install nushell to run this test")
+    return nu
+
+
+def _bootstrap_one_liner() -> str:
+    """Squash the bootstrap exactly like the Swift spawn path does.
+
+    The bundled file must stay join-safe: statement-per-line, comments and
+    blank lines removable, the remainder joinable with '; '.
+    """
+    assert BOOTSTRAP.exists(), f"missing bundled nushell bootstrap: {BOOTSTRAP}"
+    lines = []
+    for raw in BOOTSTRAP.read_text(encoding="utf-8").splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        lines.append(stripped)
+    one_liner = "; ".join(lines)
+    assert one_liner, "bootstrap squashed to an empty command"
+    assert "\n" not in one_liner
+    return one_liner
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(0o755)
+
+
+def _make_sandbox(tmp: Path, env_nu_body: str) -> dict:
+    home = tmp / "home"
+    xdg = tmp / "xdg"
+    nushell_config = xdg / "nushell"
+    nushell_config.mkdir(parents=True)
+    home.mkdir()
+
+    (nushell_config / "env.nu").write_text(env_nu_body, encoding="utf-8")
+    (nushell_config / "config.nu").write_text("", encoding="utf-8")
+
+    decoy_dir = tmp / "decoy-bin"
+    decoy_dir.mkdir()
+    _write_executable(
+        decoy_dir / "claude",
+        '#!/bin/sh\nprintf \'DECOY-CLAUDE %s\\n\' "$*"\n',
+    )
+
+    shim_dir = tmp / "cmux-cli-shims" / SURFACE_ID
+    shim_dir.mkdir(parents=True)
+    _write_executable(
+        shim_dir / "claude",
+        '#!/bin/sh\nprintf \'SHIM-CLAUDE %s\\n\' "$*"\n',
+    )
+
+    env = {key: value for key, value in os.environ.items() if not key.startswith("CMUX")}
+    env.update(
+        {
+            "LC_ALL": "C",
+            "LANG": "C",
+            "TERM": "xterm-256color",
+            "HOME": str(home),
+            "XDG_CONFIG_HOME": str(xdg),
+            # cmux spawns the surface with the shim dir already first on PATH.
+            "PATH": os.pathsep.join(
+                [str(shim_dir), "/usr/bin", "/bin", "/usr/sbin", "/sbin"]
+            ),
+            "CMUX_SURFACE_ID": SURFACE_ID,
+        }
+    )
+    return {"env": env, "decoy_dir": decoy_dir, "shim_dir": shim_dir}
+
+
+def _run_nu(nu: str, env: dict, script: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [nu, "-l", "-c", script],
+        env=env,
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+
+_DECOY_PREPEND_ENV_NU = """
+$env.PATH = ($env.PATH | split row (char esep) | prepend "__DECOY_DIR__")
+"""
+
+_DECOY_PREPEND_STRING_PATH_ENV_NU = """
+$env.PATH = ($env.PATH | split row (char esep) | prepend "__DECOY_DIR__" | str join (char esep))
+"""
+
+
+def _debug(proc: subprocess.CompletedProcess) -> str:
+    return (
+        f"\nexit={proc.returncode}"
+        f"\n--- nu stdout ---\n{proc.stdout}"
+        f"\n--- nu stderr ---\n{proc.stderr}"
+    )
+
+
+def test_nushell_bootstrap_refronts_shim_over_user_path_prepends() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    one_liner = _bootstrap_one_liner()
+
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-refront-") as td:
+        tmp = Path(td)
+        sandbox = _make_sandbox(
+            tmp,
+            _DECOY_PREPEND_ENV_NU.replace("__DECOY_DIR__", str(tmp / "decoy-bin")),
+        )
+        env = sandbox["env"]
+        decoy_claude = str(sandbox["decoy_dir"] / "claude")
+        shim_claude = str(sandbox["shim_dir"] / "claude")
+
+        # Control: the user prepend shadows the shim without the bootstrap.
+        control = _run_nu(nu, env, "which claude | get 0.path")
+        assert control.returncode == 0, "control `which claude` failed" + _debug(control)
+        assert control.stdout.strip() == decoy_claude, (
+            "sandbox is not faithful: expected the decoy claude to shadow the "
+            f"shim without the bootstrap (got {control.stdout.strip()!r})"
+            + _debug(control)
+        )
+
+        # With the bootstrap (same post-config execution point as cmux's -e
+        # payload), the shim must win again.
+        fixed = _run_nu(nu, env, one_liner + "; which claude | get 0.path")
+        assert fixed.returncode == 0, "bootstrap run failed" + _debug(fixed)
+        assert fixed.stdout.strip() == shim_claude, (
+            "bootstrap did not re-front the cmux shim dir over the user's "
+            f"PATH prepends (got {fixed.stdout.strip()!r})" + _debug(fixed)
+        )
+
+        # And actually running `claude` must hit the shim, args intact.
+        ran = _run_nu(nu, env, one_liner + "; claude --resume 0123-fake-id")
+        assert ran.returncode == 0, "running claude via bootstrap failed" + _debug(ran)
+        assert "SHIM-CLAUDE --resume 0123-fake-id" in ran.stdout, (
+            "running `claude` did not execute the cmux shim" + _debug(ran)
+        )
+        assert "DECOY-CLAUDE" not in ran.stdout, (
+            "running `claude` executed the user binary instead of the shim"
+            + _debug(ran)
+        )
+
+
+def test_nushell_bootstrap_normalizes_string_path() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    one_liner = _bootstrap_one_liner()
+
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-strpath-") as td:
+        tmp = Path(td)
+        sandbox = _make_sandbox(
+            tmp,
+            _DECOY_PREPEND_STRING_PATH_ENV_NU.replace(
+                "__DECOY_DIR__", str(tmp / "decoy-bin")
+            ),
+        )
+        env = sandbox["env"]
+        shim_claude = str(sandbox["shim_dir"] / "claude")
+
+        fixed = _run_nu(
+            nu,
+            env,
+            one_liner + "; print ($env.PATH | describe); which claude | get 0.path",
+        )
+        assert fixed.returncode == 0, (
+            "bootstrap failed on a user config that left PATH a string"
+            + _debug(fixed)
+        )
+        stdout_lines = [line for line in fixed.stdout.splitlines() if line.strip()]
+        assert stdout_lines and stdout_lines[0].startswith("list"), (
+            "bootstrap must normalize a string PATH back to a list "
+            f"(got type {stdout_lines[0] if stdout_lines else '<empty>'!r})"
+            + _debug(fixed)
+        )
+        assert stdout_lines[-1] == shim_claude, (
+            "bootstrap did not re-front the shim when PATH was a string"
+            + _debug(fixed)
+        )
+
+
+def test_nushell_bootstrap_noops_outside_cmux() -> None:
+    nu = _require_nu()
+    if nu is None:
+        return
+    one_liner = _bootstrap_one_liner()
+
+    with tempfile.TemporaryDirectory(prefix="cmux-nu-noop-") as td:
+        tmp = Path(td)
+        sandbox = _make_sandbox(
+            tmp,
+            _DECOY_PREPEND_ENV_NU.replace("__DECOY_DIR__", str(tmp / "decoy-bin")),
+        )
+        env = sandbox["env"]
+        env.pop("CMUX_SURFACE_ID", None)
+        decoy_claude = str(sandbox["decoy_dir"] / "claude")
+
+        outside = _run_nu(nu, env, one_liner + "; which claude | get 0.path")
+        assert outside.returncode == 0, (
+            "bootstrap errored outside a cmux surface" + _debug(outside)
+        )
+        assert outside.stdout.strip() == decoy_claude, (
+            "bootstrap must not reorder PATH outside a cmux surface "
+            f"(got {outside.stdout.strip()!r})" + _debug(outside)
+        )
+
+
+if __name__ == "__main__":
+    test_nushell_bootstrap_refronts_shim_over_user_path_prepends()
+    test_nushell_bootstrap_normalizes_string_path()
+    test_nushell_bootstrap_noops_outside_cmux()
+    if _find_nu() is None:
+        print("SKIP: nushell (nu) not found; nothing was verified")
+    else:
+        print("PASS: cmux nushell bootstrap re-fronts the CLI shim over user PATH prepends")

--- a/tests/test_nushell_shim_path_refront.py
+++ b/tests/test_nushell_shim_path_refront.py
@@ -46,6 +46,7 @@ SURFACE_ID = "nushell-refront-test"
 
 
 def _find_nu() -> Optional[str]:
+    """Locate a nu binary: CMUX_TEST_NU_BIN override, PATH, then Homebrew paths."""
     override = os.environ.get("CMUX_TEST_NU_BIN")
     candidates = [
         override,
@@ -60,6 +61,7 @@ def _find_nu() -> Optional[str]:
 
 
 def _require_nu() -> Optional[str]:
+    """Return a nu path, skip loudly when absent locally, fail when CI is set."""
     nu = _find_nu()
     if nu is None:
         if os.environ.get("CI"):
@@ -91,11 +93,13 @@ def _bootstrap_one_liner() -> str:
 
 
 def _write_executable(path: Path, contents: str) -> None:
+    """Write `contents` to `path` and mark it executable."""
     path.write_text(contents, encoding="utf-8")
     path.chmod(0o755)
 
 
 def _make_sandbox(tmp: Path, env_nu_body: str) -> dict:
+    """Build an isolated HOME/XDG tree with a decoy claude, a shim claude, and the env cmux would spawn with."""
     home = tmp / "home"
     xdg = tmp / "xdg"
     nushell_config = xdg / "nushell"
@@ -138,6 +142,7 @@ def _make_sandbox(tmp: Path, env_nu_body: str) -> dict:
 
 
 def _run_nu(nu: str, env: dict, script: str) -> subprocess.CompletedProcess:
+    """Run `script` through `nu -l -c`, mirroring how cmux launches login nushell."""
     return subprocess.run(
         [nu, "-l", "-c", script],
         env=env,
@@ -158,6 +163,7 @@ $env.PATH = ($env.PATH | split row (char esep) | prepend "__DECOY_DIR__" | str j
 
 
 def _debug(proc: subprocess.CompletedProcess) -> str:
+    """Render process output for assertion failure messages."""
     return (
         f"\nexit={proc.returncode}"
         f"\n--- nu stdout ---\n{proc.stdout}"


### PR DESCRIPTION
Fixes #10050

Nushell login shells get no shell integration: `applyManagedShellSpecificStartupEnvironment` has cases for zsh, bash, and fish, and `nu` falls through `default:`. For a nushell user this breaks in three places:

1. Claude sessions are never captured. A typical `env.nu` rebuilds PATH with its own prepends, which shadows the per-surface `cmux-cli-shims` shim. The zsh and fish integrations recover from this; nushell has nothing, so `cmux-claude-wrapper` never runs and `~/.cmuxterm/claude-hook-sessions.json` never gets written. Session resume and Claude notifications never work at all.
2. Even with a captured session, every resume command is a parse error in nushell. The strings are POSIX (`cd -- '…' 2>/dev/null || [ ! -d '…' ] && 'claude' '--resume' '<id>'`), and nushell rejects `&&`, `||`, `[ … ]`, and quoted command heads like `'claude'`.
3. None of the socket reporting runs: busy/idle state, cwd tracking, tty registration, port-scan kicks.

## The fix

Capture: a `case "nu"` that launches nushell as `'<shell>' -l -e '<payload>'`, mirroring the fish replacement command. `--execute` runs the payload after the user's config and then opens the REPL. The payload is the new bundled `cmux-nushell-bootstrap.nu` squashed to one line: it moves `cmux-cli-shims` entries back to the front of PATH, then sources the integration file (path baked in as a literal, since nushell `source` needs a parse-time constant). If the bundle files are missing, the shell starts vanilla, same as the zsh/fish guards.

Resume: commands stay POSIX everywhere. At the points where cmux types a command into the user's interactive shell (panel resume, session drag-drop, clipboard copy, startup/fork/hibernation inline inputs) they get wrapped as `^/bin/sh -c "<escaped>"`, the same delegate-to-sh idea as the #5639 wrapper token. Inline inputs embedded into the zsh launcher scripts are not wrapped. The scripts instead grow a `nu)` dispatch branch that runs the command through /bin/sh and then execs nushell with the bootstrap payload rebuilt from `CMUX_SHELL_INTEGRATION_DIR`, so a resumed surface keeps its shim. (The first dogfood round caught a wrapped string reaching /bin/sh: `/bin/sh: ^/bin/sh: No such file or directory`. There are regression tests for exactly that now.)

Integration: `cmux-nushell-integration.nu` provides what the fish integration provides, with the same wire formats: report_tty, report_shell_state, report_pwd, ports_kick, claude/grok wrapper defs, scrollback restore, keyboard-protocol reset, remote relay fallback. State lives in `_CMUX_*` env vars and the hooks are registered as strings so `def --env` mutations persist across prompts; background sends use `job spawn`. The zsh-only extras (git-branch probes, PR polling, Ghostty job-table patching) are not replicated; fish doesn't have them either.

## Commits

Two commits, red then green.

1. Tests only. Three Python suites drive real `nu` against the bundled files: shim re-fronting under a hostile `env.nu`, the sh envelope (quoting edges, non-ASCII printf substitutions, env prefixes, and a pin that the legacy POSIX string stays a parse error), and the hook wire formats against a unix-socket fixture. CI installs a pinned, checksum-verified nushell 0.113.1 in the shard that runs the wrapper tests. Locally the tests skip with a message when `nu` is absent; on CI they fail instead, so they can never silently skip.
2. The fix, plus Swift tests: nu rows in `ShellStartupMatrixTests`, the missing-bundle fallback, real-nu resume dispatch regressions next to the existing fish/tcsh #5639 tests, an end-to-end run of the generated launcher script under zsh with a fake nu login shell, and `NushellTypedShellCommandTests` in CMUXAgentLaunch. `/usr/local/bin/nu` comes out of the unsupported-shells matrix row, which is the clearest red-to-green flip in the diff.

## Verified

Dogfooded over two rounds on a machine whose login shell is nushell 0.113.1: capture, app-relaunch auto-resume (including the resumed surface keeping its shim), panel resume, and session drag-drop. The design choices (why `-e`, why delegate to /bin/sh instead of teaching every builder a second dialect) came from probing real nu; the Python tests encode those probes.

No user-facing strings changed, so nothing to localize.

## Not covered

Full zsh parity (git-branch probes, PR polling, job-table patching), nushell on remote `cmux ssh` hosts, and users with a custom Ghostty `command`, who skip the replacement command; fish has the same limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Nushell (`nu`) support for shell startup and typed, shell-safe session resume/command execution.
  * Introduced Nushell shell-integration for activity reporting, PWD tracking, port “kicks,” keyboard reset, and kitty scrollback restore.
  * Ensured `cmux-cli-shims` are re-fronted in Nushell PATH during bootstrap.
* **Bug Fixes**
  * Corrected Nushell resume/launcher behavior by routing command evaluation through a `/bin/sh -c` boundary and preserving integration on re-entry.
* **Tests / CI**
  * Expanded Nushell regression and end-to-end coverage (hooks, quoting/escaping, shim refronting, dialect handling).
  * Updated CI to install a pinned NuShell binary for macOS test shards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->