### PR TITLE
Fix bash shell-integration socket sends: prefer/usr/bin/nc (port #7789 to bash)

### DIFF
--- a/Resources/shell-integration/cmux-bash-integration.bash
+++ b/Resources/shell-integration/cmux-bash-integration.bash
@@ -13,8 +13,23 @@ _cmux_detect_send_tool() {
 }
 # Detection deferred to after _cmux_fix_path (end of file).
 
+# BSD nc at /usr/bin/nc is preferred: it always supports -U, it waits for the
+# server to process the line and close (which preserves send order across a
+# batched child and keeps the peer alive through cmuxOnly ancestry checks), and
+# -w bounds its lifetime. The cached $_CMUX_SEND_TOOL clients below stay as
+# fallbacks for non-macOS shells, but they cannot be trusted first on macOS:
+# ncat's --send-only half-closes and exits before the server's peer-ancestry
+# check completes, so a detached send loses the cmuxOnly authorization race and
+# is dropped silently -- report_pwd, report_shell_state, ports_kick and git/PR
+# reports all vanish. This mirrors the zsh transport fix from #7789.
 _cmux_send() {
     local payload="$1"
+    if [[ -x /usr/bin/nc ]]; then
+        # Apple's nc defines -N as `num_probes` (not OpenBSD's shutdown-after-EOF
+        # flag), so the -N form fails option parsing; use the bounded -w form.
+        printf '%s\n' "$payload" | /usr/bin/nc -w 1 -U "$CMUX_SOCKET_PATH" >/dev/null 2>&1 || true
+        return 0
+    fi
     case "$_CMUX_SEND_TOOL" in
         ncat)
             printf '%s\n' "$payload" | ncat -w 1 -U "$CMUX_SOCKET_PATH" --send-only

--- a/cmuxTests/ShellIntegrationSendTransportTests.swift
+++ b/cmuxTests/ShellIntegrationSendTransportTests.swift
@@ -9,7 +9,7 @@ import Testing
 
 struct ShellIntegrationSendTransportTests {
     /// End-to-end contract for `_cmux_send`: sourcing the bundled integration
-    /// in a fresh zsh and sending one payload must deliver that payload to a
+    /// in a fresh shell and sending one payload must deliver that payload to a
     /// unix-socket listener even when a PATH-first `nc` without unix-socket
     /// support (GNU netcat's shape) shadows the system client. This transport
     /// carries the whole hook channel (report_tty, ports_kick,
@@ -29,8 +29,56 @@ struct ShellIntegrationSendTransportTests {
         if: NSUserName() != "runner",
         "subprocess unix-socket delivery is flaky on CI app-host runners; run locally or on a fleet Mac"
     ))
-    func sendDeliversPayloadDespiteShadowedPathNC() throws {
-        let result = try Self.deliverViaIntegration(shimmed: true)
+    func sendDeliversPayloadDespiteShadowedPathNC_zsh() throws {
+        let result = try Self.deliverViaIntegration(
+            shell: "/bin/zsh",
+            shellArgs: ["-f", "-c"],
+            integrationName: "cmux-zsh-integration.zsh",
+            probe: { path in
+                """
+                source '\(path)'
+                print -r -- "diag: usrbin_nc_executable=$([[ -x /usr/bin/nc ]] && echo 1 || echo 0)"
+                print -r -- "diag: path_nc=$(whence -p nc 2>/dev/null)"
+                _cmux_send 'transport probe'
+                print -r -- "diag: send_rc=$?"
+                """
+            },
+            shimmed: true
+        )
+        #expect(
+            result.delivered == "transport probe",
+            "The pinned system client must deliver even with a broken PATH-first nc. exit=\(result.exitStatus) log:\n\(result.diagnostics.suffix(1200))"
+        )
+    }
+
+    /// Same contract for the bash integration. `cmux-bash-integration.bash`
+    /// preferred `ncat --send-only` from a detached child, which half-closes
+    /// and exits before the server's cmuxOnly peer-ancestry check completes, so
+    /// every hook was dropped silently on macOS (report_pwd never landed, panes
+    /// restored to `~`). Preferring `/usr/bin/nc -w 1 -U` — which waits for the
+    /// server to close, keeping the peer alive through the ancestry check —
+    /// must deliver even when a broken PATH-first `nc` shadows the system
+    /// client. This is the bash counterpart of the zsh fix in #7789.
+    @Test(.enabled(
+        if: NSUserName() != "runner",
+        "subprocess unix-socket delivery is flaky on CI app-host runners; run locally or on a fleet Mac"
+    ))
+    func sendDeliversPayloadDespiteShadowedPathNC_bash() throws {
+        let result = try Self.deliverViaIntegration(
+            shell: "/bin/bash",
+            shellArgs: ["--norc", "--noprofile", "-c"],
+            integrationName: "cmux-bash-integration.bash",
+            probe: { path in
+                """
+                source '\(path)'
+                printf 'diag: usrbin_nc_executable=%s\\n' "$([[ -x /usr/bin/nc ]] && echo 1 || echo 0)"
+                printf 'diag: path_nc=%s\\n' "$(command -v nc 2>/dev/null)"
+                _cmux_send 'transport probe'
+                printf 'diag: send_rc=%s\\n' "$?"
+                """
+            },
+            shimmed: true
+        )
         #expect(
             result.delivered == "transport probe",
             "The pinned system client must deliver even with a broken PATH-first nc. exit=\(result.exitStatus) log:\n\(result.diagnostics.suffix(1200))"
@@ -43,12 +91,18 @@ struct ShellIntegrationSendTransportTests {
         let exitStatus: Int32
     }
 
-    private static func deliverViaIntegration(shimmed: Bool) throws -> DeliveryResult {
+    private static func deliverViaIntegration(
+        shell: String,
+        shellArgs: [String],
+        integrationName: String,
+        probe: (String) -> String,
+        shimmed: Bool
+    ) throws -> DeliveryResult {
         let script = try #require(
             RemoteInteractiveShellBootstrapBuilder.bundledShellIntegrationScript(
-                named: "cmux-zsh-integration.zsh"
+                named: integrationName
             ),
-            "cmux-zsh-integration.zsh must ship in the app bundle"
+            "\(integrationName) must ship in the app bundle"
         )
         // Deliberately short root: unix socket paths must fit
         // sockaddr_un.sun_path (104 bytes on Darwin), and the default
@@ -57,7 +111,7 @@ struct ShellIntegrationSendTransportTests {
             .appendingPathComponent("cmux-st-\(UUID().uuidString.prefix(8))", isDirectory: true)
         try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: dir) }
-        let scriptFile = dir.appendingPathComponent("integration.zsh")
+        let scriptFile = dir.appendingPathComponent(integrationName)
         try script.write(to: scriptFile, atomically: true, encoding: .utf8)
         let socketPath = dir.appendingPathComponent("t.sock").path
 
@@ -84,22 +138,13 @@ struct ShellIntegrationSendTransportTests {
         defer { try? logHandle.close() }
 
         let process = Process()
-        process.executableURL = URL(fileURLWithPath: "/bin/zsh")
+        process.executableURL = URL(fileURLWithPath: shell)
         process.environment = [
             "CMUX_SOCKET_PATH": socketPath,
             "PATH": path,
             "HOME": dir.path,
         ]
-        process.arguments = [
-            "-f", "-c",
-            """
-            source '\(scriptFile.path)'
-            print -r -- "diag: usrbin_nc_executable=$([[ -x /usr/bin/nc ]] && echo 1 || echo 0)"
-            print -r -- "diag: path_nc=$(whence -p nc 2>/dev/null)"
-            _cmux_send 'transport probe'
-            print -r -- "diag: send_rc=$?"
-            """,
-        ]
+        process.arguments = shellArgs + [probe(scriptFile.path)]
         process.standardOutput = logHandle
         process.standardError = logHandle
         try process.run()


### PR DESCRIPTION
Fixes #8134.

## Cause

On **bash**, every shell-integration socket send is dropped silently, so `report_pwd` never reaches the app — a pane's working directory is never tracked, and **session restore always reopens bash panes in `~`**. Git-branch, PR, and listening-port hooks die on the same channel.

`_cmux_send` in `cmux-bash-integration.bash` prefers `ncat` when it's on PATH (Homebrew nmap is common) and sends with `ncat -w 1 -U … --send-only` from a detached child. `--send-only` half-closes and the child exits instantly, so the connection loses the **live peer-ancestry authorization race in cmuxOnly mode** — the same failure #7789 fixed for zsh and #7100 describes for detached process trees. That PR only touched `cmux-zsh-integration.zsh`; bash was never ported and still ships the old transport on `main`.

## Fix

`_cmux_send` now prefers **`/usr/bin/nc -w 1 -U`** first, mirroring the zsh fix: BSD `nc` always supports `-U`, waits for the server to process the line and close (keeping the peer alive through the cmuxOnly ancestry check), and `-w` bounds its lifetime. Apple's `nc` defines `-N` as `num_probes` (not OpenBSD's shutdown-after-EOF), so the bounded `-w` form is used directly. The cached `$_CMUX_SEND_TOOL` clients (ncat/socat/PATH-nc) remain as fallbacks for non-macOS shells.

Minimal, transport-only change; no behavior change for shells without `/usr/bin/nc`.

## Testing

Verified on macOS 26.5.1 / arm64 / `bash 3.2.57`, cmux 0.64.19, with Homebrew `ncat` on PATH (so the old code selected `ncat`). Driving `report_pwd` for a pane's own panel id and reading the persisted `workingDirectory` from the session snapshot:

- Old path — `ncat … --send-only` in a detached `( … & )` child: **dropped**, `workingDirectory` never changes; panes restore to `~`.
- New path — `/usr/bin/nc -w 1 -U`: **persists within ~1s**; `cd` is reflected and the pane restores to that directory.

Follow-up worth considering: a bash analog of `ShellIntegrationSendTransportTests.sendDeliversPayloadToUnixSocketListener` (added for zsh in #7789), sourcing the bundled bash integration in `bash --norc` and asserting one `_cmux_send` payload reaches a unix-socket listener. Happy to add it if you'd like it in this PR.

Fixes #8134 (the bash side of #7704). References #7789, #7100.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8135"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786682875&installation_id=133855650&pr_number=8135&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8135&signature=2a1cf44092d549c6677de473854700c264b977f928ab7e343baf094f652ddfb5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes dropped bash shell-integration socket sends on macOS by preferring `/usr/bin/nc -w 1 -U`. This restores delivery of `report_pwd` and other hooks so panes reopen in the last directory.

- **Bug Fixes**
  - `_cmux_send` now uses `/usr/bin/nc` first; it waits for the server and keeps the peer alive through cmuxOnly checks.
  - Uses `-w` since Apple `nc` does not support OpenBSD `-N`; avoids the detached `ncat --send-only` half-close issue.
  - Adds a bash regression test mirroring the zsh case and generalizes the test helper for multiple shells; keeps fallbacks (`ncat`, `socat`, PATH `nc`) unchanged for non-macOS.

<sup>Written for commit ef11f0290a3138f65e885fe57bf4d6eb74701f86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8135?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS shell integration by prioritizing the system-provided networking utility when communicating with the application.
  * Added a bounded connection timeout for outgoing shell communication to reduce the chance of hangs.
  * Preserved fallback behavior for environments where the preferred utility isn’t available.
* **Tests**
  * Expanded coverage by splitting the shell integration send regression into separate bash and zsh test cases, validating the delivered payload for each.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->