### PR TITLE
Fix iOS deployment target for Iroh framework compatibility

### DIFF
--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -58,7 +58,7 @@ CMUX_CRASH_REPORTING_ENABLED = YES
 // ==========================================
 // Platform Configuration
 // ==========================================
-IPHONEOS_DEPLOYMENT_TARGET = 18.4
+IPHONEOS_DEPLOYMENT_TARGET = 18.0
 
 // (1 == iPhone, 2 == iPad)
 TARGETED_DEVICE_FAMILY = 1,2


### PR DESCRIPTION
iOS app was set to 18.4 minimum but CmuxIrohTransport and Iroh framework require iOS 18.0. Lower deployment target to 18.0 to resolve ASC ITMS-90208 error during internal TestFlight upload.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8220"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786762478&installation_id=133855650&pr_number=8220&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8220&signature=2a61c5fc1c57b7cda4461a4ec3c69b96becbbb588d81d1015de1ced9deee2221"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowered the iOS deployment target from 18.4 to 18.0 to match the Iroh framework and CmuxIrohTransport requirements, fixing App Store Connect error ITMS-90208. Updates `IPHONEOS_DEPLOYMENT_TARGET` in `ios/Config/Shared.xcconfig` to unblock TestFlight uploads.

<sup>Written for commit bf86c2e2aeb66dd0dafade3e32a717b8709568b9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8220?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Compatibility**
  * Expanded iOS compatibility to support devices running iOS 18.0 and later.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->