### PR TITLE
Restore native docs channel picker and fix deploy

### DIFF
--- a/.github/workflows/docs-deploy-reusable.yml
+++ b/.github/workflows/docs-deploy-reusable.yml
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: oven-sh/setup-bun@735343b667d3e6f658f2770b6acb544c95b55c72 # v2.0.0
+      - uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
       - run: bun install --frozen-lockfile
         working-directory: web
       - run: |

--- a/web/app/[locale]/components/docs-sidebar.tsx
+++ b/web/app/[locale]/components/docs-sidebar.tsx
@@ -65,11 +65,6 @@ export function DocsSidebar({
 
   return (
     <>
-      <DocsVersionPicker
-        channel={channel}
-        releaseLabel={releaseLabel}
-        nightlyLabel={nightlyLabel}
-      />
       <DocsSearch onNavigate={onNavigate} />
       <nav className="space-y-0.5" data-pagefind-ignore="all">
         {navItems.map((entry) => {
@@ -107,6 +102,11 @@ export function DocsSidebar({
           );
         })}
       </nav>
+      <DocsVersionPicker
+        channel={channel}
+        releaseLabel={releaseLabel}
+        nightlyLabel={nightlyLabel}
+      />
     </>
   );
 }

--- a/web/app/[locale]/components/docs-version-picker.tsx
+++ b/web/app/[locale]/components/docs-version-picker.tsx
@@ -1,48 +1,6 @@
 "use client";
 
-import { Select } from "@base-ui-components/react/select";
 import { docsChannelUrl } from "@/app/lib/docs-channel";
-
-type Channel = "release" | "nightly";
-
-function ChannelDot({ channel }: { channel: Channel }) {
-  return (
-    <span
-      aria-hidden
-      className={`size-1.5 shrink-0 rounded-full ${
-        channel === "release" ? "bg-emerald-500" : "bg-violet-500"
-      }`}
-    />
-  );
-}
-
-function ChevronIcon() {
-  return (
-    <svg aria-hidden width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <path
-        d="m4 5.5 3 3 3-3"
-        stroke="currentColor"
-        strokeWidth="1.25"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
-
-function CheckIcon() {
-  return (
-    <svg aria-hidden width="14" height="14" viewBox="0 0 14 14" fill="none">
-      <path
-        d="m3 7.25 2.5 2.5L11 4.5"
-        stroke="currentColor"
-        strokeWidth="1.5"
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-    </svg>
-  );
-}
 
 export function DocsVersionPicker({
   channel,
@@ -54,63 +12,24 @@ export function DocsVersionPicker({
   nightlyLabel: string;
 }) {
   const label = `${releaseLabel} / ${nightlyLabel}`;
-  const channels: { value: Channel; label: string }[] = [
-    { value: "release", label: releaseLabel },
-    { value: "nightly", label: nightlyLabel },
-  ];
 
   return (
-    <div className="px-3 pb-4" data-pagefind-ignore="all">
-      <Select.Root<Channel>
-        items={channels}
+    <label className="block px-3 pt-4 pb-4" data-pagefind-ignore="all">
+      <span className="sr-only">{label}</span>
+      <select
+        aria-label={label}
         value={channel}
-        onValueChange={(value) => {
-          if (!value || value === channel) return;
+        onChange={(event) => {
+          const value = event.target.value as "release" | "nightly";
+          if (value === channel) return;
           const { pathname, search, hash } = window.location;
-          window.location.assign(
-            docsChannelUrl(value, pathname, search, hash),
-          );
+          window.location.assign(docsChannelUrl(value, pathname, search, hash));
         }}
+        className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-[13px] text-foreground"
       >
-        <Select.Trigger
-          aria-label={label}
-          className="group flex h-9 w-full items-center justify-between rounded-lg border border-border bg-code-bg px-2.5 text-[13px] font-medium text-foreground shadow-sm outline-none transition-colors hover:border-muted focus-visible:ring-2 focus-visible:ring-foreground/20 data-[popup-open]:border-muted"
-        >
-          <span className="flex min-w-0 items-center gap-2">
-            <ChannelDot channel={channel} />
-            <Select.Value className="truncate" />
-          </span>
-          <Select.Icon className="ml-2 shrink-0 text-muted transition-transform group-data-[popup-open]:rotate-180">
-            <ChevronIcon />
-          </Select.Icon>
-        </Select.Trigger>
-        <Select.Portal>
-          <Select.Positioner
-            align="start"
-            alignItemWithTrigger={false}
-            className="z-[80] w-[var(--anchor-width)] outline-none"
-            sideOffset={6}
-          >
-            <Select.Popup className="w-full origin-[var(--transform-origin)] rounded-lg border border-border bg-background p-1 text-[13px] shadow-[0_12px_32px_rgba(0,0,0,0.16)] outline-none transition-[transform,opacity] data-[ending-style]:scale-95 data-[ending-style]:opacity-0 data-[starting-style]:scale-95 data-[starting-style]:opacity-0">
-              <Select.List>
-                {channels.map((item) => (
-                  <Select.Item
-                    key={item.value}
-                    value={item.value}
-                    className="relative flex h-8 cursor-default select-none items-center gap-2 rounded-md px-2 pr-8 text-muted outline-none data-[highlighted]:bg-code-bg data-[highlighted]:text-foreground data-[selected]:font-medium data-[selected]:text-foreground"
-                  >
-                    <ChannelDot channel={item.value} />
-                    <Select.ItemText>{item.label}</Select.ItemText>
-                    <Select.ItemIndicator className="absolute right-2 text-foreground">
-                      <CheckIcon />
-                    </Select.ItemIndicator>
-                  </Select.Item>
-                ))}
-              </Select.List>
-            </Select.Popup>
-          </Select.Positioner>
-        </Select.Portal>
-      </Select.Root>
-    </div>
+        <option value="release">{releaseLabel}</option>
+        <option value="nightly">{nightlyLabel}</option>
+      </select>
+    </label>
   );
 }


### PR DESCRIPTION
## Summary
- restore the native release/nightly selector below Changelog
- fix the broken `setup-bun` action pin in docs deployment CI

## Testing
- `bun test tests/docs-channel.test.ts tests/docs-search-index.test.ts tests/docs-search-utils.test.ts tests/client-config-env.test.ts`
- `bun run typecheck`
- focused ESLint
- `actionlint .github/workflows/docs-deploy-reusable.yml`
- rendered nightly `/docs/base`: native selector follows Changelog
- verified `oven-sh/setup-bun@0c5077e...` exists

## Failure fixed
https://github.com/manaflow-ai/cmux/actions/runs/29411036747

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8172"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786706499&installation_id=133855650&pr_number=8172&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8172&signature=0573aad9aa39aac92ccb8c709cb5bc681ef25a5b6c09b0f07a109e852a7f50ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the native release/nightly docs channel picker and places it below the Changelog in the sidebar. Also fixes the docs deploy by pinning the Bun setup action to a stable v2.

- **Refactors**
  - Replaced `@base-ui-components/react/select` with a native `<select>` and moved the picker below the Changelog.

- **Bug Fixes**
  - Pinned `oven-sh/setup-bun` to v2 in the docs deploy workflow to resolve CI failures.

<sup>Written for commit ebb86011a1f57590d3f0b729e3a0ebfd62566b56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8172?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility & Usability**
  * Replaced the custom documentation version picker with a native, accessible dropdown.
  * Documentation version selection now navigates directly to the chosen release or nightly documentation.
  * Repositioned the version picker within the documentation sidebar for improved navigation flow.

* **Maintenance**
  * Updated the documentation deployment workflow to use a newer setup action revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->