### PR TITLE
Fix two main breakages from the CI-disabled window: reorderPanel overflow, double shortcut notification

### DIFF
--- a/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasModel.swift
+++ b/Packages/macOS/CmuxCanvasUI/Sources/CmuxCanvasUI/CanvasModel.swift
@@ -148,8 +148,11 @@ public final class CanvasModel {
               let panelIds = layout.panelIds(in: paneID),
               let currentIndex = panelIds.firstIndex(of: panel),
               !panelIds.isEmpty else { return false }
+        // `offset` may be Int.min/Int.max; saturate instead of trapping.
+        let (sum, overflowed) = currentIndex.addingReportingOverflow(offset)
+        let target = overflowed ? (offset > 0 ? Int.max : Int.min) : sum
         let destinationIndex = min(
-            max(currentIndex + offset, panelIds.startIndex),
+            max(target, panelIds.startIndex),
             panelIds.index(before: panelIds.endIndex)
         )
         guard destinationIndex != currentIndex else { return true }

--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -92,8 +92,13 @@ final class HostSettingsActions: SettingsHostActions {
     }
 
     func notifyShortcutSettingsDidChange() {
-        KeyboardShortcutSettings.settingsFileStore.reload()
-        KeyboardShortcutSettings.notifySettingsFileDidChange()
+        // reload() already posts didChangeNotification when the file's
+        // contents changed; posting again here double-notified every
+        // listener. Only post when the reload saw no change, so callers
+        // still get exactly one notification either way.
+        if !KeyboardShortcutSettings.settingsFileStore.reload() {
+            KeyboardShortcutSettings.notifySettingsFileDidChange()
+        }
     }
 
     func applyLanguageOverride(_ language: AppLanguage) {

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -134,7 +134,10 @@ final class CmuxSettingsFileStore {
         }
     }
 
-    func reload() {
+    /// Returns whether the reload posted `didChangeNotification`, so callers
+    /// that must guarantee a notification can post one without double-firing.
+    @discardableResult
+    func reload() -> Bool {
         reload(
             applyLiveDefaultSideEffects: true,
             synchronizeManagedAppearanceTerminalTheme: true
@@ -145,10 +148,11 @@ final class CmuxSettingsFileStore {
         applyManagedDefaultBatchSideEffects(drainDeferredManagedDefaultSideEffects())
     }
 
+    @discardableResult
     private func reload(
         applyLiveDefaultSideEffects: Bool,
         synchronizeManagedAppearanceTerminalTheme: Bool
-    ) {
+    ) -> Bool {
         let previousState = synchronized {
             (
                 shortcuts: shortcutsByAction,
@@ -183,7 +187,9 @@ final class CmuxSettingsFileStore {
             || previousState.whenClauses != resolved.whenClauses
             || previousState.sourcePath != resolved.path {
             KeyboardShortcutSettings.notifySettingsFileDidChange(center: notificationCenter)
+            return true
         }
+        return false
     }
 
     func override(for action: KeyboardShortcutSettings.Action) -> StoredShortcut? {


### PR DESCRIPTION
Main has been red since today's window where the repo's CI workflows were manually disabled — two PRs merged unchecked and each broke a different job. Both fixes here:

1. **`CanvasModel.reorderPanel` arithmetic overflow** (from https://github.com/manaflow-ai/cmux/pull/8080): `currentIndex + offset` trapped on `Int.max`/`Int.min` before the clamp, crashing the whole CmuxCanvasUI suite mid-run (`swift-package-tests` red). Fixed with a saturating `addingReportingOverflow` before the existing clamp. `swift test --package-path Packages/macOS/CmuxCanvasUI`: 45/45 with the summary printed.

2. **Double `didChangeNotification` on settings-file change** (from https://github.com/manaflow-ai/cmux/pull/8091): `notifyShortcutSettingsDidChange()` called `reload()` (which posts when contents changed) then posted again unconditionally, so every real change notified listeners twice; `changedSettingsFilePostsOneShortcutNotification` fails on exactly this (`app-host unit tests (4/4)` red, three runs in a row here and on main's own CI). `reload()` now reports whether it posted and the action posts only when it didn't, keeping the exactly-once contract both #8091 tests encode.

Related flaky-test hardening tracked separately: https://github.com/manaflow-ai/cmux/issues/8159

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved panel reordering so very large movement values no longer risk failures; the target position is safely constrained while preserving the existing reorder/selection behavior.
  * Fixed shortcut settings change updates to avoid duplicate notifications, ensuring listeners receive a single, consistent update when the settings file is reloaded.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->