### PR TITLE
remote-tmux: give a freshly split mirror pane key focus so you can type without clicking

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8183,6 +8183,13 @@ final class GhosttySurfaceScrollView: NSView {
     private var searchOverlayMutationGeneration: UInt64 = 0
     private var observers: [NSObjectProtocol] = []
     private var windowObservers: [NSObjectProtocol] = []
+    /// One-shot hook consumed the next time this view attaches to a window
+    /// (`viewDidMoveToWindow` with `window != nil`). A single owner arms it to
+    /// act on the mount edge — the remote-tmux mirror uses it to establish key
+    /// focus on a freshly created pane whose view SwiftUI has not yet inserted.
+    /// Consumed before it runs, so reparent churn after the first attach never
+    /// re-fires it.
+    var onDidAttachToWindow: (() -> Void)?
     private var scrollbarTrackingArea: NSTrackingArea?
     private var isLiveScrolling = false
     private var lastSentRow: Int?
@@ -9163,6 +9170,10 @@ final class GhosttySurfaceScrollView: NSView {
         windowObservers.forEach { NotificationCenter.default.removeObserver($0) }
         windowObservers.removeAll()
         guard let window else { return }
+        if let attachHook = onDidAttachToWindow {
+            onDidAttachToWindow = nil
+            attachHook()
+        }
         windowObservers.append(NotificationCenter.default.addObserver(
             forName: NSWindow.didBecomeKeyNotification,
             object: window,

--- a/Sources/RemoteTmuxWindowMirror.swift
+++ b/Sources/RemoteTmuxWindowMirror.swift
@@ -128,6 +128,12 @@ final class RemoteTmuxWindowMirror: RemoteTmuxControlPaneMutationOwner {
     /// active pane, so exactly one creation drives key focus — never a later
     /// active-pane echo or a co-attached client's pane switch.
     @ObservationIgnored private var panesAwaitingCreationFocus: Set<Int> = []
+    /// Bumped on every active-pane transition, including to `nil`. A pending
+    /// creation-focus intent captures this when it arms; any intervening
+    /// transition — even one that returns to the same pane (N→O→N) —
+    /// invalidates the intent, so an attach hook that fires later can never
+    /// replay a stale activation as a focus steal.
+    @ObservationIgnored private(set) var paneActivationGeneration: UInt64 = 0
     @ObservationIgnored var isApplyingRemoteLayout = false
     @ObservationIgnored var isApplyingTmuxFocus = false
     @ObservationIgnored var lastDividerPositions: [UUID: CGFloat] = [:]
@@ -397,7 +403,7 @@ final class RemoteTmuxWindowMirror: RemoteTmuxControlPaneMutationOwner {
             panelsByPaneId[paneId] = nil
             cwdByPaneId[paneId] = nil
             panesAwaitingCreationFocus.remove(paneId)
-            if activePaneId == paneId { activePaneId = nil }
+            if activePaneId == paneId { recordActivePane(nil) }
         }
         lastRenderedGrids = lastRenderedGrids.filter { livePaneIds.contains($0.key) }
         // Structural change (split/close/re-nest) vs geometry-only reflow: only
@@ -484,14 +490,14 @@ final class RemoteTmuxWindowMirror: RemoteTmuxControlPaneMutationOwner {
     /// tmux truth, not local focus alone. Tolerates unknown panes: the
     /// matching layout may still be pending its rects publication.
     func noteRemoteActivePane(_ paneId: Int) {
-        if activePaneId != paneId { activePaneId = paneId }
+        recordActivePane(paneId)
         focusBonsplitPane(forTmuxPane: paneId)
         establishCreationKeyFocusIfPending(forPane: paneId)
     }
 
     func setActivePane(_ paneId: Int, fromTmux: Bool) {
         guard layout.paneIDsInOrder.contains(paneId) else { return }
-        if activePaneId != paneId { activePaneId = paneId }
+        recordActivePane(paneId)
         focusBonsplitPane(forTmuxPane: paneId)
         if !fromTmux {
             connection?.send("select-pane -t @\(windowId).%\(paneId)")
@@ -513,6 +519,14 @@ final class RemoteTmuxWindowMirror: RemoteTmuxControlPaneMutationOwner {
               let panel = panelsByPaneId[paneId] else { return }
         panesAwaitingCreationFocus.remove(paneId)
         onEstablishPaneKeyFocus?(paneId, panel)
+    }
+
+    /// Records an active-pane transition; every change bumps the activation
+    /// generation that pending creation-focus intents are validated against.
+    private func recordActivePane(_ paneId: Int?) {
+        guard activePaneId != paneId else { return }
+        activePaneId = paneId
+        paneActivationGeneration &+= 1
     }
 
     /// Records the user-focused pane and asks tmux to make it active.
@@ -588,48 +602,167 @@ final class RemoteTmuxWindowMirror: RemoteTmuxControlPaneMutationOwner {
         cwdByPaneId.removeAll()
         panesAwaitingCreationFocus.removeAll()
         lastRenderedGrids.removeAll()
-        activePaneId = nil
+        recordActivePane(nil)
         connection = nil
+    }
+
+    /// What to do with a freshly created pane's key focus, given the state the
+    /// guards can see. Pure so the policy is pinned by a truth table without a
+    /// live window (``RemoteTmuxMirrorPaneKeyFocusDecisionTests``).
+    enum PaneKeyFocusDecision: Equatable {
+        /// The view is mounted in a visible key window, the pane is still the
+        /// one the user just created and made active, and the responder chain
+        /// still belongs to the terminal layer: focus it now.
+        case focusNow
+        /// Everything still holds but the view has not reached a presentation
+        /// window — it is unattached, or attached to the surface's offscreen
+        /// bootstrap/parking window. Both states end in another
+        /// `viewDidMoveToWindow` (the parking window is never where a pane is
+        /// presented), so (re-)arm the attach hook and decide again on that
+        /// edge. No timer; an intent whose pane never gets presented dies on
+        /// the pane-switch or teardown guards instead.
+        case waitForMount
+        /// The intent is dead: the pane is no longer the active one, the
+        /// mirror is gone or off screen, the view's final attachment is in a
+        /// hidden or non-key window (which has no attach edge to wait on), or
+        /// the user has since focused a non-terminal responder (a search
+        /// field, a palette). Focus stays where it is — never steal it,
+        /// never hold a stale intent.
+        case skip
+    }
+
+    /// The guard set every focus attempt shares (at the creation event, and
+    /// again on each attach edge). Only pre-presentation states wait — they
+    /// have an exact edge (`viewDidMoveToWindow` fires again when the view
+    /// leaves the parking window for its presentation window). Everything
+    /// else either focuses or cancels: a real window that is hidden or not
+    /// key has no wakeup edge, so retaining the intent would risk a stale
+    /// focus steal later.
+    static func paneKeyFocusDecision(
+        mirrorAlive: Bool,
+        paneStillActive: Bool,
+        mirrorOnScreen: Bool,
+        viewInWindow: Bool,
+        inParkingWindow: Bool,
+        viewVisibleInUI: Bool,
+        windowIsKey: Bool,
+        responderYields: Bool
+    ) -> PaneKeyFocusDecision {
+        guard mirrorAlive, paneStillActive, mirrorOnScreen else { return .skip }
+        guard viewInWindow, !inParkingWindow else { return .waitForMount }
+        guard viewVisibleInUI, windowIsKey, responderYields else { return .skip }
+        return .focusNow
     }
 
     /// Establishes key focus on a freshly created pane the way a click does —
     /// `moveFocus()` makes the pane surface the window's first responder directly,
     /// since a mirror pane surface is not a workspace Bonsplit tab and so cannot
-    /// travel the guarded `applyFirstResponderIfNeeded` path. Retries briefly
-    /// because the seam fires from the control-stream event that makes the pane
-    /// active, which can land before SwiftUI has mounted the pane's hosted view.
+    /// travel the guarded `applyFirstResponderIfNeeded` path. The seam fires from
+    /// the control-stream event that makes the pane active, which can land before
+    /// SwiftUI has mounted the pane's hosted view; in that case the view's own
+    /// attach edge (`onDidAttachToWindow`, consumed once per fire from
+    /// `viewDidMoveToWindow`) re-runs the decision — no timer, no retry. An
+    /// attach that lands in the surface's offscreen bootstrap/parking window
+    /// re-arms the hook: leaving that window for the presentation window is
+    /// itself another attach edge.
     ///
     /// Every attempt re-checks the mirror is still on screen and this pane is
-    /// still its active pane, so a pane switch (a click elsewhere, a co-attached
-    /// client, or a tab change) that lands within the retry window cancels the
-    /// pending focus rather than stealing it back. A mirror whose panes are not
-    /// hosted in a key window — a background tab, or any headless caller — never
-    /// moves the first responder at all.
+    /// still its active pane on the SAME activation that armed the intent — an
+    /// activation generation captured at arm time invalidates the intent on
+    /// any intervening pane switch, even one that returns to this pane
+    /// (N→O→N), so a hook that fires later can never replay a stale
+    /// activation. The user focusing a non-terminal responder such as a
+    /// search field also cancels, since a late mount must not pull focus out
+    /// of it. A mirror whose panes land in a hidden or non-key window — a
+    /// background tab, or any headless caller — never moves the first
+    /// responder and never keeps the intent alive. If the view never mounts,
+    /// the armed hook is simply never called and focus stays where it was.
     static func establishPaneKeyFocusWhenMounted(
         paneId: Int,
         panel: TerminalPanel,
-        mirror: RemoteTmuxWindowMirror?,
-        attemptsRemaining: Int = 6
+        mirror: RemoteTmuxWindowMirror?
     ) {
-        guard attemptsRemaining > 0,
-              let mirror,
-              !mirror.isTornDown,
-              mirror.activePaneId == paneId,
-              mirror.isEffectivelyVisibleForSizing else { return }
+        attemptPaneKeyFocus(
+            paneId: paneId,
+            panel: panel,
+            mirror: mirror,
+            armedGeneration: mirror?.paneActivationGeneration ?? 0
+        )
+    }
+
+    private static func attemptPaneKeyFocus(
+        paneId: Int,
+        panel: TerminalPanel,
+        mirror: RemoteTmuxWindowMirror?,
+        armedGeneration: UInt64
+    ) {
         let hostedView = panel.hostedView
-        if hostedView.isVisibleInUI,
-           let window = hostedView.uiWindow,
-           window.isKeyWindow {
+        switch paneKeyFocusDecision(
+            paneId: paneId,
+            hostedView: hostedView,
+            mirror: mirror,
+            armedGeneration: armedGeneration
+        ) {
+        case .focusNow:
             hostedView.moveFocus()
-            return
+        case .waitForMount:
+            hostedView.onDidAttachToWindow = { [weak mirror, weak panel] in
+                // One hop off the view-insertion/layout pass that delivered
+                // `viewDidMoveToWindow`; mutating the first responder inside it
+                // is unsafe. This is a re-entrancy guard, not a wait.
+                Task { @MainActor in
+                    guard let panel else { return }
+                    attemptPaneKeyFocus(
+                        paneId: paneId,
+                        panel: panel,
+                        mirror: mirror,
+                        armedGeneration: armedGeneration
+                    )
+                }
+            }
+        case .skip:
+            break
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.016) { [weak mirror] in
-            establishPaneKeyFocusWhenMounted(
-                paneId: paneId,
-                panel: panel,
-                mirror: mirror,
-                attemptsRemaining: attemptsRemaining - 1
-            )
-        }
+    }
+
+    private static func paneKeyFocusDecision(
+        paneId: Int,
+        hostedView: GhosttySurfaceScrollView,
+        mirror: RemoteTmuxWindowMirror?,
+        armedGeneration: UInt64
+    ) -> PaneKeyFocusDecision {
+        // Mount state reads the view's OWN window — the state
+        // `viewDidMoveToWindow` reports on. `uiWindow` differs from it in
+        // exactly one case: the attach landed in the surface's offscreen
+        // bootstrap/parking window, which `TerminalSurface.uiWindow` filters
+        // to nil. That case must wait (the presentation reattach is another
+        // attach edge), not consume the intent.
+        let window = hostedView.window
+        return paneKeyFocusDecision(
+            mirrorAlive: mirror.map { !$0.isTornDown } ?? false,
+            paneStillActive: mirror?.activePaneId == paneId
+                && mirror?.paneActivationGeneration == armedGeneration,
+            mirrorOnScreen: mirror?.isEffectivelyVisibleForSizing == true,
+            viewInWindow: window != nil,
+            inParkingWindow: window != nil && hostedView.uiWindow == nil,
+            viewVisibleInUI: hostedView.isVisibleInUI,
+            windowIsKey: window?.isKeyWindow == true,
+            responderYields: window.map { responderYieldsToPaneFocus($0.firstResponder) } ?? true
+        )
+    }
+
+    /// Whether the window's current first responder belongs to the terminal
+    /// content layer — nothing, the window itself, or a responder owned by a
+    /// terminal surface view (``cmuxOwningGhosttyView(for:)``, which also
+    /// resolves field editors to their owner). Anything else — a search
+    /// field's editor, a palette, a sidebar text view — means the user has
+    /// since put focus somewhere deliberate, and the pending creation focus
+    /// must cancel instead of stealing it. The terminal search overlay mounts
+    /// inside the pane's scroll view but not inside its surface view, so it
+    /// correctly reads as foreign here.
+    private static func responderYieldsToPaneFocus(_ responder: NSResponder?) -> Bool {
+        guard let responder else { return true }
+        if responder is NSWindow { return true }
+        return cmuxOwningGhosttyView(for: responder) != nil
     }
 }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1329,6 +1329,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F11ED7AB0004000400040004 /* RemoteTmuxMirrorNewTabPlacement.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11ED7AB0003000300030003 /* RemoteTmuxMirrorNewTabPlacement.swift */; };
 		F11ED7AB0001000100010001 /* RemoteTmuxMirrorNewTabPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F11ED7AB0002000200020002 /* RemoteTmuxMirrorNewTabPlacementTests.swift */; };
 		A2A2A2A2A2A2A2A2A2A20002 /* RemoteTmuxMirrorPaneInputMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2B2B2B2B2B2B2B2B2B20002 /* RemoteTmuxMirrorPaneInputMappingTests.swift */; };
+		A1A1A1A1A1A1A1A1A1A10003 /* RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1B1B1B1B1B1B1B1B1B10003 /* RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift */; };
 		74060000000000000000000C /* RemoteTmuxMirrorPlacementTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 74060000000000000000000B /* RemoteTmuxMirrorPlacementTests.swift */; };
 		838000000000000000000004 /* RemoteTmuxMirrorRenameHarness.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838000000000000000000003 /* RemoteTmuxMirrorRenameHarness.swift */; };
 		838000000000000000000002 /* RemoteTmuxMirrorRenameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 838000000000000000000001 /* RemoteTmuxMirrorRenameTests.swift */; };
@@ -3445,6 +3446,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F11ED7AB0003000300030003 /* RemoteTmuxMirrorNewTabPlacement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorNewTabPlacement.swift; sourceTree = "<group>"; };
 		F11ED7AB0002000200020002 /* RemoteTmuxMirrorNewTabPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorNewTabPlacementTests.swift; sourceTree = "<group>"; };
 		B2B2B2B2B2B2B2B2B2B20002 /* RemoteTmuxMirrorPaneInputMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorPaneInputMappingTests.swift; sourceTree = "<group>"; };
+		B1B1B1B1B1B1B1B1B1B10003 /* RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift; sourceTree = "<group>"; };
 		74060000000000000000000B /* RemoteTmuxMirrorPlacementTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorPlacementTests.swift; sourceTree = "<group>"; };
 		838000000000000000000003 /* RemoteTmuxMirrorRenameHarness.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorRenameHarness.swift; sourceTree = "<group>"; };
 		838000000000000000000001 /* RemoteTmuxMirrorRenameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RemoteTmuxMirrorRenameTests.swift; sourceTree = "<group>"; };
@@ -6294,6 +6296,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				783300000000000000000001 /* RemoteTmuxMirrorLayoutIdentityTests.swift */,
 				5C7032605BF360630E6E207A /* RemoteTmuxConnectionWindowSizingTests.swift */,
 				B1B1B1B1B1B1B1B1B1B10001 /* RemoteTmuxMirrorNewPaneKeyFocusTests.swift */,
+				B1B1B1B1B1B1B1B1B1B10003 /* RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift */,
 				B2B2B2B2B2B2B2B2B2B20002 /* RemoteTmuxMirrorPaneInputMappingTests.swift */,
 				4D8BD9A2D8B7F7A27B77B289 /* RemoteTmuxRectPublicationTests.swift */,
 				79380000000000000000000B /* RemoteTmuxLayoutNodePatchingTests.swift */,
@@ -8788,6 +8791,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A1A1A1A1A1A1A1A1A1A10001 /* RemoteTmuxMirrorNewPaneKeyFocusTests.swift in Sources */,
 				F11ED7AB0001000100010001 /* RemoteTmuxMirrorNewTabPlacementTests.swift in Sources */,
 				A2A2A2A2A2A2A2A2A2A20002 /* RemoteTmuxMirrorPaneInputMappingTests.swift in Sources */,
+				A1A1A1A1A1A1A1A1A1A10003 /* RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift in Sources */,
 				74060000000000000000000C /* RemoteTmuxMirrorPlacementTests.swift in Sources */,
 				838000000000000000000004 /* RemoteTmuxMirrorRenameHarness.swift in Sources */,
 				838000000000000000000002 /* RemoteTmuxMirrorRenameTests.swift in Sources */,

--- a/cmuxTests/RemoteTmuxMirrorNewPaneKeyFocusTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorNewPaneKeyFocusTests.swift
@@ -146,4 +146,78 @@ struct RemoteTmuxMirrorNewPaneKeyFocusTests {
             "Only pane creation may drive key focus; a plain active-pane switch must not"
         )
     }
+
+    /// A pending focus intent captures `paneActivationGeneration` when it arms
+    /// and is invalidated by ANY later transition — `activePaneId` alone cannot
+    /// tell N→O→N apart from N staying put, and a stale intent firing after
+    /// that round trip would be a focus steal. The generation must therefore
+    /// bump on every transition, including back to the original pane, and must
+    /// NOT bump on a repeated report of the already-active pane (or churn
+    /// without a pane switch would cancel a legitimate pending focus).
+    @Test
+    func activationGenerationBumpsOnEveryTransitionIncludingABA() throws {
+        let harness = Harness()
+        harness.splitMakingPaneFiveActive()
+        let armed = harness.mirror.paneActivationGeneration
+
+        // N→O→N: away and back. Two transitions, two bumps.
+        harness.mirror.noteRemoteActivePane(4)
+        harness.mirror.noteRemoteActivePane(5)
+
+        #expect(harness.mirror.activePaneId == 5)
+        #expect(
+            harness.mirror.paneActivationGeneration == armed + 2,
+            "An N→O→N round trip must invalidate a generation captured at N's activation"
+        )
+
+        // A repeated report of the already-active pane is not a transition.
+        harness.mirror.noteRemoteActivePane(5)
+        #expect(harness.mirror.paneActivationGeneration == armed + 2)
+    }
+
+    /// The attach-edge mechanics the establishment leans on: an armed
+    /// `onDidAttachToWindow` hook fires exactly once, is consumed before it
+    /// runs, and a later reparent does not replay it. This drives the real
+    /// `viewDidMoveToWindow` edge on the real pane view, not the policy table.
+    @Test
+    func attachHookFiresOnceAndIsConsumedByTheAttachEdge() throws {
+        let harness = Harness()
+        harness.splitMakingPaneFiveActive()
+        let newPane = try #require(harness.mirror.panel(forPane: 5))
+        let hostedView = newPane.hostedView
+        // A fresh pane's view starts parked in the surface's offscreen
+        // bootstrap window; detach so the test drives a clean attach edge.
+        hostedView.removeFromSuperview()
+        try #require(hostedView.window == nil)
+
+        var fired = 0
+        var slotWasClearedBeforeCallbackRan = false
+        hostedView.onDidAttachToWindow = { [weak hostedView] in
+            fired += 1
+            // Consumption must happen BEFORE the callback runs, or a hook
+            // that re-arms from inside its own fire would be clobbered.
+            slotWasClearedBeforeCallbackRan = hostedView?.onDidAttachToWindow == nil
+        }
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 200),
+            styleMask: [.borderless],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        defer { window.orderOut(nil) }
+        window.contentView?.addSubview(hostedView)
+
+        #expect(fired == 1, "attaching to a window must fire the armed hook exactly once")
+        #expect(
+            slotWasClearedBeforeCallbackRan,
+            "the hook slot must already be nil while the callback runs"
+        )
+
+        // A later reparent must not replay a consumed hook.
+        hostedView.removeFromSuperview()
+        window.contentView?.addSubview(hostedView)
+        #expect(fired == 1, "a consumed hook must not fire again on reparent churn")
+    }
 }

--- a/cmuxTests/RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorPaneKeyFocusDecisionTests.swift
@@ -1,0 +1,114 @@
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Pins the pure policy behind establishing key focus on a freshly created
+/// mirror pane. The mirror drives focus from the control-stream event that
+/// makes the pane active; the view may not have reached its presentation
+/// window yet, so the policy decides between focusing now, (re-)arming the
+/// attach hook (`onDidAttachToWindow`), and dropping the intent. Waiting is
+/// only allowed for states that end in another attach edge (unattached, or
+/// parked in the surface's offscreen bootstrap window); a final attachment
+/// that cannot take focus cancels instead, so no stale intent survives to
+/// steal focus later. The decision is a pure function of the guard inputs,
+/// so the table below covers it without a live window or run loop.
+@MainActor
+@Suite
+struct RemoteTmuxMirrorPaneKeyFocusDecisionTests {
+
+    private typealias Decision = RemoteTmuxWindowMirror.PaneKeyFocusDecision
+
+    private static func decide(
+        mirrorAlive: Bool = true,
+        paneStillActive: Bool = true,
+        mirrorOnScreen: Bool = true,
+        viewInWindow: Bool = true,
+        inParkingWindow: Bool = false,
+        viewVisibleInUI: Bool = true,
+        windowIsKey: Bool = true,
+        responderYields: Bool = true
+    ) -> Decision {
+        RemoteTmuxWindowMirror.paneKeyFocusDecision(
+            mirrorAlive: mirrorAlive,
+            paneStillActive: paneStillActive,
+            mirrorOnScreen: mirrorOnScreen,
+            viewInWindow: viewInWindow,
+            inParkingWindow: inParkingWindow,
+            viewVisibleInUI: viewVisibleInUI,
+            windowIsKey: windowIsKey,
+            responderYields: responderYields
+        )
+    }
+
+    @Test("pane presented in a visible key window is focused immediately")
+    func focusesMountedPane() {
+        #expect(Self.decide() == .focusNow)
+    }
+
+    @Test("unattached pane waits for the attach edge instead of a timer")
+    func waitsForMount() {
+        #expect(Self.decide(viewInWindow: false) == .waitForMount)
+        // The key/visibility reads of a detached view are meaningless; only
+        // the attach edge can make them real.
+        #expect(Self.decide(viewInWindow: false, viewVisibleInUI: false, windowIsKey: false)
+            == .waitForMount)
+    }
+
+    @Test("an attach into the parking window re-arms for the presentation attach")
+    func parkingWindowWaits() {
+        // Portal churn routes views through the surface's offscreen bootstrap
+        // window; consuming the intent there would strand the freshly split
+        // pane unfocused. Waiting is live, not stale: leaving the parking
+        // window for the presentation window fires viewDidMoveToWindow again.
+        #expect(Self.decide(inParkingWindow: true, windowIsKey: false) == .waitForMount)
+        #expect(Self.decide(inParkingWindow: true, viewVisibleInUI: false, windowIsKey: false)
+            == .waitForMount)
+    }
+
+    @Test("a final attach into a non-key or hidden window cancels, not waits")
+    func nonKeyFinalAttachmentCancels() {
+        // A real window that is not key (or a hidden host) has no attach edge
+        // left to wait on; keeping the intent alive would let it fire much
+        // later and steal focus.
+        #expect(Self.decide(windowIsKey: false) == .skip)
+        #expect(Self.decide(viewVisibleInUI: false) == .skip)
+    }
+
+    @Test("a pane switch cancels the pending focus")
+    func paneSwitchCancels() {
+        #expect(Self.decide(paneStillActive: false, viewInWindow: false) == .skip)
+        #expect(Self.decide(paneStillActive: false) == .skip)
+    }
+
+    @Test("a dead or torn-down mirror never moves the responder")
+    func tornDownSkips() {
+        #expect(Self.decide(mirrorAlive: false) == .skip)
+        #expect(Self.decide(mirrorAlive: false, viewInWindow: false) == .skip)
+    }
+
+    @Test("a background or headless mirror never moves the responder")
+    func backgroundSkips() {
+        #expect(Self.decide(mirrorOnScreen: false) == .skip)
+        #expect(Self.decide(mirrorOnScreen: false, viewInWindow: false) == .skip)
+    }
+
+    @Test("a foreign first responder cancels instead of being robbed")
+    func foreignResponderCancels() {
+        // The user focused a search field or palette after the split; a late
+        // mount must not pull focus out of it.
+        #expect(Self.decide(responderYields: false) == .skip)
+    }
+
+    @Test("the foreign-responder read only decides at presentation time")
+    func foreignResponderIgnoredWhileUnpresented() {
+        // An unattached or parked view reads some other window's responder
+        // state (or none at all); the check is deferred to focus time.
+        #expect(Self.decide(viewInWindow: false, responderYields: false) == .waitForMount)
+        #expect(Self.decide(inParkingWindow: true, windowIsKey: false, responderYields: false)
+            == .waitForMount)
+    }
+}


### PR DESCRIPTION
## What you see

Split a pane in a mirrored tmux session and the new pane lights up with the selection highlight but takes no keyboard input — you have to click it before you can type. Both panes render a hollow cursor, so neither one actually holds key focus.

Repro:
1. Open a mirrored session.
2. Split a window.
3. Try to type. Nothing lands until you click the new pane.

## Root cause

A window mirror renders each tmux pane as its own `TerminalPanel` inside the mirror's own split tree. Those panels are not workspace split-tabs, so the app's normal focus path — `focusPanel` and the surface's active- and visibility-transition first-responder edges — can't resolve them. A freshly split pane is born already active and already visible inside an already-visible tab, so none of those edges fire and key focus is never established. Only a click (`mouseDown` -> `becomeFirstResponder`) sets it.

## The fix

Track the panes the mirror just created. The first time such a pane becomes the active pane, drive the same first-responder establishment a click does (`moveFocus`), on the creation event edge. Every attempt re-checks that the mirror is still on screen, that this pane is still the active one, and that its window is key — so switching panes cancels a pending focus instead of stealing it, and a background or headless mirror never moves the responder. It's consumed once per created pane, so a later active-pane echo won't re-drive it.

## Tests

- A mirror-layer regression test (red before the fix) that asserts the mirror drives key focus onto the newly split pane's own panel — that panel was empty before.
- A control test that a routine active-pane switch does not re-drive focus.
- Pane input-mapping guards.

The tests assert that the mirror drove focus rather than leaning on AppKit responder timing, so they're timing-independent.

## Known follow-ups

- Establishment currently uses a short bounded retry (~6 x 16ms) to wait for the new pane's surface to mount into the key window. That's a soft timer. The cleaner design drives it off the surface's mount/visibility event edge, or better, makes key focus reconcile to tmux's active pane as a first-class invariant (tmux is the authority) so split, close, zoom, and click are all handled the same way.
- Runtime GUI verification of the split-then-type gesture is still worth doing before this comes out of draft.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8132"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786682358&installation_id=133855650&pr_number=8132&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8132&signature=8a47c798dbed8f7af2f89fb7fc8f9e81529ed914585d93082ff797c7b94c6400"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Newly split panes in a tmux mirror now get keyboard focus on mount, so you can type right away without clicking. Focus is driven from the pane view’s attach edge, with guards to prevent steals in background tabs, across pane switches (A→B→A), or when a non-terminal control is focused.

- **Bug Fixes**
  - Add a one-shot `onDidAttachToWindow` hook on the pane’s `GhosttySurfaceScrollView`; it’s consumed before the callback runs, re-arms only while unattached or in the parking window, and then drives `moveFocus` — no timers or polling.
  - Extract pure policy `paneKeyFocusDecision` (`focusNow`/`waitForMount`/`skip`): wait only when unattached or parked; skip for hidden/non-key windows or when the first responder isn’t in the terminal layer.
  - Track `paneActivationGeneration`; bump on every active-pane transition (including N→O→N and teardown) and validate pending intents against the armed generation to block stale steals.
  - Tests: new `RemoteTmuxMirrorPaneKeyFocusDecisionTests` (truth table) and expanded `RemoteTmuxMirrorNewPaneKeyFocusTests` (attach-hook one-shot and generation bump).

<sup>Written for commit bbd1999e4772d42475a7d6c546b5b5c2342af107. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8132?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

