### PR TITLE
Derive mobile host port from dev tag

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/MobileHostPortPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/MobileHostPortPolicy.swift
@@ -1,47 +1,61 @@
 import Foundation
 
 /// Pure policy for the Mac-side mobile pairing host's preferred TCP port.
-public enum MobileHostPortPolicy {
+public struct MobileHostPortPolicy: Sendable {
+    /// Inclusive TCP port range accepted by the mobile-host setting.
     public static let validPortRange: ClosedRange<Int> = 1...65_535
+
+    /// Dynamic/private TCP port range used for deterministic tagged DEBUG defaults.
     public static let taggedDevelopmentPortRange: ClosedRange<Int> = 49_152...65_535
+
+    private let portDefaultsKey: String
+    private let catalogDefaultPort: Int
+
+    /// Creates a policy for the supplied settings key and catalog default.
+    public init(
+        portDefaultsKey: String = SettingCatalog().mobile.iOSPairingPort.userDefaultsKey,
+        catalogDefaultPort: Int = SettingCatalog().mobile.iOSPairingPort.defaultValue
+    ) {
+        self.portDefaultsKey = portDefaultsKey
+        self.catalogDefaultPort = catalogDefaultPort
+    }
 
     /// Returns the preferred port for the mobile host listener.
     ///
     /// A valid explicit setting wins. When unset or invalid, tagged DEBUG builds
     /// derive a stable port from ``SocketControlSettings/launchTag(environment:)``;
     /// release and untagged builds use the catalog default.
-    public static func configuredPort(
+    public func configuredPort(
         defaults: UserDefaults = .standard,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Int {
-        let catalogPort = SettingCatalog().mobile.iOSPairingPort
         let fallback = defaultConfiguredPort(
             environment: environment,
-            catalogDefaultPort: catalogPort.defaultValue
+            catalogDefaultPort: catalogDefaultPort
         )
-        guard let raw = defaults.object(forKey: catalogPort.userDefaultsKey) as? Int else {
+        guard let raw = defaults.object(forKey: portDefaultsKey) as? Int else {
             return fallback
         }
-        return validPortRange.contains(raw) ? raw : fallback
+        return Self.validPortRange.contains(raw) ? raw : fallback
     }
 
     /// Returns the desired listener port, or `nil` when a stored explicit value is
     /// present but invalid and should not disturb a running listener.
-    public static func resolvedDesiredPort(
+    public func resolvedDesiredPort(
         defaults: UserDefaults = .standard,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Int? {
-        let catalogPort = SettingCatalog().mobile.iOSPairingPort
-        guard let raw = defaults.object(forKey: catalogPort.userDefaultsKey) as? Int else {
+        guard let raw = defaults.object(forKey: portDefaultsKey) as? Int else {
             return defaultConfiguredPort(
                 environment: environment,
-                catalogDefaultPort: catalogPort.defaultValue
+                catalogDefaultPort: catalogDefaultPort
             )
         }
-        return validPortRange.contains(raw) ? raw : nil
+        return Self.validPortRange.contains(raw) ? raw : nil
     }
 
-    public static func defaultConfiguredPort(
+    /// Returns the fallback port for unset or invalid settings.
+    public func defaultConfiguredPort(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         catalogDefaultPort: Int = SettingCatalog().mobile.iOSPairingPort.defaultValue
     ) -> Int {
@@ -57,7 +71,7 @@ public enum MobileHostPortPolicy {
     }
 
     #if DEBUG
-    private static func taggedDevelopmentDefaultPort(
+    private func taggedDevelopmentDefaultPort(
         environment: [String: String],
         catalogDefaultPort: Int
     ) -> Int? {
@@ -73,8 +87,8 @@ public enum MobileHostPortPolicy {
             hash &*= 16_777_619
         }
 
-        let lowerBound = taggedDevelopmentPortRange.lowerBound
-        let upperBound = taggedDevelopmentPortRange.upperBound
+        let lowerBound = Self.taggedDevelopmentPortRange.lowerBound
+        let upperBound = Self.taggedDevelopmentPortRange.upperBound
         let portCount = upperBound - lowerBound + 1
         var port = lowerBound + Int(hash % UInt32(portCount))
         if port == catalogDefaultPort {

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/MobileHostPortPolicy.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/SocketControl/MobileHostPortPolicy.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Pure policy for the Mac-side mobile pairing host's preferred TCP port.
+public enum MobileHostPortPolicy {
+    public static let validPortRange: ClosedRange<Int> = 1...65_535
+    public static let taggedDevelopmentPortRange: ClosedRange<Int> = 49_152...65_535
+
+    /// Returns the preferred port for the mobile host listener.
+    ///
+    /// A valid explicit setting wins. When unset or invalid, tagged DEBUG builds
+    /// derive a stable port from ``SocketControlSettings/launchTag(environment:)``;
+    /// release and untagged builds use the catalog default.
+    public static func configuredPort(
+        defaults: UserDefaults = .standard,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int {
+        let catalogPort = SettingCatalog().mobile.iOSPairingPort
+        let fallback = defaultConfiguredPort(
+            environment: environment,
+            catalogDefaultPort: catalogPort.defaultValue
+        )
+        guard let raw = defaults.object(forKey: catalogPort.userDefaultsKey) as? Int else {
+            return fallback
+        }
+        return validPortRange.contains(raw) ? raw : fallback
+    }
+
+    /// Returns the desired listener port, or `nil` when a stored explicit value is
+    /// present but invalid and should not disturb a running listener.
+    public static func resolvedDesiredPort(
+        defaults: UserDefaults = .standard,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int? {
+        let catalogPort = SettingCatalog().mobile.iOSPairingPort
+        guard let raw = defaults.object(forKey: catalogPort.userDefaultsKey) as? Int else {
+            return defaultConfiguredPort(
+                environment: environment,
+                catalogDefaultPort: catalogPort.defaultValue
+            )
+        }
+        return validPortRange.contains(raw) ? raw : nil
+    }
+
+    public static func defaultConfiguredPort(
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        catalogDefaultPort: Int = SettingCatalog().mobile.iOSPairingPort.defaultValue
+    ) -> Int {
+        #if DEBUG
+        if let port = taggedDevelopmentDefaultPort(
+            environment: environment,
+            catalogDefaultPort: catalogDefaultPort
+        ) {
+            return port
+        }
+        #endif
+        return catalogDefaultPort
+    }
+
+    #if DEBUG
+    private static func taggedDevelopmentDefaultPort(
+        environment: [String: String],
+        catalogDefaultPort: Int
+    ) -> Int? {
+        guard let tag = SocketControlSettings.launchTag(environment: environment) else {
+            return nil
+        }
+        let normalizedTag = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedTag.isEmpty, normalizedTag != "default" else { return nil }
+
+        var hash: UInt32 = 2_166_136_261
+        for byte in normalizedTag.utf8 {
+            hash ^= UInt32(byte)
+            hash &*= 16_777_619
+        }
+
+        let lowerBound = taggedDevelopmentPortRange.lowerBound
+        let upperBound = taggedDevelopmentPortRange.upperBound
+        let portCount = upperBound - lowerBound + 1
+        var port = lowerBound + Int(hash % UInt32(portCount))
+        if port == catalogDefaultPort {
+            port = lowerBound + ((port - lowerBound + 1) % portCount)
+        }
+        return port
+    }
+    #endif
+}

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/MobileHostPortPolicyTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/MobileHostPortPolicyTests.swift
@@ -13,16 +13,17 @@ import Testing
         let catalogDefault = SettingCatalog().mobile.iOSPairingPort.defaultValue
         let nodivsEnvironment = [SocketControlSettings.launchTagEnvKey: "nodivs"]
         let wtodoEnvironment = [SocketControlSettings.launchTagEnvKey: "wtodo"]
+        let policy = MobileHostPortPolicy()
 
-        let nodivs = MobileHostPortPolicy.configuredPort(
+        let nodivs = policy.configuredPort(
             defaults: defaults,
             environment: nodivsEnvironment
         )
-        let nodivsRelaunch = MobileHostPortPolicy.configuredPort(
+        let nodivsRelaunch = policy.configuredPort(
             defaults: defaults,
             environment: nodivsEnvironment
         )
-        let wtodo = MobileHostPortPolicy.configuredPort(
+        let wtodo = policy.configuredPort(
             defaults: defaults,
             environment: wtodoEnvironment
         )
@@ -33,7 +34,7 @@ import Testing
         #expect(nodivs != wtodo)
         #expect(MobileHostPortPolicy.taggedDevelopmentPortRange.contains(nodivs))
         #expect(MobileHostPortPolicy.taggedDevelopmentPortRange.contains(wtodo))
-        #expect(MobileHostPortPolicy.resolvedDesiredPort(
+        #expect(policy.resolvedDesiredPort(
             defaults: defaults,
             environment: wtodoEnvironment
         ) == wtodo)
@@ -47,12 +48,13 @@ import Testing
 
         defaults.set(9000, forKey: SettingCatalog().mobile.iOSPairingPort.userDefaultsKey)
         let environment = [SocketControlSettings.launchTagEnvKey: "nodivs"]
+        let policy = MobileHostPortPolicy()
 
-        #expect(MobileHostPortPolicy.configuredPort(
+        #expect(policy.configuredPort(
             defaults: defaults,
             environment: environment
         ) == 9000)
-        #expect(MobileHostPortPolicy.resolvedDesiredPort(
+        #expect(policy.resolvedDesiredPort(
             defaults: defaults,
             environment: environment
         ) == 9000)

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/MobileHostPortPolicyTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SocketControl/MobileHostPortPolicyTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import Testing
+
+@testable import CmuxSettings
+
+@Suite struct MobileHostPortPolicyTests {
+    #if DEBUG
+    @Test func taggedDebugDefaultUsesStablePerTagPortWhenUnset() throws {
+        let suiteName = "MobileHostPortPolicyTests.Tagged.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let catalogDefault = SettingCatalog().mobile.iOSPairingPort.defaultValue
+        let nodivsEnvironment = [SocketControlSettings.launchTagEnvKey: "nodivs"]
+        let wtodoEnvironment = [SocketControlSettings.launchTagEnvKey: "wtodo"]
+
+        let nodivs = MobileHostPortPolicy.configuredPort(
+            defaults: defaults,
+            environment: nodivsEnvironment
+        )
+        let nodivsRelaunch = MobileHostPortPolicy.configuredPort(
+            defaults: defaults,
+            environment: nodivsEnvironment
+        )
+        let wtodo = MobileHostPortPolicy.configuredPort(
+            defaults: defaults,
+            environment: wtodoEnvironment
+        )
+
+        #expect(nodivs == nodivsRelaunch)
+        #expect(nodivs != catalogDefault)
+        #expect(wtodo != catalogDefault)
+        #expect(nodivs != wtodo)
+        #expect(MobileHostPortPolicy.taggedDevelopmentPortRange.contains(nodivs))
+        #expect(MobileHostPortPolicy.taggedDevelopmentPortRange.contains(wtodo))
+        #expect(MobileHostPortPolicy.resolvedDesiredPort(
+            defaults: defaults,
+            environment: wtodoEnvironment
+        ) == wtodo)
+    }
+    #endif
+
+    @Test func validOverrideWinsOverTaggedDefault() throws {
+        let suiteName = "MobileHostPortPolicyTests.Override.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(9000, forKey: SettingCatalog().mobile.iOSPairingPort.userDefaultsKey)
+        let environment = [SocketControlSettings.launchTagEnvKey: "nodivs"]
+
+        #expect(MobileHostPortPolicy.configuredPort(
+            defaults: defaults,
+            environment: environment
+        ) == 9000)
+        #expect(MobileHostPortPolicy.resolvedDesiredPort(
+            defaults: defaults,
+            environment: environment
+        ) == 9000)
+    }
+}

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -477,12 +477,14 @@ final class MobileHostService {
     /// release and untagged builds keep the catalog default. The listener still
     /// falls back to an OS-assigned ephemeral port if this port is unavailable
     /// at bind time.
-    nonisolated static func configuredPort(defaults: UserDefaults = .standard) -> Int {
-        let fallback = defaultConfiguredPort()
-        guard let raw = defaults.object(forKey: portDefaultsKey) as? Int else {
-            return fallback
-        }
-        return (1...65535).contains(raw) ? raw : fallback
+    nonisolated static func configuredPort(
+        defaults: UserDefaults = .standard,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int {
+        MobileHostPortPolicy.configuredPort(
+            defaults: defaults,
+            environment: environment
+        )
     }
 
     /// The port a settings change should reconcile the *running* listener to, or
@@ -493,48 +495,15 @@ final class MobileHostService {
     /// running listener and silently rebind it to the default port. Returns the
     /// launch identity's default when unset, the override when valid, and `nil`
     /// when the stored value is out of range.
-    nonisolated static func resolvedDesiredPort(defaults: UserDefaults = .standard) -> Int? {
-        guard let raw = defaults.object(forKey: portDefaultsKey) as? Int else {
-            return defaultConfiguredPort()
-        }
-        return (1...65535).contains(raw) ? raw : nil
-    }
-
-    nonisolated private static func defaultConfiguredPort() -> Int {
-        #if DEBUG
-        if let port = taggedDevelopmentDefaultPort() {
-            return port
-        }
-        #endif
-        return SettingCatalog().mobile.iOSPairingPort.defaultValue
-    }
-
-    #if DEBUG
-    nonisolated private static func taggedDevelopmentDefaultPort(
+    nonisolated static func resolvedDesiredPort(
+        defaults: UserDefaults = .standard,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Int? {
-        guard let tag = SocketControlSettings.launchTag(environment: environment) else {
-            return nil
-        }
-        let normalizedTag = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !normalizedTag.isEmpty, normalizedTag != "default" else { return nil }
-
-        var hash: UInt32 = 2_166_136_261
-        for byte in normalizedTag.utf8 {
-            hash ^= UInt32(byte)
-            hash &*= 16_777_619
-        }
-
-        let lowerBound = 49_152
-        let upperBound = 65_535
-        let portCount = upperBound - lowerBound + 1
-        var port = lowerBound + Int(hash % UInt32(portCount))
-        if port == CmxMobileDefaults.defaultHostPort {
-            port = lowerBound + ((port - lowerBound + 1) % portCount)
-        }
-        return port
+        MobileHostPortPolicy.resolvedDesiredPort(
+            defaults: defaults,
+            environment: environment
+        )
     }
-    #endif
 
     /// Pure reconciliation between the desired settings and the live listener
     /// state. Factored out so the restart-on-port-change decision is unit

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -481,7 +481,7 @@ final class MobileHostService {
         defaults: UserDefaults = .standard,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Int {
-        MobileHostPortPolicy.configuredPort(
+        MobileHostPortPolicy().configuredPort(
             defaults: defaults,
             environment: environment
         )
@@ -499,7 +499,7 @@ final class MobileHostService {
         defaults: UserDefaults = .standard,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> Int? {
-        MobileHostPortPolicy.resolvedDesiredPort(
+        MobileHostPortPolicy().resolvedDesiredPort(
             defaults: defaults,
             environment: environment
         )

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -472,12 +472,13 @@ final class MobileHostService {
     /// The preferred TCP port the listener should try to bind, read from
     /// settings.
     ///
-    /// Falls back to the catalog default (which mirrors
-    /// `CmxMobileDefaults.defaultHostPort`) when unset or outside the valid
-    /// `1...65535` range. The listener still falls back to an OS-assigned
-    /// ephemeral port if this port is unavailable at bind time.
+    /// Falls back to the launch identity's default when unset or outside the
+    /// valid `1...65535` range. Tagged DEBUG builds get a stable per-tag port;
+    /// release and untagged builds keep the catalog default. The listener still
+    /// falls back to an OS-assigned ephemeral port if this port is unavailable
+    /// at bind time.
     nonisolated static func configuredPort(defaults: UserDefaults = .standard) -> Int {
-        let fallback = SettingCatalog().mobile.iOSPairingPort.defaultValue
+        let fallback = defaultConfiguredPort()
         guard let raw = defaults.object(forKey: portDefaultsKey) as? Int else {
             return fallback
         }
@@ -490,14 +491,50 @@ final class MobileHostService {
     /// Distinguished from ``configuredPort(defaults:)`` so an invalid value the
     /// user is still editing (the field shows a warning) does not tear down a
     /// running listener and silently rebind it to the default port. Returns the
-    /// catalog default when unset, the override when valid, and `nil` when the
-    /// stored value is out of range.
+    /// launch identity's default when unset, the override when valid, and `nil`
+    /// when the stored value is out of range.
     nonisolated static func resolvedDesiredPort(defaults: UserDefaults = .standard) -> Int? {
         guard let raw = defaults.object(forKey: portDefaultsKey) as? Int else {
-            return SettingCatalog().mobile.iOSPairingPort.defaultValue
+            return defaultConfiguredPort()
         }
         return (1...65535).contains(raw) ? raw : nil
     }
+
+    nonisolated private static func defaultConfiguredPort() -> Int {
+        #if DEBUG
+        if let port = taggedDevelopmentDefaultPort() {
+            return port
+        }
+        #endif
+        return SettingCatalog().mobile.iOSPairingPort.defaultValue
+    }
+
+    #if DEBUG
+    nonisolated private static func taggedDevelopmentDefaultPort(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int? {
+        guard let tag = SocketControlSettings.launchTag(environment: environment) else {
+            return nil
+        }
+        let normalizedTag = tag.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !normalizedTag.isEmpty, normalizedTag != "default" else { return nil }
+
+        var hash: UInt32 = 2_166_136_261
+        for byte in normalizedTag.utf8 {
+            hash ^= UInt32(byte)
+            hash &*= 16_777_619
+        }
+
+        let lowerBound = 49_152
+        let upperBound = 65_535
+        let portCount = upperBound - lowerBound + 1
+        var port = lowerBound + Int(hash % UInt32(portCount))
+        if port == CmxMobileDefaults.defaultHostPort {
+            port = lowerBound + ((port - lowerBound + 1) % portCount)
+        }
+        return port
+    }
+    #endif
 
     /// Pure reconciliation between the desired settings and the live listener
     /// state. Factored out so the restart-on-port-change decision is unit

--- a/cmuxTests/MobileHostAuthorizationTests.swift
+++ b/cmuxTests/MobileHostAuthorizationTests.swift
@@ -59,6 +59,37 @@ struct MobileHostAuthorizationTests {
         #expect(authorization.createdWorkspaceIDs == Set(["created-workspace"]))
         #expect(authorization.createdTerminalIDs == Set(["created-terminal"]))
     }
+    @Test func testPhysicalDeviceAttachURLUsesActualSelectedRouteEndpoint() throws {
+        let store = MobileAttachTicketStore()
+        let route = try CmxAttachRoute(
+            id: "tailscale",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.7", port: 52_461),
+            priority: 10
+        )
+        let ticket = try store.createTicket(
+            workspaceID: "",
+            terminalID: nil,
+            routes: [route],
+            ttl: 3600,
+            macUserID: "mac-user",
+            macPairingCompatibilityVersion: CmxMobileDefaults.pairingCompatibilityVersion,
+            macAppVersion: "0.65.0",
+            macAppBuild: "9"
+        )
+
+        let payload = try store.payload(for: ticket, target: .physicalDevice)
+        let rawURL = try #require(payload["attach_url"] as? String)
+        let components = try #require(URLComponents(string: rawURL))
+        let decoded = try CmxPairingQRCode().decode(components)
+
+        #expect(decoded.routes == [route])
+        guard case let .hostPort(host, port) = decoded.routes.first?.endpoint else {
+            return #expect(Bool(false), "expected host/port route")
+        }
+        #expect(host == "100.64.0.7")
+        #expect(port == 52_461)
+    }
     @Test func testMobileWorkspaceRPCRequiresAuthorization() async {
         let request = MobileHostRPCRequest(
             id: "workspace-list",

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -1,6 +1,7 @@
 import CMUXMobileCore
 import CmuxIrohTransport
 import CmuxSettings
+import Darwin
 import Foundation
 import Testing
 
@@ -10,6 +11,7 @@ import Testing
 @testable import cmux
 #endif
 
+@Suite(.serialized)
 struct MobileHostServiceSettingsTests {
     @Test func mobileHostListenerDefaultsOffUntilIOSPairingIsEnabled() throws {
         let suiteName = "MobileHostServiceSettingsTests.\(UUID().uuidString)"
@@ -29,9 +31,51 @@ struct MobileHostServiceSettingsTests {
         let suiteName = "MobileHostServiceSettingsTests.Port.Default.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
+        Self.withoutLaunchTag {
+            let expected = SettingCatalog().mobile.iOSPairingPort.defaultValue
+            #expect(MobileHostService.configuredPort(defaults: defaults) == expected)
+        }
+    }
 
-        let expected = SettingCatalog().mobile.iOSPairingPort.defaultValue
-        #expect(MobileHostService.configuredPort(defaults: defaults) == expected)
+    #if DEBUG
+    @Test func configuredPortUsesStableTagDerivedDefaultWhenUnset() throws {
+        let suiteName = "MobileHostServiceSettingsTests.Port.Tagged.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        let catalogDefault = SettingCatalog().mobile.iOSPairingPort.defaultValue
+        let nodivs = Self.withLaunchTag("nodivs") {
+            MobileHostService.configuredPort(defaults: defaults)
+        }
+        let nodivsRelaunch = Self.withLaunchTag("nodivs") {
+            MobileHostService.configuredPort(defaults: defaults)
+        }
+        let wtodo = Self.withLaunchTag("wtodo") {
+            MobileHostService.configuredPort(defaults: defaults)
+        }
+
+        #expect(nodivs == nodivsRelaunch)
+        #expect(nodivs != catalogDefault)
+        #expect(wtodo != catalogDefault)
+        #expect(nodivs != wtodo)
+        #expect((49_152...65_535).contains(nodivs))
+        #expect((49_152...65_535).contains(wtodo))
+        Self.withLaunchTag("wtodo") {
+            #expect(MobileHostService.resolvedDesiredPort(defaults: defaults) == wtodo)
+        }
+    }
+    #endif
+
+    @Test func configuredPortHonorsValidOverrideEvenWhenTagged() throws {
+        let suiteName = "MobileHostServiceSettingsTests.Port.Valid.Tagged.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+
+        defaults.set(9000, forKey: MobileHostService.portDefaultsKey)
+        Self.withLaunchTag("nodivs") {
+            #expect(MobileHostService.configuredPort(defaults: defaults) == 9000)
+            #expect(MobileHostService.resolvedDesiredPort(defaults: defaults) == 9000)
+        }
     }
 
     @Test func configuredPortHonorsValidOverride() throws {
@@ -107,6 +151,35 @@ struct MobileHostServiceSettingsTests {
         #expect(MobileHostService.syncDecision(enabled: true, listenerRunning: true, desiredPort: 9000, appliedPort: 58465) == .restart)
         // Running but the applied port is unknown: restart to reconcile.
         #expect(MobileHostService.syncDecision(enabled: true, listenerRunning: true, desiredPort: 58465, appliedPort: nil) == .restart)
+    }
+
+    private static func withLaunchTag<T>(_ tag: String, _ body: () throws -> T) rethrows -> T {
+        try withEnvironmentValue(SocketControlSettings.launchTagEnvKey, value: tag, body)
+    }
+
+    private static func withoutLaunchTag<T>(_ body: () throws -> T) rethrows -> T {
+        try withEnvironmentValue(SocketControlSettings.launchTagEnvKey, value: nil, body)
+    }
+
+    private static func withEnvironmentValue<T>(
+        _ key: String,
+        value: String?,
+        _ body: () throws -> T
+    ) rethrows -> T {
+        let previous = getenv(key).map { String(cString: $0) }
+        if let value {
+            setenv(key, value, 1)
+        } else {
+            unsetenv(key)
+        }
+        defer {
+            if let previous {
+                setenv(key, previous, 1)
+            } else {
+                unsetenv(key)
+            }
+        }
+        return try body()
     }
 }
 

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -1,7 +1,6 @@
 import CMUXMobileCore
 import CmuxIrohTransport
 import CmuxSettings
-import Darwin
 import Foundation
 import Testing
 
@@ -31,9 +30,12 @@ struct MobileHostServiceSettingsTests {
         let suiteName = "MobileHostServiceSettingsTests.Port.Default.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
-        Self.withoutLaunchTag {
+        Self.withoutLaunchTag { environment in
             let expected = SettingCatalog().mobile.iOSPairingPort.defaultValue
-            #expect(MobileHostService.configuredPort(defaults: defaults) == expected)
+            #expect(MobileHostService.configuredPort(
+                defaults: defaults,
+                environment: environment
+            ) == expected)
         }
     }
 
@@ -44,24 +46,36 @@ struct MobileHostServiceSettingsTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         let catalogDefault = SettingCatalog().mobile.iOSPairingPort.defaultValue
-        let nodivs = Self.withLaunchTag("nodivs") {
-            MobileHostService.configuredPort(defaults: defaults)
+        let nodivs = Self.withLaunchTag("nodivs") { environment in
+            MobileHostService.configuredPort(
+                defaults: defaults,
+                environment: environment
+            )
         }
-        let nodivsRelaunch = Self.withLaunchTag("nodivs") {
-            MobileHostService.configuredPort(defaults: defaults)
+        let nodivsRelaunch = Self.withLaunchTag("nodivs") { environment in
+            MobileHostService.configuredPort(
+                defaults: defaults,
+                environment: environment
+            )
         }
-        let wtodo = Self.withLaunchTag("wtodo") {
-            MobileHostService.configuredPort(defaults: defaults)
+        let wtodo = Self.withLaunchTag("wtodo") { environment in
+            MobileHostService.configuredPort(
+                defaults: defaults,
+                environment: environment
+            )
         }
 
         #expect(nodivs == nodivsRelaunch)
         #expect(nodivs != catalogDefault)
         #expect(wtodo != catalogDefault)
         #expect(nodivs != wtodo)
-        #expect((49_152...65_535).contains(nodivs))
-        #expect((49_152...65_535).contains(wtodo))
-        Self.withLaunchTag("wtodo") {
-            #expect(MobileHostService.resolvedDesiredPort(defaults: defaults) == wtodo)
+        #expect(MobileHostPortPolicy.taggedDevelopmentPortRange.contains(nodivs))
+        #expect(MobileHostPortPolicy.taggedDevelopmentPortRange.contains(wtodo))
+        Self.withLaunchTag("wtodo") { environment in
+            #expect(MobileHostService.resolvedDesiredPort(
+                defaults: defaults,
+                environment: environment
+            ) == wtodo)
         }
     }
     #endif
@@ -72,9 +86,15 @@ struct MobileHostServiceSettingsTests {
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
         defaults.set(9000, forKey: MobileHostService.portDefaultsKey)
-        Self.withLaunchTag("nodivs") {
-            #expect(MobileHostService.configuredPort(defaults: defaults) == 9000)
-            #expect(MobileHostService.resolvedDesiredPort(defaults: defaults) == 9000)
+        Self.withLaunchTag("nodivs") { environment in
+            #expect(MobileHostService.configuredPort(
+                defaults: defaults,
+                environment: environment
+            ) == 9000)
+            #expect(MobileHostService.resolvedDesiredPort(
+                defaults: defaults,
+                environment: environment
+            ) == 9000)
         }
     }
 
@@ -93,10 +113,13 @@ struct MobileHostServiceSettingsTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        Self.withoutLaunchTag {
+        Self.withoutLaunchTag { environment in
             defaults.set(invalidPort, forKey: MobileHostService.portDefaultsKey)
             let expected = SettingCatalog().mobile.iOSPairingPort.defaultValue
-            #expect(MobileHostService.configuredPort(defaults: defaults) == expected)
+            #expect(MobileHostService.configuredPort(
+                defaults: defaults,
+                environment: environment
+            ) == expected)
         }
     }
 
@@ -105,9 +128,12 @@ struct MobileHostServiceSettingsTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        Self.withoutLaunchTag {
+        Self.withoutLaunchTag { environment in
             // Unset -> catalog default (a valid desired port).
-            #expect(MobileHostService.resolvedDesiredPort(defaults: defaults)
+            #expect(MobileHostService.resolvedDesiredPort(
+                defaults: defaults,
+                environment: environment
+            )
                 == SettingCatalog().mobile.iOSPairingPort.defaultValue)
         }
 
@@ -157,33 +183,21 @@ struct MobileHostServiceSettingsTests {
         #expect(MobileHostService.syncDecision(enabled: true, listenerRunning: true, desiredPort: 58465, appliedPort: nil) == .restart)
     }
 
-    private static func withLaunchTag<T>(_ tag: String, _ body: () throws -> T) rethrows -> T {
-        try withEnvironmentValue(SocketControlSettings.launchTagEnvKey, value: tag, body)
-    }
-
-    private static func withoutLaunchTag<T>(_ body: () throws -> T) rethrows -> T {
-        try withEnvironmentValue(SocketControlSettings.launchTagEnvKey, value: nil, body)
-    }
-
-    private static func withEnvironmentValue<T>(
-        _ key: String,
-        value: String?,
-        _ body: () throws -> T
+    private static func withLaunchTag<T>(
+        _ tag: String,
+        _ body: ([String: String]) throws -> T
     ) rethrows -> T {
-        let previous = getenv(key).map { String(cString: $0) }
-        if let value {
-            setenv(key, value, 1)
-        } else {
-            unsetenv(key)
-        }
-        defer {
-            if let previous {
-                setenv(key, previous, 1)
-            } else {
-                unsetenv(key)
-            }
-        }
-        return try body()
+        var environment = ProcessInfo.processInfo.environment
+        environment[SocketControlSettings.launchTagEnvKey] = tag
+        return try body(environment)
+    }
+
+    private static func withoutLaunchTag<T>(
+        _ body: ([String: String]) throws -> T
+    ) rethrows -> T {
+        var environment = ProcessInfo.processInfo.environment
+        environment[SocketControlSettings.launchTagEnvKey] = nil
+        return try body(environment)
     }
 }
 

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -10,7 +10,7 @@ import Testing
 @testable import cmux
 #endif
 
-@Suite(.serialized)
+@Suite
 struct MobileHostServiceSettingsTests {
     @Test func mobileHostListenerDefaultsOffUntilIOSPairingIsEnabled() throws {
         let suiteName = "MobileHostServiceSettingsTests.\(UUID().uuidString)"

--- a/cmuxTests/MobileHostServiceSettingsTests.swift
+++ b/cmuxTests/MobileHostServiceSettingsTests.swift
@@ -93,9 +93,11 @@ struct MobileHostServiceSettingsTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        defaults.set(invalidPort, forKey: MobileHostService.portDefaultsKey)
-        let expected = SettingCatalog().mobile.iOSPairingPort.defaultValue
-        #expect(MobileHostService.configuredPort(defaults: defaults) == expected)
+        Self.withoutLaunchTag {
+            defaults.set(invalidPort, forKey: MobileHostService.portDefaultsKey)
+            let expected = SettingCatalog().mobile.iOSPairingPort.defaultValue
+            #expect(MobileHostService.configuredPort(defaults: defaults) == expected)
+        }
     }
 
     @Test func resolvedDesiredPortIsNilForInvalidSoRunningListenerIsNotDisturbed() throws {
@@ -103,32 +105,34 @@ struct MobileHostServiceSettingsTests {
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        // Unset → catalog default (a valid desired port).
-        #expect(MobileHostService.resolvedDesiredPort(defaults: defaults)
-            == SettingCatalog().mobile.iOSPairingPort.defaultValue)
+        Self.withoutLaunchTag {
+            // Unset -> catalog default (a valid desired port).
+            #expect(MobileHostService.resolvedDesiredPort(defaults: defaults)
+                == SettingCatalog().mobile.iOSPairingPort.defaultValue)
+        }
 
-        // Valid override → that port.
+        // Valid override -> that port.
         defaults.set(58_470, forKey: MobileHostService.portDefaultsKey)
         #expect(MobileHostService.resolvedDesiredPort(defaults: defaults) == 58_470)
 
-        // Invalid override → nil, so syncToSettings keeps the running listener
+        // Invalid override -> nil, so syncToSettings keeps the running listener
         // on its applied port instead of restarting onto the default.
         defaults.set(70_000, forKey: MobileHostService.portDefaultsKey)
         #expect(MobileHostService.resolvedDesiredPort(defaults: defaults) == nil)
     }
 
     @Test func portApplyPreBindClassifiesNonBindCases() {
-        // Out of range → invalid, regardless of anything else.
+        // Out of range -> invalid, regardless of anything else.
         #expect(MobileHostService.portApplyPreBindOutcome(enabled: true, currentBoundPort: nil, requestedPort: 0) == .invalid)
         #expect(MobileHostService.portApplyPreBindOutcome(enabled: true, currentBoundPort: nil, requestedPort: 70000) == .invalid)
-        // Pairing off → saved for when it's enabled.
+        // Pairing off -> saved for when it's enabled.
         #expect(MobileHostService.portApplyPreBindOutcome(enabled: false, currentBoundPort: nil, requestedPort: 58465) == .savedWhileDisabled)
-        // Already bound to the requested port → applied, no bind attempt.
+        // Already bound to the requested port -> applied, no bind attempt.
         #expect(MobileHostService.portApplyPreBindOutcome(enabled: true, currentBoundPort: 58465, requestedPort: 58465) == .applied(58465))
     }
 
     @Test func portApplyPreBindReturnsNilWhenABindIsNeeded() {
-        // Enabled, valid, different from the bound port → needs a real bind
+        // Enabled, valid, different from the bound port -> needs a real bind
         // attempt (make-before-break), signalled by nil.
         #expect(MobileHostService.portApplyPreBindOutcome(enabled: true, currentBoundPort: 58465, requestedPort: 58470) == nil)
         // Not running yet, enabled, valid → also needs a bind.


### PR DESCRIPTION
Closes https://github.com/manaflow-ai/cmux/issues/7691

## Summary
- derive the debug mobile-host default port from `CMUX_TAG` when no explicit port is configured
- keep production, untagged debug, and explicit configured ports unchanged
- cover tag-derived allocation and attach-ticket endpoint propagation with focused regression tests

## Verification
- `./scripts/lint-pbxproj-test-wiring.sh`
- `git diff --check`
- `swift test --package-path Packages/macOS/CmuxSettings --filter MobileHostPortPolicyTests`
- `./scripts/reload.sh --tag mh7691`
- launched `mh7691`, verified `/tmp/cmux-debug-mh7691.sock`, `identify`, `window display "LG HDR 4K"`, and `rpc mobile.host.status {}`
- relaunched `mh7691` and verified `configured_port == port == 59315` again

## Dogfood status
- macOS tagged build is ready at `http://127.0.0.1:17320/mh7691`
- iOS simulator dogfood is blocked locally because the tagged web dev server cannot start without Stack web app keys in local secrets; only dogfood email/password are configured
- CI failed once on unrelated `HostSettingsShortcutNotificationTests.changedSettingsFilePostsOneShortcutNotification` and `CmuxCanvasUI` signal 5; failed jobs were rerun and are pending
