### PR TITLE
Group tab context menu actions

### DIFF
--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -3088,7 +3088,7 @@ final class Workspace: Identifiable, ObservableObject {
             switch source {
             case .closeButton:
                 self?.markTabCloseButtonClose(surfaceId: tabId)
-            case .middleClick:
+            case .middleClick, .contextMenu:
                 self?.markTabStripMiddleClickClose(surfaceId: tabId)
             }
         }
@@ -9662,6 +9662,7 @@ final class Workspace: Identifiable, ObservableObject {
         var shortcuts: [TabContextAction: KeyboardShortcut] = [:]
         let mappings: [(TabContextAction, KeyboardShortcutSettings.Action)] = [
             (.rename, .renameTab),
+            (.close, .closeTab),
             (.toggleZoom, .toggleSplitZoom),
             (.newTerminalToRight, .newSurface),
         ]
@@ -12611,6 +12612,9 @@ extension Workspace: BonsplitDelegate {
         case .clearName:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             setPanelCustomTitle(panelId: panelId, title: nil)
+        case .close:
+            // Bonsplit handles this through its shared tab-close request path.
+            break
         case .copyIdentifiers:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             copyIdentifiersToPasteboard(surfaceId: panelId)
@@ -12651,6 +12655,8 @@ extension Workspace: BonsplitDelegate {
         case .duplicate:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             _ = duplicateBrowserToRight(panelId: panelId)
+        case .disconnectRemote:
+            disconnectRemoteConnection(clearConfiguration: false)
         case .togglePin:
             guard let panelId = panelIdFromSurfaceId(tab.id) else { return }
             let shouldPin = !pinnedPanelIds.contains(panelId)


### PR DESCRIPTION
## Summary

- Group tab context actions by intent: current tab, create, arrange, contextual, view/state, and developer.
- Add Close Tab beside Rename Tab.
- Route context-menu closes through the shared close request path so pinned-tab and close-warning behavior stays consistent.
- Preserve conditional browser, conversation, and SSH actions without empty separators.

Depends on https://github.com/manaflow-ai/bonsplit/pull/186.

## Verification

- `swift test` in `vendor/bonsplit`: 203 tests passed.
- English and Japanese localization files pass `plutil -lint`.
- Tagged macOS build passed: https://github.com/manaflow-ai/cmux/actions/runs/29460167554.
- Native context menu entrypoint exercised in `cmux DEV tabgrp`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8208"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786756029&installation_id=133855650&pr_number=8208&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8208&signature=55491943ba54510c5b5d177bdcb46ed6ee761ccaa611742045be7d8d67db3cc0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reorganized the tab context menu by intent and routed context‑menu closes through the shared close path to keep pinned‑tab and close‑warning behavior consistent. Also adds Close Tab next to Rename Tab.

- **New Features**
  - Grouped actions into: current tab, create, arrange, contextual, view/state, developer.
  - Added Close Tab beside Rename Tab; mapped `.close` to the `.closeTab` shortcut.
  - Context‑menu Close now uses the same path as middle‑click.
  - Preserved conditional browser, conversation, and SSH items without blank separators.
  - Added support for Disconnect Remote from the context menu.

- **Dependencies**
  - Updated `vendor/bonsplit`; depends on `bonsplit` PR #186.

<sup>Written for commit 4c82096c8b40d80738fbf37589ecc7c7d57c3f1e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8208?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for closing tabs through the tab context menu.
  - Added the configured close-tab keyboard shortcut to the tab context menu.
  - Added a context-menu action for disconnecting remote connections while preserving their configuration.

- **Bug Fixes**
  - Improved tab closing behavior when initiated through middle-click or the context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->