### PR TITLE
Pause automatic Nightly builds during CI/CD pause

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly macOS build
 
 on:
-  # CI/CD pause: July 14-21, 2026. Keep Nightly available only for an explicit,
-  # necessary release; restore the main push trigger after the pause ends.
+  # CI/CD pause: keep Nightly available only for an explicit, necessary release.
+  # Restore the main push trigger when the repository-wide pause is lifted.
   workflow_dispatch:
     inputs:
       force:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,8 @@
 name: Nightly macOS build
 
 on:
-  push:
-    branches: [main]
+  # CI/CD pause: July 14-21, 2026. Keep Nightly available only for an explicit,
+  # necessary release; restore the main push trigger after the pause ends.
   workflow_dispatch:
     inputs:
       force:


### PR DESCRIPTION
## Summary

Remove the `main` push trigger while the repository-wide CI/CD pause is active. Keep explicit manual dispatch available for a necessary release. Restore automatic Nightly only when the pause is explicitly lifted.

## Testing

- `actionlint .github/workflows/nightly.yml`
- `bash tests/test_nightly_universal_build.sh`
- `git diff --check`

## Demo Video

Not applicable, workflow-only change.

## Checklist

- [x] Main pushes no longer start Nightly
- [x] Manual emergency Nightly remains available
- [x] No app/runtime code changed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a notice that CI/CD activity will be paused from July 14–21, 2026, and noted when normal behavior should resume.
* **CI/CD Updates**
  * Temporarily removed the “main” push trigger so the affected workflow will no longer start on those pushes during the pause window.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->