### PR TITLE
Fix shortcut settings notification fanout

### DIFF
--- a/Sources/HostSettingsActions.swift
+++ b/Sources/HostSettingsActions.swift
@@ -92,8 +92,9 @@ final class HostSettingsActions: SettingsHostActions {
     }
 
     func notifyShortcutSettingsDidChange() {
-        KeyboardShortcutSettings.settingsFileStore.reload()
-        KeyboardShortcutSettings.notifySettingsFileDidChange()
+        KeyboardShortcutSettings.settingsFileStore.reload(
+            notifyShortcutSettingsEvenIfUnchanged: true
+        )
     }
 
     func applyLanguageOverride(_ language: AppLanguage) {

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -134,10 +134,11 @@ final class CmuxSettingsFileStore {
         }
     }
 
-    func reload() {
+    func reload(notifyShortcutSettingsEvenIfUnchanged: Bool = false) {
         reload(
             applyLiveDefaultSideEffects: true,
-            synchronizeManagedAppearanceTerminalTheme: true
+            synchronizeManagedAppearanceTerminalTheme: true,
+            notifyShortcutSettingsEvenIfUnchanged: notifyShortcutSettingsEvenIfUnchanged
         )
     }
 
@@ -147,7 +148,8 @@ final class CmuxSettingsFileStore {
 
     private func reload(
         applyLiveDefaultSideEffects: Bool,
-        synchronizeManagedAppearanceTerminalTheme: Bool
+        synchronizeManagedAppearanceTerminalTheme: Bool,
+        notifyShortcutSettingsEvenIfUnchanged: Bool = false
     ) {
         let previousState = synchronized {
             (
@@ -179,7 +181,8 @@ final class CmuxSettingsFileStore {
         }
         saveImportedManagedDefaults(resolved.managedUserDefaults)
 
-        if previousState.shortcuts != resolved.shortcuts
+        if notifyShortcutSettingsEvenIfUnchanged
+            || previousState.shortcuts != resolved.shortcuts
             || previousState.whenClauses != resolved.whenClauses
             || previousState.sourcePath != resolved.path {
             KeyboardShortcutSettings.notifySettingsFileDidChange(center: notificationCenter)


### PR DESCRIPTION
## Summary

- make `CmuxSettingsFileStore.reload` the single owner of shortcut-settings notifications
- let the Settings host request one notification even when the persisted shortcut snapshot is unchanged
- remove the host-side duplicate post that made changed settings emit twice

## Context

The post-merge `app-host unit tests (4/4)` run for #8110 exposed this deterministic regression from #8091: reloading a changed settings file already posted `didChangeNotification`, then `HostSettingsActions` posted it again. The existing host regression expects exactly one notification for both changed and unchanged saves.

## Validation

- `git diff --check`
- focused `HostSettingsShortcutNotificationTests` running through `scripts/ci/run-app-host-xcodebuild.sh` (local compiler is heavily contended and the wrapper automatically retried after its idle watchdog)
- CI will run the full app-host shard

## Localization

No user-facing strings changed; no localization catalog updates are required.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8157"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786695955&installation_id=133855650&pr_number=8157&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8157&signature=2f39770ffa4a9fa1257908cc6294a6b65498f75b8bd94bcfb26546089567cd38"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes double-posted shortcut settings notifications by making `CmuxSettingsFileStore.reload` the single owner of fanout. Restores exactly one `didChange` event per save, even when the snapshot is unchanged.

- Bug Fixes
  - Centralized notifications in `CmuxSettingsFileStore.reload`.
  - Added `notifyShortcutSettingsEvenIfUnchanged` flag to `reload(...)`.
  - Updated `HostSettingsActions.notifyShortcutSettingsDidChange` to call `reload(notifyShortcutSettingsEvenIfUnchanged: true)` and removed the extra `KeyboardShortcutSettings.notifySettingsFileDidChange()` call.

<sup>Written for commit 1f6484658e03ef1e2580ae216e3d8cfba4ed624d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8157?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Shortcut settings changes are now reliably refreshed and reported, even when the shortcut values remain unchanged.
  * Improved consistency when reloading keyboard shortcut settings after configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->