### PR TITLE
Retry transient Iroh host cold starts

### DIFF
--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime+PolicyRefresh.swift
@@ -2,18 +2,76 @@ import CMUXMobileCore
 import Foundation
 
 extension CmxIrohHostRuntime {
+    func resolveInitialPolicy(
+        supervisor: CmxIrohEndpointSupervisor,
+        expectedEndpointID: CmxIrohPeerIdentity,
+        revision: UInt64
+    ) async throws -> ResolvedPolicy {
+        try await revokePendingBeforeRegistration()
+        try requireCurrent(revision)
+        var failureCount = 0
+        while true {
+            try requireCurrent(revision)
+            do {
+                return try await resolvePolicyAfterPendingRevocations(
+                    supervisor: supervisor,
+                    expectedEndpointID: expectedEndpointID,
+                    revision: revision,
+                    allowCachedFallback: true
+                )
+            } catch is CancellationError {
+                throw CancellationError()
+            } catch {
+                try requireCurrent(revision)
+                guard CmxIrohTrustBrokerClientError
+                    .retriesInitialActivation(error) else {
+                    throw error
+                }
+                let delay = registrationRetrySchedule.delay(
+                    failureCount: failureCount,
+                    retryAfterSeconds: (error as? CmxIrohTrustBrokerClientError)?
+                        .retryAfterSeconds,
+                    jitterUnitInterval: registrationRetryJitter()
+                )
+                failureCount = min(failureCount + 1, 20)
+                let deadline = registrationClock.now().addingTimeInterval(delay)
+                // This bounded broker backoff is the intended delay; the
+                // lifecycle-owned start task cancels the injected clock sleep.
+                try await registrationClock.sleep(until: deadline)
+            }
+        }
+    }
+
     func resolvePolicy(
         supervisor: CmxIrohEndpointSupervisor,
         expectedEndpointID: CmxIrohPeerIdentity,
         revision: UInt64,
         allowCachedFallback: Bool
     ) async throws -> ResolvedPolicy {
+        try await revokePendingBeforeRegistration()
+        try requireCurrent(revision)
+        return try await resolvePolicyAfterPendingRevocations(
+            supervisor: supervisor,
+            expectedEndpointID: expectedEndpointID,
+            revision: revision,
+            allowCachedFallback: allowCachedFallback
+        )
+    }
+
+    private func revokePendingBeforeRegistration() async throws {
         try await pendingRevocations.revokePending(
             accountID: configuration.accountID,
             beforeRegisteringTag: configuration.tag,
             using: broker
         )
-        try requireCurrent(revision)
+    }
+
+    private func resolvePolicyAfterPendingRevocations(
+        supervisor: CmxIrohEndpointSupervisor,
+        expectedEndpointID: CmxIrohPeerIdentity,
+        revision: UInt64,
+        allowCachedFallback: Bool
+    ) async throws -> ResolvedPolicy {
         let endpoint = try await supervisor.activeEndpoint()
         let address = await endpoint.address()
         guard address.identity == expectedEndpointID else {

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohHostRuntime.swift
@@ -189,11 +189,10 @@ public actor CmxIrohHostRuntime {
                 throw CmxIrohHostRuntimeError.invalidLocalBinding
             }
 
-            let policy = try await resolvePolicy(
+            let policy = try await resolveInitialPolicy(
                 supervisor: supervisor,
                 expectedEndpointID: endpointID,
-                revision: revision,
-                allowCachedFallback: true
+                revision: revision
             )
             try requireCurrent(revision)
 

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
@@ -39,7 +39,12 @@ public enum CmxIrohTrustBrokerClientError: Error, Equatable, Sendable {
         case .connectivity, .rateLimited:
             return true
         case let .rejected(statusCode, _):
-            return statusCode == 408 || statusCode == 425 || statusCode == 429
+            // A server failure cannot establish trust, so retrying the request
+            // is safe while the lifecycle-owned start task remains current.
+            return statusCode == 408
+                || statusCode == 425
+                || statusCode == 429
+                || (500...599).contains(statusCode)
         case .invalidBaseURL,
              .missingAuthentication,
              .invalidAuthentication,

--- a/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
+++ b/Packages/Shared/CmuxIrohTransport/Sources/CmuxIrohTransport/CmxIrohTrustBrokerClientError.swift
@@ -32,6 +32,23 @@ public enum CmxIrohTrustBrokerClientError: Error, Equatable, Sendable {
         }
     }
 
+    /// Accepts only failures that are safe to retry before any binding is trusted.
+    static func retriesInitialActivation(_ error: any Error) -> Bool {
+        guard let brokerError = error as? Self else { return false }
+        switch brokerError {
+        case .connectivity, .rateLimited:
+            return true
+        case let .rejected(statusCode, _):
+            return statusCode == 408 || statusCode == 425 || statusCode == 429
+        case .invalidBaseURL,
+             .missingAuthentication,
+             .invalidAuthentication,
+             .nonHTTPResponse,
+             .invalidResponse:
+            return false
+        }
+    }
+
     /// The validated server retry floor, when present.
     public var retryAfterSeconds: Int? {
         guard case let .rateLimited(_, retryAfterSeconds) = self else { return nil }

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimePolicyTests.swift
@@ -148,7 +148,7 @@ extension CmxIrohHostRuntimeTests {
 
     @Test(arguments: [
         CmxIrohTrustBrokerClientError.missingAuthentication,
-        .rejected(statusCode: 503, code: "unavailable"),
+        .rejected(statusCode: 400, code: "invalid_request"),
         .invalidResponse,
     ])
     func terminalBrokerFailureNeverUsesCachedPolicy(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -37,6 +37,38 @@ struct CmxIrohHostRuntimeTests {
         await runtime.stop()
     }
 
+    @Test("cold start retries transient broker service failures before becoming active")
+    func coldStartRetriesTransientBrokerServiceFailure() async throws {
+        let fixture = try HostRuntimeFixture()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .rejected(statusCode: 503, code: "unavailable")
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
+            ),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            registrationClock: ImmediateHostActivationClock(),
+            registrationRetrySchedule: CmxIrohRetrySchedule(
+                initialDelay: 1,
+                maximumDelay: 1,
+                jitterFraction: 0
+            ),
+            registrationRetryJitter: { 0 },
+            handleTransport: { session, _ in await session.close() }
+        )
+
+        try await runtime.start()
+
+        #expect(await broker.observedRegistrationCount() == 2)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
     @Test("cold start does not retry an untrusted broker response")
     func coldStartDoesNotRetryInvalidBrokerResponse() async throws {
         let fixture = try HostRuntimeFixture()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -37,6 +37,117 @@ struct CmxIrohHostRuntimeTests {
         await runtime.stop()
     }
 
+    @Test("cold start does not retry an untrusted broker response")
+    func coldStartDoesNotRetryInvalidBrokerResponse() async throws {
+        let fixture = try HostRuntimeFixture()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .invalidResponse
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
+            ),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            registrationClock: ImmediateHostActivationClock(),
+            handleTransport: { session, _ in await session.close() }
+        )
+
+        await #expect(throws: CmxIrohTrustBrokerClientError.invalidResponse) {
+            try await runtime.start()
+        }
+
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .failed)
+    }
+
+    @Test("stopping during cold-start backoff prevents a stale registration retry")
+    func stopDuringColdStartBackoffPreventsRetry() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let clock = HostRegistrationRenewalClock(now: now)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .connectivity
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
+            ),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            registrationClock: clock,
+            registrationRetrySchedule: CmxIrohRetrySchedule(
+                initialDelay: 1,
+                maximumDelay: 1,
+                jitterFraction: 0
+            ),
+            registrationRetryJitter: { 0 },
+            handleTransport: { session, _ in await session.close() }
+        )
+        let start = Task {
+            try await runtime.start()
+        }
+
+        await clock.waitUntilSleeping()
+        let deadline = try #require(clock.observedSleepDeadlines().first)
+        await runtime.stop()
+        clock.advance(to: deadline)
+
+        await #expect(throws: CmxIrohHostRuntimeError.superseded) {
+            try await start.value
+        }
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await runtime.snapshot().state == .inactive)
+    }
+
+    @Test("cancelling cold-start backoff cancels its delay and closes the endpoint")
+    func cancellingColdStartBackoffCancelsDelay() async throws {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let fixture = try HostRuntimeFixture(now: now)
+        let clock = HostRegistrationRenewalClock(now: now)
+        let endpoint = TestIrohEndpoint(identity: fixture.endpointID)
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .connectivity
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(endpoints: [endpoint]),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            registrationClock: clock,
+            registrationRetrySchedule: CmxIrohRetrySchedule(
+                initialDelay: 7,
+                maximumDelay: 7,
+                jitterFraction: 0
+            ),
+            registrationRetryJitter: { 0 },
+            handleTransport: { session, _ in await session.close() }
+        )
+        let start = Task {
+            try await runtime.start()
+        }
+
+        await clock.waitUntilSleeping()
+        #expect(clock.observedSleepDeadlines() == [now.addingTimeInterval(7)])
+        start.cancel()
+
+        await #expect(throws: CancellationError.self) {
+            try await start.value
+        }
+        #expect(clock.observedCancellationCount() == 1)
+        #expect(await broker.observedRegistrationCount() == 1)
+        #expect(await endpoint.observedCloseCallCount() == 1)
+        #expect(await runtime.snapshot().state == .failed)
+    }
+
     @Test
     func pendingRevocationFailureBlocksHostRegistrationAndCachedFallback() async throws {
         let fixture = try HostRuntimeFixture()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohHostRuntimeTests.swift
@@ -5,6 +5,38 @@ import Testing
 
 @Suite
 struct CmxIrohHostRuntimeTests {
+    @Test("cold start retries transient broker connectivity before becoming active")
+    func coldStartRetriesTransientBrokerConnectivity() async throws {
+        let fixture = try HostRuntimeFixture()
+        let broker = TestIrohHostBroker(
+            registrationBinding: fixture.binding,
+            discovery: fixture.discovery,
+            registrationError: .connectivity
+        )
+        let runtime = CmxIrohHostRuntime(
+            factory: TestIrohEndpointFactory(
+                endpoints: [TestIrohEndpoint(identity: fixture.endpointID)]
+            ),
+            broker: broker,
+            configuration: fixture.configuration,
+            pendingRevocations: fixture.pendingRevocations(),
+            registrationClock: ImmediateHostActivationClock(),
+            registrationRetrySchedule: CmxIrohRetrySchedule(
+                initialDelay: 1,
+                maximumDelay: 1,
+                jitterFraction: 0
+            ),
+            registrationRetryJitter: { 0 },
+            handleTransport: { session, _ in await session.close() }
+        )
+
+        try await runtime.start()
+
+        #expect(await broker.observedRegistrationCount() == 2)
+        #expect(await runtime.snapshot().state == .active)
+        await runtime.stop()
+    }
+
     @Test
     func pendingRevocationFailureBlocksHostRegistrationAndCachedFallback() async throws {
         let fixture = try HostRuntimeFixture()

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/ImmediateHostActivationClock.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/ImmediateHostActivationClock.swift
@@ -1,0 +1,13 @@
+import Foundation
+@testable import CmuxIrohTransport
+
+/// Completes retry delays immediately so cold-start recovery tests stay deterministic.
+struct ImmediateHostActivationClock: CmxIrohRelayClock {
+    private let date = Date(timeIntervalSince1970: 1_800_000_000)
+
+    func now() -> Date {
+        date
+    }
+
+    func sleep(until _: Date) async throws {}
+}


### PR DESCRIPTION
## Summary
- retry safe transient broker failures during initial Mac Iroh activation with the existing capped backoff schedule
- cancel stale retries when the runtime stops, restarts, or its start task is cancelled
- keep pending revocation, EndpointID checks, broker validation, and terminal failures fail-closed

## Verification
- red: `swift test --filter CmxIrohHostRuntimeTests.coldStartRetriesTransientBrokerConnectivity` failed with `.connectivity` before the fix
- green: `swift test --filter CmxIrohHostRuntimeTests` passed 29 tests
- green: `swift test --skip-build` passed 348 tests across 42 suites
- tagged Mac build: `irtry` in progress

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8181"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786734804&installation_id=133855650&pr_number=8181&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8181&signature=984cfc34e45dc1c72da1d9b2ebabdd1616fb8338f4f23b4909a3d87bed4adfb6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries transient Iroh broker failures during initial host activation with capped backoff, and cancels stale retries on stop or task cancellation. Improves cold-start reliability while keeping unsafe states fail-closed.

- **Bug Fixes**
  - Retries only safe pre-trust failures (.connectivity, .rateLimited, 408/425/429, and 5xx) via `CmxIrohTrustBrokerClientError.retriesInitialActivation`, using the existing backoff and honoring Retry-After.
  - Cancels in-flight retry sleeps when the runtime stops, restarts, or the start task is cancelled; closes the endpoint to avoid leaks.
  - Enforces pending revocations, endpoint ID checks, and invalid broker responses to fail without retry.

<sup>Written for commit f51af229a39a76be90d50a041528f93041b9581f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8181?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Initial activation now uses a dedicated policy-resolution flow with automatic retries for eligible temporary broker failures.
  * Retry behavior uses bounded backoff, optional broker-provided retry delay, and jitter.
  * Supports cached-policy fallback during retry attempts.

* **Bug Fixes**
  * Invalid or untrusted broker responses now fail startup without repeated registration attempts.
  * Stopping or cancelling during the retry backoff cleanly cancels pending retries, closes the endpoint once, and updates runtime state.

* **Tests**
  * Added async tests covering cold-start retries, transient failures, invalid responses, stop/cancel behavior, and supersession/cancellation outcomes.
  * Introduced a deterministic test clock for reliable backoff timing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->