### PR TITLE
ci: allow the iOS workspace SwiftPM lockfile in the resolved-policy check

### DIFF
--- a/scripts/check-package-resolved-policy.py
+++ b/scripts/check-package-resolved-policy.py
@@ -19,6 +19,13 @@ ALLOWED_IGNORED_PREFIXES = (
 XCODE_PACKAGE_RESOLVED = (
     "cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved"
 )
+# Workspace-level lockfiles for cmux-owned Xcode workspaces. Like the project
+# lockfile above, these are expected at fixed locations rather than next to a
+# Package.swift.
+WORKSPACE_PACKAGE_RESOLVED = (
+    XCODE_PACKAGE_RESOLVED,
+    "ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved",
+)
 XCODE_PROJECT_FILE = "cmux.xcodeproj/project.pbxproj"
 XCODE_PACKAGE_REFERENCE_TOKENS = (
     "XCRemoteSwiftPackageReference",
@@ -252,7 +259,7 @@ def xcode_package_reference_changed(
 
 
 def is_expected_lockfile_path(lockfile: str, roots: set[str]) -> bool:
-    if lockfile == XCODE_PACKAGE_RESOLVED:
+    if lockfile in WORKSPACE_PACKAGE_RESOLVED:
         return True
     if has_skipped_part(lockfile):
         return False


### PR DESCRIPTION
`workflow-guard-tests` fails on current main (and every branch cut from it) with `Unexpected cmux Package.resolved location: ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved`. https://github.com/manaflow-ai/cmux/pull/8180 committed that iOS workspace lockfile, but `check-package-resolved-policy.py` only recognized the macOS project's workspace lockfile. It slipped through because PR CI is disabled during the advisory experiment; found while dispatching CI for https://github.com/manaflow-ai/cmux/pull/8186.

The iOS workspace is a cmux-owned Xcode workspace whose resolution should be tracked at exactly that fixed location (same intent as the macOS lockfile: resolution changes visible in PR diffs), so the fix generalizes the expected-location check to a tuple of workspace lockfiles and adds the iOS one. `python3 scripts/check-package-resolved-policy.py` goes red -> green on this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8191"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786746467&installation_id=133855650&pr_number=8191&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8191&signature=eb626a036bffe89fa5463fd9c45d016bf769f2bea831b2eb242c85a762f397f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows the iOS workspace SwiftPM `Package.resolved` path in `check-package-resolved-policy.py` to stop `workflow-guard-tests` failures. Extends the lockfile policy to cover both macOS and iOS cmux-owned workspaces.

- **Bug Fixes**
  - Generalized the expected lockfile check to accept workspace-level paths and added `ios/cmux.xcworkspace/xcshareddata/swiftpm/Package.resolved`.
  - Keeps resolution changes visible in PR diffs and restores CI to green.

<sup>Written for commit 43550722529785f59f0f9acff7ff2296b0f51687. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8191?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated package lockfile validation to recognize both supported Xcode project- and workspace-level locations.
  * Prevents valid workspace configurations from being incorrectly flagged during checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->