### PR TITLE
Default Claude fullscreen to full-frame repaints

### DIFF
--- a/Resources/bin/cmux-claude-wrapper
+++ b/Resources/bin/cmux-claude-wrapper
@@ -583,6 +583,16 @@ if [[ -n "$CMUX_SURFACE_ID" ]]; then
     IN_CMUX=1
 fi
 
+# Claude Code's incremental alternate-screen renderer can retain stale rows or
+# compute cursor moves from a drifted frame model. Claude's supported full-frame
+# compatibility mode makes each repaint self-contained. Default it only for
+# cmux launches and preserve an explicit user override.
+# https://github.com/manaflow-ai/cmux/issues/5680
+# https://github.com/anthropics/claude-code/issues/68461
+if [[ "$IN_CMUX" == "1" && -z "${CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT+x}" ]]; then
+    export CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1
+fi
+
 exec_real_claude_passthrough() {
     if [[ "$IN_CMUX" == "1" ]]; then
         clear_inherited_claude_session_identity_env

--- a/tests/test_claude_wrapper_fullscreen_repaint.py
+++ b/tests/test_claude_wrapper_fullscreen_repaint.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Regression: cmux Claude launches default to full alternate-screen repaints."""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+WRAPPER = ROOT / "Resources" / "bin" / "cmux-claude-wrapper"
+REPAINT_ENV = "CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT"
+
+
+def _write_executable(path: Path, contents: str) -> None:
+    path.write_text(contents, encoding="utf-8")
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def _run_wrapper(fake_claude: Path, *, in_cmux: bool, repaint: str | None) -> subprocess.CompletedProcess[str]:
+    env = dict(os.environ)
+    env["CMUX_CUSTOM_CLAUDE_PATH"] = str(fake_claude)
+    env.pop("CMUX_SOCKET_PATH", None)
+    if in_cmux:
+        env["CMUX_SURFACE_ID"] = "surface-full-repaint-test"
+    else:
+        env.pop("CMUX_SURFACE_ID", None)
+    if repaint is None:
+        env.pop(REPAINT_ENV, None)
+    else:
+        env[REPAINT_ENV] = repaint
+
+    return subprocess.run(
+        [str(WRAPPER), "--version"],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=10,
+    )
+
+
+def main() -> int:
+    failures: list[str] = []
+    with tempfile.TemporaryDirectory(prefix="cmux-claude-full-repaint-") as td:
+        fake_claude = Path(td) / "claude"
+        _write_executable(
+            fake_claude,
+            "#!/bin/sh\n"
+            f'printf \'%s\\n\' "${{{REPAINT_ENV}-__unset__}}"\n',
+        )
+
+        default_result = _run_wrapper(fake_claude, in_cmux=True, repaint=None)
+        if default_result.returncode != 0 or default_result.stdout.strip() != "1":
+            failures.append(
+                "cmux launch should default Claude fullscreen rendering to full repaints; "
+                f"got rc={default_result.returncode}, stdout={default_result.stdout!r}, "
+                f"stderr={default_result.stderr!r}"
+            )
+
+        override_result = _run_wrapper(fake_claude, in_cmux=True, repaint="0")
+        if override_result.returncode != 0 or override_result.stdout.strip() != "0":
+            failures.append(
+                "cmux launch should preserve an explicit Claude repaint override; "
+                f"got rc={override_result.returncode}, stdout={override_result.stdout!r}, "
+                f"stderr={override_result.stderr!r}"
+            )
+
+        outside_result = _run_wrapper(fake_claude, in_cmux=False, repaint=None)
+        if outside_result.returncode != 0 or outside_result.stdout.strip() != "__unset__":
+            failures.append(
+                "wrapper should not change Claude rendering outside cmux; "
+                f"got rc={outside_result.returncode}, stdout={outside_result.stdout!r}, "
+                f"stderr={outside_result.stderr!r}"
+            )
+
+    if failures:
+        print("FAIL: Claude wrapper fullscreen repaint checks failed")
+        for failure in failures:
+            print(f"- {failure}")
+        return 1
+
+    print("PASS: cmux Claude launches default to full repaints and preserve overrides")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/5680

Claude fullscreen currently redraws with sparse cursor-relative edits. When Claude's frame model drifts, `/clear` and later updates leave stale rows or overwrite the wrong cells. Raw PTY captures reproduce the same behavior outside cmux, and Anthropic reports include cursor-up sequences larger than the viewport across iTerm2, Windows Terminal, tmux, and Ghostty:

- https://github.com/anthropics/claude-code/issues/68461
- https://github.com/anthropics/claude-code/issues/77689
- https://github.com/anthropics/claude-code/issues/69619

The cmux Ghostty fork has no corresponding macOS erase or dirty-row divergence from upstream at the affected version boundary. Claude also does not emit a terminal-wide erase for `/clear`; it relies on its cached incremental frame.

This defaults Claude's supported `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` compatibility mode for launches inside cmux. Every fullscreen update becomes self-contained, while an explicit user value remains authoritative and launches outside cmux remain unchanged.

The regression test is split into a failing test commit followed by the fix commit.

Tests:

- `python3 tests/test_claude_wrapper_fullscreen_repaint.py`
- `python3 tests/test_claude_wrapper_user_binary_resolution.py`
- `python3 tests/test_issue_2448_shell_claude_wrapper_dispatch.py`
- `python3 scripts/generate-claude-launch-environment-policy.py --check`
- `bash -n Resources/bin/cmux-claude-wrapper`
- `git diff --check origin/main...HEAD`

Dogfood: cloud build `c5680` ran Claude Code 2.1.211 through `/help`, Escape, and `/clear`; the help frame disappeared without stacked or stale rows.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8204"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786752843&installation_id=133855650&pr_number=8204&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8204&signature=96ee2272d218b6132bd8d35968a31ea2ebcf3f3ba23643e7a45a4d878cb7a62b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default Claude fullscreen rendering to full-frame repaints for cmux sessions to prevent stale/garbled rows from incremental updates; preserves user overrides and leaves non-cmux launches unchanged. Fixes #5680.

- **Bug Fixes**
  - Set `CLAUDE_CODE_ALT_SCREEN_FULL_REPAINT=1` by default when running inside cmux (only if unset).
  - Added `tests/test_claude_wrapper_fullscreen_repaint.py` to verify defaulting, explicit override, and no changes outside cmux.

<sup>Written for commit 54a8264b5d4a64d177884ddc29d827d2f494af9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8204?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Claude Code fullscreen rendering automatically when running inside cmux.
  * Preserves any explicit fullscreen rendering preference.

* **Bug Fixes**
  * Reduced potential screen repaint issues in cmux sessions.

* **Tests**
  * Added regression coverage for cmux detection and rendering preference overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->