### PR TITLE
iOS: gallery filters, sort, grid, and swipe paging

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryClassifier.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryClassifier.swift
@@ -1,0 +1,59 @@
+import Foundation
+import UniformTypeIdentifiers
+
+/// Classifies gallery artifacts into the dedicated sheet filter buckets.
+public struct ChatArtifactGalleryClassifier: Sendable {
+    private let logExtensions: Set<String> = ["log", "out", "txt"]
+    private let documentExtensions: Set<String> = [
+        "doc", "docx", "key", "md", "markdown", "mdown", "mkd", "numbers",
+        "odp", "ods", "odt", "pages", "pdf", "ppt", "pptx", "rtf", "xls", "xlsx",
+    ]
+
+    /// Creates an artifact classifier.
+    public init() {}
+
+    /// Returns the artifact's dedicated filter bucket, if it has one.
+    ///
+    /// Image and directory kinds take precedence over filename extensions.
+    /// Artifacts returning `nil` remain visible under ``ChatArtifactGalleryFilter/all``.
+    ///
+    /// - Parameters:
+    ///   - kind: Preview kind assigned by the artifact host.
+    ///   - path: Artifact path whose extension supplements the preview kind.
+    /// - Returns: A dedicated filter bucket, or `nil` for All-only artifacts.
+    public func filter(
+        for kind: ChatArtifactKind,
+        path: String
+    ) -> ChatArtifactGalleryFilter? {
+        switch kind {
+        case .image:
+            return .images
+        case .directory:
+            return .folders
+        case .text, .binary:
+            break
+        }
+
+        let pathExtension = URL(fileURLWithPath: path).pathExtension.lowercased()
+        guard !pathExtension.isEmpty else { return nil }
+        if let type = UTType(filenameExtension: pathExtension),
+           type.conforms(to: .sourceCode) {
+            return .code
+        }
+        if logExtensions.contains(pathExtension) {
+            return .logs
+        }
+        if documentExtensions.contains(pathExtension) {
+            return .docs
+        }
+        return nil
+    }
+
+    /// Returns the artifact's dedicated filter bucket, if it has one.
+    ///
+    /// - Parameter item: Gallery item to classify.
+    /// - Returns: A dedicated filter bucket, or `nil` for All-only artifacts.
+    public func filter(for item: ChatArtifactGalleryItem) -> ChatArtifactGalleryFilter? {
+        filter(for: item.kind, path: item.path)
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPager.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPager.swift
@@ -1,0 +1,53 @@
+/// Sequentially loads referenced gallery pages for complete filtering and sorting.
+public struct ChatArtifactGalleryEagerPager: Sendable {
+    /// Default maximum referenced rows retained during eager loading.
+    public static let defaultMaximumReferencedRows = 2_000
+
+    private let maximumReferencedRows: Int
+
+    /// Creates an eager pager.
+    ///
+    /// - Parameter maximumReferencedRows: Maximum referenced rows to retain.
+    public init(
+        maximumReferencedRows: Int = Self.defaultMaximumReferencedRows
+    ) {
+        self.maximumReferencedRows = max(0, maximumReferencedRows)
+    }
+
+    /// Loads cursor pages sequentially until exhausted or capped.
+    ///
+    /// A repeated cursor ends the loop defensively while preserving that cursor
+    /// for a later retry rather than issuing the same request indefinitely.
+    ///
+    /// - Parameters:
+    ///   - initialSnapshot: First page or already accumulated gallery snapshot.
+    ///   - fetchPage: Async operation for one opaque cursor.
+    /// - Returns: The accumulated snapshot and cap status.
+    /// - Throws: The first page-loading error or cancellation.
+    public func loadRemaining(
+        from initialSnapshot: ChatArtifactGallerySnapshot,
+        fetchPage: @escaping @Sendable (_ cursor: String) async throws -> ChatArtifactGalleryPage
+    ) async throws -> ChatArtifactGalleryEagerPagingResult {
+        var snapshot = initialSnapshot.limitingReferenced(to: maximumReferencedRows)
+        var seenCursors: Set<String> = []
+        var truncatedRows = initialSnapshot.referenced.count > snapshot.referenced.count
+
+        while let cursor = snapshot.nextCursor,
+              snapshot.referenced.count < maximumReferencedRows,
+              seenCursors.insert(cursor).inserted {
+            try Task.checkCancellation()
+            let page = try await fetchPage(cursor)
+            try Task.checkCancellation()
+            let appended = snapshot.appending(page)
+            truncatedRows = truncatedRows || appended.referenced.count > maximumReferencedRows
+            snapshot = appended.limitingReferenced(to: maximumReferencedRows)
+        }
+
+        let hasMoreAtCap = snapshot.referenced.count >= maximumReferencedRows
+            && snapshot.nextCursor != nil
+        return ChatArtifactGalleryEagerPagingResult(
+            snapshot: snapshot,
+            reachedSafetyCap: truncatedRows || hasMoreAtCap
+        )
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPagingResult.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPagingResult.swift
@@ -1,0 +1,20 @@
+/// The completed outcome of eagerly loading referenced gallery pages.
+public struct ChatArtifactGalleryEagerPagingResult: Sendable, Equatable {
+    /// Accumulated rows and the cursor that remains after loading.
+    public let snapshot: ChatArtifactGallerySnapshot
+    /// Whether loading stopped because more than the configured row cap exists.
+    public let reachedSafetyCap: Bool
+
+    /// Creates an eager-paging result.
+    ///
+    /// - Parameters:
+    ///   - snapshot: Accumulated rows and remaining cursor.
+    ///   - reachedSafetyCap: Whether the row cap prevented complete loading.
+    public init(
+        snapshot: ChatArtifactGallerySnapshot,
+        reachedSafetyCap: Bool
+    ) {
+        self.snapshot = snapshot
+        self.reachedSafetyCap = reachedSafetyCap
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryFilter.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryFilter.swift
@@ -1,0 +1,15 @@
+/// A sheet-wide artifact-kind filter applied within every gallery group.
+public enum ChatArtifactGalleryFilter: String, CaseIterable, Sendable, Equatable {
+    /// Includes every artifact, including kinds without a dedicated filter.
+    case all
+    /// Includes image artifacts.
+    case images
+    /// Includes source-code artifacts.
+    case code
+    /// Includes log and plain-text artifacts.
+    case logs
+    /// Includes document artifacts.
+    case docs
+    /// Includes directory artifacts.
+    case folders
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryGroup.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryGroup.swift
@@ -1,0 +1,23 @@
+/// One immutable, filtered and sorted provenance group.
+public struct ChatArtifactGalleryGroup: Sendable, Equatable, Identifiable {
+    /// The group's stable provenance identity.
+    public let kind: ChatArtifactGalleryGroupKind
+    /// Visible rows in the group's selected ordering.
+    public let items: [ChatArtifactGalleryItem]
+
+    /// Stable group identity.
+    public var id: ChatArtifactGalleryGroupKind { kind }
+
+    /// Creates a gallery group.
+    ///
+    /// - Parameters:
+    ///   - kind: Stable provenance identity.
+    ///   - items: Visible rows in selected order.
+    public init(
+        kind: ChatArtifactGalleryGroupKind,
+        items: [ChatArtifactGalleryItem]
+    ) {
+        self.kind = kind
+        self.items = items
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryGroupKind.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryGroupKind.swift
@@ -1,0 +1,9 @@
+/// The fixed provenance group organization of the artifact gallery.
+public enum ChatArtifactGalleryGroupKind: String, CaseIterable, Sendable, Equatable {
+    /// Files created by the agent.
+    case created
+    /// Files attached by the user.
+    case attached
+    /// Other files referenced by the session.
+    case referenced
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPresentation.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPresentation.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// A pure sheet-wide filter and sort projection over fixed gallery groups.
+public struct ChatArtifactGalleryPresentation: Sendable, Equatable {
+    /// Created, Attached, and Referenced groups in their fixed display order.
+    public let groups: [ChatArtifactGalleryGroup]
+
+    /// Creates a grouped presentation without changing the source snapshot.
+    ///
+    /// - Parameters:
+    ///   - snapshot: Accumulated gallery rows to project.
+    ///   - filter: Sheet-wide kind filter.
+    ///   - sort: Ordering applied independently within each group.
+    ///   - classifier: Classifier used for extension-based buckets.
+    public init(
+        snapshot: ChatArtifactGallerySnapshot,
+        filter: ChatArtifactGalleryFilter = .all,
+        sort: ChatArtifactGallerySort = .recent,
+        classifier: ChatArtifactGalleryClassifier = ChatArtifactGalleryClassifier()
+    ) {
+        groups = [
+            ChatArtifactGalleryGroup(
+                kind: .created,
+                items: Self.project(snapshot.created, filter: filter, sort: sort, classifier: classifier)
+            ),
+            ChatArtifactGalleryGroup(
+                kind: .attached,
+                items: Self.project(snapshot.attached, filter: filter, sort: sort, classifier: classifier)
+            ),
+            ChatArtifactGalleryGroup(
+                kind: .referenced,
+                items: Self.project(snapshot.referenced, filter: filter, sort: sort, classifier: classifier)
+            ),
+        ]
+    }
+
+    /// Returns the visible rows for one fixed group.
+    ///
+    /// - Parameter kind: Group whose projected rows are needed.
+    /// - Returns: Visible rows, or an empty array when the group is absent.
+    public func items(in kind: ChatArtifactGalleryGroupKind) -> [ChatArtifactGalleryItem] {
+        groups.first { $0.kind == kind }?.items ?? []
+    }
+
+    private static func project(
+        _ items: [ChatArtifactGalleryItem],
+        filter: ChatArtifactGalleryFilter,
+        sort: ChatArtifactGallerySort,
+        classifier: ChatArtifactGalleryClassifier
+    ) -> [ChatArtifactGalleryItem] {
+        let filtered = filter == .all
+            ? items
+            : items.filter { classifier.filter(for: $0) == filter }
+        switch sort {
+        case .recent:
+            return filtered
+        case .name:
+            return filtered.enumerated().sorted { lhs, rhs in
+                let comparison = lhs.element.displayName.localizedCaseInsensitiveCompare(
+                    rhs.element.displayName
+                )
+                return comparison == .orderedSame
+                    ? lhs.offset < rhs.offset
+                    : comparison == .orderedAscending
+            }.map(\.element)
+        case .size:
+            return filtered.enumerated().sorted { lhs, rhs in
+                switch (lhs.element.size, rhs.element.size) {
+                case let (left?, right?) where left != right:
+                    return left > right
+                case (_?, nil):
+                    return true
+                case (nil, _?):
+                    return false
+                default:
+                    return lhs.offset < rhs.offset
+                }
+            }.map(\.element)
+        }
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
@@ -51,6 +51,17 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
         )
     }
 
+    func limitingReferenced(to maximumCount: Int) -> ChatArtifactGallerySnapshot {
+        ChatArtifactGallerySnapshot(
+            created: created,
+            attached: attached,
+            referenced: Array(referenced.prefix(max(0, maximumCount))),
+            referencedTotal: referencedTotal,
+            nextCursor: nextCursor,
+            generation: generation
+        )
+    }
+
     private init(
         created: [ChatArtifactGalleryItem],
         attached: [ChatArtifactGalleryItem],

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySort.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySort.swift
@@ -1,0 +1,9 @@
+/// A sheet-wide ordering applied independently within every artifact group.
+public enum ChatArtifactGallerySort: String, CaseIterable, Sendable, Equatable {
+    /// Preserves the host's descending last-reference sequence order.
+    case recent
+    /// Orders names ascending, case-insensitively.
+    case name
+    /// Orders known sizes largest-first, followed by unknown sizes.
+    case size
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySwipeOrder.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySwipeOrder.swift
@@ -1,0 +1,86 @@
+/// The flattened visible-file order used by gallery viewer paging.
+public struct ChatArtifactGallerySwipeOrder: Sendable, Equatable {
+    /// Visible non-folder files in paging order.
+    public let files: [ChatArtifactGalleryItem]
+
+    /// Visible non-folder paths in paging order.
+    public var paths: [String] { files.map(\.path) }
+
+    /// Number of visible files in the paging order.
+    public var count: Int { files.count }
+
+    /// Creates a paging order by flattening visible groups in display order.
+    ///
+    /// Directory rows are excluded, and a repeated path keeps its first visible
+    /// position.
+    ///
+    /// - Parameter groups: Filtered and sorted groups in display order.
+    public init(groups: [ChatArtifactGalleryGroup]) {
+        self.init(items: groups.flatMap(\.items))
+    }
+
+    /// Creates a paging order from one flat visible collection.
+    ///
+    /// - Parameter items: Filtered and sorted items in display order.
+    public init(items: [ChatArtifactGalleryItem]) {
+        var seenPaths: Set<String> = []
+        files = items.filter { item in
+            item.kind != .directory && seenPaths.insert(item.path).inserted
+        }
+    }
+
+    /// Creates a paging order from terminal-scan references.
+    ///
+    /// - Parameter references: Visible terminal references in display order.
+    public init(references: [TerminalArtifactReference]) {
+        self.init(items: references.map { reference in
+            ChatArtifactGalleryItem(
+                path: reference.path,
+                kind: reference.kind,
+                displayName: reference.displayName,
+                size: reference.size,
+                modifiedAt: reference.modifiedAt
+            )
+        })
+    }
+
+    /// Returns the bounded previous/current/next window around one file.
+    ///
+    /// - Parameter path: Current visible file path.
+    /// - Returns: At most three files, or an empty array for an unknown path.
+    public func pageWindow(around path: String) -> [ChatArtifactGalleryItem] {
+        guard let currentIndex = files.firstIndex(where: { $0.path == path }) else {
+            return []
+        }
+        let lowerBound = currentIndex > files.startIndex
+            ? files.index(before: currentIndex)
+            : currentIndex
+        let upperBound = files.index(
+            after: currentIndex < files.index(before: files.endIndex)
+                ? files.index(after: currentIndex)
+                : currentIndex
+        )
+        return Array(files[lowerBound..<upperBound])
+    }
+
+    /// Returns the file before a visible path.
+    ///
+    /// - Parameter path: Current visible file path.
+    /// - Returns: Previous path, or `nil` at the first file or for an unknown path.
+    public func previousPath(before path: String) -> String? {
+        guard let index = files.firstIndex(where: { $0.path == path }),
+              index > files.startIndex else { return nil }
+        return files[files.index(before: index)].path
+    }
+
+    /// Returns the file after a visible path.
+    ///
+    /// - Parameter path: Current visible file path.
+    /// - Returns: Next path, or `nil` at the last file or for an unknown path.
+    public func nextPath(after path: String) -> String? {
+        guard let index = files.firstIndex(where: { $0.path == path }) else { return nil }
+        let nextIndex = files.index(after: index)
+        guard nextIndex < files.endIndex else { return nil }
+        return files[nextIndex].path
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryClassifierTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryClassifierTests.swift
@@ -1,0 +1,35 @@
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat artifact gallery classifier")
+struct ChatArtifactGalleryClassifierTests {
+    struct Fixture: Sendable, CustomTestStringConvertible {
+        let path: String
+        let kind: ChatArtifactKind
+        let expected: ChatArtifactGalleryFilter?
+
+        var testDescription: String { "\(kind.rawValue):\(path)" }
+    }
+
+    @Test(arguments: [
+        Fixture(path: "/tmp/photo.swift", kind: .image, expected: .images),
+        Fixture(path: "/tmp/folder.png", kind: .directory, expected: .folders),
+        Fixture(path: "/tmp/App.swift", kind: .text, expected: .code),
+        Fixture(path: "/tmp/main.CPP", kind: .binary, expected: .code),
+        Fixture(path: "/tmp/run.log", kind: .text, expected: .logs),
+        Fixture(path: "/tmp/process.OUT", kind: .binary, expected: .logs),
+        Fixture(path: "/tmp/notes.txt", kind: .text, expected: .logs),
+        Fixture(path: "/tmp/README.md", kind: .text, expected: .docs),
+        Fixture(path: "/tmp/report.PDF", kind: .binary, expected: .docs),
+        Fixture(path: "/tmp/deck.pptx", kind: .binary, expected: .docs),
+        Fixture(path: "/tmp/table.numbers", kind: .binary, expected: .docs),
+        Fixture(path: "/tmp/archive.zip", kind: .binary, expected: nil),
+        Fixture(path: "/tmp/LICENSE", kind: .text, expected: nil),
+    ])
+    func classifiesKindAndExtensionMatrix(_ fixture: Fixture) {
+        let classifier = ChatArtifactGalleryClassifier()
+
+        #expect(classifier.filter(for: fixture.kind, path: fixture.path) == fixture.expected)
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryEagerPagerTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryEagerPagerTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat artifact gallery eager pager")
+struct ChatArtifactGalleryEagerPagerTests {
+    @Test("fetches cursors sequentially until exhausted")
+    func fetchesUntilExhausted() async throws {
+        let script = ChatArtifactGalleryPageScript(pages: [
+            "cursor-1": page(paths: ["/two"], nextCursor: "cursor-2"),
+            "cursor-2": page(paths: ["/three"], nextCursor: nil),
+        ])
+        let initial = snapshot(paths: ["/one"], nextCursor: "cursor-1", total: 3)
+
+        let result = try await ChatArtifactGalleryEagerPager().loadRemaining(from: initial) { cursor in
+            try await script.fetch(cursor: cursor)
+        }
+
+        #expect(result.snapshot.referenced.map { $0.path } == ["/one", "/two", "/three"])
+        #expect(result.snapshot.nextCursor == nil)
+        #expect(!result.reachedSafetyCap)
+        #expect(await script.requestedCursors() == ["cursor-1", "cursor-2"])
+    }
+
+    @Test("stops at the safety cap and retains the next cursor")
+    func respectsSafetyCap() async throws {
+        let script = ChatArtifactGalleryPageScript(pages: [
+            "cursor-1": page(paths: ["/two", "/three"], nextCursor: "cursor-2"),
+            "cursor-2": page(paths: ["/four"], nextCursor: nil),
+        ])
+        let initial = snapshot(paths: ["/one"], nextCursor: "cursor-1", total: 4)
+
+        let result = try await ChatArtifactGalleryEagerPager(
+            maximumReferencedRows: 3
+        ).loadRemaining(from: initial) { cursor in
+            try await script.fetch(cursor: cursor)
+        }
+
+        #expect(result.snapshot.referenced.map { $0.path } == ["/one", "/two", "/three"])
+        #expect(result.snapshot.nextCursor == "cursor-2")
+        #expect(result.reachedSafetyCap)
+        #expect(await script.requestedCursors() == ["cursor-1"])
+    }
+
+    @Test("caps an oversized final page even when its cursor is exhausted")
+    func capsOversizedFinalPage() async throws {
+        let script = ChatArtifactGalleryPageScript(pages: [
+            "cursor-1": page(paths: ["/two", "/three"], nextCursor: nil),
+        ])
+        let initial = snapshot(paths: ["/one"], nextCursor: "cursor-1", total: 3)
+
+        let result = try await ChatArtifactGalleryEagerPager(
+            maximumReferencedRows: 2
+        ).loadRemaining(from: initial) { cursor in
+            try await script.fetch(cursor: cursor)
+        }
+
+        #expect(result.snapshot.referenced.map { $0.path } == ["/one", "/two"])
+        #expect(result.snapshot.nextCursor == nil)
+        #expect(result.reachedSafetyCap)
+    }
+
+    private func snapshot(
+        paths: [String],
+        nextCursor: String?,
+        total: Int
+    ) -> ChatArtifactGallerySnapshot {
+        ChatArtifactGallerySnapshot(page: ChatArtifactGalleryPage(
+            sessionID: "session",
+            referenced: paths.map(item),
+            referencedTotal: total,
+            nextCursor: nextCursor,
+            generation: "generation"
+        ))
+    }
+
+    private func page(
+        paths: [String],
+        nextCursor: String?
+    ) -> ChatArtifactGalleryPage {
+        ChatArtifactGalleryPage(
+            sessionID: "session",
+            referenced: paths.map(item),
+            referencedTotal: paths.count,
+            nextCursor: nextCursor,
+            generation: "generation"
+        )
+    }
+
+    private func item(path: String) -> ChatArtifactGalleryItem {
+        ChatArtifactGalleryItem(
+            path: path,
+            kind: .text,
+            displayName: URL(fileURLWithPath: path).lastPathComponent
+        )
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryEagerPagerTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryEagerPagerTests.swift
@@ -61,6 +61,23 @@ struct ChatArtifactGalleryEagerPagerTests {
         #expect(result.reachedSafetyCap)
     }
 
+    @Test("stops before requesting a repeated cursor")
+    func stopsAtRepeatedCursor() async throws {
+        let script = ChatArtifactGalleryPageScript(pages: [
+            "cursor-1": page(paths: ["/two"], nextCursor: "cursor-1"),
+        ])
+        let initial = snapshot(paths: ["/one"], nextCursor: "cursor-1", total: 3)
+
+        let result = try await ChatArtifactGalleryEagerPager().loadRemaining(from: initial) { cursor in
+            try await script.fetch(cursor: cursor)
+        }
+
+        #expect(result.snapshot.referenced.map(\.path) == ["/one", "/two"])
+        #expect(result.snapshot.nextCursor == "cursor-1")
+        #expect(!result.reachedSafetyCap)
+        #expect(await script.requestedCursors() == ["cursor-1"])
+    }
+
     private func snapshot(
         paths: [String],
         nextCursor: String?,

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPageScript.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPageScript.swift
@@ -1,0 +1,32 @@
+@testable import CmuxAgentChat
+
+/// Actor-backed page script that records sequential eager-paging requests.
+actor ChatArtifactGalleryPageScript {
+    private let pages: [String: ChatArtifactGalleryPage]
+    private var cursors: [String] = []
+
+    /// Creates a page script keyed by opaque cursor.
+    ///
+    /// - Parameter pages: Pages returned for each expected cursor.
+    init(pages: [String: ChatArtifactGalleryPage]) {
+        self.pages = pages
+    }
+
+    /// Records and resolves one cursor request.
+    ///
+    /// - Parameter cursor: Requested opaque cursor.
+    /// - Returns: Scripted page for the cursor.
+    /// - Throws: ``ChatArtifactError/invalidParams`` for an unscripted cursor.
+    func fetch(cursor: String) throws -> ChatArtifactGalleryPage {
+        cursors.append(cursor)
+        guard let page = pages[cursor] else {
+            throw ChatArtifactError.invalidParams
+        }
+        return page
+    }
+
+    /// Returns cursors in request order.
+    func requestedCursors() -> [String] {
+        cursors
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPresentationTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPresentationTests.swift
@@ -1,0 +1,79 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat artifact gallery presentation")
+struct ChatArtifactGalleryPresentationTests {
+    @Test("filtering preserves group order and hides rows within every group")
+    func filterPreservesGroups() {
+        let snapshot = gallerySnapshot(
+            created: [item("/created/App.swift", kind: .text, size: 10)],
+            attached: [item("/attached/photo.png", kind: .image, size: 20)],
+            referenced: [
+                item("/referenced/notes.txt", kind: .text, size: 30),
+                item("/referenced/Tool.swift", kind: .text, size: 40),
+            ]
+        )
+
+        let presentation = ChatArtifactGalleryPresentation(
+            snapshot: snapshot,
+            filter: .code
+        )
+
+        #expect(presentation.groups.map(\.kind) == [.created, .attached, .referenced])
+        #expect(presentation.items(in: .created).map(\.displayName) == ["App.swift"])
+        #expect(presentation.items(in: .attached).isEmpty)
+        #expect(presentation.items(in: .referenced).map(\.displayName) == ["Tool.swift"])
+    }
+
+    @Test("name and size sorts reorder only within each group")
+    func sortWithinGroups() {
+        let created = [
+            item("/created/zeta.txt", kind: .text, size: nil),
+            item("/created/Alpha.txt", kind: .text, size: 1),
+            item("/created/middle.txt", kind: .text, size: 30),
+        ]
+        let referenced = [
+            item("/referenced/b.txt", kind: .text, size: 5),
+            item("/referenced/a.txt", kind: .text, size: 10),
+        ]
+        let snapshot = gallerySnapshot(created: created, referenced: referenced)
+
+        let named = ChatArtifactGalleryPresentation(snapshot: snapshot, sort: .name)
+        #expect(named.items(in: .created).map(\.displayName) == ["Alpha.txt", "middle.txt", "zeta.txt"])
+        #expect(named.items(in: .referenced).map(\.displayName) == ["a.txt", "b.txt"])
+
+        let sized = ChatArtifactGalleryPresentation(snapshot: snapshot, sort: .size)
+        #expect(sized.items(in: .created).map(\.displayName) == ["middle.txt", "Alpha.txt", "zeta.txt"])
+        #expect(sized.items(in: .referenced).map(\.displayName) == ["a.txt", "b.txt"])
+    }
+
+    private func gallerySnapshot(
+        created: [ChatArtifactGalleryItem] = [],
+        attached: [ChatArtifactGalleryItem] = [],
+        referenced: [ChatArtifactGalleryItem] = []
+    ) -> ChatArtifactGallerySnapshot {
+        ChatArtifactGallerySnapshot(page: ChatArtifactGalleryPage(
+            sessionID: "session",
+            created: created,
+            attached: attached,
+            referenced: referenced,
+            referencedTotal: referenced.count,
+            generation: "generation"
+        ))
+    }
+
+    private func item(
+        _ path: String,
+        kind: ChatArtifactKind,
+        size: Int64?
+    ) -> ChatArtifactGalleryItem {
+        ChatArtifactGalleryItem(
+            path: path,
+            kind: kind,
+            displayName: URL(fileURLWithPath: path).lastPathComponent,
+            size: size
+        )
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGallerySwipeOrderTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGallerySwipeOrderTests.swift
@@ -1,0 +1,74 @@
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat artifact gallery swipe order")
+struct ChatArtifactGallerySwipeOrderTests {
+    @Test("flattens visible groups and skips folders")
+    func flattensVisibleFiles() {
+        let first = item("/created/first.swift")
+        let folder = item("/attached/folder", kind: .directory)
+        let second = item("/attached/second.png", kind: .image)
+        let third = item("/referenced/third.log")
+        let order = ChatArtifactGallerySwipeOrder(groups: [
+            ChatArtifactGalleryGroup(kind: .created, items: [first]),
+            ChatArtifactGalleryGroup(kind: .attached, items: [folder, second]),
+            ChatArtifactGalleryGroup(kind: .referenced, items: [third, first]),
+        ])
+
+        #expect(order.paths == [first.path, second.path, third.path])
+    }
+
+    @Test("next and previous stop at visible boundaries")
+    func nextPreviousBoundaries() {
+        let first = item("/first")
+        let middle = item("/middle")
+        let last = item("/last")
+        let order = ChatArtifactGallerySwipeOrder(items: [first, middle, last])
+
+        #expect(order.previousPath(before: first.path) == nil)
+        #expect(order.nextPath(after: first.path) == middle.path)
+        #expect(order.previousPath(before: middle.path) == first.path)
+        #expect(order.nextPath(after: middle.path) == last.path)
+        #expect(order.previousPath(before: last.path) == middle.path)
+        #expect(order.nextPath(after: last.path) == nil)
+        #expect(order.nextPath(after: "/unknown") == nil)
+        #expect(order.previousPath(before: "/unknown") == nil)
+    }
+
+    @Test("keeps only adjacent pages alive around the current file")
+    func boundsPageWindow() {
+        let first = item("/first")
+        let second = item("/second")
+        let third = item("/third")
+        let fourth = item("/fourth")
+        let order = ChatArtifactGallerySwipeOrder(items: [first, second, third, fourth])
+
+        #expect(order.pageWindow(around: first.path).map(\.path) == [first.path, second.path])
+        #expect(order.pageWindow(around: second.path).map(\.path) == [first.path, second.path, third.path])
+        #expect(order.pageWindow(around: fourth.path).map(\.path) == [third.path, fourth.path])
+        #expect(order.pageWindow(around: "/unknown").isEmpty)
+    }
+
+    @Test("terminal references preserve order while excluding folders")
+    func buildsFromTerminalReferences() {
+        let references = [
+            TerminalArtifactReference(path: "/first", kind: .text, displayName: "first"),
+            TerminalArtifactReference(path: "/folder", kind: .directory, displayName: "folder"),
+            TerminalArtifactReference(path: "/last", kind: .image, displayName: "last"),
+        ]
+
+        #expect(ChatArtifactGallerySwipeOrder(references: references).paths == ["/first", "/last"])
+    }
+
+    private func item(
+        _ path: String,
+        kind: ChatArtifactKind = .text
+    ) -> ChatArtifactGalleryItem {
+        ChatArtifactGalleryItem(
+            path: path,
+            kind: kind,
+            displayName: path
+        )
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
@@ -1,0 +1,55 @@
+import CmuxAgentChat
+import SwiftUI
+
+/// Keeps only the selected artifact and its adjacent viewer pages mounted.
+struct ChatArtifactViewerPager: View {
+    let initialPath: String
+    let scope: ChatArtifactViewerScope
+    let swipeOrder: ChatArtifactGallerySwipeOrder
+    let onDone: () -> Void
+
+    @State private var selectedPath: String
+
+    init(
+        initialPath: String,
+        scope: ChatArtifactViewerScope,
+        swipeOrder: ChatArtifactGallerySwipeOrder,
+        onDone: @escaping () -> Void
+    ) {
+        self.initialPath = initialPath
+        self.scope = scope
+        self.swipeOrder = swipeOrder
+        self.onDone = onDone
+        _selectedPath = State(initialValue: initialPath)
+    }
+
+    @ViewBuilder
+    var body: some View {
+        #if os(iOS)
+        if swipeOrder.count > 1,
+           swipeOrder.files.contains(where: { $0.path == initialPath }) {
+            TabView(selection: $selectedPath) {
+                ForEach(swipeOrder.pageWindow(around: selectedPath)) { file in
+                    viewer(path: file.path)
+                        .tag(file.path)
+                }
+            }
+            .tabViewStyle(.page(indexDisplayMode: .never))
+        } else {
+            viewer(path: initialPath)
+        }
+        #else
+        viewer(path: initialPath)
+        #endif
+    }
+
+    private func viewer(path: String) -> some View {
+        NavigationStack {
+            ChatArtifactViewerRouteView(
+                path: path,
+                scope: scope,
+                onDone: onDone
+            )
+        }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -205,10 +205,16 @@ struct ChatArtifactViewerRouteView: View {
                 #else
                 await model.load(path: path, loader: loader)
                 #endif
+                await waitForViewerTaskCancellation()
+                await model.cleanup()
             }
-            .onDisappear {
-                Task { await model.cleanup() }
-            }
+    }
+
+    /// Keeps cleanup structured under the SwiftUI page task after loading ends.
+    private func waitForViewerTaskCancellation() async {
+        let (stream, continuation) = AsyncStream<Void>.makeStream()
+        defer { continuation.finish() }
+        for await _ in stream {}
     }
 
     @ViewBuilder

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerSheet.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerSheet.swift
@@ -1,23 +1,36 @@
+import CmuxAgentChat
 import SwiftUI
 
 /// A navigation container for one Mac-hosted artifact path.
 public struct ChatArtifactViewerSheet: View {
     let path: String
     let scope: ChatArtifactViewerScope
+    let swipeOrder: ChatArtifactGallerySwipeOrder
     @Environment(\.dismiss) private var dismiss
 
     /// Creates an artifact viewer that routes files and folders through the
     /// same stat-driven navigation path.
-    public init(path: String, scope: ChatArtifactViewerScope = .chat) {
+    /// - Parameters:
+    ///   - path: Initially selected artifact path.
+    ///   - scope: Authorization and navigation context for the artifact.
+    ///   - swipeOrder: Visible gallery-file order available for horizontal paging.
+    public init(
+        path: String,
+        scope: ChatArtifactViewerScope = .chat,
+        swipeOrder: ChatArtifactGallerySwipeOrder = ChatArtifactGallerySwipeOrder(items: [])
+    ) {
         self.path = path
         self.scope = scope
+        self.swipeOrder = swipeOrder
     }
 
     public var body: some View {
-        NavigationStack {
-            ChatArtifactViewerRouteView(path: path, scope: scope) {
-                dismiss()
-            }
+        ChatArtifactViewerPager(
+            initialPath: path,
+            scope: scope,
+            swipeOrder: swipeOrder
+        ) {
+            dismiss()
         }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -138,6 +138,48 @@
         }
       }
     },
+    "terminal.artifact.gallery.filter.all" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "All" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "すべて" } }
+      }
+    },
+    "terminal.artifact.gallery.filter.code" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Code" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "コード" } }
+      }
+    },
+    "terminal.artifact.gallery.filter.docs" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Docs" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "書類" } }
+      }
+    },
+    "terminal.artifact.gallery.filter.folders" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Folders" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "フォルダ" } }
+      }
+    },
+    "terminal.artifact.gallery.filter.images" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Images" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "画像" } }
+      }
+    },
+    "terminal.artifact.gallery.filter.logs" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Logs" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ログ" } }
+      }
+    },
     "terminal.artifact.gallery.kind.binary" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -240,6 +282,13 @@
         }
       }
     },
+    "terminal.artifact.gallery.loading_all" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Loading all files…" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "すべてのファイルを読み込み中…" } }
+      }
+    },
     "terminal.artifact.gallery.missing" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -331,6 +380,41 @@
             "value" : "このセッションにはファイルがありません"
           }
         }
+      }
+    },
+    "terminal.artifact.gallery.showing_first" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Showing first %lld files" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "最初の%lld件のファイルを表示" } }
+      }
+    },
+    "terminal.artifact.gallery.sort" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Sort" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "並べ替え" } }
+      }
+    },
+    "terminal.artifact.gallery.sort.name" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Name" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "名前" } }
+      }
+    },
+    "terminal.artifact.gallery.sort.recent" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Recent" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "最近" } }
+      }
+    },
+    "terminal.artifact.gallery.sort.size" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Size" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "サイズ" } }
       }
     },
     "terminal.artifact.gallery.search" : {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -137,10 +137,26 @@ extension TerminalArtifactFilesSheet {
     @ViewBuilder
     private var sessionContent: some View {
         let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
-        if query.isEmpty {
-            sessionSectionedContent(state: sessionState)
-        } else {
-            sessionSearchContent(state: searchState, query: query)
+        VStack(spacing: 0) {
+            galleryControls
+            if eagerPagingState == .loading {
+                ProgressView()
+                    .progressViewStyle(.linear)
+                    .accessibilityLabel(String(
+                        localized: "terminal.artifact.gallery.loading_all",
+                        defaultValue: "Loading all files…",
+                        bundle: .module
+                    ))
+            }
+            Divider()
+            if query.isEmpty {
+                sessionSectionedContent(state: sessionState)
+            } else {
+                sessionSearchContent(state: searchState, query: query)
+            }
+        }
+        .task(id: eagerPagingTaskID) {
+            await loadRemainingSessionPages(query: query.isEmpty ? nil : query)
         }
     }
 
@@ -168,6 +184,14 @@ extension TerminalArtifactFilesSheet {
                     await loadFirstSessionPage(query: nil, preservingContent: true)
                 }
             } else {
+                let presentation = ChatArtifactGalleryPresentation(
+                    snapshot: snapshot,
+                    filter: galleryFilter,
+                    sort: gallerySort
+                )
+                let created = presentation.items(in: .created)
+                let attached = presentation.items(in: .attached)
+                let referenced = presentation.items(in: .referenced)
                 ScrollView {
                     VStack(spacing: 0) {
                         artifactSection(
@@ -176,8 +200,8 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "Created by agent",
                                 bundle: .module
                             ),
-                            count: snapshot.created.count,
-                            items: snapshot.created,
+                            count: created.count,
+                            items: created,
                             expanded: $createdExpanded
                         )
                         artifactSection(
@@ -186,8 +210,8 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "You attached",
                                 bundle: .module
                             ),
-                            count: snapshot.attached.count,
-                            items: snapshot.attached,
+                            count: attached.count,
+                            items: attached,
                             expanded: $attachedExpanded
                         )
                         artifactSection(
@@ -196,10 +220,13 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "Referenced",
                                 bundle: .module
                             ),
-                            count: snapshot.referencedTotal,
-                            items: snapshot.referenced,
+                            count: usesCompleteSessionSnapshot
+                                ? referenced.count
+                                : snapshot.referencedTotal,
+                            items: referenced,
                             expanded: $referencedExpanded,
-                            pagingCursor: snapshot.nextCursor
+                            pagingCursor: usesCompleteSessionSnapshot ? nil : snapshot.nextCursor,
+                            showsEagerFooter: usesCompleteSessionSnapshot
                         )
                     }
                 }
@@ -218,13 +245,19 @@ extension TerminalArtifactFilesSheet {
         case .failed:
             failureView { await loadFirstSessionPage(query: query) }
         case .loaded(let snapshot):
-            if snapshot.referenced.isEmpty {
+            let presentation = ChatArtifactGalleryPresentation(
+                snapshot: snapshot,
+                filter: galleryFilter,
+                sort: gallerySort
+            )
+            let items = presentation.items(in: .referenced)
+            if items.isEmpty {
                 ContentUnavailableView.search(text: query)
             } else {
                 ScrollView {
                     if viewMode == .list {
                         LazyVStack(spacing: 0) {
-                            ForEach(snapshot.referenced) { item in
+                            ForEach(items) { item in
                                 TerminalArtifactGalleryItemView(
                                     artifact: TerminalArtifactGalleryDisplayItem(
                                         galleryItem: item,
@@ -236,14 +269,17 @@ extension TerminalArtifactFilesSheet {
                                 )
                                 Divider().padding(.leading, 72)
                             }
-                            if let cursor = snapshot.nextCursor {
+                            if !usesCompleteSessionSnapshot,
+                               let cursor = snapshot.nextCursor {
                                 pagingFooter(cursor: cursor, query: query)
+                            } else if usesCompleteSessionSnapshot {
+                                eagerPagingFooter
                             }
                         }
                     } else {
                         LazyVGrid(columns: gridColumns, spacing: 16) {
                             Section {
-                                ForEach(snapshot.referenced) { item in
+                                ForEach(items) { item in
                                     TerminalArtifactGalleryItemView(
                                         artifact: TerminalArtifactGalleryDisplayItem(
                                             galleryItem: item,
@@ -255,8 +291,11 @@ extension TerminalArtifactFilesSheet {
                                     )
                                 }
                             } footer: {
-                                if let cursor = snapshot.nextCursor {
+                                if !usesCompleteSessionSnapshot,
+                                   let cursor = snapshot.nextCursor {
                                     pagingFooter(cursor: cursor, query: query)
+                                } else if usesCompleteSessionSnapshot {
+                                    eagerPagingFooter
                                 }
                             }
                         }
@@ -275,7 +314,8 @@ extension TerminalArtifactFilesSheet {
         count: Int,
         items: [ChatArtifactGalleryItem],
         expanded: Binding<Bool>,
-        pagingCursor: String? = nil
+        pagingCursor: String? = nil,
+        showsEagerFooter: Bool = false
     ) -> some View {
         DisclosureGroup(isExpanded: expanded) {
             if viewMode == .list {
@@ -291,6 +331,8 @@ extension TerminalArtifactFilesSheet {
                     }
                     if let pagingCursor {
                         pagingFooter(cursor: pagingCursor, query: nil)
+                    } else if showsEagerFooter {
+                        eagerPagingFooter
                     }
                 }
             } else {
@@ -307,6 +349,8 @@ extension TerminalArtifactFilesSheet {
                     } footer: {
                         if let pagingCursor {
                             pagingFooter(cursor: pagingCursor, query: nil)
+                        } else if showsEagerFooter {
+                            eagerPagingFooter
                         }
                     }
                 }
@@ -371,6 +415,43 @@ extension TerminalArtifactFilesSheet {
         }
     }
 
+    @ViewBuilder
+    private var eagerPagingFooter: some View {
+        switch eagerPagingState {
+        case .idle, .loading:
+            EmptyView()
+        case .capped:
+            let format = String(
+                localized: "terminal.artifact.gallery.showing_first",
+                defaultValue: "Showing first %lld files",
+                bundle: .module
+            )
+            Text(String.localizedStringWithFormat(
+                format,
+                Int64(ChatArtifactGalleryEagerPager.defaultMaximumReferencedRows)
+            ))
+            .font(.footnote)
+            .foregroundStyle(.secondary)
+            .frame(maxWidth: .infinity)
+            .padding()
+        case .failed:
+            Button {
+                eagerPagingRetryGeneration += 1
+            } label: {
+                Label(
+                    String(
+                        localized: "terminal.artifact.gallery.retry",
+                        defaultValue: "Retry",
+                        bundle: .module
+                    ),
+                    systemImage: "arrow.clockwise"
+                )
+            }
+            .frame(maxWidth: .infinity)
+            .padding()
+        }
+    }
+
     private var loadingView: some View {
         ProgressView(String(
             localized: "terminal.artifact.gallery.loading",
@@ -415,6 +496,82 @@ extension TerminalArtifactFilesSheet {
 
     private var gridColumns: [GridItem] {
         [GridItem(.adaptive(minimum: 96), spacing: 12)]
+    }
+
+    private var galleryControls: some View {
+        HStack(spacing: 12) {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 8) {
+                    ForEach(ChatArtifactGalleryFilter.allCases, id: \.self) { filter in
+                        Button {
+                            galleryFilter = filter
+                        } label: {
+                            Text(filterTitle(filter))
+                                .font(.subheadline.weight(.medium))
+                                .foregroundStyle(galleryFilter == filter ? Color.white : Color.primary)
+                                .padding(.horizontal, 12)
+                                .padding(.vertical, 7)
+                                .background(
+                                    galleryFilter == filter
+                                        ? Color.accentColor
+                                        : Color(uiColor: .secondarySystemBackground),
+                                    in: Capsule()
+                                )
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityAddTraits(galleryFilter == filter ? .isSelected : [])
+                    }
+                }
+            }
+
+            Menu {
+                Picker(
+                    String(
+                        localized: "terminal.artifact.gallery.sort",
+                        defaultValue: "Sort",
+                        bundle: .module
+                    ),
+                    selection: $gallerySort
+                ) {
+                    ForEach(ChatArtifactGallerySort.allCases, id: \.self) { sort in
+                        Text(sortTitle(sort)).tag(sort)
+                    }
+                }
+            } label: {
+                Label(sortTitle(gallerySort), systemImage: "arrow.up.arrow.down")
+                    .font(.subheadline.weight(.medium))
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
+    }
+
+    private func filterTitle(_ filter: ChatArtifactGalleryFilter) -> String {
+        switch filter {
+        case .all:
+            String(localized: "terminal.artifact.gallery.filter.all", defaultValue: "All", bundle: .module)
+        case .images:
+            String(localized: "terminal.artifact.gallery.filter.images", defaultValue: "Images", bundle: .module)
+        case .code:
+            String(localized: "terminal.artifact.gallery.filter.code", defaultValue: "Code", bundle: .module)
+        case .logs:
+            String(localized: "terminal.artifact.gallery.filter.logs", defaultValue: "Logs", bundle: .module)
+        case .docs:
+            String(localized: "terminal.artifact.gallery.filter.docs", defaultValue: "Docs", bundle: .module)
+        case .folders:
+            String(localized: "terminal.artifact.gallery.filter.folders", defaultValue: "Folders", bundle: .module)
+        }
+    }
+
+    private func sortTitle(_ sort: ChatArtifactGallerySort) -> String {
+        switch sort {
+        case .recent:
+            String(localized: "terminal.artifact.gallery.sort.recent", defaultValue: "Recent", bundle: .module)
+        case .name:
+            String(localized: "terminal.artifact.gallery.sort.name", defaultValue: "Name", bundle: .module)
+        case .size:
+            String(localized: "terminal.artifact.gallery.sort.size", defaultValue: "Size", bundle: .module)
+        }
     }
 
     private func searchSubtitle(for item: ChatArtifactGalleryItem) -> String {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -31,46 +31,22 @@ extension TerminalArtifactFilesSheet {
         .padding(.vertical, 10)
     }
 
-    // Keep the existing single toolbar menu so the content picker never creates
-    // a second glass-backed segmented control in the navigation bar.
     var viewModePicker: some View {
-        Menu {
-            Picker(
-                String(
-                    localized: "terminal.artifact.gallery.view_mode",
-                    defaultValue: "View",
-                    bundle: .module
-                ),
-                selection: $viewMode
-            ) {
-                Label(
-                    String(
-                        localized: "terminal.artifact.gallery.view_mode.list",
-                        defaultValue: "List",
-                        bundle: .module
-                    ),
-                    systemImage: "list.bullet"
-                )
-                .tag(ViewMode.list)
-
-                Label(
-                    String(
+        Button {
+            viewMode = viewMode == .list ? .grid : .list
+        } label: {
+            Image(systemName: viewMode == .list ? "square.grid.3x3" : "list.bullet")
+                .accessibilityLabel(viewMode == .list
+                    ? String(
                         localized: "terminal.artifact.gallery.view_mode.grid",
                         defaultValue: "Icons",
                         bundle: .module
-                    ),
-                    systemImage: "square.grid.2x2"
-                )
-                .tag(ViewMode.grid)
-            }
-            .pickerStyle(.inline)
-        } label: {
-            Image(systemName: viewMode == .list ? "list.bullet" : "square.grid.2x2")
-                .accessibilityLabel(String(
-                    localized: "terminal.artifact.gallery.view_mode",
-                    defaultValue: "View",
-                    bundle: .module
-                ))
+                    )
+                    : String(
+                        localized: "terminal.artifact.gallery.view_mode.list",
+                        defaultValue: "List",
+                        bundle: .module
+                    ))
         }
     }
 
@@ -495,7 +471,10 @@ extension TerminalArtifactFilesSheet {
     }
 
     private var gridColumns: [GridItem] {
-        [GridItem(.adaptive(minimum: 96), spacing: 12)]
+        Array(
+            repeating: GridItem(.flexible(minimum: 0), spacing: 12, alignment: .top),
+            count: 3
+        )
     }
 
     private var galleryControls: some View {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -98,10 +98,12 @@ extension TerminalArtifactFilesSheet {
                     systemImage: "tray"
                 )
             } else {
+                let swipeOrder = ChatArtifactGallerySwipeOrder(references: artifacts)
                 artifactCollection(
                     artifacts.map(TerminalArtifactGalleryDisplayItem.init(reference:)),
                     loader: loader,
-                    scope: .inView
+                    scope: .inView,
+                    swipeOrder: swipeOrder
                 )
                 .refreshable { await refreshInView() }
             }
@@ -168,6 +170,7 @@ extension TerminalArtifactFilesSheet {
                 let created = presentation.items(in: .created)
                 let attached = presentation.items(in: .attached)
                 let referenced = presentation.items(in: .referenced)
+                let swipeOrder = ChatArtifactGallerySwipeOrder(groups: presentation.groups)
                 ScrollView {
                     VStack(spacing: 0) {
                         artifactSection(
@@ -178,7 +181,8 @@ extension TerminalArtifactFilesSheet {
                             ),
                             count: created.count,
                             items: created,
-                            expanded: $createdExpanded
+                            expanded: $createdExpanded,
+                            swipeOrder: swipeOrder
                         )
                         artifactSection(
                             title: String(
@@ -188,7 +192,8 @@ extension TerminalArtifactFilesSheet {
                             ),
                             count: attached.count,
                             items: attached,
-                            expanded: $attachedExpanded
+                            expanded: $attachedExpanded,
+                            swipeOrder: swipeOrder
                         )
                         artifactSection(
                             title: String(
@@ -201,6 +206,7 @@ extension TerminalArtifactFilesSheet {
                                 : snapshot.referencedTotal,
                             items: referenced,
                             expanded: $referencedExpanded,
+                            swipeOrder: swipeOrder,
                             pagingCursor: usesCompleteSessionSnapshot ? nil : snapshot.nextCursor,
                             showsEagerFooter: usesCompleteSessionSnapshot
                         )
@@ -227,6 +233,7 @@ extension TerminalArtifactFilesSheet {
                 sort: gallerySort
             )
             let items = presentation.items(in: .referenced)
+            let swipeOrder = ChatArtifactGallerySwipeOrder(items: items)
             if items.isEmpty {
                 ContentUnavailableView.search(text: query)
             } else {
@@ -241,7 +248,9 @@ extension TerminalArtifactFilesSheet {
                                     ),
                                     layout: .list,
                                     loader: sessionLoader,
-                                    open: { open(item.path, scope: .session) }
+                                    open: {
+                                        open(item.path, scope: .session, swipeOrder: swipeOrder)
+                                    }
                                 )
                                 Divider().padding(.leading, 72)
                             }
@@ -263,7 +272,9 @@ extension TerminalArtifactFilesSheet {
                                         ),
                                         layout: .grid,
                                         loader: sessionLoader,
-                                        open: { open(item.path, scope: .session) }
+                                        open: {
+                                            open(item.path, scope: .session, swipeOrder: swipeOrder)
+                                        }
                                     )
                                 }
                             } footer: {
@@ -290,6 +301,7 @@ extension TerminalArtifactFilesSheet {
         count: Int,
         items: [ChatArtifactGalleryItem],
         expanded: Binding<Bool>,
+        swipeOrder: ChatArtifactGallerySwipeOrder,
         pagingCursor: String? = nil,
         showsEagerFooter: Bool = false
     ) -> some View {
@@ -301,7 +313,9 @@ extension TerminalArtifactFilesSheet {
                             artifact: TerminalArtifactGalleryDisplayItem(galleryItem: item),
                             layout: .list,
                             loader: sessionLoader,
-                            open: { open(item.path, scope: .session) }
+                            open: {
+                                open(item.path, scope: .session, swipeOrder: swipeOrder)
+                            }
                         )
                         Divider().padding(.leading, 72)
                     }
@@ -319,7 +333,9 @@ extension TerminalArtifactFilesSheet {
                                 artifact: TerminalArtifactGalleryDisplayItem(galleryItem: item),
                                 layout: .grid,
                                 loader: sessionLoader,
-                                open: { open(item.path, scope: .session) }
+                                open: {
+                                    open(item.path, scope: .session, swipeOrder: swipeOrder)
+                                }
                             )
                         }
                     } footer: {
@@ -344,7 +360,8 @@ extension TerminalArtifactFilesSheet {
     private func artifactCollection(
         _ artifacts: [TerminalArtifactGalleryDisplayItem],
         loader: ChatArtifactLoader,
-        scope: Scope
+        scope: Scope,
+        swipeOrder: ChatArtifactGallerySwipeOrder
     ) -> some View {
         switch viewMode {
         case .list:
@@ -355,7 +372,9 @@ extension TerminalArtifactFilesSheet {
                             artifact: artifact,
                             layout: .list,
                             loader: loader,
-                            open: { open(artifact.path, scope: scope) }
+                            open: {
+                                open(artifact.path, scope: scope, swipeOrder: swipeOrder)
+                            }
                         )
                         Divider().padding(.leading, 72)
                     }
@@ -369,7 +388,9 @@ extension TerminalArtifactFilesSheet {
                             artifact: artifact,
                             layout: .grid,
                             loader: loader,
-                            open: { open(artifact.path, scope: scope) }
+                            open: {
+                                open(artifact.path, scope: scope, swipeOrder: swipeOrder)
+                            }
                         )
                     }
                 }
@@ -579,8 +600,16 @@ extension TerminalArtifactFilesSheet {
         return "\(provenance) · \(modifiedAt.formatted(date: .abbreviated, time: .omitted))"
     }
 
-    private func open(_ path: String, scope: Scope) {
-        selection = TerminalArtifactPathSelection(path: path, scope: scope)
+    private func open(
+        _ path: String,
+        scope: Scope,
+        swipeOrder: ChatArtifactGallerySwipeOrder
+    ) {
+        selection = TerminalArtifactPathSelection(
+            path: path,
+            scope: scope,
+            swipeOrder: swipeOrder
+        )
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -83,7 +83,8 @@ struct TerminalArtifactFilesSheet: View {
         .sheet(item: $selection) { selection in
             ChatArtifactViewerSheet(
                 path: selection.path,
-                scope: selection.scope == .session ? .chat : .terminal
+                scope: selection.scope == .session ? .chat : .terminal,
+                swipeOrder: selection.swipeOrder
             )
             .environment(
                 \.chatArtifactLoader,
@@ -377,6 +378,7 @@ struct TerminalArtifactFilesSheet: View {
     struct TerminalArtifactPathSelection: Identifiable {
         let path: String
         let scope: Scope
+        let swipeOrder: ChatArtifactGallerySwipeOrder
         var id: String { "\(scope)#\(path)" }
     }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -280,7 +280,16 @@ struct TerminalArtifactFilesSheet: View {
             startThumbnailPrefetch(
                 result.snapshot.referenced.filter { !previousPaths.contains($0.path) }
             )
-            eagerPagingState = result.reachedSafetyCap ? .capped : .idle
+            if result.reachedSafetyCap {
+                eagerPagingState = .capped
+            } else if result.snapshot.nextCursor != nil {
+                // A defensive cursor-loop stop is incomplete, so surface the
+                // existing retry affordance instead of presenting partial
+                // transformed results as complete.
+                eagerPagingState = .failed
+            } else {
+                eagerPagingState = .idle
+            }
         } catch is CancellationError {
             return
         } catch {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -33,6 +33,11 @@ struct TerminalArtifactFilesSheet: View {
     @State var sessionLoader = ChatArtifactLoader.unsupported()
     @State var scope: Scope = .session
     @State var viewMode: ViewMode = .list
+    @State var galleryFilter: ChatArtifactGalleryFilter = .all
+    @State var gallerySort: ChatArtifactGallerySort = .recent
+    @State var eagerPagingState: EagerPagingState = .idle
+    @State var eagerPagingRetryGeneration = 0
+    @State var eagerPagingRevision = 0
     @State var searchQuery = ""
     @State var selection: TerminalArtifactPathSelection?
     @State var createdExpanded = true
@@ -179,6 +184,7 @@ struct TerminalArtifactFilesSheet: View {
             } else {
                 sessionState = .loaded(snapshot)
             }
+            eagerPagingRevision += 1
             startThumbnailPrefetch(page.referenced)
         } catch is CancellationError {
             return
@@ -223,6 +229,66 @@ struct TerminalArtifactFilesSheet: View {
         }
     }
 
+    func loadRemainingSessionPages(query: String?) async {
+        guard let source, let sessionID, usesCompleteSessionSnapshot else {
+            eagerPagingState = .idle
+            return
+        }
+        let initialState = query == nil ? sessionState : searchState
+        guard case .loaded(let initialSnapshot) = initialState else {
+            eagerPagingState = .idle
+            return
+        }
+        guard initialSnapshot.nextCursor != nil else {
+            eagerPagingState = initialSnapshot.referenced.count
+                < initialSnapshot.referencedTotal ? .capped : .idle
+            return
+        }
+
+        let expectedFilter = galleryFilter
+        let expectedSort = gallerySort
+        let expectedQuery = query
+        eagerPagingState = .loading
+        do {
+            let result = try await ChatArtifactGalleryEagerPager().loadRemaining(
+                from: initialSnapshot
+            ) { cursor in
+                try await source.chatArtifactGallery(
+                    sessionID: sessionID,
+                    cursor: cursor,
+                    pageSize: Self.pageSize,
+                    query: expectedQuery
+                )
+            }
+            let currentQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+            let queryIsCurrent = expectedQuery.map { $0 == currentQuery }
+                ?? currentQuery.isEmpty
+            guard !Task.isCancelled,
+                  galleryFilter == expectedFilter,
+                  gallerySort == expectedSort,
+                  queryIsCurrent else { return }
+            let currentState = query == nil ? sessionState : searchState
+            guard case .loaded(let currentSnapshot) = currentState,
+                  currentSnapshot.generation == initialSnapshot.generation,
+                  currentSnapshot.nextCursor == initialSnapshot.nextCursor else { return }
+            if query == nil {
+                sessionState = .loaded(result.snapshot)
+            } else {
+                searchState = .loaded(result.snapshot)
+            }
+            let previousPaths = Set(initialSnapshot.referenced.map(\.path))
+            startThumbnailPrefetch(
+                result.snapshot.referenced.filter { !previousPaths.contains($0.path) }
+            )
+            eagerPagingState = result.reachedSafetyCap ? .capped : .idle
+        } catch is CancellationError {
+            return
+        } catch {
+            guard !Task.isCancelled else { return }
+            eagerPagingState = .failed
+        }
+    }
+
     private func startThumbnailPrefetch(_ items: [ChatArtifactGalleryItem]) {
         let loader = sessionLoader
         let task = Task(priority: .low) {
@@ -243,6 +309,29 @@ struct TerminalArtifactFilesSheet: View {
     }
 
     static let pageSize = 60
+
+    var usesCompleteSessionSnapshot: Bool {
+        galleryFilter != .all || gallerySort != .recent
+    }
+
+    var eagerPagingTaskID: String {
+        let query = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        let state = query.isEmpty ? sessionState : searchState
+        let cursor: String
+        if case .loaded(let snapshot) = state {
+            cursor = "\(snapshot.generation)#\(snapshot.nextCursor ?? "exhausted")"
+        } else {
+            cursor = "unloaded"
+        }
+        return [
+            galleryFilter.rawValue,
+            gallerySort.rawValue,
+            query,
+            cursor,
+            String(eagerPagingRevision),
+            String(eagerPagingRetryGeneration),
+        ].joined(separator: "#")
+    }
 
     enum InViewLoadState: Equatable {
         case loading
@@ -267,6 +356,13 @@ struct TerminalArtifactFilesSheet: View {
     enum ViewMode: Hashable {
         case list
         case grid
+    }
+
+    enum EagerPagingState: Equatable {
+        case idle
+        case loading
+        case capped
+        case failed
     }
 
     struct TerminalArtifactPathSelection: Identifiable {


### PR DESCRIPTION
The chip gallery's only organization was the Created/Attached/Referenced grouping sorted by last mention; image-heavy sessions rendered as a long list and moving between files meant closing and reopening the viewer.

The grouping stays exactly as it was; new sheet-wide controls layer over it: filter chips (All, Images, Code, Logs, Docs, Folders) and a sort menu (Recent, Name, Size) apply across every group at once, backed by a unit-tested classifier. Because referenced rows page from the server, activating a non-default filter or sort eagerly fetches the remaining pages (2000-row safety cap with a "showing first 2000" footer; an incomplete fetch surfaces the retry affordance rather than posing as complete). A list/grid toggle renders three-column thumbnail tiles using the existing cached thumbnails. The viewer gains horizontal swipe paging over the currently visible filtered-and-sorted order (folders skipped), keeping only previous/current/next pages alive with structured per-page cancellation. Rows below ForEach boundaries keep receiving immutable snapshots per the repo's lazy-list rules.

Tests: CmuxAgentChat 314 (classifier matrix, filter/sort over grouped snapshots, eager paging + cap, swipe order), CmuxAgentChatUI 72; iOS simulator-triple builds pass for all touched packages; 12 new strings localized EN+JA.

Part 6a of the chip-files-gallery completion stack, based on https://github.com/manaflow-ai/cmux/pull/8103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8105"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786663914&installation_id=133855650&pr_number=8105&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8105&signature=14da25928a0a942a2c409265268fc8aef5eb5c96c352599cfd2a0dad1a5ed9b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds filter chips, sort, a 3‑column grid, and horizontal swipe paging to the iOS chip gallery while keeping the Created/Attached/Referenced groups. Non‑default filters/sorts trigger eager referenced-page loading with a 2,000‑row safety cap, loading bar, and clear retry UI.

- **New Features**
  - Filter chips: All, Images, Code, Logs, Docs, Folders; sort menu: Recent, Name, Size (applied within each group).
  - Eager-load remaining referenced pages when using non-default filter/sort; cap at 2,000 with “showing first 2000” footer, loading bar, and retry.
  - List/grid toggle with a 3‑column thumbnail grid using cached thumbnails.
  - Viewer gains horizontal swipe paging over the current filtered/sorted files (folders skipped); only prev/current/next pages stay mounted.
  - Added unit tests for classifier, presentation, eager pager, and swipe order; new EN/JA strings.

- **Bug Fixes**
  - Incomplete referenced paging no longer appears complete; a retry is shown instead.
  - Viewer cleanup is now structured under the page task to avoid dangling work when swiping/closing.

<sup>Written for commit ea92959407ee85f9ab1fdba255ef4ba698d2c177. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8105?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

