### PR TITLE
Fix animated update popover resize reentrancy

### DIFF
--- a/Packages/macOS/CmuxUpdaterUI/Package.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Package.swift
@@ -14,6 +14,7 @@ let package = Package(
         ),
     ],
     dependencies: [
+        .package(path: "../CmuxAppKitSupportUI"),
         .package(path: "../CmuxFoundation"),
         .package(path: "../CmuxUpdater"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
@@ -22,6 +23,7 @@ let package = Package(
         .target(
             name: "CmuxUpdaterUI",
             dependencies: [
+                "CmuxAppKitSupportUI",
                 "CmuxFoundation",
                 "CmuxUpdater",
                 .product(name: "Sparkle", package: "Sparkle"),

--- a/Packages/macOS/CmuxUpdaterUI/Package.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Package.swift
@@ -14,7 +14,6 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(path: "../CmuxAppKitSupportUI"),
         .package(path: "../CmuxFoundation"),
         .package(path: "../CmuxUpdater"),
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.9.0"),
@@ -23,7 +22,6 @@ let package = Package(
         .target(
             name: "CmuxUpdaterUI",
             dependencies: [
-                "CmuxAppKitSupportUI",
                 "CmuxFoundation",
                 "CmuxUpdater",
                 .product(name: "Sparkle", package: "Sparkle"),

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
@@ -102,7 +102,7 @@ public struct UpdatePill: View {
     }
 }
 
-private struct UpdatePillPopoverAnchor: NSViewRepresentable {
+struct UpdatePillPopoverAnchor: NSViewRepresentable {
     @Binding var isPresented: Bool
     let model: UpdateStateModel
     let actions: any UpdateActionsHost
@@ -148,8 +148,9 @@ private struct UpdatePillPopoverAnchor: NSViewRepresentable {
         private let hostingController = NSHostingController(rootView: AnyView(EmptyView()))
         private var popover: NSPopover?
 
-        init(isPresented: Binding<Bool>) {
+        init(isPresented: Binding<Bool>, popover: NSPopover? = nil) {
             _isPresented = isPresented
+            self.popover = popover
         }
 
         func updateRootView(_ rootView: AnyView) {

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
@@ -147,11 +147,10 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
         weak var anchorView: NSView?
         private let hostingController = NSHostingController(rootView: AnyView(EmptyView()))
         private var visibleUpdateTask: Task<Void, Never>?
-        private var popover: NSPopover?
+        var popover: NSPopover?
 
-        init(isPresented: Binding<Bool>, popover: NSPopover? = nil) {
+        init(isPresented: Binding<Bool>) {
             _isPresented = isPresented
-            self.popover = popover
         }
 
         func updateRootView(_ rootView: AnyView) {

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
@@ -1,4 +1,5 @@
 public import SwiftUI
+import CmuxAppKitSupportUI
 import CmuxFoundation
 public import CmuxUpdater
 import AppKit
@@ -146,6 +147,7 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
 
         weak var anchorView: NSView?
         private let hostingController = NSHostingController(rootView: AnyView(EmptyView()))
+        private let visibleUpdateScheduler = CmuxPopoverVisibleUpdateScheduler()
         private var popover: NSPopover?
 
         init(isPresented: Binding<Bool>, popover: NSPopover? = nil) {
@@ -154,10 +156,17 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
         }
 
         func updateRootView(_ rootView: AnyView) {
-            hostingController.rootView = rootView
-            hostingController.view.invalidateIntrinsicContentSize()
-            hostingController.view.layoutSubtreeIfNeeded()
-            updateContentSize()
+            guard popover?.isShown == true else {
+                visibleUpdateScheduler.cancel()
+                applyRootView(rootView)
+                return
+            }
+            // Leave the representable update before touching the shown popover; AppKit's
+            // animated resize can otherwise re-enter SwiftUI's active view-graph update.
+            visibleUpdateScheduler.schedule { [weak self] in
+                guard let self, self.popover?.isShown == true else { return }
+                self.applyRootView(rootView)
+            }
         }
 
         func present() {
@@ -169,13 +178,14 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
 
             anchorView.superview?.layoutSubtreeIfNeeded()
             let popover = popover ?? makePopover()
-            updateContentSize()
             guard !popover.isShown else { return }
+            updateContentSize()
 
             popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .maxY)
         }
 
         func dismiss() {
+            visibleUpdateScheduler.cancel()
             popover?.performClose(nil)
         }
 
@@ -185,6 +195,7 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
         }
 
         func popoverDidClose(_ notification: Notification) {
+            visibleUpdateScheduler.cancel()
             popover = nil
             if isPresented {
                 isPresented = false
@@ -201,13 +212,23 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
             return popover
         }
 
+        private func applyRootView(_ rootView: AnyView) {
+            CmuxPopoverMutation.performWithoutImplicitAnimation {
+                hostingController.rootView = rootView
+                hostingController.view.invalidateIntrinsicContentSize()
+                hostingController.view.layoutSubtreeIfNeeded()
+            }
+            updateContentSize()
+        }
+
         private func updateContentSize() {
             let fittingSize = hostingController.view.fittingSize
             guard fittingSize.width > 0, fittingSize.height > 0 else { return }
-            popover?.contentSize = NSSize(
+            guard let popover else { return }
+            CmuxPopoverMutation.setContentSize(NSSize(
                 width: ceil(fittingSize.width),
                 height: ceil(fittingSize.height)
-            )
+            ), on: popover)
         }
     }
 }

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePill.swift
@@ -1,5 +1,4 @@
 public import SwiftUI
-import CmuxAppKitSupportUI
 import CmuxFoundation
 public import CmuxUpdater
 import AppKit
@@ -147,7 +146,7 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
 
         weak var anchorView: NSView?
         private let hostingController = NSHostingController(rootView: AnyView(EmptyView()))
-        private let visibleUpdateScheduler = CmuxPopoverVisibleUpdateScheduler()
+        private var visibleUpdateTask: Task<Void, Never>?
         private var popover: NSPopover?
 
         init(isPresented: Binding<Bool>, popover: NSPopover? = nil) {
@@ -157,14 +156,16 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
 
         func updateRootView(_ rootView: AnyView) {
             guard popover?.isShown == true else {
-                visibleUpdateScheduler.cancel()
+                cancelVisibleUpdate()
                 applyRootView(rootView)
                 return
             }
             // Leave the representable update before touching the shown popover; AppKit's
             // animated resize can otherwise re-enter SwiftUI's active view-graph update.
-            visibleUpdateScheduler.schedule { [weak self] in
-                guard let self, self.popover?.isShown == true else { return }
+            visibleUpdateTask?.cancel()
+            visibleUpdateTask = Task { @MainActor [weak self] in
+                guard !Task.isCancelled, let self, self.popover?.isShown == true else { return }
+                self.visibleUpdateTask = nil
                 self.applyRootView(rootView)
             }
         }
@@ -185,7 +186,7 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
         }
 
         func dismiss() {
-            visibleUpdateScheduler.cancel()
+            cancelVisibleUpdate()
             popover?.performClose(nil)
         }
 
@@ -195,7 +196,7 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
         }
 
         func popoverDidClose(_ notification: Notification) {
-            visibleUpdateScheduler.cancel()
+            cancelVisibleUpdate()
             popover = nil
             if isPresented {
                 isPresented = false
@@ -212,8 +213,13 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
             return popover
         }
 
+        private func cancelVisibleUpdate() {
+            visibleUpdateTask?.cancel()
+            visibleUpdateTask = nil
+        }
+
         private func applyRootView(_ rootView: AnyView) {
-            CmuxPopoverMutation.performWithoutImplicitAnimation {
+            performWithoutImplicitAnimation {
                 hostingController.rootView = rootView
                 hostingController.view.invalidateIntrinsicContentSize()
                 hostingController.view.layoutSubtreeIfNeeded()
@@ -225,10 +231,25 @@ struct UpdatePillPopoverAnchor: NSViewRepresentable {
             let fittingSize = hostingController.view.fittingSize
             guard fittingSize.width > 0, fittingSize.height > 0 else { return }
             guard let popover else { return }
-            CmuxPopoverMutation.setContentSize(NSSize(
+            let size = NSSize(
                 width: ceil(fittingSize.width),
                 height: ceil(fittingSize.height)
-            ), on: popover)
+            )
+            if popover.isShown {
+                performWithoutImplicitAnimation {
+                    popover.contentSize = size
+                }
+            } else {
+                popover.contentSize = size
+            }
+        }
+
+        private func performWithoutImplicitAnimation(_ body: () -> Void) {
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0
+                context.allowsImplicitAnimation = false
+                body()
+            }
         }
     }
 }

--- a/Packages/macOS/CmuxUpdaterUI/Tests/CmuxUpdaterUITests/UpdatePillPopoverResizeTests.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Tests/CmuxUpdaterUITests/UpdatePillPopoverResizeTests.swift
@@ -15,11 +15,12 @@ struct UpdatePillPopoverResizeTests {
             isPresented: Binding(
                 get: { isPresented },
                 set: { isPresented = $0 }
-            ),
-            popover: popover
+            )
         )
+        coordinator.popover = popover
 
         coordinator.updateRootView(popoverContent(width: 180, height: 80))
+        await Task.yield()
         #expect(popover.isShown)
         #expect(popover.animates)
         popover.resetRecordedAssignments()

--- a/Packages/macOS/CmuxUpdaterUI/Tests/CmuxUpdaterUITests/UpdatePillPopoverResizeTests.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Tests/CmuxUpdaterUITests/UpdatePillPopoverResizeTests.swift
@@ -1,0 +1,65 @@
+import AppKit
+import SwiftUI
+import Testing
+@testable import CmuxUpdaterUI
+
+@MainActor
+@Suite("Update pill popover resize", .serialized)
+struct UpdatePillPopoverResizeTests {
+    @Test("Visible content refresh does not resize the popover synchronously")
+    func visibleContentRefreshDoesNotResizeSynchronously() async {
+        var isPresented = true
+        let popover = VisibleRecordingPopover()
+        popover.animates = true
+        let coordinator = UpdatePillPopoverAnchor.Coordinator(
+            isPresented: Binding(
+                get: { isPresented },
+                set: { isPresented = $0 }
+            ),
+            popover: popover
+        )
+
+        coordinator.updateRootView(popoverContent(width: 180, height: 80))
+        #expect(popover.isShown)
+        #expect(popover.animates)
+        popover.resetRecordedAssignments()
+
+        coordinator.updateRootView(popoverContent(width: 360, height: 240))
+
+        #expect(
+            popover.assignedSizes.isEmpty,
+            "A visible representable update must return before changing NSPopover.contentSize"
+        )
+        await Task.yield()
+        #expect(popover.assignedSizes == [NSSize(width: 360, height: 240)])
+    }
+
+    private func popoverContent(width: CGFloat, height: CGFloat) -> AnyView {
+        AnyView(
+            Color.clear
+                .frame(width: width, height: height)
+                .fixedSize()
+        )
+    }
+}
+
+@MainActor
+/// Supplies shown-popover state without requiring a WindowServer and records the real AppKit mutation boundary.
+private final class VisibleRecordingPopover: NSPopover {
+    private var storedContentSize = NSSize.zero
+    private(set) var assignedSizes: [NSSize] = []
+
+    override var isShown: Bool { true }
+
+    override var contentSize: NSSize {
+        get { storedContentSize }
+        set {
+            storedContentSize = newValue
+            assignedSizes.append(newValue)
+        }
+    }
+
+    func resetRecordedAssignments() {
+        assignedSizes.removeAll()
+    }
+}


### PR DESCRIPTION
## Summary

- defer shown update-pill popover root-view/layout changes until the active SwiftUI representable update has returned
- apply shown popover layout and content-size changes without implicit AppKit animation
- cancel coalesced visible updates when the popover closes or is dismissed
- add a behavior-level regression test that proves a visible update cannot synchronously mutate `NSPopover.contentSize`

Fixes #8166.

## Test-first proof

- `024cdcfe48` adds the regression test and fails with a synchronous `(360.0, 240.0)` assignment.
- `20667f9e8c` adds the production fix and makes the same test pass.

## Verification

- AWS M4 Pro, Apple Silicon, macOS 15.7.4 (24G517)
- `swift test --package-path Packages/macOS/CmuxUpdaterUI --filter UpdatePillPopoverResizeTests` — 1 test in 1 suite passed
- `swift test --package-path Packages/macOS/CmuxUpdaterUI` — 4 tests in 2 suites passed
- `./scripts/lint-pbxproj-test-wiring.sh` — passed (496 files checked)
- `./scripts/check-pbxproj.sh` — passed
- `python3 scripts/check-workspace-package-groups.py --check` — passed

## Build note

`./scripts/reload.sh --tag issue-8166-fix` compiled the changed `CmuxUpdaterUI` target but the root app build remains blocked by the branch-baseline `Sources/Workspace.swift:3067:81` error (`Bool` has no member `hidden`). No app was launched.

No user-facing strings or localization catalogs changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8195"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786747961&installation_id=133855650&pr_number=8195&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8195&signature=5d476e5591b494bce8cd1fcff8c658c9f4654fbe020807ade681a0e7da007643"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a reentrancy crash when the Update Pill popover resizes while visible by deferring representable updates and disabling implicit AppKit animation for size changes. Adds a stricter regression test to ensure visible updates don’t synchronously change `NSPopover.contentSize`. Fixes #8166.

- **Bug Fixes**
  - Defer visible root-view updates via a local `Task` in `UpdatePillPopoverAnchor.Coordinator`; cancel on close/dismiss.
  - When shown, apply root-view/layout and `contentSize` changes with implicit AppKit animations disabled (`NSAnimationContext` duration 0).
  - Expose `UpdatePillPopoverAnchor` and coordinator `popover` for test injection; add `UpdatePillPopoverResizeTests` to assert no synchronous change and a single deferred `contentSize` assignment.

<sup>Written for commit 1a9e38126a5d1a4f5f6e3cd3e7fc79bcfe9af36a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8195?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved update popover resizing to apply visible content changes smoothly and asynchronously.
  * Prevented abrupt or conflicting size updates while the update popover is open.

* **Tests**
  * Added coverage verifying that popover size changes are deferred appropriately and applied with the expected dimensions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->