### PR TITLE
Add internal provisioning profile support to iOS TestFlight workflow

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -428,26 +428,38 @@ jobs:
       - name: Install beta provisioning profile
         env:
           IOS_BETA_PROVISIONING_PROFILE_BASE64: ${{ secrets.IOS_BETA_PROVISIONING_PROFILE_BASE64 }}
+          IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64: ${{ secrets.IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64 }}
         run: |
           set -euo pipefail
-          if [ -z "${IOS_BETA_PROVISIONING_PROFILE_BASE64:-}" ]; then
-            echo "Missing IOS_BETA_PROVISIONING_PROFILE_BASE64 secret" >&2
+          # Determine which profile to use based on bundle ID
+          if [ "${IOS_BETA_BUNDLE_ID:-dev.cmux.app.beta}" = "dev.cmux.app.internal" ]; then
+            PROFILE_BASE64="${IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64}"
+            EXPECTED_APP_ID="7WLXT3NR37.dev.cmux.app.internal"
+            PROFILE_TYPE="internal"
+          else
+            PROFILE_BASE64="${IOS_BETA_PROVISIONING_PROFILE_BASE64}"
+            EXPECTED_APP_ID="7WLXT3NR37.dev.cmux.app.beta"
+            PROFILE_TYPE="beta"
+          fi
+
+          if [ -z "${PROFILE_BASE64:-}" ]; then
+            echo "Missing provisioning profile secret for $PROFILE_TYPE" >&2
             exit 1
           fi
 
-          TMP_PROFILE="$RUNNER_TEMP/cmux-beta.mobileprovision"
-          TMP_PLIST="$RUNNER_TEMP/cmux-beta-profile.plist"
-          printf '%s' "$IOS_BETA_PROVISIONING_PROFILE_BASE64" | base64 --decode > "$TMP_PROFILE"
+          TMP_PROFILE="$RUNNER_TEMP/cmux-${PROFILE_TYPE}.mobileprovision"
+          TMP_PLIST="$RUNNER_TEMP/cmux-${PROFILE_TYPE}-profile.plist"
+          printf '%s' "$PROFILE_BASE64" | base64 --decode > "$TMP_PROFILE"
           security cms -D -i "$TMP_PROFILE" > "$TMP_PLIST"
 
           APP_ID="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:application-identifier" "$TMP_PLIST")"
-          if [ "$APP_ID" != "7WLXT3NR37.dev.cmux.app.beta" ]; then
-            echo "Beta provisioning profile targets unexpected app ID: $APP_ID" >&2
+          if [ "$APP_ID" != "$EXPECTED_APP_ID" ]; then
+            echo "$PROFILE_TYPE provisioning profile targets unexpected app ID: $APP_ID (expected $EXPECTED_APP_ID)" >&2
             exit 1
           fi
           APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:aps-environment" "$TMP_PLIST")"
           if [ "$APS_ENVIRONMENT" != "production" ]; then
-            echo "Beta provisioning profile aps-environment is '$APS_ENVIRONMENT', expected 'production'" >&2
+            echo "$PROFILE_TYPE provisioning profile aps-environment is '$APS_ENVIRONMENT', expected 'production'" >&2
             exit 1
           fi
           PROFILE_NAME="$(/usr/libexec/PlistBuddy -c "Print :Name" "$TMP_PLIST")"
@@ -455,7 +467,7 @@ jobs:
           mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
           cp "$TMP_PROFILE" "$HOME/Library/MobileDevice/Provisioning Profiles/$PROFILE_UUID.mobileprovision"
           echo "IOS_BETA_PROVISIONING_PROFILE_NAME=$PROFILE_NAME" >> "$GITHUB_ENV"
-          echo "Installed beta provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
+          echo "Installed $PROFILE_TYPE provisioning profile: $PROFILE_NAME ($PROFILE_UUID)"
 
       - name: Archive, export, and upload to TestFlight
         id: upload


### PR DESCRIPTION
Support separate internal and beta provisioning profiles, selected based on bundle ID. Internal builds (dev.cmux.app.internal) now use the internal provisioning profile from GitHub Secrets. Fixes export mismatch error when uploading internal builds to TestFlight.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8185"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786742035&installation_id=133855650&pr_number=8185&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8185&signature=6442df49d00d0b3aaee182290d5e5c54cedb1c3f97181843cc822174d3410117"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add internal iOS TestFlight support by selecting the correct provisioning profile based on the bundle ID. Fixes export mismatch errors when uploading `dev.cmux.app.internal` builds.

- New Features
  - Auto-selects provisioning profile by `IOS_BETA_BUNDLE_ID` (internal vs beta).
  - Uses `IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64` for internal builds and logs which profile is installed.
  - Validates application-identifier and `aps-environment=production` to prevent mismatches.

- Migration
  - Add GitHub secret `IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64` with the internal profile (base64).
  - Set `IOS_BETA_BUNDLE_ID=dev.cmux.app.internal` for internal builds.

<sup>Written for commit ed19d9bbdeba0737ce20a48bfae75b141b0edf44. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8185?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS beta build provisioning to support both internal and external testing profiles.
  * Added validation to ensure provisioning profiles target the correct app and use production push notifications.
  * Automatically selects and installs the appropriate profile for the selected beta environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->