### PR TITLE
iOS: Always show animated spinner for reconnecting state

### DIFF
--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatusRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacConnectionStatusRow.swift
@@ -27,7 +27,7 @@ struct MobileMacConnectionStatusRow: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 10) {
-                if showsSpinner {
+                if showsSpinner || status == .reconnecting {
                     ProgressView()
                         .controlSize(.small)
                         .frame(width: 24)


### PR DESCRIPTION
The reconnection indicator should always show an animated ProgressView(), never a static SF Symbol.

**Issue:** MobileMacConnectionStatusRow was checking only the `showsSpinner` parameter, so even when status was `.reconnecting`, it could show the static `arrow.triangle.2.circlepath.circle.fill` symbol instead of an animated spinner.

**Fix:** Force ProgressView() whenever `status == .reconnecting`, ensuring consistent animated feedback for connection recovery at all times.

This is a principled fix that addresses the root cause: the reconnecting state should always indicate activity with an animated spinner, not a static symbol that might be misunderstood as a static progress indicator.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8182"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786734871&installation_id=133855650&pr_number=8182&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8182&signature=df45d791a5596e4c2d9c48d1b9e5980e89735e962c8ac2ebfea46f95ebee0015"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Force `ProgressView()` in `MobileMacConnectionStatusRow` whenever status is `.reconnecting` to ensure consistent, animated feedback instead of a static symbol. Previously, the row only respected `showsSpinner`, which could show a static icon during reconnection.

<sup>Written for commit c264455d3b870714eeb8f8f3c1188e2982998b3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8182?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * The connection status now displays a loading indicator while reconnecting, providing clearer feedback during connection attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->