### PR TITLE
Document workspace-action in the cmux skill

### DIFF
--- a/skills/cmux/SKILL.md
+++ b/skills/cmux/SKILL.md
@@ -23,7 +23,13 @@ cmux new-split right --panel pane:1
 cmux move-surface --surface surface:7 --pane pane:2 --focus true
 cmux split-off --surface surface:7 right
 cmux reorder-surface --surface surface:7 --before surface:3
-cmux trigger-flash --surface surface:7            # attention cue
+
+# workspace context-menu actions (color, description, rename, pin, ...)
+cmux workspace-action --action set-color --color Blue
+cmux workspace-action --action set-description --description "Ship checklist"
+
+# attention cue
+cmux trigger-flash --surface surface:7
 ```
 
 ## Handle model
@@ -43,7 +49,7 @@ Terminal rendering (font, cursor style, theme, scrollback, `background-opacity`,
 | Reference | When to Use |
 |-----------|-------------|
 | [references/handles-and-identify.md](references/handles-and-identify.md) | Handle syntax, self-identify, caller targeting |
-| [references/windows-workspaces.md](references/windows-workspaces.md) | Window/workspace lifecycle and reorder/move |
+| [references/windows-workspaces.md](references/windows-workspaces.md) | Window/workspace lifecycle, reorder/move, and context-menu actions (color, description, rename) |
 | [references/panes-surfaces.md](references/panes-surfaces.md) | Splits, surfaces, move/reorder, focus routing |
 | [references/trigger-flash-and-health.md](references/trigger-flash-and-health.md) | Flash cue and surface health checks |
 | [../cmux-workspace/SKILL.md](../cmux-workspace/SKILL.md) | Current caller workspace rules and non-disruptive automation |

--- a/skills/cmux/references/windows-workspaces.md
+++ b/skills/cmux/references/windows-workspaces.md
@@ -19,3 +19,17 @@ cmux close-workspace --workspace workspace:4
 cmux reorder-workspace --workspace workspace:4 --before workspace:2
 cmux move-workspace-to-window --workspace workspace:4 --window window:1
 ```
+
+## Context-Menu Actions
+
+`cmux workspace-action` runs the workspace right-click actions (color, description, rename, pin, read state, ordering). Defaults to the caller's workspace; override with `--workspace <id|ref|index>`.
+
+```bash
+cmux workspace-action --action set-color --color Blue      # name or #RRGGBB hex
+cmux workspace-action --action set-description --description "Ship checklist"
+cmux workspace-action --action rename --title "infra"
+cmux workspace-action --action pin
+cmux workspace-action --action clear-color
+```
+
+Other actions: `unpin`, `clear-name`, `clear-description`, `mark-read`/`mark-unread`, `move-up`/`move-down`/`move-top`, `close-others`/`close-above`/`close-below`. Named colors: Red, Crimson, Orange, Amber, Olive, Green, Teal, Aqua, Blue, Navy, Indigo, Purple, Magenta, Rose, Brown, Charcoal. `set-color` tints a single workspace (stored as workspace state); the `workspaceColors` block in `cmux.json` defines the shared palette and selection/badge colors, not per-workspace assignments.


### PR DESCRIPTION
## What

Documents `cmux workspace-action` in the bundled **cmux skill** (`skills/cmux/`). This is the command behind the workspace context-menu actions — `set-color`, `set-description`, `rename`, `pin`/`unpin`, `mark-read`/`mark-unread`, `move-up`/`move-down`/`move-top`, `close-others`/`close-above`/`close-below`, `clear-color`/`clear-description`.

## Why

The skill covers windows, workspaces, panes, surfaces, focus, moves, reorder, identify, and trigger-flash — but had **zero** mentions of `workspace-action` across `SKILL.md` and all four reference files. Because these actions live under the top-level `workspace-action` command rather than as `cmux workspace` subcommands, they're effectively undiscoverable from the skill: an agent reading it (or exploring `cmux workspace --help`, which lists `list/create/rename/close/select/status/...` but not color or description) reasonably concludes there's *no* CLI to color or describe a workspace — when in fact there is. Hit this in practice: recoloring/adding a description to a workspace looked impossible from the skill until `workspace-action` was found by grepping `--help` output.

The command itself is already canonical in `docs/cli-contract.md`; this only closes the gap in the skill docs.

## Changes

- `skills/cmux/references/windows-workspaces.md` — new **Context-Menu Actions** section with the full action/flag set, examples, and the named-color list.
- `skills/cmux/SKILL.md` — Fast Start examples (`set-color` / `set-description` / `rename`) and a reference-table hint so it's found on first look.

Docs-only; no code or CLI behavior changes. Action names, flags, and named colors mirror `docs/cli-contract.md` and `cmux workspace-action --help`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8177"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786724088&installation_id=133855650&pr_number=8177&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8177&signature=8aac0dc113c89325a7fc4badf1ae48db88229d98db768ac986ac650c403ba7a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Documents `cmux workspace-action` in the `cmux` skill to surface workspace context‑menu actions (set/clear color, set/clear description, rename, pin/unpin, mark-read/unread, ordering, close variants). Adds Fast Start examples in `skills/cmux/SKILL.md` and a Context‑Menu Actions section in `skills/cmux/references/windows-workspaces.md` with commands (named colors and `#RRGGBB`), default-to-caller behavior with `--workspace` override, and a note that per‑workspace tint is separate from the `workspaceColors` palette in `cmux.json`; docs‑only, no CLI changes.

<sup>Written for commit f48edc0bfb5e5367559674d723958b844bc2c699. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8177?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added examples for managing workspace context-menu actions.
  * Documented `cmux workspace-action` options, including setting color, description, renaming, pinning, and clearing.
  * Expanded the window workspaces reference to cover supported actions and the list of named colors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->