### PR TITLE
Open path:line[:col] cmd-click links at the right position

### DIFF
--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/String+TerminalPathTokens.swift
@@ -153,6 +153,16 @@ extension String {
             }
         }
 
+        // `path:line` / `path:line:col` locators (compiler output, grep -n,
+        // stack traces) point at the file itself. Probe the locator-stripped
+        // spelling after every literal candidate, so a real file whose name
+        // ends in a colon-number still wins first.
+        for candidate in candidates {
+            if let stripped = candidate.splittingTrailingLineColumn()?.token {
+                append(stripped)
+            }
+        }
+
         return candidates
     }
 

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileLinePosition.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/PathResolution/TerminalFileLinePosition.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+/// A 1-based line (and optional column) locator peeled off a path token.
+///
+/// Compilers, `grep -n`, and stack traces print file references as
+/// `path:line` or `path:line:column`; this captures the trailing position so
+/// cmd-click can forward it to the editor.
+public struct TerminalFileLinePosition: Sendable, Equatable {
+    public let line: Int
+    public let column: Int?
+
+    public init(line: Int, column: Int?) {
+        self.line = line
+        self.column = column
+    }
+}
+
+extension String {
+    /// Peels a trailing `:line` or `:line:column` locator off the receiver.
+    ///
+    /// The locator segments must be positive ASCII integers and the remaining
+    /// token must be non-empty, so ordinary paths (and `path:` with no number)
+    /// are left untouched. Whether the stripped token names a real file is not
+    /// checked here — the resolver's existence probe is the real guard, so a
+    /// file literally named with a colon still resolves via the literal
+    /// candidate.
+    ///
+    /// - Returns: The token without the locator plus the parsed position, or
+    ///   `nil` when there is no numeric locator.
+    public func splittingTrailingLineColumn() -> (token: String, position: TerminalFileLinePosition)? {
+        func peelNumber(from text: Substring) -> (rest: Substring, value: Int)? {
+            guard let colon = text.lastIndex(of: ":") else { return nil }
+            let digits = text[text.index(after: colon)...]
+            guard !digits.isEmpty,
+                  digits.allSatisfy({ $0.isASCII && $0.isNumber }),
+                  let value = Int(digits), value > 0 else { return nil }
+            return (text[..<colon], value)
+        }
+
+        guard let last = peelNumber(from: self[...]) else { return nil }
+
+        if let previous = peelNumber(from: last.rest) {
+            let token = String(previous.rest)
+            guard !token.isEmpty else { return nil }
+            return (token, TerminalFileLinePosition(line: previous.value, column: last.value))
+        }
+
+        let token = String(last.rest)
+        guard !token.isEmpty else { return nil }
+        return (token, TerminalFileLinePosition(line: last.value, column: nil))
+    }
+}
+
+/// Derives the editor line/column locator for a resolved cmd-click target.
+public enum TerminalFilePathLineLocator {
+    /// The position to open `resolvedPath` at, given the `rawToken` the user
+    /// clicked.
+    ///
+    /// Returns the token's trailing locator, unless the resolved file itself
+    /// carries the same numeric suffix (a real filename ending in `:line`), in
+    /// which case the digits are part of the name and no position is forwarded.
+    public static func position(
+        rawToken: String,
+        resolvedPath: String
+    ) -> TerminalFileLinePosition? {
+        guard let (_, position) = rawToken.splittingTrailingLineColumn() else { return nil }
+        if let (_, resolvedPosition) = resolvedPath.splittingTrailingLineColumn(),
+           resolvedPosition == position {
+            return nil
+        }
+        return position
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -239,3 +239,37 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
         )
     }
 }
+
+
+@Suite struct TerminalLineColumnLocatorResolutionTests {
+    @Test func resolvesLineLocatorToTheFileItself() {
+        let existingFile = "/repo/src/state.js"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveQuicklookPath(
+                "src/state.js:87",
+                cwd: "/repo"
+            ) == existingFile
+        )
+    }
+
+    @Test func resolvesLineColumnLocatorToTheFileItself() {
+        let existingFile = "/repo/src/state.js"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([existingFile])).resolveQuicklookPath(
+                "src/state.js:87:12",
+                cwd: "/repo"
+            ) == existingFile
+        )
+    }
+
+    @Test func prefersLiteralFileEndingInColonNumberOverStrippedForm() {
+        let literalFile = "/repo/weird:87"
+        let strippedFile = "/repo/weird"
+        #expect(
+            TerminalPathResolver(fileExists: existsIn([literalFile, strippedFile])).resolveQuicklookPath(
+                "weird:87",
+                cwd: "/repo"
+            ) == literalFile
+        )
+    }
+}

--- a/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
+++ b/Packages/macOS/CmuxTerminalCore/Tests/CmuxTerminalCoreTests/TerminalPathResolverTests.swift
@@ -241,6 +241,50 @@ private func existsIn(_ existingPaths: Set<String>) -> @Sendable (String) -> Boo
 }
 
 
+@Suite struct TerminalTrailingLineColumnTests {
+    @Test func splitsLineOnlyLocator() {
+        let split = "src/state.js:87".splittingTrailingLineColumn()
+        #expect(split?.token == "src/state.js")
+        #expect(split?.position == TerminalFileLinePosition(line: 87, column: nil))
+    }
+
+    @Test func splitsLineAndColumnLocator() {
+        let split = "/abs/state.js:87:12".splittingTrailingLineColumn()
+        #expect(split?.token == "/abs/state.js")
+        #expect(split?.position == TerminalFileLinePosition(line: 87, column: 12))
+    }
+
+    @Test func ignoresPathWithoutNumericSuffix() {
+        #expect("/abs/state.js".splittingTrailingLineColumn() == nil)
+        #expect("/abs/state.js:".splittingTrailingLineColumn() == nil)
+        #expect("/abs/state.js:noline".splittingTrailingLineColumn() == nil)
+    }
+
+    @Test func rejectsZeroAndEmptyToken() {
+        #expect("/abs/state.js:0".splittingTrailingLineColumn() == nil)
+        #expect(":87".splittingTrailingLineColumn() == nil)
+    }
+
+    @Test func locatorForwardsPositionWhenResolvedPathHasNoSuffix() {
+        #expect(
+            TerminalFilePathLineLocator.position(
+                rawToken: "src/state.js:87",
+                resolvedPath: "/repo/src/state.js"
+            ) == TerminalFileLinePosition(line: 87, column: nil)
+        )
+    }
+
+    @Test func locatorSkipsPositionWhenResolvedFileEndsInColonNumber() {
+        // A real file literally named `weird:87`: the digits are the name.
+        #expect(
+            TerminalFilePathLineLocator.position(
+                rawToken: "weird:87",
+                resolvedPath: "/repo/weird:87"
+            ) == nil
+        )
+    }
+}
+
 @Suite struct TerminalLineColumnLocatorResolutionTests {
     @Test func resolvesLineLocatorToTheFileItself() {
         let existingFile = "/repo/src/state.js"

--- a/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/FileOpen/PreferredEditorService.swift
+++ b/Packages/macOS/CmuxWorkspaces/Sources/CmuxWorkspaces/FileOpen/PreferredEditorService.swift
@@ -57,6 +57,16 @@ public struct PreferredEditorService: FileOpening {
     }
 
     public func open(_ url: URL) {
+        open(url, line: nil, column: nil)
+    }
+
+    /// Opens `url` at an optional 1-based line (and column) locator.
+    ///
+    /// When a line is given and a command is configured, the argument is the
+    /// `path:line[:col]` locator form that Zed, VS Code (`code`), and Sublime
+    /// accept. The capture seam and the system-default fallback always receive
+    /// the bare path — non-editor handlers cannot take a position.
+    public func open(_ url: URL, line: Int?, column: Int?) {
         if capture.appendLineIfConfigured(
             envKey: "CMUX_UI_TEST_CAPTURE_OPEN_PATH",
             line: url.path
@@ -69,9 +79,17 @@ public struct PreferredEditorService: FileOpening {
             return
         }
 
+        var argument = url.path
+        if let line {
+            argument += ":\(line)"
+            if let column {
+                argument += ":\(column)"
+            }
+        }
+
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/bin/sh")
-        process.arguments = ["-c", "\(command) \(url.path.posixShellSingleQuoted)"]
+        process.arguments = ["-c", "\(command) \(argument.posixShellSingleQuoted)"]
         process.standardOutput = FileHandle.nullDevice
         process.standardError = FileHandle.nullDevice
 

--- a/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/FileOpen/PreferredEditorServiceTests.swift
+++ b/Packages/macOS/CmuxWorkspaces/Tests/CmuxWorkspacesTests/FileOpen/PreferredEditorServiceTests.swift
@@ -97,6 +97,66 @@ struct PreferredEditorServiceTests {
         #expect(opener.openedURLs.isEmpty)
     }
 
+    @Test func configuredCommandReceivesLineColumnLocator() async throws {
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let marker = scratch.appendingPathComponent("received.txt")
+        let script = scratch.appendingPathComponent("editor.sh")
+        try #"""
+        #!/bin/sh
+        printf %s "$1" > '\#(marker.path)'
+        """#.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: script.path
+        )
+
+        let opener = RecordingSystemOpener()
+        let service = PreferredEditorService(
+            editor: FixedEditor(resolvedCommand: script.path),
+            capture: UITestCaptureSink(environment: [:]),
+            systemOpener: opener
+        )
+
+        service.open(URL(fileURLWithPath: "/tmp/state.js"), line: 87, column: 12)
+
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: marker.path) {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let received = try String(contentsOf: marker, encoding: .utf8)
+        #expect(received == "/tmp/state.js:87:12")
+        #expect(opener.openedURLs.isEmpty)
+    }
+
+    @Test func lineOnlyLocatorOmitsColumn() async throws {
+        let scratch = try makeScratchDirectory()
+        defer { try? FileManager.default.removeItem(at: scratch) }
+        let marker = scratch.appendingPathComponent("received.txt")
+        let script = scratch.appendingPathComponent("editor.sh")
+        try #"""
+        #!/bin/sh
+        printf %s "$1" > '\#(marker.path)'
+        """#.write(to: script, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o755], ofItemAtPath: script.path
+        )
+
+        let opener = RecordingSystemOpener()
+        let service = PreferredEditorService(
+            editor: FixedEditor(resolvedCommand: script.path),
+            capture: UITestCaptureSink(environment: [:]),
+            systemOpener: opener
+        )
+
+        service.open(URL(fileURLWithPath: "/tmp/state.js"), line: 87, column: nil)
+
+        for _ in 0..<200 where !FileManager.default.fileExists(atPath: marker.path) {
+            try await Task.sleep(for: .milliseconds(25))
+        }
+        let received = try String(contentsOf: marker, encoding: .utf8)
+        #expect(received == "/tmp/state.js:87")
+        #expect(opener.openedURLs.isEmpty)
+    }
+
     @Test func failingCommandFallsBackToSystemOpen() async {
         let opener = RecordingSystemOpener()
         let service = PreferredEditorService(

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -6512,7 +6512,21 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         cmuxDebugLog("link.wordFallback resolved=\(resolution.path) source=\(resolution.source.rawValue)")
         #endif
 
-        PreferredEditorService(defaults: .standard).open(URL(fileURLWithPath: resolution.path))
+        openInPreferredEditor(resolution)
+    }
+
+    /// Open a resolved cmd-click target in the preferred editor, forwarding a
+    /// `path:line[:col]` locator when the clicked token carried one.
+    private func openInPreferredEditor(_ resolution: WordPathResolution) {
+        let position = TerminalFilePathLineLocator.position(
+            rawToken: resolution.rawToken,
+            resolvedPath: resolution.path
+        )
+        PreferredEditorService(defaults: .standard).open(
+            URL(fileURLWithPath: resolution.path),
+            line: position?.line,
+            column: position?.column
+        )
     }
 
     /// Check if the word under the mouse cursor resolves to an existing file/directory
@@ -6944,7 +6958,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             return resolution
         }
 
-        PreferredEditorService(defaults: .standard).open(URL(fileURLWithPath: resolution.path))
+        openInPreferredEditor(resolution)
         return resolution
     }
 


### PR DESCRIPTION
## Summary

- **What changed?** Cmd-click on a terminal file path with a trailing line locator — `src/state.js:87` or `src/state.js:87:12`, the form printed by compilers, `grep -n`, and stack traces — now resolves to the file and opens the editor at that line/column. Previously such a token did not linkify at all (no pointing-hand cursor, dead click).
- **Why?** The cmd-click path resolver locates the clicked token by probing it for existence. `src/state.js:87` is never a real file, so resolution returned `nil` and the link silently no-op'd. The bare path `src/state.js` worked; the `:87` broke detection.

The fix has two parts, both in the shared, well-tested path layer:

1. `TerminalPathResolver` now probes the locator-stripped spelling as an additional candidate — appended **after** every literal candidate, so a real file whose name genuinely ends in `:<number>` still wins first. Locator segments must be positive integers and leave a non-empty token, and the existence probe is the real guard, so ordinary paths and `path:` (no number) are untouched.
2. The trailing `:line[:col]` is parsed off the clicked token and forwarded to the preferred editor as the `path:line[:col]` argument that Zed, VS Code (`code`), and Sublime accept. The UI-test capture seam and the system-default fallback still receive the bare path (non-editor handlers can't take a position), and the in-cmux preview route already opens the stripped path.

No user-facing strings were added, so no localization changes.

## Testing

Behavior lives entirely in the pure `String`/`TerminalPathResolver`/`PreferredEditorService` layer. Added a two-commit red/green regression (commit 1 = failing test, commit 2 = fix) plus unit coverage:

- `TerminalPathResolverTests` — locator resolution (`:line`, `:line:col`), literal-file-with-colon precedence, `splittingTrailingLineColumn` parsing (rejects `path:`, `path:noline`, `:0`, empty token), and the `TerminalFilePathLineLocator` rawToken-vs-resolved-path guard.
- `PreferredEditorServiceTests` — the configured editor command receives `path:87:12` and `path:87`, while capture/fallback keep the bare path.

Verified by extracting the pure sources + their real tests into a standalone SwiftPM package and running `swift test` (the full app build needs the GhosttyKit xcframework + submodules):

- Resolver suite: **33 tests, 6 suites — all pass**. Confirmed the two locator-resolution tests go **red** when the candidate-stripping is removed (proves the regression test catches the bug).
- Editor-service suite: **6 tests — all pass** (including the 4 pre-existing, so bare-path behavior is unchanged).

Not verified locally: the full macOS app/Xcode build of `GhosttyTerminalView.swift` (requires the GhosttyKit binary + `bonsplit` submodule not present in a shallow fork clone). The app-target edit is two call sites routed through one new private helper using the public `TerminalFilePathLineLocator` API.

## Demo Video

- N/A (behavior verified via unit tests; the app-target build could not be produced in this environment).

## Review Trigger (Copy/Paste as PR comment)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Checklist

- [x] I tested the change locally (unit tests via standalone SwiftPM package; app-target build not possible in this environment)
- [x] I added or updated tests for behavior changes
- [ ] I updated docs/changelog if needed (no docs/changelog impact)
- [x] I requested bot reviews after my latest commit (copy/paste block above or equivalent)
- [ ] All code review bot comments are resolved
- [ ] All human review comments are resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8152"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786693228&installation_id=133855650&pr_number=8152&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8152&signature=1f336ec1c4e4ae5d030b550b6ec2ab8bb6193a88b0d27e3cc9de55778e6c1662"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes cmd-click on terminal paths with trailing line/column (e.g., src/state.js:87:12) so the file opens at the correct position in the preferred editor. Previously these tokens didn’t linkify; now they resolve and pass `path:line[:col]` to editors like Zed, `code`, and Sublime.

- **Bug Fixes**
  - `TerminalPathResolver` now also probes a locator-stripped candidate after literal candidates, preserving real filenames that end with `:<number>`.
  - Added parsing of trailing `:line[:col]` and a guard to avoid treating literal colon-number filenames as positions; position is forwarded only when appropriate.
  - `PreferredEditorService.open` accepts optional line/column and sends `path:line[:col]` to the editor command; capture and system-open still receive the bare path.
  - `GhosttyTerminalView` now forwards the parsed line/column when opening in the preferred editor.

<sup>Written for commit 431a2dea17911bc5eda18df81250be4b1c0c191a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8152?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cmd-clicking file references with `:line` or `:line:column` locators now opens the file at the specified position in the preferred editor.
  * File resolution now supports paths with trailing line and column references while preserving valid filenames containing colon-number segments.
  * Preferred editor commands receive line and column information when available.

* **Bug Fixes**
  * Improved handling of ambiguous file paths and locator suffixes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
