### PR TITLE
iOS: anchor the terminal files chip to the top

### DIFF
--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceArtifactChipHost.swift
@@ -28,7 +28,10 @@ final class GhosttySurfaceArtifactChipHost {
         container.addSubview(view)
     }
 
-    func layout(in bounds: CGRect, toolbarTop: CGFloat) {
+    // Anchored to the terminal's top edge: pinned above the toolbar it covered
+    // the input row, which users type into far more often than they read the
+    // first terminal line.
+    func layout(in bounds: CGRect, topInset: CGFloat) {
         guard let content = container.subviews.first else {
             container.frame = .zero
             return
@@ -43,7 +46,7 @@ final class GhosttySurfaceArtifactChipHost {
         let height = max(44, fitting.height)
         container.frame = CGRect(
             x: (bounds.width - width) / 2,
-            y: max(8, toolbarTop - height - 8),
+            y: max(8, topInset + 8),
             width: width,
             height: height
         ).integral
@@ -61,7 +64,7 @@ final class GhosttySurfaceArtifactChipHost {
             }
             if animated {
                 if container.alpha < 0.01 {
-                    container.transform = CGAffineTransform(translationX: 0, y: 8)
+                    container.transform = CGAffineTransform(translationX: 0, y: -8)
                 }
                 UIView.animate(
                     withDuration: 0.2,
@@ -79,7 +82,7 @@ final class GhosttySurfaceArtifactChipHost {
         container.accessibilityElementsHidden = true
         let changes = { [weak self] in
             self?.container.alpha = 0
-            self?.container.transform = CGAffineTransform(translationX: 0, y: 8)
+            self?.container.transform = CGAffineTransform(translationX: 0, y: -8)
         }
         let completion: (Bool) -> Void = { [weak self] _ in
             guard let self, !self.visibilityRequested else { return }

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1358,7 +1358,7 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
     }
 
     private func layoutArtifactChip(using snapshot: TerminalViewportSnapshot) {
-        artifactChipHost.layout(in: bounds, toolbarTop: snapshot.toolbarFrame.minY)
+        artifactChipHost.layout(in: bounds, topInset: safeAreaInsets.top)
     }
 
     private var artifactChipShouldBeVisible: Bool {


### PR DESCRIPTION
The files chip sat pinned just above the bottom toolbar, covering the terminal input row users type into. It now anchors at the terminal's top safe-area inset and slides in from the top edge.

Isolated cherry-pick of the fix from the chip-gallery stack (https://github.com/manaflow-ai/cmux/pull/8103) so it ships ahead of the rest; the stack merge later resolves as a no-op for these two files. CmuxMobileTerminal compiles clean for the iOS simulator triple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8124"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786677712&installation_id=133855650&pr_number=8124&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8124&signature=61d44fb56d4ad31b57a7546e00558c11d9cfc149d773b9c2571e5ce1efd90170"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchored the terminal files chip to the top safe-area inset on iOS in `CmuxMobileTerminal` so it no longer covers the input row. It now slides in/out from the top edge.

- **Bug Fixes**
  - Position uses `safeAreaInsets.top` instead of the toolbar frame.
  - Updated animation to translate from above the terminal (negative Y).

<sup>Written for commit df8a16b04bdaeed5e111a1650498e3858a9f9d7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8124?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved artifact chip positioning on iOS to account for top safe-area insets.
  * Adjusted chip placement and animation transitions for more consistent layout behavior across toolbar and bottom-dock configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->