### PR TITLE
feat: add branch input to TestFlight workflow

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -14,6 +14,10 @@ on:
   # release flow. See nightly.yml for the rolling dogfood lane.
   workflow_dispatch:
     inputs:
+      branch:
+        description: Optional branch to checkout (for hotfix releases; defaults to main)
+        required: false
+        default: ""
       build_number:
         description: CFBundleVersion to stamp (defaults to UTC yyyyMMddHHmmss)
         required: false
@@ -341,6 +345,7 @@ jobs:
           # range since the last beta.
           fetch-depth: 0
           fetch-tags: true
+          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Select Xcode
         run: |


### PR DESCRIPTION
Allows manual TestFlight uploads to run on any branch via workflow_dispatch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8217"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786761369&installation_id=133855650&pr_number=8217&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8217&signature=ff6e792b425833d33e0d8c9ffc13bad95b7dbf0ee016d933b3ccae4e9f3dc7fb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `branch` input to the TestFlight workflow so manual uploads can run from any branch. Defaults to the triggering branch to simplify hotfix releases.

- **New Features**
  - Added `branch` input to `workflow_dispatch` in `ios-testflight.yml`.
  - Checkout now sets `ref` to `${{ github.event.inputs.branch || github.ref_name }}` to build the specified branch (or current by default).

<sup>Written for commit 19aa7dfef64e3e89cd3b1e1ff675eb87e9865863. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8217?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an optional branch or ref selection when manually starting iOS TestFlight builds.
  * Builds continue to use the current branch automatically when no selection is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->