### PR TITLE
Fix automatic terminal top inset

### DIFF
--- a/Sources/GhosttyScrollView.swift
+++ b/Sources/GhosttyScrollView.swift
@@ -5,6 +5,20 @@ import AppKit
 final class GhosttyScrollView: NSScrollView {
     weak var surfaceView: GhosttyNSView?
 
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+
+        // Bonsplit lays out the tab strip outside this viewport, so AppKit must not
+        // infer another terminal-content inset from the window title bar.
+        automaticallyAdjustsContentInsets = false
+        contentInsets = NSEdgeInsetsZero
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
     // Keep keyboard routing on the terminal surface; this wrapper is viewport plumbing.
     override var acceptsFirstResponder: Bool { false }
 

--- a/Sources/GhosttyScrollView.swift
+++ b/Sources/GhosttyScrollView.swift
@@ -1,0 +1,26 @@
+import AppKit
+
+/// Provides viewport plumbing while Ghostty owns terminal scrollback.
+@MainActor
+final class GhosttyScrollView: NSScrollView {
+    weak var surfaceView: GhosttyNSView?
+
+    // Keep keyboard routing on the terminal surface; this wrapper is viewport plumbing.
+    override var acceptsFirstResponder: Bool { false }
+
+    override func scrollWheel(with event: NSEvent) {
+        guard let surfaceView else {
+            super.scrollWheel(with: event)
+            return
+        }
+
+        // Route wheel gestures to the terminal surface so Ghostty handles scrollback.
+        // Letting NSScrollView consume these events moves the wrapper viewport itself,
+        // which causes pane-content drift instead of terminal scrollback movement.
+        GhosttyNSView.focusLog("GhosttyScrollView.scrollWheel: surface scroll")
+        if window?.firstResponder !== surfaceView {
+            window?.makeFirstResponder(surfaceView)
+        }
+        surfaceView.scrollWheel(with: event)
+    }
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7869,31 +7869,6 @@ extension Notification.Name {
     )
 }
 
-// MARK: - Scroll View Wrapper (Ghostty-style scrollbar)
-
-private final class GhosttyScrollView: NSScrollView {
-    weak var surfaceView: GhosttyNSView?
-
-    // Keep keyboard routing on the terminal surface; this wrapper is viewport plumbing.
-    override var acceptsFirstResponder: Bool { false }
-
-    override func scrollWheel(with event: NSEvent) {
-        guard let surfaceView else {
-            super.scrollWheel(with: event)
-            return
-        }
-
-        // Route wheel gestures to the terminal surface so Ghostty handles scrollback.
-        // Letting NSScrollView consume these events moves the wrapper viewport itself,
-        // which causes pane-content drift instead of terminal scrollback movement.
-        GhosttyNSView.focusLog("GhosttyScrollView.scrollWheel: surface scroll")
-        if window?.firstResponder !== surfaceView {
-            window?.makeFirstResponder(surfaceView)
-        }
-        surfaceView.scrollWheel(with: event)
-    }
-}
-
 private final class GhosttyFlashOverlayView: NSView {
     override var acceptsFirstResponder: Bool { false }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -3373,7 +3373,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         )
     }
 
-    fileprivate static func focusLog(_ message: String) {
+    static func focusLog(_ message: String) {
         guard focusDebugEnabled else { return }
         AppDelegate.shared?.focusLog.append(message)
         #if DEBUG

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -852,6 +852,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */; };
 		7269A0017269A0017269A001 /* GhosttyPhysicalInputFocusReassertionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7269A0027269A0027269A002 /* GhosttyPhysicalInputFocusReassertionTests.swift */; };
 		5C0011AA0000000000000001 /* GhosttyScrollPreciseBoostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C0011AA0000000000000002 /* GhosttyScrollPreciseBoostTests.swift */; };
+		816400000000000000000001 /* GhosttyScrollView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816400000000000000000002 /* GhosttyScrollView.swift */; };
+		816400000000000000000003 /* GhosttyScrollViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816400000000000000000004 /* GhosttyScrollViewTests.swift */; };
 		B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */; };
 		A5F100000000000000000009 /* GhosttySurfaceScrollView+NotificationScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */; };
 		A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */; };
@@ -2769,6 +2771,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		3069F1D10000000000000004 /* GhosttyPasteboardFidelityTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPasteboardFidelityTests.swift; sourceTree = "<group>"; };
 		7269A0027269A0027269A002 /* GhosttyPhysicalInputFocusReassertionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyPhysicalInputFocusReassertionTests.swift; sourceTree = "<group>"; };
 		5C0011AA0000000000000002 /* GhosttyScrollPreciseBoostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyScrollPreciseBoostTests.swift; sourceTree = "<group>"; };
+		816400000000000000000002 /* GhosttyScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyScrollView.swift; sourceTree = "<group>"; };
+		816400000000000000000004 /* GhosttyScrollViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyScrollViewTests.swift; sourceTree = "<group>"; };
 		9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/GhosttySurfaceConfigurationRefresh.swift; sourceTree = "<group>"; };
 		A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttySurfaceScrollView+NotificationScroll.swift"; sourceTree = "<group>"; };
 		A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalAppearance.swift; sourceTree = "<group>"; };
@@ -4516,6 +4520,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C4041001000000000000001A /* CommandClickFileOpenRouter.swift */,
 				C40410010000000000000020 /* FileExplorerDoubleClickActionSettings.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
+				816400000000000000000002 /* GhosttyScrollView.swift */,
 				A11E5E1E0000000000000002 /* TerminalSelectionAccessibilityNotifier.swift */,
 				A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */,
 				D78971000000000000000002 /* GhosttyNotificationScrollRuntimeBridge.swift */,
@@ -5675,6 +5680,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE1A070000000000000002 /* SavedLayoutStoreTests.swift */,
 				5830CA11BAC0000000000001 /* SocketCallbackAwaiterMainThreadTests.swift */,
 				5C0011AA0000000000000002 /* GhosttyScrollPreciseBoostTests.swift */,
+				816400000000000000000004 /* GhosttyScrollViewTests.swift */,
 				C0793DC7D7B61CF54886EC36 /* RemoteTmuxControlParserTests.swift */,
 				9C3345C0EC55F1C725B3A4E3 /* RemoteTmuxControlParserLayoutTests.swift */,
 				B0555302B0555302B0555302 /* RemoteTmuxControlStreamParserBudgetTests.swift */,
@@ -6737,6 +6743,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C75100010000000000000001 /* GhosttyNSView+SelectionTranslation.swift in Sources */,
 				EC010E01 /* GhosttyNSView+TerminalCustomUpload.swift in Sources */,
 				C54860070000000000000001 /* GhosttyNSViewSurfaceLinkCopy.swift in Sources */,
+				816400000000000000000001 /* GhosttyScrollView.swift in Sources */,
 				B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */,
 				A5F100000000000000000009 /* GhosttySurfaceScrollView+NotificationScroll.swift in Sources */,
 				A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */,
@@ -7854,6 +7861,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				3069F1D10000000000000003 /* GhosttyPasteboardFidelityTests.swift in Sources */,
 				7269A0017269A0017269A001 /* GhosttyPhysicalInputFocusReassertionTests.swift in Sources */,
 				5C0011AA0000000000000001 /* GhosttyScrollPreciseBoostTests.swift in Sources */,
+				816400000000000000000003 /* GhosttyScrollViewTests.swift in Sources */,
 				C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */,
 				D7AB34400000000000000003 /* GhosttyTerminalViewVisibilityPolicyTests.swift in Sources */,
 				3865A0053865A0053865A005 /* GlobalSearchShortcutSettingsTests.swift in Sources */,

--- a/cmuxTests/GhosttyScrollViewTests.swift
+++ b/cmuxTests/GhosttyScrollViewTests.swift
@@ -18,8 +18,8 @@ struct GhosttyScrollViewTests {
             "the terminal viewport must not inherit a second top inset from window chrome"
         )
         #expect(scrollView.contentInsets.top == 0)
-        #expect(scrollView.contentInsets.leading == 0)
+        #expect(scrollView.contentInsets.left == 0)
         #expect(scrollView.contentInsets.bottom == 0)
-        #expect(scrollView.contentInsets.trailing == 0)
+        #expect(scrollView.contentInsets.right == 0)
     }
 }

--- a/cmuxTests/GhosttyScrollViewTests.swift
+++ b/cmuxTests/GhosttyScrollViewTests.swift
@@ -1,0 +1,25 @@
+import AppKit
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("Ghostty terminal scroll view")
+struct GhosttyScrollViewTests {
+    @Test func terminalViewportOwnsItsContentInsets() {
+        let scrollView = GhosttyScrollView(frame: .zero)
+
+        #expect(
+            !scrollView.automaticallyAdjustsContentInsets,
+            "the terminal viewport must not inherit a second top inset from window chrome"
+        )
+        #expect(scrollView.contentInsets.top == 0)
+        #expect(scrollView.contentInsets.leading == 0)
+        #expect(scrollView.contentInsets.bottom == 0)
+        #expect(scrollView.contentInsets.trailing == 0)
+    }
+}


### PR DESCRIPTION
## Summary

- make the Ghostty terminal scroll view the sole owner of its viewport content inset
- disable AppKit's automatic titlebar inset adjustment because bonsplit already lays the surface tab strip outside the terminal viewport
- add a Swift Testing regression that exercises the real `NSScrollView` configuration

## Root cause

`NSScrollView.automaticallyAdjustsContentInsets` defaults to `true` and may add a top inset for overlapping window chrome. cmux already gives the bonsplit tab strip its own layout region above the terminal, so leaving that AppKit behavior enabled creates two possible inset owners and can move the first terminal row down by another chrome-height band.

The fix establishes one invariant at construction: terminal viewports do not inherit window-chrome insets, and their explicit content inset starts at zero. It does not subtract a tab-bar-sized magic constant.

Inspection also ruled out the suspected bonsplit change: stable 0.64.19 and the affected Nightly use the same bonsplit revision. Deterministic row-one markers on the same macOS 15 host and an isolated Nightly on macOS 26 showed no Ghostty row-origin shift, narrowing the conditional gap to AppKit's host-dependent automatic inset behavior.

## Regression proof

The test-only SHA `076dbd1a1ecdad20631881330cc0e35ceb82a69f` fails on macOS 26 because the real `GhosttyScrollView` reports `automaticallyAdjustsContentInsets == true`:

https://github.com/manaflow-ai/cmux/actions/runs/29409351884

## Validation

- [focused fixed-SHA test](https://github.com/manaflow-ai/cmux/actions/runs/29409839575) passed in `test-e2e.yml`: `cmuxTests/GhosttyScrollViewTests`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- Swift parser check for the extracted source and regression test
- no user-facing strings changed; localization catalogs are unaffected
- the Swift file-length budget script and TSV were removed from current `main`; the new files are 40 and 25 lines and no budget files are touched

https://github.com/manaflow-ai/cmux/issues/8164

Closes #8164

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8168"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786704990&installation_id=133855650&pr_number=8168&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8168&signature=eab87e02789165382e09d4afd4d443e89f9ce7880c92c756256612fbbe7702f2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the terminal’s top gap by disabling AppKit’s automatic content inset and making the terminal viewport own a zero inset. Fixes #8164.

- **Bug Fixes**
  - Set NSScrollView.automaticallyAdjustsContentInsets=false and contentInsets=0 so AppKit doesn’t add a titlebar-derived top inset; bonsplit already places the tab strip outside the viewport.
  - Added a regression test to assert automatic insets are off and all contentInsets are zero.

- **Refactors**
  - Extracted GhosttyScrollView into its own file and made GhosttyNSView.focusLog internal for reuse.

<sup>Written for commit d8f70ea2ebd364de502a0198f83f5998cfc38b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8168?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed terminal scrollback behavior to prevent pane content from drifting during scrolling.
  - Prevented unwanted content offsets caused by window title bar insets.
  - Ensured scrolling is handled by the terminal surface without stealing keyboard focus.

- **Tests**
  - Added coverage verifying that terminal scroll views use zero content insets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
