### PR TITLE
TestFlight: document internal provisioning profile blocker

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -439,7 +439,7 @@ jobs:
             PROFILE_BASE64="${IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64}"
             EXPECTED_APP_ID="7WLXT3NR37.dev.cmux.app.internal"
             PROFILE_TYPE="internal"
-            SKIP_APS_ENVIRONMENT_CHECK=true
+            SKIP_APS_ENVIRONMENT_CHECK=false
           else
             PROFILE_BASE64="${IOS_BETA_PROVISIONING_PROFILE_BASE64}"
             EXPECTED_APP_ID="7WLXT3NR37.dev.cmux.app.beta"
@@ -462,7 +462,7 @@ jobs:
             echo "$PROFILE_TYPE provisioning profile targets unexpected app ID: $APP_ID (expected $EXPECTED_APP_ID)" >&2
             exit 1
           fi
-          # Check aps-environment, but skip for internal profiles (ASC profile may not have it yet)
+          # Check aps-environment for every TestFlight provisioning profile.
           if [ "${SKIP_APS_ENVIRONMENT_CHECK:-false}" != "true" ]; then
             APS_ENVIRONMENT="$(/usr/libexec/PlistBuddy -c "Print :Entitlements:aps-environment" "$TMP_PLIST" 2>/dev/null || echo "")"
             if [ -z "$APS_ENVIRONMENT" ] || [ "$APS_ENVIRONMENT" != "production" ]; then

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -439,8 +439,6 @@ jobs:
             PROFILE_BASE64="${IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64}"
             EXPECTED_APP_ID="7WLXT3NR37.dev.cmux.app.internal"
             PROFILE_TYPE="internal"
-            # Internal profile created in ASC but may lack push notifications entitlement
-            # Set to true to skip aps-environment check for internal builds
             SKIP_APS_ENVIRONMENT_CHECK=true
           else
             PROFILE_BASE64="${IOS_BETA_PROVISIONING_PROFILE_BASE64}"


### PR DESCRIPTION
Build #7 successfully archived & exported but failed validation: the app requires aps-environment (push notifications) but the internal provisioning profile lacks this entitlement.

**Blocker:** The internal provisioning profile in ASC must be created/updated with Push Notifications enabled, and the GitHub secret IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64 must be set.

**Steps to resolve:**
1. Go to App Store Connect → Certificates, IDs & Profiles → Profiles
2. Create or edit the provisioning profile for `dev.cmux.app.internal`  
3. Enable 'Push Notifications' capability
4. Download the profile and set:
   ```bash
   base64 < cmux_INTERNAL.mobileprovision | gh secret set IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64 --repo manaflow-ai/cmux --body -
   ```
5. Re-trigger iOS TestFlight build once secret is set

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8201"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786751089&installation_id=133855650&pr_number=8201&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8201&signature=54864924ccb97a185901c8804dadedbb7e4a31227eae7f7a36982af4d7a1ee97"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces push-notification entitlement validation for internal TestFlight builds. Internal provisioning profile must include `aps-environment=production` to pass validation and upload.

- **Migration**
  - In App Store Connect → Profiles, create or edit the profile for dev.cmux.app.internal.
  - Enable Push Notifications.
  - Download the profile, base64-encode it, and update the `IOS_BETA_PROVISIONING_PROFILE_INTERNAL_BASE64` secret.
  - Re-run the iOS TestFlight workflow.

<sup>Written for commit 4ef211b0e33765438c12c7b84a261d23301c1641. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8201?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS beta (TestFlight) provisioning profile selection for internal builds.
  * Ensured the expected app identifier and provisioning type are set correctly for internal profiles, with push-notification environment validation applied consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->