### PR TITLE
iOS: single toolbar owner and stable page identity for the artifact viewer

### DIFF
--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryClassifier.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/ChatArtifactGalleryClassifier.swift
@@ -3,10 +3,10 @@ import UniformTypeIdentifiers
 
 /// Classifies gallery artifacts into the dedicated sheet filter buckets.
 public struct ChatArtifactGalleryClassifier: Sendable {
-    private let logExtensions: Set<String> = ["log", "out", "txt"]
+    private let logExtensions: Set<String> = ["log", "out"]
     private let documentExtensions: Set<String> = [
         "doc", "docx", "key", "md", "markdown", "mdown", "mkd", "numbers",
-        "odp", "ods", "odt", "pages", "pdf", "ppt", "pptx", "rtf", "xls", "xlsx",
+        "odp", "ods", "odt", "pages", "pdf", "ppt", "pptx", "rtf", "txt", "xls", "xlsx",
     ]
 
     /// Creates an artifact classifier.
@@ -55,5 +55,41 @@ public struct ChatArtifactGalleryClassifier: Sendable {
     /// - Returns: A dedicated filter bucket, or `nil` for All-only artifacts.
     public func filter(for item: ChatArtifactGalleryItem) -> ChatArtifactGalleryFilter? {
         filter(for: item.kind, path: item.path)
+    }
+
+    /// Returns the shared SF Symbol for an artifact gallery row.
+    ///
+    /// PDF, Office, Markdown, plain-text, and otherwise generic files share
+    /// one document glyph. Only images, source code, logs, and folders use
+    /// distinct presentation.
+    ///
+    /// - Parameters:
+    ///   - kind: Preview kind assigned by the artifact host.
+    ///   - path: Artifact path whose extension supplements the preview kind.
+    /// - Returns: SF Symbol name for list and grid placeholders.
+    public func systemImageName(
+        for kind: ChatArtifactKind,
+        path: String
+    ) -> String {
+        switch kind {
+        case .image:
+            return "photo"
+        case .directory:
+            return "folder"
+        case .text, .binary:
+            break
+        }
+        switch filter(for: kind, path: path) {
+        case .code:
+            return "chevron.left.forwardslash.chevron.right"
+        case .logs:
+            return "text.alignleft"
+        case .images:
+            return "photo"
+        case .folders:
+            return "folder"
+        case .docs, .all, nil:
+            return "doc.text"
+        }
     }
 }

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactAuthorizationStore.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactAuthorizationStore.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+/// Retains bounded terminal-scan generations for subsequent artifact reads.
+public actor TerminalArtifactAuthorizationStore {
+    private typealias Generation = (
+        ordinal: UInt64,
+        canonicalPaths: Set<String>,
+        expiresAt: Date
+    )
+
+    private let timeToLive: TimeInterval
+    private let maximumGenerationsPerSurface: Int
+    private let maximumSurfaceCount: Int
+    private var generationsBySurfaceKey: [String: [Generation]] = [:]
+    private var nextOrdinalBySurfaceKey: [String: UInt64] = [:]
+    private var lastAccessBySurfaceKey: [String: Date] = [:]
+
+    /// Creates a bounded authorization store.
+    ///
+    /// - Parameters:
+    ///   - timeToLive: Lifetime of each scan generation in seconds.
+    ///   - maximumGenerationsPerSurface: Maximum concurrent listings retained for one surface.
+    ///   - maximumSurfaceCount: Maximum terminal surfaces retained at once.
+    public init(
+        timeToLive: TimeInterval = 10 * 60,
+        maximumGenerationsPerSurface: Int = 4,
+        maximumSurfaceCount: Int = 64
+    ) {
+        self.timeToLive = max(1, timeToLive)
+        self.maximumGenerationsPerSurface = max(1, maximumGenerationsPerSurface)
+        self.maximumSurfaceCount = max(1, maximumSurfaceCount)
+    }
+
+    /// Records one canonical terminal-scan generation.
+    ///
+    /// - Parameters:
+    ///   - workspaceID: Workspace containing the scanned terminal.
+    ///   - surfaceID: Scanned terminal surface.
+    ///   - canonicalPaths: Canonical paths returned to the listing client.
+    ///   - date: Scan completion time.
+    public func record(
+        workspaceID: String,
+        surfaceID: String,
+        canonicalPaths: Set<String>,
+        at date: Date = Date()
+    ) {
+        purgeExpired(at: date)
+        let key = surfaceKey(workspaceID: workspaceID, surfaceID: surfaceID)
+        let ordinal = (nextOrdinalBySurfaceKey[key] ?? 0) &+ 1
+        nextOrdinalBySurfaceKey[key] = ordinal
+        var generations = generationsBySurfaceKey[key] ?? []
+        generations.append((
+            ordinal: ordinal,
+            canonicalPaths: canonicalPaths,
+            expiresAt: date.addingTimeInterval(timeToLive)
+        ))
+        if generations.count > maximumGenerationsPerSurface {
+            generations.removeFirst(generations.count - maximumGenerationsPerSurface)
+        }
+        generationsBySurfaceKey[key] = generations
+        lastAccessBySurfaceKey[key] = date
+        evictLeastRecentSurfacesIfNeeded()
+    }
+
+    /// Returns the union of unexpired scan generations for one terminal.
+    ///
+    /// - Parameters:
+    ///   - workspaceID: Workspace containing the terminal.
+    ///   - surfaceID: Terminal surface being read.
+    ///   - date: Read time used for deterministic expiry.
+    /// - Returns: Canonical paths listed by retained scan generations.
+    public func authorizedPaths(
+        workspaceID: String,
+        surfaceID: String,
+        at date: Date = Date()
+    ) -> Set<String> {
+        purgeExpired(at: date)
+        let key = surfaceKey(workspaceID: workspaceID, surfaceID: surfaceID)
+        guard let generations = generationsBySurfaceKey[key] else { return [] }
+        lastAccessBySurfaceKey[key] = date
+        return generations.reduce(into: Set<String>()) { result, generation in
+            result.formUnion(generation.canonicalPaths)
+        }
+    }
+
+    private func surfaceKey(workspaceID: String, surfaceID: String) -> String {
+        "\(workspaceID)\u{0}\(surfaceID)"
+    }
+
+    private func purgeExpired(at date: Date) {
+        for key in Array(generationsBySurfaceKey.keys) {
+            let retained = generationsBySurfaceKey[key, default: []]
+                .filter { $0.expiresAt > date }
+            if retained.isEmpty {
+                generationsBySurfaceKey.removeValue(forKey: key)
+                nextOrdinalBySurfaceKey.removeValue(forKey: key)
+                lastAccessBySurfaceKey.removeValue(forKey: key)
+            } else {
+                generationsBySurfaceKey[key] = retained
+            }
+        }
+    }
+
+    private func evictLeastRecentSurfacesIfNeeded() {
+        while generationsBySurfaceKey.count > maximumSurfaceCount,
+              let oldestKey = lastAccessBySurfaceKey.min(by: { $0.value < $1.value })?.key {
+            generationsBySurfaceKey.removeValue(forKey: oldestKey)
+            nextOrdinalBySurfaceKey.removeValue(forKey: oldestKey)
+            lastAccessBySurfaceKey.removeValue(forKey: oldestKey)
+        }
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactTapHitTester.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Artifacts/TerminalArtifactTapHitTester.swift
@@ -58,7 +58,7 @@ public struct TerminalArtifactTapHitTester: Sendable {
             ))
         }
 
-        let normalizedPath = TerminalArtifactPathDetector().tokens(in: rawPath).first?.path ?? token.path
+        let normalizedPath = Self.normalizedPath(in: rawPath) ?? token.path
         return StitchedPath(path: normalizedPath, segments: segments)
     }
 
@@ -76,7 +76,7 @@ public struct TerminalArtifactTapHitTester: Sendable {
                 index = line.index(after: index)
             }
             let raw = String(line[tokenStart..<index])
-            guard let path = TerminalArtifactPathDetector().tokens(in: raw).first?.path else {
+            guard let path = Self.normalizedPath(in: raw) else {
                 continue
             }
             let leadingTrim = String(raw.prefix(while: Self.leadingTrimCharacters.contains))
@@ -91,6 +91,36 @@ public struct TerminalArtifactTapHitTester: Sendable {
             ))
         }
         return result
+    }
+
+    /// Transcript prose often names a file without a slash. Keep the gallery's
+    /// broad path detector conservative, but make the tapped token itself
+    /// actionable when it has an unambiguous filename extension.
+    private static func normalizedPath(in raw: String) -> String? {
+        if let path = TerminalArtifactPathDetector().tokens(in: raw).first?.path {
+            return path
+        }
+
+        var candidate = raw.trimmingCharacters(in: bareFilenameLeadingCharacters)
+        while let scalar = candidate.unicodeScalars.last,
+              bareFilenameTrailingCharacters.contains(scalar) {
+            candidate.removeLast()
+        }
+        guard !candidate.isEmpty,
+              !candidate.contains("/"),
+              !candidate.contains("@"),
+              !candidate.contains("://"),
+              !candidate.unicodeScalars.contains(where: forbiddenBareFilenameCharacters.contains)
+        else { return nil }
+
+        let path = candidate as NSString
+        let pathExtension = path.pathExtension
+        let basename = path.deletingPathExtension
+        guard !basename.isEmpty,
+              !pathExtension.isEmpty,
+              candidate.contains(where: { $0.isLetter })
+        else { return nil }
+        return candidate
     }
 
     private func leadingContinuation(in line: String) -> Continuation? {
@@ -185,6 +215,9 @@ public struct TerminalArtifactTapHitTester: Sendable {
     }
 
     private static let leadingTrimCharacters: Set<Character> = ["\"", "'", "`", "(", "[", "{", "<"]
+    private static let bareFilenameLeadingCharacters = CharacterSet(charactersIn: "\"'`([{<")
+    private static let bareFilenameTrailingCharacters = CharacterSet(charactersIn: "\"'`)]}>,;:!?.")
+    private static let forbiddenBareFilenameCharacters = CharacterSet(charactersIn: "<>\"'\\`")
     private static let pathContinuationCharacters: Set<Character> = [
         "/", ".", "_", "-", "+", "=", "~", "@", "%", ":", "\\",
     ]

--- a/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Session/ChatSessionSurfaceIndex.swift
+++ b/Packages/Shared/CmuxAgentChat/Sources/CmuxAgentChat/Session/ChatSessionSurfaceIndex.swift
@@ -34,4 +34,49 @@ public struct ChatSessionSurfaceIndex<SessionID: Hashable & Sendable>: Sendable 
     public func sessionIDs(surfaceID: String) -> Set<SessionID> {
         sessionIDsBySurfaceID[surfaceID] ?? []
     }
+
+    /// Returns valid indexed sessions, rebuilding a missing surface entry from authoritative records.
+    ///
+    /// The full record dictionary is scanned only when the index has no valid
+    /// entry for `surfaceID`. Any recovered bindings are retained so later
+    /// lookups return directly from the index.
+    ///
+    /// - Parameters:
+    ///   - surfaceID: Terminal surface UUID string.
+    ///   - records: Authoritative records keyed by session identity.
+    ///   - recordSurfaceID: Key path to each record's current surface binding.
+    /// - Returns: Session IDs currently associated with the surface.
+    public mutating func sessionIDs<Record: Sendable>(
+        surfaceID: String,
+        healingFrom records: [SessionID: Record],
+        recordSurfaceID: KeyPath<Record, String?>
+    ) -> Set<SessionID> {
+        let indexed = sessionIDsBySurfaceID[surfaceID] ?? []
+        var validIndexed: Set<SessionID> = []
+        for sessionID in indexed {
+            guard let record = records[sessionID],
+                  record[keyPath: recordSurfaceID] == surfaceID else {
+                update(
+                    sessionID: sessionID,
+                    previousSurfaceID: surfaceID,
+                    currentSurfaceID: nil
+                )
+                continue
+            }
+            validIndexed.insert(sessionID)
+        }
+        guard validIndexed.isEmpty else { return validIndexed }
+
+        var recovered: Set<SessionID> = []
+        for (sessionID, record) in records
+        where record[keyPath: recordSurfaceID] == surfaceID {
+            recovered.insert(sessionID)
+            update(
+                sessionID: sessionID,
+                previousSurfaceID: nil,
+                currentSurfaceID: surfaceID
+            )
+        }
+        return recovered
+    }
 }

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryClassifierTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatArtifactGalleryClassifierTests.swift
@@ -8,28 +8,30 @@ struct ChatArtifactGalleryClassifierTests {
         let path: String
         let kind: ChatArtifactKind
         let expected: ChatArtifactGalleryFilter?
+        let expectedSystemImage: String
 
         var testDescription: String { "\(kind.rawValue):\(path)" }
     }
 
     @Test(arguments: [
-        Fixture(path: "/tmp/photo.swift", kind: .image, expected: .images),
-        Fixture(path: "/tmp/folder.png", kind: .directory, expected: .folders),
-        Fixture(path: "/tmp/App.swift", kind: .text, expected: .code),
-        Fixture(path: "/tmp/main.CPP", kind: .binary, expected: .code),
-        Fixture(path: "/tmp/run.log", kind: .text, expected: .logs),
-        Fixture(path: "/tmp/process.OUT", kind: .binary, expected: .logs),
-        Fixture(path: "/tmp/notes.txt", kind: .text, expected: .logs),
-        Fixture(path: "/tmp/README.md", kind: .text, expected: .docs),
-        Fixture(path: "/tmp/report.PDF", kind: .binary, expected: .docs),
-        Fixture(path: "/tmp/deck.pptx", kind: .binary, expected: .docs),
-        Fixture(path: "/tmp/table.numbers", kind: .binary, expected: .docs),
-        Fixture(path: "/tmp/archive.zip", kind: .binary, expected: nil),
-        Fixture(path: "/tmp/LICENSE", kind: .text, expected: nil),
+        Fixture(path: "/tmp/photo.swift", kind: .image, expected: .images, expectedSystemImage: "photo"),
+        Fixture(path: "/tmp/folder.png", kind: .directory, expected: .folders, expectedSystemImage: "folder"),
+        Fixture(path: "/tmp/App.swift", kind: .text, expected: .code, expectedSystemImage: "chevron.left.forwardslash.chevron.right"),
+        Fixture(path: "/tmp/main.CPP", kind: .binary, expected: .code, expectedSystemImage: "chevron.left.forwardslash.chevron.right"),
+        Fixture(path: "/tmp/run.log", kind: .text, expected: .logs, expectedSystemImage: "text.alignleft"),
+        Fixture(path: "/tmp/process.OUT", kind: .binary, expected: .logs, expectedSystemImage: "text.alignleft"),
+        Fixture(path: "/tmp/notes.txt", kind: .text, expected: .docs, expectedSystemImage: "doc.text"),
+        Fixture(path: "/tmp/README.md", kind: .text, expected: .docs, expectedSystemImage: "doc.text"),
+        Fixture(path: "/tmp/report.PDF", kind: .binary, expected: .docs, expectedSystemImage: "doc.text"),
+        Fixture(path: "/tmp/deck.pptx", kind: .binary, expected: .docs, expectedSystemImage: "doc.text"),
+        Fixture(path: "/tmp/table.numbers", kind: .binary, expected: .docs, expectedSystemImage: "doc.text"),
+        Fixture(path: "/tmp/archive.zip", kind: .binary, expected: nil, expectedSystemImage: "doc.text"),
+        Fixture(path: "/tmp/LICENSE", kind: .text, expected: nil, expectedSystemImage: "doc.text"),
     ])
     func classifiesKindAndExtensionMatrix(_ fixture: Fixture) {
         let classifier = ChatArtifactGalleryClassifier()
 
         #expect(classifier.filter(for: fixture.kind, path: fixture.path) == fixture.expected)
+        #expect(classifier.systemImageName(for: fixture.kind, path: fixture.path) == fixture.expectedSystemImage)
     }
 }

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatSessionSurfaceIndexTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/ChatSessionSurfaceIndexTests.swift
@@ -47,4 +47,23 @@ struct ChatSessionSurfaceIndexTests {
         expectParity(surfaceID: "surface-a")
         expectParity(surfaceID: "surface-b")
     }
+
+    @Test("an index miss scans authoritative records once and self-heals")
+    func selfHealsFromAuthoritativeRecords() {
+        let records = [
+            "one": Record(sessionID: "one", surfaceID: "surface-a"),
+            "two": Record(sessionID: "two", surfaceID: "surface-a"),
+            "other": Record(sessionID: "other", surfaceID: "surface-b"),
+        ]
+        var index = ChatSessionSurfaceIndex<String>()
+
+        let healed = index.sessionIDs(
+            surfaceID: "surface-a",
+            healingFrom: records,
+            recordSurfaceID: \.surfaceID
+        )
+
+        #expect(healed == ["one", "two"])
+        #expect(index.sessionIDs(surfaceID: "surface-a") == healed)
+    }
 }

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalArtifactAuthorizationStoreTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalArtifactAuthorizationStoreTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+
+@testable import CmuxAgentChat
+
+@Suite("Terminal artifact authorization snapshots")
+struct TerminalArtifactAuthorizationStoreTests {
+    @Test("a listed path remains authorized after it scrolls off screen")
+    func listedPathSurvivesLiveScreenChange() async {
+        let listedPath = "/safe/report.txt"
+        let scanScope = TerminalArtifactScope(
+            terminalText: "open \(listedPath)",
+            workingDirectory: "/safe",
+            resolver: FakeResolver(files: [listedPath])
+        )
+        let listedPaths = Set(scanScope.artifactPaths())
+        let liveScopeAfterScroll = TerminalArtifactScope(
+            terminalText: "prompt with no artifact path",
+            workingDirectory: "/safe",
+            resolver: FakeResolver(files: [listedPath])
+        )
+        let store = TerminalArtifactAuthorizationStore(
+            timeToLive: 60,
+            maximumGenerationsPerSurface: 2
+        )
+        let scannedAt = Date(timeIntervalSince1970: 100)
+
+        await store.record(
+            workspaceID: "workspace",
+            surfaceID: "surface",
+            canonicalPaths: listedPaths,
+            at: scannedAt
+        )
+        let snapshotPaths = await store.authorizedPaths(
+            workspaceID: "workspace",
+            surfaceID: "surface",
+            at: scannedAt.addingTimeInterval(30)
+        )
+        let snapshotScope = ChatArtifactScope(
+            referencedPaths: snapshotPaths,
+            resolver: FakeResolver(files: [listedPath])
+        )
+
+        #expect(liveScopeAfterScroll.canonicalPath(for: listedPath) == nil)
+        #expect(snapshotScope.canonicalFilePath(for: listedPath) == listedPath)
+    }
+
+    @Test("authorization is bounded by TTL and retained generations")
+    func boundedLifetimeAndGenerations() async {
+        let store = TerminalArtifactAuthorizationStore(
+            timeToLive: 60,
+            maximumGenerationsPerSurface: 2
+        )
+        let start = Date(timeIntervalSince1970: 100)
+
+        await store.record(
+            workspaceID: "workspace",
+            surfaceID: "surface",
+            canonicalPaths: ["/safe/one.txt"],
+            at: start
+        )
+        await store.record(
+            workspaceID: "workspace",
+            surfaceID: "surface",
+            canonicalPaths: ["/safe/two.txt"],
+            at: start.addingTimeInterval(1)
+        )
+        await store.record(
+            workspaceID: "workspace",
+            surfaceID: "surface",
+            canonicalPaths: ["/safe/three.txt"],
+            at: start.addingTimeInterval(2)
+        )
+
+        #expect(await store.authorizedPaths(
+            workspaceID: "workspace",
+            surfaceID: "surface",
+            at: start.addingTimeInterval(30)
+        ) == ["/safe/two.txt", "/safe/three.txt"])
+        #expect(await store.authorizedPaths(
+            workspaceID: "workspace",
+            surfaceID: "surface",
+            at: start.addingTimeInterval(63)
+        ).isEmpty)
+    }
+
+    private struct FakeResolver: ChatArtifactScope.FileSystemResolving {
+        let files: Set<String>
+
+        func resolveSymlinks(of path: String) -> String? {
+            (path as NSString).standardizingPath
+        }
+
+        func isDirectory(_ path: String) -> Bool? {
+            files.contains(path) ? false : nil
+        }
+    }
+}

--- a/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalArtifactTapHitTesterTests.swift
+++ b/Packages/Shared/CmuxAgentChat/Tests/CmuxAgentChatTests/TerminalArtifactTapHitTesterTests.swift
@@ -85,6 +85,30 @@ struct TerminalArtifactTapHitTesterTests {
         #expect(resolved == path)
     }
 
+    @Test("resolves a bare filename referenced by terminal transcript prose")
+    func resolvesBareFilename() {
+        let resolved = TerminalArtifactTapHitTester().path(
+            in: "Inspect data.csv, then continue.",
+            col: 10,
+            row: 0,
+            columns: 80
+        )
+
+        #expect(resolved == "data.csv")
+    }
+
+    @Test("trims sentence punctuation from a bare filename")
+    func trimsBareFilenamePunctuation() {
+        let resolved = TerminalArtifactTapHitTester().path(
+            in: "The log is build.log.",
+            col: 15,
+            row: 0,
+            columns: 80
+        )
+
+        #expect(resolved == "build.log")
+    }
+
     @Test("uses terminal cell width for CJK text before a path")
     func cjkPrefixUsesTerminalColumns() {
         let path = "/tmp/note.txt"

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderRoute.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderRoute.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Carries the original folder loader and scope into one lazily pushed child route.
+struct ChatArtifactFolderRoute: Sendable {
+    let path: String
+    let scope: ChatArtifactViewerScope
+    let loader: ChatArtifactLoader
+
+    init(
+        parentPath: String,
+        childName: String,
+        scope: ChatArtifactViewerScope,
+        loader: ChatArtifactLoader
+    ) {
+        path = (parentPath as NSString).appendingPathComponent(childName)
+        self.scope = scope
+        self.loader = loader
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactFolderView.swift
@@ -42,11 +42,13 @@ struct ChatArtifactFolderView: View {
                         Section {
                             ForEach(listing.entries) { entry in
                                 NavigationLink {
+                                    let route = childRoute(for: entry)
                                     ChatArtifactViewerDestination(
-                                        path: childPath(named: entry.name),
-                                        scope: scope,
+                                        path: route.path,
+                                        scope: route.scope,
                                         onDone: onDone
                                     )
+                                    .environment(\.chatArtifactLoader, route.loader)
                                 } label: {
                                     rowLabel(entry)
                                 }
@@ -124,6 +126,15 @@ struct ChatArtifactFolderView: View {
 
     private func childPath(named name: String) -> String {
         (path as NSString).appendingPathComponent(name)
+    }
+
+    private func childRoute(for entry: ChatArtifactDirectoryEntry) -> ChatArtifactFolderRoute {
+        ChatArtifactFolderRoute(
+            parentPath: path,
+            childName: entry.name,
+            scope: scope,
+            loader: loader
+        )
     }
 
     private var parentPath: String {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightingStatusPill.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactHighlightingStatusPill.swift
@@ -10,7 +10,9 @@ struct ChatArtifactHighlightingStatusPill: View {
 
     var body: some View {
         Button {
-            isExpanded.toggle()
+            withAnimation(.snappy) {
+                isExpanded.toggle()
+            }
         } label: {
             HStack(alignment: .firstTextBaseline, spacing: 8) {
                 Image(systemName: "paintbrush.slash")
@@ -20,6 +22,7 @@ struct ChatArtifactHighlightingStatusPill: View {
                         .font(.caption)
                         .multilineTextAlignment(.leading)
                         .fixedSize(horizontal: false, vertical: true)
+                        .transition(.opacity)
                 } else {
                     Text(String(
                         localized: "chat.artifact.highlighting.off",
@@ -27,6 +30,7 @@ struct ChatArtifactHighlightingStatusPill: View {
                         bundle: .module
                     ))
                     .font(.caption.weight(.semibold))
+                    .transition(.opacity)
                 }
                 Image(systemName: isExpanded ? "xmark.circle.fill" : "chevron.right")
                     .imageScale(.small)
@@ -36,11 +40,11 @@ struct ChatArtifactHighlightingStatusPill: View {
             .padding(.horizontal, 12)
             .padding(.vertical, 8)
             .frame(maxWidth: isExpanded ? 360 : nil, alignment: .leading)
-            .background(.thinMaterial, in: Capsule())
+            .background(Color.secondary.opacity(0.12), in: Capsule())
+            .clipShape(Capsule())
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
-        .animation(.snappy, value: isExpanded)
     }
 
     private var explanation: String {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineIndex.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineIndex.swift
@@ -9,15 +9,19 @@ struct ChatArtifactLineIndex: Equatable, Sendable {
 
     /// Adds line starts from one newly decoded streaming chunk.
     mutating func append(_ text: String) {
+        append(ChatArtifactLineIndexBatch(text: text))
+    }
+
+    /// Applies a batch whose UTF-16 scan may have been computed off-main.
+    mutating func append(_ batch: ChatArtifactLineIndexBatch) {
         let baseOffset = loadedUTF16Length
-        var chunkOffset = 0
-        for codeUnit in text.utf16 {
-            chunkOffset += 1
-            if codeUnit == 0x0A {
-                lineStartOffsets.append(baseOffset + chunkOffset)
-            }
+        lineStartOffsets.reserveCapacity(
+            lineStartOffsets.count + batch.relativeLineStartOffsets.count
+        )
+        for relativeOffset in batch.relativeLineStartOffsets {
+            lineStartOffsets.append(baseOffset + relativeOffset)
         }
-        loadedUTF16Length += chunkOffset
+        loadedUTF16Length += batch.utf16Length
     }
 
     /// Clamps a one-based requested line to the range currently loaded.

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineIndexBatch.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactLineIndexBatch.swift
@@ -1,0 +1,18 @@
+/// Precomputed line-index contribution for one streamed text chunk.
+struct ChatArtifactLineIndexBatch: Equatable, Sendable {
+    let utf16Length: Int
+    let relativeLineStartOffsets: [Int]
+
+    init(text: String) {
+        var utf16Length = 0
+        var lineStartOffsets: [Int] = []
+        for codeUnit in text.utf16 {
+            utf16Length += 1
+            if codeUnit == 0x0A {
+                lineStartOffsets.append(utf16Length)
+            }
+        }
+        self.utf16Length = utf16Length
+        relativeLineStartOffsets = lineStartOffsets
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownBlock.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownBlock.swift
@@ -1,0 +1,19 @@
+/// One document-level Markdown block with structure preserved for layout.
+struct ChatArtifactMarkdownBlock: Identifiable, Equatable, Sendable {
+    enum Kind: Equatable, Sendable {
+        case heading(level: Int)
+        case paragraph
+        case bullet(indent: Int)
+        case ordered(marker: String, indent: Int)
+        case quote
+        case rule
+        case code(language: String?)
+        case tableRow(isHeader: Bool)
+    }
+
+    let index: Int
+    let kind: Kind
+    let text: String
+
+    var id: Int { index }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownDocument.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownDocument.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+/// Parses Markdown into stable block-level values before SwiftUI lays it out.
+struct ChatArtifactMarkdownDocument: Equatable, Sendable {
+    let blocks: [ChatArtifactMarkdownBlock]
+
+    init(markdown: String) {
+        var parsed: [ChatArtifactMarkdownBlock] = []
+        for segment in ChatProseSegmenter().segments(from: markdown) {
+            switch segment.kind {
+            case .text:
+                for textBlock in ChatTextBlockParser().blocks(from: segment.content) {
+                    parsed.append(contentsOf: Self.blocks(from: textBlock))
+                }
+            case .code(let language):
+                parsed.append(ChatArtifactMarkdownBlock(
+                    index: parsed.count,
+                    kind: .code(language: language),
+                    text: segment.content
+                ))
+            }
+        }
+        blocks = parsed.enumerated().map { index, block in
+            ChatArtifactMarkdownBlock(index: index, kind: block.kind, text: block.text)
+        }
+    }
+
+    private static func blocks(from block: ChatTextBlock) -> [ChatArtifactMarkdownBlock] {
+        switch block.kind {
+        case .heading(let level):
+            return [markdownBlock(kind: .heading(level: level), text: block.text)]
+        case .paragraph:
+            return paragraphBlocks(from: block.text)
+        case .bullet(let indent):
+            return [markdownBlock(kind: .bullet(indent: indent), text: block.text)]
+        case .ordered(let marker, let indent):
+            return [markdownBlock(kind: .ordered(marker: marker, indent: indent), text: block.text)]
+        case .quote:
+            return [markdownBlock(kind: .quote, text: block.text)]
+        case .rule:
+            return [markdownBlock(kind: .rule, text: "")]
+        }
+    }
+
+    /// Splits GitHub-style tables out of paragraph runs while preserving surrounding prose.
+    private static func paragraphBlocks(from text: String) -> [ChatArtifactMarkdownBlock] {
+        let lines = text.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+        var result: [ChatArtifactMarkdownBlock] = []
+        var paragraphLines: [String] = []
+        var index = 0
+
+        while index < lines.count {
+            let startsTable = index + 1 < lines.count
+                && tableCells(in: lines[index]) != nil
+                && isTableSeparator(lines[index + 1])
+            if !startsTable {
+                paragraphLines.append(lines[index])
+                index += 1
+                continue
+            }
+
+            if !paragraphLines.isEmpty {
+                result.append(markdownBlock(
+                    kind: .paragraph,
+                    text: paragraphLines.joined(separator: "\n")
+                ))
+                paragraphLines.removeAll(keepingCapacity: true)
+            }
+
+            if let headerCells = tableCells(in: lines[index]) {
+                result.append(markdownBlock(
+                    kind: .tableRow(isHeader: true),
+                    text: headerCells.joined(separator: " │ ")
+                ))
+            }
+            index += 2
+            while index < lines.count, let cells = tableCells(in: lines[index]) {
+                result.append(markdownBlock(
+                    kind: .tableRow(isHeader: false),
+                    text: cells.joined(separator: " │ ")
+                ))
+                index += 1
+            }
+        }
+
+        if !paragraphLines.isEmpty {
+            result.append(markdownBlock(
+                kind: .paragraph,
+                text: paragraphLines.joined(separator: "\n")
+            ))
+        }
+        return result
+    }
+
+    private static func tableCells(in line: String) -> [String]? {
+        let cells = line
+            .split(separator: "|", omittingEmptySubsequences: true)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+        guard cells.count >= 2, cells.allSatisfy({ !$0.isEmpty }) else { return nil }
+        return cells
+    }
+
+    private static func isTableSeparator(_ line: String) -> Bool {
+        guard let cells = tableCells(in: line) else { return false }
+        return cells.allSatisfy { cell in
+            let withoutColons = cell.trimmingCharacters(in: CharacterSet(charactersIn: ":"))
+            return withoutColons.count >= 3 && withoutColons.allSatisfy { $0 == "-" }
+        }
+    }
+
+    private static func markdownBlock(
+        kind: ChatArtifactMarkdownBlock.Kind,
+        text: String
+    ) -> ChatArtifactMarkdownBlock {
+        ChatArtifactMarkdownBlock(index: 0, kind: kind, text: text)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactMarkdownView.swift
@@ -7,15 +7,95 @@ struct ChatArtifactMarkdownView: View {
 
     var body: some View {
         ScrollView {
-            Text(renderedMarkdown)
-                .textSelection(.enabled)
-                .frame(maxWidth: .infinity, alignment: .leading)
-                .padding()
+            LazyVStack(alignment: .leading, spacing: 12) {
+                ForEach(ChatArtifactMarkdownDocument(markdown: markdown).blocks) { block in
+                    blockView(block)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding()
         }
     }
 
-    private var renderedMarkdown: AttributedString {
-        let options = AttributedString.MarkdownParsingOptions(interpretedSyntax: .full)
+    @ViewBuilder
+    private func blockView(_ block: ChatArtifactMarkdownBlock) -> some View {
+        switch block.kind {
+        case .heading(let level):
+            Text(renderedInline(block.text))
+                .font(headingFont(level: level))
+                .textSelection(.enabled)
+                .padding(.top, block.index == 0 ? 0 : 4)
+        case .paragraph:
+            Text(renderedInline(block.text))
+                .font(.body)
+                .textSelection(.enabled)
+        case .bullet(let indent):
+            listRow(marker: "•", text: block.text, indent: indent)
+        case .ordered(let marker, let indent):
+            listRow(marker: marker, text: block.text, indent: indent)
+        case .quote:
+            HStack(spacing: 10) {
+                Rectangle()
+                    .fill(.tertiary)
+                    .frame(width: 3)
+                Text(renderedInline(block.text))
+                    .foregroundStyle(.secondary)
+                    .textSelection(.enabled)
+            }
+        case .rule:
+            Divider()
+                .padding(.vertical, 4)
+        case .code(let language):
+            VStack(alignment: .leading, spacing: 6) {
+                if let language, !language.isEmpty {
+                    Text(verbatim: language.uppercased())
+                        .font(.caption2.weight(.semibold).monospaced())
+                        .foregroundStyle(.secondary)
+                }
+                ScrollView(.horizontal) {
+                    Text(verbatim: block.text.isEmpty ? " " : block.text)
+                        .font(.body.monospaced())
+                        .textSelection(.enabled)
+                }
+            }
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(.secondary.opacity(0.1), in: .rect(cornerRadius: 8))
+        case .tableRow(let isHeader):
+            ScrollView(.horizontal) {
+                Text(verbatim: block.text)
+                    .font(.system(.body, design: .monospaced).weight(isHeader ? .semibold : .regular))
+                    .textSelection(.enabled)
+            }
+            .padding(.vertical, isHeader ? 4 : 0)
+        }
+    }
+
+    private func listRow(marker: String, text: String, indent: Int) -> some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Text(verbatim: marker)
+                .foregroundStyle(.secondary)
+                .frame(minWidth: 20, alignment: .trailing)
+            Text(renderedInline(text))
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .textSelection(.enabled)
+        }
+        .padding(.leading, CGFloat(min(indent, 4)) * 16)
+    }
+
+    private func headingFont(level: Int) -> Font {
+        switch level {
+        case 1: .title.weight(.bold)
+        case 2: .title2.weight(.bold)
+        case 3: .title3.weight(.semibold)
+        default: .headline
+        }
+    }
+
+    private func renderedInline(_ markdown: String) -> AttributedString {
+        var options = AttributedString.MarkdownParsingOptions()
+        options.interpretedSyntax = .inlineOnlyPreservingWhitespace
+        options.failurePolicy = .returnPartiallyParsedIfPossible
         return (try? AttributedString(markdown: markdown, options: options))
             ?? AttributedString(markdown)
     }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPageControllerState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPageControllerState.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Pure ordering and completed-selection state for the UIKit artifact pager.
+struct ChatArtifactPageControllerState: Equatable, Sendable {
+    private(set) var paths: [String]
+    private(set) var selectedPath: String
+
+    init(paths: [String], selectedPath: String) {
+        self.paths = Self.unique(paths)
+        self.selectedPath = selectedPath
+        normalizeSelection()
+    }
+
+    @discardableResult
+    mutating func update(paths: [String], selectedPath: String) -> Bool {
+        let uniquePaths = Self.unique(paths)
+        let didChangePaths = self.paths != uniquePaths
+        self.paths = uniquePaths
+        self.selectedPath = selectedPath
+        normalizeSelection()
+        return didChangePaths
+    }
+
+    mutating func completeTransition(to path: String) -> Bool {
+        guard paths.contains(path), path != selectedPath else { return false }
+        selectedPath = path
+        return true
+    }
+
+    func path(before path: String) -> String? {
+        guard let index = paths.firstIndex(of: path), index > paths.startIndex else {
+            return nil
+        }
+        return paths[paths.index(before: index)]
+    }
+
+    func path(after path: String) -> String? {
+        guard let index = paths.firstIndex(of: path),
+              paths.index(after: index) < paths.endIndex else {
+            return nil
+        }
+        return paths[paths.index(after: index)]
+    }
+
+    func isForwardTransition(from source: String?, to destination: String) -> Bool {
+        guard let source,
+              let sourceIndex = paths.firstIndex(of: source),
+              let destinationIndex = paths.firstIndex(of: destination) else {
+            return true
+        }
+        return destinationIndex >= sourceIndex
+    }
+
+    private mutating func normalizeSelection() {
+        if !paths.contains(selectedPath), let firstPath = paths.first {
+            selectedPath = firstPath
+        }
+    }
+
+    private static func unique(_ paths: [String]) -> [String] {
+        var seen: Set<String> = []
+        return paths.filter { seen.insert($0).inserted }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPageViewController.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPageViewController.swift
@@ -1,0 +1,47 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// Bridges path-stable artifact hosts into UIKit's transactional page controller.
+struct ChatArtifactPageViewController: UIViewControllerRepresentable {
+    let pages: [ChatArtifactViewerHostedPage]
+    @Binding var selectedPath: String
+    let isPagingEnabled: Bool
+
+    func makeCoordinator() -> ChatArtifactPageViewControllerCoordinator {
+        ChatArtifactPageViewControllerCoordinator()
+    }
+
+    func makeUIViewController(context: Context) -> UIPageViewController {
+        let controller = UIPageViewController(
+            transitionStyle: .scroll,
+            navigationOrientation: .horizontal
+        )
+        controller.view.backgroundColor = .systemBackground
+        controller.view.isOpaque = true
+        controller.view.clipsToBounds = true
+        controller.dataSource = context.coordinator
+        controller.delegate = context.coordinator
+        context.coordinator.attach(controller)
+        context.coordinator.update(
+            pages: pages,
+            selectedPath: selectedPath,
+            selection: $selectedPath,
+            isPagingEnabled: isPagingEnabled
+        )
+        return controller
+    }
+
+    func updateUIViewController(
+        _ controller: UIPageViewController,
+        context: Context
+    ) {
+        context.coordinator.update(
+            pages: pages,
+            selectedPath: selectedPath,
+            selection: $selectedPath,
+            isPagingEnabled: isPagingEnabled
+        )
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPageViewControllerCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactPageViewControllerCoordinator.swift
@@ -1,0 +1,147 @@
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+/// Owns one clipped hosting controller per path and commits only completed page transitions.
+@MainActor
+final class ChatArtifactPageViewControllerCoordinator: NSObject,
+    UIPageViewControllerDataSource,
+    UIPageViewControllerDelegate
+{
+    private weak var pageController: UIPageViewController?
+    private var state = ChatArtifactPageControllerState(paths: [], selectedPath: "")
+    private var pagesByPath: [String: ChatArtifactViewerHostedPage] = [:]
+    private var hostsByPath: [String: UIHostingController<ChatArtifactViewerHostedPage>] = [:]
+    private var selection: Binding<String>?
+    private var isTransitioning = false
+    private var needsDataSourceReload = false
+
+    func attach(_ controller: UIPageViewController) {
+        pageController = controller
+    }
+
+    func update(
+        pages: [ChatArtifactViewerHostedPage],
+        selectedPath: String,
+        selection: Binding<String>,
+        isPagingEnabled: Bool
+    ) {
+        self.selection = selection
+        pagesByPath = Dictionary(uniqueKeysWithValues: pages.map { ($0.path, $0) })
+        for page in pages {
+            hostsByPath[page.path]?.rootView = page
+        }
+        needsDataSourceReload = state.update(
+            paths: pages.map(\.path),
+            selectedPath: selectedPath
+        ) || needsDataSourceReload
+        configurePaging(isEnabled: isPagingEnabled)
+        guard !isTransitioning else { return }
+        removeUnusedHosts()
+        reloadDataSourceIfNeeded()
+        synchronizeDisplayedPage()
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerBefore viewController: UIViewController
+    ) -> UIViewController? {
+        guard let path = path(for: viewController),
+              let previousPath = state.path(before: path) else {
+            return nil
+        }
+        return host(for: previousPath)
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        viewControllerAfter viewController: UIViewController
+    ) -> UIViewController? {
+        guard let path = path(for: viewController),
+              let nextPath = state.path(after: path) else {
+            return nil
+        }
+        return host(for: nextPath)
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        willTransitionTo pendingViewControllers: [UIViewController]
+    ) {
+        isTransitioning = true
+    }
+
+    func pageViewController(
+        _ pageViewController: UIPageViewController,
+        didFinishAnimating finished: Bool,
+        previousViewControllers: [UIViewController],
+        transitionCompleted completed: Bool
+    ) {
+        isTransitioning = false
+        if completed,
+           let displayed = pageViewController.viewControllers?.first,
+           let path = path(for: displayed),
+           state.completeTransition(to: path) {
+            selection?.wrappedValue = path
+        }
+        removeUnusedHosts()
+        reloadDataSourceIfNeeded()
+        synchronizeDisplayedPage()
+    }
+
+    private func synchronizeDisplayedPage() {
+        guard let pageController,
+              let destination = host(for: state.selectedPath) else {
+            return
+        }
+        let current = pageController.viewControllers?.first
+        guard current !== destination else { return }
+        let direction: UIPageViewController.NavigationDirection = state.isForwardTransition(
+            from: current.flatMap(path(for:)),
+            to: state.selectedPath
+        ) ? .forward : .reverse
+        pageController.setViewControllers(
+            [destination],
+            direction: direction,
+            animated: false
+        )
+    }
+
+    private func host(for path: String) -> UIHostingController<ChatArtifactViewerHostedPage>? {
+        if let host = hostsByPath[path] {
+            return host
+        }
+        guard let page = pagesByPath[path] else { return nil }
+        let host = UIHostingController(rootView: page)
+        host.view.backgroundColor = .systemBackground
+        host.view.isOpaque = true
+        host.view.clipsToBounds = true
+        hostsByPath[path] = host
+        return host
+    }
+
+    private func path(for viewController: UIViewController) -> String? {
+        hostsByPath.first { $0.value === viewController }?.key
+    }
+
+    private func removeUnusedHosts() {
+        let retainedPaths = Set(state.paths)
+        hostsByPath = hostsByPath.filter { retainedPaths.contains($0.key) }
+    }
+
+    private func reloadDataSourceIfNeeded() {
+        guard needsDataSourceReload, let pageController else { return }
+        pageController.dataSource = nil
+        pageController.dataSource = self
+        needsDataSourceReload = false
+    }
+
+    private func configurePaging(isEnabled: Bool) {
+        guard let pageController else { return }
+        for case let scrollView as UIScrollView in pageController.view.subviews {
+            scrollView.isScrollEnabled = isEnabled
+            scrollView.clipsToBounds = true
+        }
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextAccessibilityContent.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextAccessibilityContent.swift
@@ -1,0 +1,23 @@
+import Foundation
+
+/// Retains a bounded prefix for the artifact text view's single accessibility element.
+struct ChatArtifactTextAccessibilityContent: Equatable, Sendable {
+    static let maximumCharacterCount = 2_048
+
+    private(set) var excerpt = ""
+    private(set) var isTruncated = false
+
+    mutating func append(_ text: String) {
+        guard !text.isEmpty else { return }
+        let remaining = Self.maximumCharacterCount - excerpt.count
+        guard remaining > 0 else {
+            isTruncated = true
+            return
+        }
+        let prefix = text.prefix(remaining)
+        excerpt.append(contentsOf: prefix)
+        if prefix.endIndex != text.endIndex {
+            isTruncated = true
+        }
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextAppendPolicy.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextAppendPolicy.swift
@@ -1,0 +1,56 @@
+/// Coalesces streamed text chunks while scrolling must remain uninterrupted.
+struct ChatArtifactTextAppendPolicy: Equatable, Sendable {
+    private enum DeferralState: Equatable, Sendable {
+        case idle
+        case tracking
+        case decelerating
+        case programmaticAnimation
+    }
+
+    private var state = DeferralState.idle
+    private var pendingChunkCount = 0
+
+    var isDeferring: Bool {
+        state != .idle
+    }
+
+    mutating func enqueue(chunkCount: Int) -> Int {
+        guard chunkCount > 0 else { return 0 }
+        pendingChunkCount += chunkCount
+        return state == .idle ? drain() : 0
+    }
+
+    mutating func beginTracking() {
+        state = .tracking
+    }
+
+    mutating func endTracking(willDecelerate: Bool) -> Int {
+        state = willDecelerate ? .decelerating : .idle
+        return state == .idle ? drain() : 0
+    }
+
+    mutating func endDecelerating() -> Int {
+        state = .idle
+        return drain()
+    }
+
+    mutating func beginProgrammaticAnimation() {
+        state = .programmaticAnimation
+    }
+
+    mutating func endProgrammaticAnimation() -> Int {
+        guard state == .programmaticAnimation else { return 0 }
+        state = .idle
+        return drain()
+    }
+
+    mutating func reset() {
+        state = .idle
+        pendingChunkCount = 0
+    }
+
+    private mutating func drain() -> Int {
+        defer { pendingChunkCount = 0 }
+        return pendingChunkCount
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextContainerView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextContainerView.swift
@@ -16,6 +16,8 @@ final class ChatArtifactTextContainerView: UIView {
         super.init(frame: frame)
 
         backgroundColor = .clear
+        isAccessibilityElement = true
+        accessibilityTraits = [.staticText, .allowsDirectInteraction]
         textView.layoutManager.allowsNonContiguousLayout = true
         textView.isEditable = false
         textView.isSelectable = true
@@ -28,6 +30,9 @@ final class ChatArtifactTextContainerView: UIView {
         )
         textView.textContainerInset = UIEdgeInsets(top: 16, left: 16, bottom: 16, right: 16)
         textView.textContainer.lineFragmentPadding = 0
+        textView.isAccessibilityElement = false
+        textView.accessibilityElementsHidden = true
+        gutterView.accessibilityElementsHidden = true
 
         gutterView.textView = textView
         gutterView.translatesAutoresizingMaskIntoConstraints = false
@@ -44,6 +49,22 @@ final class ChatArtifactTextContainerView: UIView {
             textView.topAnchor.constraint(equalTo: topAnchor),
             textView.bottomAnchor.constraint(equalTo: bottomAnchor),
         ])
+    }
+
+    /// Exposes one bounded element so accessibility never enumerates TextKit line fragments.
+    func updateAccessibility(
+        documentID: String,
+        content: ChatArtifactTextAccessibilityContent
+    ) {
+        accessibilityLabel = URL(fileURLWithPath: documentID).lastPathComponent
+        accessibilityValue = content.excerpt
+        accessibilityHint = content.isTruncated
+            ? String(
+                localized: "chat.artifact.accessibility.large_text_truncated",
+                defaultValue: "Only the beginning of this large document is exposed to assistive technologies.",
+                bundle: .module
+            )
+            : nil
     }
 
     required init?(coder: NSCoder) {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextEndJumpTarget.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextEndJumpTarget.swift
@@ -1,0 +1,11 @@
+/// Semantic destination for the artifact viewer's trailing-edge jump.
+enum ChatArtifactTextEndJumpTarget: Equatable, Sendable {
+    /// Most recently loaded text while content is still streaming.
+    case latest
+    /// Final document end after EOF is known.
+    case end
+
+    init(reachedEOF: Bool) {
+        self = reachedEOF ? .end : .latest
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextStreamBatcher.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextStreamBatcher.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+/// Splits decoded artifact text into bounded main-actor presentation updates.
+struct ChatArtifactTextStreamBatcher: Sendable {
+    static let maximumBatchBytes = 256 * 1_024
+
+    let maximumBatchBytes: Int
+
+    init(maximumBatchBytes: Int = Self.maximumBatchBytes) {
+        self.maximumBatchBytes = max(1, maximumBatchBytes)
+    }
+
+    func batches(for text: String) -> [String] {
+        guard text.utf8.count > maximumBatchBytes else {
+            return text.isEmpty ? [] : [text]
+        }
+
+        var result: [String] = []
+        var start = text.startIndex
+        var remainingBytes = text.utf8.count
+        while start < text.endIndex {
+            guard remainingBytes > maximumBatchBytes else {
+                result.append(String(text[start...]))
+                break
+            }
+
+            let utf8Start = start.samePosition(in: text.utf8)!
+            var utf8End = text.utf8.index(utf8Start, offsetBy: maximumBatchBytes)
+            while String.Index(utf8End, within: text) == nil {
+                utf8End = text.utf8.index(before: utf8End)
+            }
+            let end = String.Index(utf8End, within: text)!
+            result.append(String(text[start..<end]))
+            remainingBytes -= text[start..<end].utf8.count
+            start = end
+        }
+        return result
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextUpdatePlan.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextUpdatePlan.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+/// Determines whether a TextKit update needs an expensive full-document snapshot.
+struct ChatArtifactTextUpdatePlan: Equatable, Sendable {
+    let requiresFullTextSnapshot: Bool
+
+    init(
+        reachedEOF: Bool,
+        highlightDecision: ChatArtifactHighlightDecision,
+        searchQuery: String
+    ) {
+        let requiresHighlightText: Bool
+        if reachedEOF, case .highlight = highlightDecision {
+            requiresHighlightText = true
+        } else {
+            requiresHighlightText = false
+        }
+        requiresFullTextSnapshot = requiresHighlightText || !searchQuery.isEmpty
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -44,6 +44,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
         if isNewDocument {
             context.coordinator.resetHighlighting()
             context.coordinator.resetSearch()
+            context.coordinator.resetAccessibilityContent()
             textView.textStorage.setAttributedString(NSAttributedString())
             textView.selectedRange = NSRange(location: 0, length: 0)
             context.coordinator.documentID = documentID
@@ -57,6 +58,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
             context.coordinator.appliedChunkCount = 0
             context.coordinator.resetHighlighting()
             context.coordinator.resetSearch()
+            context.coordinator.resetAccessibilityContent()
             textView.textStorage.setAttributedString(NSAttributedString())
         }
 
@@ -82,12 +84,21 @@ struct ChatArtifactTextView: UIViewRepresentable {
             textView.selectedRange = selection
             textView.setContentOffset(contentOffset, animated: false)
             context.coordinator.appliedChunkCount += 1
+            context.coordinator.appendAccessibilityContent(chunk)
         }
 
+        let updatePlan = ChatArtifactTextUpdatePlan(
+            reachedEOF: reachedEOF,
+            highlightDecision: highlightDecision,
+            searchQuery: searchQuery
+        )
+        let fullText = updatePlan.requiresFullTextSnapshot
+            ? textView.textStorage.string
+            : nil
         context.coordinator.updateHighlighting(
             in: textView,
             documentID: documentID,
-            text: textView.textStorage.string,
+            text: fullText,
             reachedEOF: reachedEOF,
             decision: highlightDecision,
             theme: highlightTheme
@@ -95,7 +106,8 @@ struct ChatArtifactTextView: UIViewRepresentable {
         context.coordinator.updateSearch(
             in: textView,
             documentID: documentID,
-            text: textView.textStorage.string,
+            text: fullText,
+            textLength: textView.textStorage.length,
             query: searchQuery,
             reachedEOF: reachedEOF,
             previousRequestID: previousSearchRequestID,
@@ -103,6 +115,10 @@ struct ChatArtifactTextView: UIViewRepresentable {
             onSummaryChanged: onSearchSummaryChanged
         )
         containerView.updateLineNumbers(index: lineIndex, isVisible: showsLineNumbers)
+        containerView.updateAccessibility(
+            documentID: documentID,
+            content: context.coordinator.accessibilityContent
+        )
 
         if isNewDocument {
             Self.scrollToTop(textView, animated: false)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -42,20 +42,20 @@ struct ChatArtifactTextView: UIViewRepresentable {
         context.coordinator.onFontSizeChanged = onFontSizeChanged
         let isNewDocument = context.coordinator.documentID != documentID
         if isNewDocument {
+            context.coordinator.resetStreamingText()
             context.coordinator.resetHighlighting()
             context.coordinator.resetSearch()
             context.coordinator.resetAccessibilityContent()
             textView.textStorage.setAttributedString(NSAttributedString())
             textView.selectedRange = NSRange(location: 0, length: 0)
             context.coordinator.documentID = documentID
-            context.coordinator.appliedChunkCount = 0
             context.coordinator.handledTopRequestID = topRequestID
             context.coordinator.handledBottomRequestID = bottomRequestID
             context.coordinator.handledGoToLineRequestID = goToLineRequestID
         }
 
         if context.coordinator.appliedChunkCount > chunks.count {
-            context.coordinator.appliedChunkCount = 0
+            context.coordinator.resetStreamingText()
             context.coordinator.resetHighlighting()
             context.coordinator.resetSearch()
             context.coordinator.resetAccessibilityContent()
@@ -74,83 +74,72 @@ struct ChatArtifactTextView: UIViewRepresentable {
             .font: font,
             .foregroundColor: textColor,
         ]
-        while context.coordinator.appliedChunkCount < chunks.count {
-            let chunk = chunks[context.coordinator.appliedChunkCount]
-            let contentOffset = textView.contentOffset
-            let selection = textView.selectedRange
-            textView.textStorage.beginEditing()
-            textView.textStorage.append(NSAttributedString(string: chunk, attributes: attributes))
-            textView.textStorage.endEditing()
-            textView.selectedRange = selection
-            textView.setContentOffset(contentOffset, animated: false)
-            context.coordinator.appliedChunkCount += 1
-            context.coordinator.appendAccessibilityContent(chunk)
+        if context.coordinator.appliedChunkCount < chunks.count {
+            context.coordinator.enqueueTextChunks(
+                chunks[context.coordinator.appliedChunkCount...],
+                attributes: attributes,
+                in: textView
+            )
         }
 
-        let updatePlan = ChatArtifactTextUpdatePlan(
-            reachedEOF: reachedEOF,
-            highlightDecision: highlightDecision,
-            searchQuery: searchQuery
-        )
-        let fullText = updatePlan.requiresFullTextSnapshot
-            ? textView.textStorage.string
-            : nil
-        context.coordinator.updateHighlighting(
-            in: textView,
-            documentID: documentID,
-            text: fullText,
-            reachedEOF: reachedEOF,
-            decision: highlightDecision,
-            theme: highlightTheme
-        )
-        context.coordinator.updateSearch(
-            in: textView,
-            documentID: documentID,
-            text: fullText,
-            textLength: textView.textStorage.length,
-            query: searchQuery,
-            reachedEOF: reachedEOF,
-            previousRequestID: previousSearchRequestID,
-            nextRequestID: nextSearchRequestID,
-            onSummaryChanged: onSearchSummaryChanged
-        )
-        containerView.updateLineNumbers(index: lineIndex, isVisible: showsLineNumbers)
+        let coordinator = context.coordinator
+        coordinator.schedulePostAppendWork { [weak coordinator, weak textView] in
+            guard let coordinator, let textView else { return }
+            let updatePlan = ChatArtifactTextUpdatePlan(
+                reachedEOF: reachedEOF,
+                highlightDecision: highlightDecision,
+                searchQuery: searchQuery
+            )
+            let fullText = updatePlan.requiresFullTextSnapshot
+                ? textView.textStorage.string
+                : nil
+            coordinator.updateHighlighting(
+                in: textView,
+                documentID: documentID,
+                text: fullText,
+                reachedEOF: reachedEOF,
+                decision: highlightDecision,
+                theme: highlightTheme
+            )
+            coordinator.updateSearch(
+                in: textView,
+                documentID: documentID,
+                text: fullText,
+                textLength: textView.textStorage.length,
+                query: searchQuery,
+                reachedEOF: reachedEOF,
+                previousRequestID: previousSearchRequestID,
+                nextRequestID: nextSearchRequestID,
+                onSummaryChanged: onSearchSummaryChanged
+            )
+        }
+        coordinator.updateLineNumbers(index: lineIndex, isVisible: showsLineNumbers)
         containerView.updateAccessibility(
             documentID: documentID,
             content: context.coordinator.accessibilityContent
         )
 
         if isNewDocument {
-            Self.scrollToTop(textView, animated: false)
+            coordinator.scrollToTop(in: textView, animated: false)
         } else {
-            if context.coordinator.handledTopRequestID != topRequestID {
-                context.coordinator.handledTopRequestID = topRequestID
-                Self.scrollToTop(textView, animated: true)
+            if coordinator.handledTopRequestID != topRequestID {
+                coordinator.handledTopRequestID = topRequestID
+                coordinator.scrollToTop(in: textView, animated: true)
             }
-            if context.coordinator.handledBottomRequestID != bottomRequestID {
-                context.coordinator.handledBottomRequestID = bottomRequestID
+            if coordinator.handledBottomRequestID != bottomRequestID {
+                coordinator.handledBottomRequestID = bottomRequestID
                 textView.scrollRangeToVisible(
                     NSRange(location: textView.textStorage.length, length: 0)
                 )
             }
-            if context.coordinator.handledGoToLineRequestID != goToLineRequestID {
-                context.coordinator.handledGoToLineRequestID = goToLineRequestID
+            if coordinator.handledGoToLineRequestID != goToLineRequestID {
+                coordinator.handledGoToLineRequestID = goToLineRequestID
                 textView.scrollRangeToVisible(NSRange(
                     location: min(max(goToLineUTF16Offset, 0), textView.textStorage.length),
                     length: 0
                 ))
             }
         }
-    }
-
-    private static func scrollToTop(_ textView: UITextView, animated: Bool) {
-        textView.setContentOffset(
-            CGPoint(
-                x: -textView.adjustedContentInset.left,
-                y: -textView.adjustedContentInset.top
-            ),
-            animated: animated
-        )
     }
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextView.swift
@@ -50,7 +50,7 @@ struct ChatArtifactTextView: UIViewRepresentable {
             textView.selectedRange = NSRange(location: 0, length: 0)
             context.coordinator.documentID = documentID
             context.coordinator.handledTopRequestID = topRequestID
-            context.coordinator.handledBottomRequestID = bottomRequestID
+            context.coordinator.handledBottomRequestID = 0
             context.coordinator.handledGoToLineRequestID = goToLineRequestID
         }
 
@@ -121,25 +121,22 @@ struct ChatArtifactTextView: UIViewRepresentable {
 
         if isNewDocument {
             coordinator.scrollToTop(in: textView, animated: false)
-        } else {
-            if coordinator.handledTopRequestID != topRequestID {
-                coordinator.handledTopRequestID = topRequestID
-                coordinator.scrollToTop(in: textView, animated: true)
-            }
-            if coordinator.handledBottomRequestID != bottomRequestID {
-                coordinator.handledBottomRequestID = bottomRequestID
-                textView.scrollRangeToVisible(
-                    NSRange(location: textView.textStorage.length, length: 0)
-                )
-            }
-            if coordinator.handledGoToLineRequestID != goToLineRequestID {
-                coordinator.handledGoToLineRequestID = goToLineRequestID
-                textView.scrollRangeToVisible(NSRange(
-                    location: min(max(goToLineUTF16Offset, 0), textView.textStorage.length),
-                    length: 0
-                ))
-            }
+        } else if coordinator.handledTopRequestID != topRequestID {
+            coordinator.handledTopRequestID = topRequestID
+            coordinator.scrollToTop(in: textView, animated: true)
         }
+        if coordinator.handledBottomRequestID != bottomRequestID {
+            coordinator.handledBottomRequestID = bottomRequestID
+            coordinator.requestEndJump(
+                ChatArtifactTextEndJumpTarget(reachedEOF: reachedEOF),
+                in: textView
+            )
+        }
+        if coordinator.handledGoToLineRequestID != goToLineRequestID {
+            coordinator.handledGoToLineRequestID = goToLineRequestID
+            coordinator.scrollToUTF16Offset(goToLineUTF16Offset, in: textView)
+        }
+        coordinator.reconcileEndJump(reachedEOF: reachedEOF, in: textView)
     }
 }
 #endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -17,6 +17,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     private var pendingTextAttributes: [NSAttributedString.Key: Any] = [:]
     private var pendingLineNumberUpdate: (index: ChatArtifactLineIndex, isVisible: Bool)?
     private var latestPostAppendWork: (() -> Void)?
+    private var endJumpTarget: ChatArtifactTextEndJumpTarget?
     private weak var containerView: ChatArtifactTextContainerView?
     private let syntaxHighlighter = ChatArtifactSyntaxHighlighter()
     private var highlightTask: Task<Void, Never>?
@@ -67,6 +68,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     }
 
     func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        endJumpTarget = nil
         appendPolicy.beginTracking()
         suspendTextStorageWork()
     }
@@ -98,6 +100,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
         pendingTextAttributes.removeAll(keepingCapacity: false)
         pendingLineNumberUpdate = nil
         latestPostAppendWork = nil
+        endJumpTarget = nil
         appliedChunkCount = 0
     }
 
@@ -130,6 +133,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     }
 
     func scrollToTop(in textView: UITextView, animated: Bool) {
+        endJumpTarget = nil
         let target = CGPoint(
             x: -textView.adjustedContentInset.left,
             y: -textView.adjustedContentInset.top
@@ -144,6 +148,30 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
         textView.setContentOffset(target, animated: requiresAnimation)
     }
 
+    func requestEndJump(
+        _ target: ChatArtifactTextEndJumpTarget,
+        in textView: UITextView
+    ) {
+        endJumpTarget = target
+        scrollToDocumentEnd(in: textView, animated: true)
+        settleEndJumpIfReady(in: textView)
+    }
+
+    func reconcileEndJump(reachedEOF: Bool, in textView: UITextView) {
+        if reachedEOF, endJumpTarget == .latest {
+            endJumpTarget = .end
+        }
+        settleEndJumpIfReady(in: textView)
+    }
+
+    func scrollToUTF16Offset(_ offset: Int, in textView: UITextView) {
+        endJumpTarget = nil
+        textView.scrollRangeToVisible(NSRange(
+            location: min(max(offset, 0), textView.textStorage.length),
+            length: 0
+        ))
+    }
+
     private func resumeDeferredUpdates(
         releasedChunkCount: Int,
         in textView: UITextView?
@@ -154,6 +182,9 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
         }
         applyPendingLineNumbersIfReady()
         runPostAppendWorkIfReady()
+        if let textView {
+            settleEndJumpIfReady(in: textView)
+        }
     }
 
     private func flushPendingText(releasedChunkCount: Int, in textView: UITextView) {
@@ -176,8 +207,63 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
         textView.selectedRange = selection
         textView.setContentOffset(contentOffset, animated: false)
 
+        settleEndJumpIfReady(in: textView)
         applyPendingLineNumbersIfReady()
         runPostAppendWorkIfReady()
+    }
+
+    /// Replays a durable latest/end intent after streamed edits become visible.
+    private func settleEndJumpIfReady(in textView: UITextView) {
+        guard let target = endJumpTarget,
+              !appendPolicy.isDeferring,
+              pendingTextChunks.isEmpty else { return }
+        scrollToDocumentEnd(in: textView, animated: false)
+        if target == .end {
+            endJumpTarget = nil
+        }
+    }
+
+    /// Lays out only the final TextKit 1 character range and scrolls to its true bottom.
+    private func scrollToDocumentEnd(in textView: UITextView, animated: Bool) {
+        let minimumY = -textView.adjustedContentInset.top
+        var documentBottom = textView.textContainerInset.top
+            + textView.textContainerInset.bottom
+        if textView.textStorage.length > 0 {
+            let finalCharacterRange = NSRange(
+                location: textView.textStorage.length - 1,
+                length: 1
+            )
+            textView.layoutManager.allowsNonContiguousLayout = true
+            textView.layoutManager.ensureLayout(forCharacterRange: finalCharacterRange)
+            let finalGlyphRange = textView.layoutManager.glyphRange(
+                forCharacterRange: finalCharacterRange,
+                actualCharacterRange: nil
+            )
+            let finalGlyphRect = textView.layoutManager.boundingRect(
+                forGlyphRange: finalGlyphRange,
+                in: textView.textContainer
+            )
+            documentBottom += max(
+                finalGlyphRect.maxY,
+                textView.layoutManager.extraLineFragmentRect.maxY
+            )
+        }
+        let target = CGPoint(
+            x: textView.contentOffset.x,
+            y: max(
+                minimumY,
+                documentBottom
+                    - textView.bounds.height
+                    + textView.adjustedContentInset.bottom
+            )
+        )
+        let requiresAnimation = animated
+            && abs(textView.contentOffset.y - target.y) > 0.5
+        if requiresAnimation {
+            appendPolicy.beginProgrammaticAnimation()
+            suspendTextStorageWork()
+        }
+        textView.setContentOffset(target, animated: requiresAnimation)
     }
 
     private func applyPendingLineNumbersIfReady() {
@@ -553,6 +639,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
         )
         appliedSearchRange = currentRange
         if scrollToMatch {
+            endJumpTarget = nil
             textView.scrollRangeToVisible(currentRange)
         }
     }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -11,6 +11,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     var handledBottomRequestID = 0
     var handledGoToLineRequestID = 0
     var onFontSizeChanged: ((Double) -> Void)?
+    private(set) var accessibilityContent = ChatArtifactTextAccessibilityContent()
     private weak var containerView: ChatArtifactTextContainerView?
     private let syntaxHighlighter = ChatArtifactSyntaxHighlighter()
     private var highlightTask: Task<Void, Never>?
@@ -153,15 +154,24 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
         publishSearchSummary(.empty)
     }
 
+    func resetAccessibilityContent() {
+        accessibilityContent = ChatArtifactTextAccessibilityContent()
+    }
+
+    func appendAccessibilityContent(_ text: String) {
+        accessibilityContent.append(text)
+    }
+
     func updateHighlighting(
         in textView: UITextView,
         documentID: String,
-        text: String,
+        text: String?,
         reachedEOF: Bool,
         decision: ChatArtifactHighlightDecision,
         theme: ChatArtifactHighlightTheme
     ) {
-        guard reachedEOF,
+        guard let text,
+              reachedEOF,
               case .highlight(let language) = decision,
               !text.isEmpty else {
             highlightTask?.cancel()
@@ -221,7 +231,8 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     func updateSearch(
         in textView: UITextView,
         documentID: String,
-        text: String,
+        text: String?,
+        textLength: Int,
         query: String,
         reachedEOF: Bool,
         previousRequestID: Int,
@@ -236,7 +247,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
             clearSearchHighlight(in: textView)
             searchModel = ChatArtifactSearchModel()
             searchedDocumentID = documentID
-            searchedTextLength = text.utf16.count
+            searchedTextLength = textLength
             pendingSearchDocumentID = nil
             pendingSearchTextLength = 0
             pendingSearchQuery = ""
@@ -246,6 +257,7 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
             return
         }
 
+        guard let text else { return }
         let textLength = text.utf16.count
         let hasCurrentResults = searchedDocumentID == documentID
             && searchedTextLength == textLength

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactTextViewCoordinator.swift
@@ -12,6 +12,11 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
     var handledGoToLineRequestID = 0
     var onFontSizeChanged: ((Double) -> Void)?
     private(set) var accessibilityContent = ChatArtifactTextAccessibilityContent()
+    private var appendPolicy = ChatArtifactTextAppendPolicy()
+    private var pendingTextChunks: [String] = []
+    private var pendingTextAttributes: [NSAttributedString.Key: Any] = [:]
+    private var pendingLineNumberUpdate: (index: ChatArtifactLineIndex, isVisible: Bool)?
+    private var latestPostAppendWork: (() -> Void)?
     private weak var containerView: ChatArtifactTextContainerView?
     private let syntaxHighlighter = ChatArtifactSyntaxHighlighter()
     private var highlightTask: Task<Void, Never>?
@@ -59,6 +64,151 @@ final class ChatArtifactTextViewCoordinator: NSObject, UITextViewDelegate {
 
     func scrollViewDidScroll(_ scrollView: UIScrollView) {
         containerView?.gutterView.setNeedsDisplay()
+    }
+
+    func scrollViewWillBeginDragging(_ scrollView: UIScrollView) {
+        appendPolicy.beginTracking()
+        suspendTextStorageWork()
+    }
+
+    func scrollViewDidEndDragging(_ scrollView: UIScrollView, willDecelerate decelerate: Bool) {
+        resumeDeferredUpdates(
+            releasedChunkCount: appendPolicy.endTracking(willDecelerate: decelerate),
+            in: scrollView as? UITextView
+        )
+    }
+
+    func scrollViewDidEndDecelerating(_ scrollView: UIScrollView) {
+        resumeDeferredUpdates(
+            releasedChunkCount: appendPolicy.endDecelerating(),
+            in: scrollView as? UITextView
+        )
+    }
+
+    func scrollViewDidEndScrollingAnimation(_ scrollView: UIScrollView) {
+        resumeDeferredUpdates(
+            releasedChunkCount: appendPolicy.endProgrammaticAnimation(),
+            in: scrollView as? UITextView
+        )
+    }
+
+    func resetStreamingText() {
+        appendPolicy.reset()
+        pendingTextChunks.removeAll(keepingCapacity: false)
+        pendingTextAttributes.removeAll(keepingCapacity: false)
+        pendingLineNumberUpdate = nil
+        latestPostAppendWork = nil
+        appliedChunkCount = 0
+    }
+
+    func enqueueTextChunks(
+        _ chunks: ArraySlice<String>,
+        attributes: [NSAttributedString.Key: Any],
+        in textView: UITextView
+    ) {
+        guard !chunks.isEmpty else { return }
+        pendingTextChunks.append(contentsOf: chunks)
+        pendingTextAttributes = attributes
+        appliedChunkCount += chunks.count
+        for chunk in chunks {
+            appendAccessibilityContent(chunk)
+        }
+        let releasedChunkCount = appendPolicy.enqueue(chunkCount: chunks.count)
+        if releasedChunkCount > 0 {
+            flushPendingText(releasedChunkCount: releasedChunkCount, in: textView)
+        }
+    }
+
+    func updateLineNumbers(index: ChatArtifactLineIndex, isVisible: Bool) {
+        pendingLineNumberUpdate = (index, isVisible)
+        applyPendingLineNumbersIfReady()
+    }
+
+    func schedulePostAppendWork(_ work: @escaping () -> Void) {
+        latestPostAppendWork = work
+        runPostAppendWorkIfReady()
+    }
+
+    func scrollToTop(in textView: UITextView, animated: Bool) {
+        let target = CGPoint(
+            x: -textView.adjustedContentInset.left,
+            y: -textView.adjustedContentInset.top
+        )
+        let requiresAnimation = animated
+            && (abs(textView.contentOffset.x - target.x) > 0.5
+                || abs(textView.contentOffset.y - target.y) > 0.5)
+        if requiresAnimation {
+            appendPolicy.beginProgrammaticAnimation()
+            suspendTextStorageWork()
+        }
+        textView.setContentOffset(target, animated: requiresAnimation)
+    }
+
+    private func resumeDeferredUpdates(
+        releasedChunkCount: Int,
+        in textView: UITextView?
+    ) {
+        if releasedChunkCount > 0, let textView {
+            flushPendingText(releasedChunkCount: releasedChunkCount, in: textView)
+            return
+        }
+        applyPendingLineNumbersIfReady()
+        runPostAppendWorkIfReady()
+    }
+
+    private func flushPendingText(releasedChunkCount: Int, in textView: UITextView) {
+        guard !appendPolicy.isDeferring, !pendingTextChunks.isEmpty else { return }
+        assert(releasedChunkCount == pendingTextChunks.count)
+
+        let text = pendingTextChunks.joined()
+        pendingTextChunks.removeAll(keepingCapacity: true)
+        let attributes = pendingTextAttributes
+        pendingTextAttributes.removeAll(keepingCapacity: true)
+        let contentOffset = textView.contentOffset
+        let selection = textView.selectedRange
+
+        // TextKit can reset this optimization when its stack is rebuilt. Keep
+        // it explicit at the edit boundary so appends only lay out the viewport.
+        textView.layoutManager.allowsNonContiguousLayout = true
+        textView.textStorage.beginEditing()
+        textView.textStorage.append(NSAttributedString(string: text, attributes: attributes))
+        textView.textStorage.endEditing()
+        textView.selectedRange = selection
+        textView.setContentOffset(contentOffset, animated: false)
+
+        applyPendingLineNumbersIfReady()
+        runPostAppendWorkIfReady()
+    }
+
+    private func applyPendingLineNumbersIfReady() {
+        guard !appendPolicy.isDeferring,
+              pendingTextChunks.isEmpty,
+              let update = pendingLineNumberUpdate else { return }
+        pendingLineNumberUpdate = nil
+        containerView?.updateLineNumbers(index: update.index, isVisible: update.isVisible)
+    }
+
+    private func runPostAppendWorkIfReady() {
+        guard !appendPolicy.isDeferring,
+              pendingTextChunks.isEmpty else { return }
+        latestPostAppendWork?()
+    }
+
+    private func suspendTextStorageWork() {
+        highlightTask?.cancel()
+        highlightTask = nil
+        highlightGeneration += 1
+        pendingHighlightDocumentID = nil
+        pendingHighlightTextLength = 0
+        pendingHighlightLanguage = nil
+        pendingHighlightTheme = nil
+
+        searchTask?.cancel()
+        searchTask = nil
+        searchGeneration += 1
+        pendingSearchDocumentID = nil
+        pendingSearchTextLength = 0
+        pendingSearchQuery = ""
     }
 
     func updateFontSize(in textView: UITextView, pointSize: Double) {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerFileActionState.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerFileActionState.swift
@@ -1,0 +1,8 @@
+/// Immutable system-presentation state owned by one artifact page.
+struct ChatArtifactViewerFileActionState: Equatable {
+    #if os(iOS)
+    var presentation: ChatArtifactFileActionPresentation? = nil
+    #endif
+    var isRunning = false
+    var showsError = false
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerHostedPage.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerHostedPage.swift
@@ -1,0 +1,37 @@
+#if os(iOS)
+import QuickLook
+import SwiftUI
+
+/// Gives one path one stable SwiftUI hosting root inside the UIKit pager.
+struct ChatArtifactViewerHostedPage: View {
+    let model: ChatArtifactViewerPageModel
+    let scope: ChatArtifactViewerScope
+    let loader: ChatArtifactLoader
+    let onImageMinimumZoomChanged: (String, Bool) -> Void
+    let onDone: () -> Void
+
+    var path: String { model.path }
+
+    var body: some View {
+        let snapshot = model.snapshot
+        ChatArtifactViewerRouteView(
+            snapshot: snapshot,
+            scope: scope,
+            actions: model.actions(
+                loader: loader,
+                quickLookCanPreview: { fileURL in
+                    QLPreviewController.canPreview(ChatArtifactQuickLookItem(
+                        fileURL: fileURL,
+                        title: snapshot.displayName
+                    ))
+                }
+            ),
+            onImageMinimumZoomChanged: {
+                onImageMinimumZoomChanged(snapshot.path, $0)
+            },
+            onDone: onDone
+        )
+        .clipped()
+    }
+}
+#endif

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -191,14 +191,32 @@ final class ChatArtifactViewerModel {
             size: stat.size
         ) { chunk in
             try Task.checkCancellation()
-            let decoded = try await decoder.decode(chunk.data, eof: chunk.eof)
+            let decodedBatches = try await decoder.decodeBatches(chunk.data, eof: chunk.eof)
             try Task.checkCancellation()
-            await self.receiveText(
-                decoded,
-                chunk: chunk,
-                path: path,
-                isMarkdown: isMarkdown
-            )
+            if decodedBatches.isEmpty {
+                await self.receiveText(
+                    "",
+                    chunk: chunk,
+                    path: path,
+                    isMarkdown: isMarkdown,
+                    isFinalBatch: true
+                )
+            } else {
+                for (index, decoded) in decodedBatches.enumerated() {
+                    try Task.checkCancellation()
+                    let isFinalBatch = index == decodedBatches.index(before: decodedBatches.endIndex)
+                    await self.receiveText(
+                        decoded,
+                        chunk: chunk,
+                        path: path,
+                        isMarkdown: isMarkdown,
+                        isFinalBatch: isFinalBatch
+                    )
+                    if !isFinalBatch {
+                        await Task.yield()
+                    }
+                }
+            }
         }
     }
 
@@ -206,15 +224,18 @@ final class ChatArtifactViewerModel {
         _ text: String,
         chunk: ChatArtifactChunk,
         path: String,
-        isMarkdown: Bool
+        isMarkdown: Bool,
+        isFinalBatch: Bool
     ) {
         guard path == activePath else { return }
         if !text.isEmpty {
             textChunks.append(text)
             textLineIndex.append(text)
         }
-        updateProgress(for: chunk)
-        textReachedEOF = chunk.eof
+        if isFinalBatch {
+            updateProgress(for: chunk)
+            textReachedEOF = chunk.eof
+        }
         state = isMarkdown ? .markdown : .text
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerModel.swift
@@ -205,8 +205,13 @@ final class ChatArtifactViewerModel {
                 for (index, decoded) in decodedBatches.enumerated() {
                     try Task.checkCancellation()
                     let isFinalBatch = index == decodedBatches.index(before: decodedBatches.endIndex)
+                    let lineIndexBatch = await Task.detached(priority: .userInitiated) {
+                        ChatArtifactLineIndexBatch(text: decoded)
+                    }.value
+                    try Task.checkCancellation()
                     await self.receiveText(
                         decoded,
+                        lineIndexBatch: lineIndexBatch,
                         chunk: chunk,
                         path: path,
                         isMarkdown: isMarkdown,
@@ -222,6 +227,7 @@ final class ChatArtifactViewerModel {
 
     private func receiveText(
         _ text: String,
+        lineIndexBatch: ChatArtifactLineIndexBatch? = nil,
         chunk: ChatArtifactChunk,
         path: String,
         isMarkdown: Bool,
@@ -230,7 +236,11 @@ final class ChatArtifactViewerModel {
         guard path == activePath else { return }
         if !text.isEmpty {
             textChunks.append(text)
-            textLineIndex.append(text)
+            if let lineIndexBatch {
+                textLineIndex.append(lineIndexBatch)
+            } else {
+                textLineIndex.append(text)
+            }
         }
         if isFinalBatch {
             updateProgress(for: chunk)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageActions.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageActions.swift
@@ -1,0 +1,17 @@
+import Foundation
+
+/// Closure actions let a viewer page mutate its owner without retaining an observable model.
+struct ChatArtifactViewerPageActions {
+    let load: @MainActor () async -> Void
+    let cleanup: @MainActor () async -> Void
+    let retry: @MainActor () -> Void
+    let setSearchQuery: @MainActor (String) -> Void
+    let setSearchSummary: @MainActor (ChatArtifactSearchSummary) -> Void
+    let selectPreviousSearchResult: @MainActor () -> Void
+    let selectNextSearchResult: @MainActor () -> Void
+    let dismissSearch: @MainActor () -> Void
+    let setGoToLineText: @MainActor (String) -> Void
+    let goToLine: @MainActor (Int) -> Void
+    let dismissGoToLine: @MainActor () -> Void
+    let setFontSize: @MainActor (Double) -> Void
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageModel.swift
@@ -1,0 +1,220 @@
+import CmuxAgentChat
+import Foundation
+import Observation
+
+/// Owns mutable content and controls for one stable artifact path.
+@Observable
+@MainActor
+final class ChatArtifactViewerPageModel {
+    let path: String
+
+    private let viewerModel: ChatArtifactViewerModel
+    private let textPreferences: ChatArtifactTextPreferences
+    private let textLayoutKind: ChatArtifactTextLayoutKind
+    private(set) var retryGeneration = 0
+    private(set) var topRequestID = 0
+    private(set) var bottomRequestID = 0
+    private(set) var isSearchPresented = false
+    private(set) var searchQuery = ""
+    private(set) var searchSummary = ChatArtifactSearchSummary.empty
+    private(set) var previousSearchRequestID = 0
+    private(set) var nextSearchRequestID = 0
+    private(set) var showsLineNumbers = true
+    private(set) var isGoToLinePresented = false
+    private(set) var goToLineText = ""
+    private(set) var goToLineUTF16Offset = 0
+    private(set) var goToLineRequestID = 0
+    private(set) var wrapsLines: Bool
+    private(set) var textFontSize: Double
+    private(set) var fileActionState = ChatArtifactViewerFileActionState()
+
+    init(
+        path: String,
+        textPreferences: ChatArtifactTextPreferences,
+        viewerModel: ChatArtifactViewerModel = ChatArtifactViewerModel()
+    ) {
+        self.path = path
+        self.textPreferences = textPreferences
+        self.viewerModel = viewerModel
+        let layoutKind = ChatArtifactTextLayoutKind(path: path)
+        textLayoutKind = layoutKind
+        wrapsLines = textPreferences.wrapsLines(for: layoutKind)
+        textFontSize = textPreferences.fontSize(for: layoutKind)
+    }
+
+    var snapshot: ChatArtifactViewerPageSnapshot {
+        ChatArtifactViewerPageSnapshot(
+            path: path,
+            state: viewerModel.state,
+            textChunks: viewerModel.textChunks,
+            fetchedBytes: viewerModel.fetchedBytes,
+            totalBytes: viewerModel.totalBytes,
+            textReachedEOF: viewerModel.textReachedEOF,
+            markdownPresentation: viewerModel.markdownPresentation,
+            textHighlightDecision: viewerModel.textHighlightDecision,
+            textLineIndex: viewerModel.textLineIndex,
+            hasFileActions: viewerModel.hasFileActions,
+            isTextFile: viewerModel.isTextFile,
+            canCopyContents: viewerModel.canCopyContents,
+            retryGeneration: retryGeneration,
+            topRequestID: topRequestID,
+            bottomRequestID: bottomRequestID,
+            isSearchPresented: isSearchPresented,
+            searchQuery: searchQuery,
+            searchSummary: searchSummary,
+            previousSearchRequestID: previousSearchRequestID,
+            nextSearchRequestID: nextSearchRequestID,
+            showsLineNumbers: showsLineNumbers,
+            isGoToLinePresented: isGoToLinePresented,
+            goToLineText: goToLineText,
+            goToLineUTF16Offset: goToLineUTF16Offset,
+            goToLineRequestID: goToLineRequestID,
+            wrapsLines: wrapsLines,
+            textFontSize: textFontSize,
+            fileActionState: fileActionState
+        )
+    }
+
+    func load(
+        loader: ChatArtifactLoader,
+        quickLookCanPreview: @MainActor (URL) -> Bool
+    ) async {
+        await viewerModel.load(
+            path: path,
+            loader: loader,
+            quickLookCanPreview: quickLookCanPreview
+        )
+    }
+
+    func cleanup() async {
+        await viewerModel.cleanup()
+    }
+
+    func retry() {
+        retryGeneration += 1
+    }
+
+    func toggleSearch() {
+        if isSearchPresented {
+            dismissSearch()
+        } else {
+            dismissGoToLine()
+            isSearchPresented = true
+        }
+    }
+
+    func dismissSearch() {
+        isSearchPresented = false
+        searchQuery = ""
+        searchSummary = .empty
+    }
+
+    func setSearchQuery(_ query: String) {
+        searchQuery = query
+    }
+
+    func setSearchSummary(_ summary: ChatArtifactSearchSummary) {
+        searchSummary = summary
+    }
+
+    func selectPreviousSearchResult() {
+        previousSearchRequestID += 1
+    }
+
+    func selectNextSearchResult() {
+        nextSearchRequestID += 1
+    }
+
+    func toggleGoToLine() {
+        if isGoToLinePresented {
+            dismissGoToLine()
+        } else {
+            dismissSearch()
+            isGoToLinePresented = true
+        }
+    }
+
+    func dismissGoToLine() {
+        isGoToLinePresented = false
+        goToLineText = ""
+    }
+
+    func setGoToLineText(_ text: String) {
+        goToLineText = text
+    }
+
+    func goToLine(_ requestedLine: Int) {
+        let line = viewerModel.textLineIndex.clampedLine(requestedLine)
+        goToLineText = String(line)
+        goToLineUTF16Offset = viewerModel.textLineIndex.offset(forLine: line)
+        goToLineRequestID += 1
+    }
+
+    func requestTop() {
+        topRequestID += 1
+    }
+
+    func requestBottom() {
+        bottomRequestID += 1
+    }
+
+    func toggleLineNumbers() {
+        showsLineNumbers.toggle()
+    }
+
+    func toggleWordWrap() {
+        wrapsLines.toggle()
+        textPreferences.setWrapsLines(wrapsLines, for: textLayoutKind)
+    }
+
+    func setFontSize(_ fontSize: Double) {
+        textFontSize = textPreferences.setFontSize(fontSize, for: textLayoutKind)
+    }
+
+    func selectMarkdownMode(_ mode: ChatArtifactMarkdownMode) {
+        if mode == .rendered {
+            dismissSearch()
+            dismissGoToLine()
+        }
+        viewerModel.selectMarkdownMode(mode)
+    }
+
+    #if os(iOS)
+    func prepareShare(loader: ChatArtifactLoader) async {
+        await prepareFileAction(loader: loader, presentation: ChatArtifactFileActionPresentation.share)
+    }
+
+    func prepareSave(loader: ChatArtifactLoader) async {
+        await prepareFileAction(loader: loader, presentation: ChatArtifactFileActionPresentation.save)
+    }
+
+    func setFileActionPresentation(_ presentation: ChatArtifactFileActionPresentation?) {
+        fileActionState.presentation = presentation
+    }
+
+    func setShowsFileActionError(_ isPresented: Bool) {
+        fileActionState.showsError = isPresented
+    }
+
+    private func prepareFileAction(
+        loader: ChatArtifactLoader,
+        presentation: (URL) -> ChatArtifactFileActionPresentation
+    ) async {
+        guard !fileActionState.isRunning else { return }
+        fileActionState.isRunning = true
+        defer { fileActionState.isRunning = false }
+        do {
+            let fileURL = try await ChatArtifactFileActionStore.applicationDefault.materialize(
+                path: path,
+                loader: loader
+            )
+            try Task.checkCancellation()
+            fileActionState.presentation = presentation(fileURL)
+        } catch is CancellationError {
+            return
+        } catch {
+            fileActionState.showsError = true
+        }
+    }
+    #endif
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageModel.swift
@@ -90,6 +90,31 @@ final class ChatArtifactViewerPageModel {
         await viewerModel.cleanup()
     }
 
+    func actions(
+        loader: ChatArtifactLoader,
+        quickLookCanPreview: @escaping @MainActor (URL) -> Bool
+    ) -> ChatArtifactViewerPageActions {
+        ChatArtifactViewerPageActions(
+            load: {
+                await self.load(
+                    loader: loader,
+                    quickLookCanPreview: quickLookCanPreview
+                )
+            },
+            cleanup: { await self.cleanup() },
+            retry: { self.retry() },
+            setSearchQuery: { self.setSearchQuery($0) },
+            setSearchSummary: { self.setSearchSummary($0) },
+            selectPreviousSearchResult: { self.selectPreviousSearchResult() },
+            selectNextSearchResult: { self.selectNextSearchResult() },
+            dismissSearch: { self.dismissSearch() },
+            setGoToLineText: { self.setGoToLineText($0) },
+            goToLine: { self.goToLine($0) },
+            dismissGoToLine: { self.dismissGoToLine() },
+            setFontSize: { self.setFontSize($0) }
+        )
+    }
+
     func retry() {
         retryGeneration += 1
     }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageSnapshot.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageSnapshot.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// Immutable render state for one path-keyed artifact viewer page.
+struct ChatArtifactViewerPageSnapshot: Identifiable, Equatable {
+    let path: String
+    let state: ChatArtifactViewerState
+    let textChunks: [String]
+    let fetchedBytes: Int64
+    let totalBytes: Int64?
+    let textReachedEOF: Bool
+    let markdownPresentation: ChatArtifactMarkdownPresentation
+    let textHighlightDecision: ChatArtifactHighlightDecision
+    let textLineIndex: ChatArtifactLineIndex
+    let hasFileActions: Bool
+    let isTextFile: Bool
+    let canCopyContents: Bool
+    let retryGeneration: Int
+    let topRequestID: Int
+    let bottomRequestID: Int
+    let isSearchPresented: Bool
+    let searchQuery: String
+    let searchSummary: ChatArtifactSearchSummary
+    let previousSearchRequestID: Int
+    let nextSearchRequestID: Int
+    let showsLineNumbers: Bool
+    let isGoToLinePresented: Bool
+    let goToLineText: String
+    let goToLineUTF16Offset: Int
+    let goToLineRequestID: Int
+    let wrapsLines: Bool
+    let textFontSize: Double
+    let fileActionState: ChatArtifactViewerFileActionState
+
+    var id: String { path }
+
+    var displayName: String {
+        URL(fileURLWithPath: path).lastPathComponent
+    }
+
+    var renderedText: String {
+        textChunks.joined()
+    }
+
+    var shouldShowTextJumpControls: Bool {
+        state == .text
+            || (state == .markdown && markdownPresentation.mode == .raw)
+    }
+
+    var hasViewerActions: Bool {
+        hasFileActions
+            || shouldShowTextJumpControls
+            || (state == .markdown && markdownPresentation.isRenderedAvailable)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageSnapshot.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPageSnapshot.swift
@@ -51,4 +51,10 @@ struct ChatArtifactViewerPageSnapshot: Identifiable, Equatable {
             || shouldShowTextJumpControls
             || (state == .markdown && markdownPresentation.isRenderedAvailable)
     }
+
+    var showsHighlightingStatusPill: Bool {
+        shouldShowTextJumpControls
+            && textHighlightDecision.showsHighlightingOffPill
+            && totalBytes != nil
+    }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
@@ -86,15 +86,11 @@ struct ChatArtifactViewerPager: View {
     private var pagerContent: some View {
         #if os(iOS)
         if model.usesPaging {
-            TabView(selection: selectionBinding) {
-                ForEach(model.pageSnapshots) { snapshot in
-                    viewer(snapshot: snapshot)
-                        .id(snapshot.path)
-                        .tag(snapshot.path)
-                }
-            }
-            .tabViewStyle(.page(indexDisplayMode: .never))
-            .scrollDisabled(zoomedPath != nil)
+            ChatArtifactPageViewController(
+                pages: model.pageModels.map(hostedPage),
+                selectedPath: selectionBinding,
+                isPagingEnabled: zoomedPath == nil
+            )
         } else {
             viewer(snapshot: model.toolbarSnapshot)
                 .id(model.toolbarSnapshot.path)
@@ -104,6 +100,26 @@ struct ChatArtifactViewerPager: View {
             .id(model.toolbarSnapshot.path)
         #endif
     }
+
+    #if os(iOS)
+    private func hostedPage(model: ChatArtifactViewerPageModel) -> ChatArtifactViewerHostedPage {
+        ChatArtifactViewerHostedPage(
+            model: model,
+            scope: scope,
+            loader: loader,
+            onImageMinimumZoomChanged: { path, isAtMinimum in
+                if isAtMinimum {
+                    if zoomedPath == path {
+                        zoomedPath = nil
+                    }
+                } else {
+                    zoomedPath = path
+                }
+            },
+            onDone: onDone
+        )
+    }
+    #endif
 
     private func viewer(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
         ChatArtifactViewerRouteView(

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
@@ -1,14 +1,20 @@
 import CmuxAgentChat
 import SwiftUI
 
-/// Keeps only the selected artifact and its adjacent viewer pages mounted.
+#if os(iOS)
+import QuickLook
+import UIKit
+#endif
+
+/// Owns path-stable viewer pages and the destination's only navigation toolbar.
 struct ChatArtifactViewerPager: View {
     let initialPath: String
     let scope: ChatArtifactViewerScope
     let swipeOrder: ChatArtifactGallerySwipeOrder
     let onDone: () -> Void
 
-    @State private var selectedPath: String
+    @Environment(\.chatArtifactLoader) private var loader
+    @State private var model: ChatArtifactViewerPagerModel
     @State private var zoomedPath: String?
 
     init(
@@ -21,44 +27,335 @@ struct ChatArtifactViewerPager: View {
         self.scope = scope
         self.swipeOrder = swipeOrder
         self.onDone = onDone
-        _selectedPath = State(initialValue: initialPath)
+        _model = State(initialValue: ChatArtifactViewerPagerModel(
+            initialPath: initialPath,
+            swipeOrder: swipeOrder,
+            textPreferences: ChatArtifactTextPreferences(defaults: .standard)
+        ))
     }
 
     @ViewBuilder
     var body: some View {
+        pagerContent
+            .navigationTitle(model.toolbarSnapshot.displayName)
+            #if os(iOS)
+            .navigationBarTitleDisplayMode(.inline)
+            #endif
+            .toolbar {
+                #if os(iOS)
+                ToolbarItemGroup(placement: .topBarTrailing) {
+                    if model.toolbarSnapshot.hasViewerActions {
+                        viewerActionsMenu(snapshot: model.toolbarSnapshot)
+                    }
+                    doneButton
+                }
+                #else
+                ToolbarItem(placement: .cancellationAction) {
+                    doneButton
+                }
+                #endif
+            }
+            #if os(iOS)
+            .chatArtifactFileActionPresentation(fileActionPresentationBinding)
+            .alert(
+                String(
+                    localized: "chat.artifact.action_failed.title",
+                    defaultValue: "Couldn't complete action",
+                    bundle: .module
+                ),
+                isPresented: fileActionErrorBinding
+            ) {
+                Button(String(localized: "chat.artifact.ok", defaultValue: "OK", bundle: .module)) {}
+            } message: {
+                Text(String(
+                    localized: "chat.artifact.action_failed.message",
+                    defaultValue: "Check the connection to your Mac and try again.",
+                    bundle: .module
+                ))
+            }
+            #endif
+            .onChange(of: initialPath) { _, newPath in
+                model.update(initialPath: newPath, swipeOrder: swipeOrder)
+            }
+            .onChange(of: swipeOrder) { _, newOrder in
+                model.update(swipeOrder: newOrder)
+            }
+    }
+
+    @ViewBuilder
+    private var pagerContent: some View {
         #if os(iOS)
-        if swipeOrder.count > 1,
-           swipeOrder.files.contains(where: { $0.path == initialPath }) {
-            TabView(selection: $selectedPath) {
-                ForEach(swipeOrder.pageWindow(around: selectedPath)) { file in
-                    viewer(path: file.path)
-                        .tag(file.path)
+        if model.usesPaging {
+            TabView(selection: selectionBinding) {
+                ForEach(model.pageSnapshots) { snapshot in
+                    viewer(snapshot: snapshot)
+                        .id(snapshot.path)
+                        .tag(snapshot.path)
                 }
             }
             .tabViewStyle(.page(indexDisplayMode: .never))
             .scrollDisabled(zoomedPath != nil)
         } else {
-            viewer(path: initialPath)
+            viewer(snapshot: model.toolbarSnapshot)
+                .id(model.toolbarSnapshot.path)
         }
         #else
-        viewer(path: initialPath)
+        viewer(snapshot: model.toolbarSnapshot)
+            .id(model.toolbarSnapshot.path)
         #endif
     }
 
-    private func viewer(path: String) -> some View {
+    private func viewer(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
         ChatArtifactViewerRouteView(
-            path: path,
+            snapshot: snapshot,
             scope: scope,
+            actions: model.actions(
+                for: snapshot.path,
+                loader: loader,
+                quickLookCanPreview: { fileURL in
+                    #if os(iOS)
+                    QLPreviewController.canPreview(ChatArtifactQuickLookItem(
+                        fileURL: fileURL,
+                        title: snapshot.displayName
+                    ))
+                    #else
+                    false
+                    #endif
+                }
+            ),
             onImageMinimumZoomChanged: { isAtMinimum in
                 if isAtMinimum {
-                    if zoomedPath == path {
+                    if zoomedPath == snapshot.path {
                         zoomedPath = nil
                     }
                 } else {
-                    zoomedPath = path
+                    zoomedPath = snapshot.path
                 }
             },
             onDone: onDone
         )
     }
+
+    private var selectionBinding: Binding<String> {
+        Binding(
+            get: { model.selectedPath },
+            set: { model.select(path: $0) }
+        )
+    }
+
+    private var doneButton: some View {
+        Button(String(localized: "chat.artifact.done", defaultValue: "Done", bundle: .module)) {
+            onDone()
+        }
+    }
+
+    #if os(iOS)
+    private func viewerActionsMenu(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
+        Menu {
+            if snapshot.hasFileActions {
+                Section {
+                    fileActionButtons(snapshot: snapshot)
+                }
+            }
+            if snapshot.shouldShowTextJumpControls {
+                Section {
+                    textViewerActionButtons(snapshot: snapshot)
+                }
+            }
+            if snapshot.state == .markdown,
+               snapshot.markdownPresentation.isRenderedAvailable {
+                Section {
+                    Picker(
+                        String(
+                            localized: "chat.artifact.markdown.view",
+                            defaultValue: "Markdown view",
+                            bundle: .module
+                        ),
+                        selection: markdownModeBinding
+                    ) {
+                        Text(String(
+                            localized: "chat.artifact.markdown.raw",
+                            defaultValue: "Raw",
+                            bundle: .module
+                        ))
+                        .tag(ChatArtifactMarkdownMode.raw)
+                        Text(String(
+                            localized: "chat.artifact.markdown.rendered",
+                            defaultValue: "Rendered",
+                            bundle: .module
+                        ))
+                        .tag(ChatArtifactMarkdownMode.rendered)
+                    }
+                }
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.viewer.actions",
+                    defaultValue: "Viewer actions",
+                    bundle: .module
+                ),
+                systemImage: "ellipsis.circle"
+            )
+        }
+        .disabled(snapshot.fileActionState.isRunning)
+    }
+
+    @ViewBuilder
+    private func fileActionButtons(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
+        Button {
+            Task { await model.prepareShare(loader: loader) }
+        } label: {
+            Label(
+                String(localized: "chat.artifact.share", defaultValue: "Share", bundle: .module),
+                systemImage: "square.and.arrow.up"
+            )
+        }
+        Button {
+            Task { await model.prepareSave(loader: loader) }
+        } label: {
+            Label(
+                String(localized: "chat.artifact.save_to_files", defaultValue: "Save to Files", bundle: .module),
+                systemImage: "folder.badge.plus"
+            )
+        }
+        if snapshot.isTextFile {
+            Button {
+                UIPasteboard.general.string = snapshot.renderedText
+            } label: {
+                Label(
+                    String(localized: "chat.artifact.copy_contents", defaultValue: "Copy contents", bundle: .module),
+                    systemImage: "doc.on.doc"
+                )
+            }
+            .disabled(!snapshot.canCopyContents)
+        }
+        Button {
+            UIPasteboard.general.string = snapshot.path
+        } label: {
+            Label(
+                String(localized: "chat.artifact.copy_path", defaultValue: "Copy path", bundle: .module),
+                systemImage: "link"
+            )
+        }
+    }
+
+    @ViewBuilder
+    private func textViewerActionButtons(snapshot: ChatArtifactViewerPageSnapshot) -> some View {
+        Button {
+            withAnimation(.snappy) {
+                model.toggleSearch()
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.search.title",
+                    defaultValue: "Search",
+                    bundle: .module
+                ),
+                systemImage: "magnifyingglass"
+            )
+        }
+        Button {
+            withAnimation(.snappy) {
+                model.toggleGoToLine()
+            }
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.line.goto",
+                    defaultValue: "Go to line",
+                    bundle: .module
+                ),
+                systemImage: "text.line.first.and.arrowtriangle.forward"
+            )
+        }
+        Button {
+            model.requestTop()
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.jump.top",
+                    defaultValue: "Top",
+                    bundle: .module
+                ),
+                systemImage: "arrow.up.to.line"
+            )
+        }
+        Button {
+            model.requestBottom()
+        } label: {
+            Label(jumpToBottomTitle(snapshot: snapshot), systemImage: "arrow.down.to.line")
+        }
+        Button {
+            model.toggleLineNumbers()
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.line.numbers",
+                    defaultValue: "Line numbers",
+                    bundle: .module
+                ),
+                systemImage: snapshot.showsLineNumbers ? "checkmark" : "number"
+            )
+        }
+        Button {
+            model.toggleWordWrap()
+        } label: {
+            Label(
+                String(
+                    localized: "chat.artifact.wrap",
+                    defaultValue: "Word wrap",
+                    bundle: .module
+                ),
+                systemImage: snapshot.wrapsLines ? "checkmark" : "text.justify.left"
+            )
+        }
+    }
+
+    private var markdownModeBinding: Binding<ChatArtifactMarkdownMode> {
+        Binding(
+            get: { model.toolbarSnapshot.markdownPresentation.mode },
+            set: { model.selectMarkdownMode($0) }
+        )
+    }
+
+    private var fileActionPresentationBinding: Binding<ChatArtifactFileActionPresentation?> {
+        let path = model.toolbarSnapshot.path
+        return Binding(
+            get: {
+                model.toolbarSnapshot.path == path
+                    ? model.toolbarSnapshot.fileActionState.presentation
+                    : nil
+            },
+            set: { model.setFileActionPresentation($0, for: path) }
+        )
+    }
+
+    private var fileActionErrorBinding: Binding<Bool> {
+        let path = model.toolbarSnapshot.path
+        return Binding(
+            get: {
+                model.toolbarSnapshot.path == path
+                    && model.toolbarSnapshot.fileActionState.showsError
+            },
+            set: { model.setShowsFileActionError($0, for: path) }
+        )
+    }
+
+    private func jumpToBottomTitle(snapshot: ChatArtifactViewerPageSnapshot) -> String {
+        if snapshot.textReachedEOF {
+            return String(
+                localized: "chat.artifact.jump.end",
+                defaultValue: "End",
+                bundle: .module
+            )
+        }
+        return String(
+            localized: "chat.artifact.jump.bottom",
+            defaultValue: "Bottom",
+            bundle: .module
+        )
+    }
+    #endif
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPager.swift
@@ -301,7 +301,7 @@ struct ChatArtifactViewerPager: View {
         Button {
             model.requestBottom()
         } label: {
-            Label(jumpToBottomTitle(snapshot: snapshot), systemImage: "arrow.down.to.line")
+            Label(jumpToEndTitle(snapshot: snapshot), systemImage: "arrow.down.to.line")
         }
         Button {
             model.toggleLineNumbers()
@@ -359,19 +359,21 @@ struct ChatArtifactViewerPager: View {
         )
     }
 
-    private func jumpToBottomTitle(snapshot: ChatArtifactViewerPageSnapshot) -> String {
-        if snapshot.textReachedEOF {
+    private func jumpToEndTitle(snapshot: ChatArtifactViewerPageSnapshot) -> String {
+        switch ChatArtifactTextEndJumpTarget(reachedEOF: snapshot.textReachedEOF) {
+        case .end:
             return String(
                 localized: "chat.artifact.jump.end",
                 defaultValue: "End",
                 bundle: .module
             )
+        case .latest:
+            return String(
+                localized: "chat.artifact.jump.latest",
+                defaultValue: "Latest",
+                bundle: .module
+            )
         }
-        return String(
-            localized: "chat.artifact.jump.bottom",
-            defaultValue: "Bottom",
-            bundle: .module
-        )
     }
     #endif
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPagerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPagerModel.swift
@@ -34,6 +34,10 @@ final class ChatArtifactViewerPagerModel {
         pagePaths.compactMap { pagesByPath[$0]?.snapshot }
     }
 
+    var pageModels: [ChatArtifactViewerPageModel] {
+        pagePaths.compactMap { pagesByPath[$0] }
+    }
+
     var toolbarSnapshot: ChatArtifactViewerPageSnapshot {
         selectedPageModel.snapshot
     }
@@ -73,24 +77,9 @@ final class ChatArtifactViewerPagerModel {
         let page = path == selectedPath
             ? selectedPageModel
             : pagesByPath[path]!
-        return ChatArtifactViewerPageActions(
-            load: {
-                await page.load(
-                    loader: loader,
-                    quickLookCanPreview: quickLookCanPreview
-                )
-            },
-            cleanup: { await page.cleanup() },
-            retry: { page.retry() },
-            setSearchQuery: { page.setSearchQuery($0) },
-            setSearchSummary: { page.setSearchSummary($0) },
-            selectPreviousSearchResult: { page.selectPreviousSearchResult() },
-            selectNextSearchResult: { page.selectNextSearchResult() },
-            dismissSearch: { page.dismissSearch() },
-            setGoToLineText: { page.setGoToLineText($0) },
-            goToLine: { page.goToLine($0) },
-            dismissGoToLine: { page.dismissGoToLine() },
-            setFontSize: { page.setFontSize($0) }
+        return page.actions(
+            loader: loader,
+            quickLookCanPreview: quickLookCanPreview
         )
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPagerModel.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerPagerModel.swift
@@ -1,0 +1,176 @@
+import CmuxAgentChat
+import Foundation
+import Observation
+
+/// Retains one page owner per visible path while projecting a single selected toolbar state.
+@Observable
+@MainActor
+final class ChatArtifactViewerPagerModel {
+    private(set) var selectedPath: String
+    private(set) var swipeOrder: ChatArtifactGallerySwipeOrder
+    private let textPreferences: ChatArtifactTextPreferences
+    @ObservationIgnored private var selectedPageModel: ChatArtifactViewerPageModel
+    @ObservationIgnored
+    private var pagesByPath: [String: ChatArtifactViewerPageModel] = [:]
+
+    init(
+        initialPath: String,
+        swipeOrder: ChatArtifactGallerySwipeOrder,
+        textPreferences: ChatArtifactTextPreferences
+    ) {
+        selectedPath = initialPath
+        self.swipeOrder = swipeOrder
+        self.textPreferences = textPreferences
+        let initialPage = ChatArtifactViewerPageModel(
+            path: initialPath,
+            textPreferences: textPreferences
+        )
+        selectedPageModel = initialPage
+        pagesByPath[initialPath] = initialPage
+        reconcilePages()
+    }
+
+    var pageSnapshots: [ChatArtifactViewerPageSnapshot] {
+        pagePaths.compactMap { pagesByPath[$0]?.snapshot }
+    }
+
+    var toolbarSnapshot: ChatArtifactViewerPageSnapshot {
+        selectedPageModel.snapshot
+    }
+
+    var usesPaging: Bool {
+        swipeOrder.count > 1 && swipeOrder.paths.contains(selectedPath)
+    }
+
+    func select(path: String) {
+        guard path != selectedPath, swipeOrder.paths.contains(path) else { return }
+        selectedPageModel = page(for: path)
+        selectedPath = path
+        reconcilePages()
+    }
+
+    func update(
+        initialPath: String? = nil,
+        swipeOrder: ChatArtifactGallerySwipeOrder
+    ) {
+        self.swipeOrder = swipeOrder
+        if let initialPath, initialPath != selectedPath {
+            selectedPageModel = page(for: initialPath)
+            selectedPath = initialPath
+        }
+        reconcilePages()
+    }
+
+    func pageIdentity(for path: String) -> ObjectIdentifier? {
+        pagesByPath[path].map(ObjectIdentifier.init)
+    }
+
+    func actions(
+        for path: String,
+        loader: ChatArtifactLoader,
+        quickLookCanPreview: @escaping @MainActor (URL) -> Bool
+    ) -> ChatArtifactViewerPageActions {
+        let page = path == selectedPath
+            ? selectedPageModel
+            : pagesByPath[path]!
+        return ChatArtifactViewerPageActions(
+            load: {
+                await page.load(
+                    loader: loader,
+                    quickLookCanPreview: quickLookCanPreview
+                )
+            },
+            cleanup: { await page.cleanup() },
+            retry: { page.retry() },
+            setSearchQuery: { page.setSearchQuery($0) },
+            setSearchSummary: { page.setSearchSummary($0) },
+            selectPreviousSearchResult: { page.selectPreviousSearchResult() },
+            selectNextSearchResult: { page.selectNextSearchResult() },
+            dismissSearch: { page.dismissSearch() },
+            setGoToLineText: { page.setGoToLineText($0) },
+            goToLine: { page.goToLine($0) },
+            dismissGoToLine: { page.dismissGoToLine() },
+            setFontSize: { page.setFontSize($0) }
+        )
+    }
+
+    func toggleSearch() {
+        selectedPage.toggleSearch()
+    }
+
+    func toggleGoToLine() {
+        selectedPage.toggleGoToLine()
+    }
+
+    func requestTop() {
+        selectedPage.requestTop()
+    }
+
+    func requestBottom() {
+        selectedPage.requestBottom()
+    }
+
+    func toggleLineNumbers() {
+        selectedPage.toggleLineNumbers()
+    }
+
+    func toggleWordWrap() {
+        selectedPage.toggleWordWrap()
+    }
+
+    func selectMarkdownMode(_ mode: ChatArtifactMarkdownMode) {
+        selectedPage.selectMarkdownMode(mode)
+    }
+
+    #if os(iOS)
+    func prepareShare(loader: ChatArtifactLoader) async {
+        let page = selectedPage
+        await page.prepareShare(loader: loader)
+    }
+
+    func prepareSave(loader: ChatArtifactLoader) async {
+        let page = selectedPage
+        await page.prepareSave(loader: loader)
+    }
+
+    func setFileActionPresentation(
+        _ presentation: ChatArtifactFileActionPresentation?,
+        for path: String
+    ) {
+        pagesByPath[path]?.setFileActionPresentation(presentation)
+    }
+
+    func setShowsFileActionError(_ isPresented: Bool, for path: String) {
+        pagesByPath[path]?.setShowsFileActionError(isPresented)
+    }
+    #endif
+
+    private var selectedPage: ChatArtifactViewerPageModel {
+        selectedPageModel
+    }
+
+    private var pagePaths: [String] {
+        guard swipeOrder.paths.contains(selectedPath) else { return [selectedPath] }
+        return swipeOrder.pageWindow(around: selectedPath).map(\.path)
+    }
+
+    private func page(for path: String) -> ChatArtifactViewerPageModel {
+        if let page = pagesByPath[path] {
+            return page
+        }
+        let page = ChatArtifactViewerPageModel(
+            path: path,
+            textPreferences: textPreferences
+        )
+        pagesByPath[path] = page
+        return page
+    }
+
+    private func reconcilePages() {
+        var nextPages: [String: ChatArtifactViewerPageModel] = [:]
+        for path in pagePaths {
+            nextPages[path] = page(for: path)
+        }
+        pagesByPath = nextPages
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -286,7 +286,7 @@ struct ChatArtifactViewerRouteView: View {
 
     @ViewBuilder
     private var highlightingStatusPill: some View {
-        if snapshot.textHighlightDecision.showsHighlightingOffPill,
+        if snapshot.showsHighlightingStatusPill,
            let totalBytes = snapshot.totalBytes {
             HStack {
                 Spacer(minLength: 16)

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/ChatArtifactViewerRouteView.swift
@@ -3,338 +3,44 @@ import SwiftUI
 
 #if canImport(UIKit)
 import UIKit
-#if os(iOS)
-import QuickLook
-#endif
 #elseif canImport(AppKit)
 import AppKit
 #endif
 
-/// The shared stat-driven route for every artifact entry point and folder level.
+/// Renders one immutable artifact page snapshot without contributing navigation chrome.
 struct ChatArtifactViewerRouteView: View {
-    let path: String
+    let snapshot: ChatArtifactViewerPageSnapshot
     let scope: ChatArtifactViewerScope
+    let actions: ChatArtifactViewerPageActions
     let onDone: () -> Void
     let onImageMinimumZoomChanged: (Bool) -> Void
-    private let textPreferences: ChatArtifactTextPreferences
-    private let textLayoutKind: ChatArtifactTextLayoutKind
 
-    @Environment(\.chatArtifactLoader) private var loader
     @Environment(\.colorScheme) private var colorScheme
-    @State private var model = ChatArtifactViewerModel()
-    @State private var retryGeneration = 0
-    @State private var topRequestID = 0
-    @State private var bottomRequestID = 0
-    @State private var isSearchPresented = false
-    @State private var searchQuery = ""
-    @State private var searchSummary = ChatArtifactSearchSummary.empty
-    @State private var previousSearchRequestID = 0
-    @State private var nextSearchRequestID = 0
-    @State private var showsLineNumbers = true
-    @State private var isGoToLinePresented = false
-    @State private var goToLineText = ""
-    @State private var goToLineUTF16Offset = 0
-    @State private var goToLineRequestID = 0
-    @State private var wrapsLines: Bool
-    @State private var textFontSize: Double
-    #if os(iOS)
-    @State private var fileActionPresentation: ChatArtifactFileActionPresentation?
-    @State private var isFileActionRunning = false
-    @State private var showsFileActionError = false
-    #endif
 
     init(
-        path: String,
+        snapshot: ChatArtifactViewerPageSnapshot,
         scope: ChatArtifactViewerScope,
-        textPreferences: ChatArtifactTextPreferences = ChatArtifactTextPreferences(
-            defaults: .standard
-        ),
+        actions: ChatArtifactViewerPageActions,
         onImageMinimumZoomChanged: @escaping (Bool) -> Void = { _ in },
         onDone: @escaping () -> Void
     ) {
-        self.path = path
+        self.snapshot = snapshot
         self.scope = scope
+        self.actions = actions
         self.onDone = onDone
         self.onImageMinimumZoomChanged = onImageMinimumZoomChanged
-        self.textPreferences = textPreferences
-        let layoutKind = ChatArtifactTextLayoutKind(path: path)
-        textLayoutKind = layoutKind
-        _wrapsLines = State(initialValue: textPreferences.wrapsLines(for: layoutKind))
-        _textFontSize = State(initialValue: textPreferences.fontSize(for: layoutKind))
     }
 
     var body: some View {
         content
-            .navigationTitle(displayName)
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-            .toolbar {
-                #if os(iOS)
-                ToolbarItemGroup(placement: .topBarTrailing) {
-                    if hasViewerActions {
-                        viewerActionsMenu
-                    }
-                    doneButton
-                }
-                #else
-                ToolbarItem(placement: .cancellationAction) {
-                    doneButton
-                }
-                #endif
-            }
-            #if os(iOS)
-            .chatArtifactFileActionPresentation($fileActionPresentation)
-            .alert(
-                String(
-                    localized: "chat.artifact.action_failed.title",
-                    defaultValue: "Couldn't complete action",
-                    bundle: .module
-                ),
-                isPresented: $showsFileActionError
-            ) {
-                Button(String(localized: "chat.artifact.ok", defaultValue: "OK", bundle: .module)) {}
-            } message: {
-                Text(String(
-                    localized: "chat.artifact.action_failed.message",
-                    defaultValue: "Check the connection to your Mac and try again.",
-                    bundle: .module
-                ))
-            }
-            #endif
-            .task(id: "\(path)\u{0}\(retryGeneration)") {
-                #if os(iOS)
-                await model.load(
-                    path: path,
-                    loader: loader,
-                    quickLookCanPreview: canQuickLookPreview
-                )
-                #else
-                await model.load(path: path, loader: loader)
-                #endif
+            .task(id: "\(path)\u{0}\(snapshot.retryGeneration)") {
+                await actions.load()
                 await waitForViewerTaskCancellation()
-                await model.cleanup()
+                await actions.cleanup()
             }
     }
 
-    private var doneButton: some View {
-        Button(String(localized: "chat.artifact.done", defaultValue: "Done", bundle: .module)) {
-            onDone()
-        }
-    }
-
-    #if os(iOS)
-    private var hasViewerActions: Bool {
-        model.hasFileActions
-            || shouldShowTextJumpControls
-            || (model.state == .markdown && model.markdownPresentation.isRenderedAvailable)
-    }
-
-    private var viewerActionsMenu: some View {
-        Menu {
-            if model.hasFileActions {
-                Section {
-                    fileActionButtons
-                }
-            }
-            if shouldShowTextJumpControls {
-                Section {
-                    textViewerActionButtons
-                }
-            }
-            if model.state == .markdown,
-               model.markdownPresentation.isRenderedAvailable {
-                Section {
-                    Picker(
-                        String(
-                            localized: "chat.artifact.markdown.view",
-                            defaultValue: "Markdown view",
-                            bundle: .module
-                        ),
-                        selection: markdownModeBinding
-                    ) {
-                        Text(String(
-                            localized: "chat.artifact.markdown.raw",
-                            defaultValue: "Raw",
-                            bundle: .module
-                        ))
-                        .tag(ChatArtifactMarkdownMode.raw)
-                        Text(String(
-                            localized: "chat.artifact.markdown.rendered",
-                            defaultValue: "Rendered",
-                            bundle: .module
-                        ))
-                        .tag(ChatArtifactMarkdownMode.rendered)
-                    }
-                }
-            }
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.viewer.actions",
-                    defaultValue: "Viewer actions",
-                    bundle: .module
-                ),
-                systemImage: "ellipsis.circle"
-            )
-        }
-        .disabled(isFileActionRunning)
-    }
-
-    @ViewBuilder
-    private var fileActionButtons: some View {
-        Button {
-            prepareFileAction(.share)
-        } label: {
-            Label(
-                String(localized: "chat.artifact.share", defaultValue: "Share", bundle: .module),
-                systemImage: "square.and.arrow.up"
-            )
-        }
-        Button {
-            prepareFileAction(.save)
-        } label: {
-            Label(
-                String(localized: "chat.artifact.save_to_files", defaultValue: "Save to Files", bundle: .module),
-                systemImage: "folder.badge.plus"
-            )
-        }
-        if model.isTextFile {
-            Button {
-                UIPasteboard.general.string = model.renderedText
-            } label: {
-                Label(
-                    String(localized: "chat.artifact.copy_contents", defaultValue: "Copy contents", bundle: .module),
-                    systemImage: "doc.on.doc"
-                )
-            }
-            .disabled(!model.canCopyContents)
-        }
-        Button {
-            UIPasteboard.general.string = path
-        } label: {
-            Label(
-                String(localized: "chat.artifact.copy_path", defaultValue: "Copy path", bundle: .module),
-                systemImage: "link"
-            )
-        }
-    }
-
-    @ViewBuilder
-    private var textViewerActionButtons: some View {
-        Button {
-            withAnimation(.snappy) {
-                if isSearchPresented {
-                    dismissSearch()
-                } else {
-                    dismissGoToLine()
-                    isSearchPresented = true
-                }
-            }
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.search.title",
-                    defaultValue: "Search",
-                    bundle: .module
-                ),
-                systemImage: "magnifyingglass"
-            )
-        }
-        Button {
-            withAnimation(.snappy) {
-                if isGoToLinePresented {
-                    dismissGoToLine()
-                } else {
-                    dismissSearch()
-                    isGoToLinePresented = true
-                }
-            }
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.line.goto",
-                    defaultValue: "Go to line",
-                    bundle: .module
-                ),
-                systemImage: "text.line.first.and.arrowtriangle.forward"
-            )
-        }
-        Button {
-            topRequestID += 1
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.jump.top",
-                    defaultValue: "Top",
-                    bundle: .module
-                ),
-                systemImage: "arrow.up.to.line"
-            )
-        }
-        Button {
-            bottomRequestID += 1
-        } label: {
-            Label(jumpToBottomTitle, systemImage: "arrow.down.to.line")
-        }
-        Button {
-            showsLineNumbers.toggle()
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.line.numbers",
-                    defaultValue: "Line numbers",
-                    bundle: .module
-                ),
-                systemImage: showsLineNumbers ? "checkmark" : "number"
-            )
-        }
-        Button {
-            wrapsLines.toggle()
-            textPreferences.setWrapsLines(
-                wrapsLines,
-                for: textLayoutKind
-            )
-        } label: {
-            Label(
-                String(
-                    localized: "chat.artifact.wrap",
-                    defaultValue: "Word wrap",
-                    bundle: .module
-                ),
-                systemImage: wrapsLines ? "checkmark" : "text.justify.left"
-            )
-        }
-    }
-
-    private enum PreparedFileAction {
-        case share
-        case save
-    }
-
-    private func prepareFileAction(_ action: PreparedFileAction) {
-        guard !isFileActionRunning else { return }
-        isFileActionRunning = true
-        Task {
-            do {
-                let fileURL = try await ChatArtifactFileActionStore.applicationDefault.materialize(
-                    path: path,
-                    loader: loader
-                )
-                try Task.checkCancellation()
-                fileActionPresentation = switch action {
-                case .share: .share(fileURL)
-                case .save: .save(fileURL)
-                }
-            } catch is CancellationError {
-                // The viewer is going away; no error needs presenting.
-            } catch {
-                showsFileActionError = true
-            }
-            isFileActionRunning = false
-        }
-    }
-    #endif
+    private var path: String { snapshot.path }
 
     /// Keeps cleanup structured under the SwiftUI page task after loading ends.
     private func waitForViewerTaskCancellation() async {
@@ -345,13 +51,13 @@ struct ChatArtifactViewerRouteView: View {
 
     @ViewBuilder
     private var content: some View {
-        switch model.state {
+        switch snapshot.state {
         case .loading:
             VStack(spacing: 12) {
                 ProgressView(
                     value: progressValue(
-                        fetched: model.fetchedBytes,
-                        total: model.totalBytes
+                        fetched: snapshot.fetchedBytes,
+                        total: snapshot.totalBytes
                     )
                 )
                 .progressViewStyle(.linear)
@@ -359,11 +65,11 @@ struct ChatArtifactViewerRouteView: View {
                 Text(String(localized: "chat.artifact.loading", defaultValue: "Loading preview", bundle: .module))
                     .font(.subheadline)
                     .foregroundStyle(.secondary)
-                if model.fetchedBytes > 0 || model.totalBytes != nil {
+                if snapshot.fetchedBytes > 0 || snapshot.totalBytes != nil {
                     Text(
                         verbatim: progressText(
-                            fetched: model.fetchedBytes,
-                            total: model.totalBytes
+                            fetched: snapshot.fetchedBytes,
+                            total: snapshot.totalBytes
                         )
                     )
                     .font(.caption.monospacedDigit())
@@ -420,7 +126,7 @@ struct ChatArtifactViewerRouteView: View {
             #endif
         case .quickLook(let fileURL):
             #if os(iOS)
-            ChatArtifactQuickLookView(fileURL: fileURL, title: displayName)
+            ChatArtifactQuickLookView(fileURL: fileURL, title: snapshot.displayName)
                 .ignoresSafeArea(.container, edges: .bottom)
             #else
             unavailableView(
@@ -430,7 +136,7 @@ struct ChatArtifactViewerRouteView: View {
             #endif
         case .text:
             VStack(spacing: 0) {
-                if !model.textReachedEOF {
+                if !snapshot.textReachedEOF {
                     streamingProgressHeader
                 }
                 searchBar
@@ -440,11 +146,11 @@ struct ChatArtifactViewerRouteView: View {
             }
         case .markdown:
             VStack(spacing: 0) {
-                if !model.textReachedEOF {
+                if !snapshot.textReachedEOF {
                     streamingProgressHeader
                 }
-                if model.markdownPresentation.mode == .rendered {
-                    ChatArtifactMarkdownView(markdown: model.renderedText)
+                if snapshot.markdownPresentation.mode == .rendered {
+                    ChatArtifactMarkdownView(markdown: snapshot.renderedText)
                 } else {
                     searchBar
                     goToLineBar
@@ -494,12 +200,12 @@ struct ChatArtifactViewerRouteView: View {
         HStack(spacing: 10) {
             ProgressView(
                 value: progressValue(
-                    fetched: model.fetchedBytes,
-                    total: model.totalBytes
+                    fetched: snapshot.fetchedBytes,
+                    total: snapshot.totalBytes
                 )
             )
             .progressViewStyle(.linear)
-            Text(verbatim: progressText(fetched: model.fetchedBytes, total: model.totalBytes))
+            Text(verbatim: progressText(fetched: snapshot.fetchedBytes, total: snapshot.totalBytes))
                 .font(.caption2.monospacedDigit())
                 .foregroundStyle(.secondary)
                 .fixedSize()
@@ -514,34 +220,27 @@ struct ChatArtifactViewerRouteView: View {
         #if canImport(UIKit)
         ChatArtifactTextView(
             documentID: path,
-            chunks: model.textChunks,
-            reachedEOF: model.textReachedEOF,
-            highlightDecision: model.textHighlightDecision,
+            chunks: snapshot.textChunks,
+            reachedEOF: snapshot.textReachedEOF,
+            highlightDecision: snapshot.textHighlightDecision,
             highlightTheme: colorScheme == .dark ? .dark : .light,
-            searchQuery: searchQuery,
-            previousSearchRequestID: previousSearchRequestID,
-            nextSearchRequestID: nextSearchRequestID,
-            onSearchSummaryChanged: { summary in
-                searchSummary = summary
-            },
-            lineIndex: model.textLineIndex,
-            showsLineNumbers: showsLineNumbers,
-            goToLineUTF16Offset: goToLineUTF16Offset,
-            goToLineRequestID: goToLineRequestID,
-            wrapsLines: wrapsLines,
-            fontPointSize: textFontSize,
-            onFontSizeChanged: { fontSize in
-                textFontSize = textPreferences.setFontSize(
-                    fontSize,
-                    for: textLayoutKind
-                )
-            },
-            topRequestID: topRequestID,
-            bottomRequestID: bottomRequestID
+            searchQuery: snapshot.searchQuery,
+            previousSearchRequestID: snapshot.previousSearchRequestID,
+            nextSearchRequestID: snapshot.nextSearchRequestID,
+            onSearchSummaryChanged: { actions.setSearchSummary($0) },
+            lineIndex: snapshot.textLineIndex,
+            showsLineNumbers: snapshot.showsLineNumbers,
+            goToLineUTF16Offset: snapshot.goToLineUTF16Offset,
+            goToLineRequestID: snapshot.goToLineRequestID,
+            wrapsLines: snapshot.wrapsLines,
+            fontPointSize: snapshot.textFontSize,
+            onFontSizeChanged: { actions.setFontSize($0) },
+            topRequestID: snapshot.topRequestID,
+            bottomRequestID: snapshot.bottomRequestID
         )
         #else
         ScrollView {
-            Text(model.renderedText)
+            Text(snapshot.renderedText)
                 .font(.system(.body, design: .monospaced))
                 .textSelection(.enabled)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -552,13 +251,13 @@ struct ChatArtifactViewerRouteView: View {
 
     @ViewBuilder
     private var goToLineBar: some View {
-        if isGoToLinePresented {
+        if snapshot.isGoToLinePresented {
             ChatArtifactGoToLineBar(
-                lineText: $goToLineText,
-                onGo: goToLine,
+                lineText: goToLineTextBinding,
+                onGo: { actions.goToLine($0) },
                 onClose: {
                     withAnimation(.snappy) {
-                        dismissGoToLine()
+                        actions.dismissGoToLine()
                     }
                 }
             )
@@ -568,16 +267,16 @@ struct ChatArtifactViewerRouteView: View {
 
     @ViewBuilder
     private var searchBar: some View {
-        if isSearchPresented {
+        if snapshot.isSearchPresented {
             ChatArtifactSearchBar(
-                query: $searchQuery,
-                summary: searchSummary,
-                isStillLoading: !model.textReachedEOF,
-                onPrevious: { previousSearchRequestID += 1 },
-                onNext: { nextSearchRequestID += 1 },
+                query: searchQueryBinding,
+                summary: snapshot.searchSummary,
+                isStillLoading: !snapshot.textReachedEOF,
+                onPrevious: { actions.selectPreviousSearchResult() },
+                onNext: { actions.selectNextSearchResult() },
                 onClose: {
                     withAnimation(.snappy) {
-                        dismissSearch()
+                        actions.dismissSearch()
                     }
                 }
             )
@@ -587,8 +286,8 @@ struct ChatArtifactViewerRouteView: View {
 
     @ViewBuilder
     private var highlightingStatusPill: some View {
-        if model.textHighlightDecision.showsHighlightingOffPill,
-           let totalBytes = model.totalBytes {
+        if snapshot.textHighlightDecision.showsHighlightingOffPill,
+           let totalBytes = snapshot.totalBytes {
             HStack {
                 Spacer(minLength: 16)
                 ChatArtifactHighlightingStatusPill(
@@ -621,7 +320,7 @@ struct ChatArtifactViewerRouteView: View {
             }
             if retry {
                 Button {
-                    retryGeneration += 1
+                    actions.retry()
                 } label: {
                     Label(
                         String(localized: "chat.artifact.retry", defaultValue: "Retry", bundle: .module),
@@ -657,66 +356,17 @@ struct ChatArtifactViewerRouteView: View {
         #endif
     }
 
-    private var displayName: String {
-        URL(fileURLWithPath: path).lastPathComponent
-    }
-
-    private var markdownModeBinding: Binding<ChatArtifactMarkdownMode> {
+    private var searchQueryBinding: Binding<String> {
         Binding(
-            get: { model.markdownPresentation.mode },
-            set: { mode in
-                if mode == .rendered {
-                    dismissSearch()
-                    dismissGoToLine()
-                }
-                model.selectMarkdownMode(mode)
-            }
+            get: { snapshot.searchQuery },
+            set: { actions.setSearchQuery($0) }
         )
     }
 
-    private func dismissSearch() {
-        isSearchPresented = false
-        searchQuery = ""
-        searchSummary = .empty
-    }
-
-    private func dismissGoToLine() {
-        isGoToLinePresented = false
-        goToLineText = ""
-    }
-
-    private func goToLine(_ requestedLine: Int) {
-        let line = model.textLineIndex.clampedLine(requestedLine)
-        goToLineText = String(line)
-        goToLineUTF16Offset = model.textLineIndex.offset(forLine: line)
-        goToLineRequestID += 1
-    }
-
-    private var shouldShowTextJumpControls: Bool {
-        model.state == .text
-            || (model.state == .markdown && model.markdownPresentation.mode == .raw)
-    }
-
-    #if os(iOS)
-    private func canQuickLookPreview(_ fileURL: URL) -> Bool {
-        QLPreviewController.canPreview(
-            ChatArtifactQuickLookItem(fileURL: fileURL, title: displayName)
-        )
-    }
-    #endif
-
-    private var jumpToBottomTitle: String {
-        if model.textReachedEOF {
-            return String(
-                localized: "chat.artifact.jump.end",
-                defaultValue: "End",
-                bundle: .module
-            )
-        }
-        return String(
-            localized: "chat.artifact.jump.bottom",
-            defaultValue: "Bottom",
-            bundle: .module
+    private var goToLineTextBinding: Binding<String> {
+        Binding(
+            get: { snapshot.goToLineText },
+            set: { actions.setGoToLineText($0) }
         )
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkDecoder.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Artifacts/UTF8ChunkDecoder.swift
@@ -3,9 +3,11 @@ import Foundation
 /// Owns one UTF-8 assembler while an artifact stream crosses actor boundaries.
 actor UTF8ChunkDecoder {
     private var assembler = UTF8ChunkAssembler()
+    private let batcher = ChatArtifactTextStreamBatcher()
 
-    /// Decodes the next raw chunk without moving byte scanning onto the main actor.
-    func decode(_ data: Data, eof: Bool) throws -> String {
-        try assembler.append(data, eof: eof)
+    /// Decodes and batches the next raw chunk without moving either operation onto the main actor.
+    func decodeBatches(_ data: Data, eof: Bool) throws -> [String] {
+        let decoded = try assembler.append(data, eof: eof)
+        return batcher.batches(for: decoded)
     }
 }

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -32,6 +32,13 @@
         "ja" : { "stringUnit" : { "state" : "translated", "value" : "操作を完了できませんでした" } }
       }
     },
+    "chat.artifact.accessibility.large_text_truncated" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : { "stringUnit" : { "state" : "translated", "value" : "Only the beginning of this large document is exposed to assistive technologies." } },
+        "ja" : { "stringUnit" : { "state" : "translated", "value" : "この大きな書類では、先頭部分のみが支援技術に公開されます。" } }
+      }
+    },
     "chat.artifact.actions.title" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
+++ b/Packages/iOS/CmuxAgentChatUI/Sources/CmuxAgentChatUI/Resources/Localizable.xcstrings
@@ -315,6 +315,23 @@
         }
       }
     },
+    "chat.artifact.jump.latest" : {
+      "extractionState" : "manual",
+      "localizations" : {
+        "en" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "Latest"
+          }
+        },
+        "ja" : {
+          "stringUnit" : {
+            "state" : "translated",
+            "value" : "最新"
+          }
+        }
+      }
+    },
     "chat.artifact.jump.top" : {
       "extractionState" : "manual",
       "localizations" : {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactMarkdownDocumentTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactMarkdownDocumentTests.swift
@@ -1,0 +1,42 @@
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact Markdown document")
+struct ChatArtifactMarkdownDocumentTests {
+    @Test("preserves headings paragraphs lists code and table rows as distinct blocks")
+    func documentStructure() {
+        let document = ChatArtifactMarkdownDocument(markdown: """
+        # Guide
+
+        Intro with **bold** text.
+
+        - one
+        2. two
+
+        ```swift
+        print("hi")
+        ```
+
+        | kind | file |
+        | --- | --- |
+        | log | build.log |
+        | data | data.csv |
+        """)
+
+        #expect(document.blocks.map(\.kind) == [
+            .heading(level: 1),
+            .paragraph,
+            .bullet(indent: 0),
+            .ordered(marker: "2.", indent: 0),
+            .code(language: "swift"),
+            .tableRow(isHeader: true),
+            .tableRow(isHeader: false),
+            .tableRow(isHeader: false),
+        ])
+        #expect(document.blocks[0].text == "Guide")
+        #expect(document.blocks[4].text == "print(\"hi\")")
+        #expect(document.blocks[5].text == "kind │ file")
+        #expect(document.blocks[7].text == "data │ data.csv")
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPresentationBoundaryTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPresentationBoundaryTests.swift
@@ -33,6 +33,28 @@ struct ChatArtifactPresentationBoundaryTests {
         #expect(!didCompleteUnknown)
     }
 
+    @Test("completed selection reports an expanded neighbor topology exactly once")
+    func pageTopologyReload() {
+        let notes = "/notes.md"
+        let data = "/data.csv"
+        let log = "/build.log"
+        var state = ChatArtifactPageControllerState(
+            paths: [notes, data],
+            selectedPath: notes
+        )
+
+        let didComplete = state.completeTransition(to: data)
+        #expect(didComplete)
+        let didExpandPaths = state.update(paths: [notes, data, log], selectedPath: data)
+        #expect(didExpandPaths)
+        #expect(state.path(after: data) == log)
+        let didChangeDeduplicatedPaths = state.update(
+            paths: [notes, data, log, data],
+            selectedPath: data
+        )
+        #expect(!didChangeDeduplicatedPaths)
+    }
+
     @Test("large skipped-highlight updates need no full TextKit snapshot")
     func textUpdatePlanning() {
         let streaming = ChatArtifactTextUpdatePlan(

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPresentationBoundaryTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactPresentationBoundaryTests.swift
@@ -1,0 +1,108 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+#if canImport(UIKit)
+import UIKit
+#endif
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact presentation boundaries")
+struct ChatArtifactPresentationBoundaryTests {
+    @Test("rapid completed transitions preserve one unique selected path")
+    func rapidPageTransitions() {
+        let allPaths = ["/notes.md", "/data.csv", "/build.log"]
+        var state = ChatArtifactPageControllerState(
+            paths: allPaths,
+            selectedPath: allPaths[0]
+        )
+
+        for index in 0..<60 {
+            let next = allPaths[index.isMultiple(of: 2) ? 1 : 0]
+            let didComplete = state.completeTransition(to: next)
+            #expect(didComplete)
+            state.update(paths: allPaths + [allPaths[1]], selectedPath: next)
+            #expect(state.paths == allPaths)
+            #expect(state.selectedPath == next)
+        }
+
+        #expect(state.path(before: "/data.csv") == "/notes.md")
+        #expect(state.path(after: "/data.csv") == "/build.log")
+        let didCompleteUnknown = state.completeTransition(to: "/unknown")
+        #expect(!didCompleteUnknown)
+    }
+
+    @Test("large skipped-highlight updates need no full TextKit snapshot")
+    func textUpdatePlanning() {
+        let streaming = ChatArtifactTextUpdatePlan(
+            reachedEOF: false,
+            highlightDecision: .skippedForSize,
+            searchQuery: ""
+        )
+        let finished = ChatArtifactTextUpdatePlan(
+            reachedEOF: true,
+            highlightDecision: .skippedForSize,
+            searchQuery: ""
+        )
+        let searched = ChatArtifactTextUpdatePlan(
+            reachedEOF: false,
+            highlightDecision: .skippedForSize,
+            searchQuery: "error"
+        )
+
+        #expect(!streaming.requiresFullTextSnapshot)
+        #expect(!finished.requiresFullTextSnapshot)
+        #expect(searched.requiresFullTextSnapshot)
+    }
+
+    @Test("accessibility projection remains a single bounded excerpt")
+    func boundedAccessibilityContent() {
+        var content = ChatArtifactTextAccessibilityContent()
+        content.append(String(repeating: "x", count: 100_000))
+        content.append("tail")
+
+        #expect(content.excerpt.count == ChatArtifactTextAccessibilityContent.maximumCharacterCount)
+        #expect(content.isTruncated)
+        #expect(!content.excerpt.contains("tail"))
+    }
+
+    #if canImport(UIKit)
+    @Test("large text remains interactive behind one bounded accessibility element")
+    @MainActor
+    func textContainerInteractionAndAccessibility() {
+        let container = ChatArtifactTextContainerView()
+
+        #expect(container.isUserInteractionEnabled)
+        #expect(container.textView.isUserInteractionEnabled)
+        #expect(container.textView.isScrollEnabled)
+        #expect(container.isAccessibilityElement)
+        #expect(!container.textView.isAccessibilityElement)
+        #expect(container.textView.accessibilityElementsHidden)
+    }
+    #endif
+
+    @Test("child routes retain the live loader and exact descendant path")
+    func folderChildLoaderRouting() async throws {
+        let expected = ChatArtifactDirectoryListing(entries: [])
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            supportsDirectoryBrowsing: true,
+            scope: .terminal(workspaceID: "workspace", surfaceID: "surface"),
+            list: { path in
+                #expect(path == "/project/docs")
+                return expected
+            }
+        )
+        let route = ChatArtifactFolderRoute(
+            parentPath: "/project",
+            childName: "docs",
+            scope: .terminal,
+            loader: loader
+        )
+
+        #expect(route.path == "/project/docs")
+        #expect(route.loader.scope == loader.scope)
+        #expect(try await route.loader.list(path: route.path) == expected)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTextAppendPolicyTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTextAppendPolicyTests.swift
@@ -1,0 +1,27 @@
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact text append policy")
+struct ChatArtifactTextAppendPolicyTests {
+    @Test("coalesces tracked and decelerating appends until scrolling becomes idle")
+    func defersUserScrollAppends() {
+        var policy = ChatArtifactTextAppendPolicy()
+
+        #expect(policy.enqueue(chunkCount: 1) == 1)
+        policy.beginTracking()
+        #expect(policy.enqueue(chunkCount: 2) == 0)
+        #expect(policy.endTracking(willDecelerate: true) == 0)
+        #expect(policy.enqueue(chunkCount: 3) == 0)
+        #expect(policy.endDecelerating() == 5)
+    }
+
+    @Test("protects an animated top jump from streamed appends")
+    func defersProgrammaticScrollAppends() {
+        var policy = ChatArtifactTextAppendPolicy()
+
+        policy.beginProgrammaticAnimation()
+        #expect(policy.enqueue(chunkCount: 2) == 0)
+        #expect(policy.endProgrammaticAnimation() == 2)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTextEndJumpTargetTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactTextEndJumpTargetTests.swift
@@ -1,0 +1,12 @@
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact text end jump target")
+struct ChatArtifactTextEndJumpTargetTests {
+    @Test("streaming targets latest and EOF targets the final end")
+    func followsStreamingState() {
+        #expect(ChatArtifactTextEndJumpTarget(reachedEOF: false) == .latest)
+        #expect(ChatArtifactTextEndJumpTarget(reachedEOF: true) == .end)
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerModelTests.swift
@@ -6,6 +6,30 @@ import Testing
 
 @Suite
 struct ChatArtifactViewerModelTests {
+    @Test("large transport chunks are published in bounded UI batches")
+    @MainActor
+    func batchesLargeTransportChunks() async {
+        let line = "0123456789abcdef 漢🙂\n"
+        let text = String(repeating: line, count: 20_000)
+        let data = Data(text.utf8)
+        let loader = Self.loader(totalSize: Int64(data.count)) { _, onChunk in
+            try await onChunk(ChatArtifactChunk(
+                data: data,
+                offset: 0,
+                totalSize: Int64(data.count),
+                eof: true
+            ))
+        }
+        let model = ChatArtifactViewerModel()
+
+        await model.load(path: "/tmp/large.log", loader: loader)
+
+        #expect(model.textChunks.count > 1)
+        #expect(model.textChunks.allSatisfy { $0.utf8.count <= 262_160 })
+        #expect(model.renderedText == text)
+        #expect(model.textReachedEOF)
+    }
+
     @Test
     @MainActor
     func exposesFirstChunkBeforeEOFAndCompletesProgress() async throws {

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
@@ -1,0 +1,88 @@
+import CmuxAgentChat
+import Foundation
+import Testing
+
+@testable import CmuxAgentChatUI
+
+@Suite("Artifact viewer pager ownership")
+struct ChatArtifactViewerPagerModelTests {
+    @Test("keeps page identity stable across gallery snapshot updates")
+    @MainActor
+    func keepsStablePageIdentity() throws {
+        let defaults = try #require(UserDefaults(suiteName: "cmux.viewer-pager.\(UUID().uuidString)"))
+        let initialOrder = swipeOrder([
+            item(path: "/logs/build.log", size: 11_000_000),
+            item(path: "/logs/test.log", size: 2_000),
+        ])
+        let model = ChatArtifactViewerPagerModel(
+            initialPath: "/logs/build.log",
+            swipeOrder: initialOrder,
+            textPreferences: ChatArtifactTextPreferences(defaults: defaults)
+        )
+        let initialIdentity = try #require(model.pageIdentity(for: "/logs/build.log"))
+
+        model.update(swipeOrder: swipeOrder([
+            item(path: "/logs/new.log", size: 40),
+            item(path: "/logs/build.log", size: 11_500_000),
+            item(path: "/logs/test.log", size: 2_000),
+        ]))
+
+        #expect(model.pageIdentity(for: "/logs/build.log") == initialIdentity)
+        #expect(model.pageSnapshots.map(\.path) == ["/logs/new.log", "/logs/build.log"])
+    }
+
+    @Test("projects toolbar state from exactly the selected page")
+    @MainActor
+    func projectsOneToolbarState() throws {
+        let defaults = try #require(UserDefaults(suiteName: "cmux.viewer-toolbar.\(UUID().uuidString)"))
+        let model = ChatArtifactViewerPagerModel(
+            initialPath: "/first.txt",
+            swipeOrder: swipeOrder([
+                item(path: "/first.txt", size: 10),
+                item(path: "/second.txt", size: 20),
+                item(path: "/third.txt", size: 30),
+            ]),
+            textPreferences: ChatArtifactTextPreferences(defaults: defaults)
+        )
+
+        #expect(model.toolbarSnapshot.path == "/first.txt")
+        model.select(path: "/second.txt")
+        #expect(model.toolbarSnapshot.path == "/second.txt")
+        #expect(model.pageSnapshots.count == 3)
+    }
+
+    @Test("snapshot refreshes do not replay jump requests")
+    @MainActor
+    func keepsJumpRequestIdentity() throws {
+        let defaults = try #require(UserDefaults(suiteName: "cmux.viewer-jumps.\(UUID().uuidString)"))
+        let model = ChatArtifactViewerPagerModel(
+            initialPath: "/build.log",
+            swipeOrder: swipeOrder([item(path: "/build.log", size: 11_000_000)]),
+            textPreferences: ChatArtifactTextPreferences(defaults: defaults)
+        )
+
+        model.requestTop()
+        let requestID = model.toolbarSnapshot.topRequestID
+        model.update(swipeOrder: swipeOrder([
+            item(path: "/build.log", size: 11_500_000),
+            item(path: "/new.log", size: 100),
+        ]))
+
+        #expect(requestID == 1)
+        #expect(model.toolbarSnapshot.topRequestID == requestID)
+    }
+
+    private func swipeOrder(_ items: [ChatArtifactGalleryItem]) -> ChatArtifactGallerySwipeOrder {
+        ChatArtifactGallerySwipeOrder(items: items)
+    }
+
+    private func item(path: String, size: Int64) -> ChatArtifactGalleryItem {
+        ChatArtifactGalleryItem(
+            path: path,
+            kind: .text,
+            displayName: URL(fileURLWithPath: path).lastPathComponent,
+            size: size,
+            modifiedAt: Date(timeIntervalSince1970: Double(size))
+        )
+    }
+}

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
@@ -9,7 +9,9 @@ struct ChatArtifactViewerPagerModelTests {
     @Test("keeps page identity stable across gallery snapshot updates")
     @MainActor
     func keepsStablePageIdentity() throws {
-        let defaults = try #require(UserDefaults(suiteName: "cmux.viewer-pager.\(UUID().uuidString)"))
+        let suiteName = "cmux.viewer-pager.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let initialOrder = swipeOrder([
             item(path: "/logs/build.log", size: 11_000_000),
             item(path: "/logs/test.log", size: 2_000),
@@ -28,13 +30,19 @@ struct ChatArtifactViewerPagerModelTests {
         ]))
 
         #expect(model.pageIdentity(for: "/logs/build.log") == initialIdentity)
-        #expect(model.pageSnapshots.map(\.path) == ["/logs/new.log", "/logs/build.log"])
+        #expect(model.pageSnapshots.map(\.path) == [
+            "/logs/new.log",
+            "/logs/build.log",
+            "/logs/test.log",
+        ])
     }
 
     @Test("projects toolbar state from exactly the selected page")
     @MainActor
     func projectsOneToolbarState() throws {
-        let defaults = try #require(UserDefaults(suiteName: "cmux.viewer-toolbar.\(UUID().uuidString)"))
+        let suiteName = "cmux.viewer-toolbar.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
         let model = ChatArtifactViewerPagerModel(
             initialPath: "/first.txt",
             swipeOrder: swipeOrder([
@@ -51,24 +59,73 @@ struct ChatArtifactViewerPagerModelTests {
         #expect(model.pageSnapshots.count == 3)
     }
 
-    @Test("snapshot refreshes do not replay jump requests")
+    @Test("streamed snapshots and gallery refreshes do not replay jump requests")
     @MainActor
-    func keepsJumpRequestIdentity() throws {
-        let defaults = try #require(UserDefaults(suiteName: "cmux.viewer-jumps.\(UUID().uuidString)"))
+    func keepsJumpRequestIdentity() async throws {
+        let suiteName = "cmux.viewer-jumps.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let path = "/build-\(UUID().uuidString).log"
+        let firstData = Data("first\n".utf8)
+        let secondData = Data("second\n".utf8)
+        let totalSize = Int64(firstData.count + secondData.count)
+        let stream = ControlledArtifactStream(chunks: [
+            ChatArtifactChunk(data: firstData, offset: 0, totalSize: totalSize, eof: false),
+            ChatArtifactChunk(
+                data: secondData,
+                offset: Int64(firstData.count),
+                totalSize: totalSize,
+                eof: true
+            ),
+        ])
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { _ in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: totalSize,
+                    modifiedAt: Date(timeIntervalSince1970: 1),
+                    kind: .text,
+                    mimeType: "text/plain"
+                )
+            },
+            stream: { _, onChunk in
+                try await stream.fetch(onChunk: onChunk)
+            }
+        )
         let model = ChatArtifactViewerPagerModel(
-            initialPath: "/build.log",
-            swipeOrder: swipeOrder([item(path: "/build.log", size: 11_000_000)]),
+            initialPath: path,
+            swipeOrder: swipeOrder([item(path: path, size: totalSize)]),
             textPreferences: ChatArtifactTextPreferences(defaults: defaults)
         )
+        let identity = try #require(model.pageIdentity(for: path))
 
         model.requestTop()
         let requestID = model.toolbarSnapshot.topRequestID
+        let actions = model.actions(
+            for: path,
+            loader: loader,
+            quickLookCanPreview: { _ in false }
+        )
+        let loadTask = Task { await actions.load() }
+        await stream.waitUntilFirstChunkDelivered()
+
+        #expect(model.pageIdentity(for: path) == identity)
+        #expect(model.toolbarSnapshot.textChunks == ["first\n"])
+        #expect(model.toolbarSnapshot.topRequestID == requestID)
         model.update(swipeOrder: swipeOrder([
-            item(path: "/build.log", size: 11_500_000),
+            item(path: path, size: totalSize),
             item(path: "/new.log", size: 100),
         ]))
 
         #expect(requestID == 1)
+        #expect(model.pageIdentity(for: path) == identity)
+        #expect(model.toolbarSnapshot.topRequestID == requestID)
+
+        await stream.resume()
+        await loadTask.value
+        #expect(model.toolbarSnapshot.textChunks == ["first\n", "second\n"])
         #expect(model.toolbarSnapshot.topRequestID == requestID)
     }
 

--- a/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
+++ b/Packages/iOS/CmuxAgentChatUI/Tests/CmuxAgentChatUITests/ChatArtifactViewerPagerModelTests.swift
@@ -59,6 +59,64 @@ struct ChatArtifactViewerPagerModelTests {
         #expect(model.pageSnapshots.count == 3)
     }
 
+    @Test("projects the highlighting pill only from the selected page")
+    @MainActor
+    func projectsSelectedPagePill() async throws {
+        let suiteName = "cmux.viewer-pill.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        let logPath = "/logs/build.log"
+        let csvPath = "/data.csv"
+        let logSize = ChatArtifactSyntaxHighlightPolicy.maxHighlightBytes + 1
+        let loader = ChatArtifactLoader(
+            supportsArtifacts: true,
+            stat: { path in
+                ChatArtifactStat(
+                    exists: true,
+                    isDirectory: false,
+                    size: path == logPath ? logSize : 1,
+                    modifiedAt: Date(timeIntervalSince1970: 1),
+                    kind: .text,
+                    mimeType: "text/plain"
+                )
+            },
+            stream: { path, onChunk in
+                let totalSize = path == logPath ? logSize : 1
+                try await onChunk(ChatArtifactChunk(
+                    data: Data("x".utf8),
+                    offset: 0,
+                    totalSize: totalSize,
+                    eof: true
+                ))
+            }
+        )
+        let model = ChatArtifactViewerPagerModel(
+            initialPath: logPath,
+            swipeOrder: swipeOrder([
+                item(path: logPath, size: logSize),
+                item(path: csvPath, size: 1),
+            ]),
+            textPreferences: ChatArtifactTextPreferences(defaults: defaults)
+        )
+
+        await model.actions(
+            for: logPath,
+            loader: loader,
+            quickLookCanPreview: { _ in false }
+        ).load()
+        await model.actions(
+            for: csvPath,
+            loader: loader,
+            quickLookCanPreview: { _ in false }
+        ).load()
+
+        #expect(model.toolbarSnapshot.path == logPath)
+        #expect(model.toolbarSnapshot.showsHighlightingStatusPill)
+        model.select(path: csvPath)
+        #expect(model.toolbarSnapshot.path == csvPath)
+        #expect(!model.toolbarSnapshot.showsHighlightingStatusPill)
+    }
+
     @Test("streamed snapshots and gallery refreshes do not replay jump requests")
     @MainActor
     func keepsJumpRequestIdentity() async throws {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/GhosttySurfaceCoordinator+Artifacts.swift
@@ -241,25 +241,27 @@ extension GhosttySurfaceRepresentable.Coordinator {
             }
         }
 
-        func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {
+        func ghosttySurfaceView(
+            _ surfaceView: GhosttySurfaceView,
+            didTapAtCol col: Int,
+            row: Int
+        ) async -> GhosttySurfaceTapDisposition {
             // Forward to the Mac's real surface as a left click; libghostty
             // reports it to a TUI with mouse mode, or no-ops on a normal screen.
-            Task { @MainActor [weak self] in
-                guard let self else { return }
-                if self.artifactFilesEnabled,
-                   let snapshot = await surfaceView.visibleTextForArtifactHitTesting() {
-                    if let path = TerminalArtifactTapHitTester().path(
-                        in: snapshot.text,
-                        col: col,
-                        row: row,
-                        columns: snapshot.columns
-                    ) {
-                        self.onArtifactPathTapped(path)
-                        return
-                    }
+            if artifactFilesEnabled,
+               let snapshot = await surfaceView.visibleTextForArtifactHitTesting() {
+                if let path = TerminalArtifactTapHitTester().path(
+                    in: snapshot.text,
+                    col: col,
+                    row: row,
+                    columns: snapshot.columns
+                ) {
+                    onArtifactPathTapped(path)
+                    return .openedArtifact
                 }
-                await self.store?.clickTerminal(surfaceID: self.surfaceID, col: col, row: row)
             }
+            await store?.clickTerminal(surfaceID: surfaceID, col: col, row: row)
+            return .focusTerminal
         }
 
         func ghosttySurfaceView(

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChildCountFormatter.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactChildCountFormatter.swift
@@ -1,0 +1,30 @@
+#if os(iOS)
+import Foundation
+
+/// Resolves localized folder-child inflection markup before gallery rendering.
+struct TerminalArtifactChildCountFormatter: Sendable {
+    private let locale: Locale
+
+    init(locale: Locale = .autoupdatingCurrent) {
+        self.locale = locale
+    }
+
+    func string(count: Int, isCapped: Bool) -> String {
+        if isCapped {
+            return String(
+                localized: "terminal.artifact.gallery.child_count_capped",
+                defaultValue: "\(count)+ items",
+                bundle: .module,
+                locale: locale
+            )
+        }
+        let attributed = AttributedString(
+            localized: "terminal.artifact.gallery.child_count",
+            defaultValue: "^[\(count) item](inflect: true)",
+            bundle: .module,
+            locale: locale
+        )
+        return String(attributed.characters)
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet+Content.swift
@@ -673,6 +673,7 @@ extension TerminalArtifactFilesSheet {
         selection = TerminalArtifactPathSelection(
             path: path,
             scope: scope,
+            usesSessionAuthorization: scope == .session || sessionID != nil,
             swipeOrder: swipeOrder
         )
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactFilesSheet.swift
@@ -2,6 +2,7 @@
 import CmuxAgentChat
 import CmuxAgentChatUI
 import CmuxMobileShell
+import Foundation
 import SwiftUI
 
 struct TerminalArtifactContext: Identifiable {
@@ -16,8 +17,35 @@ struct TerminalArtifactSelection: Identifiable, Equatable {
     let workspaceID: String
     let surfaceID: String
     let path: String
+    let sessionID: String?
 
-    var id: String { "\(workspaceID)#\(surfaceID)#\(path)" }
+    init(
+        workspaceID: String,
+        surfaceID: String,
+        path: String,
+        session: ChatSessionDescriptor?
+    ) {
+        self.workspaceID = workspaceID
+        self.surfaceID = surfaceID
+
+        if (path as NSString).isAbsolutePath {
+            self.path = (path as NSString).standardizingPath
+            sessionID = session?.id
+        } else if let session,
+                  let workingDirectory = session.workingDirectory,
+                  (workingDirectory as NSString).isAbsolutePath {
+            self.path = ((workingDirectory as NSString).appendingPathComponent(path) as NSString)
+                .standardizingPath
+            sessionID = session.id
+        } else {
+            self.path = path
+            sessionID = nil
+        }
+    }
+
+    var usesSessionAuthorization: Bool { sessionID != nil }
+
+    var id: String { "\(workspaceID)#\(surfaceID)#\(sessionID ?? "terminal")#\(path)" }
 }
 
 struct TerminalArtifactFilesSheet: View {
@@ -99,14 +127,14 @@ struct TerminalArtifactFilesSheet: View {
                 if let selection {
                     ChatArtifactViewerDestination(
                         path: selection.path,
-                        scope: selection.scope == .session ? .chat : .terminal,
+                        scope: selection.usesSessionAuthorization ? .chat : .terminal,
                         swipeOrder: selection.swipeOrder
                     ) {
                         dismiss()
                     }
                     .environment(
                         \.chatArtifactLoader,
-                        selection.scope == .session ? sessionLoader : loader
+                        selection.usesSessionAuthorization ? sessionLoader : loader
                     )
                 }
             }
@@ -536,8 +564,9 @@ struct TerminalArtifactFilesSheet: View {
     struct TerminalArtifactPathSelection: Identifiable {
         let path: String
         let scope: Scope
+        let usesSessionAuthorization: Bool
         let swipeOrder: ChatArtifactGallerySwipeOrder
-        var id: String { "\(scope)#\(path)" }
+        var id: String { "\(scope)#\(usesSessionAuthorization)#\(path)" }
     }
 }
 #endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
@@ -260,17 +260,9 @@ struct TerminalArtifactGalleryItemView: View {
     }
 
     private func childCountText(_ childCount: Int) -> String {
-        if artifact.childCountIsCapped {
-            return String(
-                localized: "terminal.artifact.gallery.child_count_capped",
-                defaultValue: "\(childCount)+ items",
-                bundle: .module
-            )
-        }
-        return String(
-            localized: "terminal.artifact.gallery.child_count",
-            defaultValue: "^[\(childCount) item](inflect: true)",
-            bundle: .module
+        TerminalArtifactChildCountFormatter().string(
+            count: childCount,
+            isCapped: artifact.childCountIsCapped
         )
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/TerminalArtifactGalleryItemView.swift
@@ -312,16 +312,10 @@ struct TerminalArtifactGalleryItemView: View {
     }
 
     private var symbolName: String {
-        switch artifact.kind {
-        case .image:
-            return "photo"
-        case .text:
-            return "doc.text"
-        case .binary:
-            return "doc.fill"
-        case .directory:
-            return "folder"
-        }
+        ChatArtifactGalleryClassifier().systemImageName(
+            for: artifact.kind,
+            path: artifact.path
+        )
     }
 
     private static let thumbnailDimension = 256

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView+TerminalArtifacts.swift
@@ -40,7 +40,8 @@ extension WorkspaceDetailView {
             selectedTerminalArtifact = TerminalArtifactSelection(
                 workspaceID: workspace.id.rawValue,
                 surfaceID: terminalID,
-                path: path
+                path: path,
+                session: chosenChatSession
             )
         },
         onVisibleArtifactCountChanged: { count in

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceDetailView.swift
@@ -265,16 +265,13 @@ struct WorkspaceDetailView: View {
             if let selectedTerminalArtifact {
                 ChatArtifactViewerDestination(
                     path: selectedTerminalArtifact.path,
-                    scope: .terminal
+                    scope: selectedTerminalArtifact.usesSessionAuthorization ? .chat : .terminal
                 ) {
                     self.selectedTerminalArtifact = nil
                 }
                     .environment(
                         \.chatArtifactLoader,
-                        terminalArtifactLoader(
-                            workspaceID: selectedTerminalArtifact.workspaceID,
-                            surfaceID: selectedTerminalArtifact.surfaceID
-                        )
+                        artifactLoader(for: selectedTerminalArtifact)
                     )
             }
         }
@@ -350,6 +347,24 @@ struct WorkspaceDetailView: View {
                     path: path
                 )
             }
+        )
+    }
+
+    private func artifactLoader(for selection: TerminalArtifactSelection) -> ChatArtifactLoader {
+        guard let sessionID = selection.sessionID else {
+            return terminalArtifactLoader(
+                workspaceID: selection.workspaceID,
+                surfaceID: selection.surfaceID
+            )
+        }
+        guard store.supportsChatArtifacts,
+              let source = store.makeChatEventSource() else {
+            return .unsupported(cache: terminalArtifactThumbnailCache)
+        }
+        return ChatArtifactLoader(
+            source: source,
+            sessionID: sessionID,
+            cache: terminalArtifactThumbnailCache
         )
     }
     #endif

--- a/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChildCountFormatterTests.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Tests/CmuxMobileShellUITests/TerminalArtifactChildCountFormatterTests.swift
@@ -1,0 +1,26 @@
+import Foundation
+import Testing
+
+@testable import CmuxMobileShellUI
+
+@Suite("Terminal artifact child-count formatting")
+struct TerminalArtifactChildCountFormatterTests {
+    @Test("resolves English inflection markup into singular and plural text")
+    func englishInflection() {
+        let formatter = TerminalArtifactChildCountFormatter(locale: Locale(identifier: "en"))
+
+        #expect(formatter.string(count: 1, isCapped: false) == "1 item")
+        #expect(formatter.string(count: 11, isCapped: false) == "11 items")
+        #expect(!formatter.string(count: 11, isCapped: false).contains("inflect"))
+        #expect(formatter.string(count: 500, isCapped: true) == "500+ items")
+    }
+
+    @Test("uses the Japanese localized count without English inflection markup")
+    func japaneseCount() {
+        let formatter = TerminalArtifactChildCountFormatter(locale: Locale(identifier: "ja"))
+
+        #expect(formatter.string(count: 1, isCapped: false) == "1項目")
+        #expect(formatter.string(count: 11, isCapped: false) == "11項目")
+        #expect(formatter.string(count: 500, isCapped: true) == "500項目以上")
+    }
+}

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceTapDisposition.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceTapDisposition.swift
@@ -1,0 +1,13 @@
+#if canImport(UIKit)
+/// Tells the terminal surface whether a completed tap should claim keyboard focus.
+public enum GhosttySurfaceTapDisposition: Sendable {
+    /// The host opened an artifact for the tapped path; terminal focus must remain unchanged.
+    case openedArtifact
+    /// The tap belongs to the terminal and should raise or restore its input focus.
+    case focusTerminal
+
+    var shouldFocusTerminal: Bool {
+        self == .focusTerminal
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceView.swift
@@ -1569,17 +1569,26 @@ public final class GhosttySurfaceView: UIView, TerminalSurfaceHosting {
             setChromeHidden(false)
         }
         let cell = scrollCell(at: gesture.location(in: self))
-        delegate?.ghosttySurfaceView(self, didTapAtCol: cell.col, row: cell.row)
-        // A tap inside the composer band is excluded by the gesture recognizer
-        // (`gestureRecognizer(_:shouldReceive:)`), so any tap reaching here is a
-        // deliberate terminal tap. Only a reveal-from-hide with the composer still
-        // presented re-focuses the composer; every other terminal tap focuses the
-        // terminal proxy as before.
-        if wasHidden, composerActive {
-            delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
-            focusMountedComposerField()
-        } else {
-            focusInput()
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            let disposition = await self.delegate?.ghosttySurfaceView(
+                self,
+                didTapAtCol: cell.col,
+                row: cell.row
+            ) ?? .focusTerminal
+            guard disposition.shouldFocusTerminal else { return }
+
+            // A tap inside the composer band is excluded by the gesture recognizer
+            // (`gestureRecognizer(_:shouldReceive:)`), so any tap reaching here is a
+            // deliberate terminal tap. Only a reveal-from-hide with the composer still
+            // presented re-focuses the composer; every other terminal tap focuses the
+            // terminal proxy as before. Artifact taps never enter this focus path.
+            if wasHidden, self.composerActive {
+                self.delegate?.ghosttySurfaceViewDidRequestComposerFocus(self)
+                self.focusMountedComposerField()
+            } else {
+                self.focusInput()
+            }
         }
     }
 

--- a/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceViewDelegate.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Sources/CmuxMobileTerminal/GhosttySurfaceViewDelegate.swift
@@ -28,7 +28,11 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
     /// cell, so TUIs with mouse reporting (lazygit/htop/fzf) receive the click.
     /// The Mac's libghostty self-gates: a normal screen treats it as a harmless
     /// empty selection. Optional.
-    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int)
+    func ghosttySurfaceView(
+        _ surfaceView: GhosttySurfaceView,
+        didTapAtCol col: Int,
+        row: Int
+    ) async -> GhosttySurfaceTapDisposition
     /// The user tapped the "customize" button at the end of the input-accessory
     /// bar; the host should present the toolbar shortcuts editor. Optional.
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView)
@@ -77,8 +81,14 @@ public protocol GhosttySurfaceViewDelegate: AnyObject {
 public extension GhosttySurfaceViewDelegate {
     /// Default no-op so hosts without remote scroll forwarding can ignore it.
     func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didScrollLines lines: Double, atCol col: Int, row: Int) {}
-    /// Default no-op so hosts without remote click forwarding can ignore it.
-    func ghosttySurfaceView(_ surfaceView: GhosttySurfaceView, didTapAtCol col: Int, row: Int) {}
+    /// Default terminal disposition so hosts without remote click forwarding retain input focus.
+    func ghosttySurfaceView(
+        _ surfaceView: GhosttySurfaceView,
+        didTapAtCol col: Int,
+        row: Int
+    ) async -> GhosttySurfaceTapDisposition {
+        .focusTerminal
+    }
     /// Default no-op so hosts without a toolbar editor can ignore the request.
     func ghosttySurfaceViewDidRequestToolbarSettings(_ surfaceView: GhosttySurfaceView) {}
     /// Default no-op so hosts without terminal artifacts can ignore the request.

--- a/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceTapDispositionTests.swift
+++ b/Packages/iOS/CmuxMobileTerminal/Tests/CmuxMobileTerminalTests/GhosttySurfaceTapDispositionTests.swift
@@ -1,0 +1,12 @@
+import Testing
+
+@testable import CmuxMobileTerminal
+
+@Suite("Terminal surface tap disposition")
+struct GhosttySurfaceTapDispositionTests {
+    @Test("only terminal taps claim input focus")
+    func inputFocus() {
+        #expect(GhosttySurfaceTapDisposition.focusTerminal.shouldFocusTerminal)
+        #expect(!GhosttySurfaceTapDisposition.openedArtifact.shouldFocusTerminal)
+    }
+}

--- a/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
+++ b/Sources/Mobile/AgentChat/AgentChatSessionRegistry.swift
@@ -47,9 +47,22 @@ final class AgentChatSessionRegistry {
 
     /// Creates a registry.
     ///
-    /// - Parameter hookStore: Reader for the per-agent hook session stores.
-    init(hookStore: AgentChatHookSessionStore = AgentChatHookSessionStore()) {
+    /// - Parameters:
+    ///   - hookStore: Reader for the per-agent hook session stores.
+    ///   - restoredRecords: Records restored before live observation begins.
+    init(
+        hookStore: AgentChatHookSessionStore = AgentChatHookSessionStore(),
+        restoredRecords: [AgentChatSessionRecord] = []
+    ) {
         self.hookStore = hookStore
+        for record in restoredRecords {
+            records[record.sessionID] = record
+            versionBySessionID[record.sessionID] = record.version
+        }
+        rebuildSessionIndexes()
+        for record in records.values {
+            syncProcessExitWatch(for: record)
+        }
     }
 
     /// All known sessions, optionally restricted to one workspace, most
@@ -139,10 +152,7 @@ final class AgentChatSessionRegistry {
                 }
                 stampLifecycleTransition(previous: nil, current: &record, at: session.sampledAt)
                 stampVersion(&record)
-                records[targetSessionID] = record
-                syncProcessExitWatch(for: record)
-                updateSessionIndexes(previous: nil, current: record)
-                onRecordChanged?(record, nil)
+                storeRecord(record, replacing: nil)
             } else {
                 guard let current = records[targetSessionID] else { continue }
                 if reviveEndedObservedSessionIfNeeded(current: current, observed: session, now: now) {
@@ -260,9 +270,7 @@ final class AgentChatSessionRegistry {
         if let live = liveSession(surfaceID: surfaceID) {
             return live
         }
-        return sessionSurfaceIndex.sessionIDs(surfaceID: surfaceID)
-            .compactMap { records[$0] }
-            .filter { $0.surfaceID == surfaceID }
+        return indexedRecords(surfaceID: surfaceID)
             .max { $0.lastActivityAt < $1.lastActivityAt }
     }
 
@@ -302,7 +310,6 @@ final class AgentChatSessionRegistry {
         mutate(&record)
         stampLifecycleTransition(previous: previous, current: &record, at: Date())
         stampVersion(&record)
-        records[sessionID] = record
         #if DEBUG
         if previous.state != record.state {
             cmuxDebugLog(
@@ -311,9 +318,7 @@ final class AgentChatSessionRegistry {
             )
         }
         #endif
-        syncProcessExitWatch(for: record)
-        updateSessionIndexes(previous: previous, current: record)
-        onRecordChanged?(record, previous)
+        storeRecord(record, replacing: previous)
     }
 
     #if DEBUG
@@ -388,10 +393,7 @@ final class AgentChatSessionRegistry {
                 record.rememberHookStoreSessionID(entry.sessionID)
                 stampLifecycleTransition(previous: nil, current: &record, at: entry.updatedAt ?? Date())
                 stampVersion(&record)
-                records[sessionID] = record
-                syncProcessExitWatch(for: record)
-                updateSessionIndexes(previous: nil, current: record)
-                onRecordChanged?(record, nil)
+                storeRecord(record, replacing: nil)
             }
         }
     }
@@ -476,10 +478,7 @@ final class AgentChatSessionRegistry {
         record.state = Self.nextState(previous: record.state, event: event)
         stampLifecycleTransition(previous: previous, current: &record, at: event.receivedAt)
         stampVersion(&record)
-        records[sessionID] = record
-        syncProcessExitWatch(for: record)
-        updateSessionIndexes(previous: previous, current: record)
-        onRecordChanged?(record, previous)
+        storeRecord(record, replacing: previous)
         if shouldConsultStore {
             backfillBindingsFromStore(
                 sessionID: sessionID,
@@ -556,18 +555,7 @@ final class AgentChatSessionRegistry {
             .map(\.sessionID)
         guard !aliases.isEmpty else { return }
         for alias in aliases {
-            guard var record = records.removeValue(forKey: alias) else { continue }
-            stampVersion(&record)
-            exitWatchers[alias]?.source.cancel()
-            exitWatchers[alias] = nil
-            hookStoreConsultedAt.removeValue(forKey: alias)
-            updateSessionIndexes(previous: record, current: nil)
-            onRecordRemoved?(record)
-        }
-        if let indexed = liveSessionIDBySurfaceID[surfaceID],
-           aliases.contains(indexed) {
-            liveSessionIDBySurfaceID.removeValue(forKey: surfaceID)
-            rebuildLiveSessionIndex(surfaceID: surfaceID)
+            removeRecord(sessionID: alias)
         }
     }
 
@@ -650,10 +638,7 @@ final class AgentChatSessionRegistry {
         )
         stampLifecycleTransition(previous: nil, current: &record, at: now)
         stampVersion(&record)
-        records[sessionID] = record
-        syncProcessExitWatch(for: record)
-        updateSessionIndexes(previous: nil, current: record)
-        onRecordChanged?(record, nil)
+        storeRecord(record, replacing: nil)
     }
 
     /// Reads one session's hook-store entry OFF the main actor and applies any
@@ -692,6 +677,57 @@ final class AgentChatSessionRegistry {
         update(sessionID: sessionID) { record in
             record.adoptMissingBindings(from: entry, includingPID: record.pid == nil)
         }
+    }
+
+    /// Stores one record and reconciles every derived registry structure.
+    private func storeRecord(
+        _ record: AgentChatSessionRecord,
+        replacing previous: AgentChatSessionRecord?
+    ) {
+        records[record.sessionID] = record
+        syncProcessExitWatch(for: record)
+        updateSessionIndexes(previous: previous, current: record)
+        onRecordChanged?(record, previous)
+    }
+
+    /// Removes one record and reconciles every derived registry structure.
+    private func removeRecord(sessionID: String) {
+        guard var record = records.removeValue(forKey: sessionID) else { return }
+        stampVersion(&record)
+        exitWatchers[sessionID]?.source.cancel()
+        exitWatchers[sessionID] = nil
+        hookStoreConsultedAt.removeValue(forKey: sessionID)
+        updateSessionIndexes(previous: record, current: nil)
+        onRecordRemoved?(record)
+    }
+
+    /// Rebuilds all derived indexes after records are restored at initialization.
+    private func rebuildSessionIndexes() {
+        sessionSurfaceIndex = ChatSessionSurfaceIndex<String>()
+        liveSessionIDBySurfaceID.removeAll(keepingCapacity: true)
+        liveClaudeSessionIDsBySurfaceID.removeAll(keepingCapacity: true)
+        for record in records.values {
+            updateSessionIndexes(previous: nil, current: record)
+        }
+    }
+
+    /// Resolves indexed records and repairs a missing or stale surface entry.
+    private func indexedRecords(surfaceID: String) -> [AgentChatSessionRecord] {
+        let before = sessionSurfaceIndex.sessionIDs(surfaceID: surfaceID)
+        let sessionIDs = sessionSurfaceIndex.sessionIDs(
+            surfaceID: surfaceID,
+            healingFrom: records,
+            recordSurfaceID: \.surfaceID
+        )
+        #if DEBUG
+        if before != sessionIDs, !sessionIDs.isEmpty {
+            cmuxDebugLog(
+                "agentChat.surfaceIndex divergence surface=\(surfaceID.prefix(8)) "
+                + "indexed=\(before.count) recovered=\(sessionIDs.count)"
+            )
+        }
+        #endif
+        return sessionIDs.compactMap { records[$0] }
     }
 
     private func updateSessionIndexes(
@@ -745,8 +781,7 @@ final class AgentChatSessionRegistry {
 
     private func rebuildLiveSessionIndex(surfaceID: String?) {
         guard let surfaceID else { return }
-        if let newest = sessionSurfaceIndex.sessionIDs(surfaceID: surfaceID)
-            .compactMap({ records[$0] })
+        if let newest = indexedRecords(surfaceID: surfaceID)
             .filter({ $0.surfaceID == surfaceID && $0.state != .ended })
             .max(by: { $0.lastActivityAt < $1.lastActivityAt }) {
             liveSessionIDBySurfaceID[surfaceID] = newest.sessionID

--- a/Sources/TerminalController+MobileTerminalArtifacts.swift
+++ b/Sources/TerminalController+MobileTerminalArtifacts.swift
@@ -44,7 +44,7 @@ extension TerminalController {
         let visibleOnly = v2Bool(params, "visible_only") ?? false
         let countOnly = v2Bool(params, "count_only") ?? false
         let includeDirectories = v2Bool(params, "include_directories") ?? false
-        let resolution = mobileTerminalArtifactContext(
+        let resolution = await mobileTerminalArtifactContext(
             params: params,
             requiresPath: false,
             includeScrollback: !visibleOnly,
@@ -79,11 +79,16 @@ extension TerminalController {
         let response = await Task.detached(priority: .utility) {
             context.scan(includeDirectories: includeDirectories)
         }.value
+        await terminalArtifactAuthorizationStore.record(
+            workspaceID: context.workspaceID,
+            surfaceID: context.surfaceID,
+            canonicalPaths: Set(response.artifacts.map(\.path))
+        )
         return TerminalArtifactWire.result(response)
     }
 
     func v2MobileTerminalArtifactStat(params: [String: Any]) async -> V2CallResult {
-        let resolution = mobileTerminalArtifactContext(params: params, requiresPath: true)
+        let resolution = await mobileTerminalArtifactContext(params: params, requiresPath: true)
         guard case .success(let context) = resolution else {
             return resolution.failureResult
         }
@@ -107,7 +112,7 @@ extension TerminalController {
     }
 
     func v2MobileTerminalArtifactFetch(params: [String: Any]) async -> V2CallResult {
-        let resolution = mobileTerminalArtifactContext(params: params, requiresPath: true)
+        let resolution = await mobileTerminalArtifactContext(params: params, requiresPath: true)
         guard case .success(let context) = resolution else {
             return resolution.failureResult
         }
@@ -132,7 +137,7 @@ extension TerminalController {
     }
 
     func v2MobileTerminalArtifactThumbnail(params: [String: Any]) async -> V2CallResult {
-        let resolution = mobileTerminalArtifactContext(params: params, requiresPath: true)
+        let resolution = await mobileTerminalArtifactContext(params: params, requiresPath: true)
         guard case .success(let context) = resolution else {
             return resolution.failureResult
         }
@@ -155,7 +160,7 @@ extension TerminalController {
     }
 
     func v2MobileTerminalArtifactList(params: [String: Any]) async -> V2CallResult {
-        let resolution = mobileTerminalArtifactContext(params: params, requiresPath: true)
+        let resolution = await mobileTerminalArtifactContext(params: params, requiresPath: true)
         guard case .success(let context) = resolution else {
             return resolution.failureResult
         }
@@ -181,7 +186,7 @@ extension TerminalController {
         requiresPath: Bool,
         includeScrollback: Bool = true,
         includeTerminalText: Bool = true
-    ) -> TerminalArtifactContextResolution {
+    ) async -> TerminalArtifactContextResolution {
         guard let workspaceID = v2RawString(params, "workspace_id")?.trimmingCharacters(in: .whitespacesAndNewlines),
               let surfaceID = v2RawString(params, "surface_id")?.trimmingCharacters(in: .whitespacesAndNewlines),
               !workspaceID.isEmpty,
@@ -196,6 +201,12 @@ extension TerminalController {
                 data: nil
             ))
         }
+        let scanAuthorizedPaths = requiresPath
+            ? await terminalArtifactAuthorizationStore.authorizedPaths(
+                workspaceID: workspaceID,
+                surfaceID: surfaceID
+            )
+            : []
         let directoryAccessMode = mobileArtifactDirectoryAccessMode()
         return v2MainSync { () -> TerminalArtifactContextResolution in
             guard let resolved = mobileResolveWorkspaceAndSurface(params: params, requireTerminal: true),
@@ -219,10 +230,13 @@ extension TerminalController {
                 $0.currentOrMostRecentSessionRecord(surfaceID: resolvedSurfaceID.uuidString)?.sessionID
             }
             return .success(TerminalArtifactReadContext(
+                workspaceID: workspaceID,
+                surfaceID: surfaceID,
                 terminalText: terminalText,
                 workingDirectory: workingDirectory,
                 requestedPath: v2RawString(params, "path"),
                 sessionID: sessionID,
+                scanAuthorizedPaths: scanAuthorizedPaths,
                 directoryAccessMode: directoryAccessMode
             ))
         }
@@ -305,23 +319,32 @@ private struct TerminalArtifactReadContext: Sendable {
         case forbidden
     }
 
+    let workspaceID: String
+    let surfaceID: String
     private let terminalText: String
     private let workingDirectory: String?
     let requestedPath: String?
     let sessionID: String?
+    private let scanAuthorizedPaths: Set<String>
     private let directoryAccessMode: ChatArtifactScope.DirectoryAccessMode
 
     init(
+        workspaceID: String,
+        surfaceID: String,
         terminalText: String,
         workingDirectory: String?,
         requestedPath: String?,
         sessionID: String?,
+        scanAuthorizedPaths: Set<String>,
         directoryAccessMode: ChatArtifactScope.DirectoryAccessMode
     ) {
+        self.workspaceID = workspaceID
+        self.surfaceID = surfaceID
         self.terminalText = terminalText
         self.workingDirectory = workingDirectory
         self.requestedPath = requestedPath
         self.sessionID = sessionID
+        self.scanAuthorizedPaths = scanAuthorizedPaths
         self.directoryAccessMode = directoryAccessMode
     }
 
@@ -351,10 +374,19 @@ private struct TerminalArtifactReadContext: Sendable {
         _ operation: (ArtifactByteReader, String) throws -> T
     ) throws -> T {
         guard let requestedPath else { throw Error.forbidden }
+        let resolver = ChatArtifactScope.FoundationResolver()
+        let snapshotScope = ChatArtifactScope(
+            referencedPaths: scanAuthorizedPaths,
+            directoryAccessMode: directoryAccessMode,
+            resolver: resolver
+        )
+        if let canonicalPath = snapshotScope.canonicalFilePath(for: requestedPath) {
+            return try operation(ArtifactByteReader(), canonicalPath)
+        }
         let scope = TerminalArtifactScope(
             terminalText: terminalText,
             workingDirectory: workingDirectory,
-            resolver: ChatArtifactScope.FoundationResolver(),
+            resolver: resolver,
             directoryAccessMode: directoryAccessMode
         )
         guard let canonicalPath = scope.canonicalPath(for: requestedPath) else {
@@ -367,10 +399,19 @@ private struct TerminalArtifactReadContext: Sendable {
         _ operation: (ArtifactByteReader, String) throws -> T
     ) throws -> T {
         guard let requestedPath else { throw Error.forbidden }
+        let resolver = ChatArtifactScope.FoundationResolver()
+        let snapshotScope = ChatArtifactScope(
+            referencedPaths: scanAuthorizedPaths,
+            directoryAccessMode: directoryAccessMode,
+            resolver: resolver
+        )
+        if let canonicalPath = snapshotScope.canonicalDirectoryListPath(for: requestedPath) {
+            return try operation(ArtifactByteReader(), canonicalPath)
+        }
         let scope = TerminalArtifactScope(
             terminalText: terminalText,
             workingDirectory: workingDirectory,
-            resolver: ChatArtifactScope.FoundationResolver(),
+            resolver: resolver,
             directoryAccessMode: directoryAccessMode
         )
         guard let canonicalPath = scope.canonicalDirectoryListPath(for: requestedPath) else {

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -16,6 +16,7 @@ import CmuxSwiftRenderUI
 import Carbon.HIToolbox
 import CMUXMobileCore
 import CMUXAgentLaunch
+import CmuxAgentChat
 import Foundation
 import os
 import Bonsplit
@@ -125,6 +126,7 @@ class TerminalController {
     @MainActor private(set) var authCoordinator: AuthCoordinator?
     @MainActor private(set) var browserSignInFlow: HostBrowserSignInFlow?
     @MainActor var agentChatTranscriptService: AgentChatTranscriptService?
+    nonisolated let terminalArtifactAuthorizationStore: TerminalArtifactAuthorizationStore
     // Sendable value type; injected at construction so socket auth never reaches a global.
     private nonisolated let passwordStore: SocketControlPasswordStore
     nonisolated let socketClientCapabilityAuthority: SocketClientCapabilityAuthority
@@ -354,6 +356,7 @@ class TerminalController {
         socketClientPreauthorizationLimiter: SocketClientPreauthorizationLimiter = .init(
             maximumConcurrentClaims: 32
         ),
+        terminalArtifactAuthorizationStore: TerminalArtifactAuthorizationStore = .init(),
         remoteProxyBroker: any RemoteProxyBrokering = RemoteProxyBroker(
             tunnelProvider: RemoteDaemonProxyTunnelProvider(strings: .appLocalized, ptyBridgeStrings: AppRemotePTYBridgeStrings())
         )
@@ -361,6 +364,7 @@ class TerminalController {
         self.passwordStore = passwordStore
         self.socketClientCapabilityAuthority = Self.makeSocketClientCapabilityAuthority()
         self.socketClientPreauthorizationLimiter = socketClientPreauthorizationLimiter
+        self.terminalArtifactAuthorizationStore = terminalArtifactAuthorizationStore
         self.transport = transport
         self.remoteProxyBroker = remoteProxyBroker
         let serverEventTarget = ServerEventTarget()

--- a/cmuxTests/AgentChatSessionRegistryLifecycleTests.swift
+++ b/cmuxTests/AgentChatSessionRegistryLifecycleTests.swift
@@ -464,6 +464,39 @@ struct AgentChatSessionRegistryLifecycleTests {
         #expect(service.hasBoundedReadableTranscript(record))
     }
 
+    @MainActor
+    @Test func restoreStyleInitializationRebuildsSurfaceLookup() throws {
+        let surfaceID = UUID().uuidString
+        let older = AgentChatSessionRecord(
+            sessionID: "older",
+            agentKind: .codex,
+            workspaceID: UUID().uuidString,
+            surfaceID: surfaceID,
+            workingDirectory: "/Users/example/project",
+            transcriptPath: "/tmp/older.jsonl",
+            state: .ended,
+            lastActivityAt: Date(timeIntervalSince1970: 100),
+            title: nil,
+            pid: nil
+        )
+        let newer = AgentChatSessionRecord(
+            sessionID: "newer",
+            agentKind: .claude,
+            workspaceID: UUID().uuidString,
+            surfaceID: surfaceID,
+            workingDirectory: "/Users/example/project",
+            transcriptPath: "/tmp/newer.jsonl",
+            state: .ended,
+            lastActivityAt: Date(timeIntervalSince1970: 200),
+            title: nil,
+            pid: nil
+        )
+        let registry = AgentChatSessionRegistry(restoredRecords: [older, newer])
+
+        let resolved = try #require(registry.currentOrMostRecentSession(surfaceID: surfaceID))
+        #expect(resolved.sessionID == newer.sessionID)
+    }
+
     private func temporaryHomeDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("cmux-agent-chat-\(UUID().uuidString)", isDirectory: true)


### PR DESCRIPTION
From a user screen recording of the live build: the viewer's navigation bar accumulated duplicated Done/actions groups as pages were swiped (each live pager page contributed its own toolbar), scrolling a streaming log snapped back to the top (page identity churned on streaming/live-refresh updates, rebuilding the text view), and collapsing the highlighting pill left a translucent ghost (implicit material morph animating with the frame).

The pager is now the single toolbar owner: one trailing ToolbarItemGroup (actions menu + Done) fed by the selected page's snapshot; pages render content only and expose actions through immutable per-page action bundles. Page models are owned per path in a stable window (previous/current/next), so streaming progress and live-refresh ticks update snapshots without recreating the hosted text view, and the ownership test locks that in (red commit proves the test fails without the fix). The pill collapse animates opacity and frame over a clipped solid translucent background with no material morph.

Tests: CmuxAgentChatUI 83 across 20 suites (new pager ownership coverage red-then-green); iOS simulator-triple build passes; no new strings; no lockfile changes. Verified-implementation pipeline evidence (sim recording, frame splits, accessibility button counts, Instruments hitch trace) follows in this PR before merge consideration.

Part 8 of the chip-files-gallery completion stack, based on https://github.com/manaflow-ai/cmux/pull/8121.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8130"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786681093&installation_id=133855650&pr_number=8130&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8130&signature=40d2c72b215a6064e4c3bd2de6dff9126c01f9d06cc684eebf10ea18f9c87c7f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the artifact viewer pager the single toolbar owner and keeps page identity stable across updates. Streamed text is batched and scroll-safe, Markdown blocks are preserved, large-doc accessibility is bounded, artifact taps honor session auth (including In View scans), end jumps land on final content, and gallery document glyphs are unified.

- **Bug Fixes**
  - Restored terminal artifact taps; openings no longer steal terminal focus and use session authorization when needed.
  - Preserved In View scan authorization so listed paths remain openable after they scroll off screen.
  - Fixed folder navigation by carrying the original loader/scope into child routes so nested items open correctly.
  - Bounded streaming updates (<=256 KB) and deferred appends while scrolling; “Jump to End” targets Latest while streaming and final EOF after completion.
  - Unified document glyphs and classification (e.g., `.txt` now treated as docs, not logs).

- **Refactors**
  - Added a UIKit pager bridge with one hosting root per path and a completed-transition state model.
  - Introduced per-path page models and immutable snapshots; the route view renders snapshots only, with tests for stable identity, bounded streaming, neighbor reloads, and surface index self-healing.

<sup>Written for commit 7a8c57eeec2d9015a4fe87f8af53c2052a7bf1a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8130?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

