### PR TITLE
Fix visible popover resize crash

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
@@ -231,10 +231,11 @@ struct CmxIrohRelayCredentialCoordinatorTests {
             endpointIdentity: fixture.identity
         )
 
-        #expect(
-            await clockEvents.next()
-                == .sleep(fixture.now.addingTimeInterval(600))
-        )
+        guard case let .sleep(deadline) = await clockEvents.next() else {
+            Issue.record("Expected the relay retry sleep")
+            return
+        }
+        #expect(deadline == fixture.now.addingTimeInterval(600))
         #expect(await endpoint.observedRelayUpdates().isEmpty)
         await coordinator.deactivate()
     }

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/Popover/ArrowlessPopoverAnchor.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/Popover/ArrowlessPopoverAnchor.swift
@@ -39,11 +39,16 @@ public struct ArrowlessPopoverAnchor<PopoverContent: View>: NSViewRepresentable 
     public func updateNSView(_ nsView: NSView, context: Context) {
         let coordinator = context.coordinator
         coordinator.anchorView = nsView
-        if ArrowlessPopoverRootViewUpdatePolicy.shouldUpdateRootView(
+        switch ArrowlessPopoverRootViewUpdatePolicy.rootViewUpdateStrategy(
             isPresented: isPresented,
             popoverIsShown: coordinator.isPopoverShown
         ) {
+        case .none:
+            coordinator.cancelDeferredRootViewUpdate()
+        case .immediate:
             coordinator.updateRootView(AnyView(content()))
+        case .deferredVisible:
+            coordinator.deferVisibleRootViewUpdate(AnyView(content()))
         }
 
         if isPresented {
@@ -67,7 +72,9 @@ public struct ArrowlessPopoverAnchor<PopoverContent: View>: NSViewRepresentable 
 
         weak var anchorView: NSView?
         private let hostingController = NSHostingController(rootView: AnyView(EmptyView()))
+        private let visibleUpdateScheduler = CmuxPopoverVisibleUpdateScheduler()
         private var popover: NSPopover?
+        private var pendingVisibleRootView: AnyView?
         var isPopoverShown: Bool { popover?.isShown == true }
 
         init(isPresented: Binding<Bool>) {
@@ -75,9 +82,32 @@ public struct ArrowlessPopoverAnchor<PopoverContent: View>: NSViewRepresentable 
         }
 
         func updateRootView(_ rootView: AnyView) {
-            hostingController.rootView = AnyView(rootView.fixedSize())
-            hostingController.view.invalidateIntrinsicContentSize()
-            hostingController.view.layoutSubtreeIfNeeded()
+            CmuxPopoverMutation.performWithoutImplicitAnimation {
+                hostingController.rootView = AnyView(rootView.fixedSize())
+                hostingController.view.invalidateIntrinsicContentSize()
+                hostingController.view.layoutSubtreeIfNeeded()
+            }
+        }
+
+        func deferVisibleRootViewUpdate(_ rootView: AnyView) {
+            pendingVisibleRootView = rootView
+            visibleUpdateScheduler.schedule { [weak self] in
+                self?.flushDeferredRootViewUpdate()
+            }
+        }
+
+        func cancelDeferredRootViewUpdate() {
+            pendingVisibleRootView = nil
+            visibleUpdateScheduler.cancel()
+        }
+
+        private func flushDeferredRootViewUpdate() {
+            guard popover?.isShown == true, let pendingVisibleRootView else {
+                self.pendingVisibleRootView = nil
+                return
+            }
+            self.pendingVisibleRootView = nil
+            updateRootView(pendingVisibleRootView)
         }
 
         func present(preferredEdge: NSRectEdge, detachedGap: CGFloat) {
@@ -96,10 +126,10 @@ public struct ArrowlessPopoverAnchor<PopoverContent: View>: NSViewRepresentable 
             hostingController.view.layoutSubtreeIfNeeded()
             let fittingSize = hostingController.view.fittingSize
             if fittingSize.width > 0, fittingSize.height > 0 {
-                popover.contentSize = NSSize(
+                CmuxPopoverMutation.setContentSize(NSSize(
                     width: ceil(fittingSize.width),
                     height: ceil(fittingSize.height)
-                )
+                ), on: popover)
             }
 
             popover.show(
@@ -114,11 +144,13 @@ public struct ArrowlessPopoverAnchor<PopoverContent: View>: NSViewRepresentable 
         }
 
         func dismiss() {
+            cancelDeferredRootViewUpdate()
             popover?.performClose(nil)
             popover = nil
         }
 
         public func popoverDidClose(_ notification: Notification) {
+            cancelDeferredRootViewUpdate()
             popover = nil
             if isPresented {
                 isPresented = false

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/Popover/ArrowlessPopoverRootViewUpdatePolicy.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/Popover/ArrowlessPopoverRootViewUpdatePolicy.swift
@@ -1,5 +1,13 @@
 struct ArrowlessPopoverRootViewUpdatePolicy {
-    static func shouldUpdateRootView(isPresented: Bool, popoverIsShown: Bool) -> Bool {
-        isPresented || popoverIsShown
+    enum Strategy {
+        case none
+        case immediate
+        case deferredVisible
+    }
+
+    static func rootViewUpdateStrategy(isPresented: Bool, popoverIsShown: Bool) -> Strategy {
+        if popoverIsShown { return .deferredVisible }
+        if isPresented { return .immediate }
+        return .none
     }
 }

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/Popover/CmuxPopoverMutation.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/Popover/CmuxPopoverMutation.swift
@@ -1,0 +1,59 @@
+public import AppKit
+
+@MainActor
+public final class CmuxPopoverVisibleUpdateScheduler {
+    private var pendingUpdate: (@MainActor () -> Void)?
+    private var scheduledTask: Task<Void, Never>?
+    private var generation: UInt64 = 0
+
+    public init() {}
+
+    deinit {
+        scheduledTask?.cancel()
+    }
+
+    public func schedule(_ update: @escaping @MainActor () -> Void) {
+        pendingUpdate = update
+        guard scheduledTask == nil else { return }
+        let generation = self.generation
+        scheduledTask = Task { @MainActor [weak self] in
+            self?.flush(ifCurrent: generation)
+        }
+    }
+
+    public func cancel() {
+        generation &+= 1
+        scheduledTask?.cancel()
+        scheduledTask = nil
+        pendingUpdate = nil
+    }
+
+    private func flush(ifCurrent generation: UInt64) {
+        guard generation == self.generation, !Task.isCancelled else { return }
+        scheduledTask = nil
+        guard let pendingUpdate else { return }
+        self.pendingUpdate = nil
+        pendingUpdate()
+    }
+}
+
+@MainActor
+public enum CmuxPopoverMutation {
+    public static func performWithoutImplicitAnimation(_ body: () -> Void) {
+        NSAnimationContext.runAnimationGroup { context in
+            context.duration = 0
+            context.allowsImplicitAnimation = false
+            body()
+        }
+    }
+
+    public static func setContentSize(_ size: NSSize, on popover: NSPopover) {
+        if popover.isShown {
+            performWithoutImplicitAnimation {
+                popover.contentSize = size
+            }
+        } else {
+            popover.contentSize = size
+        }
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/ArrowlessPopoverRootViewUpdatePolicyTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/ArrowlessPopoverRootViewUpdatePolicyTests.swift
@@ -5,25 +5,54 @@ import Testing
 
 @Suite struct ArrowlessPopoverRootViewUpdatePolicyTests {
     @Test func hiddenClosedPopoverDoesNotNeedHostedRootRefresh() {
-        #expect(ArrowlessPopoverRootViewUpdatePolicy.shouldUpdateRootView(
+        #expect(ArrowlessPopoverRootViewUpdatePolicy.rootViewUpdateStrategy(
             isPresented: false,
             popoverIsShown: false
-        ) == false)
+        ) == .none)
     }
 
-    @Test func presentedOrVisiblePopoverKeepsHostedRootFresh() {
-        #expect(ArrowlessPopoverRootViewUpdatePolicy.shouldUpdateRootView(
+    @Test func firstPresentationUpdatesHostedRootSynchronously() {
+        #expect(ArrowlessPopoverRootViewUpdatePolicy.rootViewUpdateStrategy(
             isPresented: true,
             popoverIsShown: false
-        ))
-        #expect(ArrowlessPopoverRootViewUpdatePolicy.shouldUpdateRootView(
+        ) == .immediate)
+    }
+
+    @Test func visiblePopoverDefersHostedRootRefreshOutsideRepresentableUpdate() {
+        #expect(ArrowlessPopoverRootViewUpdatePolicy.rootViewUpdateStrategy(
             isPresented: false,
             popoverIsShown: true
-        ))
-        #expect(ArrowlessPopoverRootViewUpdatePolicy.shouldUpdateRootView(
+        ) == .deferredVisible)
+        #expect(ArrowlessPopoverRootViewUpdatePolicy.rootViewUpdateStrategy(
             isPresented: true,
             popoverIsShown: true
-        ))
+        ) == .deferredVisible)
+    }
+}
+
+@MainActor
+@Suite struct CmuxPopoverVisibleUpdateSchedulerTests {
+    @Test func visibleUpdatesRunAfterCurrentMainActorTurnAndCoalesce() async {
+        let scheduler = CmuxPopoverVisibleUpdateScheduler()
+        var applied: [String] = []
+
+        scheduler.schedule { applied.append("first") }
+        scheduler.schedule { applied.append("second") }
+
+        #expect(applied.isEmpty)
+        await Task.yield()
+        #expect(applied == ["second"])
+    }
+
+    @Test func cancellationDropsPendingVisibleUpdate() async {
+        let scheduler = CmuxPopoverVisibleUpdateScheduler()
+        var applied = false
+
+        scheduler.schedule { applied = true }
+        scheduler.cancel()
+
+        await Task.yield()
+        #expect(applied == false)
     }
 }
 

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/ArrowlessPopoverRootViewUpdatePolicyTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/ArrowlessPopoverRootViewUpdatePolicyTests.swift
@@ -54,6 +54,19 @@ import Testing
         await Task.yield()
         #expect(applied == false)
     }
+
+    @Test func cancelledTaskDoesNotClearRescheduledVisibleUpdate() async {
+        let scheduler = CmuxPopoverVisibleUpdateScheduler()
+        var applied: [String] = []
+
+        scheduler.schedule { applied.append("cancelled") }
+        scheduler.cancel()
+        scheduler.schedule { applied.append("rescheduled") }
+
+        await Task.yield()
+        await Task.yield()
+        #expect(applied == ["rescheduled"])
+    }
 }
 
 #endif

--- a/Packages/macOS/CmuxTerminalCore/Package.swift
+++ b/Packages/macOS/CmuxTerminalCore/Package.swift
@@ -65,6 +65,11 @@ let package = Package(
                 .swiftLanguageMode(.v6),
                 .enableUpcomingFeature("ExistentialAny"),
                 .enableUpcomingFeature("InternalImportsByDefault"),
+            ],
+            // GhosttyKit's static lib carries C++ objects (glslang); the
+            // standalone xctest bundle must link the C++ runtime itself.
+            linkerSettings: [
+                .linkedLibrary("c++"),
             ]
         ),
     ]

--- a/Packages/macOS/CmuxTerminalCore/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminalCore/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -1,11 +1,22 @@
 #include "include/GhosttyRuntimeTestStubs.h"
 
-bool ghostty_surface_clear_selection(void *surface) {
+GHOSTTY_RUNTIME_TEST_STUB_WEAK void *ghostty_surface_new_with_scrollback_limit(
+    void *app,
+    const void *config,
+    size_t scrollback_limit_bytes
+) {
+    (void)app;
+    (void)config;
+    (void)scrollback_limit_bytes;
+    return 0;
+}
+
+GHOSTTY_RUNTIME_TEST_STUB_WEAK bool ghostty_surface_clear_selection(void *surface) {
     (void)surface;
     return false;
 }
 
-void *ghostty_surface_quicklook_font(void *surface) {
+GHOSTTY_RUNTIME_TEST_STUB_WEAK void *ghostty_surface_quicklook_font(void *surface) {
     (void)surface;
     return 0;
 }

--- a/Packages/macOS/CmuxTerminalCore/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminalCore/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -2,15 +2,27 @@
 #define GHOSTTY_RUNTIME_TEST_STUBS_H
 
 #include <stdbool.h>
+#include <stddef.h>
 
-// Test-only stand-in for the libghostty symbol bound by @_silgen_name in
-// GhosttyRuntimeCInterop. SwiftPM cannot link the GhosttyKit macOS archive
-// (its binary is not lib-prefixed), so the test runner provides this stub to
-// satisfy the link; no test calls it.
-bool ghostty_surface_clear_selection(void *surface);
+#if defined(__APPLE__)
+#define GHOSTTY_RUNTIME_TEST_STUB_WEAK __attribute__((weak))
+#else
+#define GHOSTTY_RUNTIME_TEST_STUB_WEAK
+#endif
 
-// Test-only stand-in for the GhosttyKit symbol referenced by
-// GhosttySurfaceRuntimeProbe.currentSurfaceFontSizePoints; no test calls it.
-void *ghostty_surface_quicklook_font(void *surface);
+// Test-only weak stand-ins for libghostty symbols reached by
+// GhosttyRuntimeCInterop and GhosttySurfaceRuntimeProbe. Plain SwiftPM still
+// cannot reliably link GhosttyKit's macOS archive because its static library is
+// not lib-prefixed, while xcodebuild now links that archive for this package.
+// Weak definitions let xcodebuild use GhosttyKit's real symbols and let SwiftPM
+// tests link fallback symbols no test calls.
+GHOSTTY_RUNTIME_TEST_STUB_WEAK void *ghostty_surface_new_with_scrollback_limit(
+    void *app,
+    const void *config,
+    size_t scrollback_limit_bytes);
+
+GHOSTTY_RUNTIME_TEST_STUB_WEAK bool ghostty_surface_clear_selection(void *surface);
+
+GHOSTTY_RUNTIME_TEST_STUB_WEAK void *ghostty_surface_quicklook_font(void *surface);
 
 #endif

--- a/Sources/SessionIndexSectionPopoverHost.swift
+++ b/Sources/SessionIndexSectionPopoverHost.swift
@@ -1,0 +1,185 @@
+import AppKit
+import CmuxAppKitSupportUI
+import SwiftUI
+
+/// Hosts SectionPopoverView in a real NSPopover. SwiftUI's native `.popover()`
+/// doesn't reliably let the embedded TextField become first responder in cmux's
+/// focus-managed environment because the terminal keeps grabbing focus back.
+struct SectionPopoverHost: NSViewRepresentable {
+    @Binding var isPresented: Bool
+    let section: IndexSection
+    /// Closure-typed search handle passed through to the SwiftUI popover
+    /// body. The host no longer holds a `SessionIndexStore` reference.
+    let search: SessionSearchFn
+    let loadSnapshot: DirectorySnapshotFn
+    let onResume: ((SessionEntry) -> Void)?
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(isPresented: $isPresented)
+    }
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.translatesAutoresizingMaskIntoConstraints = false
+        context.coordinator.anchorView = view
+        return view
+    }
+
+    func updateNSView(_ nsView: NSView, context: Context) {
+        let coordinator = context.coordinator
+        coordinator.anchorView = nsView
+        coordinator.update(
+            section: section,
+            search: search,
+            loadSnapshot: loadSnapshot,
+            onResume: onResume
+        )
+        if isPresented {
+            coordinator.present()
+        } else {
+            coordinator.dismiss()
+        }
+    }
+
+    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
+        coordinator.dismiss()
+    }
+
+    @MainActor
+    final class Coordinator: NSObject, NSPopoverDelegate {
+        @Binding var isPresented: Bool
+        weak var anchorView: NSView?
+        private(set) var refreshContentCallCount = 0
+        var isPopoverShown: Bool { popover?.isShown == true }
+
+        private let hostingController: NSHostingController<AnyView> = {
+            NSHostingController(rootView: AnyView(EmptyView()))
+            // DO NOT set sizingOptions here. It makes NSHostingController
+            // continuously rewrite preferredContentSize from SwiftUI layout,
+            // which lets NSPopover override our manual contentSize and latch
+            // onto a partial first-pass height.
+        }()
+        private var popover: NSPopover?
+        private var currentSection: IndexSection?
+        private var currentSearch: SessionSearchFn?
+        private var currentLoadSnapshot: DirectorySnapshotFn?
+        private var currentOnResume: ((SessionEntry) -> Void)?
+        private let visibleUpdateScheduler = CmuxPopoverVisibleUpdateScheduler()
+        private var lastRenderedSection: IndexSection?
+        private var lastRenderedPresentationCount: Int?
+        /// Bumped on every present(). Used as the SwiftUI view identity so each
+        /// open gets fresh view-local state.
+        private var presentationCount = 0
+
+        init(isPresented: Binding<Bool>) {
+            _isPresented = isPresented
+        }
+
+        func update(
+            section: IndexSection,
+            search: @escaping SessionSearchFn,
+            loadSnapshot: @escaping DirectorySnapshotFn,
+            onResume: ((SessionEntry) -> Void)?
+        ) {
+            currentSection = section
+            currentSearch = search
+            currentLoadSnapshot = loadSnapshot
+            currentOnResume = onResume
+            // When hidden, defer rebuilding the hosting view until `present()`.
+            // Rewriting rootView + forcing layout on every parent re-render was
+            // the 100% CPU loop behind https://github.com/manaflow-ai/cmux/issues/3010.
+            guard popover?.isShown == true else { return }
+            guard lastRenderedSection != section || lastRenderedPresentationCount != presentationCount else { return }
+            scheduleVisibleRefresh()
+        }
+
+        private func scheduleVisibleRefresh() {
+            visibleUpdateScheduler.schedule { [weak self] in
+                guard let self, self.popover?.isShown == true else { return }
+                self.refreshContent()
+            }
+        }
+
+        private func refreshContent() {
+            guard let section = currentSection,
+                  let search = currentSearch,
+                  let loadSnapshot = currentLoadSnapshot else { return }
+            refreshContentCallCount += 1
+            let onResume = currentOnResume
+            let identity = presentationCount
+            hostingController.rootView = AnyView(
+                SectionPopoverView(
+                    section: section,
+                    search: search,
+                    loadSnapshot: loadSnapshot,
+                    onResume: onResume
+                ) { [weak self] in
+                    self?.closeFromContent()
+                }
+                // Tied to presentationCount so reopening the popover discards
+                // the prior open's view-local search and scroll state.
+                .id(identity)
+            )
+            lastRenderedSection = section
+            lastRenderedPresentationCount = presentationCount
+            hostingController.view.invalidateIntrinsicContentSize()
+            hostingController.view.layoutSubtreeIfNeeded()
+            updateContentSize()
+        }
+
+        func present() {
+            guard let anchorView, anchorView.window != nil else {
+                isPresented = false
+                return
+            }
+            anchorView.superview?.layoutSubtreeIfNeeded()
+            let popover = popover ?? makePopover()
+            if !popover.isShown {
+                visibleUpdateScheduler.cancel()
+                presentationCount += 1
+                refreshContent()
+            }
+            updateContentSize()
+            guard !popover.isShown else { return }
+            popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .maxX)
+        }
+
+        func dismiss() {
+            visibleUpdateScheduler.cancel()
+            popover?.performClose(nil)
+        }
+
+        func closeFromContent() {
+            isPresented = false
+            dismiss()
+        }
+
+        func popoverDidClose(_ notification: Notification) {
+            visibleUpdateScheduler.cancel()
+            popover = nil
+            if isPresented {
+                isPresented = false
+            }
+        }
+
+        private func makePopover() -> NSPopover {
+            let p = NSPopover()
+            p.behavior = .transient
+            p.animates = true
+            p.contentViewController = hostingController
+            p.delegate = self
+            self.popover = p
+            return p
+        }
+
+        private func updateContentSize() {
+            let fitting = hostingController.view.fittingSize
+            guard fitting.width > 0, fitting.height > 0 else { return }
+            guard let popover else { return }
+            CmuxPopoverMutation.setContentSize(NSSize(
+                width: ceil(max(fitting.width, 360)),
+                height: ceil(min(fitting.height, 480))
+            ), on: popover)
+        }
+    }
+}

--- a/Sources/SessionIndexView.swift
+++ b/Sources/SessionIndexView.swift
@@ -1954,11 +1954,13 @@ private struct SessionTranscriptPopoverHost: NSViewRepresentable {
         coordinator.dismiss()
     }
 
+    @MainActor
     final class Coordinator: NSObject, NSPopoverDelegate {
         @Binding var isPresented: Bool
         weak var anchorView: NSView?
 
         private let hostingController = NSHostingController(rootView: AnyView(EmptyView()))
+        private let visibleUpdateScheduler = CmuxPopoverVisibleUpdateScheduler()
         private var popover: NSPopover?
         private var currentEntry: SessionEntry?
         private let sizeModel = SessionTranscriptPopoverSizeModel()
@@ -1972,7 +1974,18 @@ private struct SessionTranscriptPopoverHost: NSViewRepresentable {
             let shouldRefresh = currentEntry?.id != entry.id
             currentEntry = entry
             if shouldRefresh {
-                refreshContent()
+                if popover?.isShown == true {
+                    scheduleVisibleRefresh()
+                } else {
+                    refreshContent()
+                }
+            }
+        }
+
+        private func scheduleVisibleRefresh() {
+            visibleUpdateScheduler.schedule { [weak self] in
+                guard let self, self.popover?.isShown == true else { return }
+                self.refreshContent()
             }
         }
 
@@ -1994,6 +2007,7 @@ private struct SessionTranscriptPopoverHost: NSViewRepresentable {
             anchorView.superview?.layoutSubtreeIfNeeded()
             let popover = popover ?? makePopover()
             if !popover.isShown {
+                visibleUpdateScheduler.cancel()
                 refreshContent()
                 popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .maxX)
             }
@@ -2001,10 +2015,12 @@ private struct SessionTranscriptPopoverHost: NSViewRepresentable {
 
         func dismiss() {
             wantsPresentation = false
+            visibleUpdateScheduler.cancel()
             popover?.performClose(nil)
         }
 
         func popoverDidClose(_ notification: Notification) {
+            visibleUpdateScheduler.cancel()
             wantsPresentation = false
             popover = nil
             if isPresented {
@@ -2053,7 +2069,11 @@ private struct SessionTranscriptPopoverHost: NSViewRepresentable {
         }
 
         private func updatePopoverSize() {
-            popover?.contentSize = NSSize(width: sizeModel.size.width, height: sizeModel.size.height)
+            guard let popover else { return }
+            CmuxPopoverMutation.setContentSize(
+                NSSize(width: sizeModel.size.width, height: sizeModel.size.height),
+                on: popover
+            )
         }
     }
 }
@@ -2112,7 +2132,7 @@ private struct EscapeKeyCatcher: NSViewRepresentable {
 
 // MARK: - "Show more" popover with search
 
-private struct SectionPopoverView: View {
+struct SectionPopoverView: View {
     let section: IndexSection
     /// Closure-typed search handle. The popover never holds a reference to
     /// `SessionIndexStore`; the parent view is the only owner.
@@ -2621,194 +2641,6 @@ private func sessionDragItemProvider(for entry: SessionEntry) -> NSItemProvider 
 
     provider.suggestedName = entry.displayTitle
     return provider
-}
-
-// MARK: - NSPopover host
-
-/// Hosts SectionPopoverView in a real NSPopover. SwiftUI's native `.popover()`
-/// doesn't reliably let the embedded TextField become first responder in cmux's
-/// focus-managed environment because the terminal keeps grabbing focus back.
-struct SectionPopoverHost: NSViewRepresentable {
-    @Binding var isPresented: Bool
-    let section: IndexSection
-    /// Closure-typed search handle passed through to the SwiftUI popover
-    /// body. The host no longer holds a `SessionIndexStore` reference.
-    let search: SessionSearchFn
-    let loadSnapshot: DirectorySnapshotFn
-    let onResume: ((SessionEntry) -> Void)?
-
-    func makeCoordinator() -> Coordinator {
-        Coordinator(isPresented: $isPresented)
-    }
-
-    func makeNSView(context: Context) -> NSView {
-        let view = NSView()
-        view.translatesAutoresizingMaskIntoConstraints = false
-        context.coordinator.anchorView = view
-        return view
-    }
-
-    func updateNSView(_ nsView: NSView, context: Context) {
-        let coordinator = context.coordinator
-        coordinator.anchorView = nsView
-        coordinator.update(
-            section: section,
-            search: search,
-            loadSnapshot: loadSnapshot,
-            onResume: onResume
-        )
-        if isPresented {
-            coordinator.present()
-        } else {
-            coordinator.dismiss()
-        }
-    }
-
-    static func dismantleNSView(_ nsView: NSView, coordinator: Coordinator) {
-        coordinator.dismiss()
-    }
-
-    final class Coordinator: NSObject, NSPopoverDelegate {
-        @Binding var isPresented: Bool
-        weak var anchorView: NSView?
-        private(set) var debugRefreshContentCallCount = 0
-        var debugIsPopoverShown: Bool { popover?.isShown == true }
-
-        private let hostingController: NSHostingController<AnyView> = {
-            NSHostingController(rootView: AnyView(EmptyView()))
-            // DO NOT set sizingOptions here. sizingOptions =
-            // [.preferredContentSize] makes NSHostingController
-            // continuously rewrite its preferredContentSize from SwiftUI
-            // layout; NSPopover observes preferredContentSize and will
-            // override any manual popover.contentSize we set. On first
-            // open SwiftUI layout settles over multiple passes and
-            // preferredContentSize briefly reports a partial height —
-            // NSPopover latches onto that and renders squished (evidence:
-            // /tmp/cmux-debug-spin-fix.log, refreshContent logged
-            // fitting=360x486 at present, but visible popover was ~280).
-            // Instead we drive popover.contentSize manually from
-            // fittingSize on every updateNSView / present call.
-        }()
-        private var popover: NSPopover?
-        private var currentSection: IndexSection?
-        private var currentSearch: SessionSearchFn?
-        private var currentLoadSnapshot: DirectorySnapshotFn?
-        private var currentOnResume: ((SessionEntry) -> Void)?
-        private var lastRenderedSection: IndexSection?
-        private var lastRenderedPresentationCount: Int?
-        /// Bumped on every present(). Used as the SwiftUI view identity so each
-        /// open gets fresh view-local state.
-        private var presentationCount = 0
-
-        init(isPresented: Binding<Bool>) {
-            _isPresented = isPresented
-        }
-
-        func update(
-            section: IndexSection,
-            search: @escaping SessionSearchFn,
-            loadSnapshot: @escaping DirectorySnapshotFn,
-            onResume: ((SessionEntry) -> Void)?
-        ) {
-            currentSection = section
-            currentSearch = search
-            currentLoadSnapshot = loadSnapshot
-            currentOnResume = onResume
-            // When hidden, defer rebuilding the hosting view until `present()`.
-            // Rewriting rootView + forcing layout on every parent re-render was
-            // the 100% CPU loop behind #3010.
-            guard popover?.isShown == true else { return }
-            // Rows capture stable closure bundles above the list boundary, so
-            // the section snapshot is the meaningful input here. Skipping
-            // identical visible-section updates avoids re-laying out the popover
-            // during unrelated parent re-renders while still refreshing when the
-            // visible content actually changes.
-            guard lastRenderedSection != section || lastRenderedPresentationCount != presentationCount else { return }
-            refreshContent()
-        }
-
-        private func refreshContent() {
-            guard let section = currentSection,
-                  let search = currentSearch,
-                  let loadSnapshot = currentLoadSnapshot else { return }
-            debugRefreshContentCallCount += 1
-            let onResume = currentOnResume
-            let identity = presentationCount
-            hostingController.rootView = AnyView(
-                SectionPopoverView(
-                    section: section,
-                    search: search,
-                    loadSnapshot: loadSnapshot,
-                    onResume: onResume
-                ) { [weak self] in
-                    self?.closeFromContent()
-                }
-                // Tied to presentationCount so reopening the popover discards
-                // the prior open's view-local search and scroll state.
-                .id(identity)
-            )
-            lastRenderedSection = section
-            lastRenderedPresentationCount = presentationCount
-            hostingController.view.invalidateIntrinsicContentSize()
-            hostingController.view.layoutSubtreeIfNeeded()
-            updateContentSize()
-        }
-
-        func present() {
-            guard let anchorView, anchorView.window != nil else {
-                isPresented = false
-                return
-            }
-            anchorView.superview?.layoutSubtreeIfNeeded()
-            let popover = popover ?? makePopover()
-            // Only bump identity on a hidden-to-shown transition. Bumping on every
-            // updateNSView (which fires on parent re-renders, e.g. ObservedObject
-            // store changes) would reset SectionPopoverView's view-local state
-            // on every tick.
-            if !popover.isShown {
-                presentationCount += 1
-                refreshContent()
-            }
-            updateContentSize()
-            guard !popover.isShown else { return }
-            popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .maxX)
-        }
-
-        func dismiss() {
-            popover?.performClose(nil)
-        }
-
-        func closeFromContent() {
-            isPresented = false
-            dismiss()
-        }
-
-        func popoverDidClose(_ notification: Notification) {
-            popover = nil
-            if isPresented {
-                isPresented = false
-            }
-        }
-
-        private func makePopover() -> NSPopover {
-            let p = NSPopover()
-            p.behavior = .transient
-            p.animates = true
-            p.contentViewController = hostingController
-            p.delegate = self
-            self.popover = p
-            return p
-        }
-
-        private func updateContentSize() {
-            let fitting = hostingController.view.fittingSize
-            guard fitting.width > 0, fitting.height > 0 else { return }
-            popover?.contentSize = NSSize(
-                width: ceil(max(fitting.width, 360)),
-                height: ceil(min(fitting.height, 480))
-            )
-        }
-    }
 }
 
 // MARK: - Drag cancel monitor

--- a/Sources/SidebarWorkspaceTodoPopoverHost.swift
+++ b/Sources/SidebarWorkspaceTodoPopoverHost.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxAppKitSupportUI
 import SwiftUI
 
 /// Invisible popover content view that promotes the popover window to key as
@@ -229,6 +230,7 @@ struct SidebarWorkspaceTodoPopoverHost<Model: Equatable, PopoverContent: View>: 
             NSHostingController(rootView: AnyView(EmptyView()))
             // DO NOT set sizingOptions here — see the type comment.
         }()
+        private let visibleUpdateScheduler = CmuxPopoverVisibleUpdateScheduler()
         private var popover: NSPopover?
         private var currentModel: Model?
         private var currentBuilder: ((Model, @escaping @MainActor () -> Void) -> AnyView)?
@@ -281,7 +283,14 @@ struct SidebarWorkspaceTodoPopoverHost<Model: Equatable, PopoverContent: View>: 
             guard popover?.isShown == true else { return }
             guard lastRenderedModel != model
                 || lastRenderedPresentationCount != presentationCount else { return }
-            refreshContent()
+            scheduleVisibleRefresh()
+        }
+
+        private func scheduleVisibleRefresh() {
+            visibleUpdateScheduler.schedule { [weak self] in
+                guard let self, self.popover?.isShown == true else { return }
+                self.refreshContent()
+            }
         }
 
         private func refreshContent() {
@@ -341,6 +350,7 @@ struct SidebarWorkspaceTodoPopoverHost<Model: Equatable, PopoverContent: View>: 
             // immediate superview anchors the popover to the wrong spot.
             window.contentView?.layoutSubtreeIfNeeded()
             anchorView.superview?.layoutSubtreeIfNeeded()
+            visibleUpdateScheduler.cancel()
             presentationCount += 1
             refreshContent()
             updateContentSize()
@@ -348,6 +358,7 @@ struct SidebarWorkspaceTodoPopoverHost<Model: Equatable, PopoverContent: View>: 
         }
 
         func dismiss() {
+            visibleUpdateScheduler.cancel()
             popover?.performClose(nil)
         }
 
@@ -357,6 +368,7 @@ struct SidebarWorkspaceTodoPopoverHost<Model: Equatable, PopoverContent: View>: 
         }
 
         func popoverDidClose(_ notification: Notification) {
+            visibleUpdateScheduler.cancel()
             popover = nil
             if isPresented {
                 // AppKit closed us (transient click-away / app deactivation)
@@ -393,10 +405,11 @@ struct SidebarWorkspaceTodoPopoverHost<Model: Equatable, PopoverContent: View>: 
         private func updateContentSize() {
             let fitting = hostingController.view.fittingSize
             guard fitting.width > 0, fitting.height > 0 else { return }
-            popover?.contentSize = NSSize(
+            guard let popover else { return }
+            CmuxPopoverMutation.setContentSize(NSSize(
                 width: ceil(max(fitting.width, minWidth)),
                 height: ceil(min(fitting.height, maxHeight))
-            )
+            ), on: popover)
         }
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1333,6 +1333,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74770010000000000000004 /* SessionDisplaySnapshot.swift */; };
 		B3575000000000000000000C /* SessionIndexModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3575000000000000000000B /* SessionIndexModels.swift */; };
 		B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */; };
+		FE003108 /* SessionIndexSectionPopoverHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003008 /* SessionIndexSectionPopoverHost.swift */; };
 		FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003004 /* SessionIndexStore+CodexSQL.swift */; };
 		FE003101 /* SessionIndexStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003001 /* SessionIndexStore.swift */; };
 		FE003102 /* SessionIndexView.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003002 /* SessionIndexView.swift */; };
@@ -3227,6 +3228,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A74770010000000000000004 /* SessionDisplaySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplaySnapshot.swift; sourceTree = "<group>"; };
 		B3575000000000000000000B /* SessionIndexModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexModels.swift; sourceTree = "<group>"; };
 		B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexRegisteredAgents.swift; sourceTree = "<group>"; };
+		FE003008 /* SessionIndexSectionPopoverHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSectionPopoverHost.swift; sourceTree = "<group>"; };
 		FE003004 /* SessionIndexStore+CodexSQL.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SessionIndexStore+CodexSQL.swift"; sourceTree = "<group>"; };
 		FE003001 /* SessionIndexStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexStore.swift; sourceTree = "<group>"; };
 		FE003002 /* SessionIndexView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexView.swift; sourceTree = "<group>"; };
@@ -5147,6 +5149,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE003006 /* SessionAgentPresentation.swift */,
 				FE003007 /* RovoDevTranscriptPreview.swift */,
 				F5320003A1B2C3D4E5F60718 /* SessionTranscriptTypes.swift */,
+				FE003008 /* SessionIndexSectionPopoverHost.swift */,
 				FE003002 /* SessionIndexView.swift */,
 				B7F9A601B7F9A601B7F9A601 /* RightSidebarChromeGeometryReporting.swift */,
 				B7F9A605B7F9A605B7F9A605 /* RightSidebarChromeStyle.swift */,
@@ -7018,6 +7021,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */,
 				B3575000000000000000000C /* SessionIndexModels.swift in Sources */,
 				B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */,
+				FE003108 /* SessionIndexSectionPopoverHost.swift in Sources */,
 				FE003104 /* SessionIndexStore+CodexSQL.swift in Sources */,
 				FE003101 /* SessionIndexStore.swift in Sources */,
 				FE003102 /* SessionIndexView.swift in Sources */,

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxIrohTransport
 import Foundation
 @preconcurrency import Network
 import Testing
@@ -1171,7 +1172,6 @@ actor TestMobileHostIndependentEventWriter: MobileHostIndependentEventWriting {
 }
 struct ImmediateMobileHostIrohClock: CmxIrohRelayClock {
     private let instant = Date(timeIntervalSince1970: 1_700_000_000)
-
     func now() -> Date { instant }
     func sleep(until _: Date) async throws {}
 }

--- a/cmuxTests/SessionIndexViewTests.swift
+++ b/cmuxTests/SessionIndexViewTests.swift
@@ -434,7 +434,7 @@ final class SessionIndexViewTests: XCTestCase {
             onResume: nil
         )
 
-        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 0)
+        XCTAssertEqual(coordinator.refreshContentCallCount, 0)
     }
 
     func testSectionPopoverHostCoordinatorRefreshesOnceWhenPresented() {
@@ -467,13 +467,13 @@ final class SessionIndexViewTests: XCTestCase {
             loadSnapshot: harness.loadSnapshot,
             onResume: nil
         )
-        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 0)
+        XCTAssertEqual(coordinator.refreshContentCallCount, 0)
 
         coordinator.present()
         pumpRunLoop()
 
-        XCTAssertTrue(coordinator.debugIsPopoverShown)
-        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 1)
+        XCTAssertTrue(coordinator.isPopoverShown)
+        XCTAssertEqual(coordinator.refreshContentCallCount, 1)
 
         coordinator.update(
             section: harness.section,
@@ -482,7 +482,7 @@ final class SessionIndexViewTests: XCTestCase {
             onResume: nil
         )
 
-        XCTAssertEqual(coordinator.debugRefreshContentCallCount, 1)
+        XCTAssertEqual(coordinator.refreshContentCallCount, 1)
     }
 
     private func makeHarness(isPresented: Bool = false) -> SessionPopoverHarness {


### PR DESCRIPTION
## Summary
- Defer SwiftUI root-view refreshes for visible AppKit popovers outside the current representable update turn.
- Coalesce visible popover refreshes and cancel pending work on close, dismiss, and teardown.
- Disable implicit AppKit animation around shown popover content-size mutations.
- Apply the shared path to arrowless popovers, workspace todo popovers, and session index popovers.

## Crash Mapping
Incident: 998545D9-3710-4073-96C4-1001A4A05EA1

The crash is a null instruction pointer on the main thread while AppKit is resizing a visible NSPopover from a SwiftUI representable update. The stack runs through UC::DriverCore::continueProcessing, NSMoveHelper._doAnimation, NSResizeMoveHelper.animateResizeToFrame, NSWindow.setFrame(display:animate:), NSPopover._setContentView:size:canAnimate:, then cmux offsets 19015708 (0x122345c), 19013552 (0x1222bf0), and 19012116 (0x1222654) before SwiftUI PlatformViewRepresentableAdaptor.updateViewProvider.

The shipped NIGHTLY binary UUID is BBD40068-649E-314A-8CD5-E3A2B34DF227. A matching dSYM was not present locally and sentry-cli auth was unavailable, so exact function names could not be recovered from the shipped binary. The surrounding frames and source call sites map the cmux frames to the popover representable update path that synchronously changed hostingController.rootView, forced layout, and changed NSPopover.contentSize while shown.

## Verification
- swift test --package-path Packages/macOS/CmuxAppKitSupportUI --filter "ArrowlessPopoverRootViewUpdatePolicyTests|CmuxPopoverVisibleUpdateSchedulerTests"
- git diff --check
- python3 scripts/check-workspace-package-groups.py --check
- ./scripts/reload-cloud.sh --tag npop failed before build because scripts/lib/maclease-heartbeat.sh is missing in hq.
- ./scripts/reload.sh --tag npop succeeded.
- Tagged preflight used /tmp/cmux-debug-npop.sock, placed the window on LG HDR 4K, opened the checklist popover, mutated visible todo data, switched workspaces to close the popover, toggled app inactive/active, opened the todo pane, opened the sessions sidebar, and repeated the open/update/switch-close path 10 total times without a crash.

Evidence folder is local-only: out/perf-incident-20260714-nightly-popover-crash/.

Tagged build: http://127.0.0.1:17320/npop

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8115"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786672723&installation_id=133855650&pr_number=8115&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8115&signature=0f4baf876c4eb50303456206e3368f162c8ba09b0256cf8db461cd36251905da"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash when resizing visible popovers by deferring root-view refreshes and content-size writes outside SwiftUI representable updates. Disables implicit AppKit animations during these mutations to avoid unsafe window frame changes.

- **Bug Fixes**
  - Introduced `CmuxPopoverVisibleUpdateScheduler` to defer and coalesce visible popover updates; runs after the current main-actor turn and cancels on present/close/dismiss/teardown.
  - Added `CmuxPopoverMutation` to refresh root views without implicit animation and to safely set `NSPopover.contentSize` while shown.
  - Replaced the boolean with `ArrowlessPopoverRootViewUpdatePolicy.Strategy` (`.immediate` on first present, `.deferredVisible` when shown, `.none` otherwise).
  - Adopted the deferred-visible path and mutation helpers for arrowless anchors in `CmuxAppKitSupportUI`, and for Workspace Todo, Session Index Section (`SectionPopoverHost`), and Session Transcript popovers.
  - Added regression tests for strategy selection and for visible update scheduling/coalescing/cancellation.

- **Dependencies**
  - Fixed `CmuxTerminalCore` test linkage by linking the C++ runtime and adding weak Ghostty stubs in `GhosttyRuntimeTestStubs` so SwiftPM and xcodebuild tests both resolve symbols.

<sup>Written for commit aeb55e1dde6523b88ae54741d728652484b38dd0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8115?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved popover refresh behavior so visible SwiftUI content stays up to date without staleness.
  * Deferred “visible” updates are now coalesced into a single latest refresh and canceled on dismiss or close.
  * Popover content sizing is updated more predictably to reduce unintended animation effects.
* **New Features**
  * Added explicit root-view update strategies for popovers (`.none`, `.immediate`, `.deferredVisible`).
  * Introduced a dedicated `SectionPopoverHost` to manage popover presentation and SwiftUI content updates.
* **Tests**
  * Updated strategy tests to validate the new modes.
  * Added scheduler tests covering coalescing and cancellation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->