### PR TITLE
Add background target for command actions

### DIFF
--- a/Sources/CmuxConfig.swift
+++ b/Sources/CmuxConfig.swift
@@ -332,6 +332,12 @@ struct CmuxResolvedNotificationHook: Sendable, Hashable {
 enum CmuxConfigTerminalCommandTarget: String, Codable, Sendable, Hashable {
     case currentTerminal
     case newTabInCurrentPane
+    /// Run the command as a headless child process: no terminal surface is
+    /// created or focused. The child receives the cmux context environment
+    /// (CMUX_WORKSPACE_ID, CMUX_SURFACE_ID of the focused terminal,
+    /// CMUX_SOCKET_PATH, CMUX_BUNDLED_CLI_PATH), so hotkey scripts can drive
+    /// the bundled CLI without flashing a tab.
+    case background
 
     static let defaultForActions: CmuxConfigTerminalCommandTarget = .newTabInCurrentPane
 }

--- a/Sources/CmuxConfigExecutor.swift
+++ b/Sources/CmuxConfigExecutor.swift
@@ -1,4 +1,5 @@
 import AppKit
+import CmuxSettings
 import Foundation
 
 @MainActor
@@ -116,7 +117,7 @@ struct CmuxConfigExecutor {
         guard let command = action.terminalCommand else { return false }
         let target = action.terminalCommandTarget ?? .newTabInCurrentPane
         let targetTerminal = (target == .currentTerminal) ? tabManager.selectedWorkspace?.focusedTerminalPanel : nil
-        let targetWorkspace = (target == .newTabInCurrentPane) ? tabManager.selectedWorkspace : nil
+        let targetWorkspace = (target == .currentTerminal) ? nil : tabManager.selectedWorkspace
         return prepareShellInputIfAuthorized(
             command,
             confirm: action.confirm ?? false,
@@ -135,6 +136,8 @@ struct CmuxConfigExecutor {
             case .newTabInCurrentPane:
                 targetWorkspace?.clearSplitZoom()
                 targetWorkspace?.newTerminalSurfaceInFocusedPane(focus: true, initialInput: shellInput)
+            case .background:
+                launchBackgroundProcess(shellInput, workspace: targetWorkspace)
             }
             onExecuted?()
         }
@@ -176,6 +179,71 @@ struct CmuxConfigExecutor {
             presentingWindow: presentingWindow
         ) {
             onAuthorized(shellCommand + "\n")
+        }
+    }
+
+    /// Live children spawned by `background` command actions, keyed by pid so
+    /// they stay referenced until they exit.
+    private static var backgroundProcesses: [Int32: Process] = [:]
+
+    /// Runs a `background`-target command action as a headless child process.
+    /// Mirrors the environment terminal-based actions see (workspace, focused
+    /// surface, socket, bundled CLI) so scripts can drive cmux without a tab.
+    static func launchBackgroundProcess(_ shellInput: String, workspace: Workspace?) {
+        let command = shellInput.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !command.isEmpty else { return }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+
+        var environment = ProcessInfo.processInfo.environment
+        if let cliURL = Bundle.main.resourceURL?.appendingPathComponent("bin/cmux"),
+           FileManager.default.isExecutableFile(atPath: cliURL.path) {
+            environment["CMUX_BUNDLED_CLI_PATH"] = cliURL.path
+        }
+        environment["CMUX_SOCKET_PATH"] = TerminalController.shared.activeSocketPath(
+            preferredPath: SocketControlSettings.socketPath()
+        )
+        environment.removeValue(forKey: "CMUX_SOCKET")
+        if let workspace {
+            environment["CMUX_WORKSPACE_ID"] = workspace.id.uuidString
+            if let surfaceId = workspace.focusedPanelId {
+                environment["CMUX_SURFACE_ID"] = surfaceId.uuidString
+            }
+        }
+        process.environment = environment
+        process.currentDirectoryURL = URL(
+            fileURLWithPath: workspace?.resolvedWorkingDirectory()
+                ?? FileManager.default.homeDirectoryForCurrentUser.path
+        )
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        process.terminationHandler = { terminated in
+            let pid = terminated.processIdentifier
+            let status = terminated.terminationStatus
+            Task { @MainActor in
+                backgroundProcesses.removeValue(forKey: pid)
+                guard status != 0 else { return }
+#if DEBUG
+                cmuxDebugLog("background action exited status=\(status)")
+#endif
+                NSSound.beep()
+            }
+        }
+
+        do {
+            try process.run()
+            backgroundProcesses[process.processIdentifier] = process
+            if !process.isRunning {
+                backgroundProcesses.removeValue(forKey: process.processIdentifier)
+            }
+        } catch {
+#if DEBUG
+            cmuxDebugLog("background action launch failed errorType=\(type(of: error))")
+#endif
+            NSSound.beep()
         }
     }
 

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -12663,6 +12663,8 @@ extension Workspace: BonsplitDelegate {
                     initialInput: shellInput,
                     inheritWorkingDirectoryFallback: true
                 )
+            case .background:
+                CmuxConfigExecutor.launchBackgroundProcess(shellInput, workspace: self)
             }
         }
         guard didExecute else {

--- a/cmuxTests/CmuxConfigTests.swift
+++ b/cmuxTests/CmuxConfigTests.swift
@@ -300,6 +300,23 @@ final class CmuxConfigDecodingTests: XCTestCase {
         XCTAssertEqual(button.action, .command("codex"))
     }
 
+    func testDecodeCommandActionBackgroundTarget() throws {
+        let json = """
+        {
+          "actions": {
+            "queue-prompt": {
+              "type": "command",
+              "command": "my-capture-script",
+              "target": "background"
+            }
+          }
+        }
+        """
+        let config = try decode(json)
+        let action = try XCTUnwrap(resolvedActions(from: config)["queue-prompt"])
+        XCTAssertEqual(action.terminalCommandTarget, .background)
+    }
+
     func testResolveSurfaceTabBarActionReferenceCanOverrideTitleAndIcon() throws {
         let json = """
         {

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -1836,7 +1836,7 @@
       "actionFieldKeywords": "Extra search terms for Command Palette.",
       "actionFieldPalette": "Defaults to true for custom actions. Set false to hide the action from Command Palette while keeping it callable elsewhere.",
       "actionFieldShortcut": "Optional action shortcut, using the same single-stroke or two-stroke chord syntax as settings shortcuts.",
-      "actionFieldTarget": "For command and agent actions only. Use currentTerminal or newTabInCurrentPane.",
+      "actionFieldTarget": "For command and agent actions only. Use currentTerminal or newTabInCurrentPane. Command actions also accept background, which runs the command as a headless child process (no terminal tab); the process gets CMUX_WORKSPACE_ID, CMUX_SURFACE_ID of the focused terminal, CMUX_SOCKET_PATH, and CMUX_BUNDLED_CLI_PATH.",
       "actionFieldConfirm": "Ask before running the action.",
       "actionFieldNewWorkspaceMenu": "Set true to offer any action in the new-workspace plus-button menu, or false to hide a workspace action from it.",
       "commandPaletteBehavior": "Command Palette behavior",


### PR DESCRIPTION
Adds `"target": "background"` for `command` actions (and surface tab bar buttons): the command runs as a headless child process instead of opening a terminal tab.

## Motivation

Command actions bound to a shortcut currently have to open a terminal surface (`newTabInCurrentPane`) or type into the focused one (`currentTerminal`). For actions whose job is to drive cmux itself through the bundled CLI (read a screen, send keys, focus a surface), the throwaway tab steals focus and flashes on every keypress.

Concrete use case: a `cmd+enter` action that captures the draft in a Claude Code input box and re-delivers it as a fresh prompt after the current turn finishes (hard prompt queueing). The script only needs the socket, not a terminal — but today every queued message costs a visible tab flash. With `"target": "background"` the same action is completely invisible:

```jsonc
"actions": {
  "queue-prompt": {
    "type": "command",
    "title": "Queue prompt for Claude",
    "command": "claude-queue capture",
    "target": "background",
    "shortcut": "cmd+enter"
  }
}
```

## Implementation

- New `CmuxConfigTerminalCommandTarget.background` case.
- `CmuxConfigExecutor.launchBackgroundProcess` runs `/bin/sh -c <command>` via `Process`, modeled on `launchDiffViewerProcess`:
  - environment: `CMUX_WORKSPACE_ID` (selected workspace), `CMUX_SURFACE_ID` (focused terminal), `CMUX_SOCKET_PATH`, `CMUX_BUNDLED_CLI_PATH`; `CMUX_SOCKET` removed
  - cwd: the workspace's resolved working directory (falls back to home)
  - stdin/stdout/stderr: null devices; children are retained until exit; non-zero exit beeps (and logs in DEBUG)
- The trust/confirm flow is unchanged — background commands go through the same `prepareShellInputIfAuthorized` path and trust descriptor (which already includes the target).
- Surface tab bar buttons with a background action run the same helper.
- Docs: `actionFieldTarget` string in `web/messages/en.json` (other locales left to the translation pipeline).
- Test: decode test for `"target": "background"` in `CmuxConfigTests`.

## Testing

- `xcodebuild` Debug build passes; exhaustive target switches verified by the compiler.
- Live-tested in a tagged debug build: a project-config action with `"target": "background"` + `"shortcut"` writes a marker file with the injected `CMUX_*` env; no terminal surface is created and focus never leaves the current tab; `newTabInCurrentPane` and `currentTerminal` behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786720139&installation_id=133855650&pr_number=8176&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8176&signature=dad9430b9f19c9c34f4479dce34fc2ce6c50672761c23634859863d59ff0d9e3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add support for the new `"target": "background"` option on command actions to run commands without opening a terminal tab. This removes tab flashes and focus changes when hotkeys run cmux-driving scripts.

- **New Features**
  - Runs the command as a headless child process; no surface is created or focused.
  - Passes workspace context via env: CMUX_WORKSPACE_ID, CMUX_SURFACE_ID, CMUX_SOCKET_PATH, CMUX_BUNDLED_CLI_PATH; uses the workspace working directory.
  - Works from surface tab bar buttons; trust/confirm flow is unchanged.
  - Non-zero exits beep; existing targets keep their current behavior.

<sup>Written for commit 2a59cae79ae77c8798141d226702e480c1df2d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8176?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a `background` target for custom terminal commands.
  * Background commands run without opening or focusing a terminal surface.
  * Commands receive cmux environment variables for workspace, surface, socket, and bundled CLI access.
  * Background execution supports focused workspace and surface context.

* **Documentation**
  * Updated custom command configuration guidance to describe the new target.

* **Tests**
  * Added coverage for decoding background-target command actions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->