### PR TITLE
Bundle cmux GPL and corresponding source directions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -124,6 +124,9 @@ jobs:
       - name: Validate create-dmg version pinning
         run: ./tests/test_ci_create_dmg_pinned.sh
 
+      - name: Validate app bundle license compliance
+        run: ./tests/test_app_bundle_license_compliance.sh
+
       - name: Validate unit-test SwiftPM retry guard
         run: ./tests/test_ci_unit_test_spm_retry.sh
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -704,6 +704,7 @@ jobs:
             CMUX_SMOKE_ALLOW_UNSUPPORTED_GUI=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
             CMUX_SMOKE_DIRECT_EXEC=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
             ./scripts/verify-app-bundle-channel-metadata.sh "$app_path" nightly
+            ./scripts/verify-app-bundle-licenses.sh "$app_path"
             rm -f "$zip_submit"
 
             dmg_tmp_dir="$(mktemp -d)"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -449,6 +449,7 @@ jobs:
           CMUX_SMOKE_ALLOW_UNSUPPORTED_GUI=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$APP_PATH"
           CMUX_SMOKE_DIRECT_EXEC=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$APP_PATH"
           ./scripts/verify-app-bundle-channel-metadata.sh "$APP_PATH" stable
+          ./scripts/verify-app-bundle-licenses.sh "$APP_PATH"
           rm -f "$ZIP_SUBMIT"
           # create-dmg generates a styled drag-to-install DMG
           create-dmg \

--- a/Sources/AboutLicenseContent.swift
+++ b/Sources/AboutLicenseContent.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+struct AboutLicenseContent {
+    static let repositoryURL = URL(string: "https://github.com/manaflow-ai/cmux")!
+
+    static func load(from bundle: Bundle) -> String {
+        let missingMessage = String(
+            localized: "about.licenses.notFound",
+            defaultValue: "Licenses file not found.",
+            bundle: bundle
+        )
+        let projectLicense = resourceText(
+            named: "LICENSE",
+            fileExtension: nil,
+            in: bundle
+        ) ?? missingMessage
+        let thirdPartyLicenses = resourceText(
+            named: "THIRD_PARTY_LICENSES",
+            fileExtension: "md",
+            in: bundle
+        ) ?? missingMessage
+        let projectHeading = String(
+            localized: "about.licenses.projectHeading",
+            defaultValue: "cmux Project License",
+            bundle: bundle
+        )
+        let projectSourceLabel = String(
+            localized: "about.licenses.projectSource",
+            defaultValue: "Project source",
+            bundle: bundle
+        )
+        let correspondingSourceLabel = String(
+            localized: "about.licenses.correspondingSource",
+            defaultValue: "Corresponding source for this build",
+            bundle: bundle
+        )
+
+        return """
+        # \(projectHeading)
+
+        \(projectSourceLabel): \(repositoryURL.absoluteString)
+        \(correspondingSourceLabel): \(correspondingSourceURL(in: bundle).absoluteString)
+
+        \(projectLicense)
+
+        ---
+
+        \(thirdPartyLicenses)
+        """
+    }
+
+    static func correspondingSourceURL(in bundle: Bundle) -> URL {
+        correspondingSourceURL(
+            version: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
+            bundleIdentifier: bundle.bundleIdentifier,
+            commit: bundle.object(forInfoDictionaryKey: "CMUXCommit") as? String
+        )
+    }
+
+    static func correspondingSourceURL(
+        version: String?,
+        bundleIdentifier: String?,
+        commit: String?
+    ) -> URL {
+        if bundleIdentifier == "com.cmuxterm.app", let version = normalized(version) {
+            return repositoryURL
+                .appendingPathComponent("tree", isDirectory: true)
+                .appendingPathComponent("v\(version)")
+        }
+        if let commit = normalized(commit) {
+            return repositoryURL
+                .appendingPathComponent("tree", isDirectory: true)
+                .appendingPathComponent(commit)
+        }
+        return repositoryURL
+    }
+
+    private static func resourceText(
+        named name: String,
+        fileExtension: String?,
+        in bundle: Bundle
+    ) -> String? {
+        guard let url = bundle.url(forResource: name, withExtension: fileExtension) else {
+            return nil
+        }
+        return try? String(contentsOf: url, encoding: .utf8)
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        guard let value else { return nil }
+        let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return normalized.isEmpty ? nil : normalized
+    }
+}

--- a/Sources/AboutLicenseContent.swift
+++ b/Sources/AboutLicenseContent.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-struct AboutLicenseContent {
+nonisolated struct AboutLicenseContent {
     let bundle: Bundle
     let repositoryURL: URL
 

--- a/Sources/AboutLicenseContent.swift
+++ b/Sources/AboutLicenseContent.swift
@@ -1,9 +1,18 @@
 import Foundation
 
 struct AboutLicenseContent {
-    static let repositoryURL = URL(string: "https://github.com/manaflow-ai/cmux")!
+    let bundle: Bundle
+    let repositoryURL: URL
 
-    static func load(from bundle: Bundle) -> String {
+    init(
+        bundle: Bundle,
+        repositoryURL: URL = URL(string: "https://github.com/manaflow-ai/cmux")!
+    ) {
+        self.bundle = bundle
+        self.repositoryURL = repositoryURL
+    }
+
+    func load() -> String {
         let missingMessage = String(
             localized: "about.licenses.notFound",
             defaultValue: "Licenses file not found.",
@@ -39,7 +48,7 @@ struct AboutLicenseContent {
         # \(projectHeading)
 
         \(projectSourceLabel): \(repositoryURL.absoluteString)
-        \(correspondingSourceLabel): \(correspondingSourceURL(in: bundle).absoluteString)
+        \(correspondingSourceLabel): \(correspondingSourceURL().absoluteString)
 
         \(projectLicense)
 
@@ -49,7 +58,7 @@ struct AboutLicenseContent {
         """
     }
 
-    static func correspondingSourceURL(in bundle: Bundle) -> URL {
+    func correspondingSourceURL() -> URL {
         correspondingSourceURL(
             version: bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String,
             bundleIdentifier: bundle.bundleIdentifier,
@@ -57,7 +66,7 @@ struct AboutLicenseContent {
         )
     }
 
-    static func correspondingSourceURL(
+    func correspondingSourceURL(
         version: String?,
         bundleIdentifier: String?,
         commit: String?
@@ -75,7 +84,7 @@ struct AboutLicenseContent {
         return repositoryURL
     }
 
-    private static func resourceText(
+    private func resourceText(
         named name: String,
         fileExtension: String?,
         in bundle: Bundle
@@ -86,7 +95,7 @@ struct AboutLicenseContent {
         return try? String(contentsOf: url, encoding: .utf8)
     }
 
-    private static func normalized(_ value: String?) -> String? {
+    private func normalized(_ value: String?) -> String? {
         guard let value else { return nil }
         let normalized = value.trimmingCharacters(in: .whitespacesAndNewlines)
         return normalized.isEmpty ? nil : normalized

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2246,7 +2246,7 @@ private final class AcknowledgmentsWindowController: ReleasingWindowController {
             backing: .buffered,
             defer: false
         )
-        window.title = String(localized: "about.licenses.windowTitle", defaultValue: "Third-Party Licenses")
+        window.title = String(localized: "about.licenses", defaultValue: "Licenses")
         window.identifier = NSUserInterfaceItemIdentifier("cmux.licenses")
         window.center()
         window.contentView = NSHostingView(rootView: AcknowledgmentsView())
@@ -2264,13 +2264,7 @@ private final class AcknowledgmentsWindowController: ReleasingWindowController {
 }
 
 private struct AcknowledgmentsView: View {
-    private let content: String = {
-        if let url = Bundle.main.url(forResource: "THIRD_PARTY_LICENSES", withExtension: "md"),
-           let text = try? String(contentsOf: url) {
-            return text
-        }
-        return String(localized: "about.licenses.notFound", defaultValue: "Licenses file not found.")
-    }()
+    private let content = AboutLicenseContent.load(from: .main)
 
     var body: some View {
         ScrollView {

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -2264,7 +2264,7 @@ private final class AcknowledgmentsWindowController: ReleasingWindowController {
 }
 
 private struct AcknowledgmentsView: View {
-    private let content = AboutLicenseContent.load(from: .main)
+    private let content = AboutLicenseContent(bundle: .main).load()
 
     var body: some View {
         ScrollView {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A11CE0040000000000000001 /* AboutLicenseContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CE0030000000000000001 /* AboutLicenseContent.swift */; };
 		A11CE0010000000000000001 /* AboutLicensesResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */; };
 		A9E020000000000000000006 /* agent-session-react in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000006 /* agent-session-react */; };
 		A9E020000000000000000007 /* agent-session-solid in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000007 /* agent-session-solid */; };
@@ -944,6 +945,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */; };
 		C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */; };
 		87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */; };
+		A11CE0060000000000000001 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = A11CE0050000000000000001 /* LICENSE */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
 		53750022A0B1C2D3E4F50022 /* MacAuthComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */; };
 		D1F0A00600000000000000C1 /* MacPairedMacBackupBody.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */; };
@@ -2020,6 +2022,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A11CE0030000000000000001 /* AboutLicenseContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutLicenseContent.swift; sourceTree = "<group>"; };
 		A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutLicensesResourceTests.swift; sourceTree = "<group>"; };
 		A9E010000000000000000006 /* agent-session-react */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-react"; sourceTree = "<group>"; };
 		A9E010000000000000000007 /* agent-session-solid */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-solid"; sourceTree = "<group>"; };
@@ -2889,6 +2892,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSpaceKeyTests.swift; sourceTree = "<group>"; };
 		C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutTestSettingsIsolation.swift; sourceTree = "<group>"; };
 		F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastSurfaceClosePreferenceTests.swift; sourceTree = "<group>"; };
+		A11CE0050000000000000001 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
 		53750023A0B1C2D3E4F50023 /* MacAuthComposition.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacAuthComposition.swift; sourceTree = "<group>"; };
 		D1F0A00600000000000000C2 /* MacPairedMacBackupBody.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MacPairedMacBackupBody.swift; sourceTree = "<group>"; };
@@ -3990,6 +3994,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		087C454FFF74443AB06942C3 /* Resources */ = {
 			isa = PBXGroup;
 			children = (
+				A11CE0050000000000000001 /* LICENSE */,
 				B2E7294509CC42FE9191870E /* xterm-ghostty */,
 				A5002001 /* THIRD_PARTY_LICENSES.md */,
 					C1ADE20001A1B2C3D4E5F719 /* cmux-claude-wrapper */,
@@ -4191,6 +4196,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001041 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A11CE0030000000000000001 /* AboutLicenseContent.swift */,
 				3023B1003023B1003023B100 /* ConfigSource.swift */,
 				3023B1013023B1013023B101 /* ConfigSettingsView.swift */,
 				A11EAB000000000000000001 /* AppearanceSettings.swift */,
@@ -6240,6 +6246,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001623 /* cmux.sdef in Resources */,
 				FEED0A00000000000000F007 /* feed-tui in Resources */,
 				DA7A10CA710E000000000004 /* InfoPlist.xcstrings in Resources */,
+				A11CE0060000000000000001 /* LICENSE in Resources */,
 				DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */,
 				A9D9000000000000000F0017 /* markdown-viewer in Resources */,
 				FEED0000000000000000F007 /* opencode-plugin.js in Resources */,
@@ -6381,6 +6388,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			buildActionMask = 2147483647;
 			files = (
 
+				A11CE0040000000000000001 /* AboutLicenseContent.swift in Sources */,
 				C7AF10000000000000000005 /* AgentChatArtifactGalleryBuilder.swift in Sources */,
 				C7AF10000000000000000001 /* AgentChatArtifactIndex.swift in Sources */,
 					C7A52E000000000000000002 /* AgentChatEndedTranscriptListabilityCache.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		A11CE0010000000000000001 /* AboutLicensesResourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */; };
 		A9E020000000000000000006 /* agent-session-react in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000006 /* agent-session-react */; };
 		A9E020000000000000000007 /* agent-session-solid in Resources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000007 /* agent-session-solid */; };
 		C7AF10000000000000000005 /* AgentChatArtifactGalleryBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF10000000000000000006 /* AgentChatArtifactGalleryBuilder.swift */; };
@@ -2019,6 +2020,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AboutLicensesResourceTests.swift; sourceTree = "<group>"; };
 		A9E010000000000000000006 /* agent-session-react */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-react"; sourceTree = "<group>"; };
 		A9E010000000000000000007 /* agent-session-solid */ = {isa = PBXFileReference; lastKnownFileType = folder; path = "agent-session-solid"; sourceTree = "<group>"; };
 		C7AF10000000000000000006 /* AgentChatArtifactGalleryBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "AgentChatArtifactGalleryBuilder.swift"; sourceTree = "<group>"; };
@@ -5422,6 +5424,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F1000003A1B2C3D4E5F60718 /* cmuxTests */ = {
 			isa = PBXGroup;
 			children = (
+				A11CE0020000000000000001 /* AboutLicensesResourceTests.swift */,
 				F2000001A1B2C3D4E5F60718 /* UpdatePillReleaseVisibilityTests.swift */,
 				F3000001A1B2C3D4E5F60718 /* CJKIMEInputTests.swift */,
 				D3571003A1B2C3D4E5F60718 /* CJKIMEMarkedSelectionTests.swift */,
@@ -7730,6 +7733,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A11CE0010000000000000001 /* AboutLicensesResourceTests.swift in Sources */,
 				CDFE000000000000000000C1 /* AgentChatProseStreamerTests.swift in Sources */,
 				C7A51F000000000000000002 /* AgentChatSessionRegistryClaudeObservationTests.swift in Sources */,
 				C7A51C000000000000000002 /* AgentChatSessionRegistryHookStoreTests.swift in Sources */,

--- a/cmuxTests/AboutLicensesResourceTests.swift
+++ b/cmuxTests/AboutLicensesResourceTests.swift
@@ -1,0 +1,53 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("About licenses resources")
+struct AboutLicensesResourceTests {
+    @Test("The project GPL is available to the About licenses UI")
+    func projectLicenseIsBundled() throws {
+        let url = try #require(Bundle.main.url(forResource: "LICENSE", withExtension: nil))
+        let contents = try String(contentsOf: url, encoding: .utf8)
+
+        #expect(contents.contains("Copyright (c) 2024-present Manaflow, Inc."))
+        #expect(contents.contains("GNU GENERAL PUBLIC LICENSE"))
+        #expect(contents.contains("Version 3, 29 June 2007"))
+    }
+
+    @Test("The About licenses content includes the project GPL and source directions")
+    func aboutContentIncludesProjectLicenseAndSourceDirections() throws {
+        let contents = AboutLicenseContent.load(from: .main)
+
+        #expect(contents.contains("Copyright (c) 2024-present Manaflow, Inc."))
+        #expect(contents.contains("GNU GENERAL PUBLIC LICENSE"))
+        #expect(contents.contains(AboutLicenseContent.repositoryURL.absoluteString))
+        #expect(contents.contains(AboutLicenseContent.correspondingSourceURL(in: .main).absoluteString))
+    }
+
+    @Test("Stable builds link corresponding source to their exact version tag")
+    func stableBuildUsesVersionTag() {
+        let url = AboutLicenseContent.correspondingSourceURL(
+            version: "0.64.19",
+            bundleIdentifier: "com.cmuxterm.app",
+            commit: "abcdef123"
+        )
+
+        #expect(url.absoluteString == "https://github.com/manaflow-ai/cmux/tree/v0.64.19")
+    }
+
+    @Test("Development builds link corresponding source to their commit")
+    func developmentBuildUsesCommit() {
+        let url = AboutLicenseContent.correspondingSourceURL(
+            version: "0.64.19",
+            bundleIdentifier: "com.cmuxterm.app.debug.licpkg",
+            commit: "abcdef123"
+        )
+
+        #expect(url.absoluteString == "https://github.com/manaflow-ai/cmux/tree/abcdef123")
+    }
+}

--- a/cmuxTests/AboutLicensesResourceTests.swift
+++ b/cmuxTests/AboutLicensesResourceTests.swift
@@ -40,11 +40,14 @@ struct AboutLicensesResourceTests {
         #expect(url.absoluteString == "https://github.com/manaflow-ai/cmux/tree/v0.64.19")
     }
 
-    @Test("Development builds link corresponding source to their commit")
-    func developmentBuildUsesCommit() {
+    @Test(
+        "Non-stable builds link corresponding source to their commit",
+        arguments: ["com.cmuxterm.app.debug.licpkg", "com.cmuxterm.app.nightly"]
+    )
+    func nonStableBuildUsesCommit(bundleIdentifier: String) {
         let url = AboutLicenseContent.correspondingSourceURL(
             version: "0.64.19",
-            bundleIdentifier: "com.cmuxterm.app.debug.licpkg",
+            bundleIdentifier: bundleIdentifier,
             commit: "abcdef123"
         )
 

--- a/cmuxTests/AboutLicensesResourceTests.swift
+++ b/cmuxTests/AboutLicensesResourceTests.swift
@@ -21,23 +21,28 @@ struct AboutLicensesResourceTests {
 
     @Test("The About licenses content includes the project GPL and source directions")
     func aboutContentIncludesProjectLicenseAndSourceDirections() throws {
-        let contents = AboutLicenseContent.load(from: .main)
+        let licenseContent = AboutLicenseContent(bundle: .main)
+        let contents = licenseContent.load()
 
         #expect(contents.contains("Copyright (c) 2024-present Manaflow, Inc."))
         #expect(contents.contains("GNU GENERAL PUBLIC LICENSE"))
-        #expect(contents.contains(AboutLicenseContent.repositoryURL.absoluteString))
-        #expect(contents.contains(AboutLicenseContent.correspondingSourceURL(in: .main).absoluteString))
+        #expect(contents.contains(licenseContent.repositoryURL.absoluteString))
+        #expect(contents.contains(licenseContent.correspondingSourceURL().absoluteString))
     }
 
     @Test("Stable builds link corresponding source to their exact version tag")
     func stableBuildUsesVersionTag() {
-        let url = AboutLicenseContent.correspondingSourceURL(
+        let repositoryURL = URL(string: "https://example.com/cmux-source")!
+        let url = AboutLicenseContent(
+            bundle: .main,
+            repositoryURL: repositoryURL
+        ).correspondingSourceURL(
             version: "0.64.19",
             bundleIdentifier: "com.cmuxterm.app",
             commit: "abcdef123"
         )
 
-        #expect(url.absoluteString == "https://github.com/manaflow-ai/cmux/tree/v0.64.19")
+        #expect(url.absoluteString == "https://example.com/cmux-source/tree/v0.64.19")
     }
 
     @Test(
@@ -45,7 +50,7 @@ struct AboutLicensesResourceTests {
         arguments: ["com.cmuxterm.app.debug.licpkg", "com.cmuxterm.app.nightly"]
     )
     func nonStableBuildUsesCommit(bundleIdentifier: String) {
-        let url = AboutLicenseContent.correspondingSourceURL(
+        let url = AboutLicenseContent(bundle: .main).correspondingSourceURL(
             version: "0.64.19",
             bundleIdentifier: bundleIdentifier,
             commit: "abcdef123"

--- a/scripts/build-sign-upload.sh
+++ b/scripts/build-sign-upload.sh
@@ -111,6 +111,7 @@ echo "App notarized"
 
 # --- Create and notarize DMG ---
 echo "Creating DMG..."
+./scripts/verify-app-bundle-licenses.sh "$APP_PATH"
 rm -f cmux-macos.dmg
 create-dmg --codesign "$SIGN_HASH" cmux-macos.dmg "$APP_PATH"
 echo "Notarizing DMG..."

--- a/scripts/verify-app-bundle-licenses.sh
+++ b/scripts/verify-app-bundle-licenses.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+usage: verify-app-bundle-licenses.sh <app-path>
+
+Verifies that a built cmux app contains the canonical project GPL and its
+third-party license notices before the app is placed in a distributed DMG.
+EOF
+}
+
+if [[ $# -ne 1 ]]; then
+  usage >&2
+  exit 2
+fi
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+APP_PATH="$1"
+RESOURCES_PATH="$APP_PATH/Contents/Resources"
+SOURCE_LICENSE="$ROOT_DIR/LICENSE"
+BUNDLED_LICENSE="$RESOURCES_PATH/LICENSE"
+BUNDLED_THIRD_PARTY="$RESOURCES_PATH/THIRD_PARTY_LICENSES.md"
+
+if [[ ! -d "$APP_PATH/Contents" ]]; then
+  echo "error: app bundle not found at $APP_PATH" >&2
+  exit 1
+fi
+
+if [[ ! -s "$BUNDLED_LICENSE" ]]; then
+  echo "error: cmux project license missing or empty at $BUNDLED_LICENSE" >&2
+  exit 1
+fi
+
+if ! cmp -s "$SOURCE_LICENSE" "$BUNDLED_LICENSE"; then
+  echo "error: bundled cmux project license differs from $SOURCE_LICENSE" >&2
+  exit 1
+fi
+
+if [[ ! -s "$BUNDLED_THIRD_PARTY" ]]; then
+  echo "error: third-party licenses missing or empty at $BUNDLED_THIRD_PARTY" >&2
+  exit 1
+fi
+
+echo "verified app bundle licenses: $APP_PATH"

--- a/tests/test_app_bundle_license_compliance.sh
+++ b/tests/test_app_bundle_license_compliance.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+VERIFIER="$ROOT_DIR/scripts/verify-app-bundle-licenses.sh"
+TMP_DIR="$(mktemp -d)"
+APP_PATH="$TMP_DIR/cmux.app"
+RESOURCES_PATH="$APP_PATH/Contents/Resources"
+
+cleanup() {
+  rm -rf "$TMP_DIR"
+}
+trap cleanup EXIT
+
+mkdir -p "$RESOURCES_PATH"
+cp "$ROOT_DIR/LICENSE" "$RESOURCES_PATH/LICENSE"
+cp "$ROOT_DIR/THIRD_PARTY_LICENSES.md" "$RESOURCES_PATH/THIRD_PARTY_LICENSES.md"
+
+"$VERIFIER" "$APP_PATH"
+
+rm "$RESOURCES_PATH/LICENSE"
+if "$VERIFIER" "$APP_PATH" >/dev/null 2>&1; then
+  echo "FAIL: verifier accepted an app without the cmux project license" >&2
+  exit 1
+fi
+
+cp "$ROOT_DIR/LICENSE" "$RESOURCES_PATH/LICENSE"
+printf '\nmodified\n' >> "$RESOURCES_PATH/LICENSE"
+if "$VERIFIER" "$APP_PATH" >/dev/null 2>&1; then
+  echo "FAIL: verifier accepted a project license that differs from the repository license" >&2
+  exit 1
+fi
+
+cp "$ROOT_DIR/LICENSE" "$RESOURCES_PATH/LICENSE"
+rm "$RESOURCES_PATH/THIRD_PARTY_LICENSES.md"
+if "$VERIFIER" "$APP_PATH" >/dev/null 2>&1; then
+  echo "FAIL: verifier accepted an app without third-party licenses" >&2
+  exit 1
+fi
+
+echo "PASS: app bundle license compliance verifier rejects incomplete artifacts"


### PR DESCRIPTION
## Summary
- bundle the canonical cmux GPL and show it before third-party notices in About > Licenses
- show repository and build-specific corresponding-source URLs for stable and non-stable builds
- block stable, nightly, and manual DMG creation when project or third-party licenses are missing

## Testing
- `./tests/test_app_bundle_license_compliance.sh`
- `xcrun swiftc -typecheck Sources/AboutLicenseContent.swift`
- `jq empty Resources/Localizable.xcstrings`
- `./scripts/check-pbxproj.sh`
- `./tests/test_ci_pbxproj_test_wiring.sh`
- tagged build: [Blacksmith run 29467309100](https://github.com/manaflow-ai/cmux/actions/runs/29467309100)
- final `licp2` app passed byte-exact bundle-license verification and strict deep code-signature verification
- About > Licenses preflight confirmed project copyright, GPL, repository and corresponding-source URLs, and third-party notices

Focused `cmux-unit` execution could not dispatch because all 11 cloud test builders were busy and local Xcode was occupied by unrelated long-running Ghostty builds. The merge gate provides final test-target coverage.

## Issues
- Related: license compliance audit requested by the repository owner
