### PR TITLE
Fix iOS framework MinimumOSVersion packaging

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -127,6 +127,111 @@ verify_ipa_bundle_identity() {
   return 0
 }
 
+resolve_ios_minimum_os_version() {
+  local app="$1"
+  local minimum_os configured_minimum_os
+
+  minimum_os="$("$PLISTBUDDY" -c 'Print :MinimumOSVersion' "$app/Info.plist" 2>/dev/null || true)"
+  if [[ -n "$minimum_os" ]]; then
+    printf '%s\n' "$minimum_os"
+    return 0
+  fi
+
+  configured_minimum_os="$(read_xcconfig_setting IPHONEOS_DEPLOYMENT_TARGET "$SHARED_XCCONFIG")"
+  if [[ -n "$configured_minimum_os" ]]; then
+    printf '%s\n' "$configured_minimum_os"
+    return 0
+  fi
+
+  echo "error: could not resolve iOS MinimumOSVersion from $app/Info.plist or IPHONEOS_DEPLOYMENT_TARGET in $SHARED_XCCONFIG" >&2
+  return 1
+}
+
+stamp_ios_framework_minimum_os_versions() {
+  local app="$1"
+  local minimum_os="$2"
+
+  if [[ ! -d "$app/Frameworks" ]]; then
+    return 0
+  fi
+
+  while IFS= read -r -d '' framework_info; do
+    local changed
+    changed="$(python3 - "$framework_info" "$minimum_os" <<'PY'
+import plistlib
+import sys
+
+plist_path, minimum_os = sys.argv[1], sys.argv[2]
+with open(plist_path, "rb") as handle:
+    info = plistlib.load(handle)
+
+current = info.get("MinimumOSVersion")
+if isinstance(current, str) and current.strip():
+    raise SystemExit(0)
+
+info["MinimumOSVersion"] = minimum_os
+with open(plist_path, "wb") as handle:
+    plistlib.dump(info, handle)
+print("1")
+PY
+)"
+    if [[ "$changed" == "1" ]]; then
+      echo "stamped MinimumOSVersion=$minimum_os on nested framework: ${framework_info#$app/}"
+    fi
+  done < <(find "$app/Frameworks" -maxdepth 2 -path '*.framework/Info.plist' -type f -print0)
+}
+
+verify_ipa_framework_minimum_os_versions() {
+  local ipa="$1"
+  local workdir app status
+
+  workdir="$(mktemp -d)"
+  if ! ( cd "$workdir" && unzip -q "$ipa" ); then
+    echo "error: could not unzip IPA to verify framework MinimumOSVersion metadata: $ipa" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+  app="$(find "$workdir/Payload" -maxdepth 1 -name '*.app' -type d 2>/dev/null | head -n 1)"
+  if [[ -z "$app" || ! -d "$app" ]]; then
+    echo "error: IPA has no Payload/*.app to verify framework MinimumOSVersion metadata: $ipa" >&2
+    rm -rf "$workdir"
+    return 1
+  fi
+
+  python3 - "$app" <<'PY'
+import plistlib
+import sys
+from pathlib import Path
+
+app = Path(sys.argv[1])
+frameworks = app / "Frameworks"
+bad = []
+
+if frameworks.is_dir():
+    for plist_path in sorted(frameworks.glob("*.framework/Info.plist")):
+        try:
+            info = plistlib.loads(plist_path.read_bytes())
+        except Exception as exc:
+            bad.append(f"{plist_path.relative_to(app)}: unreadable Info.plist ({exc})")
+            continue
+        value = info.get("MinimumOSVersion")
+        if not isinstance(value, str) or not value.strip():
+            bad.append(f"{plist_path.relative_to(app)}: MinimumOSVersion is missing or empty")
+
+if bad:
+    print(
+        "error: iOS framework metadata is incomplete; App Store Connect rejects embedded frameworks without MinimumOSVersion",
+        file=sys.stderr,
+    )
+    for item in bad:
+        print(f"error: {item}", file=sys.stderr)
+    raise SystemExit(1)
+PY
+  status=$?
+  rm -rf "$workdir"
+  return "$status"
+}
+
 verify_app_store_ipa_has_no_external_purchase_links() {
   local ipa="$1"
   local workdir app matches
@@ -908,10 +1013,10 @@ fi
 #
 # This runs on the MANUAL signing path only: it re-signs with the named
 # distribution cert from the local keychain ("Apple Distribution: Manaflow,
-# Inc."), which is present for local/fleet-archive beta cuts. The cmux iOS app is
-# a single self-contained bundle (no Frameworks/, no PlugIns/, GhosttyKit is
-# static), so only the top-level .app is signed; there is no nested code to
-# re-sign. Two alternatives were ruled out: an ad-hoc archive (CODE_SIGN_IDENTITY
+# Inc."), which is present for local/fleet-archive beta cuts. Nested frameworks
+# are stamped and signed before the top-level .app so App Store Connect validates
+# their bundle metadata and the final app signature still encloses the repaired
+# payload. Two alternatives were ruled out: an ad-hoc archive (CODE_SIGN_IDENTITY
 # "-") is rejected by the iOS SDK for an entitled app, and signing on the shared
 # fleet would put distribution material on shared Macs.
 if [[ "$SIGNING" == "manual" ]]; then
@@ -939,6 +1044,8 @@ if [[ "$SIGNING" == "manual" ]]; then
     echo "error: could not find Payload/*.app inside the exported IPA to re-sign" >&2
     exit 1
   fi
+  RESIGN_MINIMUM_OS="$(resolve_ios_minimum_os_version "$RESIGN_APP")" || exit 1
+  stamp_ios_framework_minimum_os_versions "$RESIGN_APP" "$RESIGN_MINIMUM_OS"
 
   # Start from the exported app's current (profile-baseline) entitlements, then
   # MERGE the profile's authorized Entitlements dict, then every key from the
@@ -993,6 +1100,11 @@ with open(merged_path, "wb") as f:
 PY
   plutil -lint "$MERGED_ENTITLEMENTS" >/dev/null
 
+  if [[ -d "$RESIGN_APP/Frameworks" ]]; then
+    while IFS= read -r -d '' nested_framework; do
+      codesign --force --sign "$RESIGN_IDENTITY" --timestamp "$nested_framework"
+    done < <(find "$RESIGN_APP/Frameworks" -maxdepth 1 -type d -name '*.framework' -print0)
+  fi
   codesign --force --sign "$RESIGN_IDENTITY" --entitlements "$MERGED_ENTITLEMENTS" --timestamp "$RESIGN_APP"
 
   # HARD GATES on the signed .app: the entitlement we are fixing must be present,
@@ -1047,6 +1159,12 @@ else
   fi
   echo "automatic-signed IPA verified to carry aps-environment=production: $IPA_PATH"
 fi
+
+if ! verify_ipa_framework_minimum_os_versions "$IPA_PATH"; then
+  echo "error: signed IPA framework MinimumOSVersion metadata is incomplete; refusing to upload before App Store Connect rejects it" >&2
+  exit 1
+fi
+echo "signed IPA framework MinimumOSVersion metadata verified"
 
 echo "IPA_PATH=$IPA_PATH"
 

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -649,7 +649,11 @@ def test_upload_beta_lane_uses_beta_marketing_version(tmp: Path, fakebin: Path) 
         info.get("CFBundleShortVersionString") == BETA_MARKETING_VERSION,
         "final signed beta IPA keeps the beta marketing version",
     )
-    _assert_iroh_framework_minimum_os(ipa_path, "18.0")
+    expected_minimum_os = _read_xcconfig_setting(
+        ROOT / "ios" / "Config" / "Shared.xcconfig",
+        "IPHONEOS_DEPLOYMENT_TARGET",
+    )
+    _assert_iroh_framework_minimum_os(ipa_path, expected_minimum_os)
 
 
 def test_upload_beta_archive_path_accepts_marketing_version_override(tmp: Path, fakebin: Path) -> None:

--- a/tests/test_ios_appstore_lane_identity.py
+++ b/tests/test_ios_appstore_lane_identity.py
@@ -332,6 +332,16 @@ if "-exportArchive" in args:
     payload_root = export_path / "Payload"
     app = payload_root / "cmux.app"
     write_plist(app / "Info.plist", archived_info)
+    iroh = app / "Frameworks" / "Iroh.framework"
+    write_plist(
+        iroh / "Info.plist",
+        {{
+            "CFBundleExecutable": "Iroh",
+            "CFBundleIdentifier": "org.iroh.Iroh",
+            "CFBundlePackageType": "FMWK",
+        }},
+    )
+    (iroh / "Iroh").write_text("fake iroh framework binary", encoding="utf-8")
     profile_marker = "beta profile" if bundle_id == BETA_BUNDLE_ID else "fake profile"
     (app / "embedded.mobileprovision").write_text(profile_marker, encoding="utf-8")
     ipa = export_path / "cmux.ipa"
@@ -521,6 +531,17 @@ def _write_fake_archive(path: Path, *, bundle_id: str, build_number: str, market
     (app / "Info.plist").write_bytes(_plist_bytes(info))
 
 
+def _assert_iroh_framework_minimum_os(ipa_path: Path, expected: str) -> None:
+    with zipfile.ZipFile(ipa_path) as zf:
+        info = plistlib.loads(
+            zf.read("Payload/cmux.app/Frameworks/Iroh.framework/Info.plist")
+        )
+    _check(
+        info.get("MinimumOSVersion") == expected,
+        f"final IPA stamps Iroh.framework MinimumOSVersion={expected}",
+    )
+
+
 def _copy_isolated_ios_upload_repo(target: Path) -> Path:
     repo = target / "repo"
     for relative in (
@@ -628,6 +649,7 @@ def test_upload_beta_lane_uses_beta_marketing_version(tmp: Path, fakebin: Path) 
         info.get("CFBundleShortVersionString") == BETA_MARKETING_VERSION,
         "final signed beta IPA keeps the beta marketing version",
     )
+    _assert_iroh_framework_minimum_os(ipa_path, "18.0")
 
 
 def test_upload_beta_archive_path_accepts_marketing_version_override(tmp: Path, fakebin: Path) -> None:


### PR DESCRIPTION
## Summary
- stamp missing `MinimumOSVersion` on embedded iOS frameworks during the manual TestFlight/App Store re-sign path
- re-sign nested frameworks before the top-level app bundle after metadata repair
- add a post-package gate so missing framework `MinimumOSVersion` fails before App Store Connect
- add regression coverage with a fake `Iroh.framework` embedded in the IPA

## Failure Evidence
- Active failing run: https://github.com/manaflow-ai/cmux/actions/runs/29387943412
- Failing job/check: https://github.com/manaflow-ai/cmux/actions/runs/29387943412/job/87265031884
- Step: `Archive, export, and upload to TestFlight`
- Triggering commit: `267ed6ceea9d396e1d1d55770295f59fc3ebd5f4`
- Apple rejection: `Invalid MinimumOSVersion` / `Missing Info.plist value` for `cmux.app/Frameworks/Iroh.framework`

## Testing
- `bash -n ios/scripts/upload-testflight.sh`
- `git diff --check origin/main...HEAD`
- `python3 tests/test_ios_appstore_lane_identity.py`

No runtime app reload: this only changes CI/CD packaging scripts and tests.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8131"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786681940&installation_id=133855650&pr_number=8131&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8131&signature=307ee8e13deb4b95e9637958f6de009b239952b26e2d0c906333bd54fad51736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes App Store/TestFlight rejection by stamping MinimumOSVersion on embedded iOS frameworks and re-signing nested frameworks before the app in the manual signing path. Adds a pre-upload check to fail CI early; packaging scripts and tests only, no runtime impact.

- **Bug Fixes**
  - Stamp MinimumOSVersion on embedded frameworks (from app Info.plist or IPHONEOS_DEPLOYMENT_TARGET in `Shared.xcconfig`).
  - Re-sign nested frameworks first, then the top-level app, so repaired metadata is enclosed by the final signature.
  - Add IPA verification gate that fails if any embedded framework lacks MinimumOSVersion; add regression test with a fake Iroh.framework to assert the stamped value.

<sup>Written for commit a7e82129817659a83a7e85e9233b61849e671db3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS release uploads by ensuring embedded frameworks include the required minimum OS version metadata.
  * Added validation to prevent uploads when framework metadata is missing or invalid.
  * Updated manually signed builds to apply and preserve the required framework metadata.

* **Tests**
  * Expanded release validation to confirm embedded frameworks contain the expected minimum OS version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->