### PR TITLE
Refresh Nightly compilation cache four times daily

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -129,8 +129,16 @@ jobs:
           set -euo pipefail
           echo "toolchain=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
+      - name: Look up Xcode compilation cache
+        id: compilation-cache-lookup
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build-universal/CompilationCache.noindex
+          key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ needs.decide.outputs.head_sha }}
+          lookup-only: true
+
       - name: Cache Xcode compilation results
-        id: compilation-cache
+        if: steps.compilation-cache-lookup.outputs.cache-hit != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build-universal/CompilationCache.noindex
@@ -139,14 +147,14 @@ jobs:
             xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
 
       - name: Install compilation dependencies
-        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        if: steps.compilation-cache-lookup.outputs.cache-hit != 'true'
         run: |
           ./scripts/install-rust-ci.sh
           ./scripts/install-zig-ci.sh
           ./scripts/download-prebuilt-ghosttykit.sh
 
       - name: Cache Swift packages
-        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        if: steps.compilation-cache-lookup.outputs.cache-hit != 'true'
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: .spm-cache
@@ -154,11 +162,11 @@ jobs:
           restore-keys: spm-
 
       - name: Sanitize Swift package cache
-        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        if: steps.compilation-cache-lookup.outputs.cache-hit != 'true'
         run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
 
       - name: Refresh universal nightly compilation cache
-        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        if: steps.compilation-cache-lookup.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
@@ -172,7 +180,7 @@ jobs:
             CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
 
       - name: Bound Xcode compilation cache size
-        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        if: steps.compilation-cache-lookup.outputs.cache-hit != 'true'
         run: |
           set -euo pipefail
           cache_path="build-universal/CompilationCache.noindex"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -117,6 +117,7 @@ jobs:
       - name: Checkout cache ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ needs.decide.outputs.head_sha }}
           submodules: recursive
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,8 +1,10 @@
 name: Nightly macOS build
 
 on:
-  # CI/CD pause: keep Nightly available only for an explicit, necessary release.
-  # Restore the main push trigger when the repository-wide pause is lifted.
+  # Refresh the rolling compilation cache four times daily without publishing.
+  schedule:
+    - cron: "17 */6 * * *"
+  # CI/CD pause: keep signed Nightly releases available only when dispatched.
   workflow_dispatch:
     inputs:
       force:
@@ -97,9 +99,98 @@ jobs:
               ])
               .write();
 
+  refresh-compilation-cache:
+    needs: decide
+    if: github.event_name == 'schedule'
+    runs-on: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+    timeout-minutes: 25
+    steps:
+      - name: Clear stale git locks (self-hosted reused workspace)
+        shell: bash
+        run: |
+          ws="${GITHUB_WORKSPACE:-$PWD}"
+          rm -f "$ws/.git/index.lock" 2>/dev/null || true
+          if [ -d "$ws/.git/modules" ]; then
+            find "$ws/.git/modules" -type f -name "*.lock" -delete 2>/dev/null || true
+          fi
+
+      - name: Checkout cache ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ needs.decide.outputs.head_sha }}
+          submodules: recursive
+
+      - name: Select Xcode
+        run: ./scripts/select-nightly-xcodes.sh
+
+      - name: Compute Xcode compilation cache key
+        id: compilation-cache-key
+        run: |
+          set -euo pipefail
+          echo "toolchain=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Xcode compilation results
+        id: compilation-cache
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build-universal/CompilationCache.noindex
+          key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ needs.decide.outputs.head_sha }}
+          restore-keys: |
+            xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
+
+      - name: Install compilation dependencies
+        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        run: |
+          ./scripts/install-rust-ci.sh
+          ./scripts/install-zig-ci.sh
+          ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Cache Swift packages
+        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .spm-cache
+          key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-
+
+      - name: Sanitize Swift package cache
+        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
+      - name: Refresh universal nightly compilation cache
+        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
+            -destination 'generic/platform=macOS' \
+            -clonedSourcePackagesDirPath .spm-cache \
+            -showBuildTimingSummary \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            COMPILATION_CACHE_ENABLE_CACHING=YES \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
+
+      - name: Bound Xcode compilation cache size
+        if: steps.compilation-cache.outputs.cache-hit != 'true'
+        run: |
+          set -euo pipefail
+          cache_path="build-universal/CompilationCache.noindex"
+          max_cache_kib=$((3 * 1024 * 1024))
+          if [ -d "$cache_path" ]; then
+            cache_kib=$(du -sk "$cache_path" | awk '{print $1}')
+          else
+            cache_kib=0
+          fi
+          echo "Xcode compilation cache size: ${cache_kib} KiB (limit: ${max_cache_kib} KiB)"
+          if [ "$cache_kib" -gt "$max_cache_kib" ]; then
+            echo "Xcode compilation cache exceeds 3 GiB; skipping cache save"
+            rm -rf "$cache_path"
+          fi
+
   build-sign-notarize-nightly:
     needs: decide
-    if: needs.decide.outputs.should_build == 'true'
+    if: needs.decide.outputs.should_build == 'true' && github.event_name != 'schedule'
     # Run on the macOS 15 host that carries the signing/notarization secrets.
     # Import the Apple Developer ID intermediate chain into the build keychain
     # below so signing does not depend on mutable runner login-keychain state.
@@ -158,16 +249,14 @@ jobs:
 
       # Xcode 26 compilation caching reuses unchanged Swift/Clang compilation
       # results even though each nightly uses a clean DerivedData directory.
-      # Rotate the immutable Actions cache key weekly: the first nightly saves
-      # that week's snapshot, while later nightlies restore it without uploading
-      # another multi-GB copy. Do not fall back across weeks, so a rejected cache
-      # cannot be restored forever. The post-build guard also caps snapshot size.
+      # Key snapshots by source revision and restore the newest compatible
+      # predecessor. Scheduled refreshes and release builds advance the same
+      # rolling cache instead of leaving one weekly snapshot to become stale.
       - name: Compute Xcode compilation cache key
         if: needs.decide.outputs.should_publish != 'true' || steps.current_head_prebuild.outputs.still_current == 'true'
         id: compilation-cache-key
         run: |
           set -euo pipefail
-          echo "utc_week=$(date -u +%Y-W%W)" >> "$GITHUB_OUTPUT"
           echo "toolchain=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
 
       - name: Cache Xcode compilation results
@@ -175,7 +264,9 @@ jobs:
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: build-universal/CompilationCache.noindex
-          key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ steps.compilation-cache-key.outputs.utc_week }}
+          key: xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ needs.decide.outputs.head_sha }}
+          restore-keys: |
+            xcode-compilation-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
 
       # Provide node/npm explicitly. The build/sign/notarize job can land on a
       # self-hosted macOS runner (the iOS-CI minis match the same label) that has
@@ -298,7 +389,7 @@ jobs:
           fi
           echo "Xcode compilation cache size: ${cache_kib} KiB (limit: ${max_cache_kib} KiB)"
           if [ "$cache_kib" -gt "$max_cache_kib" ]; then
-            echo "Xcode compilation cache exceeds 3 GiB; skipping this week's cache save"
+            echo "Xcode compilation cache exceeds 3 GiB; skipping cache save"
             rm -rf "$cache_path"
           fi
 

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -45,13 +45,15 @@ if ! awk '
   /^  refresh-compilation-cache:/ { in_refresh=1; next }
   in_refresh && /^  [a-zA-Z0-9_-]+:/ { in_refresh=0 }
   in_refresh && /if: github\.event_name == '\''schedule'\''/ { saw_schedule_gate=1 }
+  in_refresh && /^      - name: Look up Xcode compilation cache/ { saw_lookup=1 }
+  in_refresh && /uses: actions\/cache\/restore@/ { saw_restore_action=1 }
+  in_refresh && /lookup-only: true/ { saw_lookup_only=1 }
   in_refresh && /^      - name: Cache Xcode compilation results/ { saw_cache=1 }
-  in_refresh && /id: compilation-cache/ { saw_cache_id=1 }
   in_refresh && /^      - name: Refresh universal nightly compilation cache/ { saw_refresh=1 }
-  in_refresh && /if: steps\.compilation-cache\.outputs\.cache-hit != '\''true'\''/ { saw_change_gate=1 }
-  END { exit !(saw_schedule_gate && saw_cache && saw_cache_id && saw_refresh && saw_change_gate) }
+  in_refresh && /if: steps\.compilation-cache-lookup\.outputs\.cache-hit != '\''true'\''/ { saw_change_gate=1 }
+  END { exit !(saw_schedule_gate && saw_lookup && saw_restore_action && saw_lookup_only && saw_cache && saw_refresh && saw_change_gate) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: scheduled cache refreshes must skip compilation when main is unchanged"
+  echo "FAIL: scheduled cache refreshes must use a metadata lookup and skip cache downloads and compilation when main is unchanged"
   exit 1
 fi
 

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -28,11 +28,35 @@ if ! awk '
   in_cache && /path: build-universal\/CompilationCache\.noindex/ { saw_path=1 }
   in_cache && /key: xcode-compilation-nightly-/ { saw_key=1 }
   in_cache && /steps\.compilation-cache-key\.outputs\.toolchain/ { saw_toolchain=1 }
-  in_cache && /steps\.compilation-cache-key\.outputs\.utc_week/ { saw_week=1 }
+  in_cache && /needs\.decide\.outputs\.head_sha/ { saw_head_sha=1 }
   in_cache && /restore-keys:/ { saw_restore=1 }
-  END { exit !(saw_path && saw_key && saw_toolchain && saw_week && !saw_restore) }
+  END { exit !(saw_path && saw_key && saw_toolchain && saw_head_sha && saw_restore) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must use one toolchain-scoped cache per week without stale fallback"
+  echo "FAIL: nightly workflow must roll toolchain-scoped caches forward by source revision"
+  exit 1
+fi
+
+if ! grep -Fq 'cron: "17 */6 * * *"' "$WORKFLOW_FILE"; then
+  echo "FAIL: nightly workflow must refresh compilation caches four times daily"
+  exit 1
+fi
+
+if ! awk '
+  /^  refresh-compilation-cache:/ { in_refresh=1; next }
+  in_refresh && /^  [a-zA-Z0-9_-]+:/ { in_refresh=0 }
+  in_refresh && /if: github\.event_name == '\''schedule'\''/ { saw_schedule_gate=1 }
+  in_refresh && /^      - name: Cache Xcode compilation results/ { saw_cache=1 }
+  in_refresh && /id: compilation-cache/ { saw_cache_id=1 }
+  in_refresh && /^      - name: Refresh universal nightly compilation cache/ { saw_refresh=1 }
+  in_refresh && /if: steps\.compilation-cache\.outputs\.cache-hit != '\''true'\''/ { saw_change_gate=1 }
+  END { exit !(saw_schedule_gate && saw_cache && saw_cache_id && saw_refresh && saw_change_gate) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: scheduled cache refreshes must skip compilation when main is unchanged"
+  exit 1
+fi
+
+if ! grep -Fq "if: needs.decide.outputs.should_build == 'true' && github.event_name != 'schedule'" "$WORKFLOW_FILE"; then
+  echo "FAIL: scheduled cache refreshes must not sign, notarize, or publish Nightly"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary
- refresh the unsigned Nightly compilation cache every six hours on changed main revisions
- roll cache snapshots forward by source revision instead of freezing one snapshot per week
- keep scheduled runs out of signing, notarization, and publishing

## Testing
- `actionlint .github/workflows/nightly.yml`
- `bash tests/test_nightly_universal_build.sh`
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8128"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786678756&installation_id=133855650&pr_number=8128&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8128&signature=e9b57c73564f20ba82c248a8a50dcaf808748bce69712ad4a35deca4aa67bb89"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refresh the unsigned Nightly compilation cache every six hours, roll it forward by commit, and skip unchanged cache downloads to keep builds fast. Scheduled runs only warm the cache and never sign, notarize, or publish.

- **New Features**
  - Add `cron`-based `refresh-compilation-cache` job (4x daily) to restore/save `build-universal/CompilationCache.noindex` via `actions/cache`, using metadata-only `actions/cache/restore` with `lookup-only: true` to avoid downloading existing snapshots, and `actions/checkout` with `persist-credentials: false`.
  - Cache key uses Xcode toolchain hash + `head_sha`, with restore-keys to reuse the newest compatible snapshot.
  - On schedule, compile only on cache miss, sanitize SwiftPM cache, cap size at 3 GiB, and gate the signed Nightly job to skip signing/notarization/publishing.

<sup>Written for commit 84cb5adfc2e80c930e203b7968ae5d375e47557c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8128?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Added scheduled macOS compilation-cache refreshes to improve build readiness and reduce repeated compilation.
  * Updated cache handling to use build-specific keys with safe toolchain-based fallback.

* **Bug Fixes**
  * Prevented scheduled cache refresh runs from triggering signing, notarization, or publishing steps.
  * Ensured compilation is skipped when a valid cache is available and oversized caches are removed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->