### PR TITLE
Attach the mobile workspace-list observer only while a phone subscribes

### DIFF
--- a/Sources/Mobile/MobileWorkspaceListObserver.swift
+++ b/Sources/Mobile/MobileWorkspaceListObserver.swift
@@ -25,6 +25,8 @@ final class MobileWorkspaceListObserver {
     private var notificationsCancellable: AnyCancellable?
     private var unreadIndicatorsCancellable: AnyCancellable?
     private var perWorkspaceCancellables: [UUID: AnyCancellable] = [:]
+    private var subscriptionsChangeObserver: NSObjectProtocol?
+    private var pipelinesAttached = false
     private var lastSummaryHash: Int = 0
     /// Throttle window with `latest: true`. First event in a burst emits
     /// immediately (iPhone gets the change in milliseconds), subsequent
@@ -33,13 +35,73 @@ final class MobileWorkspaceListObserver {
     /// per 80 ms. Hash-diff suppresses no-op rebroadcasts.
     private let throttleMilliseconds: Int = 80
 
+    #if DEBUG
+    /// Test seam: fidelity tests exercise the pipelines without a live phone
+    /// connection, so they force presence on instead of registering a real
+    /// mobile subscriber.
+    static var subscriberPresenceOverrideForTesting: Bool?
+    var pipelinesAttachedForTesting: Bool { pipelinesAttached }
+    #endif
+
+    /// Whether any mobile client currently subscribes to `workspace.updated`.
+    /// The observer's entire publisher graph (five global streams plus ~a dozen
+    /// per-workspace streams, all throttled on the main run loop) and the
+    /// full-list summary hash it computes per delivery exist only to feed that
+    /// event, so with no subscriber the graph stays detached and agent-driven
+    /// workspace churn costs the main thread nothing here.
+    private var hasWorkspaceListSubscribers: Bool {
+        #if DEBUG
+        if let override = Self.subscriberPresenceOverrideForTesting { return override }
+        #endif
+        return MobileHostService.hasEventSubscribers(topic: "workspace.updated")
+    }
+
     init(tabManager: TabManager, notificationStore: TerminalNotificationStore? = nil) {
         self.tabManager = tabManager
         self.notificationStore = notificationStore
         #if DEBUG
         cmuxDebugLog("mobile.observer init tabs=\(tabManager.tabs.count)")
         #endif
-        attach(to: tabManager)
+        subscriptionsChangeObserver = NotificationCenter.default.addObserver(
+            forName: .mobileHostEventSubscriptionsDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.reconcilePipelines()
+            }
+        }
+        reconcilePipelines()
+    }
+
+    deinit {
+        if let subscriptionsChangeObserver {
+            NotificationCenter.default.removeObserver(subscriptionsChangeObserver)
+        }
+    }
+
+    private func reconcilePipelines() {
+        guard let tabManager else { return }
+        let wantsPipelines = hasWorkspaceListSubscribers
+        if wantsPipelines, !pipelinesAttached {
+            pipelinesAttached = true
+            attach(to: tabManager)
+        } else if !wantsPipelines, pipelinesAttached {
+            pipelinesAttached = false
+            detachPipelines()
+        }
+    }
+
+    private func detachPipelines() {
+        #if DEBUG
+        cmuxDebugLog("mobile.observer detach: no workspace.updated subscribers")
+        #endif
+        tabsCancellable = nil
+        selectionCancellable = nil
+        groupsCancellable = nil
+        notificationsCancellable = nil
+        unreadIndicatorsCancellable = nil
+        perWorkspaceCancellables.removeAll()
     }
 
     private func attach(to tabManager: TabManager) {

--- a/cmuxTests/AppDelegateMainWindowTestingSupport.swift
+++ b/cmuxTests/AppDelegateMainWindowTestingSupport.swift
@@ -73,6 +73,9 @@ extension AppDelegate {
             cmuxConfigStore: cmuxConfigStore,
             window: nil
         )
+        // Fidelity tests exercise the observer's pipelines without a live
+        // phone subscriber; force presence on so the graph attaches.
+        MobileWorkspaceListObserver.subscriberPresenceOverrideForTesting = true
         ensureMobileWorkspaceListObserver(for: tabManager)
         notifyMainWindowContextsDidChange()
         return windowId

--- a/cmuxTests/AppDelegateMainWindowTestingSupport.swift
+++ b/cmuxTests/AppDelegateMainWindowTestingSupport.swift
@@ -73,8 +73,11 @@ extension AppDelegate {
             cmuxConfigStore: cmuxConfigStore,
             window: nil
         )
-        // Fidelity tests exercise the observer's pipelines without a live
-        // phone subscriber; force presence on so the graph attaches.
+        // Context-based tests exercise observer pipelines without a live phone
+        // subscriber; force presence on so the graph attaches (pre-gate
+        // behavior). This is deliberately sticky across tests: any test that
+        // asserts detached-by-default must set the override itself, as
+        // observerPipelinesFollowSubscriberPresence does with save/restore.
         MobileWorkspaceListObserver.subscriberPresenceOverrideForTesting = true
         ensureMobileWorkspaceListObserver(for: tabManager)
         notifyMainWindowContextsDidChange()

--- a/cmuxTests/MobileWorkspaceListFidelityTests.swift
+++ b/cmuxTests/MobileWorkspaceListFidelityTests.swift
@@ -51,6 +51,39 @@ struct MobileWorkspaceListFidelityTests {
         return (workspace, orderedIds)
     }
 
+    @Test func observerPipelinesFollowSubscriberPresence() throws {
+        let previousOverride = MobileWorkspaceListObserver.subscriberPresenceOverrideForTesting
+        defer { MobileWorkspaceListObserver.subscriberPresenceOverrideForTesting = previousOverride }
+
+        // With no mobile client subscribed to workspace.updated, the observer
+        // must not build its publisher graph: every agent-driven workspace
+        // mutation would otherwise run throttled deliveries plus a full-list
+        // summary hash on the main thread for nobody.
+        MobileWorkspaceListObserver.subscriberPresenceOverrideForTesting = false
+        let manager = TabManager()
+        let observer = MobileWorkspaceListObserver(tabManager: manager)
+        #expect(!observer.pipelinesAttachedForTesting)
+
+        // First subscriber arrives: the graph attaches (with its forced
+        // initial emit) off the subscription-change notification.
+        MobileWorkspaceListObserver.subscriberPresenceOverrideForTesting = true
+        NotificationCenter.default.post(
+            name: .mobileHostEventSubscriptionsDidChange,
+            object: nil,
+            userInfo: ["topics": ["workspace.updated"]]
+        )
+        #expect(observer.pipelinesAttachedForTesting)
+
+        // Last subscriber leaves: the graph detaches again.
+        MobileWorkspaceListObserver.subscriberPresenceOverrideForTesting = false
+        NotificationCenter.default.post(
+            name: .mobileHostEventSubscriptionsDidChange,
+            object: nil,
+            userInfo: ["topics": ["workspace.updated"]]
+        )
+        #expect(!observer.pipelinesAttachedForTesting)
+    }
+
     @Test func orderedPanelIdsMatchesBonsplitSpatialOrder() throws {
         let (workspace, createdOrder) = try makeWorkspaceWithSplitTerminals(count: 3)
 


### PR DESCRIPTION
First evidence-backed fix from the typing-latency diagnosis program.

A 30s Time Profiler trace of the production NIGHTLY while churning (28 workspaces, live agents, 47-91% CPU) attributed **38% of main-thread CPU to Combine Throttle/Publishers traffic from `MobileWorkspaceListObserver`**: five global streams plus ~a dozen per-workspace streams, all throttled on `RunLoop.main`, each delivery running a full-list summary hash plus per-workspace notification-store preview signatures. `emitEvent` is subscriber-gated, but all of that work ran before the gate — so it burned the main thread continuously under agent churn even with no phone attached. Keystrokes queue behind exactly these run-loop turns, which is why typing feels worst in agent input fields while agents stream.

Fix: attach the observer's publisher graph only while a mobile client subscribes to `workspace.updated`, detach when the last subscriber leaves, keyed off `.mobileHostEventSubscriptionsDidChange` (the same signal the terminal byte tee uses — shared behavior, not a new mechanism). Attach keeps the forced initial emit, so a freshly paired phone still receives current state immediately. Regression test `observerPipelinesFollowSubscriberPresence` covers the attach/detach lifecycle; fidelity tests force presence on via the shared testing support so they keep exercising the pipelines.

Verified on a tagged Debug build (`mobgt`): under workspace creation and title churn with no phone, the observer logs only its two init lines — previously it hashed and logged continuously. Behavior with a subscribed phone is unchanged by construction (same attach body, same initial emit).

Trace artifacts: `out/instruments-20260715-170350/` in cmuxterm-hq (Time Profiler trace + weighted analysis). Remaining diagnosis follow-ups tracked in the typing-latency program: Swift type-metadata churn inside publisher payloads, SwiftUI re-layout share, background file-scan/text-search sweeps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8219"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786761649&installation_id=133855650&pr_number=8219&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8219&signature=b27e4c4f7148eb768a7207be315dd5f506fb09c404ca03d1547f9e46666cdd14"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Attach the mobile workspace-list observer only while a phone subscribes to `workspace.updated`, and detach it when the last subscriber leaves. This removes unnecessary main-thread Combine work with no phone connected, improving typing latency under agent churn.

- **Refactors**
  - Listen to `.mobileHostEventSubscriptionsDidChange` and attach/detach pipelines based on subscriber presence.
  - Keep the forced initial emit on attach so a newly paired phone gets current state immediately.
  - Add `detachPipelines()` to clear all cancellables and track `pipelinesAttached`.
  - Testing: add a sticky `subscriberPresenceOverrideForTesting` (forced on for context-based tests) and `observerPipelinesFollowSubscriberPresence` to verify attach/detach via subscription changes.

<sup>Written for commit b29180fbc8238d072dbb5c8172d4e98eca3d2fcc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8219?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Workspace update monitoring now activates only when mobile clients subscribe to workspace updates, reducing unnecessary background processing.
  * Monitoring detaches automatically when no subscribers remain and updates its behavior as subscription counts change.

* **Bug Fixes**
  * Improved workspace list update handling in response to mobile event subscription changes.

* **Tests**
  * Added a new fidelity test to verify monitoring follows subscriber presence (attaches/detaches) when subscription notifications are posted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->