### PR TITLE
temp: Allow ios-hotfix-chip-top TestFlight upload for beta hotfix

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -312,10 +312,11 @@ jobs:
   upload:
     name: Upload to TestFlight
     needs: decide
-    # Only ever publish from main. push/schedule always run on main; this also
-    # blocks publishing arbitrary code by dispatching the workflow against a
-    # feature branch (the ASC secrets are only meant to ship reviewed main).
-    if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
+    # Only ever publish from main (or ios-hotfix-chip-top for targeted beta hotfixes).
+    # push/schedule always run on main; this also blocks publishing arbitrary code by
+    # dispatching the workflow against a feature branch (the ASC secrets are only meant
+    # to ship reviewed main). TEMPORARY: gate for ios-hotfix-chip-top hotfix release only.
+    if: needs.decide.outputs.should_build == 'true' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ios-hotfix-chip-top')
     runs-on: ${{ vars.MACOS_RUNNER_IOS || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 60
     outputs:
@@ -602,7 +603,7 @@ jobs:
   assign-external-group:
     name: Assign build to external TestFlight group
     needs: [decide, upload]
-    if: always() && (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && github.ref == 'refs/heads/main' && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
+    if: always() && (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ios-hotfix-chip-top') && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 40
     env:
@@ -659,7 +660,7 @@ jobs:
   assign-internal-group:
     name: Assign build to internal TestFlight group
     needs: [decide, upload]
-    if: (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && github.ref == 'refs/heads/main' && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
+    if: (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ios-hotfix-chip-top') && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 40
     env:


### PR DESCRIPTION
Temporarily gates the iOS TestFlight upload workflow to also accept the `ios-hotfix-chip-top` branch, enabling a targeted beta hotfix release with just the chip-top fix without pulling all of main's untested changes.

**Important:** This change should be reverted immediately after the hotfix is successfully released to TestFlight beta testers.

PR flow:
1. Merge this PR
2. Trigger workflow on ios-hotfix-chip-top branch via workflow_dispatch  
3. After hotfix uploads to TestFlight, revert this PR

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8216"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786761122&installation_id=133855650&pr_number=8216&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8216&signature=4a409b7e892da5af88a204b14e6dc3a6a10d7d600162adca568767f12574a1bf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Temporarily allows the iOS TestFlight workflow to run from the `ios-hotfix-chip-top` branch, enabling a targeted beta hotfix without pulling in untested `main`. The gate covers upload and both internal/external group assignment jobs and will be reverted after the hotfix.

- **Migration**
  - Merge this PR.
  - Trigger the iOS TestFlight workflow on `ios-hotfix-chip-top` via workflow_dispatch.
  - After the hotfix is in TestFlight, revert this change.

<sup>Written for commit 23668f45733c499fa480026aae77bd9baebb7efe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8216?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded iOS TestFlight release support to include the `ios-hotfix-chip-top` branch.
  * Enabled TestFlight upload and tester assignment steps for eligible hotfix builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->