### PR TITLE
Fix unauthenticated GitHub sidebar polling

### DIFF
--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -37,7 +37,6 @@ actor GitHubPullRequestRequestCoordinator {
     private var transportTail: Task<Void, Never>?
     private var rateLimitRetryDateByAuthorizationFingerprint: [Data: Date] = [:]
     private var rateLimitAuthorizationFingerprintsInInsertionOrder: [Data] = []
-    private var mostRecentAuthorizationFingerprint: Data?
 
     init(
         session: URLSession? = nil,
@@ -68,9 +67,8 @@ actor GitHubPullRequestRequestCoordinator {
         }
         let requestKey = RequestKey(
             endpoint: endpoint,
-            authorizationFingerprint: Data(SHA256.hash(data: Data(authHeader.utf8)))
+            authorizationFingerprint: Self.authorizationFingerprint(for: authHeader)
         )
-        mostRecentAuthorizationFingerprint = requestKey.authorizationFingerprint
         guard activeRateLimitRetryDate(
             for: requestKey.authorizationFingerprint
         ) == nil else { return nil }
@@ -99,9 +97,13 @@ actor GitHubPullRequestRequestCoordinator {
         return response
     }
 
-    func retryDate() -> Date? {
-        guard let mostRecentAuthorizationFingerprint else { return nil }
-        return activeRateLimitRetryDate(for: mostRecentAuthorizationFingerprint)
+    func retryDate(authHeader: String) -> Date? {
+        guard !authHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        return activeRateLimitRetryDate(
+            for: Self.authorizationFingerprint(for: authHeader)
+        )
     }
 
     private func executeRequest(
@@ -228,6 +230,10 @@ actor GitHubPullRequestRequestCoordinator {
     private func activeRateLimitRetryDate(for authorizationFingerprint: Data) -> Date? {
         removeExpiredRateLimitRetryDates()
         return rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint]
+    }
+
+    private static func authorizationFingerprint(for authHeader: String) -> Data {
+        Data(SHA256.hash(data: Data(authHeader.utf8)))
     }
 
     private func removeExpiredRateLimitRetryDates() {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -24,6 +24,13 @@ actor GitHubPullRequestRequestCoordinator {
     private struct InFlightRequest: Sendable {
         let id: UUID
         let task: Task<WorkspacePullRequestHTTPResponse?, Never>
+        let predecessor: TransportLink?
+        var waiterIDs: Set<UUID>
+    }
+
+    private struct TransportLink: Sendable {
+        let id: UUID
+        let task: Task<WorkspacePullRequestHTTPResponse?, Never>
     }
 
     private let session: URLSession
@@ -34,7 +41,7 @@ actor GitHubPullRequestRequestCoordinator {
     private var cachedResponseKeysInInsertionOrder: [RequestKey] = []
     private var cachedResponseBodyByteCount = 0
     private var inFlightRequestByRequestKey: [RequestKey: InFlightRequest] = [:]
-    private var transportTail: Task<Void, Never>?
+    private var transportTail: TransportLink?
     private var rateLimitRetryDateByAuthorizationFingerprint: [Data: Date] = [:]
     private var rateLimitAuthorizationFingerprintsInInsertionOrder: [Data] = []
 
@@ -72,29 +79,54 @@ actor GitHubPullRequestRequestCoordinator {
         guard activeRateLimitRetryDate(
             for: requestKey.authorizationFingerprint
         ) == nil else { return nil }
+        guard !Task.isCancelled else { return nil }
 
-        if let inFlight = inFlightRequestByRequestKey[requestKey] {
-            return await inFlight.task.value
-        }
-
-        let requestID = UUID()
-        let predecessor = transportTail
-        let task = Task<WorkspacePullRequestHTTPResponse?, Never> { [weak self] in
-            _ = await predecessor?.value
-            guard let self else { return nil }
-            return await self.executeRequest(
-                requestKey: requestKey,
-                authHeader: authHeader
+        let waiterID = UUID()
+        let requestID: UUID
+        let task: Task<WorkspacePullRequestHTTPResponse?, Never>
+        if var inFlight = inFlightRequestByRequestKey[requestKey] {
+            inFlight.waiterIDs.insert(waiterID)
+            inFlightRequestByRequestKey[requestKey] = inFlight
+            requestID = inFlight.id
+            task = inFlight.task
+        } else {
+            requestID = UUID()
+            let predecessor = transportTail
+            task = Task<WorkspacePullRequestHTTPResponse?, Never> { [weak self] in
+                _ = await predecessor?.task.value
+                guard !Task.isCancelled, let self else { return nil }
+                return await self.executeRequest(
+                    requestKey: requestKey,
+                    authHeader: authHeader
+                )
+            }
+            inFlightRequestByRequestKey[requestKey] = InFlightRequest(
+                id: requestID,
+                task: task,
+                predecessor: predecessor,
+                waiterIDs: [waiterID]
             )
+            transportTail = TransportLink(id: requestID, task: task)
         }
-        inFlightRequestByRequestKey[requestKey] = InFlightRequest(id: requestID, task: task)
-        transportTail = Task { _ = await task.value }
 
-        let response = await task.value
-        if inFlightRequestByRequestKey[requestKey]?.id == requestID {
-            inFlightRequestByRequestKey.removeValue(forKey: requestKey)
+        return await withTaskCancellationHandler {
+            let response = await task.value
+            releaseWaiter(
+                waiterID,
+                requestID: requestID,
+                requestKey: requestKey
+            )
+            return Task.isCancelled ? nil : response
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task {
+                await self.releaseWaiter(
+                    waiterID,
+                    requestID: requestID,
+                    requestKey: requestKey
+                )
+            }
         }
-        return response
     }
 
     func retryDate(authHeader: String) -> Date? {
@@ -151,6 +183,28 @@ actor GitHubPullRequestRequestCoordinator {
             return WorkspacePullRequestHTTPResponse(statusCode: httpResponse.statusCode, data: data)
         } catch {
             return nil
+        }
+    }
+
+    private func releaseWaiter(
+        _ waiterID: UUID,
+        requestID: UUID,
+        requestKey: RequestKey
+    ) {
+        guard var inFlight = inFlightRequestByRequestKey[requestKey],
+              inFlight.id == requestID,
+              inFlight.waiterIDs.remove(waiterID) != nil else {
+            return
+        }
+        guard inFlight.waiterIDs.isEmpty else {
+            inFlightRequestByRequestKey[requestKey] = inFlight
+            return
+        }
+
+        inFlightRequestByRequestKey.removeValue(forKey: requestKey)
+        inFlight.task.cancel()
+        if transportTail?.id == requestID {
+            transportTail = inFlight.predecessor
         }
     }
 

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -1,6 +1,10 @@
 import CryptoKit
 import Foundation
 
+private func githubAuthorizationFingerprint(for authHeader: String) -> Data {
+    Data(SHA256.hash(data: Data(authHeader.utf8)))
+}
+
 /// Process-scoped transport policy for GitHub pull-request probes.
 ///
 /// A single instance is shared by every app window. It owns the reusable
@@ -75,7 +79,7 @@ actor GitHubPullRequestRequestCoordinator {
         }
         let requestKey = RequestKey(
             endpoint: endpoint,
-            authorizationFingerprint: Self.authorizationFingerprint(for: authHeader)
+            authorizationFingerprint: githubAuthorizationFingerprint(for: authHeader)
         )
         guard activeRateLimitRetryDate(
             for: requestKey.authorizationFingerprint
@@ -132,7 +136,7 @@ actor GitHubPullRequestRequestCoordinator {
             return nil
         }
         return activeRateLimitRetryDate(
-            for: Self.authorizationFingerprint(for: authHeader)
+            for: githubAuthorizationFingerprint(for: authHeader)
         )
     }
 
@@ -315,10 +319,6 @@ actor GitHubPullRequestRequestCoordinator {
     private func activeRateLimitRetryDate(for authorizationFingerprint: Data) -> Date? {
         removeExpiredRateLimitRetryDates()
         return rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint]
-    }
-
-    private static func authorizationFingerprint(for authHeader: String) -> Data {
-        Data(SHA256.hash(data: Data(authHeader.utf8)))
     }
 
     private func removeExpiredRateLimitRetryDates() {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -16,7 +16,7 @@ actor GitHubPullRequestRequestCoordinator {
     private static let maximumConcurrentTransportCount = 3
     private static let maximumRateLimitIdentityCount = 32
 
-    private struct RequestKey: Hashable, Sendable {
+    internal struct RequestKey: Hashable, Sendable {
         let endpoint: String
         let authorizationFingerprint: Data
     }
@@ -26,13 +26,13 @@ actor GitHubPullRequestRequestCoordinator {
         let data: Data
     }
 
-    private struct InFlightRequest: Sendable {
+    internal struct InFlightRequest: Sendable {
         let id: UUID
         let task: Task<WorkspacePullRequestHTTPResponse?, Never>
         var waiterIDs: Set<UUID>
     }
 
-    private struct QueuedTransport: Sendable {
+    internal struct QueuedTransport: Sendable {
         let id: UUID
         let continuation: CheckedContinuation<Bool, Never>
     }
@@ -44,9 +44,9 @@ actor GitHubPullRequestRequestCoordinator {
     private var cachedResponseByRequestKey: [RequestKey: CachedResponse] = [:]
     private var cachedResponseKeysInInsertionOrder: [RequestKey] = []
     private var cachedResponseBodyByteCount = 0
-    private var inFlightRequestByRequestKey: [RequestKey: InFlightRequest] = [:]
+    internal var inFlightRequestByRequestKey: [RequestKey: InFlightRequest] = [:]
     private var activeTransportCount = 0
-    private var queuedTransports: [QueuedTransport] = []
+    internal var queuedTransports: [QueuedTransport] = []
     private var rateLimitRetryDateByAuthorizationFingerprint: [Data: Date] = [:]
     private var rateLimitAuthorizationFingerprintsInInsertionOrder: [Data] = []
 

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -20,13 +20,19 @@ actor GitHubPullRequestRequestCoordinator {
 
     private let session: URLSession
     private let now: @Sendable () -> Date
+    private let maximumCachedResponseCount: Int
+    private let maximumCachedResponseBodyBytes: Int
     private var cachedResponseByEndpoint: [String: CachedResponse] = [:]
+    private var cachedResponseEndpointsInInsertionOrder: [String] = []
+    private var cachedResponseBodyByteCount = 0
     private var inFlightRequestByEndpoint: [String: InFlightRequest] = [:]
     private var transportTail: Task<Void, Never>?
     private var rateLimitRetryDate: Date?
 
     init(
         session: URLSession? = nil,
+        maximumCachedResponseCount: Int = 128,
+        maximumCachedResponseBodyBytes: Int = 4 * 1024 * 1024,
         now: @escaping @Sendable () -> Date = { Date() }
     ) {
         if let session {
@@ -37,6 +43,8 @@ actor GitHubPullRequestRequestCoordinator {
             configuration.timeoutIntervalForResource = max(PullRequestProbeService.probeTimeout, 8)
             self.session = URLSession(configuration: configuration)
         }
+        self.maximumCachedResponseCount = max(0, maximumCachedResponseCount)
+        self.maximumCachedResponseBodyBytes = max(0, maximumCachedResponseBodyBytes)
         self.now = now
     }
 
@@ -114,9 +122,9 @@ actor GitHubPullRequestRequestCoordinator {
 
             if httpResponse.statusCode == 200 {
                 if let etag = httpResponse.value(forHTTPHeaderField: "ETag"), !etag.isEmpty {
-                    cachedResponseByEndpoint[endpoint] = CachedResponse(etag: etag, data: data)
+                    storeCachedResponse(CachedResponse(etag: etag, data: data), for: endpoint)
                 } else {
-                    cachedResponseByEndpoint.removeValue(forKey: endpoint)
+                    removeCachedResponse(for: endpoint)
                 }
             }
             return WorkspacePullRequestHTTPResponse(statusCode: httpResponse.statusCode, data: data)
@@ -126,21 +134,52 @@ actor GitHubPullRequestRequestCoordinator {
     }
 
     private func updateRateLimit(from response: HTTPURLResponse) {
-        let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
-        let isExhausted = remaining == "0" || response.statusCode == 403 || response.statusCode == 429
-        guard isExhausted,
-              let rawReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset"),
-              let resetSeconds = TimeInterval(rawReset) else {
+        if response.value(forHTTPHeaderField: "X-RateLimit-Remaining") == "0",
+           let rawReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset"),
+           let resetSeconds = TimeInterval(rawReset) {
+            // GitHub reports whole epoch seconds. Waiting through the following
+            // second avoids racing the boundary and immediately receiving another
+            // exhausted response.
+            extendRateLimitRetryDate(to: Date(timeIntervalSince1970: resetSeconds + 1))
+        }
+
+        if response.statusCode == 403 || response.statusCode == 429,
+           let rawRetryAfter = response.value(forHTTPHeaderField: "Retry-After"),
+           let retryAfter = TimeInterval(rawRetryAfter),
+           retryAfter > 0 {
+            extendRateLimitRetryDate(to: now().addingTimeInterval(retryAfter))
+        }
+    }
+
+    private func extendRateLimitRetryDate(to retryDate: Date) {
+        guard retryDate > now() else { return }
+        rateLimitRetryDate = max(rateLimitRetryDate ?? .distantPast, retryDate)
+    }
+
+    private func storeCachedResponse(_ response: CachedResponse, for endpoint: String) {
+        removeCachedResponse(for: endpoint)
+        guard maximumCachedResponseCount > 0,
+              maximumCachedResponseBodyBytes > 0,
+              response.data.count <= maximumCachedResponseBodyBytes else {
             return
         }
 
-        // GitHub reports whole epoch seconds. Waiting through the following
-        // second avoids racing the boundary and immediately receiving another
-        // exhausted response.
-        let resetDate = Date(timeIntervalSince1970: resetSeconds + 1)
-        if resetDate > now() {
-            rateLimitRetryDate = max(rateLimitRetryDate ?? .distantPast, resetDate)
+        cachedResponseByEndpoint[endpoint] = response
+        cachedResponseEndpointsInInsertionOrder.append(endpoint)
+        cachedResponseBodyByteCount += response.data.count
+
+        while cachedResponseByEndpoint.count > maximumCachedResponseCount
+            || cachedResponseBodyByteCount > maximumCachedResponseBodyBytes {
+            guard let oldestEndpoint = cachedResponseEndpointsInInsertionOrder.first else { break }
+            removeCachedResponse(for: oldestEndpoint)
         }
+    }
+
+    private func removeCachedResponse(for endpoint: String) {
+        if let removedResponse = cachedResponseByEndpoint.removeValue(forKey: endpoint) {
+            cachedResponseBodyByteCount -= removedResponse.data.count
+        }
+        cachedResponseEndpointsInInsertionOrder.removeAll { $0 == endpoint }
     }
 
     private func activeRateLimitRetryDate() -> Date? {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -60,8 +60,7 @@ actor GitHubPullRequestRequestCoordinator {
 
     func response(
         endpoint: String,
-        authHeader: String?,
-        sessionOverride: URLSession? = nil
+        authHeader: String?
     ) async -> WorkspacePullRequestHTTPResponse? {
         guard let authHeader,
               !authHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
@@ -82,14 +81,12 @@ actor GitHubPullRequestRequestCoordinator {
 
         let requestID = UUID()
         let predecessor = transportTail
-        let requestSession = sessionOverride ?? session
         let task = Task<WorkspacePullRequestHTTPResponse?, Never> { [weak self] in
             _ = await predecessor?.value
             guard let self else { return nil }
             return await self.executeRequest(
                 requestKey: requestKey,
-                authHeader: authHeader,
-                session: requestSession
+                authHeader: authHeader
             )
         }
         inFlightRequestByRequestKey[requestKey] = InFlightRequest(id: requestID, task: task)
@@ -109,8 +106,7 @@ actor GitHubPullRequestRequestCoordinator {
 
     private func executeRequest(
         requestKey: RequestKey,
-        authHeader: String,
-        session: URLSession
+        authHeader: String
     ) async -> WorkspacePullRequestHTTPResponse? {
         guard activeRateLimitRetryDate(
             for: requestKey.authorizationFingerprint

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -5,10 +5,11 @@ import Foundation
 ///
 /// A single instance is shared by every app window. It owns the reusable
 /// session, conditional-response cache, rate-limit deadline, in-flight request
-/// coalescing, and a one-request transport queue. Keeping these concerns here
+/// coalescing, and a bounded transport pool. Keeping these concerns here
 /// prevents per-window pollers from independently consuming the same GitHub
 /// rate-limit pool.
 actor GitHubPullRequestRequestCoordinator {
+    private static let maximumConcurrentTransportCount = 3
     private static let maximumRateLimitIdentityCount = 32
 
     private struct RequestKey: Hashable, Sendable {
@@ -24,13 +25,12 @@ actor GitHubPullRequestRequestCoordinator {
     private struct InFlightRequest: Sendable {
         let id: UUID
         let task: Task<WorkspacePullRequestHTTPResponse?, Never>
-        let predecessor: TransportLink?
         var waiterIDs: Set<UUID>
     }
 
-    private struct TransportLink: Sendable {
+    private struct QueuedTransport: Sendable {
         let id: UUID
-        let task: Task<WorkspacePullRequestHTTPResponse?, Never>
+        let continuation: CheckedContinuation<Bool, Never>
     }
 
     private let session: URLSession
@@ -41,7 +41,8 @@ actor GitHubPullRequestRequestCoordinator {
     private var cachedResponseKeysInInsertionOrder: [RequestKey] = []
     private var cachedResponseBodyByteCount = 0
     private var inFlightRequestByRequestKey: [RequestKey: InFlightRequest] = [:]
-    private var transportTail: TransportLink?
+    private var activeTransportCount = 0
+    private var queuedTransports: [QueuedTransport] = []
     private var rateLimitRetryDateByAuthorizationFingerprint: [Data: Date] = [:]
     private var rateLimitAuthorizationFingerprintsInInsertionOrder: [Data] = []
 
@@ -91,11 +92,10 @@ actor GitHubPullRequestRequestCoordinator {
             task = inFlight.task
         } else {
             requestID = UUID()
-            let predecessor = transportTail
             task = Task<WorkspacePullRequestHTTPResponse?, Never> { [weak self] in
-                _ = await predecessor?.task.value
                 guard !Task.isCancelled, let self else { return nil }
                 return await self.executeRequest(
+                    requestID: requestID,
                     requestKey: requestKey,
                     authHeader: authHeader
                 )
@@ -103,10 +103,8 @@ actor GitHubPullRequestRequestCoordinator {
             inFlightRequestByRequestKey[requestKey] = InFlightRequest(
                 id: requestID,
                 task: task,
-                predecessor: predecessor,
                 waiterIDs: [waiterID]
             )
-            transportTail = TransportLink(id: requestID, task: task)
         }
 
         return await withTaskCancellationHandler {
@@ -139,9 +137,13 @@ actor GitHubPullRequestRequestCoordinator {
     }
 
     private func executeRequest(
+        requestID: UUID,
         requestKey: RequestKey,
         authHeader: String
     ) async -> WorkspacePullRequestHTTPResponse? {
+        guard await acquireTransportPermit(requestID: requestID) else { return nil }
+        defer { releaseTransportPermit() }
+        guard !Task.isCancelled else { return nil }
         guard activeRateLimitRetryDate(
             for: requestKey.authorizationFingerprint
         ) == nil,
@@ -203,9 +205,39 @@ actor GitHubPullRequestRequestCoordinator {
 
         inFlightRequestByRequestKey.removeValue(forKey: requestKey)
         inFlight.task.cancel()
-        if transportTail?.id == requestID {
-            transportTail = inFlight.predecessor
+    }
+
+    private func acquireTransportPermit(requestID: UUID) async -> Bool {
+        guard !Task.isCancelled else { return false }
+        if activeTransportCount < Self.maximumConcurrentTransportCount {
+            activeTransportCount += 1
+            return true
         }
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                queuedTransports.append(QueuedTransport(id: requestID, continuation: continuation))
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task { await self.cancelQueuedTransport(requestID: requestID) }
+        }
+    }
+
+    private func cancelQueuedTransport(requestID: UUID) {
+        guard let index = queuedTransports.firstIndex(where: { $0.id == requestID }) else { return }
+        queuedTransports.remove(at: index).continuation.resume(returning: false)
+    }
+
+    private func releaseTransportPermit() {
+        guard !queuedTransports.isEmpty else {
+            activeTransportCount -= 1
+            return
+        }
+        queuedTransports.removeFirst().continuation.resume(returning: true)
     }
 
     private func updateRateLimit(
@@ -241,9 +273,8 @@ actor GitHubPullRequestRequestCoordinator {
     ) {
         guard retryDate > now() else { return }
         removeExpiredRateLimitRetryDates()
-        if rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint] == nil {
-            rateLimitAuthorizationFingerprintsInInsertionOrder.append(authorizationFingerprint)
-        }
+        rateLimitAuthorizationFingerprintsInInsertionOrder.removeAll { $0 == authorizationFingerprint }
+        rateLimitAuthorizationFingerprintsInInsertionOrder.append(authorizationFingerprint)
         rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint] = max(
             rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint] ?? .distantPast,
             retryDate

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// Process-scoped transport policy for GitHub pull-request probes.
+///
+/// A single instance is shared by every app window. It owns the reusable
+/// session, conditional-response cache, rate-limit deadline, in-flight request
+/// coalescing, and a one-request transport queue. Keeping these concerns here
+/// prevents per-window pollers from independently consuming the same GitHub
+/// rate-limit pool.
+actor GitHubPullRequestRequestCoordinator {
+    private struct CachedResponse: Sendable {
+        let etag: String
+        let data: Data
+    }
+
+    private struct InFlightRequest: Sendable {
+        let id: UUID
+        let task: Task<WorkspacePullRequestHTTPResponse?, Never>
+    }
+
+    private let session: URLSession
+    private let now: @Sendable () -> Date
+    private var cachedResponseByEndpoint: [String: CachedResponse] = [:]
+    private var inFlightRequestByEndpoint: [String: InFlightRequest] = [:]
+    private var transportTail: Task<Void, Never>?
+    private var rateLimitRetryDate: Date?
+
+    init(
+        session: URLSession? = nil,
+        now: @escaping @Sendable () -> Date = { Date() }
+    ) {
+        if let session {
+            self.session = session
+        } else {
+            let configuration = URLSessionConfiguration.ephemeral
+            configuration.timeoutIntervalForRequest = max(PullRequestProbeService.probeTimeout, 8)
+            configuration.timeoutIntervalForResource = max(PullRequestProbeService.probeTimeout, 8)
+            self.session = URLSession(configuration: configuration)
+        }
+        self.now = now
+    }
+
+    func response(
+        endpoint: String,
+        authHeader: String?,
+        sessionOverride: URLSession? = nil
+    ) async -> WorkspacePullRequestHTTPResponse? {
+        guard let authHeader,
+              !authHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return nil
+        }
+        guard activeRateLimitRetryDate() == nil else { return nil }
+
+        if let inFlight = inFlightRequestByEndpoint[endpoint] {
+            return await inFlight.task.value
+        }
+
+        let requestID = UUID()
+        let predecessor = transportTail
+        let requestSession = sessionOverride ?? session
+        let task = Task<WorkspacePullRequestHTTPResponse?, Never> { [weak self] in
+            _ = await predecessor?.value
+            guard let self else { return nil }
+            return await self.executeRequest(
+                endpoint: endpoint,
+                authHeader: authHeader,
+                session: requestSession
+            )
+        }
+        inFlightRequestByEndpoint[endpoint] = InFlightRequest(id: requestID, task: task)
+        transportTail = Task { _ = await task.value }
+
+        let response = await task.value
+        if inFlightRequestByEndpoint[endpoint]?.id == requestID {
+            inFlightRequestByEndpoint.removeValue(forKey: endpoint)
+        }
+        return response
+    }
+
+    func retryDate() -> Date? {
+        activeRateLimitRetryDate()
+    }
+
+    private func executeRequest(
+        endpoint: String,
+        authHeader: String,
+        session: URLSession
+    ) async -> WorkspacePullRequestHTTPResponse? {
+        guard activeRateLimitRetryDate() == nil,
+              let url = URL(string: "https://api.github.com/\(endpoint)") else {
+            return nil
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
+        request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
+        request.setValue(authHeader, forHTTPHeaderField: "Authorization")
+        if let etag = cachedResponseByEndpoint[endpoint]?.etag {
+            request.setValue(etag, forHTTPHeaderField: "If-None-Match")
+        }
+
+        do {
+            let (data, response) = try await session.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse else {
+                return nil
+            }
+            updateRateLimit(from: httpResponse)
+
+            if httpResponse.statusCode == 304,
+               let cachedResponse = cachedResponseByEndpoint[endpoint] {
+                return WorkspacePullRequestHTTPResponse(statusCode: 200, data: cachedResponse.data)
+            }
+
+            if httpResponse.statusCode == 200 {
+                if let etag = httpResponse.value(forHTTPHeaderField: "ETag"), !etag.isEmpty {
+                    cachedResponseByEndpoint[endpoint] = CachedResponse(etag: etag, data: data)
+                } else {
+                    cachedResponseByEndpoint.removeValue(forKey: endpoint)
+                }
+            }
+            return WorkspacePullRequestHTTPResponse(statusCode: httpResponse.statusCode, data: data)
+        } catch {
+            return nil
+        }
+    }
+
+    private func updateRateLimit(from response: HTTPURLResponse) {
+        let remaining = response.value(forHTTPHeaderField: "X-RateLimit-Remaining")
+        let isExhausted = remaining == "0" || response.statusCode == 403 || response.statusCode == 429
+        guard isExhausted,
+              let rawReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset"),
+              let resetSeconds = TimeInterval(rawReset) else {
+            return
+        }
+
+        // GitHub reports whole epoch seconds. Waiting through the following
+        // second avoids racing the boundary and immediately receiving another
+        // exhausted response.
+        let resetDate = Date(timeIntervalSince1970: resetSeconds + 1)
+        if resetDate > now() {
+            rateLimitRetryDate = max(rateLimitRetryDate ?? .distantPast, resetDate)
+        }
+    }
+
+    private func activeRateLimitRetryDate() -> Date? {
+        guard let rateLimitRetryDate else { return nil }
+        guard rateLimitRetryDate > now() else {
+            self.rateLimitRetryDate = nil
+            return nil
+        }
+        return rateLimitRetryDate
+    }
+}

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/GitHubPullRequestRequestCoordinator.swift
@@ -1,3 +1,4 @@
+import CryptoKit
 import Foundation
 
 /// Process-scoped transport policy for GitHub pull-request probes.
@@ -8,6 +9,13 @@ import Foundation
 /// prevents per-window pollers from independently consuming the same GitHub
 /// rate-limit pool.
 actor GitHubPullRequestRequestCoordinator {
+    private static let maximumRateLimitIdentityCount = 32
+
+    private struct RequestKey: Hashable, Sendable {
+        let endpoint: String
+        let authorizationFingerprint: Data
+    }
+
     private struct CachedResponse: Sendable {
         let etag: String
         let data: Data
@@ -22,12 +30,14 @@ actor GitHubPullRequestRequestCoordinator {
     private let now: @Sendable () -> Date
     private let maximumCachedResponseCount: Int
     private let maximumCachedResponseBodyBytes: Int
-    private var cachedResponseByEndpoint: [String: CachedResponse] = [:]
-    private var cachedResponseEndpointsInInsertionOrder: [String] = []
+    private var cachedResponseByRequestKey: [RequestKey: CachedResponse] = [:]
+    private var cachedResponseKeysInInsertionOrder: [RequestKey] = []
     private var cachedResponseBodyByteCount = 0
-    private var inFlightRequestByEndpoint: [String: InFlightRequest] = [:]
+    private var inFlightRequestByRequestKey: [RequestKey: InFlightRequest] = [:]
     private var transportTail: Task<Void, Never>?
-    private var rateLimitRetryDate: Date?
+    private var rateLimitRetryDateByAuthorizationFingerprint: [Data: Date] = [:]
+    private var rateLimitAuthorizationFingerprintsInInsertionOrder: [Data] = []
+    private var mostRecentAuthorizationFingerprint: Data?
 
     init(
         session: URLSession? = nil,
@@ -57,9 +67,16 @@ actor GitHubPullRequestRequestCoordinator {
               !authHeader.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             return nil
         }
-        guard activeRateLimitRetryDate() == nil else { return nil }
+        let requestKey = RequestKey(
+            endpoint: endpoint,
+            authorizationFingerprint: Data(SHA256.hash(data: Data(authHeader.utf8)))
+        )
+        mostRecentAuthorizationFingerprint = requestKey.authorizationFingerprint
+        guard activeRateLimitRetryDate(
+            for: requestKey.authorizationFingerprint
+        ) == nil else { return nil }
 
-        if let inFlight = inFlightRequestByEndpoint[endpoint] {
+        if let inFlight = inFlightRequestByRequestKey[requestKey] {
             return await inFlight.task.value
         }
 
@@ -70,32 +87,35 @@ actor GitHubPullRequestRequestCoordinator {
             _ = await predecessor?.value
             guard let self else { return nil }
             return await self.executeRequest(
-                endpoint: endpoint,
+                requestKey: requestKey,
                 authHeader: authHeader,
                 session: requestSession
             )
         }
-        inFlightRequestByEndpoint[endpoint] = InFlightRequest(id: requestID, task: task)
+        inFlightRequestByRequestKey[requestKey] = InFlightRequest(id: requestID, task: task)
         transportTail = Task { _ = await task.value }
 
         let response = await task.value
-        if inFlightRequestByEndpoint[endpoint]?.id == requestID {
-            inFlightRequestByEndpoint.removeValue(forKey: endpoint)
+        if inFlightRequestByRequestKey[requestKey]?.id == requestID {
+            inFlightRequestByRequestKey.removeValue(forKey: requestKey)
         }
         return response
     }
 
     func retryDate() -> Date? {
-        activeRateLimitRetryDate()
+        guard let mostRecentAuthorizationFingerprint else { return nil }
+        return activeRateLimitRetryDate(for: mostRecentAuthorizationFingerprint)
     }
 
     private func executeRequest(
-        endpoint: String,
+        requestKey: RequestKey,
         authHeader: String,
         session: URLSession
     ) async -> WorkspacePullRequestHTTPResponse? {
-        guard activeRateLimitRetryDate() == nil,
-              let url = URL(string: "https://api.github.com/\(endpoint)") else {
+        guard activeRateLimitRetryDate(
+            for: requestKey.authorizationFingerprint
+        ) == nil,
+              let url = URL(string: "https://api.github.com/\(requestKey.endpoint)") else {
             return nil
         }
 
@@ -104,7 +124,7 @@ actor GitHubPullRequestRequestCoordinator {
         request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
         request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
         request.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        if let etag = cachedResponseByEndpoint[endpoint]?.etag {
+        if let etag = cachedResponseByRequestKey[requestKey]?.etag {
             request.setValue(etag, forHTTPHeaderField: "If-None-Match")
         }
 
@@ -113,18 +133,21 @@ actor GitHubPullRequestRequestCoordinator {
             guard let httpResponse = response as? HTTPURLResponse else {
                 return nil
             }
-            updateRateLimit(from: httpResponse)
+            updateRateLimit(
+                from: httpResponse,
+                authorizationFingerprint: requestKey.authorizationFingerprint
+            )
 
             if httpResponse.statusCode == 304,
-               let cachedResponse = cachedResponseByEndpoint[endpoint] {
+               let cachedResponse = cachedResponseByRequestKey[requestKey] {
                 return WorkspacePullRequestHTTPResponse(statusCode: 200, data: cachedResponse.data)
             }
 
             if httpResponse.statusCode == 200 {
                 if let etag = httpResponse.value(forHTTPHeaderField: "ETag"), !etag.isEmpty {
-                    storeCachedResponse(CachedResponse(etag: etag, data: data), for: endpoint)
+                    storeCachedResponse(CachedResponse(etag: etag, data: data), for: requestKey)
                 } else {
-                    removeCachedResponse(for: endpoint)
+                    removeCachedResponse(for: requestKey)
                 }
             }
             return WorkspacePullRequestHTTPResponse(statusCode: httpResponse.statusCode, data: data)
@@ -133,61 +156,91 @@ actor GitHubPullRequestRequestCoordinator {
         }
     }
 
-    private func updateRateLimit(from response: HTTPURLResponse) {
+    private func updateRateLimit(
+        from response: HTTPURLResponse,
+        authorizationFingerprint: Data
+    ) {
         if response.value(forHTTPHeaderField: "X-RateLimit-Remaining") == "0",
            let rawReset = response.value(forHTTPHeaderField: "X-RateLimit-Reset"),
            let resetSeconds = TimeInterval(rawReset) {
             // GitHub reports whole epoch seconds. Waiting through the following
             // second avoids racing the boundary and immediately receiving another
             // exhausted response.
-            extendRateLimitRetryDate(to: Date(timeIntervalSince1970: resetSeconds + 1))
+            extendRateLimitRetryDate(
+                to: Date(timeIntervalSince1970: resetSeconds + 1),
+                authorizationFingerprint: authorizationFingerprint
+            )
         }
 
         if response.statusCode == 403 || response.statusCode == 429,
            let rawRetryAfter = response.value(forHTTPHeaderField: "Retry-After"),
            let retryAfter = TimeInterval(rawRetryAfter),
            retryAfter > 0 {
-            extendRateLimitRetryDate(to: now().addingTimeInterval(retryAfter))
+            extendRateLimitRetryDate(
+                to: now().addingTimeInterval(retryAfter),
+                authorizationFingerprint: authorizationFingerprint
+            )
         }
     }
 
-    private func extendRateLimitRetryDate(to retryDate: Date) {
+    private func extendRateLimitRetryDate(
+        to retryDate: Date,
+        authorizationFingerprint: Data
+    ) {
         guard retryDate > now() else { return }
-        rateLimitRetryDate = max(rateLimitRetryDate ?? .distantPast, retryDate)
+        removeExpiredRateLimitRetryDates()
+        if rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint] == nil {
+            rateLimitAuthorizationFingerprintsInInsertionOrder.append(authorizationFingerprint)
+        }
+        rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint] = max(
+            rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint] ?? .distantPast,
+            retryDate
+        )
+        while rateLimitRetryDateByAuthorizationFingerprint.count > Self.maximumRateLimitIdentityCount {
+            guard let oldestFingerprint = rateLimitAuthorizationFingerprintsInInsertionOrder.first else { break }
+            rateLimitAuthorizationFingerprintsInInsertionOrder.removeFirst()
+            rateLimitRetryDateByAuthorizationFingerprint.removeValue(forKey: oldestFingerprint)
+        }
     }
 
-    private func storeCachedResponse(_ response: CachedResponse, for endpoint: String) {
-        removeCachedResponse(for: endpoint)
+    private func storeCachedResponse(_ response: CachedResponse, for requestKey: RequestKey) {
+        removeCachedResponse(for: requestKey)
         guard maximumCachedResponseCount > 0,
               maximumCachedResponseBodyBytes > 0,
               response.data.count <= maximumCachedResponseBodyBytes else {
             return
         }
 
-        cachedResponseByEndpoint[endpoint] = response
-        cachedResponseEndpointsInInsertionOrder.append(endpoint)
+        cachedResponseByRequestKey[requestKey] = response
+        cachedResponseKeysInInsertionOrder.append(requestKey)
         cachedResponseBodyByteCount += response.data.count
 
-        while cachedResponseByEndpoint.count > maximumCachedResponseCount
+        while cachedResponseByRequestKey.count > maximumCachedResponseCount
             || cachedResponseBodyByteCount > maximumCachedResponseBodyBytes {
-            guard let oldestEndpoint = cachedResponseEndpointsInInsertionOrder.first else { break }
-            removeCachedResponse(for: oldestEndpoint)
+            guard let oldestRequestKey = cachedResponseKeysInInsertionOrder.first else { break }
+            removeCachedResponse(for: oldestRequestKey)
         }
     }
 
-    private func removeCachedResponse(for endpoint: String) {
-        if let removedResponse = cachedResponseByEndpoint.removeValue(forKey: endpoint) {
+    private func removeCachedResponse(for requestKey: RequestKey) {
+        if let removedResponse = cachedResponseByRequestKey.removeValue(forKey: requestKey) {
             cachedResponseBodyByteCount -= removedResponse.data.count
         }
-        cachedResponseEndpointsInInsertionOrder.removeAll { $0 == endpoint }
+        cachedResponseKeysInInsertionOrder.removeAll { $0 == requestKey }
     }
 
-    private func activeRateLimitRetryDate() -> Date? {
-        guard let rateLimitRetryDate else { return nil }
-        guard rateLimitRetryDate > now() else {
-            self.rateLimitRetryDate = nil
-            return nil
+    private func activeRateLimitRetryDate(for authorizationFingerprint: Data) -> Date? {
+        removeExpiredRateLimitRetryDates()
+        return rateLimitRetryDateByAuthorizationFingerprint[authorizationFingerprint]
+    }
+
+    private func removeExpiredRateLimitRetryDates() {
+        let currentDate = now()
+        rateLimitRetryDateByAuthorizationFingerprint = rateLimitRetryDateByAuthorizationFingerprint.filter {
+            $0.value > currentDate
         }
-        return rateLimitRetryDate
+        rateLimitAuthorizationFingerprintsInInsertionOrder.removeAll {
+            rateLimitRetryDateByAuthorizationFingerprint[$0] == nil
+        }
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Auth.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Auth.swift
@@ -2,8 +2,9 @@ import Foundation
 
 extension PullRequestProbeService {
     /// Resolves the API auth header: `GH_TOKEN`/`GITHUB_TOKEN` from the
-    /// environment, else `gh auth token` via the injected runner, else `nil`
-    /// (unauthenticated requests).
+    /// environment, else `gh auth token` via the injected runner. A `nil`
+    /// result suppresses transport; GitHub probes never fall back to anonymous
+    /// requests.
     nonisolated func authHeaderValue() async -> String? {
         let environment = ProcessInfo.processInfo.environment
         if let envToken = environment["GH_TOKEN"] ?? environment["GITHUB_TOKEN"] {

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
@@ -345,21 +345,6 @@ extension PullRequestProbeService {
         await requestCoordinator.response(endpoint: endpoint, authHeader: authHeader)
     }
 
-    /// Injected-session overload used by transport behavior tests. It still
-    /// exercises the same shared auth, ETag, backoff, queue, and coalescing
-    /// policy as production.
-    nonisolated func performRequest(
-        session: URLSession,
-        endpoint: String,
-        authHeader: String?
-    ) async -> WorkspacePullRequestHTTPResponse? {
-        await requestCoordinator.response(
-            endpoint: endpoint,
-            authHeader: authHeader,
-            sessionOverride: session
-        )
-    }
-
     /// The GitHub reset deadline currently suppressing transport, if any.
     public nonisolated func rateLimitRetryDate() async -> Date? {
         await requestCoordinator.retryDate()

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
@@ -27,11 +27,12 @@ extension PullRequestProbeService {
     ) async -> [String: WorkspacePullRequestRepoFetchResult] {
         guard !repoDirectoriesBySlug.isEmpty else { return [:] }
 
-        let configuration = URLSessionConfiguration.ephemeral
-        configuration.timeoutIntervalForRequest = max(Self.probeTimeout, 8)
-        configuration.timeoutIntervalForResource = max(Self.probeTimeout, 8)
-        let session = URLSession(configuration: configuration)
-        let authHeader = await authHeaderValue()
+        guard let authHeader = await authHeaderValue() else {
+            debugLog("workspace.prRefresh.authUnavailable")
+            return Dictionary(
+                uniqueKeysWithValues: repoDirectoriesBySlug.keys.map { ($0, .transientFailure) }
+            )
+        }
         var results: [String: WorkspacePullRequestRepoFetchResult] = [:]
 
         let fetchedResults = await withTaskGroup(
@@ -48,7 +49,6 @@ extension PullRequestProbeService {
                             && (cacheBySlug[repoSlug].map {
                                 now.timeIntervalSince($0.fetchedAt) < Self.repoCacheLifetime
                             } ?? false),
-                        session: session,
                         authHeader: authHeader
                     )
                     return (repoSlug, result)
@@ -75,8 +75,7 @@ extension PullRequestProbeService {
         candidateBranches: Set<String>,
         cachedEntry: WorkspacePullRequestRepoCacheEntry?,
         useCachedRecentWindow: Bool,
-        session: URLSession,
-        authHeader: String?
+        authHeader: String
     ) async -> WorkspacePullRequestRepoFetchResult {
         let normalizedCandidateBranches = Set(
             candidateBranches.compactMap(GitMetadataService.normalizedBranchName)
@@ -101,7 +100,6 @@ extension PullRequestProbeService {
                 candidateBranches: unresolvedBranches,
                 baseEntry: cachedEntry,
                 refreshedAt: Date(),
-                session: session,
                 authHeader: authHeader
             )
             debugLog(
@@ -123,7 +121,6 @@ extension PullRequestProbeService {
         while page <= Self.repoPageLimit {
             let endpoint = "repos/\(repoSlug)/pulls?state=all&sort=updated&direction=desc&per_page=\(Self.repoPageSize)&page=\(page)"
             guard let response = await performRequest(
-                session: session,
                 endpoint: endpoint,
                 authHeader: authHeader
             ) else {
@@ -165,7 +162,6 @@ extension PullRequestProbeService {
                 candidateBranches: unresolvedBranches,
                 baseEntry: recentWindowEntry,
                 refreshedAt: fetchTimestamp,
-                session: session,
                 authHeader: authHeader
             )
         }
@@ -201,8 +197,7 @@ extension PullRequestProbeService {
         candidateBranches: [String],
         baseEntry: WorkspacePullRequestRepoCacheEntry,
         refreshedAt: Date,
-        session: URLSession,
-        authHeader: String?
+        authHeader: String
     ) async -> WorkspacePullRequestBranchLookupOutcome {
         guard !candidateBranches.isEmpty else {
             return WorkspacePullRequestBranchLookupOutcome(
@@ -220,7 +215,6 @@ extension PullRequestProbeService {
                     let result = await self.branchFetchResult(
                         repoSlug: repoSlug,
                         branch: branch,
-                        session: session,
                         authHeader: authHeader
                     )
                     return (branch, result)
@@ -264,8 +258,7 @@ extension PullRequestProbeService {
     nonisolated func branchFetchResult(
         repoSlug: String,
         branch: String,
-        session: URLSession,
-        authHeader: String?
+        authHeader: String
     ) async -> WorkspacePullRequestBranchFetchResult {
         guard let endpoint = Self.branchEndpoint(
             repoSlug: repoSlug,
@@ -275,7 +268,6 @@ extension PullRequestProbeService {
         }
 
         guard let response = await performRequest(
-            session: session,
             endpoint: endpoint,
             authHeader: authHeader
         ) else {
@@ -345,35 +337,31 @@ extension PullRequestProbeService {
         )
     }
 
-    /// One GET against the GitHub API; `nil` on any transport error.
+    /// One authenticated GET through the shared GitHub request coordinator.
+    nonisolated func performRequest(
+        endpoint: String,
+        authHeader: String?
+    ) async -> WorkspacePullRequestHTTPResponse? {
+        await requestCoordinator.response(endpoint: endpoint, authHeader: authHeader)
+    }
+
+    /// Injected-session overload used by transport behavior tests. It still
+    /// exercises the same shared auth, ETag, backoff, queue, and coalescing
+    /// policy as production.
     nonisolated func performRequest(
         session: URLSession,
         endpoint: String,
         authHeader: String?
     ) async -> WorkspacePullRequestHTTPResponse? {
-        guard let url = URL(string: "https://api.github.com/\(endpoint)") else {
-            return nil
-        }
+        await requestCoordinator.response(
+            endpoint: endpoint,
+            authHeader: authHeader,
+            sessionOverride: session
+        )
+    }
 
-        var request = URLRequest(url: url)
-        request.httpMethod = "GET"
-        request.setValue("application/vnd.github+json", forHTTPHeaderField: "Accept")
-        request.setValue("cmux-workspace-pr-poller", forHTTPHeaderField: "User-Agent")
-        if let authHeader, !authHeader.isEmpty {
-            request.setValue(authHeader, forHTTPHeaderField: "Authorization")
-        }
-
-        do {
-            let (data, response) = try await session.data(for: request)
-            guard let httpResponse = response as? HTTPURLResponse else {
-                return nil
-            }
-            return WorkspacePullRequestHTTPResponse(
-                statusCode: httpResponse.statusCode,
-                data: data
-            )
-        } catch {
-            return nil
-        }
+    /// The GitHub reset deadline currently suppressing transport, if any.
+    public nonisolated func rateLimitRetryDate() async -> Date? {
+        await requestCoordinator.retryDate()
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/Probe/PullRequestProbeService+Fetch.swift
@@ -17,20 +17,29 @@ extension PullRequestProbeService {
     ///   - cacheBySlug: The caller-owned repo cache.
     ///   - now: The refresh timestamp used for cache-freshness checks.
     ///   - allowCachedResults: Whether fresh cache entries may satisfy the fetch.
-    /// - Returns: One ``WorkspacePullRequestRepoFetchResult`` per repository slug.
+    /// - Returns: The repository results and the retry deadline for the exact
+    ///   authorization credential used by this batch.
     public nonisolated func fetchRepoResults(
         repoDirectoriesBySlug: [String: String],
         candidateBranchesByRepo: [String: Set<String>],
         cacheBySlug: [String: WorkspacePullRequestRepoCacheEntry],
         now: Date,
         allowCachedResults: Bool
-    ) async -> [String: WorkspacePullRequestRepoFetchResult] {
-        guard !repoDirectoriesBySlug.isEmpty else { return [:] }
+    ) async -> (
+        repoResults: [String: WorkspacePullRequestRepoFetchResult],
+        rateLimitRetryDate: Date?
+    ) {
+        guard !repoDirectoriesBySlug.isEmpty else {
+            return (repoResults: [:], rateLimitRetryDate: nil)
+        }
 
         guard let authHeader = await authHeaderValue() else {
             debugLog("workspace.prRefresh.authUnavailable")
-            return Dictionary(
-                uniqueKeysWithValues: repoDirectoriesBySlug.keys.map { ($0, .transientFailure) }
+            return (
+                repoResults: Dictionary(
+                    uniqueKeysWithValues: repoDirectoriesBySlug.keys.map { ($0, .transientFailure) }
+                ),
+                rateLimitRetryDate: nil
             )
         }
         var results: [String: WorkspacePullRequestRepoFetchResult] = [:]
@@ -65,7 +74,10 @@ extension PullRequestProbeService {
         for (repoSlug, result) in fetchedResults {
             results[repoSlug] = result
         }
-        return results
+        return (
+            repoResults: results,
+            rateLimitRetryDate: await requestCoordinator.retryDate(authHeader: authHeader)
+        )
     }
 
     /// Fetches one repository: serve from cache when permitted and complete,
@@ -343,10 +355,5 @@ extension PullRequestProbeService {
         authHeader: String?
     ) async -> WorkspacePullRequestHTTPResponse? {
         await requestCoordinator.response(endpoint: endpoint, authHeader: authHeader)
-    }
-
-    /// The GitHub reset deadline currently suppressing transport, if any.
-    public nonisolated func rateLimitRetryDate() async -> Date? {
-        await requestCoordinator.retryDate()
     }
 }

--- a/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
+++ b/Packages/macOS/CmuxGit/Sources/CmuxGit/PullRequestProbeService.swift
@@ -13,13 +13,13 @@ public import CmuxFoundation
 /// 3. ``resolveRefreshResults(candidates:repoResults:)`` — match candidates
 ///    against the fetched data into per-panel ``WorkspacePullRequestRefreshResult``s.
 ///
-/// Like ``GitMetadataService`` it is a stateless `Sendable` value with
-/// `nonisolated async` reads (off the caller's actor, parallel across calls;
-/// see that type's `Important` note on `NonisolatedNonsendingByDefault`). The
-/// repo cache is owned by the caller and passed in. The service only retains a
-/// short-lived auth-header cache so periodic refreshes do not spawn `gh auth
-/// token` on every pass. Authentication uses `GH_TOKEN`/`GITHUB_TOKEN` or
-/// `gh auth token` via the injected ``CmuxProcess/CommandRunning``.
+/// Like ``GitMetadataService`` it is a `Sendable` value with `nonisolated
+/// async` reads. The caller owns its decoded repo cache; this service shares a
+/// request coordinator across every copy so app windows use one authenticated,
+/// conditional, rate-limit-aware GitHub transport. Authentication uses
+/// `GH_TOKEN`/`GITHUB_TOKEN` or `gh auth token` via the injected
+/// ``CmuxProcess/CommandRunning``. Without credentials, requests fail closed
+/// instead of consuming GitHub's anonymous per-IP pool.
 public struct PullRequestProbeService: Sendable {
     /// Runs `gh auth token` for the API auth header. Injected so tests supply a
     /// fake without spawning a process.
@@ -28,6 +28,10 @@ public struct PullRequestProbeService: Sendable {
     /// Caches `gh auth token` results so refresh passes do not repeatedly spawn
     /// the GitHub CLI when the app has no environment token.
     let authHeaderCache: GitHubAuthHeaderCache
+
+    /// Shared transport/cache/backoff policy. Copies of this service retain the
+    /// same actor, which is how every app window coalesces GitHub requests.
+    let requestCoordinator: GitHubPullRequestRequestCoordinator
 
     /// Debug-log sink for probe diagnostics (the app injects its debug logger
     /// in DEBUG builds; defaults to a no-op).
@@ -44,6 +48,7 @@ public struct PullRequestProbeService: Sendable {
     ) {
         self.commandRunner = commandRunner
         self.authHeaderCache = GitHubAuthHeaderCache()
+        self.requestCoordinator = GitHubPullRequestRequestCoordinator()
         self.debugLog = debugLog
     }
 

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitHubPullRequestStub.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitHubPullRequestStub.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+struct GitHubPullRequestStub: Sendable {
+    let statusCode: Int
+    let headers: [String: String]
+    let data: Data
+    let gate: String?
+
+    init(
+        statusCode: Int,
+        headers: [String: String] = [:],
+        data: Data = Data(),
+        gate: String? = nil
+    ) {
+        self.statusCode = statusCode
+        self.headers = headers
+        self.data = data
+        self.gate = gate
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitHubPullRequestStubURLProtocol.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitHubPullRequestStubURLProtocol.swift
@@ -1,0 +1,95 @@
+import Foundation
+
+// URLProtocol callbacks are synchronous, so the lock protects the fixture's small shared snapshot.
+final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Sendable {
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var stubs: [GitHubPullRequestStub] = []
+    nonisolated(unsafe) private static var requests: [URLRequest] = []
+    nonisolated(unsafe) private static var activeRequestCount = 0
+    nonisolated(unsafe) private static var maximumActiveRequestCount = 0
+    nonisolated(unsafe) private static var gatedFinishes: [String: @Sendable () -> Void] = [:]
+    nonisolated(unsafe) private static var requestSignal = GitHubPullRequestTestSignal()
+
+    @discardableResult
+    static func reset(stubs: [GitHubPullRequestStub]) -> GitHubPullRequestTestSignal {
+        lock.lock()
+        self.stubs = stubs
+        requests = []
+        activeRequestCount = 0
+        maximumActiveRequestCount = 0
+        gatedFinishes = [:]
+        let signal = GitHubPullRequestTestSignal()
+        requestSignal = signal
+        lock.unlock()
+        return signal
+    }
+
+    static func capturedRequests() -> [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    static func maximumConcurrentRequestCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return maximumActiveRequestCount
+    }
+
+    static func releaseGate(_ gate: String) {
+        lock.lock()
+        let finish = gatedFinishes.removeValue(forKey: gate)
+        lock.unlock()
+        finish?()
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "api.github.com"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.lock()
+        guard !Self.stubs.isEmpty else {
+            Self.lock.unlock()
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let stub = Self.stubs.removeFirst()
+        Self.activeRequestCount += 1
+        Self.maximumActiveRequestCount = max(Self.maximumActiveRequestCount, Self.activeRequestCount)
+        Self.lock.unlock()
+
+        let finish: @Sendable () -> Void = { [self] in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: stub.statusCode,
+                httpVersion: nil,
+                headerFields: stub.headers
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: stub.data)
+            client?.urlProtocolDidFinishLoading(self)
+            Self.lock.lock()
+            Self.activeRequestCount -= 1
+            Self.lock.unlock()
+        }
+        Self.lock.lock()
+        if let gate = stub.gate { Self.gatedFinishes[gate] = finish }
+        Self.requests.append(request)
+        let requestCount = Self.requests.count
+        let signal = Self.requestSignal
+        Self.lock.unlock()
+        Task { await signal.signal(requestCount) }
+        if stub.gate != nil {
+            return
+        } else {
+            finish()
+        }
+    }
+
+    override func stopLoading() {}
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitHubPullRequestTestSignal.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/Fixtures/GitHubPullRequestTestSignal.swift
@@ -1,0 +1,66 @@
+import Foundation
+
+actor GitHubPullRequestTestSignal {
+    private var value = 0
+    private var waiters: [UUID: (target: Int, continuation: CheckedContinuation<Bool, Never>)] = [:]
+
+    func signal(_ newValue: Int? = nil) {
+        if let newValue {
+            value = max(value, newValue)
+        } else {
+            value += 1
+        }
+        let ready = waiters.filter { $0.value.target <= value }
+        for (id, _) in ready { waiters.removeValue(forKey: id) }
+        for (_, waiter) in ready { waiter.continuation.resume(returning: true) }
+    }
+
+    func wait(until target: Int = 1, timeout: Duration = .seconds(2)) async -> Bool {
+        await withTaskGroup(of: Bool.self) { group in
+            group.addTask { await self.waitWithoutDeadline(until: target) }
+            group.addTask {
+                // A real deadline prevents a broken async test from hanging the suite.
+                do { try await Task.sleep(for: timeout) } catch { return false }
+                return false
+            }
+            let result = await group.next() ?? false
+            group.cancelAll()
+            return result
+        }
+    }
+
+    nonisolated static func waitUntil(
+        timeout: Duration = .seconds(2),
+        condition: @Sendable @escaping () async -> Bool
+    ) async -> Bool {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: timeout)
+        while clock.now < deadline {
+            if await condition() { return true }
+            // This bounded test-only poll observes actor state without a production callback seam.
+            do { try await clock.sleep(for: .milliseconds(1)) } catch { return false }
+        }
+        return await condition()
+    }
+
+    private func waitWithoutDeadline(until target: Int) async -> Bool {
+        guard value < target else { return true }
+        let id = UUID()
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    continuation.resume(returning: false)
+                    return
+                }
+                waiters[id] = (target, continuation)
+            }
+        } onCancel: { [weak self] in
+            guard let self else { return }
+            Task { await self.cancelWaiter(id: id) }
+        }
+    }
+
+    private func cancelWaiter(id: UUID) {
+        waiters.removeValue(forKey: id)?.continuation.resume(returning: false)
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -434,47 +434,45 @@ struct GitHubPullRequestRequestTests {
         }) == ["Bearer first-account-token", "Bearer second-account-token"])
     }
 
-    @Test func coordinatorUsesAtMostOneGitHubConnectionAtATime() async {
-        GitHubPullRequestStubURLProtocol.reset(stubs: [
-            .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
-            .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
-        ])
+    @Test func coordinatorUsesBoundedConcurrentTransportPool() async {
+        let gates = (0..<4).map { "pool-\($0)" }
+        GitHubPullRequestStubURLProtocol.reset(stubs: gates.map { .init(statusCode: 200, gate: $0) })
         let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
-
-        async let recent = coordinator.response(
-            endpoint: endpoint,
-            authHeader: "Bearer test-token"
-        )
-        async let branch = coordinator.response(
-            endpoint: "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:issue-8175",
-            authHeader: "Bearer test-token"
-        )
-        _ = await [recent, branch]
-
-        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 2)
-        #expect(GitHubPullRequestStubURLProtocol.maximumConcurrentRequestCount() == 1)
+        let tasks = gates.indices.map { index in
+            Task { await coordinator.response(endpoint: endpoint + "&page=\(index)", authHeader: "Bearer token") }
+        }
+        await waitForRequestCount(3)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 3)
+        #expect(GitHubPullRequestStubURLProtocol.maximumConcurrentRequestCount() == 3)
+        GitHubPullRequestStubURLProtocol.releaseGate(gates[0])
+        await waitForRequestCount(4)
+        #expect(GitHubPullRequestStubURLProtocol.maximumConcurrentRequestCount() == 3)
+        for gate in gates.dropFirst() { GitHubPullRequestStubURLProtocol.releaseGate(gate) }
+        for task in tasks { #expect(await task.value?.statusCode == 200) }
     }
 
     @Test func cancelingOnlyQueuedWaiterPreventsItsTransport() async {
-        GitHubPullRequestStubURLProtocol.reset(stubs: [
-            .init(statusCode: 200, gate: "predecessor"),
-            .init(statusCode: 200),
-        ])
+        let gates = (0..<3).map { "blocker-\($0)" }
+        let stubs = gates.map { GitHubPullRequestStubURLProtocol.Stub(statusCode: 200, gate: $0) }
+            + [.init(statusCode: 200)]
+        GitHubPullRequestStubURLProtocol.reset(stubs: stubs)
         let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
-        let predecessor = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer token") }
-        await waitForRequestCount(1)
+        let blockers = gates.indices.map { index in
+            Task { await coordinator.response(endpoint: endpoint + "&page=\(index)", authHeader: "Bearer token") }
+        }
+        await waitForRequestCount(3)
         let queued = Task {
-            await coordinator.response(endpoint: endpoint + "&page=2", authHeader: "Bearer token")
+            await coordinator.response(endpoint: endpoint + "&page=queued", authHeader: "Bearer token")
         }
         await Task.yield()
         _ = await coordinator.retryDate(authHeader: "Bearer token")
         queued.cancel()
         await Task.yield()
         _ = await coordinator.retryDate(authHeader: "Bearer token")
-        GitHubPullRequestStubURLProtocol.releaseGate("predecessor")
-        _ = await predecessor.value
+        for gate in gates { GitHubPullRequestStubURLProtocol.releaseGate(gate) }
+        for blocker in blockers { _ = await blocker.value }
         #expect(await queued.value == nil)
-        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 3)
     }
 
     @Test func cancelingOneCoalescedWaiterPreservesTransportForSurvivor() async {

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -153,6 +153,47 @@ struct GitHubPullRequestRequestTests {
         #expect(try #require(requests.last).value(forHTTPHeaderField: "If-None-Match") == "\"issue-8175\"")
     }
 
+    @Test func responseCacheEvictsOldestEndpointAtCountLimit() async {
+        let firstEndpoint = "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:first"
+        let secondEndpoint = "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:second"
+        let thirdEndpoint = "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:third"
+        let firstBody = Data("[{\"number\":1}]".utf8)
+        let secondBody = Data("[{\"number\":2}]".utf8)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, headers: ["ETag": "\"first\""], data: firstBody),
+            .init(statusCode: 200, headers: ["ETag": "\"second\""], data: secondBody),
+            .init(statusCode: 200, headers: ["ETag": "\"third\""], data: Data("[]".utf8)),
+            .init(statusCode: 304),
+            .init(statusCode: 200, data: firstBody),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(maximumCachedResponseCount: 2)
+        let session = makeSession()
+
+        for endpoint in [firstEndpoint, secondEndpoint, thirdEndpoint] {
+            _ = await coordinator.response(
+                endpoint: endpoint,
+                authHeader: "Bearer test-token",
+                sessionOverride: session
+            )
+        }
+        let retained = await coordinator.response(
+            endpoint: secondEndpoint,
+            authHeader: "Bearer test-token",
+            sessionOverride: session
+        )
+        _ = await coordinator.response(
+            endpoint: firstEndpoint,
+            authHeader: "Bearer test-token",
+            sessionOverride: session
+        )
+
+        #expect(retained?.data == secondBody)
+        let requests = GitHubPullRequestStubURLProtocol.capturedRequests()
+        #expect(requests.count == 5)
+        #expect(requests[3].value(forHTTPHeaderField: "If-None-Match") == "\"second\"")
+        #expect(requests[4].value(forHTTPHeaderField: "If-None-Match") == nil)
+    }
+
     @Test func exhaustedRateLimitSuppressesRequestsUntilReset() async {
         let reset = Int(Date().addingTimeInterval(300).timeIntervalSince1970)
         GitHubPullRequestStubURLProtocol.reset(stubs: [
@@ -180,6 +221,68 @@ struct GitHubPullRequestRequestTests {
         )
 
         #expect(suppressed == nil)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+    }
+
+    @Test func permissionDeniedResponseDoesNotTriggerPrimaryRateLimitBackoff() async {
+        let reset = Int(Date().addingTimeInterval(300).timeIntervalSince1970)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(
+                statusCode: 403,
+                headers: [
+                    "X-RateLimit-Remaining": "4999",
+                    "X-RateLimit-Reset": String(reset),
+                ]
+            ),
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let service = PullRequestProbeService()
+        let session = makeSession()
+
+        _ = await service.performRequest(
+            session: session,
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+        let subsequent = await service.performRequest(
+            session: session,
+            endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
+            authHeader: "Bearer test-token"
+        )
+
+        #expect(subsequent?.statusCode == 200)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 2)
+    }
+
+    @Test(arguments: [403, 429])
+    func secondaryRateLimitRetryAfterSuppressesRequestsUntilDeadline(statusCode: Int) async {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(
+                statusCode: statusCode,
+                headers: [
+                    "X-RateLimit-Remaining": "4999",
+                    "Retry-After": "120",
+                ]
+            ),
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(now: { now })
+        let session = makeSession()
+
+        _ = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer test-token",
+            sessionOverride: session
+        )
+        let suppressed = await coordinator.response(
+            endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
+            authHeader: "Bearer test-token",
+            sessionOverride: session
+        )
+
+        #expect(suppressed == nil)
+        #expect(await coordinator.retryDate() == now.addingTimeInterval(120))
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
     }
 

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -153,6 +153,42 @@ struct GitHubPullRequestRequestTests {
         #expect(try #require(requests.last).value(forHTTPHeaderField: "If-None-Match") == "\"issue-8175\"")
     }
 
+    @Test func changedCredentialDoesNotReuseETagOrCachedBody() async {
+        let firstBody = Data("[{\"number\":8175}]".utf8)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, headers: ["ETag": "\"first-account\""], data: firstBody),
+            .init(statusCode: 304),
+            .init(statusCode: 304),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator()
+        let session = makeSession()
+
+        _ = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer first-account-token",
+            sessionOverride: session
+        )
+        let changedAccountResponse = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer second-account-token",
+            sessionOverride: session
+        )
+        let originalAccountResponse = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer first-account-token",
+            sessionOverride: session
+        )
+
+        #expect(changedAccountResponse?.statusCode == 304)
+        #expect(changedAccountResponse?.data.isEmpty == true)
+        #expect(originalAccountResponse?.statusCode == 200)
+        #expect(originalAccountResponse?.data == firstBody)
+        let requests = GitHubPullRequestStubURLProtocol.capturedRequests()
+        #expect(requests.count == 3)
+        #expect(requests[1].value(forHTTPHeaderField: "If-None-Match") == nil)
+        #expect(requests[2].value(forHTTPHeaderField: "If-None-Match") == "\"first-account\"")
+    }
+
     @Test func responseCacheEvictsOldestEndpointAtCountLimit() async {
         let firstEndpoint = "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:first"
         let secondEndpoint = "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:second"
@@ -222,6 +258,45 @@ struct GitHubPullRequestRequestTests {
 
         #expect(suppressed == nil)
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+    }
+
+    @Test func exhaustedCredentialDoesNotBackOffChangedCredential() async {
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = Int(now.addingTimeInterval(300).timeIntervalSince1970)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(
+                statusCode: 403,
+                headers: [
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": String(reset),
+                ]
+            ),
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(now: { now })
+        let session = makeSession()
+
+        _ = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer exhausted-token",
+            sessionOverride: session
+        )
+        let changedCredentialResponse = await coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer available-token",
+            sessionOverride: session
+        )
+        let changedCredentialRetryDate = await coordinator.retryDate()
+        let originalCredentialResponse = await coordinator.response(
+            endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
+            authHeader: "Bearer exhausted-token",
+            sessionOverride: session
+        )
+
+        #expect(changedCredentialResponse?.statusCode == 200)
+        #expect(changedCredentialRetryDate == nil)
+        #expect(originalCredentialResponse == nil)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 2)
     }
 
     @Test func permissionDeniedResponseDoesNotTriggerPrimaryRateLimitBackoff() async {
@@ -309,6 +384,33 @@ struct GitHubPullRequestRequestTests {
 
         #expect(responses.allSatisfy { $0?.statusCode == 200 && $0?.data == body })
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+    }
+
+    @Test func changedCredentialDoesNotJoinInFlightEndpointRequest() async {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator()
+        let session = makeSession()
+
+        async let first = coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer first-account-token",
+            sessionOverride: session
+        )
+        async let second = coordinator.response(
+            endpoint: endpoint,
+            authHeader: "Bearer second-account-token",
+            sessionOverride: session
+        )
+        _ = await [first, second]
+
+        let requests = GitHubPullRequestStubURLProtocol.capturedRequests()
+        #expect(requests.count == 2)
+        #expect(Set(requests.compactMap {
+            $0.value(forHTTPHeaderField: "Authorization")
+        }) == ["Bearer first-account-token", "Bearer second-account-token"])
     }
 
     @Test func serviceCopiesUseAtMostOneGitHubConnectionAtATime() async {

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -278,14 +278,23 @@ struct GitHubPullRequestRequestTests {
             endpoint: endpoint,
             authHeader: "Bearer available-token"
         )
-        let changedCredentialRetryDate = await coordinator.retryDate()
+        let exhaustedCredentialRetryDate = await coordinator.retryDate(
+            authHeader: "Bearer exhausted-token"
+        )
+        let availableCredentialRetryDate = await coordinator.retryDate(
+            authHeader: "Bearer available-token"
+        )
+        let expectedExhaustedRetryDate = Date(
+            timeIntervalSince1970: TimeInterval(reset + 1)
+        )
         let originalCredentialResponse = await coordinator.response(
             endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
             authHeader: "Bearer exhausted-token"
         )
 
         #expect(changedCredentialResponse?.statusCode == 200)
-        #expect(changedCredentialRetryDate == nil)
+        #expect(exhaustedCredentialRetryDate == expectedExhaustedRetryDate)
+        #expect(availableCredentialRetryDate == nil)
         #expect(originalCredentialResponse == nil)
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 2)
     }
@@ -349,7 +358,10 @@ struct GitHubPullRequestRequestTests {
         )
 
         #expect(suppressed == nil)
-        #expect(await coordinator.retryDate() == now.addingTimeInterval(120))
+        #expect(
+            await coordinator.retryDate(authHeader: "Bearer test-token")
+                == now.addingTimeInterval(120)
+        )
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
     }
 

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -2,119 +2,6 @@ import Foundation
 import Testing
 @testable import CmuxGit
 
-private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Sendable {
-    struct Stub: Sendable {
-        let statusCode: Int
-        let headers: [String: String]
-        let data: Data
-        let delay: TimeInterval
-        let gate: String?
-
-        init(
-            statusCode: Int,
-            headers: [String: String] = [:],
-            data: Data = Data(),
-            delay: TimeInterval = 0,
-            gate: String? = nil
-        ) {
-            self.statusCode = statusCode
-            self.headers = headers
-            self.data = data
-            self.delay = delay
-            self.gate = gate
-        }
-    }
-
-    private static let lock = NSLock()
-    nonisolated(unsafe) private static var stubs: [Stub] = []
-    nonisolated(unsafe) private static var requests: [URLRequest] = []
-    nonisolated(unsafe) private static var activeRequestCount = 0
-    nonisolated(unsafe) private static var maximumActiveRequestCount = 0
-    nonisolated(unsafe) private static var gatedFinishes: [String: @Sendable () -> Void] = [:]
-
-    static func reset(stubs: [Stub]) {
-        lock.lock()
-        self.stubs = stubs
-        requests = []
-        activeRequestCount = 0
-        maximumActiveRequestCount = 0
-        gatedFinishes = [:]
-        lock.unlock()
-    }
-
-    static func capturedRequests() -> [URLRequest] {
-        lock.lock()
-        defer { lock.unlock() }
-        return requests
-    }
-
-    static func maximumConcurrentRequestCount() -> Int {
-        lock.lock()
-        defer { lock.unlock() }
-        return maximumActiveRequestCount
-    }
-
-    static func releaseGate(_ gate: String) {
-        lock.lock()
-        let finish = gatedFinishes.removeValue(forKey: gate)
-        lock.unlock()
-        finish?()
-    }
-
-    override class func canInit(with request: URLRequest) -> Bool {
-        request.url?.host == "api.github.com"
-    }
-
-    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
-        request
-    }
-
-    override func startLoading() {
-        Self.lock.lock()
-        guard !Self.stubs.isEmpty else {
-            Self.lock.unlock()
-            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
-            return
-        }
-        let stub = Self.stubs.removeFirst()
-        Self.activeRequestCount += 1
-        Self.maximumActiveRequestCount = max(
-            Self.maximumActiveRequestCount,
-            Self.activeRequestCount
-        )
-        Self.lock.unlock()
-
-        let finish: @Sendable () -> Void = { [self] in
-            let response = HTTPURLResponse(
-                url: request.url!,
-                statusCode: stub.statusCode,
-                httpVersion: nil,
-                headerFields: stub.headers
-            )!
-            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
-            client?.urlProtocol(self, didLoad: stub.data)
-            client?.urlProtocolDidFinishLoading(self)
-
-            Self.lock.lock()
-            Self.activeRequestCount -= 1
-            Self.lock.unlock()
-        }
-        Self.lock.lock()
-        if let gate = stub.gate { Self.gatedFinishes[gate] = finish }
-        Self.requests.append(request)
-        Self.lock.unlock()
-        if stub.gate != nil {
-            return
-        } else if stub.delay > 0 {
-            DispatchQueue.global().asyncAfter(deadline: .now() + stub.delay, execute: finish)
-        } else {
-            finish()
-        }
-    }
-
-    override func stopLoading() {}
-}
-
 @Suite(.serialized)
 struct GitHubPullRequestRequestTests {
     private let endpoint = "repos/manaflow-ai/cmux/pulls?state=all"
@@ -122,13 +9,9 @@ struct GitHubPullRequestRequestTests {
     private func makeSession() -> URLSession {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [GitHubPullRequestStubURLProtocol.self]
+        configuration.timeoutIntervalForRequest = 2
+        configuration.timeoutIntervalForResource = 2
         return URLSession(configuration: configuration)
-    }
-
-    private func waitForRequestCount(_ count: Int) async {
-        while GitHubPullRequestStubURLProtocol.capturedRequests().count < count {
-            await Task.yield()
-        }
     }
 
     @Test func missingCredentialsNeverStartsAnonymousTransport() async {
@@ -390,62 +273,60 @@ struct GitHubPullRequestRequestTests {
 
     @Test func duplicateEndpointRequestsShareOneInFlightTransport() async {
         let body = Data("[]".utf8)
-        GitHubPullRequestStubURLProtocol.reset(stubs: [
-            .init(statusCode: 200, data: body, delay: 0.05),
-            .init(statusCode: 200, data: body, delay: 0.05),
+        let requestsStarted = GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: body, gate: "shared"),
+            .init(statusCode: 200, data: body),
         ])
         let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
-
-        async let first = coordinator.response(
-            endpoint: endpoint,
-            authHeader: "Bearer test-token"
-        )
-        async let second = coordinator.response(
-            endpoint: endpoint,
-            authHeader: "Bearer test-token"
-        )
-        let responses = await [first, second]
+        let first = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer test-token") }
+        #expect(await requestsStarted.wait())
+        let second = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer test-token") }
+        #expect(await GitHubPullRequestTestSignal.waitUntil {
+            let inFlight = await coordinator.inFlightRequestByRequestKey
+            return inFlight.values.first?.waiterIDs.count == 2
+        })
+        GitHubPullRequestStubURLProtocol.releaseGate("shared")
+        let responses = await [first.value, second.value]
 
         #expect(responses.allSatisfy { $0?.statusCode == 200 && $0?.data == body })
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
     }
 
     @Test func changedCredentialDoesNotJoinInFlightEndpointRequest() async {
-        GitHubPullRequestStubURLProtocol.reset(stubs: [
-            .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
-            .init(statusCode: 200, data: Data("[]".utf8)),
+        let requestsStarted = GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, gate: "first"),
+            .init(statusCode: 200, gate: "second"),
         ])
         let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
-
-        async let first = coordinator.response(
-            endpoint: endpoint,
-            authHeader: "Bearer first-account-token"
-        )
-        async let second = coordinator.response(
-            endpoint: endpoint,
-            authHeader: "Bearer second-account-token"
-        )
-        _ = await [first, second]
+        let first = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer first-token") }
+        #expect(await requestsStarted.wait())
+        let second = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer second-token") }
+        #expect(await requestsStarted.wait(until: 2))
+        GitHubPullRequestStubURLProtocol.releaseGate("first")
+        GitHubPullRequestStubURLProtocol.releaseGate("second")
+        _ = await [first.value, second.value]
 
         let requests = GitHubPullRequestStubURLProtocol.capturedRequests()
         #expect(requests.count == 2)
         #expect(Set(requests.compactMap {
             $0.value(forHTTPHeaderField: "Authorization")
-        }) == ["Bearer first-account-token", "Bearer second-account-token"])
+        }) == ["Bearer first-token", "Bearer second-token"])
     }
 
     @Test func coordinatorUsesBoundedConcurrentTransportPool() async {
         let gates = (0..<4).map { "pool-\($0)" }
-        GitHubPullRequestStubURLProtocol.reset(stubs: gates.map { .init(statusCode: 200, gate: $0) })
+        let requestsStarted = GitHubPullRequestStubURLProtocol.reset(
+            stubs: gates.map { .init(statusCode: 200, gate: $0) }
+        )
         let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
         let tasks = gates.indices.map { index in
             Task { await coordinator.response(endpoint: endpoint + "&page=\(index)", authHeader: "Bearer token") }
         }
-        await waitForRequestCount(3)
+        #expect(await requestsStarted.wait(until: 3))
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 3)
         #expect(GitHubPullRequestStubURLProtocol.maximumConcurrentRequestCount() == 3)
         GitHubPullRequestStubURLProtocol.releaseGate(gates[0])
-        await waitForRequestCount(4)
+        #expect(await requestsStarted.wait(until: 4))
         #expect(GitHubPullRequestStubURLProtocol.maximumConcurrentRequestCount() == 3)
         for gate in gates.dropFirst() { GitHubPullRequestStubURLProtocol.releaseGate(gate) }
         for task in tasks { #expect(await task.value?.statusCode == 200) }
@@ -453,22 +334,28 @@ struct GitHubPullRequestRequestTests {
 
     @Test func cancelingOnlyQueuedWaiterPreventsItsTransport() async {
         let gates = (0..<3).map { "blocker-\($0)" }
-        let stubs = gates.map { GitHubPullRequestStubURLProtocol.Stub(statusCode: 200, gate: $0) }
+        let stubs = gates.map { GitHubPullRequestStub(statusCode: 200, gate: $0) }
             + [.init(statusCode: 200)]
-        GitHubPullRequestStubURLProtocol.reset(stubs: stubs)
+        let requestsStarted = GitHubPullRequestStubURLProtocol.reset(stubs: stubs)
         let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
         let blockers = gates.indices.map { index in
             Task { await coordinator.response(endpoint: endpoint + "&page=\(index)", authHeader: "Bearer token") }
         }
-        await waitForRequestCount(3)
+        #expect(await requestsStarted.wait(until: 3))
+        let cancellationFinished = GitHubPullRequestTestSignal()
         let queued = Task {
-            await coordinator.response(endpoint: endpoint + "&page=queued", authHeader: "Bearer token")
+            let response = await coordinator.response(
+                endpoint: endpoint + "&page=queued",
+                authHeader: "Bearer token"
+            )
+            await cancellationFinished.signal()
+            return response
         }
-        await Task.yield()
-        _ = await coordinator.retryDate(authHeader: "Bearer token")
+        #expect(await GitHubPullRequestTestSignal.waitUntil {
+            await coordinator.queuedTransports.count == 1
+        })
         queued.cancel()
-        await Task.yield()
-        _ = await coordinator.retryDate(authHeader: "Bearer token")
+        #expect(await cancellationFinished.wait())
         for gate in gates { GitHubPullRequestStubURLProtocol.releaseGate(gate) }
         for blocker in blockers { _ = await blocker.value }
         #expect(await queued.value == nil)
@@ -476,15 +363,17 @@ struct GitHubPullRequestRequestTests {
     }
 
     @Test func cancelingOneCoalescedWaiterPreservesTransportForSurvivor() async {
-        GitHubPullRequestStubURLProtocol.reset(stubs: [
+        let requestsStarted = GitHubPullRequestStubURLProtocol.reset(stubs: [
             .init(statusCode: 200, data: Data("[]".utf8), gate: "shared"),
         ])
         let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
         let canceled = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer token") }
-        await waitForRequestCount(1)
+        #expect(await requestsStarted.wait())
         let survivor = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer token") }
-        await Task.yield()
-        _ = await coordinator.retryDate(authHeader: "Bearer token")
+        #expect(await GitHubPullRequestTestSignal.waitUntil {
+            let inFlight = await coordinator.inFlightRequestByRequestKey
+            return inFlight.values.first?.waiterIDs.count == 2
+        })
         canceled.cancel()
         GitHubPullRequestStubURLProtocol.releaseGate("shared")
 

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -8,17 +8,20 @@ private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Se
         let headers: [String: String]
         let data: Data
         let delay: TimeInterval
+        let gate: String?
 
         init(
             statusCode: Int,
             headers: [String: String] = [:],
             data: Data = Data(),
-            delay: TimeInterval = 0
+            delay: TimeInterval = 0,
+            gate: String? = nil
         ) {
             self.statusCode = statusCode
             self.headers = headers
             self.data = data
             self.delay = delay
+            self.gate = gate
         }
     }
 
@@ -27,6 +30,7 @@ private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Se
     nonisolated(unsafe) private static var requests: [URLRequest] = []
     nonisolated(unsafe) private static var activeRequestCount = 0
     nonisolated(unsafe) private static var maximumActiveRequestCount = 0
+    nonisolated(unsafe) private static var gatedFinishes: [String: @Sendable () -> Void] = [:]
 
     static func reset(stubs: [Stub]) {
         lock.lock()
@@ -34,6 +38,7 @@ private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Se
         requests = []
         activeRequestCount = 0
         maximumActiveRequestCount = 0
+        gatedFinishes = [:]
         lock.unlock()
     }
 
@@ -47,6 +52,13 @@ private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Se
         lock.lock()
         defer { lock.unlock() }
         return maximumActiveRequestCount
+    }
+
+    static func releaseGate(_ gate: String) {
+        lock.lock()
+        let finish = gatedFinishes.removeValue(forKey: gate)
+        lock.unlock()
+        finish?()
     }
 
     override class func canInit(with request: URLRequest) -> Bool {
@@ -65,7 +77,6 @@ private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Se
             return
         }
         let stub = Self.stubs.removeFirst()
-        Self.requests.append(request)
         Self.activeRequestCount += 1
         Self.maximumActiveRequestCount = max(
             Self.maximumActiveRequestCount,
@@ -88,7 +99,13 @@ private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Se
             Self.activeRequestCount -= 1
             Self.lock.unlock()
         }
-        if stub.delay > 0 {
+        Self.lock.lock()
+        if let gate = stub.gate { Self.gatedFinishes[gate] = finish }
+        Self.requests.append(request)
+        Self.lock.unlock()
+        if stub.gate != nil {
+            return
+        } else if stub.delay > 0 {
             DispatchQueue.global().asyncAfter(deadline: .now() + stub.delay, execute: finish)
         } else {
             finish()
@@ -106,6 +123,12 @@ struct GitHubPullRequestRequestTests {
         let configuration = URLSessionConfiguration.ephemeral
         configuration.protocolClasses = [GitHubPullRequestStubURLProtocol.self]
         return URLSession(configuration: configuration)
+    }
+
+    private func waitForRequestCount(_ count: Int) async {
+        while GitHubPullRequestStubURLProtocol.capturedRequests().count < count {
+            await Task.yield()
+        }
     }
 
     @Test func missingCredentialsNeverStartsAnonymousTransport() async {
@@ -430,5 +453,45 @@ struct GitHubPullRequestRequestTests {
 
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 2)
         #expect(GitHubPullRequestStubURLProtocol.maximumConcurrentRequestCount() == 1)
+    }
+
+    @Test func cancelingOnlyQueuedWaiterPreventsItsTransport() async {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, gate: "predecessor"),
+            .init(statusCode: 200),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
+        let predecessor = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer token") }
+        await waitForRequestCount(1)
+        let queued = Task {
+            await coordinator.response(endpoint: endpoint + "&page=2", authHeader: "Bearer token")
+        }
+        await Task.yield()
+        _ = await coordinator.retryDate(authHeader: "Bearer token")
+        queued.cancel()
+        await Task.yield()
+        _ = await coordinator.retryDate(authHeader: "Bearer token")
+        GitHubPullRequestStubURLProtocol.releaseGate("predecessor")
+        _ = await predecessor.value
+        #expect(await queued.value == nil)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+    }
+
+    @Test func cancelingOneCoalescedWaiterPreservesTransportForSurvivor() async {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: Data("[]".utf8), gate: "shared"),
+        ])
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
+        let canceled = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer token") }
+        await waitForRequestCount(1)
+        let survivor = Task { await coordinator.response(endpoint: endpoint, authHeader: "Bearer token") }
+        await Task.yield()
+        _ = await coordinator.retryDate(authHeader: "Bearer token")
+        canceled.cancel()
+        GitHubPullRequestStubURLProtocol.releaseGate("shared")
+
+        #expect(await canceled.value == nil)
+        #expect(await survivor.value?.statusCode == 200)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
     }
 }

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -1,0 +1,233 @@
+import Foundation
+import Testing
+@testable import CmuxGit
+
+private final class GitHubPullRequestStubURLProtocol: URLProtocol, @unchecked Sendable {
+    struct Stub: Sendable {
+        let statusCode: Int
+        let headers: [String: String]
+        let data: Data
+        let delay: TimeInterval
+
+        init(
+            statusCode: Int,
+            headers: [String: String] = [:],
+            data: Data = Data(),
+            delay: TimeInterval = 0
+        ) {
+            self.statusCode = statusCode
+            self.headers = headers
+            self.data = data
+            self.delay = delay
+        }
+    }
+
+    private static let lock = NSLock()
+    nonisolated(unsafe) private static var stubs: [Stub] = []
+    nonisolated(unsafe) private static var requests: [URLRequest] = []
+    nonisolated(unsafe) private static var activeRequestCount = 0
+    nonisolated(unsafe) private static var maximumActiveRequestCount = 0
+
+    static func reset(stubs: [Stub]) {
+        lock.lock()
+        self.stubs = stubs
+        requests = []
+        activeRequestCount = 0
+        maximumActiveRequestCount = 0
+        lock.unlock()
+    }
+
+    static func capturedRequests() -> [URLRequest] {
+        lock.lock()
+        defer { lock.unlock() }
+        return requests
+    }
+
+    static func maximumConcurrentRequestCount() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return maximumActiveRequestCount
+    }
+
+    override class func canInit(with request: URLRequest) -> Bool {
+        request.url?.host == "api.github.com"
+    }
+
+    override class func canonicalRequest(for request: URLRequest) -> URLRequest {
+        request
+    }
+
+    override func startLoading() {
+        Self.lock.lock()
+        guard !Self.stubs.isEmpty else {
+            Self.lock.unlock()
+            client?.urlProtocol(self, didFailWithError: URLError(.badServerResponse))
+            return
+        }
+        let stub = Self.stubs.removeFirst()
+        Self.requests.append(request)
+        Self.activeRequestCount += 1
+        Self.maximumActiveRequestCount = max(
+            Self.maximumActiveRequestCount,
+            Self.activeRequestCount
+        )
+        Self.lock.unlock()
+
+        let finish: @Sendable () -> Void = { [self] in
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: stub.statusCode,
+                httpVersion: nil,
+                headerFields: stub.headers
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: stub.data)
+            client?.urlProtocolDidFinishLoading(self)
+
+            Self.lock.lock()
+            Self.activeRequestCount -= 1
+            Self.lock.unlock()
+        }
+        if stub.delay > 0 {
+            DispatchQueue.global().asyncAfter(deadline: .now() + stub.delay, execute: finish)
+        } else {
+            finish()
+        }
+    }
+
+    override func stopLoading() {}
+}
+
+@Suite(.serialized)
+struct GitHubPullRequestRequestTests {
+    private let endpoint = "repos/manaflow-ai/cmux/pulls?state=all"
+
+    private func makeSession() -> URLSession {
+        let configuration = URLSessionConfiguration.ephemeral
+        configuration.protocolClasses = [GitHubPullRequestStubURLProtocol.self]
+        return URLSession(configuration: configuration)
+    }
+
+    @Test func missingCredentialsNeverStartsAnonymousTransport() async {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let service = PullRequestProbeService()
+
+        let response = await service.performRequest(
+            session: makeSession(),
+            endpoint: endpoint,
+            authHeader: nil
+        )
+
+        #expect(response == nil)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().isEmpty)
+    }
+
+    @Test func cachedETagRevalidatesAndReusesBodyAfterNotModified() async throws {
+        let body = Data("[{\"number\":8175}]".utf8)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, headers: ["ETag": "\"issue-8175\""], data: body),
+            .init(statusCode: 304),
+        ])
+        let service = PullRequestProbeService()
+        let session = makeSession()
+
+        let first = await service.performRequest(
+            session: session,
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+        let second = await service.performRequest(
+            session: session,
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+
+        #expect(first?.statusCode == 200)
+        #expect(first?.data == body)
+        #expect(second?.statusCode == 200)
+        #expect(second?.data == body)
+        let requests = GitHubPullRequestStubURLProtocol.capturedRequests()
+        #expect(requests.count == 2)
+        #expect(try #require(requests.last).value(forHTTPHeaderField: "If-None-Match") == "\"issue-8175\"")
+    }
+
+    @Test func exhaustedRateLimitSuppressesRequestsUntilReset() async {
+        let reset = Int(Date().addingTimeInterval(300).timeIntervalSince1970)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(
+                statusCode: 403,
+                headers: [
+                    "X-RateLimit-Remaining": "0",
+                    "X-RateLimit-Reset": String(reset),
+                ]
+            ),
+            .init(statusCode: 200, data: Data("[]".utf8)),
+        ])
+        let service = PullRequestProbeService()
+        let session = makeSession()
+
+        _ = await service.performRequest(
+            session: session,
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+        let suppressed = await service.performRequest(
+            session: session,
+            endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
+            authHeader: "Bearer test-token"
+        )
+
+        #expect(suppressed == nil)
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+    }
+
+    @Test func duplicateEndpointRequestsShareOneInFlightTransport() async {
+        let body = Data("[]".utf8)
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: body, delay: 0.05),
+            .init(statusCode: 200, data: body, delay: 0.05),
+        ])
+        let service = PullRequestProbeService()
+        let session = makeSession()
+
+        async let first = service.performRequest(
+            session: session,
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+        async let second = service.performRequest(
+            session: session,
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+        let responses = await [first, second]
+
+        #expect(responses.allSatisfy { $0?.statusCode == 200 && $0?.data == body })
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
+    }
+
+    @Test func distinctEndpointsUseAtMostOneGitHubConnectionAtATime() async {
+        GitHubPullRequestStubURLProtocol.reset(stubs: [
+            .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
+            .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
+        ])
+        let service = PullRequestProbeService()
+
+        async let recent = service.performRequest(
+            session: makeSession(),
+            endpoint: endpoint,
+            authHeader: "Bearer test-token"
+        )
+        async let branch = service.performRequest(
+            session: makeSession(),
+            endpoint: "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:issue-8175",
+            authHeader: "Bearer test-token"
+        )
+        _ = await [recent, branch]
+
+        #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 2)
+        #expect(GitHubPullRequestStubURLProtocol.maximumConcurrentRequestCount() == 1)
+    }
+}

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -112,10 +112,9 @@ struct GitHubPullRequestRequestTests {
         GitHubPullRequestStubURLProtocol.reset(stubs: [
             .init(statusCode: 200, data: Data("[]".utf8)),
         ])
-        let service = PullRequestProbeService()
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
 
-        let response = await service.performRequest(
-            session: makeSession(),
+        let response = await coordinator.response(
             endpoint: endpoint,
             authHeader: nil
         )
@@ -130,16 +129,13 @@ struct GitHubPullRequestRequestTests {
             .init(statusCode: 200, headers: ["ETag": "\"issue-8175\""], data: body),
             .init(statusCode: 304),
         ])
-        let service = PullRequestProbeService()
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
 
-        let first = await service.performRequest(
-            session: session,
+        let first = await coordinator.response(
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
-        let second = await service.performRequest(
-            session: session,
+        let second = await coordinator.response(
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
@@ -160,23 +156,19 @@ struct GitHubPullRequestRequestTests {
             .init(statusCode: 304),
             .init(statusCode: 304),
         ])
-        let coordinator = GitHubPullRequestRequestCoordinator()
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
 
         _ = await coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer first-account-token",
-            sessionOverride: session
+            authHeader: "Bearer first-account-token"
         )
         let changedAccountResponse = await coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer second-account-token",
-            sessionOverride: session
+            authHeader: "Bearer second-account-token"
         )
         let originalAccountResponse = await coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer first-account-token",
-            sessionOverride: session
+            authHeader: "Bearer first-account-token"
         )
 
         #expect(changedAccountResponse?.statusCode == 304)
@@ -202,25 +194,24 @@ struct GitHubPullRequestRequestTests {
             .init(statusCode: 304),
             .init(statusCode: 200, data: firstBody),
         ])
-        let coordinator = GitHubPullRequestRequestCoordinator(maximumCachedResponseCount: 2)
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(
+            session: makeSession(),
+            maximumCachedResponseCount: 2
+        )
 
         for endpoint in [firstEndpoint, secondEndpoint, thirdEndpoint] {
             _ = await coordinator.response(
                 endpoint: endpoint,
-                authHeader: "Bearer test-token",
-                sessionOverride: session
+                authHeader: "Bearer test-token"
             )
         }
         let retained = await coordinator.response(
             endpoint: secondEndpoint,
-            authHeader: "Bearer test-token",
-            sessionOverride: session
+            authHeader: "Bearer test-token"
         )
         _ = await coordinator.response(
             endpoint: firstEndpoint,
-            authHeader: "Bearer test-token",
-            sessionOverride: session
+            authHeader: "Bearer test-token"
         )
 
         #expect(retained?.data == secondBody)
@@ -231,7 +222,8 @@ struct GitHubPullRequestRequestTests {
     }
 
     @Test func exhaustedRateLimitSuppressesRequestsUntilReset() async {
-        let reset = Int(Date().addingTimeInterval(300).timeIntervalSince1970)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = Int(now.addingTimeInterval(300).timeIntervalSince1970)
         GitHubPullRequestStubURLProtocol.reset(stubs: [
             .init(
                 statusCode: 403,
@@ -242,16 +234,16 @@ struct GitHubPullRequestRequestTests {
             ),
             .init(statusCode: 200, data: Data("[]".utf8)),
         ])
-        let service = PullRequestProbeService()
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(
+            session: makeSession(),
+            now: { now }
+        )
 
-        _ = await service.performRequest(
-            session: session,
+        _ = await coordinator.response(
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
-        let suppressed = await service.performRequest(
-            session: session,
+        let suppressed = await coordinator.response(
             endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
             authHeader: "Bearer test-token"
         )
@@ -273,24 +265,23 @@ struct GitHubPullRequestRequestTests {
             ),
             .init(statusCode: 200, data: Data("[]".utf8)),
         ])
-        let coordinator = GitHubPullRequestRequestCoordinator(now: { now })
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(
+            session: makeSession(),
+            now: { now }
+        )
 
         _ = await coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer exhausted-token",
-            sessionOverride: session
+            authHeader: "Bearer exhausted-token"
         )
         let changedCredentialResponse = await coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer available-token",
-            sessionOverride: session
+            authHeader: "Bearer available-token"
         )
         let changedCredentialRetryDate = await coordinator.retryDate()
         let originalCredentialResponse = await coordinator.response(
             endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
-            authHeader: "Bearer exhausted-token",
-            sessionOverride: session
+            authHeader: "Bearer exhausted-token"
         )
 
         #expect(changedCredentialResponse?.statusCode == 200)
@@ -300,7 +291,8 @@ struct GitHubPullRequestRequestTests {
     }
 
     @Test func permissionDeniedResponseDoesNotTriggerPrimaryRateLimitBackoff() async {
-        let reset = Int(Date().addingTimeInterval(300).timeIntervalSince1970)
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let reset = Int(now.addingTimeInterval(300).timeIntervalSince1970)
         GitHubPullRequestStubURLProtocol.reset(stubs: [
             .init(
                 statusCode: 403,
@@ -311,16 +303,16 @@ struct GitHubPullRequestRequestTests {
             ),
             .init(statusCode: 200, data: Data("[]".utf8)),
         ])
-        let service = PullRequestProbeService()
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(
+            session: makeSession(),
+            now: { now }
+        )
 
-        _ = await service.performRequest(
-            session: session,
+        _ = await coordinator.response(
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
-        let subsequent = await service.performRequest(
-            session: session,
+        let subsequent = await coordinator.response(
             endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
             authHeader: "Bearer test-token"
         )
@@ -342,18 +334,18 @@ struct GitHubPullRequestRequestTests {
             ),
             .init(statusCode: 200, data: Data("[]".utf8)),
         ])
-        let coordinator = GitHubPullRequestRequestCoordinator(now: { now })
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(
+            session: makeSession(),
+            now: { now }
+        )
 
         _ = await coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer test-token",
-            sessionOverride: session
+            authHeader: "Bearer test-token"
         )
         let suppressed = await coordinator.response(
             endpoint: "repos/manaflow-ai/cmux/pulls?state=open",
-            authHeader: "Bearer test-token",
-            sessionOverride: session
+            authHeader: "Bearer test-token"
         )
 
         #expect(suppressed == nil)
@@ -367,16 +359,13 @@ struct GitHubPullRequestRequestTests {
             .init(statusCode: 200, data: body, delay: 0.05),
             .init(statusCode: 200, data: body, delay: 0.05),
         ])
-        let service = PullRequestProbeService()
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
 
-        async let first = service.performRequest(
-            session: session,
+        async let first = coordinator.response(
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
-        async let second = service.performRequest(
-            session: session,
+        async let second = coordinator.response(
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
@@ -391,18 +380,15 @@ struct GitHubPullRequestRequestTests {
             .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
             .init(statusCode: 200, data: Data("[]".utf8)),
         ])
-        let coordinator = GitHubPullRequestRequestCoordinator()
-        let session = makeSession()
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
 
         async let first = coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer first-account-token",
-            sessionOverride: session
+            authHeader: "Bearer first-account-token"
         )
         async let second = coordinator.response(
             endpoint: endpoint,
-            authHeader: "Bearer second-account-token",
-            sessionOverride: session
+            authHeader: "Bearer second-account-token"
         )
         _ = await [first, second]
 
@@ -413,21 +399,18 @@ struct GitHubPullRequestRequestTests {
         }) == ["Bearer first-account-token", "Bearer second-account-token"])
     }
 
-    @Test func serviceCopiesUseAtMostOneGitHubConnectionAtATime() async {
+    @Test func coordinatorUsesAtMostOneGitHubConnectionAtATime() async {
         GitHubPullRequestStubURLProtocol.reset(stubs: [
             .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
             .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
         ])
-        let service = PullRequestProbeService()
-        let secondWindowService = service
+        let coordinator = GitHubPullRequestRequestCoordinator(session: makeSession())
 
-        async let recent = service.performRequest(
-            session: makeSession(),
+        async let recent = coordinator.response(
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
-        async let branch = secondWindowService.performRequest(
-            session: makeSession(),
+        async let branch = coordinator.response(
             endpoint: "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:issue-8175",
             authHeader: "Bearer test-token"
         )

--- a/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
+++ b/Packages/macOS/CmuxGit/Tests/CmuxGitTests/GitHubPullRequestRequestTests.swift
@@ -208,19 +208,20 @@ struct GitHubPullRequestRequestTests {
         #expect(GitHubPullRequestStubURLProtocol.capturedRequests().count == 1)
     }
 
-    @Test func distinctEndpointsUseAtMostOneGitHubConnectionAtATime() async {
+    @Test func serviceCopiesUseAtMostOneGitHubConnectionAtATime() async {
         GitHubPullRequestStubURLProtocol.reset(stubs: [
             .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
             .init(statusCode: 200, data: Data("[]".utf8), delay: 0.05),
         ])
         let service = PullRequestProbeService()
+        let secondWindowService = service
 
         async let recent = service.performRequest(
             session: makeSession(),
             endpoint: endpoint,
             authHeader: "Bearer test-token"
         )
-        async let branch = service.performRequest(
+        async let branch = secondWindowService.performRequest(
             session: makeSession(),
             endpoint: "repos/manaflow-ai/cmux/pulls?head=manaflow-ai:issue-8175",
             authHeader: "Bearer test-token"

--- a/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Detail/SidebarWorkspaceAuxiliaryDetailVisibility.swift
+++ b/Packages/macOS/CmuxSidebar/Sources/CmuxSidebar/Detail/SidebarWorkspaceAuxiliaryDetailVisibility.swift
@@ -21,6 +21,18 @@ public struct SidebarWorkspaceAuxiliaryDetailVisibility: Equatable, Sendable {
     /// Whether forwarded-port rows are shown.
     public let showsPorts: Bool
 
+    /// Local git metadata is needed only when at least one git-backed detail
+    /// row is visible. Callers combine this with the user's master
+    /// `watchGitStatus` preference.
+    public var requiresGitMetadata: Bool {
+        showsBranchDirectory || showsPullRequests
+    }
+
+    /// GitHub polling is useful only while the pull-request row is visible.
+    public var requiresPullRequestPolling: Bool {
+        showsPullRequests
+    }
+
     /// Creates a visibility value with each row's flag as given.
     public init(
         showsMetadata: Bool,

--- a/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/SidebarDetailVisibilityTests.swift
+++ b/Packages/macOS/CmuxSidebar/Tests/CmuxSidebarTests/SidebarDetailVisibilityTests.swift
@@ -34,6 +34,51 @@ struct SidebarWorkspaceDetailVisibilityTests {
 
 @Suite("SidebarWorkspaceAuxiliaryDetailVisibility")
 struct SidebarWorkspaceAuxiliaryDetailVisibilityTests {
+    @Test func hiddenGitRowsRequireNoBackgroundGitWork() {
+        let visibility = SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
+            showMetadata: true,
+            showLog: true,
+            showProgress: true,
+            showBranchDirectory: false,
+            showPullRequests: false,
+            showPorts: true,
+            hideAllDetails: false
+        )
+
+        #expect(!visibility.requiresGitMetadata)
+        #expect(!visibility.requiresPullRequestPolling)
+    }
+
+    @Test func pullRequestRowRequiresLocalMetadataAndGitHubPolling() {
+        let visibility = SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
+            showMetadata: false,
+            showLog: false,
+            showProgress: false,
+            showBranchDirectory: false,
+            showPullRequests: true,
+            showPorts: false,
+            hideAllDetails: false
+        )
+
+        #expect(visibility.requiresGitMetadata)
+        #expect(visibility.requiresPullRequestPolling)
+    }
+
+    @Test func hideAllDetailsSuppressesBackgroundGitRequirements() {
+        let visibility = SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
+            showMetadata: true,
+            showLog: true,
+            showProgress: true,
+            showBranchDirectory: true,
+            showPullRequests: true,
+            showPorts: true,
+            hideAllDetails: true
+        )
+
+        #expect(!visibility.requiresGitMetadata)
+        #expect(!visibility.requiresPullRequestPolling)
+    }
+
     @Test func hideAllWinsOverEveryToggle() {
         let visibility = SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
             showMetadata: true,

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
@@ -47,15 +47,14 @@ extension PullRequestPollService {
         var needsFollowUpPass = false
 
         defer {
-            if needsFollowUpPass {
+            if rateLimitRetryDate == nil,
+               needsFollowUpPass || workspacePullRequestFollowUpShouldBypassRepoCache {
                 let shouldBypassRepoCache = workspacePullRequestFollowUpShouldBypassRepoCache
                 workspacePullRequestFollowUpShouldBypassRepoCache = false
-                if rateLimitRetryDate == nil {
-                    refreshTrackedWorkspacePullRequestsIfNeeded(
-                        reason: "\(reason).followUp",
-                        allowCachedResultsOverride: shouldBypassRepoCache ? false : nil
-                    )
-                }
+                refreshTrackedWorkspacePullRequestsIfNeeded(
+                    reason: "\(reason).followUp",
+                    allowCachedResultsOverride: shouldBypassRepoCache ? false : nil
+                )
             }
         }
 
@@ -183,10 +182,6 @@ extension PullRequestPollService {
             if rerunPending {
                 workspacePullRequestNextPollAtByKey[key] = .distantPast
             }
-            if let rateLimitRetryDate,
-               workspacePullRequestNextPollAtByKey[key, default: .distantPast] < rateLimitRetryDate {
-                workspacePullRequestNextPollAtByKey[key] = rateLimitRetryDate
-            }
 
 #if DEBUG
             let label: String = {
@@ -208,6 +203,15 @@ extension PullRequestPollService {
 #endif
         }
 
+        if let rateLimitRetryDate {
+            for key in requestedKeys {
+                guard workspacePullRequestProbeStateByKey[key] != nil,
+                      workspacePullRequestNextPollAtByKey[key, default: .distantPast] < rateLimitRetryDate else {
+                    continue
+                }
+                workspacePullRequestNextPollAtByKey[key] = rateLimitRetryDate
+            }
+        }
         updateWorkspacePullRequestPollTimer()
     }
 

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService+Apply.swift
@@ -11,7 +11,8 @@ extension PullRequestPollService {
         repoResults: [String: WorkspacePullRequestRepoFetchResult],
         requestedKeys: [WorkspaceGitProbeKey],
         now: Date,
-        reason: String
+        reason: String,
+        rateLimitRetryDate: Date? = nil
     ) {
         guard let host else { return }
         guard !host.mobileHostHasRecentActivity(within: mobileHostDeferral.quietInterval) else {
@@ -49,10 +50,12 @@ extension PullRequestPollService {
             if needsFollowUpPass {
                 let shouldBypassRepoCache = workspacePullRequestFollowUpShouldBypassRepoCache
                 workspacePullRequestFollowUpShouldBypassRepoCache = false
-                refreshTrackedWorkspacePullRequestsIfNeeded(
-                    reason: "\(reason).followUp",
-                    allowCachedResultsOverride: shouldBypassRepoCache ? false : nil
-                )
+                if rateLimitRetryDate == nil {
+                    refreshTrackedWorkspacePullRequestsIfNeeded(
+                        reason: "\(reason).followUp",
+                        allowCachedResultsOverride: shouldBypassRepoCache ? false : nil
+                    )
+                }
             }
         }
 
@@ -179,6 +182,10 @@ extension PullRequestPollService {
             )
             if rerunPending {
                 workspacePullRequestNextPollAtByKey[key] = .distantPast
+            }
+            if let rateLimitRetryDate,
+               workspacePullRequestNextPollAtByKey[key, default: .distantPast] < rateLimitRetryDate {
+                workspacePullRequestNextPollAtByKey[key] = rateLimitRetryDate
             }
 
 #if DEBUG

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService.swift
@@ -266,6 +266,7 @@ public final class PullRequestPollService: PullRequestProbing {
                 candidates: candidateResolution.candidates,
                 repoResults: repoResults
             )
+            let rateLimitRetryDate = await probeService.rateLimitRetryDate()
             guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
                 guard let self else { return }
@@ -276,7 +277,8 @@ public final class PullRequestPollService: PullRequestProbing {
                     repoResults: repoResults,
                     requestedKeys: keys,
                     now: Date(),
-                    reason: reason
+                    reason: reason,
+                    rateLimitRetryDate: rateLimitRetryDate
                 )
             }
         }

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Service/PullRequestPollService.swift
@@ -255,7 +255,7 @@ public final class PullRequestPollService: PullRequestProbing {
                 gitMetadata: gitMetadataService
             )
             guard !Task.isCancelled else { return }
-            let repoResults = await probeService.fetchRepoResults(
+            let repoFetch = await probeService.fetchRepoResults(
                 repoDirectoriesBySlug: candidateResolution.repoDirectoriesBySlug,
                 candidateBranchesByRepo: candidateResolution.candidateBranchesByRepo,
                 cacheBySlug: cacheBySlug,
@@ -264,9 +264,8 @@ public final class PullRequestPollService: PullRequestProbing {
             )
             let results = PullRequestProbeService.resolveRefreshResults(
                 candidates: candidateResolution.candidates,
-                repoResults: repoResults
+                repoResults: repoFetch.repoResults
             )
-            let rateLimitRetryDate = await probeService.rateLimitRetryDate()
             guard !Task.isCancelled else { return }
             await MainActor.run { [weak self] in
                 guard let self else { return }
@@ -274,11 +273,11 @@ public final class PullRequestPollService: PullRequestProbing {
                 self.workspacePullRequestRefreshTask = nil
                 self.applyWorkspacePullRequestRefreshResults(
                     results,
-                    repoResults: repoResults,
+                    repoResults: repoFetch.repoResults,
                     requestedKeys: keys,
                     now: Date(),
                     reason: reason,
-                    rateLimitRetryDate: rateLimitRetryDate
+                    rateLimitRetryDate: repoFetch.rateLimitRetryDate
                 )
             }
         }

--- a/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
+++ b/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
@@ -365,7 +365,7 @@ import CmuxGit
         let service = makeService(host: host, clock: ManualGitPollClock())
         let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
         service.workspacePullRequestProbeStateByKey[key] = .inFlight(rerunPending: false)
-        let now = Date()
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
         let retryDate = now.addingTimeInterval(300)
 
         service.applyWorkspacePullRequestRefreshResults(
@@ -385,5 +385,65 @@ import CmuxGit
         )
 
         #expect(service.workspacePullRequestNextPollAtByKey[key] == retryDate)
+    }
+
+    @Test func rateLimitClampsEarlyContinuesAndPreservesDeferredCacheBypass() {
+        let host = RecordingSidebarGitHost()
+        host.pollingEnabled = true
+        let (rerunWorkspaceId, rerunPanelId) = host.addWorkspace(panelDirectory: "/tmp/repo")
+        let (missingWorkspaceId, missingPanelId) = host.addWorkspace(panelDirectory: "/tmp/repo")
+        let service = makeService(host: host, clock: ManualGitPollClock())
+        let rerunKey = WorkspaceGitProbeKey(
+            workspaceId: rerunWorkspaceId,
+            panelId: rerunPanelId
+        )
+        let missingResultKey = WorkspaceGitProbeKey(
+            workspaceId: missingWorkspaceId,
+            panelId: missingPanelId
+        )
+        service.workspacePullRequestProbeStateByKey[rerunKey] = .inFlight(rerunPending: true)
+        service.workspacePullRequestProbeStateByKey[missingResultKey] = .inFlight(rerunPending: false)
+        service.workspacePullRequestNextPollAtByKey[rerunKey] = .distantPast
+        service.workspacePullRequestFollowUpShouldBypassRepoCache = true
+        let now = Date(timeIntervalSince1970: 1_800_000_000)
+        let retryDate = now.addingTimeInterval(300)
+
+        service.applyWorkspacePullRequestRefreshResults(
+            [
+                WorkspacePullRequestRefreshResult(
+                    workspaceId: rerunWorkspaceId,
+                    panelId: rerunPanelId,
+                    resolution: .transientFailure,
+                    usedCachedRepoData: true
+                ),
+            ],
+            repoResults: [:],
+            requestedKeys: [rerunKey, missingResultKey],
+            now: now,
+            reason: "rateLimited",
+            rateLimitRetryDate: retryDate
+        )
+
+        #expect(service.workspacePullRequestNextPollAtByKey[rerunKey] == retryDate)
+        #expect(service.workspacePullRequestNextPollAtByKey[missingResultKey] == retryDate)
+        #expect(service.workspacePullRequestFollowUpShouldBypassRepoCache)
+
+        service.workspacePullRequestProbeStateByKey[rerunKey] = .inFlight(rerunPending: false)
+        service.applyWorkspacePullRequestRefreshResults(
+            [
+                WorkspacePullRequestRefreshResult(
+                    workspaceId: rerunWorkspaceId,
+                    panelId: rerunPanelId,
+                    resolution: .transientFailure,
+                    usedCachedRepoData: false
+                ),
+            ],
+            repoResults: [:],
+            requestedKeys: [rerunKey],
+            now: retryDate,
+            reason: "postReset"
+        )
+
+        #expect(!service.workspacePullRequestFollowUpShouldBypassRepoCache)
     }
 }

--- a/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
+++ b/Packages/macOS/CmuxSidebarGit/Tests/CmuxSidebarGitTests/PullRequestPollServiceTests.swift
@@ -353,4 +353,37 @@ import CmuxGit
         #expect(host.workspaces[0].state.panels[panelId]?.badge == nil)
         #expect(service.workspacePullRequestTrackedPanelIds(workspaceId: workspaceId).isEmpty)
     }
+
+    @Test func rateLimitResetOverridesNormalTransientFailureCadence() {
+        let host = RecordingSidebarGitHost()
+        host.pollingEnabled = true
+        let (workspaceId, panelId) = host.addWorkspace(panelDirectory: "/tmp/repo")
+        host.workspaces[0].state.panels[panelId]?.branch = SidebarPanelGitBranch(
+            branch: "issue-8175",
+            isDirty: false
+        )
+        let service = makeService(host: host, clock: ManualGitPollClock())
+        let key = WorkspaceGitProbeKey(workspaceId: workspaceId, panelId: panelId)
+        service.workspacePullRequestProbeStateByKey[key] = .inFlight(rerunPending: false)
+        let now = Date()
+        let retryDate = now.addingTimeInterval(300)
+
+        service.applyWorkspacePullRequestRefreshResults(
+            [
+                WorkspacePullRequestRefreshResult(
+                    workspaceId: workspaceId,
+                    panelId: panelId,
+                    resolution: .transientFailure,
+                    usedCachedRepoData: false
+                ),
+            ],
+            repoResults: [:],
+            requestedKeys: [key],
+            now: now,
+            reason: "rateLimited",
+            rateLimitRetryDate: retryDate
+        )
+
+        #expect(service.workspacePullRequestNextPollAtByKey[key] == retryDate)
+    }
 }

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8630,7 +8630,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             initialWorkspaceTitle: initialWorkspaceTitle,
             initialWorkingDirectory: initialWorkingDirectory,
             initialTerminalInput: initialTerminalInput,
-            autoWelcomeIfNeeded: initialTerminalInput == nil
+            autoWelcomeIfNeeded: initialTerminalInput == nil,
+            pullRequestProbeService: self.tabManager?.pullRequestProbeService
         )
         tabManager.windowId = windowId
         if let sessionWindowSnapshot {

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -1,4 +1,5 @@
 import CmuxSettings
+import CmuxSidebar
 import Foundation
 
 typealias RightSidebarWidthSettings = CmuxSettings.RightSidebarWidthSettings
@@ -50,12 +51,43 @@ extension SidebarWorkspaceDetailDefaults {
         boolValue(defaults: defaults, key: showPullRequestsKey, defaultValue: showPullRequests)
     }
 
+    static func showBranchDirectoryValue(defaults: UserDefaults) -> Bool {
+        boolValue(defaults: defaults, key: showBranchDirectoryKey, defaultValue: showBranchDirectory)
+    }
+
     static func watchGitStatusValue(defaults: UserDefaults) -> Bool {
         boolValue(defaults: defaults, key: watchGitStatusKey, defaultValue: watchGitStatus)
     }
 
+    static func auxiliaryDetailVisibility(defaults: UserDefaults) -> SidebarWorkspaceAuxiliaryDetailVisibility {
+        let hideAllDetails = SidebarCatalogSection().hideAllDetails
+        return SidebarWorkspaceAuxiliaryDetailVisibility.resolved(
+            showMetadata: boolValue(
+                defaults: defaults,
+                key: showCustomMetadataKey,
+                defaultValue: showCustomMetadata
+            ),
+            showLog: boolValue(defaults: defaults, key: showLogKey, defaultValue: showLog),
+            showProgress: boolValue(defaults: defaults, key: showProgressKey, defaultValue: showProgress),
+            showBranchDirectory: showBranchDirectoryValue(defaults: defaults),
+            showPullRequests: showPullRequestsValue(defaults: defaults),
+            showPorts: boolValue(defaults: defaults, key: showPortsKey, defaultValue: showPorts),
+            hideAllDetails: boolValue(
+                defaults: defaults,
+                key: hideAllDetails.userDefaultsKey,
+                defaultValue: hideAllDetails.defaultValue
+            )
+        )
+    }
+
+    static func gitMetadataPollingEnabled(defaults: UserDefaults) -> Bool {
+        watchGitStatusValue(defaults: defaults)
+            && auxiliaryDetailVisibility(defaults: defaults).requiresGitMetadata
+    }
+
     static func pullRequestPollingEnabled(defaults: UserDefaults) -> Bool {
-        watchGitStatusValue(defaults: defaults) && showPullRequestsValue(defaults: defaults)
+        watchGitStatusValue(defaults: defaults)
+            && auxiliaryDetailVisibility(defaults: defaults).requiresPullRequestPolling
     }
 }
 

--- a/Sources/TabManager+SidebarGitHosting.swift
+++ b/Sources/TabManager+SidebarGitHosting.swift
@@ -173,7 +173,7 @@ extension TabManager: SidebarGitHosting {
     // MARK: Environment
 
     var isGitMetadataWatchEnabled: Bool {
-        SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard)
+        SidebarWorkspaceDetailDefaults.gitMetadataPollingEnabled(defaults: .standard)
     }
 
     var isPullRequestPollingEnabled: Bool {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -456,6 +456,10 @@ class TabManager: ObservableObject {
     // entry points.
     let sidebarGitMetadataService: any SidebarGitMetadataServing
     let pullRequestProbing: any PullRequestProbing
+    /// Process-scoped GitHub transport state. AppDelegate passes this same
+    /// value to every subsequently-created window so their pollers share one
+    /// session, ETag cache, backoff deadline, and request queue.
+    let pullRequestProbeService: PullRequestProbeService
 
     init(
         initialWorkspaceTitle: String? = nil,
@@ -464,6 +468,7 @@ class TabManager: ObservableObject {
         autoWelcomeIfNeeded: Bool = true,
         commandRunner: any CommandRunning = CommandRunner(),
         gitMetadataService: GitMetadataService = GitMetadataService(),
+        pullRequestProbeService: PullRequestProbeService? = nil,
         workspaceGitMetadataReader: (any WorkspaceGitMetadataReading)? = nil,
         gitPollClock: any GitPollClock = SystemGitPollClock(),
         gitProbeLimiter: WorkspaceGitMetadataProbeLimiter? = nil,
@@ -492,10 +497,12 @@ class TabManager: ObservableObject {
 #else
         let sidebarGitDebugLog: @Sendable (String) -> Void = { _ in }
 #endif
-        let pullRequestProbeService = PullRequestProbeService(
-            commandRunner: commandRunner,
-            debugLog: sidebarGitDebugLog
-        )
+        let pullRequestProbeService = pullRequestProbeService
+            ?? PullRequestProbeService(
+                commandRunner: commandRunner,
+                debugLog: sidebarGitDebugLog
+            )
+        self.pullRequestProbeService = pullRequestProbeService
         let pullRequestPollService = PullRequestPollService(
             gitMetadataService: gitMetadataService,
             probeService: pullRequestProbeService,

--- a/Sources/TerminalController+ControlSidebarContext2.swift
+++ b/Sources/TerminalController+ControlSidebarContext2.swift
@@ -38,7 +38,7 @@ extension TerminalController {
             let validSurfaceIds = Set(tab.panels.keys)
             tab.pruneSurfaceMetadata(validSurfaceIds: validSurfaceIds)
             guard validSurfaceIds.contains(scope.panelID) else { return }
-            guard SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard) else {
+            guard SidebarWorkspaceDetailDefaults.gitMetadataPollingEnabled(defaults: .standard) else {
                 tabManager.clearSurfaceGitBranch(tabId: scope.workspaceID, surfaceId: scope.panelID)
                 return
             }
@@ -55,7 +55,7 @@ extension TerminalController {
         guard let tab = controlSidebarResolveTabForReport(tabArg: tabArg) else {
             return false
         }
-        guard SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard) else {
+        guard SidebarWorkspaceDetailDefaults.gitMetadataPollingEnabled(defaults: .standard) else {
             tab.gitBranch = nil
             return true
         }

--- a/Sources/TerminalSurfaceRuntimeWiring.swift
+++ b/Sources/TerminalSurfaceRuntimeWiring.swift
@@ -42,9 +42,6 @@ struct TerminalSurfaceViewFactory: TerminalSurfaceViewProviding {
 final class TerminalSurfaceSpawnPolicyBridge: TerminalSurfaceSpawnPolicyProviding {
     func currentSpawnPolicy() -> TerminalSurfaceSpawnPolicy {
         let integrations = AgentIntegrationSettingsStore(defaults: .standard)
-        // Startup flags express the master shell capability. Row visibility
-        // remains a live app-side polling decision and may change later.
-        let watchGitStatusEnabled = SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard)
         return TerminalSurfaceSpawnPolicy(
             socketAuthenticationEnvironment: TerminalController.shared.socketClientCapabilityEnvironment(),
             claudeHooksEnabled: integrations.claudeCodeHooksEnabled,
@@ -58,8 +55,8 @@ final class TerminalSurfaceSpawnPolicyBridge: TerminalSurfaceSpawnPolicyProvidin
             kiroNotificationLevel: integrations.kiroNotificationLevel.rawValue,
             ampHooksEnabled: integrations.ampHooksEnabled,
             shellIntegrationEnabled: UserDefaults.standard.object(forKey: "sidebarShellIntegration") as? Bool ?? true,
-            watchGitStatusEnabled: watchGitStatusEnabled,
-            showPullRequestsEnabled: watchGitStatusEnabled
+            watchGitStatusEnabled: SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard),
+            showPullRequestsEnabled: SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: .standard)
         )
     }
 

--- a/Sources/TerminalSurfaceRuntimeWiring.swift
+++ b/Sources/TerminalSurfaceRuntimeWiring.swift
@@ -55,8 +55,8 @@ final class TerminalSurfaceSpawnPolicyBridge: TerminalSurfaceSpawnPolicyProvidin
             kiroNotificationLevel: integrations.kiroNotificationLevel.rawValue,
             ampHooksEnabled: integrations.ampHooksEnabled,
             shellIntegrationEnabled: UserDefaults.standard.object(forKey: "sidebarShellIntegration") as? Bool ?? true,
-            watchGitStatusEnabled: SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard),
-            showPullRequestsEnabled: SidebarWorkspaceDetailDefaults.showPullRequestsValue(defaults: .standard)
+            watchGitStatusEnabled: SidebarWorkspaceDetailDefaults.gitMetadataPollingEnabled(defaults: .standard),
+            showPullRequestsEnabled: SidebarWorkspaceDetailDefaults.pullRequestPollingEnabled(defaults: .standard)
         )
     }
 

--- a/Sources/TerminalSurfaceRuntimeWiring.swift
+++ b/Sources/TerminalSurfaceRuntimeWiring.swift
@@ -42,6 +42,9 @@ struct TerminalSurfaceViewFactory: TerminalSurfaceViewProviding {
 final class TerminalSurfaceSpawnPolicyBridge: TerminalSurfaceSpawnPolicyProviding {
     func currentSpawnPolicy() -> TerminalSurfaceSpawnPolicy {
         let integrations = AgentIntegrationSettingsStore(defaults: .standard)
+        // Startup flags express the master shell capability. Row visibility
+        // remains a live app-side polling decision and may change later.
+        let watchGitStatusEnabled = SidebarWorkspaceDetailDefaults.watchGitStatusValue(defaults: .standard)
         return TerminalSurfaceSpawnPolicy(
             socketAuthenticationEnvironment: TerminalController.shared.socketClientCapabilityEnvironment(),
             claudeHooksEnabled: integrations.claudeCodeHooksEnabled,
@@ -55,8 +58,8 @@ final class TerminalSurfaceSpawnPolicyBridge: TerminalSurfaceSpawnPolicyProvidin
             kiroNotificationLevel: integrations.kiroNotificationLevel.rawValue,
             ampHooksEnabled: integrations.ampHooksEnabled,
             shellIntegrationEnabled: UserDefaults.standard.object(forKey: "sidebarShellIntegration") as? Bool ?? true,
-            watchGitStatusEnabled: SidebarWorkspaceDetailDefaults.gitMetadataPollingEnabled(defaults: .standard),
-            showPullRequestsEnabled: SidebarWorkspaceDetailDefaults.pullRequestPollingEnabled(defaults: .standard)
+            watchGitStatusEnabled: watchGitStatusEnabled,
+            showPullRequestsEnabled: watchGitStatusEnabled
         )
     }
 


### PR DESCRIPTION
## Summary

- fail closed when neither `GH_TOKEN`/`GITHUB_TOKEN` nor `gh auth token` provides GitHub credentials, so sidebar polling never consumes the anonymous 60-request per-IP pool
- share one process-wide GitHub request coordinator across app windows, with one reusable session, same-endpoint in-flight coalescing, and a FIFO transport pool capped at three active GitHub requests
- cache ETags and send `If-None-Match`, reusing cached response bodies on 304
- read `X-RateLimit-Remaining` and `X-RateLimit-Reset`, suppress transport through the reset boundary, and propagate that deadline to the panel poll scheduler
- derive git/PR background work from the resolved sidebar visibility policy, including `sidebar.hideAllDetails`, `sidebar.showBranchDirectory`, `sidebar.showPullRequests`, and `sidebar.watchGitStatus`

## Before / after

Before, a missing token still sent anonymous REST requests from every window, with no conditional requests or rate-limit reset backoff. Hiding both git-backed sidebar rows stopped PR polling on current main but left local git background work running.

After, every GitHub request is authenticated or skipped, steady-state responses revalidate with ETags, exhausted rate limits stop transport until reset, duplicate multi-window work coalesces behind a process-wide three-request FIFO transport pool, and hiding both rows tears down both PR and local git polling.

## Tests

- `swift test --package-path Packages/macOS/CmuxGit` (87 tests)
- `swift test --package-path Packages/macOS/CmuxSidebar` (49 tests)
- `swift test --package-path Packages/macOS/CmuxSidebarGit` (43 tests)
- `./scripts/check-pbxproj.sh`
- `./tests/test_ci_swift_warning_budget.sh`
- `./tests/test_ci_pbxproj_test_wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`

The regression tests were committed separately before the fix in `a2369ea490`; they fail against the prior implementation for anonymous transport, missing ETag reuse, missing reset backoff, duplicate requests, and concurrent connections.

Closes #8175
https://github.com/manaflow-ai/cmux/issues/8175

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786746107&installation_id=133855650&pr_number=8190&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8190&signature=2c07bb6c971ef6ce326641debf6b340507c77a1dc924a898071487aca1d7ecf1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops unauthenticated GitHub PR polling and adds a process‑wide coordinator to make requests authenticated, cacheable, coalesced, and rate‑limit aware. Sidebar visibility now correctly controls when GitHub polling and local git run, fixing #8175.

- **Bug Fixes**
  - Authentication: fail closed without creds; use `GH_TOKEN`/`GITHUB_TOKEN` or `gh auth token`; never use the anonymous 60 req/IP pool.
  - Transport: one coordinator shared across windows; FIFO pool (max 3); coalesce in‑flight by endpoint+credential; queued/coalesced waiters can cancel; transport cancels only when no waiters remain.
  - Caching: ETag cache keyed by endpoint+credential; sends If‑None‑Match; 304 reuses body only for that credential.
  - Rate limits: track per‑credential deadlines from `X‑RateLimit‑Remaining/Reset` and `Retry‑After`; suppress transport until the deadline; surface the retry date to per‑panel next‑poll times; other credentials keep polling.
  - Visibility: new `requiresGitMetadata` and `requiresPullRequestPolling`; local git runs only when branch or PR rows are visible; GitHub polling runs only when the PR row is visible; preserves the independent shell PR toggle.

<sup>Written for commit da9116a819737e1913dbfd3a210e93750ce7a83c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8190?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved GitHub pull request fetching with shared request coordination, response caching, duplicate-request prevention, and bounded concurrency.
  * Added rate-limit-aware retry scheduling to avoid unnecessary requests until GitHub access is available again.
  * Git metadata and pull request polling now automatically follow visible sidebar detail settings.
  * Added shared pull request service support across application windows.

* **Bug Fixes**
  * Requests without credentials now fail safely without anonymous GitHub requests.
  * Sidebar polling and Git branch updates are disabled when the relevant details are hidden.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->