### PR TITLE
Fix Iroh relay determinism guard

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift
@@ -231,10 +231,11 @@ struct CmxIrohRelayCredentialCoordinatorTests {
             endpointIdentity: fixture.identity
         )
 
-        #expect(
-            await clockEvents.next()
-                == .sleep(fixture.now.addingTimeInterval(600))
-        )
+        guard case let .sleep(deadline) = await clockEvents.next() else {
+            Issue.record("Expected the relay rate-limit retry sleep")
+            return
+        }
+        #expect(deadline == fixture.now.addingTimeInterval(600))
         #expect(await endpoint.observedRelayUpdates().isEmpty)
         await coordinator.deactivate()
     }


### PR DESCRIPTION
## Summary
- Rewrite the Iroh relay rate-limit retry assertion to match the clock event before asserting its deadline.
- Preserves the behavior check while avoiding the workflow guard sleep-then-assert pattern.

## Evidence
- Failing PR check: https://github.com/manaflow-ai/cmux/actions/runs/29382847820/job/87249984005, step `Validate test determinism gate`, flagged `Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohRelayCredentialCoordinatorTests.swift:236`.
- Cascading preflight failure: https://github.com/manaflow-ai/cmux/actions/runs/29382847820/job/87250305088.
- Cascading tests aggregate failure: https://github.com/manaflow-ai/cmux/actions/runs/29382847820/job/87250327741.
- Cascading CI status failure: https://github.com/manaflow-ai/cmux/actions/runs/29382847820/job/87250349876.
- Main trigger commit: https://github.com/manaflow-ai/cmux/commit/3822f1dd475f0c5ddcf961df9f17308c3066ffa1.

## Testing
- `python3 scripts/check-test-determinism.py --strict`
- `swift test --package-path Packages/Shared/CmuxIrohTransport --filter CmxIrohRelayCredentialCoordinatorTests/rateLimitRetryNeverPrecedesValidatedServerFloor`

## Issues
- Related: https://github.com/manaflow-ai/cmux/actions/runs/29381275800

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8119"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786674461&installation_id=133855650&pr_number=8119&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8119&signature=30c0c87ad4537176ccbde4fbf2ba291f687cc1a0a5f9bbe63582e955f0f349c3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the Iroh relay rate-limit retry test deterministic by first matching the clock event and then asserting its deadline, replacing the sleep-then-assert pattern. This removes a flake in the determinism gate and stabilizes CI.

<sup>Written for commit 6548de9815e4a02ada19eb745dee9b91ade35653. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8119?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved validation of scheduled retry timing in transport tests.
  * Tests now report a clear issue when the next clock event is not a sleep event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->