### PR TITLE
Make docs version picker bare

### DIFF
--- a/web/app/[locale]/components/docs-version-picker.tsx
+++ b/web/app/[locale]/components/docs-version-picker.tsx
@@ -25,7 +25,7 @@ export function DocsVersionPicker({
           const { pathname, search, hash } = window.location;
           window.location.assign(docsChannelUrl(value, pathname, search, hash));
         }}
-        className="w-full rounded-md border border-border bg-background px-2 py-1.5 text-[13px] text-foreground"
+        className="h-[30px] w-full appearance-auto border-0 bg-transparent px-1 py-0 text-[13px] text-muted-foreground shadow-none outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
       >
         <option value="release">{releaseLabel}</option>
         <option value="nightly">{nightlyLabel}</option>


### PR DESCRIPTION
## Summary
- remove the docs version picker border, fill, and rounded field styling
- keep the native Release/Nightly control below Changelog
- preserve keyboard focus and routed channel switching

## Verification
- `cd web && bun test tests/docs-channel.test.ts`
- `cd web && bun run typecheck`
- `cd web && bunx biome check app/[locale]/components/docs-version-picker.tsx`

## Localization
No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8214"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786760594&installation_id=133855650&pr_number=8214&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8214&signature=f1a7402f0801ea2f71ec1ce71a8d4108aef0e9dba41c179d7d1228da38c163f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the docs version picker a bare native select with a transparent background, no border, and muted text. Sets a 30px height, smaller padding, and native appearance; keeps the visible focus ring and continues switching channels via URL routing.

<sup>Written for commit 0e4171bea339e515dc5ffc68db503bd287cdf64b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8214?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the documentation version picker’s appearance for a cleaner layout, improved sizing, typography, and focus styling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->