### PR TITLE
fix: don't crash on AppKit-internal NSExceptions (macOS 27 SF Symbol bug)

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1389,6 +1389,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 options.attachStacktrace = true
                 // Avoid recursively capturing failed requests from Sentry's own ingestion endpoint.
                 options.enableCaptureFailedRequests = false
+                // Sentry's uncaught-NSException reporting registers
+                // NSApplicationCrashOnExceptions=YES, which turns AppKit-internal
+                // exceptions into hard crashes. On macOS 27 (beta) AppKit throws an
+                // NSException inside -[NSImageSymbolRepProvider
+                // bestRepresentationForImage:hints:] while rendering SF Symbols
+                // (see #7254), so that default converts an otherwise-recoverable
+                // OS bug into a startup/navigation crash loop. Keep the legacy
+                // catch-and-log behavior instead; crash reporting for real
+                // signal-level crashes is unaffected.
+                options.enableUncaughtNSExceptionReporting = false
                 // Redact file paths, emails, and secrets from every outgoing
                 // event, breadcrumb, and (belt-and-suspenders, if tracing is ever
                 // re-enabled) child performance span before it leaves the device.

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1396,9 +1396,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 // bestRepresentationForImage:hints:] while rendering SF Symbols
                 // (see #7254), so that default converts an otherwise-recoverable
                 // OS bug into a startup/navigation crash loop. Keep the legacy
-                // catch-and-log behavior instead; crash reporting for real
-                // signal-level crashes is unaffected.
-                options.enableUncaughtNSExceptionReporting = false
+                // catch-and-log behavior there instead; crash reporting for real
+                // signal-level crashes is unaffected, and stable macOS keeps
+                // Sentry's NSException reporting. Remove once Apple fixes the
+                // SF Symbol rendering path (FB23740635).
+                if #available(macOS 27, *) {
+                    options.enableUncaughtNSExceptionReporting = false
+                }
                 // Redact file paths, emails, and secrets from every outgoing
                 // event, breadcrumb, and (belt-and-suspenders, if tracing is ever
                 // re-enabled) child performance span before it leaves the device.


### PR DESCRIPTION
## Summary

Fixes #7254.

On macOS 27 (beta), AppKit throws an `NSException` inside `-[NSImageSymbolRepProvider bestRepresentationForImage:hints:]` while rendering SF Symbols — hit both from File Explorer directory navigation (#7254) and from startup sheets (crash loop within ~3s of launch on 0.64.19, macOS 27.0 26A5378j).

The exception itself is recoverable: AppKit's internal `@catch` in `-[_NSSimpleLRUCache objectForKey:creationBlock:]` only escalates to `+[NSApplication _crashOnException:]` when the `NSApplicationCrashOnExceptions` default is set. **sentry-cocoa 9.x defaults `enableUncaughtNSExceptionReporting` to `true` on macOS**, and its `configureCrashOnExceptions` registers exactly that default — turning the OS bug into a hard crash.

## Change

One line: `options.enableUncaughtNSExceptionReporting = false` in the `SentrySDK.start` block, restoring AppKit's legacy catch-and-log behavior. Signal-level crash reporting via SentryCrash is unaffected.

## Verification

- Confirmed the setter exists in the pinned sentry-cocoa 9.3.0.
- Runtime-verified the mechanism on the affected machine: persisting `NSApplicationCrashOnExceptions=NO` in the app domain (which overrides Sentry's `register(defaults:)`) stops the crash loop immediately — cmux stays up where it previously died ~3s after launch, with the SF Symbol rendering blank instead of killing the app.
- No regression test: the trigger is an AppKit-internal throw specific to the macOS 27 beta and can't be reproduced deterministically from the test target.

## Trade-off

Uncaught ObjC exceptions in the run loop get logged instead of crashing (pre-`NSApplicationCrashOnExceptions` behavior). If you'd rather keep Sentry's NSException reporting on stable macOS, this could be gated to macOS 27+ — happy to adjust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011zKPi5EVN3kg7238g2Hr1V

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8162"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786699612&installation_id=133855650&pr_number=8162&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8162&signature=ef36ab9a72ec834a4eb0ebc752491ecaae8911c920384d6bfc47eefdb1f09add"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `sentry-cocoa` uncaught NSException reporting on macOS 27+ to stop crash loops when AppKit throws during SF Symbol rendering. Fixes #7254 and keeps signal-level crash reporting intact.

- **Bug Fixes**
  - Gate `SentrySDK` option `enableUncaughtNSExceptionReporting = false` behind `#available(macOS 27, *)` so stable macOS keeps NSException reporting.
  - Avoid hard crashes caused by `NSApplicationCrashOnExceptions=YES` when AppKit throws in `-[NSImageSymbolRepProvider bestRepresentationForImage:hints:]` (startup sheets, File Explorer navigation) on macOS 27 beta.

<sup>Written for commit 8fe7d40ff369d7b001d55832ccdda57bd12ec56e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8162?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated crash reporting behavior on macOS 27 and later to avoid repeated startup/navigation crash loops caused by certain AppKit `NSException` events during system symbol rendering.
  * Kept the existing handling that logs these exceptions without changing signal-level crash reporting behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->