### PR TITLE
Group cmux TUI context menu actions

### DIFF
--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1645,6 +1645,7 @@ impl MenuItem {
 /// spans the full inner row including those padding cells.
 pub struct ContextMenu {
     pub items: Vec<MenuItem>,
+    all_items: Vec<MenuItem>,
     pub selected: usize,
     right_press: (u16, u16),
     right_drag_moved: bool,
@@ -1672,6 +1673,7 @@ impl ContextMenu {
         let width = label_w + 2 + Self::PAD * 2 + 2;
         let height = items.len() as u16 + 2;
         ContextMenu {
+            all_items: items.clone(),
             items,
             selected: 0,
             right_press: (x, y),
@@ -1697,6 +1699,32 @@ impl ContextMenu {
 
     fn selected_action(&self) -> Option<MenuAction> {
         self.items.get(self.selected).and_then(|item| item.action())
+    }
+
+    /// Keep every action row visible when separators are the only reason the
+    /// menu exceeds the available height. Full grouping returns after a resize.
+    pub fn fit_to_rows(&mut self, max_rows: usize) {
+        let selected_action = self.selected_action();
+        let action_count = self.all_items.iter().filter(|item| item.action().is_some()).count();
+        let mut separator_budget = max_rows.saturating_sub(action_count);
+        self.items = self
+            .all_items
+            .iter()
+            .copied()
+            .filter(|item| match item {
+                MenuItem::Action(_) => true,
+                MenuItem::Separator if separator_budget > 0 => {
+                    separator_budget -= 1;
+                    true
+                }
+                MenuItem::Separator => false,
+            })
+            .collect();
+        self.selected = selected_action
+            .and_then(|action| self.items.iter().position(|item| item.action() == Some(action)))
+            .or_else(|| self.items.iter().position(|item| item.action().is_some()))
+            .unwrap_or(0);
+        self.rect.height = self.items.len() as u16 + 2;
     }
 
     fn select_previous(&mut self) {
@@ -6758,6 +6786,30 @@ mod tests {
                 MenuAction::BrowserActivate(pane),
             ]
         );
+    }
+
+    #[test]
+    fn context_menu_drops_only_overflowing_separators_and_restores_them_after_resize() {
+        let pane = 7;
+        let mut menu = ContextMenu::at(10, 5, pane_context_menu_groups(pane, true, true));
+        menu.selected = menu
+            .items
+            .iter()
+            .position(|item| item.action() == Some(MenuAction::CopyPaneId(pane)))
+            .unwrap();
+
+        assert_eq!(menu.items.len(), 19);
+        assert_eq!(menu.items.iter().filter(|item| **item == MenuItem::Separator).count(), 4);
+        menu.fit_to_rows(18);
+        assert_eq!(menu.items.len(), 18);
+        assert_eq!(menu.items.iter().filter(|item| **item == MenuItem::Separator).count(), 3);
+        assert_eq!(menu.selected_action(), Some(MenuAction::CopyPaneId(pane)));
+        assert_eq!(menu.rect.height, 20);
+
+        menu.fit_to_rows(19);
+        assert_eq!(menu.items.len(), 19);
+        assert_eq!(menu.items.iter().filter(|item| **item == MenuItem::Separator).count(), 4);
+        assert_eq!(menu.selected_action(), Some(MenuAction::CopyPaneId(pane)));
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1700,17 +1700,21 @@ impl ContextMenu {
     }
 
     fn select_previous(&mut self) {
-        if let Some(index) =
-            self.items[..self.selected].iter().rposition(|item| item.action().is_some())
+        if let Some(index) = self
+            .items
+            .get(..self.selected)
+            .and_then(|items| items.iter().rposition(|item| item.action().is_some()))
         {
             self.selected = index;
         }
     }
 
     fn select_next(&mut self) {
-        if let Some(offset) = self.items[self.selected.saturating_add(1)..]
-            .iter()
-            .position(|item| item.action().is_some())
+        let start = self.selected.saturating_add(1);
+        if let Some(offset) = self
+            .items
+            .get(start..)
+            .and_then(|items| items.iter().position(|item| item.action().is_some()))
         {
             self.selected += offset + 1;
         }
@@ -6725,6 +6729,17 @@ mod tests {
         assert_eq!(menu.selected_action(), Some(MenuAction::NewTab(7)));
         menu.select_previous();
         assert_eq!(menu.selected_action(), Some(MenuAction::CloseTab(7)));
+
+        menu.selected = usize::MAX;
+        menu.select_previous();
+        menu.select_next();
+        assert_eq!(menu.selected, usize::MAX);
+        assert_eq!(menu.selected_action(), None);
+
+        let mut empty = ContextMenu::at(10, 5, Vec::new());
+        empty.select_previous();
+        empty.select_next();
+        assert_eq!(empty.selected_action(), None);
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/app.rs
+++ b/cmux-tui/crates/cmux-tui/src/app.rs
@@ -1618,12 +1618,33 @@ impl MenuAction {
     }
 }
 
+/// One row in a context menu. Separators divide related action groups and
+/// are skipped by keyboard and mouse selection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MenuItem {
+    Action(MenuAction),
+    Separator,
+}
+
+impl MenuItem {
+    pub fn action(self) -> Option<MenuAction> {
+        match self {
+            MenuItem::Action(action) => Some(action),
+            MenuItem::Separator => None,
+        }
+    }
+
+    pub fn label(self) -> Option<&'static str> {
+        self.action().map(|action| action.label())
+    }
+}
+
 /// Right-click context menu overlay. The rect includes the border chrome;
-/// items get a one-cell padding column on each side inside that border
-/// (no extra rows above/below), and the hover/selection highlight spans
-/// the full inner row including those padding cells.
+/// action rows get a one-cell padding column on each side inside that border,
+/// groups are divided by separator rows, and the hover/selection highlight
+/// spans the full inner row including those padding cells.
 pub struct ContextMenu {
-    pub items: Vec<MenuAction>,
+    pub items: Vec<MenuItem>,
     pub selected: usize,
     right_press: (u16, u16),
     right_drag_moved: bool,
@@ -1636,8 +1657,16 @@ impl ContextMenu {
     /// Horizontal padding between the menu edge and the item labels.
     pub const PAD: u16 = 1;
 
-    fn at(x: u16, y: u16, items: Vec<MenuAction>) -> Self {
-        let label_w = items.iter().map(|i| i.label().len()).max().unwrap_or(0) as u16;
+    fn at(x: u16, y: u16, groups: Vec<Vec<MenuAction>>) -> Self {
+        let mut items = Vec::new();
+        for group in groups.into_iter().filter(|group| !group.is_empty()) {
+            if !items.is_empty() {
+                items.push(MenuItem::Separator);
+            }
+            items.extend(group.into_iter().map(MenuItem::Action));
+        }
+        let label_w =
+            items.iter().filter_map(|item| item.label()).map(str::len).max().unwrap_or(0) as u16;
         // One space of inner padding either side of the label, plus the
         // one-cell padding column on each side, plus the border.
         let width = label_w + 2 + Self::PAD * 2 + 2;
@@ -1663,8 +1692,60 @@ impl ContextMenu {
             return None;
         }
         let row = (y - self.rect.y - 1) as usize;
-        (row < self.items.len()).then_some(row)
+        self.items.get(row)?.action().map(|_| row)
     }
+
+    fn selected_action(&self) -> Option<MenuAction> {
+        self.items.get(self.selected).and_then(|item| item.action())
+    }
+
+    fn select_previous(&mut self) {
+        if let Some(index) =
+            self.items[..self.selected].iter().rposition(|item| item.action().is_some())
+        {
+            self.selected = index;
+        }
+    }
+
+    fn select_next(&mut self) {
+        if let Some(offset) = self.items[self.selected.saturating_add(1)..]
+            .iter()
+            .position(|item| item.action().is_some())
+        {
+            self.selected += offset + 1;
+        }
+    }
+}
+
+fn pane_context_menu_groups(
+    pane: PaneId,
+    is_browser: bool,
+    external_browser: bool,
+) -> Vec<Vec<MenuAction>> {
+    let mut browser_actions = Vec::new();
+    if is_browser {
+        browser_actions.extend([
+            MenuAction::BrowserBack(pane),
+            MenuAction::BrowserForward(pane),
+            MenuAction::BrowserReload(pane),
+            MenuAction::BrowserEditUrl(pane),
+            MenuAction::BrowserCopyUrl(pane),
+        ]);
+        if external_browser {
+            browser_actions.push(MenuAction::BrowserActivate(pane));
+        }
+    }
+    vec![
+        vec![MenuAction::RenameTab(pane), MenuAction::CloseTab(pane)],
+        vec![MenuAction::NewTab(pane), MenuAction::NewBrowserTab(pane)],
+        browser_actions,
+        vec![
+            MenuAction::SplitRight(pane),
+            MenuAction::SplitDown(pane),
+            MenuAction::ClosePane(pane),
+        ],
+        vec![MenuAction::CopyTabId(pane), MenuAction::CopyPaneId(pane)],
+    ]
 }
 
 /// What a committed rename prompt applies to.
@@ -4107,15 +4188,15 @@ impl App {
                 Ok(RenderAction::Draw)
             }
             KeyCode::Up => {
-                menu.selected = menu.selected.saturating_sub(1);
+                menu.select_previous();
                 Ok(RenderAction::Draw)
             }
             KeyCode::Down => {
-                menu.selected = (menu.selected + 1).min(menu.items.len().saturating_sub(1));
+                menu.select_next();
                 Ok(RenderAction::Draw)
             }
             KeyCode::Enter => {
-                let action = menu.items[menu.selected];
+                let Some(action) = menu.selected_action() else { return Ok(RenderAction::Draw) };
                 self.menu = None;
                 self.activate_menu(action)?;
                 Ok(RenderAction::Draw)
@@ -5706,8 +5787,9 @@ impl App {
         if plain_open_click {
             self.menu = Some(menu);
         } else if let Some(item) = menu.item_at(x, y) {
-            let action = menu.items[item];
-            self.activate_menu(action)?;
+            if let Some(action) = menu.items[item].action() {
+                self.activate_menu(action)?;
+            }
         } else {
             self.menu = Some(menu);
         }
@@ -5732,7 +5814,9 @@ impl App {
         // the border chrome keep it open without activating.
         if let Some(menu) = self.menu.take() {
             if let Some(item) = menu.item_at(x, y) {
-                self.activate_menu(menu.items[item])?;
+                if let Some(action) = menu.items[item].action() {
+                    self.activate_menu(action)?;
+                }
             } else if menu.rect.contains(x, y) {
                 self.menu = Some(menu); // padding click: keep it open
             }
@@ -6250,9 +6334,8 @@ impl App {
                     x,
                     y,
                     vec![
-                        MenuAction::RenameWorkspace(id),
-                        MenuAction::CopyWorkspaceId(id),
-                        MenuAction::CloseWorkspace(id),
+                        vec![MenuAction::RenameWorkspace(id), MenuAction::CloseWorkspace(id)],
+                        vec![MenuAction::CopyWorkspaceId(id)],
                     ],
                 ));
                 return;
@@ -6261,38 +6344,21 @@ impl App {
                 self.menu = Some(ContextMenu::at(
                     x,
                     y,
-                    vec![MenuAction::RenameScreen(id), MenuAction::CloseScreen(id)],
+                    vec![vec![MenuAction::RenameScreen(id), MenuAction::CloseScreen(id)]],
                 ));
                 return;
             }
             _ => {}
         }
         if let Some(area) = self.pane_area_at(x, y) {
-            let mut items = Vec::new();
-            if self.surface_kind(area.surface) == Some(SurfaceKind::Browser) {
-                items.extend([
-                    MenuAction::BrowserBack(area.pane),
-                    MenuAction::BrowserForward(area.pane),
-                    MenuAction::BrowserReload(area.pane),
-                    MenuAction::BrowserEditUrl(area.pane),
-                    MenuAction::BrowserCopyUrl(area.pane),
-                ]);
-                if self.browser_source(area.surface) == Some(BrowserSource::External) {
-                    items.push(MenuAction::BrowserActivate(area.pane));
-                }
-            }
-            items.extend([
-                MenuAction::RenameTab(area.pane),
-                MenuAction::CopyTabId(area.pane),
-                MenuAction::CopyPaneId(area.pane),
-                MenuAction::NewTab(area.pane),
-                MenuAction::NewBrowserTab(area.pane),
-                MenuAction::SplitRight(area.pane),
-                MenuAction::SplitDown(area.pane),
-                MenuAction::CloseTab(area.pane),
-                MenuAction::ClosePane(area.pane),
-            ]);
-            self.menu = Some(ContextMenu::at(x, y, items));
+            let is_browser = self.surface_kind(area.surface) == Some(SurfaceKind::Browser);
+            let external_browser =
+                self.browser_source(area.surface) == Some(BrowserSource::External);
+            self.menu = Some(ContextMenu::at(
+                x,
+                y,
+                pane_context_menu_groups(area.pane, is_browser, external_browser),
+            ));
         }
     }
 
@@ -6568,14 +6634,14 @@ fn browser_key_mapping(
 #[cfg(test)]
 mod tests {
     use super::{
-        App, AppEvent, BACKGROUND_REFRESH_RETRIES, DeferredInput, Drag, ForwardMuxOutcome,
-        MuxTitleIngress, OrderedSession, PaneArea, PendingSessionMutation,
-        PendingSessionMutationState, PtyFailureIngress, PtyMousePressResult, RenderAction,
-        Selection, SessionCompletion, SessionCompletionAction, SidebarPluginSyncClaim,
-        SidebarPluginSyncState, SurfaceResizeDecision, SurfaceResizeOwnership,
-        browser_content_size_for_rect, browser_hover_forward_allowed, forward_mux_event,
-        forward_mux_events, pane_parts_for_rect, record_surface_resize_dispatch_result,
-        sidebar_plugin_status_settles_passive_claim,
+        App, AppEvent, BACKGROUND_REFRESH_RETRIES, ContextMenu, DeferredInput, Drag,
+        ForwardMuxOutcome, MenuAction, MenuItem, MuxTitleIngress, OrderedSession, PaneArea,
+        PendingSessionMutation, PendingSessionMutationState, PtyFailureIngress,
+        PtyMousePressResult, RenderAction, Selection, SessionCompletion, SessionCompletionAction,
+        SidebarPluginSyncClaim, SidebarPluginSyncState, SurfaceResizeDecision,
+        SurfaceResizeOwnership, browser_content_size_for_rect, browser_hover_forward_allowed,
+        forward_mux_event, forward_mux_events, pane_context_menu_groups, pane_parts_for_rect,
+        record_surface_resize_dispatch_result, sidebar_plugin_status_settles_passive_claim,
     };
     use std::collections::{HashMap, HashSet, VecDeque};
     use std::path::PathBuf;
@@ -6608,6 +6674,75 @@ mod tests {
 
     fn settled(outcome: super::SessionMutationOutcome) -> AppEvent {
         AppEvent::SessionMutationSettled { outcome, routing: false }
+    }
+
+    #[test]
+    fn pane_context_menu_groups_current_tab_creation_layout_and_ids() {
+        let pane = 7;
+        let menu = ContextMenu::at(10, 5, pane_context_menu_groups(pane, false, false));
+
+        assert_eq!(
+            menu.items,
+            vec![
+                MenuItem::Action(MenuAction::RenameTab(pane)),
+                MenuItem::Action(MenuAction::CloseTab(pane)),
+                MenuItem::Separator,
+                MenuItem::Action(MenuAction::NewTab(pane)),
+                MenuItem::Action(MenuAction::NewBrowserTab(pane)),
+                MenuItem::Separator,
+                MenuItem::Action(MenuAction::SplitRight(pane)),
+                MenuItem::Action(MenuAction::SplitDown(pane)),
+                MenuItem::Action(MenuAction::ClosePane(pane)),
+                MenuItem::Separator,
+                MenuItem::Action(MenuAction::CopyTabId(pane)),
+                MenuItem::Action(MenuAction::CopyPaneId(pane)),
+            ]
+        );
+    }
+
+    #[test]
+    fn context_menu_selection_and_hit_testing_skip_separators() {
+        let mut menu = ContextMenu::at(
+            10,
+            5,
+            vec![
+                vec![MenuAction::RenameTab(7), MenuAction::CloseTab(7)],
+                Vec::new(),
+                vec![MenuAction::NewTab(7)],
+            ],
+        );
+
+        assert_eq!(menu.item_at(10, 5), Some(0));
+        assert_eq!(menu.item_at(10, 7), None);
+        assert_eq!(menu.item_at(10, 8), Some(3));
+        assert_eq!(menu.selected_action(), Some(MenuAction::RenameTab(7)));
+
+        menu.select_next();
+        assert_eq!(menu.selected_action(), Some(MenuAction::CloseTab(7)));
+        menu.select_next();
+        assert_eq!(menu.selected_action(), Some(MenuAction::NewTab(7)));
+        menu.select_next();
+        assert_eq!(menu.selected_action(), Some(MenuAction::NewTab(7)));
+        menu.select_previous();
+        assert_eq!(menu.selected_action(), Some(MenuAction::CloseTab(7)));
+    }
+
+    #[test]
+    fn browser_context_menu_keeps_browser_actions_in_their_own_group() {
+        let pane = 7;
+        let groups = pane_context_menu_groups(pane, true, true);
+
+        assert_eq!(
+            groups[2],
+            vec![
+                MenuAction::BrowserBack(pane),
+                MenuAction::BrowserForward(pane),
+                MenuAction::BrowserReload(pane),
+                MenuAction::BrowserEditUrl(pane),
+                MenuAction::BrowserCopyUrl(pane),
+                MenuAction::BrowserActivate(pane),
+            ]
+        );
     }
 
     #[test]

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -114,6 +114,7 @@ pub fn draw_prompt(app: &mut App, frame: &mut Frame) {
 pub fn draw_menu(app: &mut App, frame: &mut Frame) {
     let screen = frame.area();
     let Some(menu) = app.menu.as_mut() else { return };
+    menu.fit_to_rows(screen.height.saturating_sub(2) as usize);
 
     // Clamp to the screen and write the final rect back so click and
     // hover hit-testing match what is drawn.

--- a/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
+++ b/cmux-tui/crates/cmux-tui/src/ui/overlay.rs
@@ -1,7 +1,7 @@
 //! Overlays drawn on top of the frame: the right-click context menu and
 //! the centered rename dialog. Menu items get a one-cell padding column
-//! each side inside a border (no extra rows), and the selected row (arrow
-//! keys or mouse hover) highlights across the inner row, padding included.
+//! each side inside a border, separator rows divide related groups, and the
+//! selected row (arrow keys or mouse hover) highlights across the inner row.
 
 use cmux_tui_core::Rect;
 use ratatui::Frame;
@@ -9,7 +9,7 @@ use ratatui::buffer::Buffer;
 use ratatui::layout::Position;
 use ratatui::style::{Modifier, Style};
 
-use crate::app::{App, ContextMenu};
+use crate::app::{App, ContextMenu, MenuItem};
 
 /// Centered prompt dialog: bordered box with title, input row, and
 /// clickable shortcut buttons. Writes the dialog, input, and button rects
@@ -152,18 +152,28 @@ pub fn draw_menu(app: &mut App, frame: &mut Frame) {
         if i as u16 >= inner_h {
             break;
         }
-        let style = if i == menu.selected { selected } else { base };
-        // The highlight spans the full inner row, side padding included.
-        for dx in 0..inner_w {
-            set_cell(buf, inner_x + dx, row_y, " ", style);
+        if *item == MenuItem::Separator {
+            set_cell(buf, x, row_y, "├", border);
+            for dx in 0..inner_w {
+                set_cell(buf, inner_x + dx, row_y, "─", border);
+            }
+            set_cell(buf, x + width - 1, row_y, "┤", border);
+            continue;
         }
-        buf.set_stringn(
-            inner_x + pad + 1,
-            row_y,
-            item.label(),
-            inner_w.saturating_sub(pad * 2) as usize,
-            style,
-        );
+        if let Some(label) = item.label() {
+            let style = if i == menu.selected { selected } else { base };
+            // The highlight spans the full inner row, side padding included.
+            for dx in 0..inner_w {
+                set_cell(buf, inner_x + dx, row_y, " ", style);
+            }
+            buf.set_stringn(
+                inner_x + pad + 1,
+                row_y,
+                label,
+                inner_w.saturating_sub(pad * 2) as usize,
+                style,
+            );
+        }
     }
 }
 

--- a/cmux-tui/docs/mouse.md
+++ b/cmux-tui/docs/mouse.md
@@ -34,7 +34,7 @@ Drag the sidebar border to resize the sidebar for the current TUI session. The c
 
 Right-click a pane for rename tab, close tab, new tab, new browser tab, browser actions when applicable, split right, split down, close pane, and ID copying. The menu separates current-tab, creation, browser, pane-layout, and ID actions. When an inner PTY app enables mouse tracking, right-click is forwarded to the app; hold Shift while right-clicking to open the cmux menu. Right-click a workspace row for rename, close, or ID copying. Right-click a screen in the status bar for rename or close.
 
-Menus draw bordered overlays. Up and Down move the selected row, Enter activates it, and Esc closes the menu. A right press, drag to a row, and release activates that row. A plain right-click opens the menu and leaves it open.
+Menus draw bordered overlays. Divider rows collapse as needed to keep every action visible when the flat menu would fit. Up and Down move the selected row, Enter activates it, and Esc closes the menu. A right press, drag to a row, and release activates that row. A plain right-click opens the menu and leaves it open.
 
 ## Selection and Clipboard
 

--- a/cmux-tui/docs/mouse.md
+++ b/cmux-tui/docs/mouse.md
@@ -32,7 +32,7 @@ Drag the sidebar border to resize the sidebar for the current TUI session. The c
 
 ## Context Menus
 
-Right-click a pane for rename tab, new tab, new browser tab, split right, split down, close tab, and close pane. When an inner PTY app enables mouse tracking, right-click is forwarded to the app; hold Shift while right-clicking to open the cmux menu. Right-click a workspace row for rename or close. Right-click a screen in the status bar for rename or close.
+Right-click a pane for rename tab, close tab, new tab, new browser tab, browser actions when applicable, split right, split down, close pane, and ID copying. The menu separates current-tab, creation, browser, pane-layout, and ID actions. When an inner PTY app enables mouse tracking, right-click is forwarded to the app; hold Shift while right-clicking to open the cmux menu. Right-click a workspace row for rename, close, or ID copying. Right-click a screen in the status bar for rename or close.
 
 Menus draw bordered overlays. Up and Down move the selected row, Enter activates it, and Esc closes the menu. A right press, drag to a row, and release activates that row. A plain right-click opens the menu and leaves it open.
 

--- a/cmux-tui/scripts/smoke-tui.py
+++ b/cmux-tui/scripts/smoke-tui.py
@@ -694,6 +694,7 @@ text = output.decode("utf-8", "replace")
 assert "Rename workspace" in text, text[-800:]
 assert "Copy workspace id" in text, text[-800:]
 assert "┌" in text, text[-800:]
+assert "├" in text, text[-800:]
 styles = render_style_snapshot(output)
 overlap = styles[6][2]  # item 1: non-selected menu row over the active workspace subtitle row.
 assert overlap["bg"] == 237 and not overlap["bold"] and not overlap["dim"], (overlap, text[-800:])
@@ -713,9 +714,23 @@ assert "Copy tab id" in text, text[-800:]
 assert "Copy pane id" in text, text[-800:]
 assert "Close tab" in text, text[-800:]
 assert "┌" in text, text[-800:]
+assert "├" in text, text[-800:]
 assert "[ OK ⏎ ]" not in text, text[-800:]
+menu_lines = render_text_snapshot(output).splitlines()
+assert "Rename tab" in menu_lines[5], menu_lines[4:18]
+assert "Close tab" in menu_lines[6], menu_lines[4:18]
+assert "├" in menu_lines[7], menu_lines[4:18]
+assert "New tab" in menu_lines[8], menu_lines[4:18]
+assert "New browser tab" in menu_lines[9], menu_lines[4:18]
+assert "├" in menu_lines[10], menu_lines[4:18]
+assert "Split right" in menu_lines[11], menu_lines[4:18]
+assert "Split down" in menu_lines[12], menu_lines[4:18]
+assert "Close pane" in menu_lines[13], menu_lines[4:18]
+assert "├" in menu_lines[14], menu_lines[4:18]
+assert "Copy tab id" in menu_lines[15], menu_lines[4:18]
+assert "Copy pane id" in menu_lines[16], menu_lines[4:18]
 output = b""
-os.write(fd, b"\x1b[<34;81;7M\x1b[<2;81;7m")
+os.write(fd, b"\x1b[<34;81;16M\x1b[<2;81;16m")
 drain(0.8)
 osc52 = re.findall(rb"\x1b\]52;c;([A-Za-z0-9+/=]+)", output)
 assert osc52, "no OSC 52 clipboard write after menu copy"
@@ -780,8 +795,8 @@ tabs_before = sum(
     for s in w["screens"]
     for p in s["panes"]
 )
-# "Close tab" sits below the copy-id and split rows.
-os.write(fd, b"\x1b[<2;81;6M\x1b[<34;81;13M\x1b[<2;81;13m")
+# "Close tab" is the second row, directly below "Rename tab".
+os.write(fd, b"\x1b[<2;81;6M\x1b[<34;81;7M\x1b[<2;81;7m")
 drain(1.0)
 tabs_after = sum(
     len(p["tabs"])


### PR DESCRIPTION
## Summary
- group pane actions into current tab, creation, browser, pane layout, and ID sections
- render non-clickable separators and skip them during keyboard and mouse navigation
- update Rust TUI docs and smoke coverage for the new row layout

## Testing
- ZIG=/opt/homebrew/Cellar/zig/0.15.2_1/bin/zig cargo test -p cmux-tui (223 passed)
- ZIG=/opt/homebrew/Cellar/zig/0.15.2_1/bin/zig cargo clippy -p cmux-tui --all-targets -- -D warnings
- isolated smoke-tui runtime replay through context-menu actions (SMOKE OK)

## Scope
- Rust cmux-tui only

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8225"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786764706&installation_id=133855650&pr_number=8225&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8225&signature=f2376f4526f44c9eea341178188a764d2f378783ac3341b59c7fa2b80d40a07b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Grouped context-menu actions in `cmux-tui` into sections with visible, non-clickable separators. When space is tight, the menu drops only extra separators so all actions remain visible.

- **New Features**
  - Pane menu groups: current tab, creation, browser (when available, adds “Activate” for external), layout, and IDs.
  - Workspace menu groups rename/close and separates copy ID; screen menu groups rename/close.
  - Separators draw as `├─┤`; Up/Down and hit-testing skip them; Enter and clicks only activate actions.

- **Refactors**
  - Added `MenuItem`; `ContextMenu` now holds `Vec<MenuItem>` and builds from grouped actions.
  - Introduced `pane_context_menu_groups(...)`, selection helpers that skip separators, and `fit_to_rows(...)` to manage separator collapse and bounds-safe selection.

<sup>Written for commit 40abcbfeaf577f8919c61820a5bf69acb69370e7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8225?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Context menus are now grouped into sections with visible separator rows.
  * Keyboard and mouse interactions treat separator rows as non-activating, ensuring Enter/right-click actions only trigger real items.
* **Bug Fixes**
  * Improved rendering for separator rows and refined label drawing to match grouped layout.
* **Documentation**
  * Expanded context-menu documentation with the grouped pane menu contents and described ID-copy actions.
* **Tests**
  * Strengthened smoke/UI snapshot assertions and added unit coverage for grouped composition and navigation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->