### PR TITLE
iOS: artifact content cache, zero-jank live refresh, file actions, image zoom + gallery server perf

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
@@ -10,6 +10,7 @@ public struct ChatArtifactGalleryBuilder: Sendable {
     /// - Parameters:
     ///   - sessionID: Session represented by the artifact index.
     ///   - items: De-duplicated transcript artifact references.
+    ///   - orderedItems: Optional generation-cached stable ordering of `items`.
     ///   - generation: Stable snapshot generation carried by page cursors.
     ///   - cursor: Per-section positions after which paging continues.
     ///   - pageSize: Maximum entries to stat and include per section.
@@ -20,6 +21,7 @@ public struct ChatArtifactGalleryBuilder: Sendable {
     public func page(
         sessionID: String,
         items: [ChatArtifactIndexedReference],
+        orderedItems: [ChatArtifactIndexedReference]? = nil,
         generation: String,
         cursor: ChatArtifactGalleryCursor?,
         pageSize: Int,
@@ -27,6 +29,7 @@ public struct ChatArtifactGalleryBuilder: Sendable {
         includeDirectories: Bool = false
     ) -> ChatArtifactGalleryPage {
         let ordering = ChatArtifactGalleryOrdering()
+        let stableItems = orderedItems ?? ordering.sorted(items)
         let normalizedQuery = query?.trimmingCharacters(in: .whitespacesAndNewlines)
         let isSearch = normalizedQuery?.isEmpty == false
         let createdCandidates: [ChatArtifactIndexedReference]
@@ -35,11 +38,11 @@ public struct ChatArtifactGalleryBuilder: Sendable {
         if let normalizedQuery, !normalizedQuery.isEmpty {
             createdCandidates = []
             attachedCandidates = []
-            referencedCandidates = ordering.search(items, query: normalizedQuery)
+            referencedCandidates = ordering.matching(stableItems, query: normalizedQuery)
         } else {
-            createdCandidates = ordering.sorted(items.filter { $0.provenance == .created })
-            attachedCandidates = ordering.sorted(items.filter { $0.provenance == .attached })
-            referencedCandidates = ordering.sorted(items.filter { $0.provenance == .referenced })
+            createdCandidates = stableItems.filter { $0.provenance == .created }
+            attachedCandidates = stableItems.filter { $0.provenance == .attached }
+            referencedCandidates = stableItems.filter { $0.provenance == .referenced }
         }
         let count = max(1, pageSize)
         let starts = pageStarts(

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
@@ -11,8 +11,8 @@ public struct ChatArtifactGalleryBuilder: Sendable {
     ///   - sessionID: Session represented by the artifact index.
     ///   - items: De-duplicated transcript artifact references.
     ///   - generation: Stable snapshot generation carried by page cursors.
-    ///   - cursor: Position after which the referenced section continues.
-    ///   - pageSize: Maximum referenced entries to include.
+    ///   - cursor: Per-section positions after which paging continues.
+    ///   - pageSize: Maximum entries to stat and include per section.
     ///   - query: Optional basename or path search.
     ///   - includeDirectories: Whether directory references are eligible for
     ///     rows. This defaults to `false` for clients without folder capability.
@@ -27,64 +27,94 @@ public struct ChatArtifactGalleryBuilder: Sendable {
         includeDirectories: Bool = false
     ) -> ChatArtifactGalleryPage {
         let ordering = ChatArtifactGalleryOrdering()
-        let eligibleItems = eligibleItems(items, includeDirectories: includeDirectories)
         let normalizedQuery = query?.trimmingCharacters(in: .whitespacesAndNewlines)
         let isSearch = normalizedQuery?.isEmpty == false
-        let candidates: [ChatArtifactIndexedReference]
+        let createdCandidates: [ChatArtifactIndexedReference]
+        let attachedCandidates: [ChatArtifactIndexedReference]
+        let referencedCandidates: [ChatArtifactIndexedReference]
         if let normalizedQuery, !normalizedQuery.isEmpty {
-            candidates = ordering.search(eligibleItems, query: normalizedQuery)
+            createdCandidates = []
+            attachedCandidates = []
+            referencedCandidates = ordering.search(items, query: normalizedQuery)
         } else {
-            candidates = ordering.sorted(eligibleItems.filter { $0.provenance == .referenced })
+            createdCandidates = ordering.sorted(items.filter { $0.provenance == .created })
+            attachedCandidates = ordering.sorted(items.filter { $0.provenance == .attached })
+            referencedCandidates = ordering.sorted(items.filter { $0.provenance == .referenced })
         }
-        let remaining = ordering.items(candidates, strictlyAfter: cursor)
-        let pageReferences = Array(remaining.prefix(pageSize))
+        let count = max(1, pageSize)
+        let starts = pageStarts(
+            cursor: cursor,
+            created: createdCandidates,
+            attached: attachedCandidates,
+            referenced: referencedCandidates,
+            ordering: ordering
+        )
+        let pageCreated = Array(createdCandidates.dropFirst(starts.created).prefix(count))
+        let pageAttached = Array(attachedCandidates.dropFirst(starts.attached).prefix(count))
+        let pageReferenced = Array(referencedCandidates.dropFirst(starts.referenced).prefix(count))
+        let nextCreatedOffset = starts.created + pageCreated.count
+        let nextAttachedOffset = starts.attached + pageAttached.count
+        let nextReferencedOffset = starts.referenced + pageReferenced.count
         let nextCursor: String?
-        if remaining.count > pageReferences.count, let last = pageReferences.last {
+        if nextCreatedOffset < createdCandidates.count
+            || nextAttachedOffset < attachedCandidates.count
+            || nextReferencedOffset < referencedCandidates.count {
+            let last = pageReferenced.last
             nextCursor = try? ChatArtifactGalleryCursor(
                 generation: generation,
-                seq: last.lastReferencedSeq,
-                path: last.path
+                seq: last?.lastReferencedSeq ?? cursor?.seq ?? .max,
+                path: last?.path ?? cursor?.path ?? "",
+                createdOffset: nextCreatedOffset,
+                attachedOffset: nextAttachedOffset,
+                referencedOffset: nextReferencedOffset
             ).token()
         } else {
             nextCursor = nil
         }
 
-        let includeCompleteSections = cursor == nil && !isSearch
-        let created = includeCompleteSections
-            ? statItems(ordering.sorted(eligibleItems.filter { $0.provenance == .created }))
-            : []
-        let attached = includeCompleteSections
-            ? statItems(ordering.sorted(eligibleItems.filter { $0.provenance == .attached }))
-            : []
         return ChatArtifactGalleryPage(
             sessionID: sessionID,
-            created: created,
-            attached: attached,
-            referenced: statItems(pageReferences),
-            referencedTotal: candidates.count,
+            created: isSearch ? [] : statItems(pageCreated, includeDirectories: includeDirectories),
+            createdTotal: createdCandidates.count,
+            attached: isSearch ? [] : statItems(pageAttached, includeDirectories: includeDirectories),
+            attachedTotal: attachedCandidates.count,
+            referenced: statItems(pageReferenced, includeDirectories: includeDirectories),
+            referencedTotal: referencedCandidates.count,
             nextCursor: nextCursor,
             generation: generation
         )
     }
 
-    private func eligibleItems(
-        _ items: [ChatArtifactIndexedReference],
-        includeDirectories: Bool
-    ) -> [ChatArtifactIndexedReference] {
-        guard !includeDirectories else { return items }
-        let reader = ArtifactByteReader()
-        return items.filter { reference in
-            (try? reader.stat(path: reference.path).isDirectory) != true
+    private func pageStarts(
+        cursor: ChatArtifactGalleryCursor?,
+        created: [ChatArtifactIndexedReference],
+        attached: [ChatArtifactIndexedReference],
+        referenced: [ChatArtifactIndexedReference],
+        ordering: ChatArtifactGalleryOrdering
+    ) -> (created: Int, attached: Int, referenced: Int) {
+        guard let cursor else { return (0, 0, 0) }
+        if let createdOffset = cursor.createdOffset,
+           let attachedOffset = cursor.attachedOffset,
+           let referencedOffset = cursor.referencedOffset {
+            return (
+                min(max(0, createdOffset), created.count),
+                min(max(0, attachedOffset), attached.count),
+                min(max(0, referencedOffset), referenced.count)
+            )
         }
+        let remaining = ordering.items(referenced, strictlyAfter: cursor)
+        return (created.count, attached.count, referenced.count - remaining.count)
     }
 
     private func statItems(
-        _ references: [ChatArtifactIndexedReference]
+        _ references: [ChatArtifactIndexedReference],
+        includeDirectories: Bool
     ) -> [ChatArtifactGalleryItem] {
         let reader = ArtifactByteReader()
-        return references.map { reference in
+        return references.compactMap { reference in
             do {
                 let stat = try reader.stat(path: reference.path)
+                guard includeDirectories || !stat.isDirectory else { return nil }
                 let listing = stat.isDirectory ? try? reader.list(path: reference.path) : nil
                 return ChatArtifactGalleryItem(
                     path: reference.path,

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
@@ -28,6 +28,13 @@ public struct ChatArtifactGalleryBuilder: Sendable {
         query: String?,
         includeDirectories: Bool = false
     ) -> ChatArtifactGalleryPage {
+        if let cursor, cursor.generation != generation {
+            return ChatArtifactGalleryPage(
+                sessionID: sessionID,
+                generation: generation,
+                requiresPagingRestart: true
+            )
+        }
         let ordering = ChatArtifactGalleryOrdering()
         let stableItems = orderedItems ?? ordering.sorted(items)
         let normalizedQuery = query?.trimmingCharacters(in: .whitespacesAndNewlines)

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryBuilder.swift
@@ -59,9 +59,16 @@ public struct ChatArtifactGalleryBuilder: Sendable {
             referenced: referencedCandidates,
             ordering: ordering
         )
-        let pageCreated = Array(createdCandidates.dropFirst(starts.created).prefix(count))
-        let pageAttached = Array(attachedCandidates.dropFirst(starts.attached).prefix(count))
-        let pageReferenced = Array(referencedCandidates.dropFirst(starts.referenced).prefix(count))
+        // Sequential fill: a page extends the grouped list strictly at its
+        // bottom (created, then attached, then referenced), so a
+        // scroll-triggered load can never insert rows into a group the user
+        // has already scrolled past.
+        var remaining = count
+        let pageCreated = Array(createdCandidates.dropFirst(starts.created).prefix(remaining))
+        remaining -= pageCreated.count
+        let pageAttached = Array(attachedCandidates.dropFirst(starts.attached).prefix(remaining))
+        remaining -= pageAttached.count
+        let pageReferenced = Array(referencedCandidates.dropFirst(starts.referenced).prefix(remaining))
         let nextCreatedOffset = starts.created + pageCreated.count
         let nextAttachedOffset = starts.attached + pageAttached.count
         let nextReferencedOffset = starts.referenced + pageReferenced.count

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryCursor.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryCursor.swift
@@ -8,12 +8,34 @@ public struct ChatArtifactGalleryCursor: Sendable, Equatable, Codable {
     public let seq: Int
     /// Path tie-breaker of the page's final row.
     public let path: String
+    let createdOffset: Int?
+    let attachedOffset: Int?
+    let referencedOffset: Int?
 
     /// Creates a stable cursor.
     public init(generation: String, seq: Int, path: String) {
         self.generation = generation
         self.seq = seq
         self.path = path
+        createdOffset = nil
+        attachedOffset = nil
+        referencedOffset = nil
+    }
+
+    init(
+        generation: String,
+        seq: Int,
+        path: String,
+        createdOffset: Int,
+        attachedOffset: Int,
+        referencedOffset: Int
+    ) {
+        self.generation = generation
+        self.seq = seq
+        self.path = path
+        self.createdOffset = createdOffset
+        self.attachedOffset = attachedOffset
+        self.referencedOffset = referencedOffset
     }
 
     /// Encodes this cursor as an opaque RPC token.

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPager.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPager.swift
@@ -38,6 +38,13 @@ public struct ChatArtifactGalleryEagerPager: Sendable {
             try Task.checkCancellation()
             let page = try await fetchPage(cursor)
             try Task.checkCancellation()
+            if page.requiresPagingRestart {
+                return ChatArtifactGalleryEagerPagingResult(
+                    snapshot: initialSnapshot,
+                    reachedSafetyCap: false,
+                    requiresPagingRestart: true
+                )
+            }
             let appended = snapshot.appending(page)
             truncatedRows = truncatedRows || appended.referenced.count > maximumReferencedRows
             snapshot = appended.limitingReferenced(to: maximumReferencedRows)

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPagingResult.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryEagerPagingResult.swift
@@ -4,17 +4,22 @@ public struct ChatArtifactGalleryEagerPagingResult: Sendable, Equatable {
     public let snapshot: ChatArtifactGallerySnapshot
     /// Whether loading stopped because more than the configured row cap exists.
     public let reachedSafetyCap: Bool
+    /// Whether the host rejected an obsolete generation cursor.
+    public let requiresPagingRestart: Bool
 
     /// Creates an eager-paging result.
     ///
     /// - Parameters:
     ///   - snapshot: Accumulated rows and remaining cursor.
     ///   - reachedSafetyCap: Whether the row cap prevented complete loading.
+    ///   - requiresPagingRestart: Whether paging must restart from a first page.
     public init(
         snapshot: ChatArtifactGallerySnapshot,
-        reachedSafetyCap: Bool
+        reachedSafetyCap: Bool,
+        requiresPagingRestart: Bool = false
     ) {
         self.snapshot = snapshot
         self.reachedSafetyCap = reachedSafetyCap
+        self.requiresPagingRestart = requiresPagingRestart
     }
 }

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryLiveRefreshState.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryLiveRefreshState.swift
@@ -1,0 +1,57 @@
+/// Defers gallery generation changes while the user is reading away from the top.
+public struct ChatArtifactGalleryLiveRefreshState: Sendable, Equatable {
+    private var pendingSnapshot: ChatArtifactGallerySnapshot?
+
+    /// Number of unseen paths waiting for explicit application.
+    public private(set) var pendingNewFileCount = 0
+
+    /// Creates an empty live-refresh state.
+    public init() {}
+
+    /// Receives a fresh first page and decides whether it is safe to show now.
+    ///
+    /// - Parameters:
+    ///   - fresh: First page from the latest session generation.
+    ///   - displayed: Snapshot currently rendered by the gallery.
+    ///   - isAtTopOrFits: Whether inserting leading rows cannot disturb a reading position.
+    /// - Returns: A reconciled snapshot to display immediately, or `nil` when a pill should be shown.
+    public mutating func receive(
+        fresh: ChatArtifactGallerySnapshot,
+        displayed: ChatArtifactGallerySnapshot,
+        isAtTopOrFits: Bool
+    ) -> ChatArtifactGallerySnapshot? {
+        guard fresh.generation != displayed.generation else { return nil }
+        let displayedPaths = Set((displayed.created + displayed.attached + displayed.referenced).map(\.path))
+        let freshPaths = Set((fresh.created + fresh.attached + fresh.referenced).map(\.path))
+        let newFileCount = freshPaths.subtracting(displayedPaths).count
+        let reconciled = displayed.reconciling(withFreshFirstPage: fresh)
+
+        guard !isAtTopOrFits, newFileCount > 0 else {
+            pendingSnapshot = nil
+            pendingNewFileCount = 0
+            return reconciled
+        }
+        pendingSnapshot = fresh
+        pendingNewFileCount = newFileCount
+        return nil
+    }
+
+    /// Applies the newest deferred first page and clears the pending pill.
+    ///
+    /// - Parameter displayed: Snapshot currently rendered by the gallery.
+    /// - Returns: The reconciled snapshot, or `nil` when no refresh is pending.
+    public mutating func applyPending(
+        to displayed: ChatArtifactGallerySnapshot
+    ) -> ChatArtifactGallerySnapshot? {
+        guard let pendingSnapshot else { return nil }
+        self.pendingSnapshot = nil
+        pendingNewFileCount = 0
+        return displayed.reconciling(withFreshFirstPage: pendingSnapshot)
+    }
+
+    /// Drops a deferred refresh when the session or scope changes.
+    public mutating func reset() {
+        pendingSnapshot = nil
+        pendingNewFileCount = 0
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryOrdering.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryOrdering.swift
@@ -46,9 +46,16 @@ public struct ChatArtifactGalleryOrdering: Sendable {
         _ items: [ChatArtifactIndexedReference],
         query: String
     ) -> [ChatArtifactIndexedReference] {
+        matching(sorted(items), query: query)
+    }
+
+    func matching(
+        _ orderedItems: [ChatArtifactIndexedReference],
+        query: String
+    ) -> [ChatArtifactIndexedReference] {
         let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !needle.isEmpty else { return sorted(items) }
-        return sorted(items).filter { item in
+        guard !needle.isEmpty else { return orderedItems }
+        return orderedItems.filter { item in
             item.path.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive]) != nil
                 || URL(fileURLWithPath: item.path).lastPathComponent.range(
                     of: needle,

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryOrderingCache.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryOrderingCache.swift
@@ -1,0 +1,59 @@
+/// Reuses the stable artifact ordering for repeated pages of one index generation.
+public actor ChatArtifactGalleryOrderingCache {
+    private struct Key: Hashable {
+        let indexID: String
+        let generation: String
+    }
+
+    private struct Entry {
+        let items: [ChatArtifactIndexedReference]
+        let access: UInt64
+    }
+
+    private let maximumEntryCount: Int
+    private var entries: [Key: Entry] = [:]
+    private var accessCounter: UInt64 = 0
+
+    /// Creates a bounded ordering cache.
+    ///
+    /// - Parameter maximumEntryCount: Maximum index generations retained.
+    public init(maximumEntryCount: Int = 8) {
+        self.maximumEntryCount = max(0, maximumEntryCount)
+    }
+
+    /// Returns one newest-first ordering, reusing it for the same index generation.
+    ///
+    /// A new generation for an index invalidates that index's previous ordering.
+    ///
+    /// - Parameters:
+    ///   - items: De-duplicated references from the authoritative index snapshot.
+    ///   - indexID: Stable identity of the transcript index.
+    ///   - generation: File generation represented by `items`.
+    /// - Returns: References in stable gallery order.
+    public func ordered(
+        _ items: [ChatArtifactIndexedReference],
+        indexID: String,
+        generation: String
+    ) -> [ChatArtifactIndexedReference] {
+        let key = Key(indexID: indexID, generation: generation)
+        accessCounter &+= 1
+        if let cached = entries[key] {
+            entries[key] = Entry(items: cached.items, access: accessCounter)
+            return cached.items
+        }
+
+        entries = entries.filter { $0.key.indexID != indexID }
+        let ordered = ChatArtifactGalleryOrdering().sorted(items)
+        guard maximumEntryCount > 0 else { return ordered }
+        entries[key] = Entry(items: ordered, access: accessCounter)
+        evictIfNeeded()
+        return ordered
+    }
+
+    private func evictIfNeeded() {
+        while entries.count > maximumEntryCount,
+              let leastRecent = entries.min(by: { $0.value.access < $1.value.access })?.key {
+            entries.removeValue(forKey: leastRecent)
+        }
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPage.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPage.swift
@@ -2,15 +2,19 @@
 public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
     /// Session that authorizes every returned path.
     public let sessionID: String
-    /// Complete created paths, present only on the first sectioned page.
+    /// Created paths in this page.
     public let created: [ChatArtifactGalleryItem]
-    /// Complete attachment paths, present only on the first sectioned page.
+    /// Total created paths in the stable snapshot.
+    public let createdTotal: Int
+    /// Attachment paths in this page.
     public let attached: [ChatArtifactGalleryItem]
+    /// Total attachment paths in the stable snapshot.
+    public let attachedTotal: Int
     /// Referenced page, or a flat all-provenance search-result page.
     public let referenced: [ChatArtifactGalleryItem]
     /// Total referenced count, or total search-result count for a query.
     public let referencedTotal: Int
-    /// Opaque cursor for the next append-only page.
+    /// Opaque cursor for the next append-only page across all sections.
     public let nextCursor: String?
     /// Snapshot generation that served this response.
     public let generation: String
@@ -19,7 +23,9 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
     public init(
         sessionID: String,
         created: [ChatArtifactGalleryItem] = [],
+        createdTotal: Int? = nil,
         attached: [ChatArtifactGalleryItem] = [],
+        attachedTotal: Int? = nil,
         referenced: [ChatArtifactGalleryItem] = [],
         referencedTotal: Int = 0,
         nextCursor: String? = nil,
@@ -27,7 +33,9 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
     ) {
         self.sessionID = sessionID
         self.created = created
+        self.createdTotal = createdTotal ?? created.count
         self.attached = attached
+        self.attachedTotal = attachedTotal ?? attached.count
         self.referenced = referenced
         self.referencedTotal = referencedTotal
         self.nextCursor = nextCursor
@@ -37,7 +45,9 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
     private enum CodingKeys: String, CodingKey {
         case sessionID = "session_id"
         case created
+        case createdTotal = "created_total"
         case attached
+        case attachedTotal = "attached_total"
         case referenced
         case referencedTotal = "referenced_total"
         case nextCursor = "next_cursor"
@@ -48,7 +58,9 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         sessionID = (try? container.decode(String.self, forKey: .sessionID)) ?? ""
         created = (try? container.decode([ChatArtifactGalleryItem].self, forKey: .created)) ?? []
+        createdTotal = (try? container.decode(Int.self, forKey: .createdTotal)) ?? created.count
         attached = (try? container.decode([ChatArtifactGalleryItem].self, forKey: .attached)) ?? []
+        attachedTotal = (try? container.decode(Int.self, forKey: .attachedTotal)) ?? attached.count
         referenced = (try? container.decode([ChatArtifactGalleryItem].self, forKey: .referenced)) ?? []
         referencedTotal = (try? container.decode(Int.self, forKey: .referencedTotal)) ?? referenced.count
         nextCursor = try? container.decode(String.self, forKey: .nextCursor)
@@ -66,7 +78,9 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
         return ChatArtifactGalleryPage(
             sessionID: sessionID,
             created: filteredCreated,
+            createdTotal: max(0, createdTotal - (created.count - filteredCreated.count)),
             attached: filteredAttached,
+            attachedTotal: max(0, attachedTotal - (attached.count - filteredAttached.count)),
             referenced: filteredReferenced,
             referencedTotal: max(0, referencedTotal - (referenced.count - filteredReferenced.count)),
             nextCursor: nextCursor,

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPage.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPage.swift
@@ -18,6 +18,8 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
     public let nextCursor: String?
     /// Snapshot generation that served this response.
     public let generation: String
+    /// Whether the request cursor belongs to an obsolete generation.
+    public let requiresPagingRestart: Bool
 
     /// Creates one gallery response page.
     public init(
@@ -29,7 +31,8 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
         referenced: [ChatArtifactGalleryItem] = [],
         referencedTotal: Int = 0,
         nextCursor: String? = nil,
-        generation: String = ""
+        generation: String = "",
+        requiresPagingRestart: Bool = false
     ) {
         self.sessionID = sessionID
         self.created = created
@@ -40,6 +43,7 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
         self.referencedTotal = referencedTotal
         self.nextCursor = nextCursor
         self.generation = generation
+        self.requiresPagingRestart = requiresPagingRestart
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -52,6 +56,7 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
         case referencedTotal = "referenced_total"
         case nextCursor = "next_cursor"
         case generation
+        case requiresPagingRestart = "requires_paging_restart"
     }
 
     public init(from decoder: any Decoder) throws {
@@ -65,6 +70,7 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
         referencedTotal = (try? container.decode(Int.self, forKey: .referencedTotal)) ?? referenced.count
         nextCursor = try? container.decode(String.self, forKey: .nextCursor)
         generation = (try? container.decode(String.self, forKey: .generation)) ?? ""
+        requiresPagingRestart = (try? container.decode(Bool.self, forKey: .requiresPagingRestart)) ?? false
     }
 
     /// Returns a compatibility view with directory rows removed.
@@ -84,7 +90,8 @@ public struct ChatArtifactGalleryPage: Sendable, Equatable, Codable {
             referenced: filteredReferenced,
             referencedTotal: max(0, referencedTotal - (referenced.count - filteredReferenced.count)),
             nextCursor: nextCursor,
-            generation: generation
+            generation: generation,
+            requiresPagingRestart: requiresPagingRestart
         )
     }
 }

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
@@ -43,6 +43,7 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
     /// - Parameter page: The next sectioned gallery page.
     /// - Returns: A snapshot containing only path-unique appended rows.
     public func appending(_ page: ChatArtifactGalleryPage) -> ChatArtifactGallerySnapshot {
+        guard !page.requiresPagingRestart else { return self }
         var seenPaths = Set((created + attached + referenced).map(\.path))
         let uniqueCreated = page.created.filter { item in
             seenPaths.insert(item.path).inserted
@@ -62,6 +63,56 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
             referencedTotal: page.referencedTotal,
             nextCursor: page.nextCursor,
             generation: page.generation
+        )
+    }
+
+    /// Rebinds paging to a fresh first page without moving already visible rows.
+    ///
+    /// Existing rows retain their exact section order. Newly discovered first-page
+    /// rows are appended, while the fresh generation and cursor become authoritative.
+    /// This is used for background stale-cursor recovery where leading insertions
+    /// could otherwise move the reader's scroll position.
+    ///
+    /// - Parameter fresh: First page from the current host generation.
+    /// - Returns: A stable-order snapshot ready to continue fresh paging.
+    public func restartingPaging(
+        withFreshFirstPage fresh: ChatArtifactGallerySnapshot
+    ) -> ChatArtifactGallerySnapshot {
+        var seenPaths = Set((created + attached + referenced).map(\.path))
+        let newCreated = fresh.created.filter { seenPaths.insert($0.path).inserted }
+        let newAttached = fresh.attached.filter { seenPaths.insert($0.path).inserted }
+        let newReferenced = fresh.referenced.filter { seenPaths.insert($0.path).inserted }
+        return ChatArtifactGallerySnapshot(
+            created: created + newCreated,
+            createdTotal: max(fresh.createdTotal, created.count + newCreated.count),
+            attached: attached + newAttached,
+            attachedTotal: max(fresh.attachedTotal, attached.count + newAttached.count),
+            referenced: referenced + newReferenced,
+            referencedTotal: max(fresh.referencedTotal, referenced.count + newReferenced.count),
+            nextCursor: fresh.nextCursor,
+            generation: fresh.generation
+        )
+    }
+
+    /// Adopts a fresh generation cursor without changing any visible row array.
+    ///
+    /// This supports a deferred live-refresh pill: paging can stop using the
+    /// rejected cursor immediately while every rendered row remains fixed.
+    ///
+    /// - Parameter fresh: First page from the current host generation.
+    /// - Returns: The unchanged rows with fresh totals and paging identity.
+    public func rebasingPaging(
+        ontoFreshFirstPage fresh: ChatArtifactGallerySnapshot
+    ) -> ChatArtifactGallerySnapshot {
+        ChatArtifactGallerySnapshot(
+            created: created,
+            createdTotal: max(fresh.createdTotal, created.count),
+            attached: attached,
+            attachedTotal: max(fresh.attachedTotal, attached.count),
+            referenced: referenced,
+            referencedTotal: max(fresh.referencedTotal, referenced.count),
+            nextCursor: fresh.nextCursor,
+            generation: fresh.generation
         )
     }
 

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
@@ -51,6 +51,33 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
         )
     }
 
+    /// Reconciles a newer first page without discarding rows already loaded.
+    ///
+    /// Fresh rows lead their provenance sections, while previously loaded rows
+    /// retain their relative order. A path that moved between provenance
+    /// sections appears only in the fresh section.
+    ///
+    /// - Parameter fresh: First-page snapshot from a newer host generation.
+    /// - Returns: A generation-updated snapshot that preserves loaded history.
+    public func reconciling(withFreshFirstPage fresh: ChatArtifactGallerySnapshot) -> ChatArtifactGallerySnapshot {
+        var seenPaths: Set<String> = []
+        let freshCreated = fresh.created.filter { seenPaths.insert($0.path).inserted }
+        let freshAttached = fresh.attached.filter { seenPaths.insert($0.path).inserted }
+        let freshReferenced = fresh.referenced.filter { seenPaths.insert($0.path).inserted }
+        let retainedCreated = created.filter { seenPaths.insert($0.path).inserted }
+        let retainedAttached = attached.filter { seenPaths.insert($0.path).inserted }
+        let retainedReferenced = referenced.filter { seenPaths.insert($0.path).inserted }
+        let mergedReferenced = freshReferenced + retainedReferenced
+        return ChatArtifactGallerySnapshot(
+            created: freshCreated + retainedCreated,
+            attached: freshAttached + retainedAttached,
+            referenced: mergedReferenced,
+            referencedTotal: max(fresh.referencedTotal, mergedReferenced.count),
+            nextCursor: fresh.nextCursor,
+            generation: fresh.generation
+        )
+    }
+
     func limitingReferenced(to maximumCount: Int) -> ChatArtifactGallerySnapshot {
         ChatArtifactGallerySnapshot(
             created: created,

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGallerySnapshot.swift
@@ -1,21 +1,25 @@
 /// Accumulated section rows and paging state for a session artifact gallery.
 public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
-    /// Created artifact rows from the first page.
+    /// Created artifact rows accumulated across pages.
     public let created: [ChatArtifactGalleryItem]
-    /// Attached artifact rows from the first page.
+    /// Complete created-row count reported by the host.
+    public let createdTotal: Int
+    /// Attached artifact rows accumulated across pages.
     public let attached: [ChatArtifactGalleryItem]
+    /// Complete attached-row count reported by the host.
+    public let attachedTotal: Int
     /// Referenced artifact rows accumulated across pages.
     public let referenced: [ChatArtifactGalleryItem]
     /// Complete referenced-row count reported by the host.
     public let referencedTotal: Int
-    /// Cursor for the next referenced page.
+    /// Cursor for the next page across any incomplete section.
     public let nextCursor: String?
     /// Host snapshot generation that served the latest page.
     public let generation: String
 
     /// Whether the complete gallery has no rows.
     public var isEmpty: Bool {
-        created.isEmpty && attached.isEmpty && referencedTotal == 0
+        createdTotal == 0 && attachedTotal == 0 && referencedTotal == 0
     }
 
     /// Creates an accumulated snapshot from a first gallery page.
@@ -23,27 +27,37 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
     /// - Parameter page: The first sectioned gallery page.
     public init(page: ChatArtifactGalleryPage) {
         created = page.created
+        createdTotal = page.createdTotal
         attached = page.attached
+        attachedTotal = page.attachedTotal
         referenced = page.referenced
         referencedTotal = page.referencedTotal
         nextCursor = page.nextCursor
         generation = page.generation
     }
 
-    /// Appends a referenced page while dropping paths already in any section.
+    /// Appends one sectioned page while dropping paths already in any section.
     ///
     /// First-seen order is preserved both across pages and within `page`.
     ///
-    /// - Parameter page: The next referenced gallery page.
+    /// - Parameter page: The next sectioned gallery page.
     /// - Returns: A snapshot containing only path-unique appended rows.
     public func appending(_ page: ChatArtifactGalleryPage) -> ChatArtifactGallerySnapshot {
         var seenPaths = Set((created + attached + referenced).map(\.path))
+        let uniqueCreated = page.created.filter { item in
+            seenPaths.insert(item.path).inserted
+        }
+        let uniqueAttached = page.attached.filter { item in
+            seenPaths.insert(item.path).inserted
+        }
         let uniqueReferenced = page.referenced.filter { item in
             seenPaths.insert(item.path).inserted
         }
         return ChatArtifactGallerySnapshot(
-            created: created,
-            attached: attached,
+            created: created + uniqueCreated,
+            createdTotal: page.createdTotal,
+            attached: attached + uniqueAttached,
+            attachedTotal: page.attachedTotal,
             referenced: referenced + uniqueReferenced,
             referencedTotal: page.referencedTotal,
             nextCursor: page.nextCursor,
@@ -70,7 +84,9 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
         let mergedReferenced = freshReferenced + retainedReferenced
         return ChatArtifactGallerySnapshot(
             created: freshCreated + retainedCreated,
+            createdTotal: max(fresh.createdTotal, freshCreated.count + retainedCreated.count),
             attached: freshAttached + retainedAttached,
+            attachedTotal: max(fresh.attachedTotal, freshAttached.count + retainedAttached.count),
             referenced: mergedReferenced,
             referencedTotal: max(fresh.referencedTotal, mergedReferenced.count),
             nextCursor: fresh.nextCursor,
@@ -81,7 +97,9 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
     func limitingReferenced(to maximumCount: Int) -> ChatArtifactGallerySnapshot {
         ChatArtifactGallerySnapshot(
             created: created,
+            createdTotal: createdTotal,
             attached: attached,
+            attachedTotal: attachedTotal,
             referenced: Array(referenced.prefix(max(0, maximumCount))),
             referencedTotal: referencedTotal,
             nextCursor: nextCursor,
@@ -91,14 +109,18 @@ public struct ChatArtifactGallerySnapshot: Sendable, Equatable {
 
     private init(
         created: [ChatArtifactGalleryItem],
+        createdTotal: Int,
         attached: [ChatArtifactGalleryItem],
+        attachedTotal: Int,
         referenced: [ChatArtifactGalleryItem],
         referencedTotal: Int,
         nextCursor: String?,
         generation: String
     ) {
         self.created = created
+        self.createdTotal = createdTotal
         self.attached = attached
+        self.attachedTotal = attachedTotal
         self.referenced = referenced
         self.referencedTotal = referencedTotal
         self.nextCursor = nextCursor

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactLRUCache.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactLRUCache.swift
@@ -1,0 +1,50 @@
+/// A small value-type least-recently-used cache for artifact infrastructure.
+public struct ChatArtifactLRUCache<Key: Hashable & Sendable, Value: Sendable>: Sendable {
+    private struct Entry: Sendable {
+        let value: Value
+        let access: UInt64
+    }
+
+    private let capacity: Int
+    private var entries: [Key: Entry] = [:]
+    private var accessCounter: UInt64 = 0
+
+    /// Number of currently retained entries.
+    public var count: Int { entries.count }
+
+    /// Creates a bounded cache.
+    ///
+    /// - Parameter capacity: Maximum retained entry count.
+    public init(capacity: Int) {
+        self.capacity = max(0, capacity)
+    }
+
+    /// Returns and marks a value as most recently used.
+    ///
+    /// - Parameter key: Cache identity to look up.
+    /// - Returns: The retained value, or `nil`.
+    public mutating func value(forKey key: Key) -> Value? {
+        guard let entry = entries[key] else { return nil }
+        accessCounter &+= 1
+        entries[key] = Entry(value: entry.value, access: accessCounter)
+        return entry.value
+    }
+
+    /// Inserts or replaces a value and evicts the least recently used entry.
+    ///
+    /// - Parameters:
+    ///   - value: Value to retain.
+    ///   - key: Cache identity for the value.
+    public mutating func insert(_ value: Value, forKey key: Key) {
+        guard capacity > 0 else {
+            entries.removeAll(keepingCapacity: false)
+            return
+        }
+        accessCounter &+= 1
+        entries[key] = Entry(value: value, access: accessCounter)
+        while entries.count > capacity,
+              let leastRecent = entries.min(by: { $0.value.access < $1.value.access })?.key {
+            entries.removeValue(forKey: leastRecent)
+        }
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactTapHitTester.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactTapHitTester.swift
@@ -45,7 +45,7 @@ public struct TerminalArtifactTapHitTester: Sendable {
         var currentRawEndColumn = token.rawEndColumn
 
         while currentRawEndColumn >= columns,
-              lines[currentRow].count >= columns,
+              Self.cellWidth(of: lines[currentRow]) >= columns,
               currentRow + 1 < lines.count,
               let continuation = leadingContinuation(in: lines[currentRow + 1]) {
             currentRow += 1
@@ -79,14 +79,15 @@ public struct TerminalArtifactTapHitTester: Sendable {
             guard let path = TerminalArtifactPathDetector().tokens(in: raw).first?.path else {
                 continue
             }
-            let leadingTrim = raw.count - raw.drop(while: Self.leadingTrimCharacters.contains).count
-            let startColumn = line.distance(from: line.startIndex, to: tokenStart) + leadingTrim
+            let leadingTrim = String(raw.prefix(while: Self.leadingTrimCharacters.contains))
+            let startColumn = Self.cellWidth(of: String(line[..<tokenStart]))
+                + Self.cellWidth(of: leadingTrim)
             result.append(TokenRange(
                 rawText: raw,
                 path: path,
                 startColumn: startColumn,
-                endColumn: startColumn + path.count,
-                rawEndColumn: line.distance(from: line.startIndex, to: index)
+                endColumn: startColumn + Self.cellWidth(of: path),
+                rawEndColumn: Self.cellWidth(of: String(line[..<index]))
             ))
         }
         return result
@@ -100,7 +101,49 @@ public struct TerminalArtifactTapHitTester: Sendable {
         }
         let text = String(line.prefix(while: { !$0.isWhitespace }))
         guard !text.isEmpty else { return nil }
-        return Continuation(text: text, endColumn: text.count)
+        return Continuation(text: text, endColumn: Self.cellWidth(of: text))
+    }
+
+    private static func cellWidth(of text: String) -> Int {
+        text.reduce(0) { $0 + cellWidth(of: $1) }
+    }
+
+    private static func cellWidth(of character: Character) -> Int {
+        let scalars = character.unicodeScalars
+        guard scalars.contains(where: { !isZeroWidth($0) }) else { return 0 }
+        if scalars.contains(where: { isWide($0) || $0.properties.isEmojiPresentation }) {
+            return 2
+        }
+        return 1
+    }
+
+    private static func isZeroWidth(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.properties.generalCategory {
+        case .nonspacingMark, .spacingMark, .enclosingMark, .control, .format:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private static func isWide(_ scalar: UnicodeScalar) -> Bool {
+        switch scalar.value {
+        case 0x1100...0x115F,
+             0x2329...0x232A,
+             0x2E80...0xA4CF,
+             0xAC00...0xD7A3,
+             0xF900...0xFAFF,
+             0xFE10...0xFE19,
+             0xFE30...0xFE6F,
+             0xFF00...0xFF60,
+             0xFFE0...0xFFE6,
+             0x16FE0...0x18DFF,
+             0x1AFF0...0x1B2FF,
+             0x20000...0x3FFFD:
+            return true
+        default:
+            return false
+        }
     }
 
     private static func isPathContinuation(_ character: Character) -> Bool {

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Session/ChatSessionSurfaceIndex.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Session/ChatSessionSurfaceIndex.swift
@@ -1,0 +1,37 @@
+/// A mutation-maintained index from terminal surfaces to chat session IDs.
+public struct ChatSessionSurfaceIndex<SessionID: Hashable & Sendable>: Sendable {
+    private var sessionIDsBySurfaceID: [String: Set<SessionID>] = [:]
+
+    /// Creates an empty surface index.
+    public init() {}
+
+    /// Reconciles one session's previous and current surface bindings.
+    ///
+    /// - Parameters:
+    ///   - sessionID: Stable identity of the changed session.
+    ///   - previousSurfaceID: Surface before the mutation, or `nil`.
+    ///   - currentSurfaceID: Surface after the mutation, or `nil`.
+    public mutating func update(
+        sessionID: SessionID,
+        previousSurfaceID: String?,
+        currentSurfaceID: String?
+    ) {
+        if let previousSurfaceID, previousSurfaceID != currentSurfaceID {
+            sessionIDsBySurfaceID[previousSurfaceID]?.remove(sessionID)
+            if sessionIDsBySurfaceID[previousSurfaceID]?.isEmpty == true {
+                sessionIDsBySurfaceID.removeValue(forKey: previousSurfaceID)
+            }
+        }
+        if let currentSurfaceID {
+            sessionIDsBySurfaceID[currentSurfaceID, default: []].insert(sessionID)
+        }
+    }
+
+    /// Returns all sessions currently bound to a surface.
+    ///
+    /// - Parameter surfaceID: Terminal surface UUID string.
+    /// - Returns: Session IDs associated with the surface.
+    public func sessionIDs(surfaceID: String) -> Set<SessionID> {
+        sessionIDsBySurfaceID[surfaceID] ?? []
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryEagerPagerTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryEagerPagerTests.swift
@@ -78,6 +78,23 @@ struct ChatArtifactGalleryEagerPagerTests {
         #expect(await script.requestedCursors() == ["cursor-1"])
     }
 
+    @Test("surfaces a stale-generation restart without changing accumulated rows")
+    func staleGenerationRestart() async throws {
+        let initial = snapshot(paths: ["/one"], nextCursor: "cursor-1", total: 3)
+
+        let result = try await ChatArtifactGalleryEagerPager().loadRemaining(from: initial) { _ in
+            ChatArtifactGalleryPage(
+                sessionID: "session",
+                generation: "new",
+                requiresPagingRestart: true
+            )
+        }
+
+        #expect(result.requiresPagingRestart)
+        #expect(!result.reachedSafetyCap)
+        #expect(result.snapshot == initial)
+    }
+
     private func snapshot(
         paths: [String],
         nextCursor: String?,

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryLiveRefreshStateTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryLiveRefreshStateTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat artifact gallery live refresh")
+struct ChatArtifactGalleryLiveRefreshStateTests {
+    @Test("a top or fitting gallery merges fresh rows immediately")
+    func mergesAtTop() throws {
+        var state = ChatArtifactGalleryLiveRefreshState()
+        let displayed = snapshot(generation: "one", paths: ["/old.txt"])
+        let fresh = snapshot(generation: "two", paths: ["/new.txt", "/old.txt"])
+
+        let received = state.receive(
+            fresh: fresh,
+            displayed: displayed,
+            isAtTopOrFits: true
+        )
+        let merged = try #require(received)
+
+        #expect(merged.referenced.map(\.path) == ["/new.txt", "/old.txt"])
+        #expect(state.pendingNewFileCount == 0)
+    }
+
+    @Test("a reading position keeps the visible snapshot and reports unseen paths")
+    func defersAwayFromTop() {
+        var state = ChatArtifactGalleryLiveRefreshState()
+        let displayed = snapshot(generation: "one", paths: ["/old.txt"])
+        let fresh = snapshot(generation: "two", paths: ["/new-a.txt", "/new-b.txt", "/old.txt"])
+
+        let merged = state.receive(
+            fresh: fresh,
+            displayed: displayed,
+            isAtTopOrFits: false
+        )
+
+        #expect(merged == nil)
+        #expect(state.pendingNewFileCount == 2)
+        #expect(displayed.referenced.map(\.path) == ["/old.txt"])
+    }
+
+    @Test("applying a pending refresh clears the pill and preserves loaded history")
+    func appliesPendingRefresh() throws {
+        var state = ChatArtifactGalleryLiveRefreshState()
+        let displayed = snapshot(generation: "one", paths: ["/old.txt", "/older.txt"])
+        let fresh = snapshot(generation: "two", paths: ["/new.txt", "/old.txt"])
+        #expect(state.receive(
+            fresh: fresh,
+            displayed: displayed,
+            isAtTopOrFits: false
+        ) == nil)
+
+        let pendingApplication = state.applyPending(to: displayed)
+        let applied = try #require(pendingApplication)
+
+        #expect(applied.referenced.map(\.path) == ["/new.txt", "/old.txt", "/older.txt"])
+        #expect(applied.referencedTotal == 3)
+        #expect(applied.generation == "two")
+        #expect(state.pendingNewFileCount == 0)
+        #expect(state.applyPending(to: applied) == nil)
+    }
+
+    private func snapshot(generation: String, paths: [String]) -> ChatArtifactGallerySnapshot {
+        ChatArtifactGallerySnapshot(page: ChatArtifactGalleryPage(
+            sessionID: "session",
+            referenced: paths.map { path in
+                ChatArtifactGalleryItem(
+                    path: path,
+                    kind: .text,
+                    displayName: URL(fileURLWithPath: path).lastPathComponent,
+                    provenance: .referenced
+                )
+            },
+            referencedTotal: paths.count,
+            generation: generation
+        ))
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryOrderingCacheTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryOrderingCacheTests.swift
@@ -1,0 +1,44 @@
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat artifact gallery ordering cache")
+struct ChatArtifactGalleryOrderingCacheTests {
+    @Test("same generation reuses its ordering and a new generation invalidates it")
+    func generationReuseAndInvalidation() async {
+        let cache = ChatArtifactGalleryOrderingCache()
+        let original = [
+            item("/older", seq: 1),
+            item("/newer", seq: 2),
+        ]
+        let changedWithoutGeneration = [item("/unexpected", seq: 100)]
+        let nextGeneration = [
+            item("/latest", seq: 3),
+            item("/newer", seq: 2),
+        ]
+
+        let first = await cache.ordered(original, indexID: "session", generation: "one")
+        let reused = await cache.ordered(
+            changedWithoutGeneration,
+            indexID: "session",
+            generation: "one"
+        )
+        let invalidated = await cache.ordered(
+            nextGeneration,
+            indexID: "session",
+            generation: "two"
+        )
+
+        #expect(first.map(\.path) == ["/newer", "/older"])
+        #expect(reused == first)
+        #expect(invalidated.map(\.path) == ["/latest", "/newer"])
+    }
+
+    private func item(_ path: String, seq: Int) -> ChatArtifactIndexedReference {
+        ChatArtifactIndexedReference(
+            path: path,
+            provenance: .referenced,
+            lastReferencedSeq: seq
+        )
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGallerySnapshotTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGallerySnapshotTests.swift
@@ -22,6 +22,10 @@ struct ChatArtifactGallerySnapshotTests {
         )
         let page = ChatArtifactGalleryPage(
             sessionID: "session",
+            created: [created, item(path: "/session/created-next.txt", provenance: .created)],
+            createdTotal: 2,
+            attached: [attached, item(path: "/session/attached-next.txt", provenance: .attached)],
+            attachedTotal: 2,
             referenced: [created, attached, referenced, next, next],
             referencedTotal: 2,
             generation: "generation"
@@ -29,9 +33,11 @@ struct ChatArtifactGallerySnapshotTests {
 
         let snapshot = ChatArtifactGallerySnapshot(page: initial).appending(page)
 
-        #expect(snapshot.created.map(\.path) == [created.path])
-        #expect(snapshot.attached.map(\.path) == [attached.path])
+        #expect(snapshot.created.map(\.path) == [created.path, "/session/created-next.txt"])
+        #expect(snapshot.attached.map(\.path) == [attached.path, "/session/attached-next.txt"])
         #expect(snapshot.referenced.map(\.path) == [referenced.path, next.path])
+        #expect(snapshot.createdTotal == 2)
+        #expect(snapshot.attachedTotal == 2)
     }
 
     private func item(

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGallerySnapshotTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGallerySnapshotTests.swift
@@ -40,6 +40,38 @@ struct ChatArtifactGallerySnapshotTests {
         #expect(snapshot.attachedTotal == 2)
     }
 
+    @Test("stale response is ignored and fresh rebase preserves exact row order")
+    func staleRestartRebase() {
+        let oldA = item(path: "/old-a", provenance: .referenced)
+        let oldB = item(path: "/old-b", provenance: .referenced)
+        let current = ChatArtifactGallerySnapshot(page: ChatArtifactGalleryPage(
+            sessionID: "session",
+            referenced: [oldA, oldB],
+            referencedTotal: 4,
+            nextCursor: "stale",
+            generation: "old"
+        ))
+        let stale = ChatArtifactGalleryPage(
+            sessionID: "session",
+            generation: "new",
+            requiresPagingRestart: true
+        )
+        let fresh = ChatArtifactGallerySnapshot(page: ChatArtifactGalleryPage(
+            sessionID: "session",
+            referenced: [item(path: "/new", provenance: .referenced), oldA],
+            referencedTotal: 5,
+            nextCursor: "fresh",
+            generation: "new"
+        ))
+
+        #expect(current.appending(stale) == current)
+        let rebased = current.rebasingPaging(ontoFreshFirstPage: fresh)
+        #expect(rebased.referenced == current.referenced)
+        #expect(rebased.nextCursor == "fresh")
+        #expect(rebased.generation == "new")
+        #expect(rebased.referencedTotal == 5)
+    }
+
     private func item(
         path: String,
         provenance: ChatArtifactProvenance

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
@@ -183,6 +183,35 @@ struct ChatArtifactGalleryTests {
         #expect(snapshot.referenced.count == 3)
     }
 
+    @Test("a cursor from another generation requests a fresh paging restart")
+    func staleGenerationCursor() throws {
+        let staleCursor = ChatArtifactGalleryCursor(
+            generation: "old",
+            seq: 10,
+            path: "/old"
+        )
+
+        let page = ChatArtifactGalleryBuilder().page(
+            sessionID: "session",
+            items: [ChatArtifactIndexedReference(
+                path: "/new",
+                provenance: .referenced,
+                lastReferencedSeq: 20
+            )],
+            generation: "new",
+            cursor: staleCursor,
+            pageSize: 10,
+            query: nil
+        )
+
+        #expect(page.requiresPagingRestart)
+        #expect(page.generation == "new")
+        #expect(page.created.isEmpty)
+        #expect(page.attached.isEmpty)
+        #expect(page.referenced.isEmpty)
+        #expect(page.nextCursor == nil)
+    }
+
     @Test("directory child counts stop at the listing cap")
     func directoryChildCountCap() throws {
         let root = FileManager.default.temporaryDirectory

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
@@ -124,7 +124,7 @@ struct ChatArtifactGalleryTests {
         #expect(oldHostPage.referencedTotal == 0)
     }
 
-    @Test("each provenance section stats only one bounded page at a time")
+    @Test("pages fill sections sequentially so loads only extend the list bottom")
     func allSectionsPageLazily() throws {
         let items = (1...3).flatMap { index in
             [
@@ -168,19 +168,49 @@ struct ChatArtifactGalleryTests {
         )
         let snapshot = ChatArtifactGallerySnapshot(page: first).appending(second)
 
+        // Sequential fill: the first page is created rows only, and every
+        // later page extends the grouped list strictly at its bottom, so a
+        // scroll-triggered load never inserts rows into an earlier group.
         #expect(first.created.count == 2)
-        #expect(first.attached.count == 2)
-        #expect(first.referenced.count == 2)
+        #expect(first.attached.isEmpty)
+        #expect(first.referenced.isEmpty)
         #expect(first.createdTotal == 3)
         #expect(first.attachedTotal == 3)
         #expect(first.referencedTotal == 3)
         #expect(second.created.count == 1)
         #expect(second.attached.count == 1)
-        #expect(second.referenced.count == 1)
-        #expect(second.nextCursor == nil)
-        #expect(snapshot.created.count == 3)
-        #expect(snapshot.attached.count == 3)
-        #expect(snapshot.referenced.count == 3)
+        #expect(second.referenced.isEmpty)
+
+        var accumulated = snapshot
+        var nextToken = second.nextCursor
+        var guardCounter = 0
+        while let token = nextToken, guardCounter < 8 {
+            let cursor = try #require(ChatArtifactGalleryCursor(token: token))
+            let page = builder.page(
+                sessionID: "session",
+                items: items,
+                generation: "generation",
+                cursor: cursor,
+                pageSize: 2,
+                query: nil,
+                includeDirectories: true
+            )
+            if !accumulated.attached.isEmpty {
+                #expect(page.created.isEmpty)
+            }
+            if !accumulated.referenced.isEmpty {
+                #expect(page.created.isEmpty)
+                #expect(page.attached.isEmpty)
+            }
+            accumulated = accumulated.appending(page)
+            nextToken = page.nextCursor
+            guardCounter += 1
+        }
+
+        #expect(nextToken == nil)
+        #expect(accumulated.created.count == 3)
+        #expect(accumulated.attached.count == 3)
+        #expect(accumulated.referenced.count == 3)
     }
 
     @Test("a cursor from another generation requests a fresh paging restart")

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryTests.swift
@@ -28,6 +28,8 @@ struct ChatArtifactGalleryTests {
         let data = try coding.encode(page)
         let json = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(json["session_id"] as? String == "session-1")
+        #expect(json["created_total"] as? Int == 1)
+        #expect(json["attached_total"] as? Int == 0)
         #expect(json["referenced_total"] as? Int == 7)
         #expect(json["next_cursor"] as? String == "cursor")
         let created = try #require(json["created"] as? [[String: Any]])
@@ -94,7 +96,7 @@ struct ChatArtifactGalleryTests {
             query: nil
         )
         #expect(legacy.referenced.map(\.path) == [file.path])
-        #expect(legacy.referencedTotal == 1)
+        #expect(legacy.referencedTotal == 2)
 
         let folders = builder.page(
             sessionID: "session",
@@ -120,6 +122,65 @@ struct ChatArtifactGalleryTests {
         #expect(oldHostPage.created.isEmpty)
         #expect(oldHostPage.referenced.isEmpty)
         #expect(oldHostPage.referencedTotal == 0)
+    }
+
+    @Test("each provenance section stats only one bounded page at a time")
+    func allSectionsPageLazily() throws {
+        let items = (1...3).flatMap { index in
+            [
+                ChatArtifactIndexedReference(
+                    path: "/missing/created-\(index).txt",
+                    provenance: .created,
+                    lastReferencedSeq: index
+                ),
+                ChatArtifactIndexedReference(
+                    path: "/missing/attached-\(index).txt",
+                    provenance: .attached,
+                    lastReferencedSeq: index
+                ),
+                ChatArtifactIndexedReference(
+                    path: "/missing/referenced-\(index).txt",
+                    provenance: .referenced,
+                    lastReferencedSeq: index
+                ),
+            ]
+        }
+        let builder = ChatArtifactGalleryBuilder()
+
+        let first = builder.page(
+            sessionID: "session",
+            items: items,
+            generation: "generation",
+            cursor: nil,
+            pageSize: 2,
+            query: nil,
+            includeDirectories: true
+        )
+        let cursor = try #require(first.nextCursor.flatMap(ChatArtifactGalleryCursor.init(token:)))
+        let second = builder.page(
+            sessionID: "session",
+            items: items,
+            generation: "generation",
+            cursor: cursor,
+            pageSize: 2,
+            query: nil,
+            includeDirectories: true
+        )
+        let snapshot = ChatArtifactGallerySnapshot(page: first).appending(second)
+
+        #expect(first.created.count == 2)
+        #expect(first.attached.count == 2)
+        #expect(first.referenced.count == 2)
+        #expect(first.createdTotal == 3)
+        #expect(first.attachedTotal == 3)
+        #expect(first.referencedTotal == 3)
+        #expect(second.created.count == 1)
+        #expect(second.attached.count == 1)
+        #expect(second.referenced.count == 1)
+        #expect(second.nextCursor == nil)
+        #expect(snapshot.created.count == 3)
+        #expect(snapshot.attached.count == 3)
+        #expect(snapshot.referenced.count == 3)
     }
 
     @Test("directory child counts stop at the listing cap")

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactLRUCacheTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactLRUCacheTests.swift
@@ -1,0 +1,21 @@
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat artifact LRU cache")
+struct ChatArtifactLRUCacheTests {
+    @Test("a cache hit protects the entry from capacity eviction")
+    func hitUpdatesRecency() {
+        var cache = ChatArtifactLRUCache<String, Int>(capacity: 2)
+        cache.insert(1, forKey: "one")
+        cache.insert(2, forKey: "two")
+
+        #expect(cache.value(forKey: "one") == 1)
+        cache.insert(3, forKey: "three")
+
+        #expect(cache.count == 2)
+        #expect(cache.value(forKey: "one") == 1)
+        #expect(cache.value(forKey: "two") == nil)
+        #expect(cache.value(forKey: "three") == 3)
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatSessionSurfaceIndexTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatSessionSurfaceIndexTests.swift
@@ -1,0 +1,50 @@
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Chat session surface index")
+struct ChatSessionSurfaceIndexTests {
+    private struct Record {
+        let sessionID: String
+        var surfaceID: String?
+    }
+
+    @Test("indexed candidates stay equivalent to a full record scan")
+    func behaviorParityWithScan() {
+        var records: [String: Record] = [:]
+        var index = ChatSessionSurfaceIndex<String>()
+
+        func expectParity(surfaceID: String) {
+            let scanned = Set(records.values.lazy
+                .filter { $0.surfaceID == surfaceID }
+                .map(\.sessionID))
+            #expect(index.sessionIDs(surfaceID: surfaceID) == scanned)
+        }
+
+        records["one"] = Record(sessionID: "one", surfaceID: "surface-a")
+        index.update(sessionID: "one", previousSurfaceID: nil, currentSurfaceID: "surface-a")
+        records["two"] = Record(sessionID: "two", surfaceID: "surface-a")
+        index.update(sessionID: "two", previousSurfaceID: nil, currentSurfaceID: "surface-a")
+        records["unbound"] = Record(sessionID: "unbound", surfaceID: nil)
+        index.update(sessionID: "unbound", previousSurfaceID: nil, currentSurfaceID: nil)
+        expectParity(surfaceID: "surface-a")
+
+        records["one"]?.surfaceID = "surface-b"
+        index.update(
+            sessionID: "one",
+            previousSurfaceID: "surface-a",
+            currentSurfaceID: "surface-b"
+        )
+        expectParity(surfaceID: "surface-a")
+        expectParity(surfaceID: "surface-b")
+
+        let removed = records.removeValue(forKey: "two")
+        index.update(
+            sessionID: "two",
+            previousSurfaceID: removed?.surfaceID,
+            currentSurfaceID: nil
+        )
+        expectParity(surfaceID: "surface-a")
+        expectParity(surfaceID: "surface-b")
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalArtifactTapHitTesterTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalArtifactTapHitTesterTests.swift
@@ -85,6 +85,20 @@ struct TerminalArtifactTapHitTesterTests {
         #expect(resolved == path)
     }
 
+    @Test("uses terminal cell width for CJK text before a path")
+    func cjkPrefixUsesTerminalColumns() {
+        let path = "/tmp/note.txt"
+
+        let resolved = TerminalArtifactTapHitTester().path(
+            in: "漢字 open \(path)",
+            col: 22,
+            row: 0,
+            columns: 80
+        )
+
+        #expect(resolved == path)
+    }
+
     @Test("does not stitch a full-width token to a new prompt")
     func doesNotStitchPrompt() {
         let path = "/tmp/exact.md"

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactContentCache.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactContentCache.swift
@@ -1,0 +1,203 @@
+import CmuxAgentChat
+import CryptoKit
+import Foundation
+
+/// Memory-fronted, purgeable disk LRU for fully fetched artifact bytes.
+public actor ChatArtifactContentCache {
+    private let directory: URL
+    private let maxDiskBytes: Int64
+    private let maxMemoryBytes: Int
+    private let fileManager = FileManager()
+    private let memoryCache = NSCache<NSString, NSData>()
+
+    /// Creates a content cache rooted at an injected directory.
+    ///
+    /// - Parameters:
+    ///   - directory: Purgeable cache directory.
+    ///   - maxDiskBytes: Maximum aggregate disk usage.
+    ///   - maxMemoryBytes: Approximate `NSCache` byte-cost limit.
+    public init(
+        directory: URL,
+        maxDiskBytes: Int64 = 256 * 1_024 * 1_024,
+        maxMemoryBytes: Int = 32 * 1_024 * 1_024
+    ) {
+        self.directory = directory
+        self.maxDiskBytes = max(0, maxDiskBytes)
+        self.maxMemoryBytes = max(0, maxMemoryBytes)
+        memoryCache.totalCostLimit = self.maxMemoryBytes
+    }
+
+    /// Creates the production cache in `Caches/<bundle>/artifact-content/`.
+    ///
+    /// - Parameters:
+    ///   - maxDiskBytes: Maximum aggregate disk usage.
+    ///   - maxMemoryBytes: Approximate `NSCache` byte-cost limit.
+    ///   - fileManager: Filesystem locator used to resolve the caches directory.
+    ///   - bundleIdentifier: Bundle-specific directory component.
+    /// - Returns: A cache configured for application use.
+    public static func applicationDefault(
+        maxDiskBytes: Int64 = 256 * 1_024 * 1_024,
+        maxMemoryBytes: Int = 32 * 1_024 * 1_024,
+        fileManager: FileManager = .default,
+        bundleIdentifier: String? = Bundle.main.bundleIdentifier
+    ) -> ChatArtifactContentCache {
+        let caches = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first
+            ?? fileManager.temporaryDirectory
+        let bundleComponent = bundleIdentifier.flatMap { $0.isEmpty ? nil : $0 } ?? "cmux"
+        return ChatArtifactContentCache(
+            directory: caches
+                .appendingPathComponent(bundleComponent, isDirectory: true)
+                .appendingPathComponent("artifact-content", isDirectory: true),
+            maxDiskBytes: maxDiskBytes,
+            maxMemoryBytes: maxMemoryBytes
+        )
+    }
+
+    /// Derives a versioned key from authorization scope and host file metadata.
+    public static func key(
+        scopeKey: String,
+        path: String,
+        modifiedAt: Date?,
+        size: Int64?
+    ) -> String? {
+        guard let modifiedAt, let size else { return nil }
+        let raw = "\(scopeKey)#\(path)#\(String(modifiedAt.timeIntervalSince1970.bitPattern, radix: 16))#\(size)"
+        return SHA256.hash(data: Data(raw.utf8)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    /// Replays a cache hit or writes a fetched stream through atomically.
+    ///
+    /// - Returns: `true` when no source fetch was needed.
+    func stream(
+        for key: String,
+        expectedSize: Int64,
+        accessedAt: Date = Date(),
+        fetch: @escaping @Sendable (
+            _ receive: @Sendable (ChatArtifactChunk) async throws -> Void
+        ) async throws -> Void,
+        receive: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws -> Bool {
+        if let data = memoryCache.object(forKey: key as NSString) {
+            let value = Data(referencing: data)
+            try? touch(fileURL(for: key), at: accessedAt)
+            try await receive(Self.chunk(data: value, totalSize: expectedSize))
+            return true
+        }
+
+        if try await replayDiskEntry(
+            for: key,
+            expectedSize: expectedSize,
+            accessedAt: accessedAt,
+            receive: receive
+        ) {
+            return true
+        }
+
+        let writer = try ChatArtifactContentCacheWriter(
+            directory: directory,
+            key: key,
+            expectedSize: expectedSize,
+            retainsMemoryCopy: expectedSize <= Int64(maxMemoryBytes)
+        )
+        do {
+            try await fetch { chunk in
+                try Task.checkCancellation()
+                try await writer.append(chunk)
+                try await receive(chunk)
+            }
+            try Task.checkCancellation()
+            let data = try await writer.finish()
+            if let data, maxMemoryBytes > 0 {
+                memoryCache.setObject(data as NSData, forKey: key as NSString, cost: data.count)
+            }
+            try touch(fileURL(for: key), at: accessedAt)
+            try enforceDiskBudget()
+            return false
+        } catch {
+            await writer.discard()
+            throw error
+        }
+    }
+
+    private func replayDiskEntry(
+        for key: String,
+        expectedSize: Int64,
+        accessedAt: Date,
+        receive: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws -> Bool {
+        let url = fileURL(for: key)
+        guard let attributes = try? fileManager.attributesOfItem(atPath: url.path),
+              (attributes[.size] as? NSNumber)?.int64Value == expectedSize else {
+            try? fileManager.removeItem(at: url)
+            return false
+        }
+        try touch(url, at: accessedAt)
+        if expectedSize == 0 {
+            try await receive(Self.chunk(data: Data(), totalSize: 0))
+            return true
+        }
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var offset: Int64 = 0
+        while offset < expectedSize {
+            try Task.checkCancellation()
+            let requested = Int(min(Int64(Self.diskReadChunkBytes), expectedSize - offset))
+            guard let data = try handle.read(upToCount: requested), !data.isEmpty else {
+                throw CocoaError(.fileReadCorruptFile)
+            }
+            let chunkOffset = offset
+            offset += Int64(data.count)
+            try await receive(ChatArtifactChunk(
+                data: data,
+                offset: chunkOffset,
+                totalSize: expectedSize,
+                eof: offset == expectedSize
+            ))
+        }
+        return true
+    }
+
+    private func fileURL(for key: String) -> URL {
+        directory.appendingPathComponent(key, isDirectory: false)
+    }
+
+    private func touch(_ url: URL, at date: Date) throws {
+        try fileManager.setAttributes([.modificationDate: date], ofItemAtPath: url.path)
+    }
+
+    private func enforceDiskBudget() throws {
+        let keys: Set<URLResourceKey> = [
+            .fileSizeKey,
+            .contentModificationDateKey,
+            .isRegularFileKey,
+            .nameKey,
+        ]
+        let urls = try fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: Array(keys),
+            options: [.skipsHiddenFiles]
+        )
+        var entries: [(url: URL, size: Int64, accessedAt: Date)] = []
+        var totalBytes: Int64 = 0
+        for url in urls {
+            let values = try url.resourceValues(forKeys: keys)
+            guard values.isRegularFile == true,
+                  values.name?.hasSuffix(".partial") != true else { continue }
+            let size = Int64(values.fileSize ?? 0)
+            totalBytes += size
+            entries.append((url, size, values.contentModificationDate ?? .distantPast))
+        }
+        guard totalBytes > maxDiskBytes else { return }
+        for entry in entries.sorted(by: { $0.accessedAt < $1.accessedAt })
+        where totalBytes > maxDiskBytes {
+            try fileManager.removeItem(at: entry.url)
+            totalBytes -= entry.size
+        }
+    }
+
+    private static func chunk(data: Data, totalSize: Int64) -> ChatArtifactChunk {
+        ChatArtifactChunk(data: data, offset: 0, totalSize: totalSize, eof: true)
+    }
+
+    private static let diskReadChunkBytes = 1 * 1_024 * 1_024
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactContentCacheWriter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactContentCacheWriter.swift
@@ -1,0 +1,79 @@
+import CmuxAgentChat
+import Foundation
+
+/// Serializes one artifact stream into an atomic content-cache entry.
+actor ChatArtifactContentCacheWriter {
+    private let expectedSize: Int64
+    private let temporaryURL: URL
+    private let destinationURL: URL
+    private var fileHandle: FileHandle?
+    private var memoryData: Data?
+    private var nextOffset: Int64 = 0
+    private var reachedEOF = false
+
+    init(
+        directory: URL,
+        key: String,
+        expectedSize: Int64,
+        retainsMemoryCopy: Bool
+    ) throws {
+        let fileManager = FileManager()
+        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        self.expectedSize = expectedSize
+        destinationURL = directory.appendingPathComponent(key, isDirectory: false)
+        temporaryURL = directory.appendingPathComponent(
+            ".\(key).\(UUID().uuidString).partial",
+            isDirectory: false
+        )
+        guard fileManager.createFile(atPath: temporaryURL.path, contents: nil) else {
+            throw CocoaError(.fileWriteUnknown)
+        }
+        do {
+            fileHandle = try FileHandle(forWritingTo: temporaryURL)
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        }
+        memoryData = retainsMemoryCopy ? Data() : nil
+        if retainsMemoryCopy, expectedSize <= Int64(Int.max) {
+            memoryData?.reserveCapacity(Int(expectedSize))
+        }
+    }
+
+    func append(_ chunk: ChatArtifactChunk) throws {
+        guard !reachedEOF,
+              chunk.offset == nextOffset,
+              chunk.totalSize == expectedSize,
+              nextOffset <= expectedSize - Int64(chunk.data.count),
+              let fileHandle else {
+            throw ChatArtifactError.macUnreachable
+        }
+        try fileHandle.write(contentsOf: chunk.data)
+        memoryData?.append(chunk.data)
+        nextOffset += Int64(chunk.data.count)
+        reachedEOF = chunk.eof
+        if reachedEOF, nextOffset != expectedSize {
+            throw ChatArtifactError.macUnreachable
+        }
+    }
+
+    func finish() throws -> Data? {
+        guard reachedEOF, nextOffset == expectedSize, let fileHandle else {
+            throw ChatArtifactError.macUnreachable
+        }
+        try fileHandle.close()
+        self.fileHandle = nil
+        let fileManager = FileManager()
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.moveItem(at: temporaryURL, to: destinationURL)
+        return memoryData
+    }
+
+    func discard() {
+        try? fileHandle?.close()
+        fileHandle = nil
+        try? FileManager().removeItem(at: temporaryURL)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFileActionPresentation.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFileActionPresentation.swift
@@ -1,0 +1,127 @@
+import SwiftUI
+
+#if os(iOS)
+import UIKit
+
+/// A system presentation prepared by an artifact file action.
+public enum ChatArtifactFileActionPresentation: Identifiable, Equatable {
+    /// Presents the standard activity controller for a local file.
+    case share(URL)
+    /// Presents the Files document picker in export-as-copy mode.
+    case save(URL)
+
+    /// Stable identity for SwiftUI sheet presentation.
+    public var id: String {
+        switch self {
+        case .share(let url):
+            return "share:\(url.path)"
+        case .save(let url):
+            return "save:\(url.path)"
+        }
+    }
+
+    fileprivate var fileURL: URL {
+        switch self {
+        case .share(let url), .save(let url):
+            return url
+        }
+    }
+}
+
+public extension View {
+    /// Presents Share or Save to Files for a materialized artifact.
+    ///
+    /// Temporary files are removed when the system controller finishes.
+    func chatArtifactFileActionPresentation(
+        _ presentation: Binding<ChatArtifactFileActionPresentation?>
+    ) -> some View {
+        modifier(ChatArtifactFileActionPresentationModifier(presentation: presentation))
+    }
+}
+
+private struct ChatArtifactFileActionPresentationModifier: ViewModifier {
+    @Binding var presentation: ChatArtifactFileActionPresentation?
+
+    func body(content: Content) -> some View {
+        content.sheet(item: $presentation) { item in
+            switch item {
+            case .share(let url):
+                ChatArtifactActivityView(fileURL: url) {
+                    finish(item)
+                }
+            case .save(let url):
+                ChatArtifactDocumentPicker(fileURL: url) {
+                    finish(item)
+                }
+            }
+        }
+    }
+
+    private func finish(_ item: ChatArtifactFileActionPresentation) {
+        presentation = nil
+        Task {
+            await ChatArtifactFileActionStore.applicationDefault.remove(item.fileURL)
+        }
+    }
+}
+
+private struct ChatArtifactActivityView: UIViewControllerRepresentable {
+    let fileURL: URL
+    let onFinish: () -> Void
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        let controller = UIActivityViewController(
+            activityItems: [fileURL],
+            applicationActivities: nil
+        )
+        controller.completionWithItemsHandler = { _, _, _, _ in
+            onFinish()
+        }
+        return controller
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
+}
+
+private struct ChatArtifactDocumentPicker: UIViewControllerRepresentable {
+    let fileURL: URL
+    let onFinish: () -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onFinish: onFinish)
+    }
+
+    func makeUIViewController(context: Context) -> UIDocumentPickerViewController {
+        let controller = UIDocumentPickerViewController(
+            forExporting: [fileURL],
+            asCopy: true
+        )
+        controller.delegate = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(
+        _ controller: UIDocumentPickerViewController,
+        context: Context
+    ) {}
+
+    final class Coordinator: NSObject, UIDocumentPickerDelegate {
+        private let onFinish: () -> Void
+
+        init(onFinish: @escaping () -> Void) {
+            self.onFinish = onFinish
+        }
+
+        func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+            onFinish()
+        }
+
+        func documentPicker(
+            _ controller: UIDocumentPickerViewController,
+            didPickDocumentsAt urls: [URL]
+        ) {
+            onFinish()
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFileActionStore.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFileActionStore.swift
@@ -1,0 +1,69 @@
+import CmuxAgentChat
+import Foundation
+
+/// Materializes host artifacts as correctly named local files for system actions.
+public actor ChatArtifactFileActionStore {
+    /// Shared purgeable store used by artifact viewers and gallery rows.
+    public static let applicationDefault = ChatArtifactFileActionStore()
+
+    private let temporaryFileStore: ChatArtifactTemporaryFileStore
+
+    /// Creates a file-action store rooted in a purgeable caches directory.
+    ///
+    /// - Parameter directory: Optional directory override used by tests.
+    public init(directory: URL? = nil) {
+        let resolvedDirectory: URL
+        if let directory {
+            resolvedDirectory = directory
+        } else {
+            let cachesDirectory = FileManager.default.urls(
+                for: .cachesDirectory,
+                in: .userDomainMask
+            ).first ?? FileManager.default.temporaryDirectory
+            resolvedDirectory = cachesDirectory.appendingPathComponent(
+                "cmux-artifact-actions",
+                isDirectory: true
+            )
+        }
+        temporaryFileStore = ChatArtifactTemporaryFileStore(directory: resolvedDirectory)
+    }
+
+    /// Stats and streams one file through the shared content cache.
+    ///
+    /// The returned URL keeps the source basename so system share and document
+    /// pickers display the filename the user expects.
+    ///
+    /// - Parameters:
+    ///   - path: Absolute path on the Mac host.
+    ///   - loader: Scoped artifact loader authorizing the path.
+    /// - Returns: A local, correctly named temporary file.
+    public func materialize(
+        path: String,
+        loader: ChatArtifactLoader
+    ) async throws -> URL {
+        let stat = try await loader.stat(path: path)
+        guard !stat.isDirectory else {
+            throw ChatArtifactError.unsupported
+        }
+        let filename = Self.filename(for: path)
+        return try await temporaryFileStore.fetch(
+            path: path,
+            expectedSize: stat.size,
+            modifiedAt: stat.modifiedAt,
+            limit: Int64.max,
+            preferredFilename: filename,
+            loader: loader,
+            progress: { _ in }
+        )
+    }
+
+    /// Removes a file previously returned by ``materialize(path:loader:)``.
+    public func remove(_ fileURL: URL) async {
+        await temporaryFileStore.remove(fileURL)
+    }
+
+    private static func filename(for path: String) -> String {
+        let candidate = URL(fileURLWithPath: path).lastPathComponent
+        return candidate.isEmpty ? "Artifact" : candidate
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderView.swift
@@ -10,6 +10,7 @@ import AppKit
 struct ChatArtifactFolderView: View {
     let path: String
     let scope: ChatArtifactViewerScope
+    let onImageMinimumZoomChanged: (Bool) -> Void
     let onDone: () -> Void
 
     @Environment(\.chatArtifactLoader) private var loader
@@ -45,6 +46,7 @@ struct ChatArtifactFolderView: View {
                                     ChatArtifactViewerRouteView(
                                         path: childPath(named: entry.name),
                                         scope: scope,
+                                        onImageMinimumZoomChanged: onImageMinimumZoomChanged,
                                         onDone: onDone
                                     )
                                 } label: {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLoader.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLoader.swift
@@ -79,6 +79,7 @@ public struct ChatArtifactLoader: Sendable {
     public let supportsArtifacts: Bool
     /// Whether directory stat results may route into a navigable folder browser.
     public let supportsDirectoryBrowsing: Bool
+    /// Authorization and cache namespace for artifact operations.
     public let scope: ChatArtifactLoaderScope
 
     private let statHandler: @Sendable (_ path: String) async throws -> ChatArtifactStat
@@ -272,7 +273,8 @@ public struct ChatArtifactLoader: Sendable {
         size: Int64? = nil,
         onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
     ) async throws {
-        guard let key = ChatArtifactContentCache.key(
+        guard scope != .unsupported,
+              let key = ChatArtifactContentCache.key(
             scopeKey: scope.cacheNamespace,
             path: path,
             modifiedAt: modifiedAt,

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLoader.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLoader.swift
@@ -93,6 +93,7 @@ public struct ChatArtifactLoader: Sendable {
     private let thumbnailHandler: @Sendable (_ path: String, _ maxDimension: Int) async throws -> ChatArtifactThumbnail
     private let listHandler: @Sendable (_ path: String) async throws -> ChatArtifactDirectoryListing
     private let thumbnailCache: ChatArtifactThumbnailCache
+    private let contentCache: ChatArtifactContentCache
 
     /// Creates a closure-backed artifact loader.
     ///
@@ -101,6 +102,7 @@ public struct ChatArtifactLoader: Sendable {
     ///   - supportsDirectoryBrowsing: Whether directory stat results may be listed.
     ///   - scope: Cache and authorization namespace for this loader.
     ///   - cache: Thumbnail cache shared by rows and viewers.
+    ///   - contentCache: Full-content cache shared by viewer routes.
     ///   - stat: Metadata operation for an absolute host path.
     ///   - fetch: Whole-file operation retained for image and compatibility callers.
     ///   - stream: Optional structured chunk operation; defaults to one callback
@@ -112,6 +114,7 @@ public struct ChatArtifactLoader: Sendable {
         supportsDirectoryBrowsing: Bool = false,
         scope: ChatArtifactLoaderScope = .unsupported,
         cache: ChatArtifactThumbnailCache = ChatArtifactThumbnailCache(),
+        contentCache: ChatArtifactContentCache = .applicationDefault(),
         stat: @escaping @Sendable (_ path: String) async throws -> ChatArtifactStat = { _ in
             throw ChatArtifactError.unsupported
         },
@@ -136,6 +139,7 @@ public struct ChatArtifactLoader: Sendable {
         self.supportsDirectoryBrowsing = supportsDirectoryBrowsing
         self.scope = scope
         self.thumbnailCache = cache
+        self.contentCache = contentCache
         statHandler = stat
         fetchHandler = fetch
         streamHandler = stream ?? { path, onChunk in
@@ -157,13 +161,15 @@ public struct ChatArtifactLoader: Sendable {
     public init(
         source: any ChatEventSource,
         sessionID: String,
-        cache: ChatArtifactThumbnailCache = ChatArtifactThumbnailCache()
+        cache: ChatArtifactThumbnailCache = ChatArtifactThumbnailCache(),
+        contentCache: ChatArtifactContentCache = .applicationDefault()
     ) {
         self.init(
             supportsArtifacts: source.supportsArtifacts,
             supportsDirectoryBrowsing: source.supportsArtifactFolders,
             scope: .chat(sessionID: sessionID),
             cache: cache,
+            contentCache: contentCache,
             stat: { path in
                 try await source.artifactStat(sessionID: sessionID, path: path)
             },
@@ -194,6 +200,7 @@ public struct ChatArtifactLoader: Sendable {
     ///   - supportsArtifacts: Whether terminal artifact operations are available.
     ///   - supportsDirectoryBrowsing: Whether terminal directory listing is available.
     ///   - cache: Thumbnail cache shared by rows and viewers.
+    ///   - contentCache: Full-content cache shared by viewer routes.
     ///   - stat: Metadata operation for an absolute host path.
     ///   - fetch: Whole-file compatibility operation.
     ///   - stream: Optional structured chunk operation.
@@ -205,6 +212,7 @@ public struct ChatArtifactLoader: Sendable {
         supportsArtifacts: Bool,
         supportsDirectoryBrowsing: Bool = false,
         cache: ChatArtifactThumbnailCache = ChatArtifactThumbnailCache(),
+        contentCache: ChatArtifactContentCache = .applicationDefault(),
         stat: @escaping @Sendable (_ path: String) async throws -> ChatArtifactStat,
         fetch: @escaping @Sendable (
             _ path: String,
@@ -224,6 +232,7 @@ public struct ChatArtifactLoader: Sendable {
             supportsDirectoryBrowsing: supportsDirectoryBrowsing,
             scope: .terminal(workspaceID: terminalWorkspaceID, surfaceID: terminalSurfaceID),
             cache: cache,
+            contentCache: contentCache,
             stat: stat,
             fetch: fetch,
             stream: stream,
@@ -232,8 +241,11 @@ public struct ChatArtifactLoader: Sendable {
         )
     }
 
-    public static func unsupported(cache: ChatArtifactThumbnailCache = ChatArtifactThumbnailCache()) -> ChatArtifactLoader {
-        ChatArtifactLoader(cache: cache)
+    public static func unsupported(
+        cache: ChatArtifactThumbnailCache = ChatArtifactThumbnailCache(),
+        contentCache: ChatArtifactContentCache = .applicationDefault()
+    ) -> ChatArtifactLoader {
+        ChatArtifactLoader(cache: cache, contentCache: contentCache)
     }
 
     public func stat(path: String) async throws -> ChatArtifactStat {
@@ -251,12 +263,33 @@ public struct ChatArtifactLoader: Sendable {
     ///
     /// - Parameters:
     ///   - path: Absolute Mac host path.
+    ///   - modifiedAt: Stat modification time used to invalidate cached bytes.
+    ///   - size: Stat byte size used to validate and invalidate cached bytes.
     ///   - onChunk: Structured callback awaited for each chunk in byte order.
     public func stream(
         path: String,
-        onChunk: @Sendable (ChatArtifactChunk) async throws -> Void
+        modifiedAt: Date? = nil,
+        size: Int64? = nil,
+        onChunk: @escaping @Sendable (ChatArtifactChunk) async throws -> Void
     ) async throws {
-        try await streamHandler(path, onChunk)
+        guard let key = ChatArtifactContentCache.key(
+            scopeKey: scope.cacheNamespace,
+            path: path,
+            modifiedAt: modifiedAt,
+            size: size
+        ), let size else {
+            try await streamHandler(path, onChunk)
+            return
+        }
+        let handler = streamHandler
+        _ = try await contentCache.stream(
+            for: key,
+            expectedSize: size,
+            fetch: { receive in
+                try await handler(path, receive)
+            },
+            receive: onChunk
+        )
     }
 
     public func thumbnail(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileStore.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileStore.swift
@@ -24,6 +24,7 @@ actor ChatArtifactTemporaryFileStore {
     func fetch(
         path: String,
         expectedSize: Int64,
+        modifiedAt: Date? = nil,
         limit: Int64,
         fallbackExtension: String? = nil,
         loader: ChatArtifactLoader,
@@ -41,7 +42,11 @@ actor ChatArtifactTemporaryFileStore {
             fileExtension: fileExtension
         )
         do {
-            try await loader.stream(path: path) { chunk in
+            try await loader.stream(
+                path: path,
+                modifiedAt: modifiedAt,
+                size: expectedSize
+            ) { chunk in
                 try Task.checkCancellation()
                 try await writer.append(chunk, limit: limit)
                 await progress(chunk)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileStore.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileStore.swift
@@ -27,6 +27,7 @@ actor ChatArtifactTemporaryFileStore {
         modifiedAt: Date? = nil,
         limit: Int64,
         fallbackExtension: String? = nil,
+        preferredFilename: String? = nil,
         loader: ChatArtifactLoader,
         progress: @escaping @Sendable (ChatArtifactChunk) async -> Void
     ) async throws -> URL {
@@ -39,7 +40,8 @@ actor ChatArtifactTemporaryFileStore {
             : originalExtension
         let writer = try ChatArtifactTemporaryFileWriter(
             directory: directory,
-            fileExtension: fileExtension
+            fileExtension: fileExtension,
+            preferredFilename: preferredFilename
         )
         do {
             try await loader.stream(
@@ -61,5 +63,10 @@ actor ChatArtifactTemporaryFileStore {
 
     func remove(_ fileURL: URL) {
         try? FileManager.default.removeItem(at: fileURL)
+        let parent = fileURL.deletingLastPathComponent()
+        if parent != directory,
+           parent.deletingLastPathComponent() == directory {
+            try? FileManager.default.removeItem(at: parent)
+        }
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileWriter.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTemporaryFileWriter.swift
@@ -8,14 +8,32 @@ actor ChatArtifactTemporaryFileWriter {
     private var fileHandle: FileHandle?
     private var nextOffset: Int64 = 0
 
-    init(directory: URL, fileExtension: String) throws {
+    init(
+        directory: URL,
+        fileExtension: String,
+        preferredFilename: String? = nil
+    ) throws {
         try FileManager.default.createDirectory(
             at: directory,
             withIntermediateDirectories: true
         )
-        var fileURL = directory.appendingPathComponent(UUID().uuidString)
-        if !fileExtension.isEmpty {
-            fileURL.appendPathExtension(fileExtension)
+        let fileURL: URL
+        if let preferredFilename {
+            let itemDirectory = directory.appendingPathComponent(
+                UUID().uuidString,
+                isDirectory: true
+            )
+            try FileManager.default.createDirectory(
+                at: itemDirectory,
+                withIntermediateDirectories: true
+            )
+            fileURL = itemDirectory.appendingPathComponent(preferredFilename)
+        } else {
+            var generatedURL = directory.appendingPathComponent(UUID().uuidString)
+            if !fileExtension.isEmpty {
+                generatedURL.appendPathExtension(fileExtension)
+            }
+            fileURL = generatedURL
         }
         guard FileManager.default.createFile(atPath: fileURL.path, contents: nil) else {
             throw CocoaError(.fileWriteUnknown)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -66,18 +66,29 @@ final class ChatArtifactViewerModel {
 
             switch route {
             case .text:
-                try await streamText(path: path, isMarkdown: false, loader: loader)
+                try await streamText(
+                    path: path,
+                    stat: loadedStat,
+                    isMarkdown: false,
+                    loader: loader
+                )
             case .markdown:
                 markdownPresentation = ChatArtifactMarkdownPresentation(
                     byteCount: loadedStat.size
                 )
-                try await streamText(path: path, isMarkdown: true, loader: loader)
+                try await streamText(
+                    path: path,
+                    stat: loadedStat,
+                    isMarkdown: true,
+                    loader: loader
+                )
             case .image:
-                try await loadImage(path: path, loader: loader)
+                try await loadImage(path: path, stat: loadedStat, loader: loader)
             case .pdf:
                 if let fileURL = try await loadTemporaryFile(
                     path: path,
                     expectedSize: loadedStat.size,
+                    modifiedAt: loadedStat.modifiedAt,
                     limit: limit,
                     fallbackExtension: "pdf",
                     loader: loader
@@ -88,6 +99,7 @@ final class ChatArtifactViewerModel {
                 if let fileURL = try await loadTemporaryFile(
                     path: path,
                     expectedSize: loadedStat.size,
+                    modifiedAt: loadedStat.modifiedAt,
                     limit: limit,
                     fallbackExtension: nil,
                     loader: loader
@@ -98,6 +110,7 @@ final class ChatArtifactViewerModel {
                 if let fileURL = try await loadTemporaryFile(
                     path: path,
                     expectedSize: loadedStat.size,
+                    modifiedAt: loadedStat.modifiedAt,
                     limit: limit,
                     fallbackExtension: nil,
                     loader: loader
@@ -148,11 +161,16 @@ final class ChatArtifactViewerModel {
 
     private func streamText(
         path: String,
+        stat: ChatArtifactStat,
         isMarkdown: Bool,
         loader: ChatArtifactLoader
     ) async throws {
         let decoder = UTF8ChunkDecoder()
-        try await loader.stream(path: path) { chunk in
+        try await loader.stream(
+            path: path,
+            modifiedAt: stat.modifiedAt,
+            size: stat.size
+        ) { chunk in
             try Task.checkCancellation()
             let decoded = try await decoder.decode(chunk.data, eof: chunk.eof)
             try Task.checkCancellation()
@@ -181,9 +199,17 @@ final class ChatArtifactViewerModel {
         state = isMarkdown ? .markdown : .text
     }
 
-    private func loadImage(path: String, loader: ChatArtifactLoader) async throws {
+    private func loadImage(
+        path: String,
+        stat: ChatArtifactStat,
+        loader: ChatArtifactLoader
+    ) async throws {
         let accumulator = ChatArtifactDataAccumulator()
-        try await loader.stream(path: path) { chunk in
+        try await loader.stream(
+            path: path,
+            modifiedAt: stat.modifiedAt,
+            size: stat.size
+        ) { chunk in
             try Task.checkCancellation()
             await accumulator.append(chunk.data, totalSize: chunk.totalSize)
             await self.receiveNonTextProgress(chunk: chunk, path: path)
@@ -197,6 +223,7 @@ final class ChatArtifactViewerModel {
     private func loadTemporaryFile(
         path: String,
         expectedSize: Int64,
+        modifiedAt: Date?,
         limit: Int64,
         fallbackExtension: String?,
         loader: ChatArtifactLoader
@@ -204,6 +231,7 @@ final class ChatArtifactViewerModel {
         let fileURL = try await temporaryFileStore.fetch(
             path: path,
             expectedSize: expectedSize,
+            modifiedAt: modifiedAt,
             limit: limit,
             fallbackExtension: fallbackExtension,
             loader: loader

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -12,6 +12,7 @@ final class ChatArtifactViewerModel {
     private(set) var totalBytes: Int64?
     private(set) var textReachedEOF = false
     private(set) var activePath: String?
+    private(set) var activeStat: ChatArtifactStat?
     private(set) var markdownPresentation = ChatArtifactMarkdownPresentation(byteCount: 0)
     private(set) var textHighlightDecision: ChatArtifactHighlightDecision = .skippedNoLanguage
     private(set) var textLineIndex = ChatArtifactLineIndex()
@@ -28,6 +29,21 @@ final class ChatArtifactViewerModel {
         textChunks.joined()
     }
 
+    var hasFileActions: Bool {
+        guard let activeStat, !activeStat.isDirectory else { return false }
+        return state != .loading
+    }
+
+    var isTextFile: Bool {
+        state == .text || state == .markdown
+    }
+
+    var canCopyContents: Bool {
+        isTextFile
+            && textReachedEOF
+            && (activeStat?.size ?? .max) <= Self.maximumCopyContentsBytes
+    }
+
     func load(
         path: String,
         loader: ChatArtifactLoader,
@@ -41,6 +57,7 @@ final class ChatArtifactViewerModel {
             try Task.checkCancellation()
             guard path == activePath else { return }
             stat = loadedStat
+            activeStat = loadedStat
             totalBytes = loadedStat.size
             textHighlightDecision = ChatArtifactSyntaxHighlightPolicy().decision(
                 path: path,
@@ -149,6 +166,7 @@ final class ChatArtifactViewerModel {
 
     private func reset(for path: String) {
         activePath = path
+        activeStat = nil
         state = .loading
         textChunks = []
         fetchedBytes = 0
@@ -284,4 +302,6 @@ final class ChatArtifactViewerModel {
             return .tooLarge(actualSize: stat?.size, limit: limitBytes)
         }
     }
+
+    private static let maximumCopyContentsBytes: Int64 = 4 * 1024 * 1024
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
@@ -9,6 +9,7 @@ struct ChatArtifactViewerPager: View {
     let onDone: () -> Void
 
     @State private var selectedPath: String
+    @State private var zoomedPath: String?
 
     init(
         initialPath: String,
@@ -35,6 +36,7 @@ struct ChatArtifactViewerPager: View {
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
+            .scrollDisabled(zoomedPath != nil)
         } else {
             viewer(path: initialPath)
         }
@@ -48,6 +50,15 @@ struct ChatArtifactViewerPager: View {
             ChatArtifactViewerRouteView(
                 path: path,
                 scope: scope,
+                onImageMinimumZoomChanged: { isAtMinimum in
+                    if isAtMinimum {
+                        if zoomedPath == path {
+                            zoomedPath = nil
+                        }
+                    } else {
+                        zoomedPath = path
+                    }
+                },
                 onDone: onDone
             )
         }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -15,6 +15,7 @@ struct ChatArtifactViewerRouteView: View {
     let path: String
     let scope: ChatArtifactViewerScope
     let onDone: () -> Void
+    let onImageMinimumZoomChanged: (Bool) -> Void
     private let textPreferences: ChatArtifactTextPreferences
     private let textLayoutKind: ChatArtifactTextLayoutKind
 
@@ -48,11 +49,13 @@ struct ChatArtifactViewerRouteView: View {
         textPreferences: ChatArtifactTextPreferences = ChatArtifactTextPreferences(
             defaults: .standard
         ),
+        onImageMinimumZoomChanged: @escaping (Bool) -> Void = { _ in },
         onDone: @escaping () -> Void
     ) {
         self.path = path
         self.scope = scope
         self.onDone = onDone
+        self.onImageMinimumZoomChanged = onImageMinimumZoomChanged
         self.textPreferences = textPreferences
         let layoutKind = ChatArtifactTextLayoutKind(path: path)
         textLayoutKind = layoutKind
@@ -352,12 +355,32 @@ struct ChatArtifactViewerRouteView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .padding()
         case .folder:
-            ChatArtifactFolderView(path: path, scope: scope, onDone: onDone)
+            ChatArtifactFolderView(
+                path: path,
+                scope: scope,
+                onImageMinimumZoomChanged: onImageMinimumZoomChanged,
+                onDone: onDone
+            )
         case .image(let data):
+            #if os(iOS)
+            if let image = UIImage(data: data) {
+                ChatArtifactZoomableImageView(
+                    image: image,
+                    onMinimumZoomChanged: onImageMinimumZoomChanged
+                )
+                .ignoresSafeArea(.container, edges: .bottom)
+                .onDisappear {
+                    onImageMinimumZoomChanged(true)
+                }
+            } else {
+                Color.clear
+            }
+            #else
             artifactImage(data: data)
                 .scaledToFit()
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding()
+            #endif
         case .pdf(let fileURL):
             #if os(iOS)
             ChatArtifactPDFView(fileURL: fileURL)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -36,6 +36,11 @@ struct ChatArtifactViewerRouteView: View {
     @State private var goToLineRequestID = 0
     @State private var wrapsLines: Bool
     @State private var textFontSize: Double
+    #if os(iOS)
+    @State private var fileActionPresentation: ChatArtifactFileActionPresentation?
+    @State private var isFileActionRunning = false
+    @State private var showsFileActionError = false
+    #endif
 
     init(
         path: String,
@@ -68,6 +73,11 @@ struct ChatArtifactViewerRouteView: View {
                     }
                 }
                 #if os(iOS)
+                if model.hasFileActions {
+                    ToolbarItem(placement: .primaryAction) {
+                        fileActionsMenu
+                    }
+                }
                 if shouldShowTextJumpControls {
                     ToolbarItemGroup(placement: .primaryAction) {
                         Button {
@@ -195,6 +205,25 @@ struct ChatArtifactViewerRouteView: View {
                 }
                 #endif
             }
+            #if os(iOS)
+            .chatArtifactFileActionPresentation($fileActionPresentation)
+            .alert(
+                String(
+                    localized: "chat.artifact.action_failed.title",
+                    defaultValue: "Couldn't complete action",
+                    bundle: .module
+                ),
+                isPresented: $showsFileActionError
+            ) {
+                Button(String(localized: "chat.artifact.ok", defaultValue: "OK", bundle: .module)) {}
+            } message: {
+                Text(String(
+                    localized: "chat.artifact.action_failed.message",
+                    defaultValue: "Check the connection to your Mac and try again.",
+                    bundle: .module
+                ))
+            }
+            #endif
             .task(id: "\(path)\u{0}\(retryGeneration)") {
                 #if os(iOS)
                 await model.load(
@@ -209,6 +238,82 @@ struct ChatArtifactViewerRouteView: View {
                 await model.cleanup()
             }
     }
+
+    #if os(iOS)
+    private var fileActionsMenu: some View {
+        Menu {
+            Button {
+                prepareFileAction(.share)
+            } label: {
+                Label(
+                    String(localized: "chat.artifact.share", defaultValue: "Share", bundle: .module),
+                    systemImage: "square.and.arrow.up"
+                )
+            }
+            Button {
+                prepareFileAction(.save)
+            } label: {
+                Label(
+                    String(localized: "chat.artifact.save_to_files", defaultValue: "Save to Files", bundle: .module),
+                    systemImage: "folder.badge.plus"
+                )
+            }
+            if model.isTextFile {
+                Button {
+                    UIPasteboard.general.string = model.renderedText
+                } label: {
+                    Label(
+                        String(localized: "chat.artifact.copy_contents", defaultValue: "Copy contents", bundle: .module),
+                        systemImage: "doc.on.doc"
+                    )
+                }
+                .disabled(!model.canCopyContents)
+            }
+            Button {
+                UIPasteboard.general.string = path
+            } label: {
+                Label(
+                    String(localized: "chat.artifact.copy_path", defaultValue: "Copy path", bundle: .module),
+                    systemImage: "link"
+                )
+            }
+        } label: {
+            Label(
+                String(localized: "chat.artifact.file_actions", defaultValue: "File actions", bundle: .module),
+                systemImage: "ellipsis.circle"
+            )
+        }
+        .disabled(isFileActionRunning)
+    }
+
+    private enum PreparedFileAction {
+        case share
+        case save
+    }
+
+    private func prepareFileAction(_ action: PreparedFileAction) {
+        guard !isFileActionRunning else { return }
+        isFileActionRunning = true
+        Task {
+            do {
+                let fileURL = try await ChatArtifactFileActionStore.applicationDefault.materialize(
+                    path: path,
+                    loader: loader
+                )
+                try Task.checkCancellation()
+                fileActionPresentation = switch action {
+                case .share: .share(fileURL)
+                case .save: .save(fileURL)
+                }
+            } catch is CancellationError {
+                // The viewer is going away; no error needs presenting.
+            } catch {
+                showsFileActionError = true
+            }
+            isFileActionRunning = false
+        }
+    }
+    #endif
 
     /// Keeps cleanup structured under the SwiftUI page task after loading ends.
     private func waitForViewerTaskCancellation() async {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactZoomPolicy.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactZoomPolicy.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+/// Scale rules shared by artifact image zoom gestures and tests.
+struct ChatArtifactZoomPolicy: Equatable, Sendable {
+    let minimumScale: Double
+    let doubleTapScale: Double
+    let maximumScale: Double
+
+    init(
+        minimumScale: Double = 1,
+        doubleTapScale: Double = 3,
+        maximumScale: Double = 8
+    ) {
+        self.minimumScale = minimumScale
+        self.doubleTapScale = doubleTapScale
+        self.maximumScale = maximumScale
+    }
+
+    func isAtMinimum(_ scale: Double) -> Bool {
+        abs(scale - minimumScale) <= 0.01
+    }
+
+    func scaleAfterDoubleTap(currentScale: Double) -> Double {
+        isAtMinimum(currentScale) ? doubleTapScale : minimumScale
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactZoomableImageView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactZoomableImageView.swift
@@ -1,0 +1,112 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// An aspect-fit image surface with native pinch, pan, and double-tap zoom.
+struct ChatArtifactZoomableImageView: UIViewRepresentable {
+    let image: UIImage
+    let onMinimumZoomChanged: (Bool) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onMinimumZoomChanged: onMinimumZoomChanged)
+    }
+
+    func makeUIView(context: Context) -> UIScrollView {
+        let scrollView = UIScrollView()
+        scrollView.delegate = context.coordinator
+        scrollView.minimumZoomScale = CGFloat(context.coordinator.policy.minimumScale)
+        scrollView.maximumZoomScale = CGFloat(context.coordinator.policy.maximumScale)
+        scrollView.zoomScale = scrollView.minimumZoomScale
+        scrollView.bouncesZoom = true
+        scrollView.showsHorizontalScrollIndicator = false
+        scrollView.showsVerticalScrollIndicator = false
+        scrollView.contentInsetAdjustmentBehavior = .never
+
+        let imageView = context.coordinator.imageView
+        imageView.image = image
+        imageView.contentMode = .scaleAspectFit
+        imageView.clipsToBounds = true
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.addSubview(imageView)
+        NSLayoutConstraint.activate([
+            imageView.leadingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: scrollView.contentLayoutGuide.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: scrollView.contentLayoutGuide.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: scrollView.contentLayoutGuide.bottomAnchor),
+            imageView.widthAnchor.constraint(equalTo: scrollView.frameLayoutGuide.widthAnchor),
+            imageView.heightAnchor.constraint(equalTo: scrollView.frameLayoutGuide.heightAnchor),
+        ])
+
+        let doubleTap = UITapGestureRecognizer(
+            target: context.coordinator,
+            action: #selector(Coordinator.didDoubleTap(_:))
+        )
+        doubleTap.numberOfTapsRequired = 2
+        scrollView.addGestureRecognizer(doubleTap)
+        context.coordinator.scrollView = scrollView
+        context.coordinator.reportMinimumZoomIfNeeded(force: true)
+        return scrollView
+    }
+
+    func updateUIView(_ scrollView: UIScrollView, context: Context) {
+        context.coordinator.onMinimumZoomChanged = onMinimumZoomChanged
+        if context.coordinator.imageView.image !== image {
+            context.coordinator.imageView.image = image
+            scrollView.setZoomScale(scrollView.minimumZoomScale, animated: false)
+        }
+        context.coordinator.reportMinimumZoomIfNeeded(force: false)
+    }
+
+    final class Coordinator: NSObject, UIScrollViewDelegate {
+        let imageView = UIImageView()
+        let policy = ChatArtifactZoomPolicy()
+        weak var scrollView: UIScrollView?
+        var onMinimumZoomChanged: (Bool) -> Void
+        private var lastReportedMinimumState: Bool?
+
+        init(onMinimumZoomChanged: @escaping (Bool) -> Void) {
+            self.onMinimumZoomChanged = onMinimumZoomChanged
+        }
+
+        func viewForZooming(in scrollView: UIScrollView) -> UIView? {
+            imageView
+        }
+
+        func scrollViewDidZoom(_ scrollView: UIScrollView) {
+            reportMinimumZoomIfNeeded(force: false)
+        }
+
+        @objc
+        func didDoubleTap(_ recognizer: UITapGestureRecognizer) {
+            guard let scrollView else { return }
+            let targetScale = CGFloat(policy.scaleAfterDoubleTap(
+                currentScale: Double(scrollView.zoomScale)
+            ))
+            if policy.isAtMinimum(Double(scrollView.zoomScale)) {
+                let location = recognizer.location(in: imageView)
+                let width = scrollView.bounds.width / targetScale
+                let height = scrollView.bounds.height / targetScale
+                scrollView.zoom(
+                    to: CGRect(
+                        x: location.x - width / 2,
+                        y: location.y - height / 2,
+                        width: width,
+                        height: height
+                    ),
+                    animated: true
+                )
+            } else {
+                scrollView.setZoomScale(targetScale, animated: true)
+            }
+        }
+
+        func reportMinimumZoomIfNeeded(force: Bool) {
+            guard let scrollView else { return }
+            let isAtMinimum = policy.isAtMinimum(Double(scrollView.zoomScale))
+            guard force || lastReportedMinimumState != isAtMinimum else { return }
+            lastReportedMinimumState = isAtMinimum
+            onMinimumZoomChanged(isAtMinimum)
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -18,6 +18,20 @@
         }
       }
     },
+    "chat.artifact.action_failed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Check the connection to your Mac and try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Macへの接続を確認して、もう一度お試しください。" } }
+      }
+    },
+    "chat.artifact.action_failed.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn't complete action" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "操作を完了できませんでした" } }
+      }
+    },
     "chat.artifact.actions.title" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -52,6 +66,20 @@
         }
       }
     },
+    "chat.artifact.copy_contents" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy contents" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "内容をコピー" } }
+      }
+    },
+    "chat.artifact.copy_path" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy path" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "パスをコピー" } }
+      }
+    },
     "chat.artifact.done" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -67,6 +95,13 @@
             "value" : "完了"
           }
         }
+      }
+    },
+    "chat.artifact.file_actions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "File actions" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "ファイル操作" } }
       }
     },
     "chat.artifact.file_missing.message" : {
@@ -545,6 +580,20 @@
         }
       }
     },
+    "chat.artifact.ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "OK" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "OK" } }
+      }
+    },
+    "chat.artifact.save_to_files" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Save to Files" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "「ファイル」に保存" } }
+      }
+    },
     "chat.artifact.search.close" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -696,6 +745,13 @@
             "value" : "ファイルが大きすぎてプレビューできません"
           }
         }
+      }
+    },
+    "chat.artifact.share" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Share" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "共有" } }
       }
     },
     "chat.artifact.text_options" : {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactContentCacheTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactContentCacheTests.swift
@@ -1,0 +1,119 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Chat artifact content cache")
+struct ChatArtifactContentCacheTests {
+    @Test("mtime and size changes invalidate the content key")
+    func keyInvalidation() throws {
+        let base = try #require(ChatArtifactContentCache.key(
+            scopeKey: "chat:session",
+            path: "/tmp/report.txt",
+            modifiedAt: Date(timeIntervalSince1970: 10),
+            size: 3
+        ))
+        let changedMTime = try #require(ChatArtifactContentCache.key(
+            scopeKey: "chat:session",
+            path: "/tmp/report.txt",
+            modifiedAt: Date(timeIntervalSince1970: 11),
+            size: 3
+        ))
+        let changedSize = try #require(ChatArtifactContentCache.key(
+            scopeKey: "chat:session",
+            path: "/tmp/report.txt",
+            modifiedAt: Date(timeIntervalSince1970: 10),
+            size: 4
+        ))
+
+        #expect(base != changedMTime)
+        #expect(base != changedSize)
+    }
+
+    @Test("disk budget evicts the least recently used content")
+    func diskLRUEviction() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let cache = ChatArtifactContentCache(
+            directory: directory,
+            maxDiskBytes: 6,
+            maxMemoryBytes: 0
+        )
+        let source = CountingContentSource(values: [
+            "a": Data([1, 1, 1]),
+            "b": Data([2, 2, 2]),
+            "c": Data([3, 3, 3]),
+        ])
+
+        try await stream(key: "a", at: 1, cache: cache, source: source)
+        try await stream(key: "b", at: 2, cache: cache, source: source)
+        try await stream(key: "a", at: 3, cache: cache, source: source)
+        try await stream(key: "c", at: 4, cache: cache, source: source)
+        try await stream(key: "a", at: 5, cache: cache, source: source)
+        try await stream(key: "b", at: 6, cache: cache, source: source)
+
+        #expect(await source.fetchCount(for: "a") == 1)
+        #expect(await source.fetchCount(for: "b") == 2)
+        #expect(await source.fetchCount(for: "c") == 1)
+    }
+
+    @Test("reopening unchanged viewer content performs no second fetch")
+    @MainActor
+    func viewerInstantHit() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let source = CountingContentSource(values: ["artifact": Data("hello".utf8)])
+        let modifiedAt = Date(timeIntervalSince1970: 100)
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            scope: .chat(sessionID: "session"),
+            contentCache: ChatArtifactContentCache(directory: directory),
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: 5,
+                    modifiedAt: modifiedAt,
+                    kind: .text,
+                    mimeType: "text/plain"
+                )
+            },
+            fetch: { _, _ in Data("hello".utf8) },
+            stream: { _, receive in
+                try await source.fetch(key: "artifact", receive: receive)
+            }
+        )
+
+        let first = ChatArtifactViewerModel()
+        await first.load(path: "/tmp/artifact.txt", loader: loader)
+        let second = ChatArtifactViewerModel()
+        await second.load(path: "/tmp/artifact.txt", loader: loader)
+
+        #expect(first.renderedText == "hello")
+        #expect(second.renderedText == "hello")
+        #expect(await source.fetchCount(for: "artifact") == 1)
+    }
+
+    private func stream(
+        key: String,
+        at seconds: TimeInterval,
+        cache: ChatArtifactContentCache,
+        source: CountingContentSource
+    ) async throws {
+        _ = try await cache.stream(
+            for: key,
+            expectedSize: 3,
+            accessedAt: Date(timeIntervalSince1970: seconds),
+            fetch: { receive in
+                try await source.fetch(key: key, receive: receive)
+            },
+            receive: { _ in }
+        )
+    }
+
+    private func temporaryDirectory() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-content-cache-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactContentCacheTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactContentCacheTests.swift
@@ -95,6 +95,32 @@ struct ChatArtifactContentCacheTests {
         #expect(await source.fetchCount(for: "artifact") == 1)
     }
 
+    @Test("unsupported loader scopes never share cached bytes")
+    func unsupportedScopeBypassesCache() async throws {
+        let directory = temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let bytes = Data("fixture".utf8)
+        let source = CountingContentSource(values: ["fixture": bytes])
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            contentCache: ChatArtifactContentCache(directory: directory),
+            stream: { _, receive in
+                try await source.fetch(key: "fixture", receive: receive)
+            }
+        )
+
+        for _ in 0..<2 {
+            try await loader.stream(
+                path: "/tmp/fixture.txt",
+                modifiedAt: Date(timeIntervalSince1970: 100),
+                size: Int64(bytes.count),
+                onChunk: { _ in }
+            )
+        }
+
+        #expect(await source.fetchCount(for: "fixture") == 2)
+    }
+
     private func stream(
         key: String,
         at seconds: TimeInterval,

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactFileActionStoreTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactFileActionStoreTests.swift
@@ -1,0 +1,62 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Chat artifact file actions")
+struct ChatArtifactFileActionStoreTests {
+    @Test("materialized files retain their source name and reuse cached bytes")
+    func materializeNamedCachedFile() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "cmux-file-action-tests-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let cacheDirectory = root.appendingPathComponent("cache", isDirectory: true)
+        let actionDirectory = root.appendingPathComponent("actions", isDirectory: true)
+        let bytes = Data("quarterly results".utf8)
+        let modifiedAt = Date(timeIntervalSince1970: 123)
+        let source = CountingContentSource(values: ["report": bytes])
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            scope: .chat(sessionID: "session"),
+            contentCache: ChatArtifactContentCache(directory: cacheDirectory),
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: Int64(bytes.count),
+                    modifiedAt: modifiedAt,
+                    kind: .text,
+                    mimeType: "text/plain"
+                )
+            },
+            fetch: { _, _ in bytes },
+            stream: { _, receive in
+                try await source.fetch(key: "report", receive: receive)
+            }
+        )
+        let store = ChatArtifactFileActionStore(directory: actionDirectory)
+
+        let first = try await store.materialize(
+            path: "/Users/example/Quarterly Report.txt",
+            loader: loader
+        )
+        let second = try await store.materialize(
+            path: "/Users/example/Quarterly Report.txt",
+            loader: loader
+        )
+
+        #expect(first.lastPathComponent == "Quarterly Report.txt")
+        #expect(second.lastPathComponent == "Quarterly Report.txt")
+        #expect(try Data(contentsOf: first) == bytes)
+        #expect(try Data(contentsOf: second) == bytes)
+        #expect(await source.fetchCount(for: "report") == 1)
+
+        await store.remove(first)
+        await store.remove(second)
+        #expect(!FileManager.default.fileExists(atPath: first.path))
+        #expect(!FileManager.default.fileExists(atPath: second.path))
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactZoomPolicyTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactZoomPolicyTests.swift
@@ -1,0 +1,26 @@
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Chat artifact zoom policy")
+struct ChatArtifactZoomPolicyTests {
+    @Test("fitted images double tap to three times and back")
+    func doubleTapToggle() {
+        let policy = ChatArtifactZoomPolicy()
+
+        #expect(policy.minimumScale == 1)
+        #expect(policy.maximumScale == 8)
+        #expect(policy.scaleAfterDoubleTap(currentScale: 1) == 3)
+        #expect(policy.scaleAfterDoubleTap(currentScale: 3) == 1)
+        #expect(policy.scaleAfterDoubleTap(currentScale: 7) == 1)
+    }
+
+    @Test("paging threshold tolerates UIScrollView scale noise")
+    func minimumThreshold() {
+        let policy = ChatArtifactZoomPolicy()
+
+        #expect(policy.isAtMinimum(1))
+        #expect(policy.isAtMinimum(1.005))
+        #expect(!policy.isAtMinimum(1.02))
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/CountingContentSource.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/CountingContentSource.swift
@@ -1,0 +1,30 @@
+import CmuxAgentChat
+import Foundation
+
+/// Supplies deterministic artifact bytes while recording source fetches.
+actor CountingContentSource {
+    private let values: [String: Data]
+    private var counts: [String: Int] = [:]
+
+    init(values: [String: Data]) {
+        self.values = values
+    }
+
+    func fetch(
+        key: String,
+        receive: @Sendable (ChatArtifactChunk) async throws -> Void
+    ) async throws {
+        let data = values[key] ?? Data()
+        counts[key, default: 0] += 1
+        try await receive(ChatArtifactChunk(
+            data: data,
+            offset: 0,
+            totalSize: Int64(data.count),
+            eof: true
+        ))
+    }
+
+    func fetchCount(for key: String) -> Int {
+        counts[key, default: 0]
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -26,6 +26,7 @@ extension GhosttySurfaceRepresentable.Coordinator {
             artifactCountState.reset()
             artifactCountNeedsRefresh = artifactFilesEnabled
             visibleArtifactCount = 0
+            freshestLocalArtifactCount = 0
             return true
         }
 
@@ -37,10 +38,14 @@ extension GhosttySurfaceRepresentable.Coordinator {
             case .none:
                 break
             case .report(let report):
-                surfaceView.reportArtifactCount(
+                guard surfaceView.reportArtifactCount(
                     report.count,
                     generation: report.surfaceGeneration
-                )
+                ) else { return }
+                onArtifactGalleryRefreshSignal(TerminalArtifactGalleryRefreshSignal(
+                    count: report.count,
+                    surfaceGeneration: report.surfaceGeneration
+                ))
             case .request(let request):
                 startArtifactCountRequest(request, surfaceView: surfaceView)
             }
@@ -74,16 +79,22 @@ extension GhosttySurfaceRepresentable.Coordinator {
                 let completion = self.artifactCountState.complete(
                     request,
                     sessionTotal: sessionTotal,
-                    currentSurfaceGeneration: surfaceView.visibleArtifactCountGeneration
+                    currentSurfaceGeneration: surfaceView.visibleArtifactCountGeneration,
+                    freshestLocalCount: self.freshestLocalArtifactCount
                 )
                 guard self.artifactCountTaskRequest == request else { return }
                 self.artifactCountTask = nil
                 self.artifactCountTaskRequest = nil
                 if case .reported(let report) = completion.outcome {
-                    surfaceView.reportArtifactCount(
+                    if surfaceView.reportArtifactCount(
                         report.count,
                         generation: report.surfaceGeneration
-                    )
+                    ) {
+                        self.onArtifactGalleryRefreshSignal(TerminalArtifactGalleryRefreshSignal(
+                            count: report.count,
+                            surfaceGeneration: report.surfaceGeneration
+                        ))
+                    }
                 }
                 if let nextRequest = completion.nextRequest {
                     self.startArtifactCountRequest(nextRequest, surfaceView: surfaceView)
@@ -183,6 +194,7 @@ extension GhosttySurfaceRepresentable.Coordinator {
             generation: UInt64
         ) {
             guard artifactFilesEnabled else { return }
+            freshestLocalArtifactCount = count
             let action = artifactCountState.trigger(
                 localCount: count,
                 surfaceGeneration: generation,
@@ -197,12 +209,17 @@ extension GhosttySurfaceRepresentable.Coordinator {
             artifactCountTaskRequest = nil
             artifactCountState.reset()
             artifactCountNeedsRefresh = artifactFilesEnabled
+            freshestLocalArtifactCount = 0
             let previousCount = visibleArtifactCount
             visibleArtifactCount = 0
             guard self.surfaceView === surfaceView else { return }
             updateArtifactChip(count: 0, enabled: artifactFilesEnabled)
             guard previousCount != 0 else { return }
             onVisibleArtifactCountChanged(0)
+            onArtifactGalleryRefreshSignal(TerminalArtifactGalleryRefreshSignal(
+                count: 0,
+                surfaceGeneration: surfaceView.visibleArtifactCountGeneration
+            ))
         }
 
         func ghosttySurfaceView(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceRepresentable.swift
@@ -50,6 +50,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
     var onArtifactFilesRequested: @MainActor (_ anchor: UnitPoint) -> Void = { _ in }
     var onArtifactPathTapped: @MainActor (_ path: String) -> Void = { _ in }
     var onVisibleArtifactCountChanged: @MainActor (_ count: Int) -> Void = { _ in }
+    var onArtifactGalleryRefreshSignal: @MainActor (TerminalArtifactGalleryRefreshSignal) -> Void = { _ in }
 
     func makeCoordinator() -> Coordinator {
         Coordinator(
@@ -61,7 +62,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             visibleArtifactCount: visibleArtifactCount,
             onArtifactFilesRequested: onArtifactFilesRequested,
             onArtifactPathTapped: onArtifactPathTapped,
-            onVisibleArtifactCountChanged: onVisibleArtifactCountChanged
+            onVisibleArtifactCountChanged: onVisibleArtifactCountChanged,
+            onArtifactGalleryRefreshSignal: onArtifactGalleryRefreshSignal
         )
     }
 
@@ -129,6 +131,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         context.coordinator.onArtifactFilesRequested = onArtifactFilesRequested
         context.coordinator.onArtifactPathTapped = onArtifactPathTapped
         context.coordinator.onVisibleArtifactCountChanged = onVisibleArtifactCountChanged
+        context.coordinator.onArtifactGalleryRefreshSignal = onArtifactGalleryRefreshSignal
         let artifactCountModeChanged = context.coordinator.updateArtifactCountMode(
             artifactFilesEnabled: artifactFilesEnabled,
             sessionArtifactCountEnabled: sessionArtifactCountEnabled
@@ -178,12 +181,14 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
         var onArtifactFilesRequested: @MainActor (_ anchor: UnitPoint) -> Void
         var onArtifactPathTapped: @MainActor (_ path: String) -> Void
         var onVisibleArtifactCountChanged: @MainActor (_ count: Int) -> Void
+        var onArtifactGalleryRefreshSignal: @MainActor (TerminalArtifactGalleryRefreshSignal) -> Void
         private var outputTask: Task<Void, Never>?
         private var liveFontTask: Task<Void, Never>?
         var artifactCountTask: Task<Void, Never>?
         var artifactCountTaskRequest: TerminalArtifactChipCountState.Request?
         var artifactCountState = TerminalArtifactChipCountState()
         var artifactCountNeedsRefresh: Bool
+        var freshestLocalArtifactCount = 0
         /// Hosts the SwiftUI ``TerminalComposerView`` so it can be installed into the
         /// surface's composer band. Built lazily on first open and torn down on
         /// dismantle; mounted/unmounted by ``setComposerMounted(_:)``.
@@ -218,7 +223,8 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             visibleArtifactCount: Int,
             onArtifactFilesRequested: @escaping @MainActor (_ anchor: UnitPoint) -> Void,
             onArtifactPathTapped: @escaping @MainActor (_ path: String) -> Void,
-            onVisibleArtifactCountChanged: @escaping @MainActor (_ count: Int) -> Void
+            onVisibleArtifactCountChanged: @escaping @MainActor (_ count: Int) -> Void,
+            onArtifactGalleryRefreshSignal: @escaping @MainActor (TerminalArtifactGalleryRefreshSignal) -> Void
         ) {
             self.workspaceID = workspaceID
             self.surfaceID = surfaceID
@@ -230,6 +236,7 @@ struct GhosttySurfaceRepresentable: UIViewRepresentable {
             self.onArtifactFilesRequested = onArtifactFilesRequested
             self.onArtifactPathTapped = onArtifactPathTapped
             self.onVisibleArtifactCountChanged = onVisibleArtifactCountChanged
+            self.onArtifactGalleryRefreshSignal = onArtifactGalleryRefreshSignal
             super.init()
         }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -306,6 +306,13 @@
         }
       }
     },
+    "terminal.artifact.gallery.new_files" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "%lld new files" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "新しいファイル%lld件" } }
+      }
+    },
     "terminal.artifact.gallery.provenance.attached" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/Resources/Localizable.xcstrings
@@ -70,6 +70,27 @@
         }
       }
     },
+    "terminal.artifact.gallery.action_failed.message" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Check the connection to your Mac and try again." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "Macへの接続を確認して、もう一度お試しください。" } }
+      }
+    },
+    "terminal.artifact.gallery.action_failed.title" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Couldn't complete action" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "操作を完了できませんでした" } }
+      }
+    },
+    "terminal.artifact.gallery.browse_folder" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Browse folder" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "フォルダを表示" } }
+      }
+    },
     "terminal.artifact.gallery.child_count" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -102,6 +123,13 @@
             "value" : "%lld項目以上"
           }
         }
+      }
+    },
+    "terminal.artifact.gallery.copy_path" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Copy path" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "パスをコピー" } }
       }
     },
     "terminal.artifact.gallery.empty" : {
@@ -313,6 +341,13 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "新しいファイル%lld件" } }
       }
     },
+    "terminal.artifact.gallery.ok" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "OK" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "OK" } }
+      }
+    },
     "terminal.artifact.gallery.provenance.attached" : {
       "extractionState" : "manual",
       "localizations" : {
@@ -401,6 +436,13 @@
       "localizations" : {
         "en" : { "stringUnit" : { "state" : "translated", "value" : "Sort" } },
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "並べ替え" } }
+      }
+    },
+    "terminal.artifact.gallery.share" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Share" } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "共有" } }
       }
     },
     "terminal.artifact.gallery.sort.name" : {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChipCountState.swift
@@ -73,7 +73,8 @@ struct TerminalArtifactChipCountState: Sendable {
     mutating func complete(
         _ request: Request,
         sessionTotal: Int?,
-        currentSurfaceGeneration: UInt64
+        currentSurfaceGeneration: UInt64,
+        freshestLocalCount: Int
     ) -> Completion {
         guard request.stateGeneration == stateGeneration,
               inFlight == request else {
@@ -110,7 +111,7 @@ struct TerminalArtifactChipCountState: Sendable {
         consecutiveRearmCount += 1
         let nextRequest = makeRequest(Pending(
             surfaceGeneration: currentSurfaceGeneration,
-            localCount: request.localCount
+            localCount: freshestLocalCount
         ))
         inFlight = nextRequest
         return Completion(outcome: outcome, nextRequest: nextRequest)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -171,8 +171,12 @@ extension TerminalArtifactFilesSheet {
                 let attached = presentation.items(in: .attached)
                 let referenced = presentation.items(in: .referenced)
                 let swipeOrder = ChatArtifactGallerySwipeOrder(groups: presentation.groups)
-                ScrollView {
-                    VStack(spacing: 0) {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        VStack(spacing: 0) {
+                            Color.clear
+                                .frame(height: 0)
+                                .id(Self.sessionScrollTopID)
                         artifactSection(
                             title: String(
                                 localized: "terminal.artifact.gallery.section.created",
@@ -211,12 +215,59 @@ extension TerminalArtifactFilesSheet {
                             showsEagerFooter: usesCompleteSessionSnapshot
                         )
                     }
+                    }
+                    .onScrollGeometryChange(for: Bool.self) { geometry in
+                        let isAtTop = geometry.contentOffset.y
+                            <= geometry.contentInsets.top + Self.sessionTopTolerance
+                        let fits = geometry.contentSize.height
+                            <= geometry.containerSize.height + Self.sessionTopTolerance
+                        return isAtTop || fits
+                    } action: { _, isAtTopOrFits in
+                        sessionViewportIsAtTopOrFits = isAtTopOrFits
+                    }
+                    .overlay(alignment: .top) {
+                        if liveRefreshState.pendingNewFileCount > 0 {
+                            newFilesPill(snapshot: snapshot, proxy: proxy)
+                                .padding(.top, 8)
+                        }
+                    }
                 }
                 .refreshable {
                     await loadFirstSessionPage(query: nil, preservingContent: true)
                 }
             }
         }
+    }
+
+    private func newFilesPill(
+        snapshot: SessionGallerySnapshot,
+        proxy: ScrollViewProxy
+    ) -> some View {
+        let format = String(
+            localized: "terminal.artifact.gallery.new_files",
+            defaultValue: "%lld new files",
+            bundle: .module
+        )
+        let title = String.localizedStringWithFormat(
+            format,
+            Int64(liveRefreshState.pendingNewFileCount)
+        )
+        return Button {
+            guard let reconciled = liveRefreshState.applyPending(to: snapshot) else { return }
+            withAnimation(.easeInOut(duration: 0.25)) {
+                sessionState = .loaded(reconciled)
+                proxy.scrollTo(Self.sessionScrollTopID, anchor: .top)
+            }
+        } label: {
+            Label(title, systemImage: "arrow.up")
+                .font(.footnote.weight(.semibold))
+                .padding(.horizontal, 12)
+                .padding(.vertical, 7)
+                .background(.regularMaterial, in: Capsule())
+                .shadow(color: .black.opacity(0.12), radius: 5, y: 2)
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
     }
 
     @ViewBuilder
@@ -497,6 +548,9 @@ extension TerminalArtifactFilesSheet {
             count: 3
         )
     }
+
+    private static let sessionScrollTopID = "terminal-artifact-gallery-top"
+    private static let sessionTopTolerance: CGFloat = 1
 
     private var galleryControls: some View {
         HStack(spacing: 12) {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -183,7 +183,7 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "Created by agent",
                                 bundle: .module
                             ),
-                            count: created.count,
+                            count: usesCompleteSessionSnapshot ? created.count : snapshot.createdTotal,
                             items: created,
                             expanded: $createdExpanded,
                             swipeOrder: swipeOrder
@@ -194,7 +194,7 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "You attached",
                                 bundle: .module
                             ),
-                            count: attached.count,
+                            count: usesCompleteSessionSnapshot ? attached.count : snapshot.attachedTotal,
                             items: attached,
                             expanded: $attachedExpanded,
                             swipeOrder: swipeOrder

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -277,11 +277,19 @@ struct TerminalArtifactFilesSheet: View {
                 guard query == searchQuery.trimmingCharacters(in: .whitespacesAndNewlines),
                       case .loaded(let current) = searchState,
                       current.nextCursor == cursor else { return }
+                if page.requiresPagingRestart {
+                    await restartPaging(after: cursor, query: query)
+                    return
+                }
                 searchState = .loaded(current.appending(page))
             } else {
                 guard searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
                       case .loaded(let current) = sessionState,
                       current.nextCursor == cursor else { return }
+                if page.requiresPagingRestart {
+                    await restartPaging(after: cursor, query: nil)
+                    return
+                }
                 sessionState = .loaded(current.appending(page))
             }
             startThumbnailPrefetch(page.referenced)
@@ -324,6 +332,13 @@ struct TerminalArtifactFilesSheet: View {
                     query: expectedQuery
                 )
             }
+            if result.requiresPagingRestart {
+                await restartPaging(
+                    after: initialSnapshot.nextCursor,
+                    query: expectedQuery
+                )
+                return
+            }
             let currentQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
             let queryIsCurrent = expectedQuery.map { $0 == currentQuery }
                 ?? currentQuery.isEmpty
@@ -358,6 +373,57 @@ struct TerminalArtifactFilesSheet: View {
             return
         } catch {
             guard !Task.isCancelled else { return }
+            eagerPagingState = .failed
+        }
+    }
+
+    private func restartPaging(after staleCursor: String?, query: String?) async {
+        guard let staleCursor, let source, let sessionID else { return }
+        let currentQuery = searchQuery.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard query.map({ $0 == currentQuery }) ?? currentQuery.isEmpty else { return }
+        let state = query == nil ? sessionState : searchState
+        guard case .loaded(let displayed) = state,
+              displayed.nextCursor == staleCursor else { return }
+        do {
+            let page = try await source.chatArtifactGallery(
+                sessionID: sessionID,
+                cursor: nil,
+                pageSize: Self.pageSize,
+                query: query
+            )
+            guard !Task.isCancelled else { return }
+            let currentState = query == nil ? sessionState : searchState
+            guard case .loaded(let current) = currentState,
+                  current.nextCursor == staleCursor else { return }
+            let fresh = SessionGallerySnapshot(page: page)
+            if query == nil {
+                if sessionViewportIsAtTopOrFits {
+                    liveRefreshState.reset()
+                    withAnimation(.easeInOut(duration: 0.25)) {
+                        sessionState = .loaded(current.reconciling(withFreshFirstPage: fresh))
+                    }
+                } else {
+                    _ = liveRefreshState.receive(
+                        fresh: fresh,
+                        displayed: current,
+                        isAtTopOrFits: false
+                    )
+                    sessionState = .loaded(current.rebasingPaging(ontoFreshFirstPage: fresh))
+                }
+            } else {
+                searchState = .loaded(current.restartingPaging(withFreshFirstPage: fresh))
+            }
+            eagerPagingState = .idle
+            eagerPagingRevision += 1
+            let currentPaths = Set((current.created + current.attached + current.referenced).map(\.path))
+            startThumbnailPrefetch(
+                (fresh.created + fresh.attached + fresh.referenced).filter {
+                    !currentPaths.contains($0.path)
+                }
+            )
+        } catch is CancellationError {
+            return
+        } catch {
             eagerPagingState = .failed
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -24,6 +24,7 @@ struct TerminalArtifactFilesSheet: View {
     let workspaceID: String
     let surfaceID: String
     let source: MobileChatEventSource?
+    let refreshSignal: TerminalArtifactGalleryRefreshSignal
     let loader: ChatArtifactLoader
 
     @State var inViewState: InViewLoadState = .loading
@@ -44,7 +45,25 @@ struct TerminalArtifactFilesSheet: View {
     @State var attachedExpanded = true
     @State var referencedExpanded = true
     @State var thumbnailPrefetchTasks: [Task<Void, Never>] = []
+    @State var liveRefreshState = ChatArtifactGalleryLiveRefreshState()
+    @State var sessionViewportIsAtTopOrFits = true
+    @State var lastHandledRefreshSignal: TerminalArtifactGalleryRefreshSignal
     @Environment(\.dismiss) private var dismiss
+
+    init(
+        workspaceID: String,
+        surfaceID: String,
+        source: MobileChatEventSource?,
+        refreshSignal: TerminalArtifactGalleryRefreshSignal,
+        loader: ChatArtifactLoader
+    ) {
+        self.workspaceID = workspaceID
+        self.surfaceID = surfaceID
+        self.source = source
+        self.refreshSignal = refreshSignal
+        self.loader = loader
+        _lastHandledRefreshSignal = State(initialValue: refreshSignal)
+    }
 
     var body: some View {
         NavigationStack {
@@ -79,6 +98,9 @@ struct TerminalArtifactFilesSheet: View {
         .frame(idealWidth: 380, idealHeight: 520)
         .task(id: "\(workspaceID)#\(surfaceID)") {
             await loadInitial()
+        }
+        .task(id: liveRefreshTaskID) {
+            await refreshSessionForLiveSignal()
         }
         .sheet(item: $selection) { selection in
             ChatArtifactViewerSheet(
@@ -183,6 +205,7 @@ struct TerminalArtifactFilesSheet: View {
                 guard query == searchQuery.trimmingCharacters(in: .whitespacesAndNewlines) else { return }
                 searchState = .loaded(snapshot)
             } else {
+                liveRefreshState.reset()
                 sessionState = .loaded(snapshot)
             }
             eagerPagingRevision += 1
@@ -197,6 +220,46 @@ struct TerminalArtifactFilesSheet: View {
                     searchState = .failed
                 }
             }
+        }
+    }
+
+    func refreshSessionForLiveSignal() async {
+        guard refreshSignal != lastHandledRefreshSignal,
+              scope == .session,
+              searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+              let source,
+              let sessionID,
+              case .loaded(let displayed) = sessionState else { return }
+        do {
+            let page = try await source.chatArtifactGallery(
+                sessionID: sessionID,
+                cursor: nil,
+                pageSize: Self.pageSize,
+                query: nil
+            )
+            guard !Task.isCancelled else { return }
+            let fresh = SessionGallerySnapshot(page: page)
+            lastHandledRefreshSignal = refreshSignal
+            if let reconciled = liveRefreshState.receive(
+                fresh: fresh,
+                displayed: displayed,
+                isAtTopOrFits: sessionViewportIsAtTopOrFits
+            ) {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    sessionState = .loaded(reconciled)
+                }
+            }
+            let displayedPaths = Set((displayed.created + displayed.attached + displayed.referenced).map(\.path))
+            startThumbnailPrefetch(
+                (fresh.created + fresh.attached + fresh.referenced).filter {
+                    !displayedPaths.contains($0.path)
+                }
+            )
+        } catch is CancellationError {
+            return
+        } catch {
+            // Keep the current gallery stable. The next accepted chip signal
+            // retries against a newer terminal/session generation.
         }
     }
 
@@ -340,6 +403,16 @@ struct TerminalArtifactFilesSheet: View {
             cursor,
             String(eagerPagingRevision),
             String(eagerPagingRetryGeneration),
+        ].joined(separator: "#")
+    }
+
+    var liveRefreshTaskID: String {
+        [
+            String(refreshSignal.surfaceGeneration),
+            String(refreshSignal.count),
+            sessionID ?? "unresolved",
+            String(describing: scope),
+            searchQuery.trimmingCharacters(in: .whitespacesAndNewlines),
         ].joined(separator: "#")
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
@@ -18,6 +18,9 @@ struct TerminalArtifactGalleryItemView: View {
     let open: () -> Void
 
     @State private var thumbnail: ChatArtifactThumbnail?
+    @State private var fileActionPresentation: ChatArtifactFileActionPresentation?
+    @State private var isFileActionRunning = false
+    @State private var showsFileActionError = false
     @ScaledMetric(relativeTo: .subheadline) private var gridNameMinHeight: CGFloat = 38
     @ScaledMetric(relativeTo: .caption2) private var gridMetadataMinHeight: CGFloat = 28
     @ScaledMetric(relativeTo: .body) private var gridSymbolSize: CGFloat = 48
@@ -37,6 +40,65 @@ struct TerminalArtifactGalleryItemView: View {
         .accessibilityLabel(artifact.displayName)
         .accessibilityValue(accessibilityDetail)
         .opacity(artifact.exists ? 1 : 0.5)
+        .contextMenu {
+            if artifact.kind != .directory {
+                Button {
+                    shareFile()
+                } label: {
+                    Label(
+                        String(
+                            localized: "terminal.artifact.gallery.share",
+                            defaultValue: "Share",
+                            bundle: .module
+                        ),
+                        systemImage: "square.and.arrow.up"
+                    )
+                }
+                .disabled(!artifact.exists || isFileActionRunning)
+            }
+            Button {
+                UIPasteboard.general.string = artifact.path
+            } label: {
+                Label(
+                    String(
+                        localized: "terminal.artifact.gallery.copy_path",
+                        defaultValue: "Copy path",
+                        bundle: .module
+                    ),
+                    systemImage: "link"
+                )
+            }
+            if artifact.kind == .directory {
+                Button(action: open) {
+                    Label(
+                        String(
+                            localized: "terminal.artifact.gallery.browse_folder",
+                            defaultValue: "Browse folder",
+                            bundle: .module
+                        ),
+                        systemImage: "folder"
+                    )
+                }
+                .disabled(!artifact.exists)
+            }
+        }
+        .chatArtifactFileActionPresentation($fileActionPresentation)
+        .alert(
+            String(
+                localized: "terminal.artifact.gallery.action_failed.title",
+                defaultValue: "Couldn't complete action",
+                bundle: .module
+            ),
+            isPresented: $showsFileActionError
+        ) {
+            Button(String(localized: "terminal.artifact.gallery.ok", defaultValue: "OK", bundle: .module)) {}
+        } message: {
+            Text(String(
+                localized: "terminal.artifact.gallery.action_failed.message",
+                defaultValue: "Check the connection to your Mac and try again.",
+                bundle: .module
+            ))
+        }
         .task(id: "\(artifact.path)#\(Self.thumbnailDimension)") {
             guard artifact.kind == .image, artifact.exists else { return }
             thumbnail = try? await loader.thumbnail(
@@ -45,6 +107,26 @@ struct TerminalArtifactGalleryItemView: View {
                 modifiedAt: artifact.modifiedAt,
                 size: artifact.size
             )
+        }
+    }
+
+    private func shareFile() {
+        guard !isFileActionRunning else { return }
+        isFileActionRunning = true
+        Task {
+            do {
+                let fileURL = try await ChatArtifactFileActionStore.applicationDefault.materialize(
+                    path: artifact.path,
+                    loader: loader
+                )
+                try Task.checkCancellation()
+                fileActionPresentation = .share(fileURL)
+            } catch is CancellationError {
+                // The row disappeared while its file was being prepared.
+            } catch {
+                showsFileActionError = true
+            }
+            isFileActionRunning = false
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryRefreshSignal.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryRefreshSignal.swift
@@ -1,0 +1,7 @@
+/// One generation-checked artifact count accepted by the terminal chip pipeline.
+struct TerminalArtifactGalleryRefreshSignal: Sendable, Equatable {
+    let count: Int
+    let surfaceGeneration: UInt64
+
+    static let initial = TerminalArtifactGalleryRefreshSignal(count: 0, surfaceGeneration: 0)
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
@@ -47,6 +47,11 @@ extension WorkspaceDetailView {
             if visibleArtifactCount != count {
                 visibleArtifactCount = count
             }
+        },
+        onArtifactGalleryRefreshSignal: { signal in
+            if artifactGalleryRefreshSignal != signal {
+                artifactGalleryRefreshSignal = signal
+            }
         }
     )
     .popover(
@@ -58,6 +63,7 @@ extension WorkspaceDetailView {
             workspaceID: context.workspaceID,
             surfaceID: context.surfaceID,
             source: store.makeChatEventSource(),
+            refreshSignal: artifactGalleryRefreshSignal,
             loader: terminalArtifactLoader(
                 workspaceID: context.workspaceID,
                 surfaceID: context.surfaceID

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -72,6 +72,7 @@ struct WorkspaceDetailView: View {
     @State var selectedTerminalArtifact: TerminalArtifactSelection?
     @State var terminalArtifactThumbnailCache = ChatArtifactThumbnailCache()
     @State var visibleArtifactCount = 0
+    @State var artifactGalleryRefreshSignal = TerminalArtifactGalleryRefreshSignal.initial
     /// App lifecycle phase used to re-pull chat sessions on foreground.
     @Environment(\.scenePhase) var scenePhase
     #endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChipCountStateTests.swift
@@ -21,7 +21,8 @@ struct TerminalArtifactChipCountStateTests {
         let completion = state.complete(
             nilTotalRequest,
             sessionTotal: nil,
-            currentSurfaceGeneration: 2
+            currentSurfaceGeneration: 2,
+            freshestLocalCount: 5
         )
         #expect(completion.outcome == .reported(.init(count: 5, surfaceGeneration: 2)))
 
@@ -33,7 +34,8 @@ struct TerminalArtifactChipCountStateTests {
         let zeroCompletion = state.complete(
             zeroRequest,
             sessionTotal: 0,
-            currentSurfaceGeneration: 3
+            currentSurfaceGeneration: 3,
+            freshestLocalCount: 6
         )
         #expect(zeroCompletion.outcome == .reported(.init(count: 6, surfaceGeneration: 3)))
     }
@@ -50,7 +52,8 @@ struct TerminalArtifactChipCountStateTests {
         #expect(resetState.complete(
             resetRequest,
             sessionTotal: 20,
-            currentSurfaceGeneration: 10
+            currentSurfaceGeneration: 10,
+            freshestLocalCount: 2
         ) == .stale)
 
         var surfaceState = TerminalArtifactChipCountState()
@@ -62,7 +65,8 @@ struct TerminalArtifactChipCountStateTests {
         let completion = surfaceState.complete(
             surfaceRequest,
             sessionTotal: 30,
-            currentSurfaceGeneration: 12
+            currentSurfaceGeneration: 12,
+            freshestLocalCount: 7
         )
         #expect(completion.outcome == .droppedForSurfaceGenerationMismatch)
         #expect(completion.nextRequest?.surfaceGeneration == 12)
@@ -80,16 +84,18 @@ struct TerminalArtifactChipCountStateTests {
         let dropped = state.complete(
             request,
             sessionTotal: 30,
-            currentSurfaceGeneration: 12
+            currentSurfaceGeneration: 12,
+            freshestLocalCount: 8
         )
         let rearmed = try #require(dropped.nextRequest)
-        #expect(rearmed.localCount == 3)
+        #expect(rearmed.localCount == 8)
         #expect(rearmed.surfaceGeneration == 12)
 
         let reported = state.complete(
             rearmed,
             sessionTotal: 30,
-            currentSurfaceGeneration: 12
+            currentSurfaceGeneration: 12,
+            freshestLocalCount: 8
         )
         #expect(reported.outcome == .reported(.init(count: 30, surfaceGeneration: 12)))
         #expect(reported.nextRequest == nil)
@@ -108,7 +114,8 @@ struct TerminalArtifactChipCountStateTests {
             let completion = state.complete(
                 request,
                 sessionTotal: 40,
-                currentSurfaceGeneration: UInt64(20 + offset)
+                currentSurfaceGeneration: UInt64(20 + offset),
+                freshestLocalCount: 4 + offset
             )
             request = try #require(completion.nextRequest)
         }
@@ -116,7 +123,8 @@ struct TerminalArtifactChipCountStateTests {
         let bounded = state.complete(
             request,
             sessionTotal: 40,
-            currentSurfaceGeneration: 100
+            currentSurfaceGeneration: 100,
+            freshestLocalCount: 100
         )
         #expect(bounded.outcome == .droppedForSurfaceGenerationMismatch)
         #expect(bounded.nextRequest == nil)
@@ -140,12 +148,14 @@ struct TerminalArtifactChipCountStateTests {
         #expect(state.complete(
             stale,
             sessionTotal: 10,
-            currentSurfaceGeneration: 31
+            currentSurfaceGeneration: 31,
+            freshestLocalCount: 2
         ) == .stale)
         #expect(state.complete(
             current,
             sessionTotal: 20,
-            currentSurfaceGeneration: 31
+            currentSurfaceGeneration: 31,
+            freshestLocalCount: 2
         ).outcome == .reported(.init(count: 20, surfaceGeneration: 31)))
     }
 
@@ -171,7 +181,8 @@ struct TerminalArtifactChipCountStateTests {
         let completion = state.complete(
             first,
             sessionTotal: 10,
-            currentSurfaceGeneration: 22
+            currentSurfaceGeneration: 22,
+            freshestLocalCount: 3
         )
         #expect(completion.outcome == .droppedForSurfaceGenerationMismatch)
         #expect(completion.nextRequest?.localCount == 3)

--- a/Sources/Mobile/AgentChat/AgentChatArtifactIndex.swift
+++ b/Sources/Mobile/AgentChat/AgentChatArtifactIndex.swift
@@ -36,7 +36,7 @@ actor AgentChatArtifactIndex {
         let snapshot: Snapshot
     }
 
-    private var cacheBySessionID: [String: CacheEntry] = [:]
+    private var cacheBySessionID = ChatArtifactLRUCache<String, CacheEntry>(capacity: 8)
 
     func snapshot(
         sessionID: String,
@@ -45,7 +45,7 @@ actor AgentChatArtifactIndex {
         workingDirectory: String?
     ) async throws -> Snapshot {
         let key = try Self.cacheKey(transcriptPath: transcriptPath, workingDirectory: workingDirectory)
-        if let cached = cacheBySessionID[sessionID], cached.key == key {
+        if let cached = cacheBySessionID.value(forKey: sessionID), cached.key == key {
             return cached.snapshot
         }
         let snapshot = try Self.buildSnapshot(
@@ -54,7 +54,7 @@ actor AgentChatArtifactIndex {
             workingDirectory: workingDirectory,
             generation: key.generation
         )
-        cacheBySessionID[sessionID] = CacheEntry(key: key, snapshot: snapshot)
+        cacheBySessionID.insert(CacheEntry(key: key, snapshot: snapshot), forKey: sessionID)
         return snapshot
     }
 

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -7,6 +7,7 @@ import Foundation
 @MainActor
 final class AgentChatSessionRegistry {
     private var records: [String: AgentChatSessionRecord] = [:]
+    private var sessionSurfaceIndex = ChatSessionSurfaceIndex<String>()
     private var liveSessionIDBySurfaceID: [String: String] = [:]
     private var liveClaudeSessionIDsBySurfaceID: [String: Set<String>] = [:]
     private let hookStore: AgentChatHookSessionStore
@@ -140,7 +141,7 @@ final class AgentChatSessionRegistry {
                 stampVersion(&record)
                 records[targetSessionID] = record
                 syncProcessExitWatch(for: record)
-                updateLiveSessionIndex(previous: nil, current: record)
+                updateSessionIndexes(previous: nil, current: record)
                 onRecordChanged?(record, nil)
             } else {
                 guard let current = records[targetSessionID] else { continue }
@@ -259,7 +260,8 @@ final class AgentChatSessionRegistry {
         if let live = liveSession(surfaceID: surfaceID) {
             return live
         }
-        return records.values
+        return sessionSurfaceIndex.sessionIDs(surfaceID: surfaceID)
+            .compactMap { records[$0] }
             .filter { $0.surfaceID == surfaceID }
             .max { $0.lastActivityAt < $1.lastActivityAt }
     }
@@ -310,7 +312,7 @@ final class AgentChatSessionRegistry {
         }
         #endif
         syncProcessExitWatch(for: record)
-        updateLiveSessionIndex(previous: previous, current: record)
+        updateSessionIndexes(previous: previous, current: record)
         onRecordChanged?(record, previous)
     }
 
@@ -388,7 +390,7 @@ final class AgentChatSessionRegistry {
                 stampVersion(&record)
                 records[sessionID] = record
                 syncProcessExitWatch(for: record)
-                updateLiveSessionIndex(previous: nil, current: record)
+                updateSessionIndexes(previous: nil, current: record)
                 onRecordChanged?(record, nil)
             }
         }
@@ -476,7 +478,7 @@ final class AgentChatSessionRegistry {
         stampVersion(&record)
         records[sessionID] = record
         syncProcessExitWatch(for: record)
-        updateLiveSessionIndex(previous: previous, current: record)
+        updateSessionIndexes(previous: previous, current: record)
         onRecordChanged?(record, previous)
         if shouldConsultStore {
             backfillBindingsFromStore(
@@ -559,7 +561,7 @@ final class AgentChatSessionRegistry {
             exitWatchers[alias]?.source.cancel()
             exitWatchers[alias] = nil
             hookStoreConsultedAt.removeValue(forKey: alias)
-            updateLiveSessionIndex(previous: record, current: nil)
+            updateSessionIndexes(previous: record, current: nil)
             onRecordRemoved?(record)
         }
         if let indexed = liveSessionIDBySurfaceID[surfaceID],
@@ -650,7 +652,7 @@ final class AgentChatSessionRegistry {
         stampVersion(&record)
         records[sessionID] = record
         syncProcessExitWatch(for: record)
-        updateLiveSessionIndex(previous: nil, current: record)
+        updateSessionIndexes(previous: nil, current: record)
         onRecordChanged?(record, nil)
     }
 
@@ -692,10 +694,17 @@ final class AgentChatSessionRegistry {
         }
     }
 
-    private func updateLiveSessionIndex(
+    private func updateSessionIndexes(
         previous: AgentChatSessionRecord?,
         current: AgentChatSessionRecord?
     ) {
+        if let sessionID = current?.sessionID ?? previous?.sessionID {
+            sessionSurfaceIndex.update(
+                sessionID: sessionID,
+                previousSurfaceID: previous?.surfaceID,
+                currentSurfaceID: current?.surfaceID
+            )
+        }
         updateLiveClaudeSessionIndex(previous: previous, current: current)
         let previousSurfaceID = Self.liveSurfaceID(previous)
         let currentSurfaceID = Self.liveSurfaceID(current)
@@ -736,7 +745,8 @@ final class AgentChatSessionRegistry {
 
     private func rebuildLiveSessionIndex(surfaceID: String?) {
         guard let surfaceID else { return }
-        if let newest = records.values
+        if let newest = sessionSurfaceIndex.sessionIDs(surfaceID: surfaceID)
+            .compactMap({ records[$0] })
             .filter({ $0.surfaceID == surfaceID && $0.state != .ended })
             .max(by: { $0.lastActivityAt < $1.lastActivityAt }) {
             liveSessionIDBySurfaceID[surfaceID] = newest.sessionID

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -54,12 +54,7 @@ extension TerminalController {
                     includeDirectories: includeDirectories
                 )
             }.value
-            var payload = ChatArtifactWire.payload(page) ?? [:]
-            if cursor != nil {
-                payload.removeValue(forKey: "created")
-                payload.removeValue(forKey: "attached")
-            }
-            return .ok(payload)
+            return .ok(ChatArtifactWire.payload(page) ?? [:])
         } catch {
             return mobileChatArtifactError(.notFound, path: "")
         }

--- a/Sources/TerminalController+MobileChatArtifacts.swift
+++ b/Sources/TerminalController+MobileChatArtifacts.swift
@@ -4,6 +4,7 @@ import Foundation
 
 private enum TerminalControllerChatArtifactIndexProvider {
     static let shared = AgentChatArtifactIndex()
+    static let ordering = ChatArtifactGalleryOrderingCache()
 }
 
 extension TerminalController {
@@ -43,10 +44,16 @@ extension TerminalController {
             let pageSize = min(max(v2Int(params, "page_size") ?? 60, 1), 100)
             let query = v2RawString(params, "query")
             let includeDirectories = v2Bool(params, "include_directories") ?? false
+            let orderedItems = await TerminalControllerChatArtifactIndexProvider.ordering.ordered(
+                indexedSession.snapshot.artifacts,
+                indexID: indexedSession.sessionID,
+                generation: indexedSession.snapshot.generation
+            )
             let page = await Task.detached(priority: .utility) {
                 AgentChatArtifactGalleryBuilder().page(
                     sessionID: indexedSession.sessionID,
                     items: indexedSession.snapshot.artifacts,
+                    orderedItems: orderedItems,
                     generation: indexedSession.snapshot.generation,
                     cursor: cursor,
                     pageSize: pageSize,


### PR DESCRIPTION
Re-opening a file refetched the whole thing over RPC every tap, new artifacts never appeared while the gallery sheet was open, fetched bytes could not leave the app, images were static fit-to-screen, and several server paths did unbounded work per request (https://github.com/manaflow-ai/cmux/issues/8044).

Fetched content now lands in a cache actor mirroring the thumbnail cache (memory + disk LRU, key = scope + path + mtime + size, so any file change invalidates; entries with unknown mtime/size are never cached); re-opening an unchanged file renders with zero fetch RPCs, and media streams through the same cache with properly named temp files materialized only for preview/share/export. While the sheet is open on session scope, the chip's existing generation signal drives live refresh: at top the list merges gently, elsewhere an unobtrusive "N new files" pill appears and the scroll position never moves. The viewer toolbar and row context menus gain Share, Save to Files, Copy contents (size-guarded), and Copy path. Images get pinch/pan/double-tap zoom; horizontal swipe-paging only engages at 1x. Server side: first-page stat work is bounded per section, gallery ordering is cached per index generation, stale-generation cursors now restart paging from a fresh first page (the Greptile finding deferred from https://github.com/manaflow-ai/cmux/pull/8075), the per-transcript index cache is LRU-bounded, session records are indexed by surface, and tap hit-testing uses terminal cell widths so CJK-prefixed paths get correct tap targets.

Tests: CmuxAgentChat 325 across 36 suites, CmuxAgentChatUI 79 across 19; iOS simulator-triple builds pass for all touched packages; 15 new strings localized EN+JA.

Part 6b (final) of the chip-files-gallery completion stack, based on https://github.com/manaflow-ai/cmux/pull/8105.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8113"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786671172&installation_id=133855650&pr_number=8113&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8113&signature=faee1a9c1ce05926b139107d41aafe89eb6708e43292c7f090e4176f347755fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an iOS artifact content cache, zero-jank live gallery refresh, file actions, and image pinch-to-zoom, plus server-side paging and ordering improvements for faster, smoother browsing. Also fixes stale-generation paging, fills pages sequentially across sections so loads only extend the list bottom, and improves terminal tap targets for CJK paths.

- **New Features**
  - Cache fetched artifact bytes (memory + disk LRU) keyed by scope, path, mtime, size; reopens avoid RPC; media streams reuse the cache; temp files are created only for share/export and keep original names.
  - Live refresh in the sheet: when at top, new files merge at the top; otherwise show a small “N new files” pill; scroll position never moves.
  - File actions in viewer and rows: Share, Save to Files, Copy contents (size-guarded), Copy path.
  - Image viewer supports pinch/pan/double-tap zoom; horizontal paging only at 1x and is disabled while zoomed.

- **Refactors**
  - Fill gallery pages sequentially across sections (created → attached → referenced) so incremental loads only extend the bottom.
  - Page artifact stats across sections and include created/attached totals; snapshots accumulate section rows across pages.
  - Cache gallery ordering per index generation; restart paging when the host reports a stale generation.
  - LRU-bound artifact index snapshots and a surface-to-session index to speed up lookups.
  - Terminal tap hit-testing now uses terminal cell widths, fixing CJK-prefixed path taps.

<sup>Written for commit 65a8bcf1deb06a62c931728e53275ef3019241d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

