### PR TITLE
iOS: gallery dogfood feedback — inline folders, jump animation, Done placement, hide missing files

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPresentation.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryPresentation.swift
@@ -5,31 +5,54 @@ public struct ChatArtifactGalleryPresentation: Sendable, Equatable {
     /// Created, Attached, and Referenced groups in their fixed display order.
     public let groups: [ChatArtifactGalleryGroup]
 
+    /// Whether every projected group has no visible rows.
+    public var isEmpty: Bool { groups.allSatisfy(\.items.isEmpty) }
+
     /// Creates a grouped presentation without changing the source snapshot.
     ///
     /// - Parameters:
     ///   - snapshot: Accumulated gallery rows to project.
     ///   - filter: Sheet-wide kind filter.
     ///   - sort: Ordering applied independently within each group.
+    ///   - includesMissingFiles: Whether rows absent from the Mac remain visible.
     ///   - classifier: Classifier used for extension-based buckets.
     public init(
         snapshot: ChatArtifactGallerySnapshot,
         filter: ChatArtifactGalleryFilter = .all,
         sort: ChatArtifactGallerySort = .recent,
+        includesMissingFiles: Bool = false,
         classifier: ChatArtifactGalleryClassifier = ChatArtifactGalleryClassifier()
     ) {
         groups = [
             ChatArtifactGalleryGroup(
                 kind: .created,
-                items: Self.project(snapshot.created, filter: filter, sort: sort, classifier: classifier)
+                items: Self.project(
+                    snapshot.created,
+                    filter: filter,
+                    sort: sort,
+                    includesMissingFiles: includesMissingFiles,
+                    classifier: classifier
+                )
             ),
             ChatArtifactGalleryGroup(
                 kind: .attached,
-                items: Self.project(snapshot.attached, filter: filter, sort: sort, classifier: classifier)
+                items: Self.project(
+                    snapshot.attached,
+                    filter: filter,
+                    sort: sort,
+                    includesMissingFiles: includesMissingFiles,
+                    classifier: classifier
+                )
             ),
             ChatArtifactGalleryGroup(
                 kind: .referenced,
-                items: Self.project(snapshot.referenced, filter: filter, sort: sort, classifier: classifier)
+                items: Self.project(
+                    snapshot.referenced,
+                    filter: filter,
+                    sort: sort,
+                    includesMissingFiles: includesMissingFiles,
+                    classifier: classifier
+                )
             ),
         ]
     }
@@ -46,11 +69,13 @@ public struct ChatArtifactGalleryPresentation: Sendable, Equatable {
         _ items: [ChatArtifactGalleryItem],
         filter: ChatArtifactGalleryFilter,
         sort: ChatArtifactGallerySort,
+        includesMissingFiles: Bool,
         classifier: ChatArtifactGalleryClassifier
     ) -> [ChatArtifactGalleryItem] {
+        let visible = includesMissingFiles ? items : items.filter(\.exists)
         let filtered = filter == .all
-            ? items
-            : items.filter { classifier.filter(for: $0) == filter }
+            ? visible
+            : visible.filter { classifier.filter(for: $0) == filter }
         switch sort {
         case .recent:
             return filtered

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPresentationTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPresentationTests.swift
@@ -49,6 +49,29 @@ struct ChatArtifactGalleryPresentationTests {
         #expect(sized.items(in: .referenced).map(\.displayName) == ["a.txt", "b.txt"])
     }
 
+    @Test("missing files are omitted from every group by default")
+    func omitsMissingFilesByDefault() {
+        let snapshot = gallerySnapshot(
+            created: [
+                item("/created/present.txt", kind: .text, size: 1),
+                item("/created/missing.txt", kind: .text, size: nil, exists: false),
+            ],
+            attached: [
+                item("/attached/missing.png", kind: .image, size: nil, exists: false),
+            ],
+            referenced: [
+                item("/referenced/present.log", kind: .text, size: 2),
+                item("/referenced/missing.log", kind: .text, size: nil, exists: false),
+            ]
+        )
+
+        let presentation = ChatArtifactGalleryPresentation(snapshot: snapshot)
+
+        #expect(presentation.items(in: .created).map(\.displayName) == ["present.txt"])
+        #expect(presentation.items(in: .attached).isEmpty)
+        #expect(presentation.items(in: .referenced).map(\.displayName) == ["present.log"])
+    }
+
     private func gallerySnapshot(
         created: [ChatArtifactGalleryItem] = [],
         attached: [ChatArtifactGalleryItem] = [],
@@ -67,13 +90,15 @@ struct ChatArtifactGalleryPresentationTests {
     private func item(
         _ path: String,
         kind: ChatArtifactKind,
-        size: Int64?
+        size: Int64?,
+        exists: Bool = true
     ) -> ChatArtifactGalleryItem {
         ChatArtifactGalleryItem(
             path: path,
             kind: kind,
             displayName: URL(fileURLWithPath: path).lastPathComponent,
-            size: size
+            size: size,
+            exists: exists
         )
     }
 }

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPresentationTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryPresentationTests.swift
@@ -70,6 +70,34 @@ struct ChatArtifactGalleryPresentationTests {
         #expect(presentation.items(in: .created).map(\.displayName) == ["present.txt"])
         #expect(presentation.items(in: .attached).isEmpty)
         #expect(presentation.items(in: .referenced).map(\.displayName) == ["present.log"])
+        #expect(ChatArtifactGallerySwipeOrder(groups: presentation.groups).paths == [
+            "/created/present.txt",
+            "/referenced/present.log",
+        ])
+    }
+
+    @Test("missing files can be restored across every group")
+    func includesMissingFilesOnRequest() {
+        let missingCreated = item("/created/missing.txt", kind: .text, size: nil, exists: false)
+        let missingAttached = item("/attached/missing.png", kind: .image, size: nil, exists: false)
+        let missingReferenced = item("/referenced/missing.log", kind: .text, size: nil, exists: false)
+        let presentation = ChatArtifactGalleryPresentation(
+            snapshot: gallerySnapshot(
+                created: [missingCreated],
+                attached: [missingAttached],
+                referenced: [missingReferenced]
+            ),
+            includesMissingFiles: true
+        )
+
+        #expect(presentation.items(in: .created) == [missingCreated])
+        #expect(presentation.items(in: .attached) == [missingAttached])
+        #expect(presentation.items(in: .referenced) == [missingReferenced])
+        #expect(ChatArtifactGallerySwipeOrder(groups: presentation.groups).paths == [
+            missingCreated.path,
+            missingAttached.path,
+            missingReferenced.path,
+        ])
     }
 
     private func gallerySnapshot(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderView.swift
@@ -10,7 +10,6 @@ import AppKit
 struct ChatArtifactFolderView: View {
     let path: String
     let scope: ChatArtifactViewerScope
-    let onImageMinimumZoomChanged: (Bool) -> Void
     let onDone: () -> Void
 
     @Environment(\.chatArtifactLoader) private var loader
@@ -43,10 +42,9 @@ struct ChatArtifactFolderView: View {
                         Section {
                             ForEach(listing.entries) { entry in
                                 NavigationLink {
-                                    ChatArtifactViewerRouteView(
+                                    ChatArtifactViewerDestination(
                                         path: childPath(named: entry.name),
                                         scope: scope,
-                                        onImageMinimumZoomChanged: onImageMinimumZoomChanged,
                                         onDone: onDone
                                     )
                                 } label: {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -105,11 +105,11 @@ struct ChatArtifactTextView: UIViewRepresentable {
         containerView.updateLineNumbers(index: lineIndex, isVisible: showsLineNumbers)
 
         if isNewDocument {
-            Self.scrollToTop(textView)
+            Self.scrollToTop(textView, animated: false)
         } else {
             if context.coordinator.handledTopRequestID != topRequestID {
                 context.coordinator.handledTopRequestID = topRequestID
-                Self.scrollToTop(textView)
+                Self.scrollToTop(textView, animated: true)
             }
             if context.coordinator.handledBottomRequestID != bottomRequestID {
                 context.coordinator.handledBottomRequestID = bottomRequestID
@@ -127,13 +127,13 @@ struct ChatArtifactTextView: UIViewRepresentable {
         }
     }
 
-    private static func scrollToTop(_ textView: UITextView) {
+    private static func scrollToTop(_ textView: UITextView, animated: Bool) {
         textView.setContentOffset(
             CGPoint(
                 x: -textView.adjustedContentInset.left,
                 y: -textView.adjustedContentInset.top
             ),
-            animated: false
+            animated: animated
         )
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerDestination.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerDestination.swift
@@ -1,0 +1,38 @@
+import CmuxAgentChat
+import SwiftUI
+
+/// The shared inline navigation destination for a Mac-hosted artifact path.
+public struct ChatArtifactViewerDestination: View {
+    private let path: String
+    private let scope: ChatArtifactViewerScope
+    private let swipeOrder: ChatArtifactGallerySwipeOrder
+    private let onDone: () -> Void
+
+    /// Creates an inline artifact viewer for an existing navigation stack.
+    ///
+    /// - Parameters:
+    ///   - path: Initially selected artifact path.
+    ///   - scope: Authorization and navigation context for the artifact.
+    ///   - swipeOrder: Visible gallery-file order available for horizontal paging.
+    ///   - onDone: Dismisses or pops the navigation container that owns the destination.
+    public init(
+        path: String,
+        scope: ChatArtifactViewerScope = .chat,
+        swipeOrder: ChatArtifactGallerySwipeOrder = ChatArtifactGallerySwipeOrder(items: []),
+        onDone: @escaping () -> Void
+    ) {
+        self.path = path
+        self.scope = scope
+        self.swipeOrder = swipeOrder
+        self.onDone = onDone
+    }
+
+    public var body: some View {
+        ChatArtifactViewerPager(
+            initialPath: path,
+            scope: scope,
+            swipeOrder: swipeOrder,
+            onDone: onDone
+        )
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
@@ -46,21 +46,19 @@ struct ChatArtifactViewerPager: View {
     }
 
     private func viewer(path: String) -> some View {
-        NavigationStack {
-            ChatArtifactViewerRouteView(
-                path: path,
-                scope: scope,
-                onImageMinimumZoomChanged: { isAtMinimum in
-                    if isAtMinimum {
-                        if zoomedPath == path {
-                            zoomedPath = nil
-                        }
-                    } else {
-                        zoomedPath = path
+        ChatArtifactViewerRouteView(
+            path: path,
+            scope: scope,
+            onImageMinimumZoomChanged: { isAtMinimum in
+                if isAtMinimum {
+                    if zoomedPath == path {
+                        zoomedPath = nil
                     }
-                },
-                onDone: onDone
-            )
-        }
+                } else {
+                    zoomedPath = path
+                }
+            },
+            onDone: onDone
+        )
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -70,141 +70,16 @@ struct ChatArtifactViewerRouteView: View {
             .navigationBarTitleDisplayMode(.inline)
             #endif
             .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button(String(localized: "chat.artifact.done", defaultValue: "Done", bundle: .module)) {
-                        onDone()
-                    }
-                }
                 #if os(iOS)
-                if model.hasFileActions {
-                    ToolbarItem(placement: .primaryAction) {
-                        fileActionsMenu
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    if hasViewerActions {
+                        viewerActionsMenu
                     }
+                    doneButton
                 }
-                if shouldShowTextJumpControls {
-                    ToolbarItemGroup(placement: .primaryAction) {
-                        Button {
-                            withAnimation(.snappy) {
-                                if isSearchPresented {
-                                    dismissSearch()
-                                } else {
-                                    dismissGoToLine()
-                                    isSearchPresented = true
-                                }
-                            }
-                        } label: {
-                            Label(
-                                String(
-                                    localized: "chat.artifact.search.title",
-                                    defaultValue: "Search",
-                                    bundle: .module
-                                ),
-                                systemImage: "magnifyingglass"
-                            )
-                        }
-                        Menu {
-                            Button {
-                                withAnimation(.snappy) {
-                                    if isGoToLinePresented {
-                                        dismissGoToLine()
-                                    } else {
-                                        dismissSearch()
-                                        isGoToLinePresented = true
-                                    }
-                                }
-                            } label: {
-                                Label(
-                                    String(
-                                        localized: "chat.artifact.line.goto",
-                                        defaultValue: "Go to line",
-                                        bundle: .module
-                                    ),
-                                    systemImage: "text.line.first.and.arrowtriangle.forward"
-                                )
-                            }
-                            Button {
-                                showsLineNumbers.toggle()
-                            } label: {
-                                Label(
-                                    String(
-                                        localized: "chat.artifact.line.numbers",
-                                        defaultValue: "Line numbers",
-                                        bundle: .module
-                                    ),
-                                    systemImage: showsLineNumbers ? "checkmark" : "number"
-                                )
-                            }
-                            Button {
-                                wrapsLines.toggle()
-                                textPreferences.setWrapsLines(
-                                    wrapsLines,
-                                    for: textLayoutKind
-                                )
-                            } label: {
-                                Label(
-                                    String(
-                                        localized: "chat.artifact.wrap",
-                                        defaultValue: "Word wrap",
-                                        bundle: .module
-                                    ),
-                                    systemImage: wrapsLines ? "checkmark" : "text.justify.left"
-                                )
-                            }
-                        } label: {
-                            Label(
-                                String(
-                                    localized: "chat.artifact.text_options",
-                                    defaultValue: "Text options",
-                                    bundle: .module
-                                ),
-                                systemImage: "textformat"
-                            )
-                        }
-                        Button {
-                            topRequestID += 1
-                        } label: {
-                            Label(
-                                String(
-                                    localized: "chat.artifact.jump.top",
-                                    defaultValue: "Top",
-                                    bundle: .module
-                                ),
-                                systemImage: "arrow.up.to.line"
-                            )
-                        }
-                        Button {
-                            bottomRequestID += 1
-                        } label: {
-                            Label(jumpToBottomTitle, systemImage: "arrow.down.to.line")
-                        }
-                    }
-                }
-                if model.state == .markdown,
-                   model.markdownPresentation.isRenderedAvailable {
-                    ToolbarItem(placement: .primaryAction) {
-                        Picker(
-                            String(
-                                localized: "chat.artifact.markdown.view",
-                                defaultValue: "Markdown view",
-                                bundle: .module
-                            ),
-                            selection: markdownModeBinding
-                        ) {
-                            Text(String(
-                                localized: "chat.artifact.markdown.raw",
-                                defaultValue: "Raw",
-                                bundle: .module
-                            ))
-                            .tag(ChatArtifactMarkdownMode.raw)
-                            Text(String(
-                                localized: "chat.artifact.markdown.rendered",
-                                defaultValue: "Rendered",
-                                bundle: .module
-                            ))
-                            .tag(ChatArtifactMarkdownMode.rendered)
-                        }
-                        .pickerStyle(.segmented)
-                    }
+                #else
+                ToolbarItem(placement: .cancellationAction) {
+                    doneButton
                 }
                 #endif
             }
@@ -242,51 +117,194 @@ struct ChatArtifactViewerRouteView: View {
             }
     }
 
+    private var doneButton: some View {
+        Button(String(localized: "chat.artifact.done", defaultValue: "Done", bundle: .module)) {
+            onDone()
+        }
+    }
+
     #if os(iOS)
-    private var fileActionsMenu: some View {
+    private var hasViewerActions: Bool {
+        model.hasFileActions
+            || shouldShowTextJumpControls
+            || (model.state == .markdown && model.markdownPresentation.isRenderedAvailable)
+    }
+
+    private var viewerActionsMenu: some View {
         Menu {
-            Button {
-                prepareFileAction(.share)
-            } label: {
-                Label(
-                    String(localized: "chat.artifact.share", defaultValue: "Share", bundle: .module),
-                    systemImage: "square.and.arrow.up"
-                )
-            }
-            Button {
-                prepareFileAction(.save)
-            } label: {
-                Label(
-                    String(localized: "chat.artifact.save_to_files", defaultValue: "Save to Files", bundle: .module),
-                    systemImage: "folder.badge.plus"
-                )
-            }
-            if model.isTextFile {
-                Button {
-                    UIPasteboard.general.string = model.renderedText
-                } label: {
-                    Label(
-                        String(localized: "chat.artifact.copy_contents", defaultValue: "Copy contents", bundle: .module),
-                        systemImage: "doc.on.doc"
-                    )
+            if model.hasFileActions {
+                Section {
+                    fileActionButtons
                 }
-                .disabled(!model.canCopyContents)
             }
-            Button {
-                UIPasteboard.general.string = path
-            } label: {
-                Label(
-                    String(localized: "chat.artifact.copy_path", defaultValue: "Copy path", bundle: .module),
-                    systemImage: "link"
-                )
+            if shouldShowTextJumpControls {
+                Section {
+                    textViewerActionButtons
+                }
+            }
+            if model.state == .markdown,
+               model.markdownPresentation.isRenderedAvailable {
+                Section {
+                    Picker(
+                        String(
+                            localized: "chat.artifact.markdown.view",
+                            defaultValue: "Markdown view",
+                            bundle: .module
+                        ),
+                        selection: markdownModeBinding
+                    ) {
+                        Text(String(
+                            localized: "chat.artifact.markdown.raw",
+                            defaultValue: "Raw",
+                            bundle: .module
+                        ))
+                        .tag(ChatArtifactMarkdownMode.raw)
+                        Text(String(
+                            localized: "chat.artifact.markdown.rendered",
+                            defaultValue: "Rendered",
+                            bundle: .module
+                        ))
+                        .tag(ChatArtifactMarkdownMode.rendered)
+                    }
+                }
             }
         } label: {
             Label(
-                String(localized: "chat.artifact.file_actions", defaultValue: "File actions", bundle: .module),
+                String(
+                    localized: "chat.artifact.viewer.actions",
+                    defaultValue: "Viewer actions",
+                    bundle: .module
+                ),
                 systemImage: "ellipsis.circle"
             )
         }
         .disabled(isFileActionRunning)
+    }
+
+    @ViewBuilder
+    private var fileActionButtons: some View {
+        Button {
+            prepareFileAction(.share)
+        } label: {
+            Label(
+                String(localized: "chat.artifact.share", defaultValue: "Share", bundle: .module),
+                systemImage: "square.and.arrow.up"
+            )
+        }
+        Button {
+            prepareFileAction(.save)
+        } label: {
+            Label(
+                String(localized: "chat.artifact.save_to_files", defaultValue: "Save to Files", bundle: .module),
+                systemImage: "folder.badge.plus"
+            )
+        }
+        if model.isTextFile {
+            Button {
+                UIPasteboard.general.string = model.renderedText
+            } label: {
+                Label(
+                    String(localized: "chat.artifact.copy_contents", defaultValue: "Copy contents", bundle: .module),
+                    systemImage: "doc.on.doc"
+                )
+            }
+            .disabled(!model.canCopyContents)
+        }
+        Button {
+            UIPasteboard.general.string = path
+        } label: {
+            Label(
+                String(localized: "chat.artifact.copy_path", defaultValue: "Copy path", bundle: .module),
+                systemImage: "link"
+            )
+        }
+    }
+
+    @ViewBuilder
+    private var textViewerActionButtons: some View {
+        Button {
+            withAnimation(.snappy) {
+                if isSearchPresented {
+                    dismissSearch()
+                } else {
+                    dismissGoToLine()
+                    isSearchPresented = true
+                }
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.search.title",
+                    defaultValue: "Search",
+                    bundle: .module
+                ),
+                systemImage: "magnifyingglass"
+            )
+        }
+        Button {
+            withAnimation(.snappy) {
+                if isGoToLinePresented {
+                    dismissGoToLine()
+                } else {
+                    dismissSearch()
+                    isGoToLinePresented = true
+                }
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.line.goto",
+                    defaultValue: "Go to line",
+                    bundle: .module
+                ),
+                systemImage: "text.line.first.and.arrowtriangle.forward"
+            )
+        }
+        Button {
+            topRequestID += 1
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.jump.top",
+                    defaultValue: "Top",
+                    bundle: .module
+                ),
+                systemImage: "arrow.up.to.line"
+            )
+        }
+        Button {
+            bottomRequestID += 1
+        } label: {
+            Label(jumpToBottomTitle, systemImage: "arrow.down.to.line")
+        }
+        Button {
+            showsLineNumbers.toggle()
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.line.numbers",
+                    defaultValue: "Line numbers",
+                    bundle: .module
+                ),
+                systemImage: showsLineNumbers ? "checkmark" : "number"
+            )
+        }
+        Button {
+            wrapsLines.toggle()
+            textPreferences.setWrapsLines(
+                wrapsLines,
+                for: textLayoutKind
+            )
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.wrap",
+                    defaultValue: "Word wrap",
+                    bundle: .module
+                ),
+                systemImage: wrapsLines ? "checkmark" : "text.justify.left"
+            )
+        }
     }
 
     private enum PreparedFileAction {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -358,7 +358,6 @@ struct ChatArtifactViewerRouteView: View {
             ChatArtifactFolderView(
                 path: path,
                 scope: scope,
-                onImageMinimumZoomChanged: onImageMinimumZoomChanged,
                 onDone: onDone
             )
         case .image(let data):

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerSheet.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerSheet.swift
@@ -25,12 +25,14 @@ public struct ChatArtifactViewerSheet: View {
     }
 
     public var body: some View {
-        ChatArtifactViewerPager(
-            initialPath: path,
-            scope: scope,
-            swipeOrder: swipeOrder
-        ) {
-            dismiss()
+        NavigationStack {
+            ChatArtifactViewerDestination(
+                path: path,
+                scope: scope,
+                swipeOrder: swipeOrder
+            ) {
+                dismiss()
+            }
         }
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -2437,6 +2437,23 @@
         }
       }
     },
+    "chat.artifact.viewer.actions" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Viewer actions"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "ビューア操作"
+          }
+        }
+      }
+    },
     "chat.artifact.wrap" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScreen.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Screen/ChatScreen.swift
@@ -17,6 +17,7 @@ public struct ChatScreen: View {
     @State private var renderer = ChatMarkdownRenderer()
     @State private var contentCache = ChatContentCache()
     @State private var selectedBlockSelection: ChatBlockSelection?
+    @State private var selectedArtifact: ChatArtifactPathSelection?
 
     private let detailBuilder = ChatBlockDetailBuilder()
     @Binding private var draft: String
@@ -91,6 +92,13 @@ public struct ChatScreen: View {
                 )
             }
         }
+        .navigationDestination(isPresented: artifactIsPresented) {
+            if let selectedArtifact {
+                ChatArtifactViewerDestination(path: selectedArtifact.path) {
+                    self.selectedArtifact = nil
+                }
+            }
+        }
         .task {
             guard runsStoreTask else { return }
             await store.run()
@@ -99,6 +107,15 @@ public struct ChatScreen: View {
         .onChange(of: store.rows.last?.id) { announceLatestAgentProse() }
         .onChange(of: store.lastErrorDescription) { announceLastError() }
         #endif
+    }
+
+    private var artifactIsPresented: Binding<Bool> {
+        Binding(
+            get: { selectedArtifact != nil },
+            set: { isPresented in
+                if !isPresented { selectedArtifact = nil }
+            }
+        )
     }
 
     @ViewBuilder
@@ -296,6 +313,9 @@ public struct ChatScreen: View {
                 store.discard(pendingID: id)
             },
             openTerminal: onOpenTerminal,
+            openArtifact: { path in
+                selectedArtifact = ChatArtifactPathSelection(path: path)
+            },
             showMessageDetail: { message in
                 selectedBlockSelection = .message(id: message.id)
             },

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatBlockDetailSheetView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatBlockDetailSheetView.swift
@@ -13,6 +13,7 @@ struct ChatBlockDetailSheetView: View {
 
     @Environment(\.dismiss) private var dismiss
     @Environment(\.chatArtifactLoader) private var artifactLoader
+    @State private var selectedArtifact: ChatArtifactPathSelection?
 
     init(detail: ChatBlockDetail, onOpenTerminal: (() -> Void)? = nil) {
         self.detail = detail
@@ -33,7 +34,12 @@ struct ChatBlockDetailSheetView: View {
                         ChatBlockDetailSectionView(section: section)
                     }
                     if artifactLoader.supportsArtifacts, !detail.artifactPaths.isEmpty {
-                        ChatBlockDetailArtifactActions(paths: detail.artifactPaths)
+                        ChatBlockDetailArtifactActions(
+                            paths: detail.artifactPaths,
+                            onOpenArtifact: { path in
+                                selectedArtifact = ChatArtifactPathSelection(path: path)
+                            }
+                        )
                     }
                 }
                 .padding(16)
@@ -62,8 +68,24 @@ struct ChatBlockDetailSheetView: View {
                 }
                 #endif
             }
+            .navigationDestination(isPresented: artifactIsPresented) {
+                if let selectedArtifact {
+                    ChatArtifactViewerDestination(path: selectedArtifact.path) {
+                        dismiss()
+                    }
+                }
+            }
         }
         .accessibilityIdentifier("ChatBlockDetailSheet")
+    }
+
+    private var artifactIsPresented: Binding<Bool> {
+        Binding(
+            get: { selectedArtifact != nil },
+            set: { isPresented in
+                if !isPresented { selectedArtifact = nil }
+            }
+        )
     }
 
     @ViewBuilder
@@ -106,6 +128,7 @@ struct ChatBlockDetailSheetView: View {
 
 private struct ChatBlockDetailArtifactActions: View {
     let paths: [String]
+    let onOpenArtifact: (String) -> Void
 
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
@@ -113,7 +136,10 @@ private struct ChatBlockDetailArtifactActions: View {
                 .font(.caption.weight(.semibold))
                 .foregroundStyle(.secondary)
             ForEach(deduplicatedPaths, id: \.self) { path in
-                ChatBlockDetailArtifactActionRow(path: path)
+                ChatBlockDetailArtifactActionRow(
+                    path: path,
+                    onOpenArtifact: onOpenArtifact
+                )
             }
         }
     }
@@ -130,8 +156,7 @@ private struct ChatBlockDetailArtifactActions: View {
 
 private struct ChatBlockDetailArtifactActionRow: View {
     let path: String
-
-    @State private var selectedArtifact: ChatArtifactPathSelection?
+    let onOpenArtifact: (String) -> Void
 
     var body: some View {
         HStack(spacing: 8) {
@@ -148,7 +173,7 @@ private struct ChatBlockDetailArtifactActionRow: View {
             }
             Spacer(minLength: 8)
             Button {
-                selectedArtifact = ChatArtifactPathSelection(path: path)
+                onOpenArtifact(path)
             } label: {
                 Label(
                     String(localized: "chat.artifact.open_item", defaultValue: "Open item", bundle: .module),
@@ -159,8 +184,5 @@ private struct ChatBlockDetailArtifactActionRow: View {
         }
         .padding(10)
         .background(.quaternary.opacity(0.5), in: .rect(cornerRadius: 8))
-        .sheet(item: $selectedArtifact) { selection in
-            ChatArtifactViewerSheet(path: selection.path)
-        }
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatMessageRowView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatMessageRowView.swift
@@ -69,7 +69,8 @@ public struct ChatMessageRowView: View {
                     attachment: attachment,
                     groupPosition: snapshot.groupPosition,
                     showsTimestamp: snapshot.showsTimestamp,
-                    timestamp: snapshot.message.timestamp
+                    timestamp: snapshot.message.timestamp,
+                    onOpenArtifact: actions.openArtifact
                 )
             case .unsupported(let payload):
                 ChatUnsupportedRowView(payload: payload)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatRowActions.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/ChatRowActions.swift
@@ -19,6 +19,9 @@ public struct ChatRowActions {
     /// Opens the session's raw terminal (the escape hatch).
     public var openTerminal: () -> Void
 
+    /// Pushes a Mac-hosted artifact in the conversation's navigation stack.
+    public var openArtifact: (String) -> Void
+
     /// Shows a non-resizing detail sheet for a compact message row.
     public var showMessageDetail: (ChatMessage) -> Void
 
@@ -35,6 +38,7 @@ public struct ChatRowActions {
     ///   - retryPending: Retries a failed pending send by pending id.
     ///   - discardPending: Discards a failed pending send by pending id.
     ///   - openTerminal: Opens the session's raw terminal.
+    ///   - openArtifact: Pushes a Mac-hosted artifact path inline.
     ///   - showMessageDetail: Presents full details for compact message rows.
     ///   - showTerminalCommandDetail: Presents full details for terminal rows.
     ///   - showCodeBlockDetail: Presents full details for prose code blocks.
@@ -43,6 +47,7 @@ public struct ChatRowActions {
         retryPending: @escaping (String) -> Void = { _ in },
         discardPending: @escaping (String) -> Void = { _ in },
         openTerminal: @escaping () -> Void = {},
+        openArtifact: @escaping (String) -> Void = { _ in },
         showMessageDetail: @escaping (ChatMessage) -> Void = { _ in },
         showTerminalCommandDetail: @escaping (TerminalCommandBlock) -> Void = { _ in },
         showCodeBlockDetail: @escaping (String, Int) -> Void = { _, _ in }
@@ -51,6 +56,7 @@ public struct ChatRowActions {
         self.retryPending = retryPending
         self.discardPending = discardPending
         self.openTerminal = openTerminal
+        self.openArtifact = openArtifact
         self.showMessageDetail = showMessageDetail
         self.showTerminalCommandDetail = showTerminalCommandDetail
         self.showCodeBlockDetail = showCodeBlockDetail

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/Rows/ChatAttachmentBubbleView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Transcript/Rows/ChatAttachmentBubbleView.swift
@@ -14,6 +14,7 @@ public struct ChatAttachmentBubbleView: View {
     private let groupPosition: ChatGroupPosition
     private let showsTimestamp: Bool
     private let timestamp: Date
+    private let onOpenArtifact: ((String) -> Void)?
 
     @Environment(\.chatTheme) private var theme
     @Environment(\.chatBubbleMaxWidth) private var bubbleMaxWidth
@@ -22,7 +23,7 @@ public struct ChatAttachmentBubbleView: View {
     @State private var thumbnailData: Data?
     @State private var thumbnailFailed = false
     @State private var thumbnailPath: String?
-    @State private var selectedArtifact: ChatArtifactPathSelection?
+    @State private var fallbackSelection: ChatArtifactPathSelection?
 
     /// Creates an attachment bubble.
     ///
@@ -32,16 +33,20 @@ public struct ChatAttachmentBubbleView: View {
     ///   - showsTimestamp: Whether the group timestamp renders under this
     ///     bubble.
     ///   - timestamp: When the attachment was sent.
+    ///   - onOpenArtifact: Pushes the host path inline when the caller owns a
+    ///     navigation stack. When omitted, the standalone bubble uses a sheet.
     public init(
         attachment: ChatAttachment,
         groupPosition: ChatGroupPosition,
         showsTimestamp: Bool,
-        timestamp: Date
+        timestamp: Date,
+        onOpenArtifact: ((String) -> Void)? = nil
     ) {
         self.attachment = attachment
         self.groupPosition = groupPosition
         self.showsTimestamp = showsTimestamp
         self.timestamp = timestamp
+        self.onOpenArtifact = onOpenArtifact
     }
 
     public var body: some View {
@@ -60,7 +65,7 @@ public struct ChatAttachmentBubbleView: View {
             .accessibilityElement(children: .combine)
         }
         .frame(maxWidth: .infinity, alignment: .trailing)
-        .sheet(item: $selectedArtifact) { selection in
+        .sheet(item: $fallbackSelection) { selection in
             ChatArtifactViewerSheet(path: selection.path)
         }
     }
@@ -69,7 +74,11 @@ public struct ChatAttachmentBubbleView: View {
     private var artifactAwareBubble: some View {
         if artifactLoader.supportsArtifacts, let hostPath = attachment.hostPath, !hostPath.isEmpty {
             Button {
-                selectedArtifact = ChatArtifactPathSelection(path: hostPath)
+                if let onOpenArtifact {
+                    onOpenArtifact(hostPath)
+                } else {
+                    fallbackSelection = ChatArtifactPathSelection(path: hostPath)
+                }
             } label: {
                 if thumbnailFailed {
                     bubble

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileDisplaySettings.swift
@@ -22,6 +22,7 @@ public final class MobileDisplaySettings {
     private nonisolated(unsafe) let defaults: UserDefaults
     private static let wrapWorkspaceTitlesKey = "cmux.mobile.wrapWorkspaceTitles"
     private static let showAltScreenNoticeKey = "cmux.mobile.showAltScreenNotice"
+    private static let showMissingFilesKey = "cmux.mobile.showMissingFiles"
     private static let workspacePreviewLineCountKey = "cmux.mobile.workspacePreviewLineCount"
     private static let unreadIndicatorLeftShiftKey = "cmux.mobile.debug.unreadIndicatorLeftShift.v2"
     private static let profilePictureLeftShiftKey = "cmux.mobile.debug.profilePictureLeftShift"
@@ -56,6 +57,13 @@ public final class MobileDisplaySettings {
     /// this writes through to the injected ``UserDefaults``.
     public var showAltScreenNotice: Bool {
         didSet { defaults.set(showAltScreenNotice, forKey: Self.showAltScreenNoticeKey) }
+    }
+
+    /// Whether artifact galleries include paths that no longer exist on the
+    /// connected Mac. Defaults to `false`. Mutating this writes through to the
+    /// injected ``UserDefaults``.
+    public var showMissingFiles: Bool {
+        didSet { defaults.set(showMissingFiles, forKey: Self.showMissingFilesKey) }
     }
 
     /// How many lines a workspace row's activity preview shows (1 or 2).
@@ -103,11 +111,13 @@ public final class MobileDisplaySettings {
     /// - Parameter defaults: The store backing the persisted preferences.
     ///   Defaults to `.standard`; tests pass a scoped suite. Stored properties
     ///   are initialized from `defaults`; absent keys read as their default
-    ///   (single-line titles, two preview lines) without a write.
+    ///   (single-line titles, hidden missing files, two preview lines) without
+    ///   a write.
     public init(defaults: UserDefaults = .standard) {
         self.defaults = defaults
         self.wrapWorkspaceTitles = defaults.bool(forKey: Self.wrapWorkspaceTitlesKey)
         self.showAltScreenNotice = defaults.object(forKey: Self.showAltScreenNoticeKey) as? Bool ?? true
+        self.showMissingFiles = defaults.bool(forKey: Self.showMissingFilesKey)
         let storedPreviewLines = defaults.object(forKey: Self.workspacePreviewLineCountKey) as? Int
         self.workspacePreviewLineCount = Self.clampedWorkspacePreviewLineCount(
             storedPreviewLines ?? Self.defaultWorkspacePreviewLineCount

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileSettingsView.swift
@@ -204,6 +204,14 @@ struct MobileSettingsView: View {
                 #endif
 
                 Section(L10n.string("mobile.settings.display", defaultValue: "Display")) {
+                    Toggle(isOn: $displaySettings.showMissingFiles) {
+                        Text(L10n.string(
+                            "mobile.settings.showMissingFiles",
+                            defaultValue: "Show missing files"
+                        ))
+                    }
+                    .accessibilityIdentifier("MobileSettingsShowMissingFiles")
+
                     Toggle(isOn: $displaySettings.wrapWorkspaceTitles) {
                         Text(L10n.string("mobile.settings.wrapTitles", defaultValue: "Wrap Workspace Titles"))
                     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -146,7 +146,16 @@ extension TerminalArtifactFilesSheet {
         case .failed:
             failureView { await loadFirstSessionPage(query: nil) }
         case .loaded(let snapshot):
-            if snapshot.isEmpty {
+            let visibleSnapshotIsEmpty = displaySettings.showMissingFiles
+                ? snapshot.isEmpty
+                : ChatArtifactGalleryPresentation(snapshot: snapshot).isEmpty
+            let presentation = ChatArtifactGalleryPresentation(
+                snapshot: snapshot,
+                filter: galleryFilter,
+                sort: gallerySort,
+                includesMissingFiles: displaySettings.showMissingFiles
+            )
+            if visibleSnapshotIsEmpty {
                 ScrollView {
                     ContentUnavailableView(
                         String(
@@ -162,11 +171,6 @@ extension TerminalArtifactFilesSheet {
                     await loadFirstSessionPage(query: nil, preservingContent: true)
                 }
             } else {
-                let presentation = ChatArtifactGalleryPresentation(
-                    snapshot: snapshot,
-                    filter: galleryFilter,
-                    sort: gallerySort
-                )
                 let created = presentation.items(in: .created)
                 let attached = presentation.items(in: .attached)
                 let referenced = presentation.items(in: .referenced)
@@ -183,7 +187,9 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "Created by agent",
                                 bundle: .module
                             ),
-                            count: usesCompleteSessionSnapshot ? created.count : snapshot.createdTotal,
+                            count: displaySettings.showMissingFiles
+                                ? (usesCompleteSessionSnapshot ? created.count : snapshot.createdTotal)
+                                : nil,
                             items: created,
                             expanded: $createdExpanded,
                             swipeOrder: swipeOrder
@@ -194,7 +200,9 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "You attached",
                                 bundle: .module
                             ),
-                            count: usesCompleteSessionSnapshot ? attached.count : snapshot.attachedTotal,
+                            count: displaySettings.showMissingFiles
+                                ? (usesCompleteSessionSnapshot ? attached.count : snapshot.attachedTotal)
+                                : nil,
                             items: attached,
                             expanded: $attachedExpanded,
                             swipeOrder: swipeOrder
@@ -205,9 +213,11 @@ extension TerminalArtifactFilesSheet {
                                 defaultValue: "Referenced",
                                 bundle: .module
                             ),
-                            count: usesCompleteSessionSnapshot
-                                ? referenced.count
-                                : snapshot.referencedTotal,
+                            count: displaySettings.showMissingFiles
+                                ? (usesCompleteSessionSnapshot
+                                    ? referenced.count
+                                    : snapshot.referencedTotal)
+                                : nil,
                             items: referenced,
                             expanded: $referencedExpanded,
                             swipeOrder: swipeOrder,
@@ -281,7 +291,8 @@ extension TerminalArtifactFilesSheet {
             let presentation = ChatArtifactGalleryPresentation(
                 snapshot: snapshot,
                 filter: galleryFilter,
-                sort: gallerySort
+                sort: gallerySort,
+                includesMissingFiles: displaySettings.showMissingFiles
             )
             let items = presentation.items(in: .referenced)
             let swipeOrder = ChatArtifactGallerySwipeOrder(items: items)
@@ -349,7 +360,7 @@ extension TerminalArtifactFilesSheet {
 
     private func artifactSection(
         title: String,
-        count: Int,
+        count: Int?,
         items: [ChatArtifactGalleryItem],
         expanded: Binding<Bool>,
         swipeOrder: ChatArtifactGallerySwipeOrder,
@@ -400,7 +411,7 @@ extension TerminalArtifactFilesSheet {
                 .padding(.vertical, 12)
             }
         } label: {
-            Text(verbatim: "\(title) (\(count))")
+            Text(verbatim: count.map { "\(title) (\($0))" } ?? title)
                 .font(.headline)
         }
         .padding(.horizontal, 16)

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -48,6 +48,7 @@ struct TerminalArtifactFilesSheet: View {
     @State var liveRefreshState = ChatArtifactGalleryLiveRefreshState()
     @State var sessionViewportIsAtTopOrFits = true
     @State var lastHandledRefreshSignal: TerminalArtifactGalleryRefreshSignal
+    @Environment(MobileDisplaySettings.self) var displaySettings
     @Environment(\.dismiss) private var dismiss
 
     init(
@@ -332,6 +333,7 @@ struct TerminalArtifactFilesSheet: View {
 
         let expectedFilter = galleryFilter
         let expectedSort = gallerySort
+        let expectedShowMissingFiles = displaySettings.showMissingFiles
         let expectedQuery = query
         eagerPagingState = .loading
         do {
@@ -358,6 +360,7 @@ struct TerminalArtifactFilesSheet: View {
             guard !Task.isCancelled,
                   galleryFilter == expectedFilter,
                   gallerySort == expectedSort,
+                  displaySettings.showMissingFiles == expectedShowMissingFiles,
                   queryIsCurrent else { return }
             let currentState = query == nil ? sessionState : searchState
             guard case .loaded(let currentSnapshot) = currentState,
@@ -463,7 +466,9 @@ struct TerminalArtifactFilesSheet: View {
     static let pageSize = 60
 
     var usesCompleteSessionSnapshot: Bool {
-        galleryFilter != .all || gallerySort != .recent
+        galleryFilter != .all
+            || gallerySort != .recent
+            || !displaySettings.showMissingFiles
     }
 
     var eagerPagingTaskID: String {
@@ -478,6 +483,7 @@ struct TerminalArtifactFilesSheet: View {
         return [
             galleryFilter.rawValue,
             gallerySort.rawValue,
+            String(displaySettings.showMissingFiles),
             query,
             cursor,
             String(eagerPagingRevision),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -94,6 +94,21 @@ struct TerminalArtifactFilesSheet: View {
                     viewModePicker
                 }
             }
+            .navigationDestination(isPresented: artifactIsPresented) {
+                if let selection {
+                    ChatArtifactViewerDestination(
+                        path: selection.path,
+                        scope: selection.scope == .session ? .chat : .terminal,
+                        swipeOrder: selection.swipeOrder
+                    ) {
+                        dismiss()
+                    }
+                    .environment(
+                        \.chatArtifactLoader,
+                        selection.scope == .session ? sessionLoader : loader
+                    )
+                }
+            }
         }
         .frame(idealWidth: 380, idealHeight: 520)
         .task(id: "\(workspaceID)#\(surfaceID)") {
@@ -102,21 +117,19 @@ struct TerminalArtifactFilesSheet: View {
         .task(id: liveRefreshTaskID) {
             await refreshSessionForLiveSignal()
         }
-        .sheet(item: $selection) { selection in
-            ChatArtifactViewerSheet(
-                path: selection.path,
-                scope: selection.scope == .session ? .chat : .terminal,
-                swipeOrder: selection.swipeOrder
-            )
-            .environment(
-                \.chatArtifactLoader,
-                selection.scope == .session ? sessionLoader : loader
-            )
-        }
         .onDisappear {
             thumbnailPrefetchTasks.forEach { $0.cancel() }
             thumbnailPrefetchTasks.removeAll()
         }
+    }
+
+    private var artifactIsPresented: Binding<Bool> {
+        Binding(
+            get: { selection != nil },
+            set: { isPresented in
+                if !isPresented { selection = nil }
+            }
+        )
     }
 
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -261,15 +261,22 @@ struct WorkspaceDetailView: View {
             TerminalPalette.background
                 .ignoresSafeArea(.container, edges: [.horizontal, .top, .bottom])
         }
-        .sheet(item: $selectedTerminalArtifact) { selection in
-            ChatArtifactViewerSheet(path: selection.path, scope: .terminal)
-                .environment(
-                    \.chatArtifactLoader,
-                    terminalArtifactLoader(
-                        workspaceID: selection.workspaceID,
-                        surfaceID: selection.surfaceID
+        .navigationDestination(isPresented: terminalArtifactIsPresented) {
+            if let selectedTerminalArtifact {
+                ChatArtifactViewerDestination(
+                    path: selectedTerminalArtifact.path,
+                    scope: .terminal
+                ) {
+                    self.selectedTerminalArtifact = nil
+                }
+                    .environment(
+                        \.chatArtifactLoader,
+                        terminalArtifactLoader(
+                            workspaceID: selectedTerminalArtifact.workspaceID,
+                            surfaceID: selectedTerminalArtifact.surfaceID
+                        )
                     )
-                )
+            }
         }
         #else
         .background(TerminalPalette.background)
@@ -286,6 +293,15 @@ struct WorkspaceDetailView: View {
     }
 
     #if os(iOS)
+    private var terminalArtifactIsPresented: Binding<Bool> {
+        Binding(
+            get: { selectedTerminalArtifact != nil },
+            set: { isPresented in
+                if !isPresented { selectedTerminalArtifact = nil }
+            }
+        )
+    }
+
     func terminalArtifactLoader(workspaceID: String, surfaceID: String) -> ChatArtifactLoader {
         guard let source = store.makeChatEventSource() else {
             return .unsupported(cache: terminalArtifactThumbnailCache)

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileDisplaySettingsTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/MobileDisplaySettingsTests.swift
@@ -42,6 +42,22 @@ import Testing
         #expect(MobileDisplaySettings(defaults: defaults).showAltScreenNotice)
     }
 
+    @Test func showMissingFilesDefaultsToFalseWithoutAWrite() throws {
+        let defaults = try makeDefaults("showMissingFilesDefaults")
+        let settings = MobileDisplaySettings(defaults: defaults)
+        #expect(!settings.showMissingFiles)
+        #expect(defaults.object(forKey: "cmux.mobile.showMissingFiles") == nil)
+    }
+
+    @Test func showMissingFilesPersistsAcrossInstances() throws {
+        let defaults = try makeDefaults("showMissingFilesPersists")
+        let settings = MobileDisplaySettings(defaults: defaults)
+        settings.showMissingFiles = true
+        #expect(MobileDisplaySettings(defaults: defaults).showMissingFiles)
+        settings.showMissingFiles = false
+        #expect(!MobileDisplaySettings(defaults: defaults).showMissingFiles)
+    }
+
     @Test func previewLineCountPersistsAcrossInstances() throws {
         let defaults = try makeDefaults("persists")
         let settings = MobileDisplaySettings(defaults: defaults)

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -5033,6 +5033,23 @@
         }
       }
     },
+    "mobile.settings.showMissingFiles": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show missing files"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "見つからないファイルを表示"
+          }
+        }
+      }
+    },
     "mobile.settings.wrapTitles": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
Four owner dogfood findings from the live build. Folders opened as an overlaying sheet; they now push inline within the presenting NavigationStack from every entry point (subfolders keep pushing, back returns to the gallery), with a sheet only where no navigation container exists. Jump-to-top now animates like jump-to-bottom (document resets stay instant). The viewer's Done button moves to the trailing edge, grouped so the PR 6b share/actions items stay reachable. Missing files (exists == false) are omitted from all gallery lists, grids, search results, and swipe order by default; a new localized "Show missing files" toggle in the iOS settings restores today's tagged rows, and while omission is active the remote group-total suffix is hidden so visible counts never contradict the list. Chip count semantics are unchanged.

Tests: CmuxAgentChat 327, CmuxAgentChatUI 80, display-settings model 11; missing-file omission landed red-then-green (test-only commit first); simulator-triple builds pass for all touched packages; EN+JA parity for new strings.

Part 7 of the chip-files-gallery completion stack, based on https://github.com/manaflow-ai/cmux/pull/8113.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8121"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786676598&installation_id=133855650&pr_number=8121&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8121&signature=a880d2014770905fb187e5a1461426d7a4181d63ffb3da5d30f1ef1afabfc14d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improve iOS artifact gallery UX: folders now push inline in existing navigation stacks, the text viewer’s jump-to-top animates, the Done button moves to the trailing side, and missing files are hidden by default with an opt-in setting.

- **New Features**
  - Inline navigation for folders and artifacts from chat, message details, terminal files, and workspace; falls back to a sheet only when no navigation container exists.
  - Text viewer: jump-to-top now animates; initial document loads stay instant.
  - iOS toolbar: Done moved to the trailing edge; actions grouped under a “Viewer actions” menu (share/save/copy, search/go-to-line/line numbers/wrap, Markdown view).
  - Missing files (exists == false) are omitted from lists, grids, search, and swipe order by default; new Settings toggle “Show missing files” restores them. When hidden, remote group totals are suppressed to avoid mismatched counts.

- **Refactors**
  - Added ChatArtifactViewerDestination and routed entry points to push inline; updated viewer pager and sheet to use a `NavigationStack` when available (`CmuxAgentChatUI`).
  - Gallery projection accepts includesMissingFiles and exposes isEmpty; tests cover omission and inclusion (`CmuxAgentChat`).
  - Persisted “Show missing files” in `MobileDisplaySettings` with tests and EN/JA strings; added settings UI in `CmuxMobileShellUI`.

<sup>Written for commit 246b090441a5879af2d3a3cbaa36f3ca2ea8f6e2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8121?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

