### PR TITLE
Keep workspace activity visible across agent races

### DIFF
--- a/CLI/CMUXAgentTurnDiffBaselineDatabase.swift
+++ b/CLI/CMUXAgentTurnDiffBaselineDatabase.swift
@@ -4,7 +4,6 @@ import SQLite3
 
 struct CMUXAgentTurnDiffBaselineDatabaseUpdate {
     var removedRecords: [CMUXAgentTurnDiffBaselineRecord]
-    var storedRecord: Bool
 }
 
 final class CMUXAgentTurnDiffBaselineDatabase {
@@ -40,13 +39,12 @@ final class CMUXAgentTurnDiffBaselineDatabase {
             nil
         )
         guard openResult == SQLITE_OK, let openedDatabase else {
-            let message = Self.sqliteMessage(openedDatabase) ?? "unknown SQLite open failure"
             sqlite3_close(openedDatabase)
-            throw CLIError(message: "Failed to open diff baseline database: \(message)")
+            throw Self.databaseError()
         }
         database = openedDatabase
         sqlite3_extended_result_codes(openedDatabase, 1)
-        _ = sqlite3_busy_timeout(openedDatabase, 5_000)
+        _ = sqlite3_busy_timeout(openedDatabase, 250)
 
         do {
             try configureSchema()
@@ -92,7 +90,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                 return nil
             }
             guard result == SQLITE_ROW else {
-                throw sqliteError("Failed to read latest diff baseline", code: result)
+                throw Self.databaseError()
             }
             return try record(from: statement, includeUntrackedPaths: true)
         }
@@ -126,7 +124,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                     return roots
                 }
                 guard result == SQLITE_ROW else {
-                    throw sqliteError("Failed to read diff baseline repositories", code: result)
+                    throw Self.databaseError()
                 }
                 if let root = text(from: statement, at: 0) {
                     roots.append(root)
@@ -137,7 +135,8 @@ final class CMUXAgentTurnDiffBaselineDatabase {
 
     func update(
         with rawRecord: CMUXAgentTurnDiffBaselineRecord,
-        preserveExistingTurnBaseline: Bool
+        preserveExistingTurnBaseline: Bool,
+        publishSnapshot: () throws -> Void
     ) throws -> CMUXAgentTurnDiffBaselineDatabaseUpdate {
         var record = rawRecord
         record.repoRoot = canonicalRepoRoot(record.repoRoot)
@@ -158,6 +157,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
             preserveExistingTurnBaseline && record.turnId != nil && existing != nil
         )
         if shouldStore {
+            try publishSnapshot()
             if let existing {
                 removedRecords.append(existing)
             }
@@ -171,8 +171,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
         try execute("COMMIT")
         committed = true
         return CMUXAgentTurnDiffBaselineDatabaseUpdate(
-            removedRecords: deduplicatedRecords(removedRecords),
-            storedRecord: shouldStore
+            removedRecords: deduplicatedRecords(removedRecords)
         )
     }
 
@@ -185,7 +184,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                     return snapshotIds
                 }
                 guard result == SQLITE_ROW else {
-                    throw sqliteError("Failed to read retained diff snapshots", code: result)
+                    throw Self.databaseError()
                 }
                 if let snapshotId = text(from: statement, at: 0) {
                     snapshotIds.insert(snapshotId)
@@ -213,10 +212,10 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                     return hashes
                 }
                 guard result == SQLITE_ROW else {
-                    throw sqliteError("Failed to read retained untracked hashes", code: result)
+                    throw Self.databaseError()
                 }
-                if let data = data(from: statement, at: 0),
-                   let decoded = try? JSONDecoder().decode([String: String].self, from: data) {
+                if let data = data(from: statement, at: 0) {
+                    let decoded = try JSONDecoder().decode([String: String].self, from: data)
                     hashes.formUnion(decoded.values)
                 }
             }
@@ -262,18 +261,13 @@ final class CMUXAgentTurnDiffBaselineDatabase {
     }
 
     private func migrateLegacyJSONIfNeeded() throws {
-        if try metadataValue(for: "legacy_json_imported") == "1" {
-            if FileManager.default.fileExists(atPath: legacyJSONPath) {
-                try withLegacyJSONLock {
-                    try? FileManager.default.removeItem(atPath: legacyJSONPath)
-                }
-            }
+        let legacyExists = FileManager.default.fileExists(atPath: legacyJSONPath)
+        if try metadataValue(for: "legacy_json_imported") == "1", !legacyExists {
             return
         }
 
         let lockPath = legacyJSONPath + ".lock"
-        if FileManager.default.fileExists(atPath: legacyJSONPath)
-            || FileManager.default.fileExists(atPath: lockPath) {
+        if legacyExists || FileManager.default.fileExists(atPath: lockPath) {
             try withLegacyJSONLock {
                 try migrateLegacyJSONWhileLocked()
             }
@@ -283,18 +277,15 @@ final class CMUXAgentTurnDiffBaselineDatabase {
     }
 
     private func migrateLegacyJSONWhileLocked() throws {
-        if try metadataValue(for: "legacy_json_imported") == "1" {
-            try? FileManager.default.removeItem(atPath: legacyJSONPath)
+        guard FileManager.default.fileExists(atPath: legacyJSONPath) else {
+            if try metadataValue(for: "legacy_json_imported") != "1" {
+                try migrateLegacyStore(CMUXAgentTurnDiffBaselineStore())
+            }
             return
         }
         let legacyURL = URL(fileURLWithPath: legacyJSONPath, isDirectory: false)
-        let legacyStore: CMUXAgentTurnDiffBaselineStore
-        if FileManager.default.fileExists(atPath: legacyURL.path) {
-            let data = try Data(contentsOf: legacyURL)
-            legacyStore = try JSONDecoder().decode(CMUXAgentTurnDiffBaselineStore.self, from: data)
-        } else {
-            legacyStore = CMUXAgentTurnDiffBaselineStore()
-        }
+        let data = try Data(contentsOf: legacyURL)
+        let legacyStore = try JSONDecoder().decode(CMUXAgentTurnDiffBaselineStore.self, from: data)
         try migrateLegacyStore(legacyStore)
         try? FileManager.default.removeItem(atPath: legacyJSONPath)
     }
@@ -307,7 +298,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                 try? execute("ROLLBACK")
             }
         }
-        if try metadataValue(for: "legacy_json_imported") != "1" {
+        if try metadataValue(for: "legacy_json_imported") != "1" || !legacyStore.records.isEmpty {
             for record in legacyStore.records.sorted(by: { $0.capturedAt < $1.capturedAt }) {
                 try upsert(record)
             }
@@ -327,14 +318,14 @@ final class CMUXAgentTurnDiffBaselineDatabase {
             mode_t(S_IRUSR | S_IWUSR)
         )
         guard descriptor >= 0 else {
-            throw CLIError(message: "Failed to open legacy diff baseline lock: \(lockPath)")
+            throw Self.databaseError()
         }
         defer { Darwin.close(descriptor) }
         guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
-            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            throw Self.databaseError()
         }
         guard flock(descriptor, LOCK_EX) == 0 else {
-            throw CLIError(message: "Failed to lock legacy diff baseline store: \(legacyJSONPath)")
+            throw Self.databaseError()
         }
         defer { _ = flock(descriptor, LOCK_UN) }
         return try body()
@@ -362,7 +353,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                 return nil
             }
             guard result == SQLITE_ROW else {
-                throw sqliteError("Failed to read existing diff baseline", code: result)
+                throw Self.databaseError()
             }
             return try self.record(from: statement, includeUntrackedPaths: false)
         }
@@ -400,11 +391,11 @@ final class CMUXAgentTurnDiffBaselineDatabase {
             try bindOptional(encodedHashes(record.untrackedPathHashes), at: 10, in: statement)
             try bindOptional(record.untrackedSnapshotId, at: 11, in: statement)
             guard sqlite3_bind_double(statement, 12, record.capturedAt) == SQLITE_OK else {
-                throw sqliteError("Failed to bind diff baseline timestamp")
+                throw Self.databaseError()
             }
             let result = sqlite3_step(statement)
             guard result == SQLITE_DONE else {
-                throw sqliteError("Failed to store diff baseline", code: result)
+                throw Self.databaseError()
             }
         }
     }
@@ -415,12 +406,12 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                    base_commit, untracked_paths, untracked_path_hashes, snapshot_id, captured_at
             FROM baselines
             WHERE captured_at < ?1 OR id NOT IN (
-                SELECT id FROM baselines ORDER BY captured_at DESC LIMIT \(Self.recordLimit)
+                SELECT id FROM baselines ORDER BY captured_at DESC, id DESC LIMIT \(Self.recordLimit)
             )
             """
         return try withStatement(sql) { statement in
             guard sqlite3_bind_double(statement, 1, cutoff) == SQLITE_OK else {
-                throw sqliteError("Failed to bind diff baseline retention cutoff")
+                throw Self.databaseError()
             }
             var records: [CMUXAgentTurnDiffBaselineRecord] = []
             while true {
@@ -429,7 +420,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                     return records
                 }
                 guard result == SQLITE_ROW else {
-                    throw sqliteError("Failed to read pruned diff baselines", code: result)
+                    throw Self.databaseError()
                 }
                 records.append(try record(from: statement, includeUntrackedPaths: false))
             }
@@ -440,16 +431,16 @@ final class CMUXAgentTurnDiffBaselineDatabase {
         let sql = """
             DELETE FROM baselines
             WHERE captured_at < ?1 OR id NOT IN (
-                SELECT id FROM baselines ORDER BY captured_at DESC LIMIT \(Self.recordLimit)
+                SELECT id FROM baselines ORDER BY captured_at DESC, id DESC LIMIT \(Self.recordLimit)
             )
             """
         try withStatement(sql) { statement in
             guard sqlite3_bind_double(statement, 1, cutoff) == SQLITE_OK else {
-                throw sqliteError("Failed to bind diff baseline retention cutoff")
+                throw Self.databaseError()
             }
             let result = sqlite3_step(statement)
             guard result == SQLITE_DONE else {
-                throw sqliteError("Failed to prune diff baselines", code: result)
+                throw Self.databaseError()
             }
         }
     }
@@ -464,7 +455,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
               let agent = text(from: statement, at: 4),
               let repoRoot = text(from: statement, at: 5),
               let baseCommit = text(from: statement, at: 6) else {
-            throw CLIError(message: "Diff baseline database contains an invalid record")
+            throw Self.databaseError()
         }
         let paths = includeUntrackedPaths ? decodedPaths(data(from: statement, at: 7)) : nil
         let hashes = try decodedHashes(data(from: statement, at: 8))
@@ -543,7 +534,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                 return nil
             }
             guard result == SQLITE_ROW else {
-                throw sqliteError("Failed to read diff baseline metadata", code: result)
+                throw Self.databaseError()
             }
             return text(from: statement, at: 0)
         }
@@ -557,7 +548,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
             try bind(value, at: 2, in: statement)
             let result = sqlite3_step(statement)
             guard result == SQLITE_DONE else {
-                throw sqliteError("Failed to store diff baseline metadata", code: result)
+                throw Self.databaseError()
             }
         }
     }
@@ -572,7 +563,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
                 return true
             }
             guard result == SQLITE_DONE else {
-                throw sqliteError("Failed to query diff baseline references", code: result)
+                throw Self.databaseError()
             }
             return false
         }
@@ -583,13 +574,13 @@ final class CMUXAgentTurnDiffBaselineDatabase {
         body: (OpaquePointer) throws -> T
     ) throws -> T {
         guard let database else {
-            throw CLIError(message: "Diff baseline database is closed")
+            throw Self.databaseError()
         }
         var statement: OpaquePointer?
         let prepareResult = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
         guard prepareResult == SQLITE_OK, let statement else {
             sqlite3_finalize(statement)
-            throw sqliteError("Failed to prepare diff baseline query", code: prepareResult)
+            throw Self.databaseError()
         }
         defer { sqlite3_finalize(statement) }
         return try body(statement)
@@ -597,23 +588,20 @@ final class CMUXAgentTurnDiffBaselineDatabase {
 
     private func execute(_ sql: String) throws {
         guard let database else {
-            throw CLIError(message: "Diff baseline database is closed")
+            throw Self.databaseError()
         }
         var errorMessage: UnsafeMutablePointer<CChar>?
         let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
         if result != SQLITE_OK {
-            let message = errorMessage.map { String(cString: $0) }
-                ?? Self.sqliteMessage(database)
-                ?? "SQLite error \(result)"
             sqlite3_free(errorMessage)
-            throw CLIError(message: "Diff baseline database error: \(message)")
+            throw Self.databaseError()
         }
     }
 
     private func bind(_ value: String, at index: Int32, in statement: OpaquePointer) throws {
         let result = sqlite3_bind_text(statement, index, value, -1, Self.transientDestructor)
         guard result == SQLITE_OK else {
-            throw sqliteError("Failed to bind diff baseline text", code: result)
+            throw Self.databaseError()
         }
     }
 
@@ -621,7 +609,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
         guard let value else {
             let result = sqlite3_bind_null(statement, index)
             guard result == SQLITE_OK else {
-                throw sqliteError("Failed to bind null diff baseline text", code: result)
+                throw Self.databaseError()
             }
             return
         }
@@ -632,7 +620,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
         guard let value else {
             let result = sqlite3_bind_null(statement, index)
             guard result == SQLITE_OK else {
-                throw sqliteError("Failed to bind null diff baseline data", code: result)
+                throw Self.databaseError()
             }
             return
         }
@@ -640,7 +628,7 @@ final class CMUXAgentTurnDiffBaselineDatabase {
             sqlite3_bind_blob(statement, index, buffer.baseAddress, Int32(buffer.count), Self.transientDestructor)
         }
         guard result == SQLITE_OK else {
-            throw sqliteError("Failed to bind diff baseline data", code: result)
+            throw Self.databaseError()
         }
     }
 
@@ -668,13 +656,10 @@ final class CMUXAgentTurnDiffBaselineDatabase {
         }
     }
 
-    private func sqliteError(_ context: String, code: Int32? = nil) -> CLIError {
-        let suffix = Self.sqliteMessage(database) ?? code.map { "SQLite error \($0)" } ?? "unknown SQLite error"
-        return CLIError(message: "\(context): \(suffix)")
-    }
-
-    private static func sqliteMessage(_ database: OpaquePointer?) -> String? {
-        guard let database, let message = sqlite3_errmsg(database) else { return nil }
-        return String(cString: message)
+    private static func databaseError() -> CLIError {
+        CLIError(message: CMUXDiffViewerLocalization.string(
+            "diffViewer.lastTurnHistoryUnavailable",
+            defaultValue: "Unable to access last-turn history."
+        ))
     }
 }

--- a/CLI/CMUXAgentTurnDiffBaselineDatabase.swift
+++ b/CLI/CMUXAgentTurnDiffBaselineDatabase.swift
@@ -1,0 +1,680 @@
+import Darwin
+import Foundation
+import SQLite3
+
+struct CMUXAgentTurnDiffBaselineDatabaseUpdate {
+    var removedRecords: [CMUXAgentTurnDiffBaselineRecord]
+    var storedRecord: Bool
+}
+
+final class CMUXAgentTurnDiffBaselineDatabase {
+    private static let schemaVersion = 1
+    private static let retentionSeconds: TimeInterval = 60 * 60 * 24 * 7
+    private static let recordLimit = 200
+    private static let transientDestructor = unsafeBitCast(-1, to: sqlite3_destructor_type.self)
+
+    private let path: String
+    private let legacyJSONPath: String
+    private var database: OpaquePointer?
+
+    init(path: String, legacyJSONPath: String) throws {
+        self.path = path
+        self.legacyJSONPath = legacyJSONPath
+
+        let databaseURL = URL(fileURLWithPath: path, isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: databaseURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true,
+            attributes: [.posixPermissions: 0o700]
+        )
+        try FileManager.default.setAttributes(
+            [.posixPermissions: 0o700],
+            ofItemAtPath: databaseURL.deletingLastPathComponent().path
+        )
+
+        var openedDatabase: OpaquePointer?
+        let openResult = sqlite3_open_v2(
+            path,
+            &openedDatabase,
+            SQLITE_OPEN_CREATE | SQLITE_OPEN_READWRITE | SQLITE_OPEN_FULLMUTEX,
+            nil
+        )
+        guard openResult == SQLITE_OK, let openedDatabase else {
+            let message = Self.sqliteMessage(openedDatabase) ?? "unknown SQLite open failure"
+            sqlite3_close(openedDatabase)
+            throw CLIError(message: "Failed to open diff baseline database: \(message)")
+        }
+        database = openedDatabase
+        sqlite3_extended_result_codes(openedDatabase, 1)
+        _ = sqlite3_busy_timeout(openedDatabase, 5_000)
+
+        do {
+            try configureSchema()
+            try migrateLegacyJSONIfNeeded()
+            try setPrivateFilePermissions()
+        } catch {
+            sqlite3_close(openedDatabase)
+            database = nil
+            throw error
+        }
+    }
+
+    deinit {
+        sqlite3_close(database)
+    }
+
+    func latestRecord(
+        repoRoot: String,
+        workspaceId: String,
+        surfaceId: String,
+        sessionId: String?
+    ) throws -> CMUXAgentTurnDiffBaselineRecord? {
+        var sql = """
+            SELECT workspace_id, surface_id, session_id, turn_id, agent, repo_root,
+                   base_commit, untracked_paths, untracked_path_hashes, snapshot_id, captured_at
+            FROM baselines
+            WHERE repo_root = ?1 AND workspace_id = ?2 AND surface_id = ?3
+            """
+        if sessionId != nil {
+            sql += " AND session_id = ?4"
+        }
+        sql += " ORDER BY captured_at DESC LIMIT 1"
+
+        return try withStatement(sql) { statement in
+            try bind(canonicalRepoRoot(repoRoot), at: 1, in: statement)
+            try bind(canonicalScopeIdentifier(workspaceId), at: 2, in: statement)
+            try bind(canonicalScopeIdentifier(surfaceId), at: 3, in: statement)
+            if let sessionId {
+                try bind(sessionId, at: 4, in: statement)
+            }
+            let result = sqlite3_step(statement)
+            if result == SQLITE_DONE {
+                return nil
+            }
+            guard result == SQLITE_ROW else {
+                throw sqliteError("Failed to read latest diff baseline", code: result)
+            }
+            return try record(from: statement, includeUntrackedPaths: true)
+        }
+    }
+
+    func repoRoots(
+        workspaceId: String,
+        surfaceId: String,
+        sessionId: String?
+    ) throws -> [String] {
+        var sql = """
+            SELECT repo_root, MAX(captured_at) AS newest
+            FROM baselines
+            WHERE workspace_id = ?1 AND surface_id = ?2
+            """
+        if sessionId != nil {
+            sql += " AND session_id = ?3"
+        }
+        sql += " GROUP BY repo_root ORDER BY newest DESC"
+
+        return try withStatement(sql) { statement in
+            try bind(canonicalScopeIdentifier(workspaceId), at: 1, in: statement)
+            try bind(canonicalScopeIdentifier(surfaceId), at: 2, in: statement)
+            if let sessionId {
+                try bind(sessionId, at: 3, in: statement)
+            }
+            var roots: [String] = []
+            while true {
+                let result = sqlite3_step(statement)
+                if result == SQLITE_DONE {
+                    return roots
+                }
+                guard result == SQLITE_ROW else {
+                    throw sqliteError("Failed to read diff baseline repositories", code: result)
+                }
+                if let root = text(from: statement, at: 0) {
+                    roots.append(root)
+                }
+            }
+        }
+    }
+
+    func update(
+        with rawRecord: CMUXAgentTurnDiffBaselineRecord,
+        preserveExistingTurnBaseline: Bool
+    ) throws -> CMUXAgentTurnDiffBaselineDatabaseUpdate {
+        var record = rawRecord
+        record.repoRoot = canonicalRepoRoot(record.repoRoot)
+        record.workspaceId = canonicalScopeIdentifier(record.workspaceId)
+        record.surfaceId = canonicalScopeIdentifier(record.surfaceId)
+
+        try execute("BEGIN IMMEDIATE")
+        var committed = false
+        defer {
+            if !committed {
+                try? execute("ROLLBACK")
+            }
+        }
+
+        var removedRecords: [CMUXAgentTurnDiffBaselineRecord] = []
+        let existing = try recordForUniqueTurn(record)
+        let shouldStore = !(
+            preserveExistingTurnBaseline && record.turnId != nil && existing != nil
+        )
+        if shouldStore {
+            if let existing {
+                removedRecords.append(existing)
+            }
+            try upsert(record)
+        }
+
+        let cutoff = Date().timeIntervalSince1970 - Self.retentionSeconds
+        let expired = try recordsForPruning(cutoff: cutoff)
+        removedRecords.append(contentsOf: expired)
+        try executePruning(cutoff: cutoff)
+        try execute("COMMIT")
+        committed = true
+        return CMUXAgentTurnDiffBaselineDatabaseUpdate(
+            removedRecords: deduplicatedRecords(removedRecords),
+            storedRecord: shouldStore
+        )
+    }
+
+    func retainedSnapshotIds() throws -> Set<String> {
+        try withStatement("SELECT snapshot_id FROM baselines WHERE snapshot_id IS NOT NULL") { statement in
+            var snapshotIds: Set<String> = []
+            while true {
+                let result = sqlite3_step(statement)
+                if result == SQLITE_DONE {
+                    return snapshotIds
+                }
+                guard result == SQLITE_ROW else {
+                    throw sqliteError("Failed to read retained diff snapshots", code: result)
+                }
+                if let snapshotId = text(from: statement, at: 0) {
+                    snapshotIds.insert(snapshotId)
+                }
+            }
+        }
+    }
+
+    func containsBaseCommit(repoRoot: String, baseCommit: String) throws -> Bool {
+        try contains(
+            sql: "SELECT 1 FROM baselines WHERE repo_root = ?1 AND base_commit = ?2 LIMIT 1",
+            values: [canonicalRepoRoot(repoRoot), baseCommit]
+        )
+    }
+
+    func retainedUntrackedHashes(repoRoot: String) throws -> Set<String> {
+        try withStatement(
+            "SELECT untracked_path_hashes FROM baselines WHERE repo_root = ?1 AND untracked_path_hashes IS NOT NULL"
+        ) { statement in
+            try bind(canonicalRepoRoot(repoRoot), at: 1, in: statement)
+            var hashes: Set<String> = []
+            while true {
+                let result = sqlite3_step(statement)
+                if result == SQLITE_DONE {
+                    return hashes
+                }
+                guard result == SQLITE_ROW else {
+                    throw sqliteError("Failed to read retained untracked hashes", code: result)
+                }
+                if let data = data(from: statement, at: 0),
+                   let decoded = try? JSONDecoder().decode([String: String].self, from: data) {
+                    hashes.formUnion(decoded.values)
+                }
+            }
+        }
+    }
+
+    private func configureSchema() throws {
+        try execute("PRAGMA journal_mode = WAL")
+        try execute("PRAGMA synchronous = NORMAL")
+        try execute("""
+            CREATE TABLE IF NOT EXISTS metadata (
+                key TEXT PRIMARY KEY,
+                value TEXT NOT NULL
+            )
+            """)
+        try execute("""
+            CREATE TABLE IF NOT EXISTS baselines (
+                id INTEGER PRIMARY KEY,
+                workspace_id TEXT NOT NULL,
+                surface_id TEXT NOT NULL,
+                session_id TEXT NOT NULL,
+                turn_id TEXT,
+                turn_key TEXT NOT NULL,
+                agent TEXT NOT NULL,
+                repo_root TEXT NOT NULL,
+                base_commit TEXT NOT NULL,
+                untracked_paths BLOB,
+                untracked_path_hashes BLOB,
+                snapshot_id TEXT,
+                captured_at REAL NOT NULL,
+                UNIQUE(repo_root, workspace_id, surface_id, session_id, turn_key)
+            )
+            """)
+        try execute("""
+            CREATE INDEX IF NOT EXISTS baselines_latest_scope_idx
+            ON baselines(repo_root, workspace_id, surface_id, session_id, captured_at DESC)
+            """)
+        try execute("""
+            CREATE INDEX IF NOT EXISTS baselines_repo_picker_idx
+            ON baselines(workspace_id, surface_id, session_id, captured_at DESC)
+            """)
+        try execute("PRAGMA user_version = \(Self.schemaVersion)")
+    }
+
+    private func migrateLegacyJSONIfNeeded() throws {
+        if try metadataValue(for: "legacy_json_imported") == "1" {
+            if FileManager.default.fileExists(atPath: legacyJSONPath) {
+                try withLegacyJSONLock {
+                    try? FileManager.default.removeItem(atPath: legacyJSONPath)
+                }
+            }
+            return
+        }
+
+        let lockPath = legacyJSONPath + ".lock"
+        if FileManager.default.fileExists(atPath: legacyJSONPath)
+            || FileManager.default.fileExists(atPath: lockPath) {
+            try withLegacyJSONLock {
+                try migrateLegacyJSONWhileLocked()
+            }
+        } else {
+            try migrateLegacyStore(CMUXAgentTurnDiffBaselineStore())
+        }
+    }
+
+    private func migrateLegacyJSONWhileLocked() throws {
+        if try metadataValue(for: "legacy_json_imported") == "1" {
+            try? FileManager.default.removeItem(atPath: legacyJSONPath)
+            return
+        }
+        let legacyURL = URL(fileURLWithPath: legacyJSONPath, isDirectory: false)
+        let legacyStore: CMUXAgentTurnDiffBaselineStore
+        if FileManager.default.fileExists(atPath: legacyURL.path) {
+            let data = try Data(contentsOf: legacyURL)
+            legacyStore = try JSONDecoder().decode(CMUXAgentTurnDiffBaselineStore.self, from: data)
+        } else {
+            legacyStore = CMUXAgentTurnDiffBaselineStore()
+        }
+        try migrateLegacyStore(legacyStore)
+        try? FileManager.default.removeItem(atPath: legacyJSONPath)
+    }
+
+    private func migrateLegacyStore(_ legacyStore: CMUXAgentTurnDiffBaselineStore) throws {
+        try execute("BEGIN IMMEDIATE")
+        var committed = false
+        defer {
+            if !committed {
+                try? execute("ROLLBACK")
+            }
+        }
+        if try metadataValue(for: "legacy_json_imported") != "1" {
+            for record in legacyStore.records.sorted(by: { $0.capturedAt < $1.capturedAt }) {
+                try upsert(record)
+            }
+            let cutoff = Date().timeIntervalSince1970 - Self.retentionSeconds
+            try executePruning(cutoff: cutoff)
+            try setMetadataValue("1", for: "legacy_json_imported")
+        }
+        try execute("COMMIT")
+        committed = true
+    }
+
+    private func withLegacyJSONLock<T>(_ body: () throws -> T) throws -> T {
+        let lockPath = legacyJSONPath + ".lock"
+        let descriptor = Darwin.open(
+            lockPath,
+            O_CREAT | O_RDWR | O_NOFOLLOW,
+            mode_t(S_IRUSR | S_IWUSR)
+        )
+        guard descriptor >= 0 else {
+            throw CLIError(message: "Failed to open legacy diff baseline lock: \(lockPath)")
+        }
+        defer { Darwin.close(descriptor) }
+        guard Darwin.fchmod(descriptor, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        guard flock(descriptor, LOCK_EX) == 0 else {
+            throw CLIError(message: "Failed to lock legacy diff baseline store: \(legacyJSONPath)")
+        }
+        defer { _ = flock(descriptor, LOCK_UN) }
+        return try body()
+    }
+
+    private func recordForUniqueTurn(
+        _ record: CMUXAgentTurnDiffBaselineRecord
+    ) throws -> CMUXAgentTurnDiffBaselineRecord? {
+        let sql = """
+            SELECT workspace_id, surface_id, session_id, turn_id, agent, repo_root,
+                   base_commit, untracked_paths, untracked_path_hashes, snapshot_id, captured_at
+            FROM baselines
+            WHERE repo_root = ?1 AND workspace_id = ?2 AND surface_id = ?3
+              AND session_id = ?4 AND turn_key = ?5
+            LIMIT 1
+            """
+        return try withStatement(sql) { statement in
+            try bind(record.repoRoot, at: 1, in: statement)
+            try bind(record.workspaceId, at: 2, in: statement)
+            try bind(record.surfaceId, at: 3, in: statement)
+            try bind(record.sessionId, at: 4, in: statement)
+            try bind(turnKey(record.turnId), at: 5, in: statement)
+            let result = sqlite3_step(statement)
+            if result == SQLITE_DONE {
+                return nil
+            }
+            guard result == SQLITE_ROW else {
+                throw sqliteError("Failed to read existing diff baseline", code: result)
+            }
+            return try self.record(from: statement, includeUntrackedPaths: false)
+        }
+    }
+
+    private func upsert(_ rawRecord: CMUXAgentTurnDiffBaselineRecord) throws {
+        var record = rawRecord
+        record.repoRoot = canonicalRepoRoot(record.repoRoot)
+        record.workspaceId = canonicalScopeIdentifier(record.workspaceId)
+        record.surfaceId = canonicalScopeIdentifier(record.surfaceId)
+        let sql = """
+            INSERT INTO baselines (
+                workspace_id, surface_id, session_id, turn_id, turn_key, agent, repo_root,
+                base_commit, untracked_paths, untracked_path_hashes, snapshot_id, captured_at
+            ) VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
+            ON CONFLICT(repo_root, workspace_id, surface_id, session_id, turn_key) DO UPDATE SET
+                turn_id = excluded.turn_id,
+                agent = excluded.agent,
+                base_commit = excluded.base_commit,
+                untracked_paths = excluded.untracked_paths,
+                untracked_path_hashes = excluded.untracked_path_hashes,
+                snapshot_id = excluded.snapshot_id,
+                captured_at = excluded.captured_at
+            """
+        try withStatement(sql) { statement in
+            try bind(record.workspaceId, at: 1, in: statement)
+            try bind(record.surfaceId, at: 2, in: statement)
+            try bind(record.sessionId, at: 3, in: statement)
+            try bindOptional(record.turnId, at: 4, in: statement)
+            try bind(turnKey(record.turnId), at: 5, in: statement)
+            try bind(record.agent, at: 6, in: statement)
+            try bind(record.repoRoot, at: 7, in: statement)
+            try bind(record.baseCommit, at: 8, in: statement)
+            try bindOptional(encodedPaths(record.untrackedPaths), at: 9, in: statement)
+            try bindOptional(encodedHashes(record.untrackedPathHashes), at: 10, in: statement)
+            try bindOptional(record.untrackedSnapshotId, at: 11, in: statement)
+            guard sqlite3_bind_double(statement, 12, record.capturedAt) == SQLITE_OK else {
+                throw sqliteError("Failed to bind diff baseline timestamp")
+            }
+            let result = sqlite3_step(statement)
+            guard result == SQLITE_DONE else {
+                throw sqliteError("Failed to store diff baseline", code: result)
+            }
+        }
+    }
+
+    private func recordsForPruning(cutoff: TimeInterval) throws -> [CMUXAgentTurnDiffBaselineRecord] {
+        let sql = """
+            SELECT workspace_id, surface_id, session_id, turn_id, agent, repo_root,
+                   base_commit, untracked_paths, untracked_path_hashes, snapshot_id, captured_at
+            FROM baselines
+            WHERE captured_at < ?1 OR id NOT IN (
+                SELECT id FROM baselines ORDER BY captured_at DESC LIMIT \(Self.recordLimit)
+            )
+            """
+        return try withStatement(sql) { statement in
+            guard sqlite3_bind_double(statement, 1, cutoff) == SQLITE_OK else {
+                throw sqliteError("Failed to bind diff baseline retention cutoff")
+            }
+            var records: [CMUXAgentTurnDiffBaselineRecord] = []
+            while true {
+                let result = sqlite3_step(statement)
+                if result == SQLITE_DONE {
+                    return records
+                }
+                guard result == SQLITE_ROW else {
+                    throw sqliteError("Failed to read pruned diff baselines", code: result)
+                }
+                records.append(try record(from: statement, includeUntrackedPaths: false))
+            }
+        }
+    }
+
+    private func executePruning(cutoff: TimeInterval) throws {
+        let sql = """
+            DELETE FROM baselines
+            WHERE captured_at < ?1 OR id NOT IN (
+                SELECT id FROM baselines ORDER BY captured_at DESC LIMIT \(Self.recordLimit)
+            )
+            """
+        try withStatement(sql) { statement in
+            guard sqlite3_bind_double(statement, 1, cutoff) == SQLITE_OK else {
+                throw sqliteError("Failed to bind diff baseline retention cutoff")
+            }
+            let result = sqlite3_step(statement)
+            guard result == SQLITE_DONE else {
+                throw sqliteError("Failed to prune diff baselines", code: result)
+            }
+        }
+    }
+
+    private func record(
+        from statement: OpaquePointer,
+        includeUntrackedPaths: Bool
+    ) throws -> CMUXAgentTurnDiffBaselineRecord {
+        guard let workspaceId = text(from: statement, at: 0),
+              let surfaceId = text(from: statement, at: 1),
+              let sessionId = text(from: statement, at: 2),
+              let agent = text(from: statement, at: 4),
+              let repoRoot = text(from: statement, at: 5),
+              let baseCommit = text(from: statement, at: 6) else {
+            throw CLIError(message: "Diff baseline database contains an invalid record")
+        }
+        let paths = includeUntrackedPaths ? decodedPaths(data(from: statement, at: 7)) : nil
+        let hashes = try decodedHashes(data(from: statement, at: 8))
+        return CMUXAgentTurnDiffBaselineRecord(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            sessionId: sessionId,
+            turnId: text(from: statement, at: 3),
+            agent: agent,
+            repoRoot: repoRoot,
+            baseCommit: baseCommit,
+            untrackedPaths: paths,
+            untrackedPathHashes: hashes,
+            untrackedSnapshotId: text(from: statement, at: 9),
+            capturedAt: sqlite3_column_double(statement, 10)
+        )
+    }
+
+    private func deduplicatedRecords(
+        _ records: [CMUXAgentTurnDiffBaselineRecord]
+    ) -> [CMUXAgentTurnDiffBaselineRecord] {
+        var seen: Set<String> = []
+        return records.filter { record in
+            let key = [
+                record.repoRoot,
+                record.workspaceId,
+                record.surfaceId,
+                record.sessionId,
+                turnKey(record.turnId),
+                String(record.capturedAt)
+            ].joined(separator: "\0")
+            return seen.insert(key).inserted
+        }
+    }
+
+    private func encodedPaths(_ paths: [String]?) -> Data? {
+        guard let paths, !paths.isEmpty else { return nil }
+        return paths.joined(separator: "\0").data(using: .utf8)
+    }
+
+    private func decodedPaths(_ data: Data?) -> [String]? {
+        guard let data, !data.isEmpty, let value = String(data: data, encoding: .utf8) else {
+            return nil
+        }
+        return value.split(separator: "\0", omittingEmptySubsequences: false).map(String.init)
+    }
+
+    private func encodedHashes(_ hashes: [String: String]?) throws -> Data? {
+        guard let hashes, !hashes.isEmpty else { return nil }
+        return try JSONEncoder().encode(hashes)
+    }
+
+    private func decodedHashes(_ data: Data?) throws -> [String: String]? {
+        guard let data, !data.isEmpty else { return nil }
+        return try JSONDecoder().decode([String: String].self, from: data)
+    }
+
+    private func turnKey(_ turnId: String?) -> String {
+        turnId ?? ""
+    }
+
+    private func canonicalScopeIdentifier(_ value: String) -> String {
+        UUID(uuidString: value)?.uuidString.lowercased() ?? value
+    }
+
+    private func canonicalRepoRoot(_ value: String) -> String {
+        URL(fileURLWithPath: NSString(string: value).expandingTildeInPath)
+            .standardizedFileURL.path
+    }
+
+    private func metadataValue(for key: String) throws -> String? {
+        try withStatement("SELECT value FROM metadata WHERE key = ?1") { statement in
+            try bind(key, at: 1, in: statement)
+            let result = sqlite3_step(statement)
+            if result == SQLITE_DONE {
+                return nil
+            }
+            guard result == SQLITE_ROW else {
+                throw sqliteError("Failed to read diff baseline metadata", code: result)
+            }
+            return text(from: statement, at: 0)
+        }
+    }
+
+    private func setMetadataValue(_ value: String, for key: String) throws {
+        try withStatement(
+            "INSERT INTO metadata(key, value) VALUES (?1, ?2) ON CONFLICT(key) DO UPDATE SET value = excluded.value"
+        ) { statement in
+            try bind(key, at: 1, in: statement)
+            try bind(value, at: 2, in: statement)
+            let result = sqlite3_step(statement)
+            guard result == SQLITE_DONE else {
+                throw sqliteError("Failed to store diff baseline metadata", code: result)
+            }
+        }
+    }
+
+    private func contains(sql: String, values: [String]) throws -> Bool {
+        try withStatement(sql) { statement in
+            for (offset, value) in values.enumerated() {
+                try bind(value, at: Int32(offset + 1), in: statement)
+            }
+            let result = sqlite3_step(statement)
+            if result == SQLITE_ROW {
+                return true
+            }
+            guard result == SQLITE_DONE else {
+                throw sqliteError("Failed to query diff baseline references", code: result)
+            }
+            return false
+        }
+    }
+
+    private func withStatement<T>(
+        _ sql: String,
+        body: (OpaquePointer) throws -> T
+    ) throws -> T {
+        guard let database else {
+            throw CLIError(message: "Diff baseline database is closed")
+        }
+        var statement: OpaquePointer?
+        let prepareResult = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+        guard prepareResult == SQLITE_OK, let statement else {
+            sqlite3_finalize(statement)
+            throw sqliteError("Failed to prepare diff baseline query", code: prepareResult)
+        }
+        defer { sqlite3_finalize(statement) }
+        return try body(statement)
+    }
+
+    private func execute(_ sql: String) throws {
+        guard let database else {
+            throw CLIError(message: "Diff baseline database is closed")
+        }
+        var errorMessage: UnsafeMutablePointer<CChar>?
+        let result = sqlite3_exec(database, sql, nil, nil, &errorMessage)
+        if result != SQLITE_OK {
+            let message = errorMessage.map { String(cString: $0) }
+                ?? Self.sqliteMessage(database)
+                ?? "SQLite error \(result)"
+            sqlite3_free(errorMessage)
+            throw CLIError(message: "Diff baseline database error: \(message)")
+        }
+    }
+
+    private func bind(_ value: String, at index: Int32, in statement: OpaquePointer) throws {
+        let result = sqlite3_bind_text(statement, index, value, -1, Self.transientDestructor)
+        guard result == SQLITE_OK else {
+            throw sqliteError("Failed to bind diff baseline text", code: result)
+        }
+    }
+
+    private func bindOptional(_ value: String?, at index: Int32, in statement: OpaquePointer) throws {
+        guard let value else {
+            let result = sqlite3_bind_null(statement, index)
+            guard result == SQLITE_OK else {
+                throw sqliteError("Failed to bind null diff baseline text", code: result)
+            }
+            return
+        }
+        try bind(value, at: index, in: statement)
+    }
+
+    private func bindOptional(_ value: Data?, at index: Int32, in statement: OpaquePointer) throws {
+        guard let value else {
+            let result = sqlite3_bind_null(statement, index)
+            guard result == SQLITE_OK else {
+                throw sqliteError("Failed to bind null diff baseline data", code: result)
+            }
+            return
+        }
+        let result = value.withUnsafeBytes { buffer in
+            sqlite3_bind_blob(statement, index, buffer.baseAddress, Int32(buffer.count), Self.transientDestructor)
+        }
+        guard result == SQLITE_OK else {
+            throw sqliteError("Failed to bind diff baseline data", code: result)
+        }
+    }
+
+    private func text(from statement: OpaquePointer, at index: Int32) -> String? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+              let pointer = sqlite3_column_text(statement, index) else {
+            return nil
+        }
+        return String(cString: pointer)
+    }
+
+    private func data(from statement: OpaquePointer, at index: Int32) -> Data? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL else { return nil }
+        let count = Int(sqlite3_column_bytes(statement, index))
+        guard count > 0, let bytes = sqlite3_column_blob(statement, index) else {
+            return Data()
+        }
+        return Data(bytes: bytes, count: count)
+    }
+
+    private func setPrivateFilePermissions() throws {
+        for candidate in [path, path + "-wal", path + "-shm"]
+            where FileManager.default.fileExists(atPath: candidate) {
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: candidate)
+        }
+    }
+
+    private func sqliteError(_ context: String, code: Int32? = nil) -> CLIError {
+        let suffix = Self.sqliteMessage(database) ?? code.map { "SQLite error \($0)" } ?? "unknown SQLite error"
+        return CLIError(message: "\(context): \(suffix)")
+    }
+
+    private static func sqliteMessage(_ database: OpaquePointer?) -> String? {
+        guard let database, let message = sqlite3_errmsg(database) else { return nil }
+        return String(cString: message)
+    }
+}

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -30610,24 +30610,6 @@ export default CMUXSessionRestore;
                 return
             }
             sendAgentFeedTelemetryUnlessSuppressed(workspaceId: workspaceId, surfaceId: surfaceId)
-            if !suppressVisibleMutations {
-                if codexSessionStartWentStaleAfterAccept() {
-                    telemetry.breadcrumb("\(def.name)-hook.session-start.stale-after-turn")
-                    didSendFeedTelemetry = true
-                    print("{}")
-                    return
-                }
-                try? recordAgentTurnDiffBaseline(
-                    agent: def.name,
-                    sessionId: sessionId,
-                    turnId: input.turnId,
-                    cwd: hookCwd ?? mapped?.cwd,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId,
-                    env: env,
-                    preserveExistingTurnBaseline: true
-                )
-            }
             if !sessionId.isEmpty {
                 if suppressVisibleMutations {
                     telemetry.breadcrumb("\(def.name)-hook.session-start.nested-suppressed")
@@ -30672,6 +30654,24 @@ export default CMUXSessionRestore;
                 workspaceId: workspaceId,
                 surfaceId: surfaceId
             )
+            if !suppressVisibleMutations {
+                if codexSessionStartWentStaleAfterAccept() {
+                    telemetry.breadcrumb("\(def.name)-hook.session-start.stale-after-turn")
+                    didSendFeedTelemetry = true
+                    print("{}")
+                    return
+                }
+                try? recordAgentTurnDiffBaseline(
+                    agent: def.name,
+                    sessionId: sessionId,
+                    turnId: input.turnId,
+                    cwd: hookCwd ?? mapped?.cwd,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    env: env,
+                    preserveExistingTurnBaseline: true
+                )
+            }
 
         case .promptSubmit:
             let mapped = sessionId.isEmpty ? nil : (try? store.lookup(sessionId: sessionId))
@@ -30852,23 +30852,6 @@ export default CMUXSessionRestore;
                 nestedPromptEvent: nestedPromptSubmit,
                 env: env
             )
-            if !suppressVisibleMutations && !incomingCodexTurnIsTerminal {
-                if codexPromptTurnWentTerminal() {
-                    stopStaleCodexPromptSubmit()
-                    return
-                }
-                try? recordAgentTurnDiffBaseline(
-                    agent: def.name,
-                    sessionId: sessionId,
-                    turnId: input.turnId,
-                    cwd: hookCwd ?? mapped?.cwd,
-                    workspaceId: workspaceId,
-                    surfaceId: surfaceId,
-                    env: env,
-                    preserveExistingTurnBaseline: activePromptDepth > 0 &&
-                        (normalizedHookValue(input.turnId).map { $0 == activePromptTurnId } ?? false)
-                )
-            }
             if incomingCodexTurnIsTerminal || codexPromptTurnWentTerminal() {
                 stopStaleCodexPromptSubmit()
                 return
@@ -31003,6 +30986,23 @@ export default CMUXSessionRestore;
                     leasePath: leasePath,
                     env: env,
                     telemetry: telemetry
+                )
+            }
+            if !suppressVisibleMutations && !incomingCodexTurnIsTerminal {
+                if codexPromptTurnWentTerminal() {
+                    stopStaleCodexPromptSubmit(restoreVisibleState: true)
+                    return
+                }
+                try? recordAgentTurnDiffBaseline(
+                    agent: def.name,
+                    sessionId: sessionId,
+                    turnId: input.turnId,
+                    cwd: hookCwd ?? mapped?.cwd,
+                    workspaceId: workspaceId,
+                    surfaceId: surfaceId,
+                    env: env,
+                    preserveExistingTurnBaseline: activePromptDepth > 0 &&
+                        (normalizedHookValue(input.turnId).map { $0 == activePromptTurnId } ?? false)
                 )
             }
 

--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -3195,9 +3195,6 @@ extension CMUXCLI {
         )
         do {
             var shouldRemoveNewSnapshot = untrackedSnapshot.snapshotId != nil
-            if let snapshotId = untrackedSnapshot.snapshotId {
-                try publishAgentTurnDiffBaselineSnapshot(snapshotId: snapshotId, storePath: storePath)
-            }
             let database = try CMUXAgentTurnDiffBaselineDatabase(
                 path: storePath,
                 legacyJSONPath: CMUXAgentTurnDiffBaselineFile.legacyJSONPath(env: env)
@@ -3205,8 +3202,12 @@ extension CMUXCLI {
             let update = try database.update(
                 with: record,
                 preserveExistingTurnBaseline: preserveExistingTurnBaseline
-            )
-            shouldRemoveNewSnapshot = !update.storedRecord && untrackedSnapshot.snapshotId != nil
+            ) {
+                if let snapshotId = untrackedSnapshot.snapshotId {
+                    try publishAgentTurnDiffBaselineSnapshot(snapshotId: snapshotId, storePath: storePath)
+                    shouldRemoveNewSnapshot = false
+                }
+            }
             pruneAgentTurnDiffBaselineArtifacts(
                 storePath: storePath,
                 removedRecords: update.removedRecords,

--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -29,12 +29,22 @@ private enum CMUXAgentTurnUntrackedSnapshotLimits {
 
 enum CMUXAgentTurnDiffBaselineFile {
     static func path(env: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        stateDirectory(env: env)
+            .appendingPathComponent("agent-turn-diff-baselines.sqlite3", isDirectory: false)
+            .path
+    }
+
+    static func legacyJSONPath(env: [String: String] = ProcessInfo.processInfo.environment) -> String {
+        stateDirectory(env: env)
+            .appendingPathComponent("agent-turn-diff-baselines.json", isDirectory: false)
+            .path
+    }
+
+    private static func stateDirectory(env: [String: String]) -> URL {
         if let overrideDirectory = normalized(env["CMUX_AGENT_HOOK_STATE_DIR"]) {
             return URL(fileURLWithPath: homeExpandedPath(overrideDirectory, env: env), isDirectory: true)
-                .appendingPathComponent("agent-turn-diff-baselines.json", isDirectory: false)
-                .path
         }
-        return homeExpandedPath("~/.cmuxterm/agent-turn-diff-baselines.json", env: env)
+        return URL(fileURLWithPath: homeExpandedPath("~/.cmuxterm", env: env), isDirectory: true)
     }
 
     private static func normalized(_ value: String?) -> String? {
@@ -3184,53 +3194,24 @@ extension CMUXCLI {
             capturedAt: Date().timeIntervalSince1970
         )
         do {
-            var removedRecords: [CMUXAgentTurnDiffBaselineRecord] = []
             var shouldRemoveNewSnapshot = untrackedSnapshot.snapshotId != nil
-            try updateAgentTurnDiffBaselineStore(path: storePath, update: { store in
-                func matchesCurrentScope(_ existing: CMUXAgentTurnDiffBaselineRecord) -> Bool {
-                    standardizedDiffSourcePath(existing.repoRoot) == repoRoot &&
-                        diffScopeIdentifierEquals(existing.workspaceId, workspaceId) &&
-                        diffScopeIdentifierEquals(existing.surfaceId, surfaceId) &&
-                        existing.sessionId == record.sessionId
-                }
-
-                let previousRecords = store.records
-                if preserveExistingTurnBaseline,
-                   let turnId = record.turnId,
-                   store.records.contains(where: { matchesCurrentScope($0) && $0.turnId == turnId }) {
-                    pruneAgentTurnDiffBaselineStore(&store)
-                    removedRecords = previousRecords.filter { previous in
-                        !store.records.contains { agentTurnDiffBaselineRecordEquals($0, previous) }
-                    }
-                    removedRecords.append(record)
-                    return
-                }
-
-                if let snapshotId = untrackedSnapshot.snapshotId {
-                    try publishAgentTurnDiffBaselineSnapshot(snapshotId: snapshotId, storePath: storePath)
-                    shouldRemoveNewSnapshot = false
-                }
-                store.records.removeAll { existing in
-                    guard matchesCurrentScope(existing) else {
-                        return false
-                    }
-                    if let turnId = record.turnId {
-                        return existing.turnId == turnId
-                    }
-                    return existing.turnId == nil
-                }
-                store.records.append(record)
-                pruneAgentTurnDiffBaselineStore(&store)
-                removedRecords = previousRecords.filter { previous in
-                    !store.records.contains { agentTurnDiffBaselineRecordEquals($0, previous) }
-                }
-            }, afterWrite: { store in
-                pruneAgentTurnDiffBaselineArtifacts(
-                    storePath: storePath,
-                    removedRecords: removedRecords,
-                    retainedRecords: store.records
-                )
-            })
+            if let snapshotId = untrackedSnapshot.snapshotId {
+                try publishAgentTurnDiffBaselineSnapshot(snapshotId: snapshotId, storePath: storePath)
+            }
+            let database = try CMUXAgentTurnDiffBaselineDatabase(
+                path: storePath,
+                legacyJSONPath: CMUXAgentTurnDiffBaselineFile.legacyJSONPath(env: env)
+            )
+            let update = try database.update(
+                with: record,
+                preserveExistingTurnBaseline: preserveExistingTurnBaseline
+            )
+            shouldRemoveNewSnapshot = !update.storedRecord && untrackedSnapshot.snapshotId != nil
+            pruneAgentTurnDiffBaselineArtifacts(
+                storePath: storePath,
+                removedRecords: update.removedRecords,
+                database: database
+            )
             if shouldRemoveNewSnapshot, let snapshotId = untrackedSnapshot.snapshotId {
                 removeAgentTurnDiffBaselineSnapshot(snapshotId: snapshotId, storePath: storePath)
             }
@@ -3283,93 +3264,43 @@ extension CMUXCLI {
         sessionId: String?,
         env: [String: String]
     ) throws -> CMUXAgentTurnDiffBaselineRecord? {
-        let store = try readAgentTurnDiffBaselineStore(path: CMUXAgentTurnDiffBaselineFile.path(env: env))
-        let repoRoot = standardizedDiffSourcePath(repoRoot)
-        let candidates = store.records.filter { record in
-            standardizedDiffSourcePath(record.repoRoot) == repoRoot
-                && diffScopeIdentifierEquals(record.workspaceId, workspaceId)
-                && diffScopeIdentifierEquals(record.surfaceId, surfaceId)
-                && (sessionId == nil || record.sessionId == sessionId)
-        }
-        return candidates.max(by: { $0.capturedAt < $1.capturedAt })
-    }
-
-    private func readAgentTurnDiffBaselineStore(path: String) throws -> CMUXAgentTurnDiffBaselineStore {
-        let url = URL(fileURLWithPath: path)
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            return CMUXAgentTurnDiffBaselineStore()
-        }
-        let data = try Data(contentsOf: url)
-        return try JSONDecoder().decode(CMUXAgentTurnDiffBaselineStore.self, from: data)
-    }
-
-    private func updateAgentTurnDiffBaselineStore(
-        path: String,
-        update: (inout CMUXAgentTurnDiffBaselineStore) throws -> Void,
-        afterWrite: ((CMUXAgentTurnDiffBaselineStore) -> Void)? = nil
-    ) throws {
-        let url = URL(fileURLWithPath: path)
-        try createPrivateDirectory(at: url.deletingLastPathComponent())
-        let lockPath = path + ".lock"
-        let fd = open(lockPath, O_CREAT | O_RDWR | O_NOFOLLOW, mode_t(S_IRUSR | S_IWUSR))
-        if fd < 0 {
-            throw CLIError(message: "Failed to open diff baseline lock: \(lockPath)")
-        }
-        defer { Darwin.close(fd) }
-
-        if flock(fd, LOCK_EX) != 0 {
-            throw CLIError(message: "Failed to lock diff baseline store: \(path)")
-        }
-        defer { _ = flock(fd, LOCK_UN) }
-        if Darwin.fchmod(fd, mode_t(S_IRUSR | S_IWUSR)) != 0 {
-            throw posixError(errno)
-        }
-
-        var store = (try? readAgentTurnDiffBaselineStore(path: path)) ?? CMUXAgentTurnDiffBaselineStore()
-        try update(&store)
-
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        try encoder.encode(store).write(to: url, options: .atomic)
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
-        afterWrite?(store)
-    }
-
-    private func pruneAgentTurnDiffBaselineStore(_ store: inout CMUXAgentTurnDiffBaselineStore) {
-        let cutoff = Date().timeIntervalSince1970 - 60 * 60 * 24 * 7
-        store.records = store.records
-            .filter { $0.capturedAt >= cutoff }
-            .sorted { $0.capturedAt > $1.capturedAt }
-        if store.records.count > 200 {
-            store.records.removeSubrange(200..<store.records.count)
-        }
+        let database = try CMUXAgentTurnDiffBaselineDatabase(
+            path: CMUXAgentTurnDiffBaselineFile.path(env: env),
+            legacyJSONPath: CMUXAgentTurnDiffBaselineFile.legacyJSONPath(env: env)
+        )
+        return try database.latestRecord(
+            repoRoot: repoRoot,
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            sessionId: sessionId
+        )
     }
 
     private func pruneAgentTurnDiffBaselineArtifacts(
         storePath: String,
         removedRecords: [CMUXAgentTurnDiffBaselineRecord],
-        retainedRecords: [CMUXAgentTurnDiffBaselineRecord]
+        database: CMUXAgentTurnDiffBaselineDatabase
     ) {
         pruneAgentTurnDiffBaselineRefs(
             removedRecords: removedRecords,
-            retainedRecords: retainedRecords
+            database: database
         )
-        pruneAgentTurnDiffBaselineSnapshots(storePath: storePath, retainedRecords: retainedRecords)
+        pruneAgentTurnDiffBaselineSnapshots(storePath: storePath, database: database)
     }
 
     private func pruneAgentTurnDiffBaselineRefs(
         removedRecords: [CMUXAgentTurnDiffBaselineRecord],
-        retainedRecords: [CMUXAgentTurnDiffBaselineRecord]
+        database: CMUXAgentTurnDiffBaselineDatabase
     ) {
         var deletedKeys: Set<String> = []
         for record in removedRecords {
             let repoRoot = standardizedDiffSourcePath(record.repoRoot)
             let key = "\(repoRoot)\u{0}\(record.baseCommit)"
             guard deletedKeys.insert(key).inserted else { continue }
-            let stillRetained = retainedRecords.contains { retained in
-                standardizedDiffSourcePath(retained.repoRoot) == repoRoot
-                    && retained.baseCommit == record.baseCommit
-            }
+            let stillRetained = (try? database.containsBaseCommit(
+                repoRoot: repoRoot,
+                baseCommit: record.baseCommit
+            )) ?? true
             guard !stillRetained else { continue }
             _ = CLIProcessRunner.runProcess(
                 executablePath: "/usr/bin/env",
@@ -3378,17 +3309,23 @@ extension CMUXCLI {
             )
         }
         var deletedBlobKeys: Set<String> = []
+        var retainedHashesByRepo: [String: Set<String>] = [:]
         for record in removedRecords {
             let repoRoot = standardizedDiffSourcePath(record.repoRoot)
+            let retainedHashes: Set<String>
+            if let cached = retainedHashesByRepo[repoRoot] {
+                retainedHashes = cached
+            } else if let loaded = try? database.retainedUntrackedHashes(repoRoot: repoRoot) {
+                retainedHashes = loaded
+                retainedHashesByRepo[repoRoot] = loaded
+            } else {
+                continue
+            }
             let blobs = Set(record.untrackedPathHashes.map { Array($0.values) } ?? [])
             for blob in blobs {
                 let key = "\(repoRoot)\u{0}\(blob)"
                 guard deletedBlobKeys.insert(key).inserted else { continue }
-                let stillRetained = retainedRecords.contains { retained in
-                    standardizedDiffSourcePath(retained.repoRoot) == repoRoot
-                        && (retained.untrackedPathHashes?.values.contains(blob) ?? false)
-                }
-                guard !stillRetained else { continue }
+                guard !retainedHashes.contains(blob) else { continue }
                 _ = CLIProcessRunner.runProcess(
                     executablePath: "/usr/bin/env",
                     arguments: ["git", "-C", repoRoot, "update-ref", "-d", agentTurnDiffBaselineUntrackedRefName(for: blob)],
@@ -3400,10 +3337,12 @@ extension CMUXCLI {
 
     private func pruneAgentTurnDiffBaselineSnapshots(
         storePath: String,
-        retainedRecords: [CMUXAgentTurnDiffBaselineRecord]
+        database: CMUXAgentTurnDiffBaselineDatabase
     ) {
         let rootURL = agentTurnDiffBaselineSnapshotRootURL(storePath: storePath)
-        let retainedSnapshotIds = Set(retainedRecords.compactMap(\.untrackedSnapshotId))
+        guard let retainedSnapshotIds = try? database.retainedSnapshotIds() else {
+            return
+        }
         guard let entries = try? FileManager.default.contentsOfDirectory(
             at: rootURL,
             includingPropertiesForKeys: [.isDirectoryKey],
@@ -3417,23 +3356,6 @@ extension CMUXCLI {
             }
             try? FileManager.default.removeItem(at: entry)
         }
-    }
-
-    private func agentTurnDiffBaselineRecordEquals(
-        _ lhs: CMUXAgentTurnDiffBaselineRecord,
-        _ rhs: CMUXAgentTurnDiffBaselineRecord
-    ) -> Bool {
-        standardizedDiffSourcePath(lhs.repoRoot) == standardizedDiffSourcePath(rhs.repoRoot)
-            && diffScopeIdentifierEquals(lhs.workspaceId, rhs.workspaceId)
-            && diffScopeIdentifierEquals(lhs.surfaceId, rhs.surfaceId)
-            && lhs.sessionId == rhs.sessionId
-            && lhs.turnId == rhs.turnId
-            && lhs.agent == rhs.agent
-            && lhs.baseCommit == rhs.baseCommit
-            && lhs.untrackedPaths == rhs.untrackedPaths
-            && lhs.untrackedPathHashes == rhs.untrackedPathHashes
-            && lhs.untrackedSnapshotId == rhs.untrackedSnapshotId
-            && lhs.capturedAt == rhs.capturedAt
     }
 
     private func diffScopeIdentifierEquals(_ lhs: String, _ rhs: String) -> Bool {
@@ -5553,28 +5475,23 @@ extension CMUXCLI {
 
     private func agentTurnDiffBaselineRepoURLs(context: DiffSourceContext) -> [URL] {
         guard let workspaceId = normalizedDiffSourceValue(context.workspaceId),
-              let surfaceId = normalizedDiffSourceValue(context.surfaceId),
-              let store = try? readAgentTurnDiffBaselineStore(
-                path: CMUXAgentTurnDiffBaselineFile.path(env: ProcessInfo.processInfo.environment)
-              ) else {
+              let surfaceId = normalizedDiffSourceValue(context.surfaceId) else {
+            return []
+        }
+        let environment = ProcessInfo.processInfo.environment
+        guard let database = try? CMUXAgentTurnDiffBaselineDatabase(
+            path: CMUXAgentTurnDiffBaselineFile.path(env: environment),
+            legacyJSONPath: CMUXAgentTurnDiffBaselineFile.legacyJSONPath(env: environment)
+        ) else {
             return []
         }
         let sessionId = normalizedDiffSourceValue(context.sessionId)
-        let matchingRecords = store.records
-            .filter { record in
-                diffScopeIdentifierEquals(record.workspaceId, workspaceId) &&
-                    diffScopeIdentifierEquals(record.surfaceId, surfaceId) &&
-                    (sessionId == nil || record.sessionId == sessionId)
-            }
-            .sorted { $0.capturedAt > $1.capturedAt }
-        var seen: Set<String> = []
-        var urls: [URL] = []
-        for record in matchingRecords {
-            let repoRoot = standardizedDiffSourcePath(record.repoRoot)
-            guard seen.insert(repoRoot).inserted else { continue }
-            urls.append(URL(fileURLWithPath: repoRoot, isDirectory: true).standardizedFileURL)
-        }
-        return urls
+        let roots = (try? database.repoRoots(
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            sessionId: sessionId
+        )) ?? []
+        return roots.map { URL(fileURLWithPath: $0, isDirectory: true).standardizedFileURL }
     }
 
     private func gitChildRepoURLs(in directoryURL: URL) -> [URL] {
@@ -6417,8 +6334,7 @@ extension CMUXCLI {
         // Branch regeneration runs on concurrent connection queues, so two
         // concurrent base selections can race this read-modify-write: the later
         // write would drop the earlier page from the manifest and 404 it.
-        // Serialize the whole sequence under a per-manifest flock, matching the
-        // flock pattern used by updateAgentTurnDiffBaselineStore.
+        // Serialize the whole sequence under a per-manifest flock.
         let lockPath = url.path + ".lock"
         let fd = open(lockPath, O_CREAT | O_RDWR | O_NOFOLLOW, mode_t(S_IRUSR | S_IWUSR))
         if fd < 0 {

--- a/Sources/Workspace+PanelLifecycle.swift
+++ b/Sources/Workspace+PanelLifecycle.swift
@@ -81,6 +81,12 @@ extension Workspace {
         return false
     }
 
+    private func hasAgentRuntime(forStatusKey statusKey: String, panelId: UUID) -> Bool {
+        (agentPIDKeysByPanelId[panelId] ?? []).contains {
+            agentStatusKey(forAgentPIDKey: $0) == statusKey
+        }
+    }
+
     private func removeAgentPIDOwnership(key: String) {
         if let previousPanelId = agentPIDPanelIdsByKey[key] {
             agentPIDKeysByPanelId[previousPanelId]?.remove(key)
@@ -274,7 +280,12 @@ extension Workspace {
         if let changedPanelId = ownedPanelId ?? panelId, didChange { AgentHibernationController.shared.recordAgentProcessChange(workspaceId: id, panelId: changedPanelId) }
         if let lifecyclePanelId = ownedPanelId ?? panelId {
             let lifecycleStatusKey = agentStatusKey(forAgentPIDKey: key)
-            if clearAgentLifecycle(key: lifecycleStatusKey, panelId: lifecyclePanelId) {
+            // A delayed teardown for a replaced session can arrive after the
+            // replacement registered its own PID key on this panel. Both keys
+            // share one lifecycle status key, so only the last runtime owner
+            // may clear the panel's running state.
+            if !hasAgentRuntime(forStatusKey: lifecycleStatusKey, panelId: lifecyclePanelId),
+               clearAgentLifecycle(key: lifecycleStatusKey, panelId: lifecyclePanelId) {
                 didChange = true
             }
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -443,6 +443,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5B00003A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
 		A5B00004A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
 		A5B00005A1B2C3D4E5F60718 /* CMUXAgentLaunch in Frameworks */ = {isa = PBXBuildFile; productRef = A5B00002A1B2C3D4E5F60718 /* CMUXAgentLaunch */; };
+		C0DE82050000000000000002 /* CMUXAgentTurnDiffBaselineDatabase.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE82050000000000000001 /* CMUXAgentTurnDiffBaselineDatabase.swift */; };
 		E3309A07 /* cmuxApp+EqualizeSplitsMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A08 /* cmuxApp+EqualizeSplitsMenu.swift */; };
 		C4160A010000000000000001 /* cmuxApp+HistoryMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4160A010000000000000002 /* cmuxApp+HistoryMenu.swift */; };
 		80410000000000000000000D /* cmuxApp+WorkspaceCommandHelpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80410000000000000000000E /* cmuxApp+WorkspaceCommandHelpers.swift */; };
@@ -2446,6 +2447,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001655 /* CmuxActionTrust.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxActionTrust.swift; sourceTree = "<group>"; };
 		C0DE43000000000000000002 /* CmuxAgentChatConfig.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxAgentChatConfig.swift; sourceTree = "<group>"; };
 		C0DE4300000000000000000A /* CmuxAgentChatConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxAgentChatConfigTests.swift; sourceTree = "<group>"; };
+		C0DE82050000000000000001 /* CMUXAgentTurnDiffBaselineDatabase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXAgentTurnDiffBaselineDatabase.swift; sourceTree = "<group>"; };
 		E3309A08 /* cmuxApp+EqualizeSplitsMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+EqualizeSplitsMenu.swift"; sourceTree = "<group>"; };
 		C4160A010000000000000002 /* cmuxApp+HistoryMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+HistoryMenu.swift"; sourceTree = "<group>"; };
 		80410000000000000000000E /* cmuxApp+WorkspaceCommandHelpers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "cmuxApp+WorkspaceCommandHelpers.swift"; sourceTree = "<group>"; };
@@ -5350,6 +5352,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE75890000000000000002 /* CMUXCLI+DiffViewerBundledAssets.swift */,
 				C0DE79210000000000000002 /* CMUXCLI+DiffViewerShortcuts.swift */,
 				B9000030A1B2C3D4E5F60719 /* cmux_open.swift */,
+				C0DE82050000000000000001 /* CMUXAgentTurnDiffBaselineDatabase.swift */,
 				CBF07000000000000000001 /* CMUXCLI+SSHStartupScripts.swift */,
 				C0DE1A060000000000000002 /* cmux_layout.swift */,
 				B9000040A1B2C3D4E5F60719 /* CMUXCLI+SSHCommandSupport.swift */,
@@ -7577,6 +7580,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B9000002A1B2C3D4E5F60719 /* cmux.swift in Sources */,
 				C0DE1A060000000000000001 /* cmux_layout.swift in Sources */,
 				B9000034A1B2C3D4E5F60719 /* cmux_open.swift in Sources */,
+				C0DE82050000000000000002 /* CMUXAgentTurnDiffBaselineDatabase.swift in Sources */,
 				D4461A487C13945177EEE9A1 /* CMUXCLI+AgentHookCatalog.swift in Sources */,
 				B9000063A1B2C3D4E5F60719 /* CMUXCLI+AgentHookDefinitions.swift in Sources */,
 				6D9C51AB30A64B1ABC819146 /* CMUXCLI+AgentHookPayload.swift in Sources */,

--- a/cmuxTests/AgentHibernationTests.swift
+++ b/cmuxTests/AgentHibernationTests.swift
@@ -257,6 +257,37 @@ struct AgentHibernationTests {
 
     @MainActor
     @Test
+    func testStaleAgentPIDCleanupPreservesRunningReplacementOnSamePanel() throws {
+        let workspace = Workspace()
+        let panelId = try #require(workspace.focusedPanelId)
+
+        workspace.recordAgentPID(
+            key: "codex.current-session",
+            pid: 222,
+            panelId: panelId,
+            refreshPorts: false
+        )
+        workspace.setAgentLifecycle(key: "codex", panelId: panelId, lifecycle: .running)
+
+        expectFalse(
+            workspace.clearAgentPID(
+                key: "codex.stale-session",
+                panelId: panelId,
+                clearStatus: true,
+                refreshPorts: false
+            )
+        )
+        expectEqual(workspace.agentHibernationLifecycleState(panelId: panelId, fallback: nil), .running)
+        expectEqual(
+            SidebarAgentActivitySummary.activeCodingAgentCount(
+                statesByPanelId: workspace.agentLifecycleStatesByPanelId
+            ),
+            1
+        )
+    }
+
+    @MainActor
+    @Test
     func testClearingAgentPIDByPanelClearsOnlyThatPanelLifecycleWhenSameStatusKeyRemains() throws {
         let workspace = Workspace()
         let firstPanelId = try #require(workspace.focusedPanelId)

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -687,7 +687,7 @@ struct CLICodexHookTimeoutRegressionTests {
         let fakeBin = root.appendingPathComponent("bin", isDirectory: true)
         let fakeGit = fakeBin.appendingPathComponent("git", isDirectory: false)
         let slowGitDone = root.appendingPathComponent("slow-git-done", isDirectory: false)
-        let baselineStore = root.appendingPathComponent("agent-turn-diff-baselines.json", isDirectory: false)
+        let baselineStore = root.appendingPathComponent("agent-turn-diff-baselines.sqlite3", isDirectory: false)
         let socketPath = makeCodexHookSocketPath("slow-diff")
         let listenerFD = try bindCodexHookUnixSocket(at: socketPath)
         let commands = CodexHookCapturedSocketCommands()

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -686,6 +686,8 @@ struct CLICodexHookTimeoutRegressionTests {
         let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
         let fakeBin = root.appendingPathComponent("bin", isDirectory: true)
         let fakeGit = fakeBin.appendingPathComponent("git", isDirectory: false)
+        let slowGitStarted = root.appendingPathComponent("slow-git-started", isDirectory: false)
+        let slowGitGate = root.appendingPathComponent("slow-git-gate", isDirectory: false)
         let slowGitDone = root.appendingPathComponent("slow-git-done", isDirectory: false)
         let baselineStore = root.appendingPathComponent("agent-turn-diff-baselines.sqlite3", isDirectory: false)
         let socketPath = makeCodexHookSocketPath("slow-diff")
@@ -695,6 +697,9 @@ struct CLICodexHookTimeoutRegressionTests {
         let surfaceId = "22222222-2222-2222-2222-222222222222"
         try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: fakeBin, withIntermediateDirectories: true)
+        guard Darwin.mkfifo(slowGitGate.path, mode_t(S_IRUSR | S_IWUSR)) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
         defer {
             Darwin.close(listenerFD)
             unlink(socketPath)
@@ -705,7 +710,7 @@ struct CLICodexHookTimeoutRegressionTests {
             "#!/bin/sh",
             "case \" $* \" in",
             "  *\" rev-parse --show-toplevel \"*) printf '%s\\n' \"$CMUX_TEST_REPO_ROOT\" ;;",
-            "  *\" stash create \"*) sleep 3; printf done > \"$CMUX_TEST_SLOW_GIT_DONE\"; exit 1 ;;",
+            "  *\" stash create \"*) printf started > \"$CMUX_TEST_SLOW_GIT_STARTED\"; cat \"$CMUX_TEST_SLOW_GIT_GATE\" >/dev/null; printf done > \"$CMUX_TEST_SLOW_GIT_DONE\"; exit 1 ;;",
             "  *\" rev-parse HEAD \"*) printf '%040d\\n' 0 ;;",
             "  *) exit 0 ;;",
             "esac",
@@ -743,6 +748,8 @@ struct CLICodexHookTimeoutRegressionTests {
             "CMUX_BUNDLED_CLI_PATH": cliPath,
             "CMUX_CODEX_PID": "4242",
             "CMUX_TEST_REPO_ROOT": root.path,
+            "CMUX_TEST_SLOW_GIT_STARTED": slowGitStarted.path,
+            "CMUX_TEST_SLOW_GIT_GATE": slowGitGate.path,
             "CMUX_TEST_SLOW_GIT_DONE": slowGitDone.path,
         ]
         let run = runCodexHookProcess(
@@ -756,13 +763,20 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(!run.timedOut, Comment(rawValue: run.stderr))
         #expect(run.status == 0, Comment(rawValue: run.stderr))
         #expect(run.stdout == "{}\n")
+        #expect(waitForFile(slowGitStarted, containing: "started", timeout: 5))
         #expect(
-            waitForCondition(timeout: 1) {
-                !FileManager.default.fileExists(atPath: slowGitDone.path)
-                    && commands.snapshot().contains { $0.hasPrefix(expectedCommandPrefix) }
-            },
-            "\(subcommand) must publish its sidebar state before the turn-diff baseline finishes"
+            commands.snapshot().contains { $0.hasPrefix(expectedCommandPrefix) },
+            "\(subcommand) must publish its sidebar state before starting the blocked turn-diff baseline"
         )
+        let gateDescriptor = Darwin.open(slowGitGate.path, O_WRONLY)
+        #expect(gateDescriptor >= 0)
+        if gateDescriptor >= 0 {
+            var byte: UInt8 = 1
+            _ = withUnsafeBytes(of: &byte) { buffer in
+                Darwin.write(gateDescriptor, buffer.baseAddress, buffer.count)
+            }
+            Darwin.close(gateDescriptor)
+        }
         #expect(waitForFile(slowGitDone, containing: "done", timeout: 5))
         #expect(waitForCondition(timeout: 2) {
             FileManager.default.fileExists(atPath: baselineStore.path)

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -129,6 +129,21 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(waitForFile(doneFile, containing: "done", timeout: 6))
     }
 
+    @Test func codexHooksPublishVisibleStateBeforeSlowTurnDiffBaseline() throws {
+        try assertCodexHookPublishesVisibleStateBeforeSlowTurnDiffBaseline(
+            eventName: "SessionStart",
+            subcommand: "session-start",
+            payload: #"{"session_id":"codex-session","cwd":"REPO_ROOT","hook_event_name":"SessionStart"}"#,
+            expectedCommandPrefix: "set_agent_pid "
+        )
+        try assertCodexHookPublishesVisibleStateBeforeSlowTurnDiffBaseline(
+            eventName: "UserPromptSubmit",
+            subcommand: "prompt-submit",
+            payload: #"{"session_id":"codex-session","turn_id":"turn-1","cwd":"REPO_ROOT","hook_event_name":"UserPromptSubmit","prompt":"work"}"#,
+            expectedCommandPrefix: "set_status codex Running "
+        )
+    }
+
     @Test func codexInstalledStopHookReturnsBeforeSlowCmuxCommandFinishes() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory
@@ -657,6 +672,101 @@ struct CLICodexHookTimeoutRegressionTests {
         #expect(session["agentLifecycle"] as? String == "idle")
         #expect(session["runtimeStatus"] as? String == "idle")
         #expect(session["terminalPromptTurnIds"] as? [String] == ["turn-done"])
+    }
+
+    private func assertCodexHookPublishesVisibleStateBeforeSlowTurnDiffBaseline(
+        eventName: String,
+        subcommand: String,
+        payload: String,
+        expectedCommandPrefix: String
+    ) throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-slow-baseline-\(subcommand)-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let fakeBin = root.appendingPathComponent("bin", isDirectory: true)
+        let fakeGit = fakeBin.appendingPathComponent("git", isDirectory: false)
+        let slowGitDone = root.appendingPathComponent("slow-git-done", isDirectory: false)
+        let baselineStore = root.appendingPathComponent("agent-turn-diff-baselines.json", isDirectory: false)
+        let socketPath = makeCodexHookSocketPath("slow-diff")
+        let listenerFD = try bindCodexHookUnixSocket(at: socketPath)
+        let commands = CodexHookCapturedSocketCommands()
+        let workspaceId = "11111111-1111-1111-1111-111111111111"
+        let surfaceId = "22222222-2222-2222-2222-222222222222"
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: fakeBin, withIntermediateDirectories: true)
+        defer {
+            Darwin.close(listenerFD)
+            unlink(socketPath)
+            try? FileManager.default.removeItem(at: root)
+        }
+
+        try makeCodexHookExecutableShellFile(at: fakeGit, lines: [
+            "#!/bin/sh",
+            "case \" $* \" in",
+            "  *\" rev-parse --show-toplevel \"*) printf '%s\\n' \"$CMUX_TEST_REPO_ROOT\" ;;",
+            "  *\" stash create \"*) sleep 3; printf done > \"$CMUX_TEST_SLOW_GIT_DONE\"; exit 1 ;;",
+            "  *\" rev-parse HEAD \"*) printf '%040d\\n' 0 ;;",
+            "  *) exit 0 ;;",
+            "esac",
+        ])
+
+        let install = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: codexHookTestEnvironment(root: root, codexHome: codexHome),
+            timeout: 5
+        )
+        #expect(!install.timedOut, Comment(rawValue: install.stderr))
+        #expect(install.status == 0, Comment(rawValue: install.stderr))
+        startCodexHookMockSocketServerAccepting(
+            listenerFD: listenerFD,
+            commands: commands,
+            surfaceId: surfaceId,
+            connectionLimit: 24
+        )
+
+        let hookCommand = try #require(
+            codexHookEntries(in: codexHome).first { $0.eventName == eventName }?.command
+        )
+        let environment = [
+            "HOME": root.path,
+            "CODEX_HOME": codexHome.path,
+            "PATH": "\(fakeBin.path):/usr/bin:/bin:/usr/sbin:/sbin",
+            "PWD": root.path,
+            "TMPDIR": root.path,
+            "CMUX_SOCKET_PATH": socketPath,
+            "CMUX_WORKSPACE_ID": workspaceId,
+            "CMUX_SURFACE_ID": surfaceId,
+            "CMUX_AGENT_HOOK_STATE_DIR": root.path,
+            "CMUX_CLI_SENTRY_DISABLED": "1",
+            "CMUX_BUNDLED_CLI_PATH": cliPath,
+            "CMUX_CODEX_PID": "4242",
+            "CMUX_TEST_REPO_ROOT": root.path,
+            "CMUX_TEST_SLOW_GIT_DONE": slowGitDone.path,
+        ]
+        let run = runCodexHookProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", hookCommand],
+            environment: environment,
+            standardInput: payload.replacingOccurrences(of: "REPO_ROOT", with: root.path),
+            timeout: 2
+        )
+
+        #expect(!run.timedOut, Comment(rawValue: run.stderr))
+        #expect(run.status == 0, Comment(rawValue: run.stderr))
+        #expect(run.stdout == "{}\n")
+        #expect(
+            waitForCondition(timeout: 1) {
+                !FileManager.default.fileExists(atPath: slowGitDone.path)
+                    && commands.snapshot().contains { $0.hasPrefix(expectedCommandPrefix) }
+            },
+            "\(subcommand) must publish its sidebar state before the turn-diff baseline finishes"
+        )
+        #expect(waitForFile(slowGitDone, containing: "done", timeout: 5))
+        #expect(waitForCondition(timeout: 2) {
+            FileManager.default.fileExists(atPath: baselineStore.path)
+        })
     }
 
     private func bundledCLIPath() throws -> String {

--- a/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
+++ b/cmuxTests/CLINotifyProcessIntegrationRegressionTests.swift
@@ -1,10 +1,73 @@
 import XCTest
 import Darwin
+import SQLite3
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
 @testable import cmux
 #endif
+
+private func readAgentTurnDiffBaselineRecords(at stateDirectoryURL: URL) throws -> [[String: Any]] {
+    let databaseURL = stateDirectoryURL.appendingPathComponent("agent-turn-diff-baselines.sqlite3")
+    var database: OpaquePointer?
+    let openResult = sqlite3_open_v2(databaseURL.path, &database, SQLITE_OPEN_READONLY, nil)
+    guard openResult == SQLITE_OK, let database else {
+        sqlite3_close(database)
+        throw NSError(
+            domain: "CLINotifyProcessIntegrationRegressionTests.diffBaselineDatabase",
+            code: Int(openResult)
+        )
+    }
+    defer { sqlite3_close(database) }
+
+    let sql = """
+        SELECT workspace_id, surface_id, session_id, turn_id, base_commit
+        FROM baselines
+        ORDER BY captured_at DESC
+        """
+    var statement: OpaquePointer?
+    let prepareResult = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+    guard prepareResult == SQLITE_OK, let statement else {
+        sqlite3_finalize(statement)
+        throw NSError(
+            domain: "CLINotifyProcessIntegrationRegressionTests.diffBaselineDatabase",
+            code: Int(prepareResult)
+        )
+    }
+    defer { sqlite3_finalize(statement) }
+
+    func text(_ index: Int32) -> String? {
+        guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+              let value = sqlite3_column_text(statement, index) else {
+            return nil
+        }
+        return String(cString: value)
+    }
+
+    var records: [[String: Any]] = []
+    while true {
+        let result = sqlite3_step(statement)
+        if result == SQLITE_DONE {
+            return records
+        }
+        guard result == SQLITE_ROW else {
+            throw NSError(
+                domain: "CLINotifyProcessIntegrationRegressionTests.diffBaselineDatabase",
+                code: Int(result)
+            )
+        }
+        var record: [String: Any] = [
+            "workspaceId": text(0) ?? "",
+            "surfaceId": text(1) ?? "",
+            "sessionId": text(2) ?? "",
+            "baseCommit": text(4) ?? ""
+        ]
+        if let turnId = text(3) {
+            record["turnId"] = turnId
+        }
+        records.append(record)
+    }
+}
 
 final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
     func testClaudeClearSessionStartMarksWorkspaceRunning() throws {
@@ -360,9 +423,7 @@ final class CLINotifyProcessIntegrationRegressionTests: XCTestCase {
             return result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
         }
         func baselineRecords() throws -> [[String: Any]] {
-            let storeURL = context.root.appendingPathComponent("agent-turn-diff-baselines.json")
-            let store = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(contentsOf: storeURL)) as? [String: Any])
-            return try XCTUnwrap(store["records"] as? [[String: Any]])
+            try readAgentTurnDiffBaselineRecords(at: context.root)
         }
 
         _ = try runGit(["init"])

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -1328,6 +1328,28 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: legacyStoreURL.path))
         let header = try Data(contentsOf: indexedStoreURL, options: .mappedIfSafe).prefix(16)
         XCTAssertEqual(String(data: header, encoding: .utf8), "SQLite format 3\0")
+
+        let downgradedWorkspaceId = UUID().uuidString.lowercased()
+        try writeDiffBaselineStore(
+            stateDirectoryURL: stateURL,
+            repoURL: repoURL,
+            workspaceId: downgradedWorkspaceId,
+            surfaceId: surfaceId,
+            baseCommit: baseCommit
+        )
+        let afterDowngrade = try runDiffCLIAndReadHTML(
+            cliPath: cliPath,
+            arguments: ["diff", "--last-turn"],
+            environmentOverrides: [
+                "CMUX_AGENT_HOOK_STATE_DIR": stateURL.path,
+                "CMUX_WORKSPACE_ID": downgradedWorkspaceId,
+                "CMUX_SURFACE_ID": surfaceId,
+                "CMUX_SESSION_ID": "session-1"
+            ],
+            currentDirectoryURL: repoURL
+        )
+        XCTAssertTrue(afterDowngrade.patch.contains("+after"), afterDowngrade.patch)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyStoreURL.path))
     }
 
     func testAgentTurnDiffBaselineStoresUntrackedSnapshotsOutsideGit() throws {

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -1279,6 +1279,56 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertEqual(lastTurnOption["selected"] as? Bool, true, html)
     }
 
+    func testAgentTurnDiffBaselineMigratesLegacyJSONToIndexedStore() throws {
+        let cliPath = try bundledCLIPath()
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let repoURL = rootURL.appendingPathComponent("repo", isDirectory: true)
+        let stateURL = rootURL.appendingPathComponent("state", isDirectory: true)
+        try FileManager.default.createDirectory(at: repoURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: stateURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        try runGit(["init"], in: repoURL)
+        try runGit(["config", "user.name", "cmux tests"], in: repoURL)
+        try runGit(["config", "user.email", "cmux@example.invalid"], in: repoURL)
+        let storyURL = repoURL.appendingPathComponent("story.txt", isDirectory: false)
+        try "before\n".write(to: storyURL, atomically: true, encoding: .utf8)
+        try runGit(["add", "story.txt"], in: repoURL)
+        try runGit(["commit", "-m", "initial"], in: repoURL)
+
+        let workspaceId = UUID().uuidString.lowercased()
+        let surfaceId = UUID().uuidString.lowercased()
+        let baseCommit = try runGitStdout(["rev-parse", "HEAD"], in: repoURL)
+        try writeDiffBaselineStore(
+            stateDirectoryURL: stateURL,
+            repoURL: repoURL,
+            workspaceId: workspaceId,
+            surfaceId: surfaceId,
+            baseCommit: baseCommit
+        )
+        try "after\n".write(to: storyURL, atomically: true, encoding: .utf8)
+
+        let lastTurn = try runDiffCLIAndReadHTML(
+            cliPath: cliPath,
+            arguments: ["diff", "--last-turn"],
+            environmentOverrides: [
+                "CMUX_AGENT_HOOK_STATE_DIR": stateURL.path,
+                "CMUX_WORKSPACE_ID": workspaceId,
+                "CMUX_SURFACE_ID": surfaceId,
+                "CMUX_SESSION_ID": "session-1"
+            ],
+            currentDirectoryURL: repoURL
+        )
+        XCTAssertTrue(lastTurn.patch.contains("+after"), lastTurn.patch)
+
+        let legacyStoreURL = stateURL.appendingPathComponent("agent-turn-diff-baselines.json")
+        let indexedStoreURL = stateURL.appendingPathComponent("agent-turn-diff-baselines.sqlite3")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyStoreURL.path))
+        let header = try Data(contentsOf: indexedStoreURL, options: .mappedIfSafe).prefix(16)
+        XCTAssertEqual(String(data: header, encoding: .utf8), "SQLite format 3\0")
+    }
+
     func testAgentTurnDiffBaselineStoresUntrackedSnapshotsOutsideGit() throws {
         let cliPath = try bundledCLIPath()
         let rootURL = FileManager.default.temporaryDirectory

--- a/cmuxTests/CMUXOpenCommandTests.swift
+++ b/cmuxTests/CMUXOpenCommandTests.swift
@@ -1,5 +1,6 @@
 import Darwin
 import Foundation
+import SQLite3
 import XCTest
 
 final class CMUXOpenCommandTests: XCTestCase {
@@ -1403,11 +1404,8 @@ final class CMUXOpenCommandTests: XCTestCase {
         )
         XCTAssertEqual(untrackedRefs.trimmingCharacters(in: .whitespacesAndNewlines), "")
 
-        let storeURL = stateURL.appendingPathComponent("agent-turn-diff-baselines.json")
-        let lockURL = stateURL.appendingPathComponent("agent-turn-diff-baselines.json.lock")
-        let storeData = try Data(contentsOf: storeURL)
-        let store = try JSONSerialization.jsonObject(with: storeData, options: []) as? [String: Any]
-        let records = try XCTUnwrap(store?["records"] as? [[String: Any]])
+        let storeURL = stateURL.appendingPathComponent("agent-turn-diff-baselines.sqlite3")
+        let records = try readDiffBaselineRecords(stateDirectoryURL: stateURL)
         let record = try XCTUnwrap(records.first)
         let snapshotId = try XCTUnwrap(record["untrackedSnapshotId"] as? String)
         let hashes = try XCTUnwrap(record["untrackedPathHashes"] as? [String: String])
@@ -1423,7 +1421,11 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertTrue(FileManager.default.fileExists(atPath: snapshotFile.path))
         XCTAssertEqual(try posixPermissions(at: stateURL), 0o700)
         XCTAssertEqual(try posixPermissions(at: storeURL), 0o600)
-        XCTAssertEqual(try posixPermissions(at: lockURL), 0o600)
+        XCTAssertFalse(
+            FileManager.default.fileExists(
+                atPath: stateURL.appendingPathComponent("agent-turn-diff-baselines.json.lock").path
+            )
+        )
         XCTAssertEqual(try posixPermissions(at: snapshotRoot), 0o700)
         XCTAssertEqual(try posixPermissions(at: snapshotDirectory), 0o700)
         XCTAssertEqual(try posixPermissions(at: filesDirectory), 0o700)
@@ -1492,10 +1494,7 @@ final class CMUXOpenCommandTests: XCTestCase {
         XCTAssertFalse(hook.timedOut, hook.stderr)
         XCTAssertEqual(hook.status, 0, hook.stderr)
 
-        let storeURL = stateURL.appendingPathComponent("agent-turn-diff-baselines.json")
-        let storeData = try Data(contentsOf: storeURL)
-        let store = try XCTUnwrap(JSONSerialization.jsonObject(with: storeData) as? [String: Any])
-        let records = try XCTUnwrap(store["records"] as? [[String: Any]])
+        let records = try readDiffBaselineRecords(stateDirectoryURL: stateURL)
         let record = try XCTUnwrap(records.first)
         XCTAssertEqual(record["baseCommit"] as? String, emptyTree)
 
@@ -1614,9 +1613,7 @@ final class CMUXOpenCommandTests: XCTestCase {
         }
 
         func diffBaselineRecords() throws -> [[String: Any]] {
-            let storeData = try Data(contentsOf: stateURL.appendingPathComponent("agent-turn-diff-baselines.json"))
-            let store = try JSONSerialization.jsonObject(with: storeData, options: []) as? [String: Any]
-            return try XCTUnwrap(store?["records"] as? [[String: Any]])
+            try readDiffBaselineRecords(stateDirectoryURL: stateURL)
         }
 
         let firstHook = try runPromptSubmit()
@@ -2534,6 +2531,94 @@ final class CMUXOpenCommandTests: XCTestCase {
             timeout: 30,
             currentDirectoryURL: directory
         )
+    }
+
+    private func readDiffBaselineRecords(stateDirectoryURL: URL) throws -> [[String: Any]] {
+        let databaseURL = stateDirectoryURL.appendingPathComponent("agent-turn-diff-baselines.sqlite3")
+        var database: OpaquePointer?
+        let openResult = sqlite3_open_v2(databaseURL.path, &database, SQLITE_OPEN_READONLY, nil)
+        guard openResult == SQLITE_OK, let database else {
+            sqlite3_close(database)
+            throw NSError(
+                domain: "CMUXOpenCommandTests.diffBaselineDatabase",
+                code: Int(openResult),
+                userInfo: [NSLocalizedDescriptionKey: "Failed to open \(databaseURL.path)"]
+            )
+        }
+        defer { sqlite3_close(database) }
+
+        let sql = """
+            SELECT workspace_id, surface_id, session_id, turn_id, agent, repo_root,
+                   base_commit, untracked_paths, untracked_path_hashes, snapshot_id, captured_at
+            FROM baselines
+            ORDER BY captured_at DESC
+            """
+        var statement: OpaquePointer?
+        let prepareResult = sqlite3_prepare_v2(database, sql, -1, &statement, nil)
+        guard prepareResult == SQLITE_OK, let statement else {
+            sqlite3_finalize(statement)
+            throw NSError(
+                domain: "CMUXOpenCommandTests.diffBaselineDatabase",
+                code: Int(prepareResult),
+                userInfo: [NSLocalizedDescriptionKey: String(cString: sqlite3_errmsg(database))]
+            )
+        }
+        defer { sqlite3_finalize(statement) }
+
+        func text(_ index: Int32) -> String? {
+            guard sqlite3_column_type(statement, index) != SQLITE_NULL,
+                  let value = sqlite3_column_text(statement, index) else {
+                return nil
+            }
+            return String(cString: value)
+        }
+        func data(_ index: Int32) -> Data? {
+            guard sqlite3_column_type(statement, index) != SQLITE_NULL else { return nil }
+            let count = Int(sqlite3_column_bytes(statement, index))
+            guard count > 0, let value = sqlite3_column_blob(statement, index) else {
+                return Data()
+            }
+            return Data(bytes: value, count: count)
+        }
+
+        var records: [[String: Any]] = []
+        while true {
+            let result = sqlite3_step(statement)
+            if result == SQLITE_DONE {
+                return records
+            }
+            guard result == SQLITE_ROW else {
+                throw NSError(
+                    domain: "CMUXOpenCommandTests.diffBaselineDatabase",
+                    code: Int(result),
+                    userInfo: [NSLocalizedDescriptionKey: String(cString: sqlite3_errmsg(database))]
+                )
+            }
+            var record: [String: Any] = [
+                "workspaceId": text(0) ?? "",
+                "surfaceId": text(1) ?? "",
+                "sessionId": text(2) ?? "",
+                "agent": text(4) ?? "",
+                "repoRoot": text(5) ?? "",
+                "baseCommit": text(6) ?? "",
+                "capturedAt": sqlite3_column_double(statement, 10)
+            ]
+            if let turnId = text(3) {
+                record["turnId"] = turnId
+            }
+            if let pathsData = data(7),
+               let paths = String(data: pathsData, encoding: .utf8)?.split(separator: "\0").map(String.init) {
+                record["untrackedPaths"] = paths
+            }
+            if let hashesData = data(8),
+               let hashes = try? JSONDecoder().decode([String: String].self, from: hashesData) {
+                record["untrackedPathHashes"] = hashes
+            }
+            if let snapshotId = text(9) {
+                record["untrackedSnapshotId"] = snapshotId
+            }
+            records.append(record)
+        }
     }
 
     private func writeDiffBaselineStore(


### PR DESCRIPTION
Three independent failures could hide or delay a running workspace:

1. Delayed teardown for a replaced session cleared the panel-scoped lifecycle shared with its live same-agent replacement. PID cleanup now clears lifecycle only when no same-agent runtime remains on that panel.
2. Session-start and prompt-submit hooks captured a turn-diff baseline before publishing PID, lifecycle, and status. Hooks now publish visible runtime state and start monitoring before auxiliary diff capture.
3. Turn-diff baselines lived in one large JSON document. Every hook locked, read, decoded, re-encoded, and atomically rewrote all retained sessions. The store is now SQLite with WAL, indexed latest-baseline lookups, one-row updates, bounded retention, and automatic legacy JSON migration.

These are ownership, priority-ordering, and storage-model fixes. They do not increase timeouts or add timing sleeps.

Regression history:
- `9499f0cc37` adds the stale-cleanup regression; `8deecfc67d` fixes it.
- `f95a42d465` adds slow-baseline regressions for session start and prompt submit; `803b6833a2` fixes them.
- `917f2c8371` changes baseline regressions to require indexed storage and migration; `c42671d079` implements SQLite.
- `84c299e84c` hardens concurrent snapshot publication, downgrade migration, retention ordering, corrupt-row errors, localization, and the timing-free hook test gate.

Validation:
- Tagged cloud build: https://github.com/manaflow-ai/cmux/actions/runs/29470222808
- The real legacy store was 60 MB with 200 records. Its full optimized JSON update averaged 577.79 ms. The indexed SQLite update averaged 32.29 ms, about 18 times faster.
- Git was not the dominant measured cost: `git stash create` took 0.10 s and untracked enumeration took 0.27 s in the large worktree.
- The one-time tagged Debug migration took 4.98 s. Visible state is published first, so that migration no longer delays the sidebar indicator.
- A subsequent tagged session-start took 0.74 s including Git, socket work, and the database update.
- Two concurrent tagged session-starts persisted both rows in 1.34 s total.
- After initial migration, a newly reappearing legacy JSON record was merged into SQLite, removed, and selected successfully by `cmux diff --last-turn`.
- Tagged runtime state reported `codex=Running`, and a native window screenshot confirmed the rendered spinner and Running label.
- Swift parse, localization JSON validation, project-file checks, codesign validation, and the tagged cloud compile passed.
