### PR TITLE
Fix iOS pairing for multiple cmux apps on one Mac

### DIFF
--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMac.swift
@@ -41,8 +41,38 @@ public struct MobilePairedMac: Codable, Equatable, Sendable, Identifiable {
     /// An SF Symbol name (ASCII, e.g. `"desktopcomputer"`) or an emoji.
     public var customIcon: String?
 
-    /// The Mac device identifier doubles as the stable `Identifiable` id.
-    public var id: String { macDeviceID }
+    /// Stable identity of this saved app instance.
+    ///
+    /// A physical Mac can run Stable, Nightly, and tagged development builds at
+    /// once. Those processes share ``macDeviceID`` but have distinct
+    /// ``instanceTag`` values, so both fields participate in list identity.
+    public var id: String { Self.pairingID(macDeviceID: macDeviceID, instanceTag: instanceTag) }
+
+    /// Builds the stable local identity for one saved Mac app instance.
+    /// - Parameters:
+    ///   - macDeviceID: Stable identifier of the physical Mac.
+    ///   - instanceTag: Authenticated app-instance tag, or `nil` for a legacy host.
+    /// - Returns: An identifier unique to the physical Mac and app instance.
+    public static func pairingID(macDeviceID: String, instanceTag: String?) -> String {
+        guard let instanceTag, !instanceTag.isEmpty else { return macDeviceID }
+        return "\(macDeviceID)\u{1F}\(instanceTag)"
+    }
+
+    /// Splits a pairing identity received from backup into its physical Mac id
+    /// and optional tagged app-instance id. Legacy physical-only ids remain valid.
+    public static func pairingIdentity(
+        from pairingID: String
+    ) -> (macDeviceID: String, instanceTag: String?) {
+        let parts = pairingID.split(
+            separator: "\u{1F}",
+            maxSplits: 1,
+            omittingEmptySubsequences: false
+        )
+        guard parts.count == 2, !parts[1].isEmpty else {
+            return (pairingID, nil)
+        }
+        return (String(parts[0]), String(parts[1]))
+    }
 
     /// The name to show: the user's custom override if set, else the Mac-reported
     /// name, else the device id.

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Records.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore+Records.swift
@@ -112,14 +112,16 @@ extension MobilePairedMacStore {
     }
 
     func hasOtherActiveMac(
-        than macDeviceID: String,
+        thanOwnerKey ownerKey: String,
+        macDeviceID: String,
         stackUserID: String?,
         teamID: String?
     ) throws -> Bool {
         var statement: OpaquePointer?
         defer { sqlite3_finalize(statement) }
         let sql = """
-            SELECT 1 FROM paired_macs WHERE is_active = 1 AND mac_device_id <> ?
+            SELECT 1 FROM paired_macs WHERE is_active = 1
+              AND (mac_device_id <> ? OR owner_key <> ?)
               AND stack_user_id IS ? AND ((? IS NULL AND team_id IS NULL)
                 OR (? IS NOT NULL AND (team_id IS ? OR team_id IS NULL))) LIMIT 1;
         """
@@ -129,7 +131,8 @@ extension MobilePairedMacStore {
         }
         let team = teamID.map(BindValue.text) ?? .null
         try bind(statement: statement, parameters: [
-            .text(macDeviceID), stackUserID.map(BindValue.text) ?? .null,
+            .text(macDeviceID), .text(ownerKey),
+            stackUserID.map(BindValue.text) ?? .null,
             team, team, team,
         ])
         return sqlite3_step(statement) == SQLITE_ROW

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStore.swift
@@ -14,7 +14,7 @@ let pairedMacStoreLog = Logger(subsystem: "com.cmuxterm.app", category: "PairedM
 /// inject it as `any MobilePairedMacStoring`.
 public actor MobilePairedMacStore: MobilePairedMacStoring {
     /// The schema version this build creates and migrates to.
-    public static let currentSchemaVersion: Int32 = 5
+    public static let currentSchemaVersion: Int32 = 6
 
     private let dbPath: String
     // `nonisolated(unsafe)` only so the (Swift 6 nonisolated) `deinit` can close
@@ -110,7 +110,8 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV3()
                 try migrateToV4()
                 try migrateToV5()
-                try setUserVersion(5)
+                try migrateToV6()
+                try setUserVersion(6)
             }
         case 1:
             try transaction {
@@ -118,27 +119,36 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 try migrateToV3()
                 try migrateToV4()
                 try migrateToV5()
-                try setUserVersion(5)
+                try migrateToV6()
+                try setUserVersion(6)
             }
         case 2:
             try transaction {
                 try migrateToV3()
                 try migrateToV4()
                 try migrateToV5()
-                try setUserVersion(5)
+                try migrateToV6()
+                try setUserVersion(6)
             }
         case 3:
             try transaction {
                 try migrateToV4()
                 try migrateToV5()
-                try setUserVersion(5)
+                try migrateToV6()
+                try setUserVersion(6)
             }
         case 4:
             try transaction {
                 try migrateToV5()
-                try setUserVersion(5)
+                try migrateToV6()
+                try setUserVersion(6)
             }
         case 5:
+            try transaction {
+                try migrateToV6()
+                try setUserVersion(6)
+            }
+        case 6:
             break
         default:
             // A newer build wrote a higher schema version. Schema migrations are
@@ -308,6 +318,80 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         }
     }
 
+    /// v6: make the authenticated app-instance tag part of durable row identity.
+    /// Stable, Nightly, and tagged development builds on one physical Mac share
+    /// `mac_device_id`; folding the normalized tag into `owner_key` lets each
+    /// process retain its own reconnect routes while preserving the existing
+    /// account/team columns and query behavior.
+    private func migrateToV6() throws {
+        try exec("""
+            CREATE TABLE paired_macs_v6 (
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                display_name TEXT,
+                stack_user_id TEXT,
+                team_id TEXT,
+                created_at REAL NOT NULL,
+                last_seen_at REAL NOT NULL,
+                is_active INTEGER NOT NULL DEFAULT 0,
+                custom_name TEXT,
+                custom_color TEXT,
+                custom_icon TEXT,
+                instance_tag TEXT,
+                PRIMARY KEY (mac_device_id, owner_key)
+            );
+        """)
+        try exec("""
+            INSERT INTO paired_macs_v6 (
+                mac_device_id, owner_key, display_name, stack_user_id, team_id,
+                created_at, last_seen_at, is_active, custom_name, custom_color,
+                custom_icon, instance_tag
+            )
+            SELECT
+                mac_device_id,
+                IFNULL(stack_user_id, '') || char(31) || IFNULL(team_id, '')
+                    || char(31) || IFNULL(instance_tag, ''),
+                display_name, stack_user_id, team_id, created_at, last_seen_at,
+                is_active, custom_name, custom_color, custom_icon, instance_tag
+            FROM paired_macs;
+        """)
+        try exec("""
+            CREATE TABLE mac_routes_v6 (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                mac_device_id TEXT NOT NULL,
+                owner_key TEXT NOT NULL,
+                route_id TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                endpoint_json TEXT NOT NULL,
+                priority INTEGER NOT NULL DEFAULT 0,
+                FOREIGN KEY (mac_device_id, owner_key)
+                    REFERENCES paired_macs_v6(mac_device_id, owner_key)
+                    ON DELETE CASCADE
+            );
+        """)
+        try exec("""
+            INSERT INTO mac_routes_v6 (
+                mac_device_id, owner_key, route_id, kind, endpoint_json, priority
+            )
+            SELECT
+                routes.mac_device_id,
+                IFNULL(macs.stack_user_id, '') || char(31) || IFNULL(macs.team_id, '')
+                    || char(31) || IFNULL(macs.instance_tag, ''),
+                routes.route_id, routes.kind, routes.endpoint_json, routes.priority
+            FROM mac_routes routes
+            JOIN paired_macs macs
+              ON macs.mac_device_id = routes.mac_device_id
+             AND macs.owner_key = routes.owner_key;
+        """)
+        try exec("DROP TABLE mac_routes;")
+        try exec("DROP TABLE paired_macs;")
+        try exec("ALTER TABLE paired_macs_v6 RENAME TO paired_macs;")
+        try exec("ALTER TABLE mac_routes_v6 RENAME TO mac_routes;")
+        try exec("CREATE INDEX IF NOT EXISTS idx_macs_stack_user ON paired_macs(stack_user_id);")
+        try exec("CREATE INDEX IF NOT EXISTS idx_macs_team ON paired_macs(stack_user_id, team_id);")
+        try exec("CREATE INDEX IF NOT EXISTS idx_routes_device ON mac_routes(mac_device_id, owner_key);")
+    }
+
     /// Column names defined on `table` (via `PRAGMA table_info`), used to make
     /// additive column migrations idempotent.
     private func tableColumns(_ table: String) throws -> Set<String> {
@@ -428,20 +512,68 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         try ensureReady()
         var didWrite = false
         try transaction {
-            let ownerKey = "\(stackUserID ?? "")\u{1F}\(teamID ?? "")"
-            let existing = try fetchMacRow(macDeviceID: macDeviceID, ownerKey: ownerKey)
-            let claimedLegacy: MacRow?
-            if existing == nil,
-               teamID != nil,
-               let legacy = try fetchMacRow(
-                    macDeviceID: macDeviceID,
-                    ownerKey: "\(stackUserID ?? "")\u{1F}"
-               ) {
-                claimedLegacy = legacy
-            } else {
-                claimedLegacy = nil
+            let recordInstanceTag: String?
+            switch routeWriteCondition {
+            case .matchingInstanceTag(let expectedInstanceTag):
+                recordInstanceTag = expectedInstanceTag
+            case .unclaimed:
+                recordInstanceTag = nil
+            case nil:
+                recordInstanceTag = instanceTag
             }
-            let current = existing ?? claimedLegacy
+            let ownerKey = Self.ownerKey(
+                stackUserID: stackUserID,
+                teamID: teamID,
+                instanceTag: recordInstanceTag
+            )
+            let existing = try fetchMacRow(macDeviceID: macDeviceID, ownerKey: ownerKey)
+            let selectedUnclaimed = recordInstanceTag == nil ? nil : try fetchMacRow(
+                macDeviceID: macDeviceID,
+                ownerKey: Self.ownerKey(
+                    stackUserID: stackUserID,
+                    teamID: teamID,
+                    instanceTag: nil
+                )
+            )
+            let teamlessExact = existing == nil && teamID != nil ? try fetchMacRow(
+                macDeviceID: macDeviceID,
+                ownerKey: Self.ownerKey(
+                    stackUserID: stackUserID,
+                    teamID: nil,
+                    instanceTag: recordInstanceTag
+                )
+            ) : nil
+            let teamlessUnclaimed = existing == nil && selectedUnclaimed == nil
+                && teamID != nil && recordInstanceTag != nil ? try fetchMacRow(
+                    macDeviceID: macDeviceID,
+                    ownerKey: Self.ownerKey(
+                        stackUserID: stackUserID,
+                        teamID: nil,
+                        instanceTag: nil
+                    )
+                ) : nil
+            let claimable = existing == nil
+                ? (selectedUnclaimed ?? teamlessExact ?? teamlessUnclaimed)
+                : nil
+            let current = existing ?? claimable
+            if routeWriteCondition == .unclaimed {
+                let hasClaimedSibling = try fetchAllMacs(
+                    stackUserID: stackUserID,
+                    teamID: teamID
+                ).contains {
+                    $0.macDeviceID == macDeviceID && $0.instanceTag != nil
+                }
+                guard !hasClaimedSibling else { return }
+            }
+            if onlyIfOlder, instanceTag == nil {
+                let hasClaimedSibling = try fetchAllMacs(
+                    stackUserID: stackUserID,
+                    teamID: teamID
+                ).contains {
+                    $0.macDeviceID == macDeviceID && $0.instanceTag != nil
+                }
+                guard !hasClaimedSibling else { return }
+            }
             if onlyIfOlder, instanceTag == nil, current?.instanceTag != nil {
                 // An authority-less backup cannot identify the process that
                 // supplied its host tuple. Reject the whole tuple instead of
@@ -471,7 +603,10 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 // A missing backup-active row may claim selection only when no
                 // live row became active after restore's initial snapshot.
                 shouldMarkActive = try !hasOtherActiveMac(
-                    than: macDeviceID, stackUserID: stackUserID, teamID: teamID
+                    thanOwnerKey: ownerKey,
+                    macDeviceID: macDeviceID,
+                    stackUserID: stackUserID,
+                    teamID: teamID
                 )
             } else {
                 shouldMarkActive = markActive ?? false
@@ -479,16 +614,16 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             if shouldMarkActive {
                 try clearActiveMacs(stackUserID: stackUserID, teamID: teamID)
             }
-            if let claimedLegacy {
+            if let claimable {
                 try moveMacRowScope(
                     macDeviceID: macDeviceID,
-                    fromOwnerKey: claimedLegacy.ownerKey,
+                    fromOwnerKey: claimable.ownerKey,
                     toOwnerKey: ownerKey,
                     teamID: teamID
                 )
             }
             let existingRoutes: [CmxAttachRoute]
-            if existing != nil || claimedLegacy != nil {
+            if existing != nil || claimable != nil {
                 existingRoutes = try fetchRoutes(
                     macDeviceID: macDeviceID,
                     ownerKey: ownerKey
@@ -506,7 +641,7 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             let routesToPersist = incomingHasIroh || pinnedIrohRoutes.isEmpty
                 ? routes
                 : routes + pinnedIrohRoutes
-            let createdAt = existing?.createdAt ?? claimedLegacy?.createdAt ?? now
+            let createdAt = existing?.createdAt ?? claimable?.createdAt ?? now
             let persistedInstanceTag = routeWriteCondition == nil
                 ? instanceTag
                 : current?.instanceTag
@@ -521,6 +656,13 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
                 lastSeenAt: now,
                 isActive: shouldMarkActive
             )
+            if existing != nil, let selectedUnclaimed,
+               selectedUnclaimed.ownerKey != ownerKey {
+                try exec(
+                    "DELETE FROM paired_macs WHERE mac_device_id = ? AND owner_key = ?;",
+                    binding: [.text(macDeviceID), .text(selectedUnclaimed.ownerKey)]
+                )
+            }
             try exec(
                 "DELETE FROM mac_routes WHERE mac_device_id = ? AND owner_key = ?;",
                 binding: [.text(macDeviceID), .text(ownerKey)]
@@ -576,9 +718,37 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
     }
 
     /// Mark one paired Mac active within its explicit account/team owner scope.
-    public func setActive(macDeviceID: String, stackUserID: String? = nil, teamID: String? = nil) throws {
+    public func setActive(
+        macDeviceID: String,
+        stackUserID: String? = nil,
+        teamID: String? = nil
+    ) throws {
         try ensureReady()
-        let ownerKey = "\(stackUserID ?? "")\u{1F}\(teamID ?? "")"
+        let instanceTag = try fetchAllMacs(
+            stackUserID: stackUserID,
+            teamID: teamID
+        ).first { $0.macDeviceID == macDeviceID }?.instanceTag
+        try setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    /// Mark one tagged paired Mac active within its account/team owner scope.
+    public func setActive(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String? = nil,
+        teamID: String? = nil
+    ) throws {
+        try ensureReady()
+        let ownerKey = Self.ownerKey(
+            stackUserID: stackUserID,
+            teamID: teamID,
+            instanceTag: instanceTag
+        )
         try transaction {
             try clearActiveMacs(stackUserID: stackUserID, teamID: teamID)
             try exec("UPDATE paired_macs SET is_active = 1 WHERE mac_device_id = ? AND owner_key = ?;",
@@ -603,6 +773,34 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
         now: Date = Date()
     ) throws {
         try ensureReady()
+        let instanceTag = try fetchAllMacs(
+            stackUserID: stackUserID,
+            teamID: teamID
+        ).first { $0.macDeviceID == macDeviceID }?.instanceTag
+        try setCustomization(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    /// Persist user-facing customizations for one tagged paired Mac.
+    public func setCustomization(
+        macDeviceID: String,
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String? = nil,
+        teamID: String? = nil,
+        now: Date = Date()
+    ) throws {
+        try ensureReady()
         // Bump last_seen_at so the change is the freshest write for this record and
         // the LWW backup/restore propagates it to the user's other devices. Leaves
         // display_name / routes / is_active untouched (the Mac owns those).
@@ -616,22 +814,55 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
             customIcon.map(BindValue.text) ?? .null,
             .real(now.timeIntervalSince1970),
             .text(macDeviceID),
-            .text("\(stackUserID ?? "")\u{1F}\(teamID ?? "")"),
+            .text(Self.ownerKey(
+                stackUserID: stackUserID,
+                teamID: teamID,
+                instanceTag: instanceTag
+            )),
         ])
     }
 
     /// Remove one paired Mac in a specific owner scope, or all matching legacy rows when unscoped.
-    public func remove(macDeviceID: String, stackUserID: String? = nil, teamID: String? = nil) throws {
-        try ensureReady()
+    public func remove(
+        macDeviceID: String,
+        stackUserID: String? = nil,
+        teamID: String? = nil
+    ) throws {
         if stackUserID == nil && teamID == nil {
+            try ensureReady()
             try exec("DELETE FROM paired_macs WHERE mac_device_id = ?;",
                      binding: [.text(macDeviceID)])
-        } else {
-            try exec(
-                "DELETE FROM paired_macs WHERE mac_device_id = ? AND owner_key = ?;",
-                binding: [.text(macDeviceID), .text("\(stackUserID ?? "")\u{1F}\(teamID ?? "")")]
-            )
+            return
         }
+        try ensureReady()
+        let instanceTag = try fetchAllMacs(
+            stackUserID: stackUserID,
+            teamID: teamID
+        ).first { $0.macDeviceID == macDeviceID }?.instanceTag
+        try remove(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    /// Remove one tagged paired Mac in a specific owner scope.
+    public func remove(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String? = nil,
+        teamID: String? = nil
+    ) throws {
+        try ensureReady()
+        try exec(
+            "DELETE FROM paired_macs WHERE mac_device_id = ? AND owner_key = ?;",
+            binding: [.text(macDeviceID), .text(Self.ownerKey(
+                stackUserID: stackUserID,
+                teamID: teamID,
+                instanceTag: instanceTag
+            ))]
+        )
     }
 
     /// Remove every locally stored paired Mac and route.
@@ -658,6 +889,14 @@ public actor MobilePairedMacStore: MobilePairedMacStoring {
 
     private func setUserVersion(_ version: Int32) throws {
         try exec("PRAGMA user_version = \(version);")
+    }
+
+    private nonisolated static func ownerKey(
+        stackUserID: String?,
+        teamID: String?,
+        instanceTag: String?
+    ) -> String {
+        "\(stackUserID ?? "")\u{1F}\(teamID ?? "")\u{1F}\(instanceTag ?? "")"
     }
 
 }

--- a/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStoring.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Sources/CmuxMobilePairedMac/MobilePairedMacStoring.swift
@@ -85,6 +85,14 @@ public protocol MobilePairedMacStoring: Sendable {
     ///   - teamID: Stack team this activation belongs to, if any.
     func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws
 
+    /// Mark one exact tagged Mac app instance active.
+    func setActive(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws
+
     /// Clear the active pairing for one visible owner scope.
     /// - Parameters:
     ///   - stackUserID: Owning Stack Auth user, if any.
@@ -112,6 +120,18 @@ public protocol MobilePairedMacStoring: Sendable {
         now: Date
     ) async throws
 
+    /// Set customizations on one exact tagged Mac app instance.
+    func setCustomization(
+        macDeviceID: String,
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws
+
     /// Remove a single paired Mac in one owner scope.
     /// - Parameters:
     ///   - macDeviceID: Mac to forget.
@@ -119,11 +139,69 @@ public protocol MobilePairedMacStoring: Sendable {
     ///   - teamID: Stack team this pairing belongs to, if any.
     func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws
 
+    /// Remove one exact tagged Mac app instance.
+    func remove(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws
+
     /// Remove all paired Macs.
     func removeAll() async throws
 }
 
 extension MobilePairedMacStoring {
+    /// Compatibility fallback for stores that predate tagged row identity.
+    public func setActive(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        try await setActive(
+            macDeviceID: macDeviceID,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    /// Compatibility fallback for stores that predate tagged row identity.
+    public func setCustomization(
+        macDeviceID: String,
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {
+        try await setCustomization(
+            macDeviceID: macDeviceID,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    /// Compatibility fallback for stores that predate tagged row identity.
+    public func remove(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        try await remove(
+            macDeviceID: macDeviceID,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
     /// In-memory/test fallback. Production SQLite and scope decorators override
     /// this with one atomic storage operation.
     @discardableResult
@@ -189,6 +267,7 @@ extension MobilePairedMacStoring {
         )
         try await setCustomization(
             macDeviceID: macDeviceID,
+            instanceTag: existing?.instanceTag,
             customName: customName,
             customColor: customColor,
             customIcon: customIcon,

--- a/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacInstanceTagTests.swift
+++ b/Packages/iOS/CmuxMobilePairedMac/Tests/CmuxMobilePairedMacTests/MobilePairedMacInstanceTagTests.swift
@@ -5,7 +5,7 @@ import Testing
 @testable import CmuxMobilePairedMac
 
 @Suite struct MobilePairedMacInstanceTagTests {
-    @Test func conditionalRestoreCannotOverwriteNewerAuthenticatedAuthority() async throws {
+    @Test func conditionalRestoreAddsDistinctTagWithoutOverwritingNewerAuthority() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
@@ -44,7 +44,12 @@ import Testing
             now: Date(timeIntervalSince1970: 10)
         )
 
-        #expect(!restored)
+        #expect(restored)
+        let records = try await store.loadAll(
+            stackUserID: "user-1",
+            teamID: "team-a"
+        )
+        #expect(Set(records.compactMap(\.instanceTag)) == ["feature-a", "feature-b"])
         let current = try #require(await store.activeMac(
             stackUserID: "user-1",
             teamID: "team-a"

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore+AuthorizedRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore+AuthorizedRoutes.swift
@@ -21,8 +21,17 @@ extension BackingUpPairedMacStore {
         } else {
             existing = []
         }
+        let instanceTag: String?
+        switch condition {
+        case .matchingInstanceTag(let expectedInstanceTag):
+            instanceTag = expectedInstanceTag
+        case .unclaimed:
+            instanceTag = nil
+        }
         let previousActive = markActive == true ? existing.first(where: \.isActive) : nil
-        let existedBeforeWrite = existing.contains { $0.macDeviceID == macDeviceID }
+        let existedBeforeWrite = existing.contains {
+            $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+        }
         let wrote = try await inner.upsertRoutesIfAuthorized(
             macDeviceID: macDeviceID,
             displayName: displayName,
@@ -38,11 +47,13 @@ extension BackingUpPairedMacStore {
         lastSignedInAccount = account
         let allowsTombstoneRevive = await clearPendingDelete(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             account: account,
             teamID: team
         ) || (markActive == true && !existedBeforeWrite)
         await uploadCurrentRecord(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             account: account,
             teamID: team,
             includesCustomizations: false,
@@ -51,9 +62,13 @@ extension BackingUpPairedMacStore {
         )
         if markActive == true,
            let previousActive,
-           previousActive.macDeviceID != macDeviceID {
+           previousActive.id != MobilePairedMac.pairingID(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+           ) {
             await uploadCurrentRecord(
                 macDeviceID: previousActive.macDeviceID,
+                instanceTag: previousActive.instanceTag,
                 account: account,
                 teamID: team,
                 includesCustomizations: false,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/BackingUpPairedMacStore.swift
@@ -84,7 +84,9 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         if markActive, let account = stackUserID, !account.isEmpty {
             let existing = (try? await inner.loadAll(stackUserID: account, teamID: team)) ?? []
             previouslyActive = existing.first { $0.isActive }
-            existedBeforeUpsert = existing.contains { $0.macDeviceID == macDeviceID }
+            existedBeforeUpsert = existing.contains {
+                $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+            }
         } else {
             previouslyActive = nil
             existedBeforeUpsert = true
@@ -106,10 +108,16 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         // selected on another device. Only `setCustomization` sends custom keys.
         guard let account = stackUserID, !account.isEmpty else { return }
         lastSignedInAccount = account
-        let allowsTombstoneRevive = await clearPendingDelete(macDeviceID: macDeviceID, account: account, teamID: team)
+        let allowsTombstoneRevive = await clearPendingDelete(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            account: account,
+            teamID: team
+        )
             || (markActive && !existedBeforeUpsert)
         await uploadCurrentRecord(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             account: account,
             teamID: team,
             includesCustomizations: false,
@@ -120,9 +128,15 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         // single-active invariant — without re-uploading the whole account, which
         // would copy other-team hosts into the selected team's DO (the local rows
         // carry no team id to filter by). See `setActive`.
-        if markActive, let previouslyActive, previouslyActive.macDeviceID != macDeviceID {
+        if markActive,
+           let previouslyActive,
+           previouslyActive.id != MobilePairedMac.pairingID(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+           ) {
             await uploadCurrentRecord(
                 macDeviceID: previouslyActive.macDeviceID,
+                instanceTag: previouslyActive.instanceTag,
                 account: account,
                 teamID: team,
                 includesCustomizations: false,
@@ -140,13 +154,19 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         now: Date
     ) async throws {
         let team = await teamIDProvider()
-        let account = try? await accountForMac(macDeviceID, teamID: team)
+        let target = try? await macFor(
+            macDeviceID,
+            instanceTag: nil,
+            stackUserID: nil,
+            teamID: team,
+            requiresExactInstanceTag: false
+        )
         try await setCustomization(
             macDeviceID: macDeviceID,
             customName: customName,
             customColor: customColor,
             customIcon: customIcon,
-            stackUserID: account,
+            stackUserID: target?.stackUserID,
             teamID: team,
             now: now
         )
@@ -171,6 +191,29 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
 
     /// Mark one paired Mac active and mirror the changed active flags to backup.
     public func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
+        let team = await resolvedTeam(teamID)
+        let target = try? await macFor(
+            macDeviceID,
+            instanceTag: nil,
+            stackUserID: stackUserID,
+            teamID: team,
+            requiresExactInstanceTag: false
+        )
+        try await setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: target?.instanceTag,
+            stackUserID: stackUserID,
+            teamID: team
+        )
+    }
+
+    /// Mark one exact tagged pairing active and mirror its active state.
+    public func setActive(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
         // Resolve the scope and the previously-active host BEFORE the flip, so we can
         // mirror exactly the two records that change. Scoped to the current team
         // (single-active is per (account, team)).
@@ -179,11 +222,20 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         if let stackUserID {
             account = stackUserID
         } else {
-            account = try? await accountForMac(macDeviceID, teamID: team)
+            account = try? await accountForMac(
+                macDeviceID,
+                instanceTag: instanceTag,
+                teamID: team
+            )
         }
         let previouslyActive = (account != nil)
             ? try? await inner.activeMac(stackUserID: account, teamID: team) : nil
-        try await inner.setActive(macDeviceID: macDeviceID, stackUserID: account, teamID: team)
+        try await inner.setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: account,
+            teamID: team
+        )
         // setActive flips the active flag for one host (and clears the previously-
         // active one in its scope) without going through `upsert`. Mirror ONLY those
         // two changed records to the DO so a "select host but don't connect, then
@@ -194,14 +246,20 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         lastSignedInAccount = account
         await uploadCurrentRecord(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             account: account,
             teamID: team,
             includesCustomizations: false,
             instanceAuthority: .preserve
         )
-        if let previouslyActive, previouslyActive.macDeviceID != macDeviceID {
+        if let previouslyActive,
+           previouslyActive.id != MobilePairedMac.pairingID(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+           ) {
             await uploadCurrentRecord(
                 macDeviceID: previouslyActive.macDeviceID,
+                instanceTag: previouslyActive.instanceTag,
                 account: account,
                 teamID: team,
                 includesCustomizations: false,
@@ -220,6 +278,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         lastSignedInAccount = stackUserID
         await uploadCurrentRecord(
             macDeviceID: previous.macDeviceID,
+            instanceTag: previous.instanceTag,
             account: stackUserID,
             teamID: team,
             includesCustomizations: false,
@@ -239,8 +298,40 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         now: Date
     ) async throws {
         let team = await resolvedTeam(teamID)
+        let target = try? await macFor(
+            macDeviceID,
+            instanceTag: nil,
+            stackUserID: stackUserID,
+            teamID: team,
+            requiresExactInstanceTag: false
+        )
+        try await setCustomization(
+            macDeviceID: macDeviceID,
+            instanceTag: target?.instanceTag,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            stackUserID: stackUserID,
+            teamID: team,
+            now: now
+        )
+    }
+
+    /// Persist customizations for one exact tagged pairing.
+    public func setCustomization(
+        macDeviceID: String,
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {
+        let team = await resolvedTeam(teamID)
         try await inner.setCustomization(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             customName: customName,
             customColor: customColor,
             customIcon: customIcon,
@@ -252,12 +343,17 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         if let stackUserID {
             account = stackUserID
         } else {
-            account = try? await accountForMac(macDeviceID, teamID: team)
+            account = try? await accountForMac(
+                macDeviceID,
+                instanceTag: instanceTag,
+                teamID: team
+            )
         }
         guard let account else { return }
         lastSignedInAccount = account
         await uploadCurrentRecord(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             account: account,
             teamID: team,
             includesCustomizations: true,
@@ -268,11 +364,38 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
     /// Remove one paired Mac locally and tombstone it in backup when signed in.
     public func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
         let team = await resolvedTeam(teamID)
+        let target = try? await macFor(
+            macDeviceID,
+            instanceTag: nil,
+            stackUserID: stackUserID,
+            teamID: team,
+            requiresExactInstanceTag: false
+        )
+        try await remove(
+            macDeviceID: macDeviceID,
+            instanceTag: target?.instanceTag,
+            stackUserID: stackUserID,
+            teamID: team
+        )
+    }
+
+    /// Remove one exact tagged pairing locally and mirror the delete.
+    public func remove(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        let team = await resolvedTeam(teamID)
         let account: String?
         if let stackUserID {
             account = stackUserID
         } else {
-            account = try? await accountForMac(macDeviceID, teamID: team)
+            account = try? await accountForMac(
+                macDeviceID,
+                instanceTag: instanceTag,
+                teamID: team
+            )
         }
         // Only mirror the delete while signed in; an anonymous removal has no
         // per-user backup to delete and would just fail auth and log noise.
@@ -286,18 +409,33 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
             // The catch below rolls this intent back if the local delete itself
             // fails, so the outbox never claims a row was forgotten locally when it
             // was not.
-            await addPendingDelete(macDeviceID: macDeviceID, scope: scope)
+            await addPendingDelete(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag,
+                scope: scope
+            )
         }
         let draining = cancelInFlightRestoresReturningTasks()
         for task in draining { _ = await task.value }
         do {
-            try await inner.remove(macDeviceID: macDeviceID, stackUserID: account, teamID: team)
+            try await inner.remove(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag,
+                stackUserID: account,
+                teamID: team
+            )
             if let scope, let backupAccount {
                 await flushPendingDeletes(scope: scope, account: backupAccount, teamID: team)
             }
         } catch {
             if let scope {
-                await clearPendingDelete(macDeviceID: macDeviceID, scope: scope)
+                await clearPendingDelete(
+                    pairingID: MobilePairedMac.pairingID(
+                        macDeviceID: macDeviceID,
+                        instanceTag: instanceTag
+                    ),
+                    scope: scope
+                )
             }
             throw error
         }
@@ -403,9 +541,31 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
     /// Resolve the owning Stack account of a paired Mac, or nil if unknown. Reads
     /// across ALL teams (find-by-id) so a Mac is resolvable regardless of which team
     /// is selected.
-    private func accountForMac(_ macDeviceID: String, teamID: String?) async throws -> String? {
-        let all = try await inner.loadAll(stackUserID: nil, teamID: teamID)
-        return all.first { $0.macDeviceID == macDeviceID }?.stackUserID
+    private func accountForMac(
+        _ macDeviceID: String,
+        instanceTag: String?,
+        teamID: String?
+    ) async throws -> String? {
+        try await macFor(
+            macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: nil,
+            teamID: teamID,
+            requiresExactInstanceTag: true
+        )?.stackUserID
+    }
+
+    private func macFor(
+        _ macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?,
+        requiresExactInstanceTag: Bool
+    ) async throws -> MobilePairedMac? {
+        try await inner.loadAll(stackUserID: stackUserID, teamID: teamID).first {
+            $0.macDeviceID == macDeviceID
+                && (!requiresExactInstanceTag || $0.instanceTag == instanceTag)
+        }
     }
 
     /// Build a backup record for a Mac from the local row. Callers choose whether
@@ -433,6 +593,7 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
     @discardableResult
     func uploadCurrentRecord(
         macDeviceID: String,
+        instanceTag: String? = nil,
         account: String,
         teamID: String? = nil,
         includesCustomizations: Bool = false,
@@ -441,7 +602,9 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
     ) async -> Bool {
         let team = await resolvedTeam(teamID)
         guard let mac = (try? await inner.loadAll(stackUserID: account, teamID: team))?
-            .first(where: { $0.macDeviceID == macDeviceID }) else { return false }
+            .first(where: {
+                $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+            }) else { return false }
         let record = Self.backupRecord(from: mac)
         let op: PairedMacBackupOp
         if allowTombstoneRevive {
@@ -519,8 +682,15 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
         await pendingDeleteStore.save(ids, scope: scope)
     }
 
-    private func addPendingDelete(macDeviceID: String, scope: String) async {
-        let trimmed = macDeviceID.trimmingCharacters(in: .whitespacesAndNewlines)
+    private func addPendingDelete(
+        macDeviceID: String,
+        instanceTag: String?,
+        scope: String
+    ) async {
+        let trimmed = MobilePairedMac.pairingID(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmed.isEmpty else { return }
         var ids = await pendingDeleteIDs(scope: scope)
         ids.insert(trimmed)
@@ -528,15 +698,26 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
     }
 
     @discardableResult
-    func clearPendingDelete(macDeviceID: String, account: String, teamID: String?) async -> Bool {
+    func clearPendingDelete(
+        macDeviceID: String,
+        instanceTag: String?,
+        account: String,
+        teamID: String?
+    ) async -> Bool {
         let scope = await nonoptionalScopeKey(account: account, teamID: teamID)
-        return await clearPendingDelete(macDeviceID: macDeviceID, scope: scope)
+        return await clearPendingDelete(
+            pairingID: MobilePairedMac.pairingID(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag
+            ),
+            scope: scope
+        )
     }
 
     @discardableResult
-    private func clearPendingDelete(macDeviceID: String, scope: String) async -> Bool {
+    private func clearPendingDelete(pairingID: String, scope: String) async -> Bool {
         var ids = await pendingDeleteIDs(scope: scope)
-        guard ids.remove(macDeviceID) != nil else { return false }
+        guard ids.remove(pairingID) != nil else { return false }
         await savePendingDeleteIDs(ids, scope: scope)
         return true
     }
@@ -544,8 +725,22 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
     private func applyPendingLocalDeletes(scope: String, account: String, teamID: String?) async {
         let ids = await pendingDeleteIDs(scope: scope)
         guard !ids.isEmpty else { return }
-        for macDeviceID in ids {
-            try? await inner.remove(macDeviceID: macDeviceID, stackUserID: account, teamID: teamID)
+        for pairingID in ids {
+            let identity = MobilePairedMac.pairingIdentity(from: pairingID)
+            if let instanceTag = identity.instanceTag {
+                try? await inner.remove(
+                    macDeviceID: identity.macDeviceID,
+                    instanceTag: instanceTag,
+                    stackUserID: account,
+                    teamID: teamID
+                )
+            } else {
+                try? await inner.remove(
+                    macDeviceID: identity.macDeviceID,
+                    stackUserID: account,
+                    teamID: teamID
+                )
+            }
         }
     }
 
@@ -553,7 +748,16 @@ public actor BackingUpPairedMacStore: MobilePairedMacStoring, PairedMacBackupRef
     private func flushPendingDeletes(scope: String, account: String, teamID: String?) async -> Set<String> {
         let ids = await pendingDeleteIDs(scope: scope)
         guard !ids.isEmpty else { return ids }
-        let ops = ids.sorted().map { PairedMacBackupOp.delete(macDeviceID: $0) }
+        let ops = ids.sorted().map { pairingID -> PairedMacBackupOp in
+            let identity = MobilePairedMac.pairingIdentity(from: pairingID)
+            if let instanceTag = identity.instanceTag {
+                return .deleteInstance(
+                    macDeviceID: identity.macDeviceID,
+                    instanceTag: instanceTag
+                )
+            }
+            return .delete(macDeviceID: identity.macDeviceID)
+        }
         guard await backup.upload(ops: ops, teamID: teamID, expectedUserID: account) else { return ids }
         await savePendingDeleteIDs([], scope: scope)
         return []

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/IOSBuildScopedPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/IOSBuildScopedPairedMacStore.swift
@@ -53,7 +53,9 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
         let selectedTeam = normalizedTeamID(teamID)
         let fallback = selectedTeam == nil
             ? nil
-            : try await scopedRows(stackUserID: stackUserID, teamID: nil).first { $0.macDeviceID == macDeviceID }
+            : try await scopedRows(stackUserID: stackUserID, teamID: nil).first {
+                matches($0, macDeviceID: macDeviceID, instanceTag: instanceTag)
+            }
         if markActive, selectedTeam != nil {
             try await inner.clearActive(stackUserID: stackUserID, teamID: scopedTeamID(nil))
         }
@@ -70,6 +72,7 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
         if let fallback, selectedTeam != nil {
             try await inner.setCustomization(
                 macDeviceID: macDeviceID,
+                instanceTag: fallback.instanceTag,
                 customName: fallback.customName,
                 customColor: fallback.customColor,
                 customIcon: fallback.customIcon,
@@ -77,7 +80,12 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
                 teamID: scopedTeamID(teamID),
                 now: now
             )
-            try await inner.remove(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: scopedTeamID(nil))
+            try await inner.remove(
+                macDeviceID: macDeviceID,
+                instanceTag: fallback.instanceTag,
+                stackUserID: stackUserID,
+                teamID: scopedTeamID(nil)
+            )
         }
     }
 
@@ -124,8 +132,12 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
         let fallbackRows = selectedTeam == nil
             ? []
             : try await scopedRows(stackUserID: stackUserID, teamID: nil)
-        let selected = selectedRows.first { $0.macDeviceID == macDeviceID }
-        let fallback = fallbackRows.first { $0.macDeviceID == macDeviceID }
+        let selected = selectedRows.first {
+            matches($0, macDeviceID: macDeviceID, instanceTag: instanceTag)
+        }
+        let fallback = fallbackRows.first {
+            matches($0, macDeviceID: macDeviceID, instanceTag: instanceTag)
+        }
         if let fallback, fallback.lastSeenAt >= now { return false }
         let currentTargetIsActive = selected?.isActive == true || fallback?.isActive == true
         let logicalScopeHasActive = (selectedRows + fallbackRows).contains(where: \.isActive)
@@ -148,6 +160,7 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
         guard wrote, fallback != nil, selectedTeam != nil else { return wrote }
         try await inner.remove(
             macDeviceID: macDeviceID,
+            instanceTag: fallback?.instanceTag,
             stackUserID: stackUserID,
             teamID: scopedTeamID(nil)
         )
@@ -167,12 +180,13 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
     ) async throws -> Bool {
         try await mutationGate.withLock {
             let selectedTeam = normalizedTeamID(teamID)
+            let instanceTag = condition.instanceTag
             let selected = try await scopedRows(stackUserID: stackUserID, teamID: teamID)
-                .first { $0.macDeviceID == macDeviceID }
+                .first { matches($0, macDeviceID: macDeviceID, instanceTag: instanceTag) }
             let fallback = selectedTeam == nil
                 ? nil
                 : try await scopedRows(stackUserID: stackUserID, teamID: nil)
-                    .first { $0.macDeviceID == macDeviceID }
+                    .first { matches($0, macDeviceID: macDeviceID, instanceTag: instanceTag) }
             let targetsFallback = fallback.map {
                 selected == nil || (selected?.lastSeenAt ?? .distantPast) < $0.lastSeenAt
             } ?? false
@@ -192,6 +206,7 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
             if wrote, markActive == true {
                 try await setActiveUnlocked(
                     macDeviceID: macDeviceID,
+                    instanceTag: instanceTag,
                     stackUserID: stackUserID,
                     teamID: teamID
                 )
@@ -203,31 +218,30 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
     public func loadAll(stackUserID: String?, teamID: String?) async throws -> [MobilePairedMac] {
         var byID: [String: MobilePairedMac] = [:]
         for mac in try await scopedRows(stackUserID: stackUserID, teamID: teamID) {
-            byID[mac.macDeviceID] = mac
+            byID[mac.id] = mac
         }
         if normalizedTeamID(teamID) != nil {
             // Restore/live races can briefly leave a selected-team row and its
-            // teamless fallback. Newest owns the host tuple; active is logical
-            // per physical Mac, so preserve it across the duplicate rows.
+            // teamless fallback. Newest owns each exact tagged app instance.
             for mac in try await scopedRows(stackUserID: stackUserID, teamID: nil) {
-                guard let selected = byID[mac.macDeviceID] else {
-                    byID[mac.macDeviceID] = mac
+                guard let selected = byID[mac.id] else {
+                    byID[mac.id] = mac
                     continue
                 }
                 if selected.lastSeenAt < mac.lastSeenAt {
                     var newest = mac
                     newest.isActive = selected.isActive || mac.isActive
-                    byID[mac.macDeviceID] = newest
+                    byID[mac.id] = newest
                 } else if mac.isActive, !selected.isActive {
                     var newest = selected
                     newest.isActive = true
-                    byID[mac.macDeviceID] = newest
+                    byID[mac.id] = newest
                 }
             }
         }
         return byID.values.sorted { lhs, rhs in
             if lhs.lastSeenAt != rhs.lastSeenAt { return lhs.lastSeenAt > rhs.lastSeenAt }
-            return lhs.macDeviceID < rhs.macDeviceID
+            return lhs.id < rhs.id
         }
     }
 
@@ -236,15 +250,33 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
     }
 
     public func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
+        let target = try await loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first { $0.macDeviceID == macDeviceID }
+        try await setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: target?.instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    public func setActive(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
         try await mutationGate.withLock {
             try await setActiveUnlocked(
-                macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: teamID
+                macDeviceID: macDeviceID, instanceTag: instanceTag,
+                stackUserID: stackUserID, teamID: teamID
             )
         }
     }
 
     private func setActiveUnlocked(
         macDeviceID: String,
+        instanceTag: String?,
         stackUserID: String?,
         teamID: String?
     ) async throws {
@@ -252,11 +284,23 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
             try await inner.clearActive(stackUserID: stackUserID, teamID: scopedTeamID(teamID))
             try await inner.clearActive(stackUserID: stackUserID, teamID: scopedTeamID(nil))
             let selectedRows = try await scopedRows(stackUserID: stackUserID, teamID: teamID)
-            let targetTeamID = selectedRows.contains { $0.macDeviceID == macDeviceID } ? teamID : nil
-            try await inner.setActive(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: scopedTeamID(targetTeamID))
+            let targetTeamID = selectedRows.contains {
+                matches($0, macDeviceID: macDeviceID, instanceTag: instanceTag)
+            } ? teamID : nil
+            try await inner.setActive(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag,
+                stackUserID: stackUserID,
+                teamID: scopedTeamID(targetTeamID)
+            )
             return
         }
-        try await inner.setActive(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: scopedTeamID(teamID))
+        try await inner.setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: scopedTeamID(teamID)
+        )
     }
 
     public func clearActive(stackUserID: String?, teamID: String?) async throws {
@@ -283,9 +327,33 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
         teamID: String?,
         now: Date
     ) async throws {
+        let target = try await loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first { $0.macDeviceID == macDeviceID }
+        try await setCustomization(
+            macDeviceID: macDeviceID,
+            instanceTag: target?.instanceTag,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    public func setCustomization(
+        macDeviceID: String,
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {
         try await mutationGate.withLock {
             try await setCustomizationUnlocked(
-                macDeviceID: macDeviceID, customName: customName,
+                macDeviceID: macDeviceID, instanceTag: instanceTag, customName: customName,
                 customColor: customColor, customIcon: customIcon,
                 stackUserID: stackUserID, teamID: teamID, now: now
             )
@@ -294,6 +362,7 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
 
     private func setCustomizationUnlocked(
         macDeviceID: String,
+        instanceTag: String?,
         customName: String?,
         customColor: String?,
         customIcon: String?,
@@ -303,9 +372,12 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
     ) async throws {
         if normalizedTeamID(teamID) != nil {
             let selectedRows = try await scopedRows(stackUserID: stackUserID, teamID: teamID)
-            let targetTeamID = selectedRows.contains { $0.macDeviceID == macDeviceID } ? teamID : nil
+            let targetTeamID = selectedRows.contains {
+                matches($0, macDeviceID: macDeviceID, instanceTag: instanceTag)
+            } ? teamID : nil
             try await inner.setCustomization(
                 macDeviceID: macDeviceID,
+                instanceTag: instanceTag,
                 customName: customName,
                 customColor: customColor,
                 customIcon: customIcon,
@@ -317,6 +389,7 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
         }
         try await inner.setCustomization(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             customName: customName,
             customColor: customColor,
             customIcon: customIcon,
@@ -327,21 +400,49 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
     }
 
     public func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
+        let target = try await loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first { $0.macDeviceID == macDeviceID }
+        try await remove(
+            macDeviceID: macDeviceID,
+            instanceTag: target?.instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    public func remove(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
         try await mutationGate.withLock {
             try await removeUnlocked(
-                macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: teamID
+                macDeviceID: macDeviceID, instanceTag: instanceTag,
+                stackUserID: stackUserID, teamID: teamID
             )
         }
     }
 
     private func removeUnlocked(
         macDeviceID: String,
+        instanceTag: String?,
         stackUserID: String?,
         teamID: String?
     ) async throws {
-        try await inner.remove(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: scopedTeamID(teamID))
+        try await inner.remove(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: scopedTeamID(teamID)
+        )
         if normalizedTeamID(teamID) != nil {
-            try await inner.remove(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: scopedTeamID(nil))
+            try await inner.remove(
+                macDeviceID: macDeviceID,
+                instanceTag: instanceTag,
+                stackUserID: stackUserID,
+                teamID: scopedTeamID(nil)
+            )
         }
     }
 
@@ -353,7 +454,12 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
 
     private func removeAllUnlocked() async throws {
         for mac in try await inner.loadAll(stackUserID: nil, teamID: nil) where isScoped(mac) {
-            try await inner.remove(macDeviceID: mac.macDeviceID, stackUserID: mac.stackUserID, teamID: mac.teamID)
+            try await inner.remove(
+                macDeviceID: mac.macDeviceID,
+                instanceTag: mac.instanceTag,
+                stackUserID: mac.stackUserID,
+                teamID: mac.teamID
+            )
         }
     }
 
@@ -387,5 +493,22 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
 
     private var scopedSuffix: String {
         "\(Self.separator)\(scope.serializedScope)"
+    }
+
+    private func matches(
+        _ mac: MobilePairedMac,
+        macDeviceID: String,
+        instanceTag: String?
+    ) -> Bool {
+        mac.macDeviceID == macDeviceID && mac.instanceTag == instanceTag
+    }
+}
+
+private extension MobilePairedMacRouteWriteCondition {
+    var instanceTag: String? {
+        switch self {
+        case .matchingInstanceTag(let instanceTag): instanceTag
+        case .unclaimed: nil
+        }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MacBuildChannel.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MacBuildChannel.swift
@@ -1,14 +1,9 @@
 import Foundation
 
-/// Derives a short, user-facing build-channel label for a Mac from what its
-/// presence heartbeat reports — its bundle id and dev tag — so the Computers
-/// screen can show whether a host is a DEV build (and which tag), Nightly, RC,
-/// Staging, or Stable.
-///
-/// The dev tag is the primary DEV signal: a tagged `reload.sh` build sets
-/// `CMUX_TAG`, so any non-`"default"` tag means a DEV build and the tag is the
-/// thing worth showing. Otherwise the channel comes from the bundle-id suffix.
-///
+/// Derives user-facing build and app names for a Mac from its bundle id and
+/// canonical app-instance tag. Live presence supplies both fields; a saved
+/// pairing can still identify Stable, Nightly, RC, Staging, or a tagged DEV
+/// build from the tag alone while offline.
 public struct MacBuildChannel: Sendable {
     /// Create a build-channel labeler.
     public init() {}
@@ -18,18 +13,56 @@ public struct MacBuildChannel: Sendable {
     /// host that reports neither a meaningful tag nor a known bundle id).
     public func label(bundleID: String?, tag: String?) -> String? {
         let trimmedTag = tag?.trimmingCharacters(in: .whitespacesAndNewlines)
-        let devTag = (trimmedTag?.isEmpty == false && trimmedTag != "default") ? trimmedTag : nil
-        if let devTag {
-            return "DEV · \(devTag)"
+        let meaningfulTag = trimmedTag?.isEmpty == false ? trimmedTag : nil
+        let bundle = (bundleID ?? "").trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+
+        if let bundleLabel = bundleLabel(bundle) {
+            guard let meaningfulTag else { return bundleLabel }
+            let normalizedTag = meaningfulTag.lowercased()
+            if normalizedTag == "default" || normalizedTag == canonicalTag(for: bundleLabel) {
+                return bundleLabel
+            }
+            return "DEV · \(meaningfulTag)"
         }
 
+        guard let meaningfulTag else { return nil }
+        let normalizedTag = meaningfulTag.lowercased()
+        if bundle.isEmpty {
+            switch normalizedTag {
+            case "default", "stable": return "Stable"
+            case "nightly": return "Nightly"
+            case "rc": return "RC"
+            case "staging": return "Staging"
+            case "dev": return "DEV"
+            default: break
+            }
+        }
+        if normalizedTag != "default" {
+            return "DEV · \(meaningfulTag)"
+        }
+        return nil
+    }
+
+    /// The Mac app name to show beside a saved pairing, such as `"cmux"`,
+    /// `"cmux Nightly"`, or `"cmux DEV my-tag"`.
+    public func appDisplayName(bundleID: String?, tag: String?) -> String? {
+        guard let label = label(bundleID: bundleID, tag: tag) else { return nil }
+        switch label {
+        case "Stable": return "cmux"
+        case "Nightly": return "cmux Nightly"
+        case "RC": return "cmux RC"
+        case "Staging": return "cmux Staging"
+        case "DEV": return "cmux DEV"
+        default:
+            let prefix = "DEV · "
+            guard label.hasPrefix(prefix) else { return nil }
+            return "cmux DEV \(label.dropFirst(prefix.count))"
+        }
+    }
+
+    private func bundleLabel(_ bundle: String) -> String? {
         // The channel is the component RIGHT AFTER the base bundle id; a tagged
-        // build appends a further `.slug` (e.g. `com.cmuxterm.app.nightly.my-tag`,
-        // `com.cmuxterm.app.rc`), so match the component, not the suffix. Mirrors
-        // the canonical `SocketPathMarkerFiles.variant` on macOS — kept in sync as
-        // channels are added (Stable/Nightly/Staging/RC). RC may not exist yet (a
-        // future release-candidate desktop build), but is handled ahead of time.
-        let bundle = (bundleID ?? "").lowercased()
+        // build appends a further `.slug` (e.g. `com.cmuxterm.app.nightly.my-tag`).
         let base = "com.cmuxterm.app"
         if bundle == base { return "Stable" }
         if bundle.hasPrefix(base + ".") {
@@ -40,12 +73,21 @@ public struct MacBuildChannel: Sendable {
             case "rc": return "RC"
             case "staging": return "Staging"
             case "debug", "dev": return "DEV"
-            default: return nil // unknown channel component — don't guess
+            default: return nil
             }
         }
-        // A non-`com.cmuxterm.app` bundle that is clearly a dev build (e.g. the iOS
-        // dev bundle `dev.cmux.*`).
         if bundle.hasPrefix("dev.cmux") { return "DEV" }
         return nil
+    }
+
+    private func canonicalTag(for label: String) -> String? {
+        switch label {
+        case "Stable": return "stable"
+        case "Nightly": return "nightly"
+        case "RC": return "rc"
+        case "Staging": return "staging"
+        case "DEV": return "dev"
+        default: return nil
+        }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacs.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ForgottenMacs.swift
@@ -33,21 +33,37 @@ extension MobileShellComposite {
         scope: MobileShellScopeSnapshot
     ) async -> [MobilePairedMac] {
         let forgottenIDs = await forgottenMacDeviceIDs(scope: scope)
-        return loadedMacs.filter { !forgottenIDs.contains($0.macDeviceID) }
+        return loadedMacs.filter {
+            !forgottenIDs.contains($0.id) && !forgottenIDs.contains($0.macDeviceID)
+        }
     }
 
-    func isForgottenMacDeviceID(_ macDeviceID: String, scope: MobileShellScopeSnapshot) async -> Bool {
-        await forgottenMacDeviceIDs(scope: scope).contains(macDeviceID)
+    func isForgottenMacDeviceID(
+        _ macDeviceID: String,
+        instanceTag: String? = nil,
+        scope: MobileShellScopeSnapshot
+    ) async -> Bool {
+        let ids = await forgottenMacDeviceIDs(scope: scope)
+        return ids.contains(macDeviceID) || ids.contains(MobilePairedMac.pairingID(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        ))
     }
 
     func removeStoredPairedMacIfForgotten(
         _ macDeviceID: String,
+        instanceTag: String? = nil,
         scope: MobileShellScopeSnapshot
     ) async -> Bool {
-        guard await isForgottenMacDeviceID(macDeviceID, scope: scope) else { return false }
+        guard await isForgottenMacDeviceID(
+            macDeviceID,
+            instanceTag: instanceTag,
+            scope: scope
+        ) else { return false }
         do {
             try await pairedMacStore?.remove(
                 macDeviceID: macDeviceID,
+                instanceTag: instanceTag,
                 stackUserID: scope.userID,
                 teamID: scope.teamID
             )
@@ -79,11 +95,26 @@ extension MobileShellComposite {
         await forgottenMacStore.save(ids, scope: key)
     }
 
-    func clearForgottenMacDeviceID(_ macDeviceID: String, scope: MobileShellScopeSnapshot?) async {
+    func clearForgottenMacDeviceID(
+        _ macDeviceID: String,
+        instanceTag: String? = nil,
+        scope: MobileShellScopeSnapshot?
+    ) async {
         guard !macDeviceID.isEmpty, let scope else { return }
-        await clearForgottenMacDeviceID(macDeviceID, scopeKey: pairedMacScopeKey(scope))
+        let ids = Set([
+            macDeviceID,
+            MobilePairedMac.pairingID(macDeviceID: macDeviceID, instanceTag: instanceTag),
+        ])
+        for id in ids {
+            await clearForgottenMacDeviceID(id, scopeKey: pairedMacScopeKey(scope))
+        }
         if scope.teamID != nil {
-            await clearForgottenMacDeviceID(macDeviceID, scopeKey: pairedMacScopeKey(userWideScope(from: scope)))
+            for id in ids {
+                await clearForgottenMacDeviceID(
+                    id,
+                    scopeKey: pairedMacScopeKey(userWideScope(from: scope))
+                )
+            }
         }
     }
 
@@ -110,6 +141,17 @@ extension MobileShellComposite {
         await forgetStoredMacDeviceIDs(macDeviceIDs, scope: scope)
     }
 
+    /// Forget one exact tagged app instance without removing sibling instances
+    /// that share the same physical Mac device id.
+    public func forgetMac(macDeviceID: String, instanceTag: String?) async {
+        guard let scope = await currentScopeSnapshot() else { return }
+        let targets = pairedMacsForIdentityMatching.filter {
+            $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+        }
+        guard !targets.isEmpty else { return }
+        await forgetStoredPairedMacs(targets, scope: scope)
+    }
+
     /// Forget exactly one stored paired-Mac row.
     ///
     /// The host picker lists stored rows, not coalesced logical computers, and its
@@ -120,40 +162,77 @@ extension MobileShellComposite {
         await forgetStoredMacDeviceIDs([macDeviceID], scope: scope)
     }
 
+    /// Forget exactly one tagged stored pairing.
+    public func forgetStoredMac(macDeviceID: String, instanceTag: String?) async {
+        guard let scope = await currentScopeSnapshot() else { return }
+        let targets = pairedMacsForIdentityMatching.filter {
+            $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+        }
+        guard !targets.isEmpty else { return }
+        await forgetStoredPairedMacs(targets, scope: scope)
+    }
+
     func forgetStoredMacDeviceIDs(
         _ macDeviceIDs: [String],
         scope: MobileShellScopeSnapshot
     ) async {
         guard !macDeviceIDs.isEmpty else { return }
         let targetIDSet = Set(macDeviceIDs)
-        let teamlessLegacyIDs = Set(pairedMacsForIdentityMatching
-            .filter { targetIDSet.contains($0.macDeviceID) && $0.teamID == nil }
-            .map(\.macDeviceID))
-        for id in macDeviceIDs {
+        var targets = pairedMacsForIdentityMatching.filter {
+            targetIDSet.contains($0.macDeviceID)
+        }
+        let foundPhysicalIDs = Set(targets.map(\.macDeviceID))
+        for id in targetIDSet.subtracting(foundPhysicalIDs) {
+            let now = Date()
+            targets.append(MobilePairedMac(
+                macDeviceID: id,
+                displayName: nil,
+                routes: [],
+                createdAt: now,
+                lastSeenAt: now,
+                isActive: false,
+                stackUserID: scope.userID,
+                teamID: scope.teamID
+            ))
+        }
+        await forgetStoredPairedMacs(targets, scope: scope)
+    }
+
+    private func forgetStoredPairedMacs(
+        _ targets: [MobilePairedMac],
+        scope: MobileShellScopeSnapshot
+    ) async {
+        guard !targets.isEmpty else { return }
+        let targetPairingIDs = Set(targets.map(\.id))
+        let targetPhysicalIDs = Set(targets.map(\.macDeviceID))
+        let teamlessLegacyIDs = Set(targets.filter { $0.teamID == nil }.map(\.id))
+        for mac in targets {
             await rememberForgottenMacDeviceID(
-                id,
+                mac.id,
                 scope: scope,
-                includeUserWideScope: teamlessLegacyIDs.contains(id)
+                includeUserWideScope: teamlessLegacyIDs.contains(mac.id)
             )
         }
         guard await isScopeCurrent(scope) else {
-            for id in macDeviceIDs {
-                await clearForgottenMacDeviceID(id, scope: scope)
+            for pairingID in targetPairingIDs {
+                await clearForgottenMacDeviceID(pairingID, scope: scope)
             }
             return
         }
         let workspacesBeforeForget = workspacesByMac
         let foregroundMacDeviceIDBeforeForget = foregroundMacDeviceID
-        let isActiveMac = pairedMacsForIdentityMatching.contains {
-            targetIDSet.contains($0.macDeviceID) && $0.isActive
-        }
-        if pairedMacsForIdentityMatching.contains(where: { targetIDSet.contains($0.macDeviceID) }) {
+        let isActiveMac = targets.contains(where: \.isActive)
+        if !targets.isEmpty {
             invalidateStoredMacReconnectAttempt()
         }
         if isActiveMac {
             disconnectLiveConnection(preservingOtherMacWorkspaceState: true)
         }
-        for id in macDeviceIDs {
+        let remainingPhysicalIDs = Set(pairedMacsForIdentityMatching
+            .filter { !targetPairingIDs.contains($0.id) }
+            .map(\.macDeviceID))
+        let fullyRemovedPhysicalIDs = targetPhysicalIDs.subtracting(remainingPhysicalIDs)
+        for id in fullyRemovedPhysicalIDs {
             if let subscription = secondaryMacSubscriptions[id] {
                 subscription.cancel()
                 secondaryMacSubscriptions[id] = nil
@@ -161,36 +240,41 @@ extension MobileShellComposite {
             pruneWorkspaceStateForForgottenMac(id)
         }
         guard await isScopeCurrent(scope) else {
-            for id in macDeviceIDs {
-                await clearForgottenMacDeviceID(id, scope: scope)
+            for pairingID in targetPairingIDs {
+                await clearForgottenMacDeviceID(pairingID, scope: scope)
             }
             workspacesByMac = workspacesBeforeForget
             foregroundMacDeviceID = foregroundMacDeviceIDBeforeForget
             return
         }
-        var removedIDs = Set<String>()
-        var failedIDs = Set<String>()
-        for id in macDeviceIDs {
+        var removedPairingIDs = Set<String>()
+        var failedPairingIDs = Set<String>()
+        for mac in targets {
             do {
                 try await pairedMacStore?.remove(
-                    macDeviceID: id,
+                    macDeviceID: mac.macDeviceID,
+                    instanceTag: mac.instanceTag,
                     stackUserID: scope.userID,
                     teamID: scope.teamID
                 )
-                removedIDs.insert(id)
+                removedPairingIDs.insert(mac.id)
             } catch {
-                failedIDs.insert(id)
-                forgottenMacLog.error("paired mac store remove failed mac=\(id, privacy: .public) error=\(String(describing: error), privacy: .public)")
+                failedPairingIDs.insert(mac.id)
+                forgottenMacLog.error("paired mac store remove failed mac=\(mac.macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
             }
         }
         guard await isScopeCurrent(scope) else { return }
-        if !failedIDs.isEmpty {
-            for id in failedIDs {
-                await clearForgottenMacDeviceID(id, scope: scope)
+        if !failedPairingIDs.isEmpty {
+            for pairingID in failedPairingIDs {
+                await clearForgottenMacDeviceID(pairingID, scope: scope)
             }
             workspacesByMac = workspacesBeforeForget
             foregroundMacDeviceID = foregroundMacDeviceIDBeforeForget
-            for id in removedIDs {
+            let removedPhysicalIDs = Set(targets
+                .filter { removedPairingIDs.contains($0.id) }
+                .map(\.macDeviceID))
+                .subtracting(remainingPhysicalIDs)
+            for id in removedPhysicalIDs {
                 pruneWorkspaceStateForForgottenMac(id)
             }
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacAliases.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacAliases.swift
@@ -13,8 +13,15 @@ extension MobileShellComposite {
     }
 
     /// Stored ids represented by a visible paired-Mac row.
-    public func pairedMacAliasIDs(for macDeviceID: String) -> [String] {
-        if let aliases = pairedMacAliasIDsByRepresentativeID[macDeviceID] {
+    public func pairedMacAliasIDs(
+        for macDeviceID: String,
+        instanceTag: String? = nil
+    ) -> [String] {
+        let pairingID = MobilePairedMac.pairingID(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag
+        )
+        if let aliases = pairedMacAliasIDsByRepresentativeID[pairingID] {
             return aliases
         }
         if let aliases = pairedMacAliasIDsByRepresentativeID.values.first(where: {
@@ -31,7 +38,7 @@ extension MobileShellComposite {
         for macDeviceID: String,
         instanceTag: String? = nil
     ) -> PresenceMap.DeviceSummary? {
-        let summaries = pairedMacAliasIDs(for: macDeviceID).compactMap {
+        let summaries = pairedMacAliasIDs(for: macDeviceID, instanceTag: instanceTag).compactMap {
             if let instanceTag {
                 presenceMap.instanceSummary(deviceId: $0, tag: instanceTag)
             } else {
@@ -63,7 +70,7 @@ extension MobileShellComposite {
     func pairedMacCustomizationsByAliasID() -> [String: MobilePairedMac] {
         displayPairedMacs.reduce(into: [String: MobilePairedMac]()) { result, mac in
             guard mac.customColor != nil || mac.customIcon != nil else { return }
-            for aliasID in pairedMacAliasIDs(for: mac.macDeviceID) {
+            for aliasID in pairedMacAliasIDs(for: mac.macDeviceID, instanceTag: mac.instanceTag) {
                 result[aliasID] = mac
             }
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacCoalescing.swift
@@ -24,7 +24,7 @@ extension MobileShellComposite {
             let key = mac.dialEndpointKey(
                 supportedKinds: supportedKinds,
                 preferNonLoopback: preferNonLoopback
-            ) ?? "device:\(mac.macDeviceID)"
+            ) ?? "device:\(mac.id)"
             orderByKey[key] = min(orderByKey[key] ?? index, index)
             guard let existing = selectedByKey[key] else {
                 selectedByKey[key] = mac
@@ -77,20 +77,20 @@ extension MobileShellComposite {
         supportedKinds: [CmxAttachTransportKind],
         preferNonLoopback: Bool
     ) -> [String: [String]] {
-        var groupKeyByMacID: [String: String] = [:]
+        var groupKeyByPairingID: [String: String] = [:]
         var idsByGroupKey: [String: [String]] = [:]
         for mac in macs {
             let key = mac.dialEndpointKey(
                 supportedKinds: supportedKinds,
                 preferNonLoopback: preferNonLoopback
-            ) ?? "device:\(mac.macDeviceID)"
-            groupKeyByMacID[mac.macDeviceID] = key
+            ) ?? "device:\(mac.id)"
+            groupKeyByPairingID[mac.id] = key
             idsByGroupKey[key, default: []].append(mac.macDeviceID)
         }
 
         var result: [String: [String]] = [:]
-        for (macID, groupKey) in groupKeyByMacID {
-            result[macID] = idsByGroupKey[groupKey] ?? [macID]
+        for (pairingID, groupKey) in groupKeyByPairingID {
+            result[pairingID] = idsByGroupKey[groupKey] ?? []
         }
         return result
     }
@@ -112,7 +112,7 @@ private extension MobilePairedMac {
             preferNonLoopback: preferNonLoopback
         )
         if case let .peer(identity, _)? = reconnectRoutes.first?.endpoint {
-            return "iroh:\(identity.endpointID):name:\(displayName.lowercased())"
+            return "iroh:\(identity.endpointID):name:\(displayName.lowercased()):instance:\(instanceTag ?? "")"
         }
         guard let (host, port) = MobileShellComposite.firstReconnectHostPortRoute(
             reconnectRoutes,
@@ -121,7 +121,7 @@ private extension MobilePairedMac {
         ), let normalizedHost = MobileShellRouteAuthPolicy.normalizedManualHost(host) else {
             return nil
         }
-        return "host:\(normalizedHost.lowercased()):\(port):name:\(displayName.lowercased())"
+        return "host:\(normalizedHost.lowercased()):\(port):name:\(displayName.lowercased()):instance:\(instanceTag ?? "")"
     }
 
     func mergingCustomization(from other: MobilePairedMac) -> MobilePairedMac {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacPersistence.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PairedMacPersistence.swift
@@ -1,4 +1,5 @@
 import CMUXMobileCore
+import CmuxMobilePairedMac
 import Foundation
 import os
 
@@ -40,7 +41,35 @@ extension MobileShellComposite {
             let scopedMacs = (try? await pairedMacStore.loadAll(
                 stackUserID: stackUserID, teamID: scope?.teamID
             )) ?? []
-            let existing = scopedMacs.first { $0.macDeviceID == ticket.macDeviceID }
+            let expectedStoredTag: String?
+            switch instanceTagUpdate {
+            case .preserve:
+                expectedStoredTag = self.activeMacInstanceTag
+            case .preserveOnlyIfUnclaimed:
+                expectedStoredTag = nil
+            case .replace(let reportedTag):
+                expectedStoredTag = reportedTag
+            }
+            let exactExisting = scopedMacs.first {
+                $0.macDeviceID == ticket.macDeviceID
+                    && $0.instanceTag == expectedStoredTag
+            }
+            let physicalMatches = scopedMacs.filter {
+                $0.macDeviceID == ticket.macDeviceID
+            }
+            let existing: MobilePairedMac?
+            if let exactExisting {
+                existing = exactExisting
+            } else if case .preserve = instanceTagUpdate,
+                      expectedStoredTag == nil {
+                // Before the foreground status probe reports its tag, the
+                // selected row is the only safe authority fallback. Never pick
+                // an arbitrary sibling merely because it was seen more recently.
+                existing = physicalMatches.first(where: \.isActive)
+                    ?? (physicalMatches.count == 1 ? physicalMatches[0] : nil)
+            } else {
+                existing = nil
+            }
             let storedTag = existing?.instanceTag
             var displayName = ticketDisplayName ?? existing?.displayName
             if displayName == nil {
@@ -96,7 +125,11 @@ extension MobileShellComposite {
                         now: Date()
                     )
                 }
-                await self.clearForgottenMacDeviceID(ticket.macDeviceID, scope: scope)
+                await self.clearForgottenMacDeviceID(
+                    ticket.macDeviceID,
+                    instanceTag: instanceTag,
+                    scope: scope
+                )
                 self.hasKnownPairedMac = true
             } catch {
                 pairedMacPersistenceLog.error(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+PresenceRouteSync.swift
@@ -52,20 +52,16 @@ extension MobileShellComposite {
                     await self.loadPairedMacs()
                 }
                 guard await self.isScopeCurrent(scope) else { return }
-                let knownMacs = self.pairedMacsForIdentityMatching
                 if self.connectionState != .connected,
-                   let activeMacID = self.pairedMacs.first(where: { $0.isActive })?.macDeviceID {
-                    let activeIDs = Self.macDeviceIDsForLogicalPairedMac(
-                        activeMacID,
-                        in: knownMacs,
-                        supportedKinds: self.runtime?.supportedRouteKinds ?? [],
-                        preferNonLoopback: Self.prefersNonLoopbackRoutes
+                   let activeMac = self.pairedMacs.first(where: { $0.isActive }) {
+                    let activeIDs = self.pairedMacAliasIDs(
+                        for: activeMac.macDeviceID,
+                        instanceTag: activeMac.instanceTag
                     )
                     let hasOnlineAuthority = activeIDs.contains { deviceID in
-                        let instanceTag = knownMacs.first { $0.macDeviceID == deviceID }?.instanceTag
                         return self.presenceMap.reconnectRouteAuthority(
                             deviceId: deviceID,
-                            pairedMacInstanceTag: instanceTag
+                            pairedMacInstanceTag: activeMac.instanceTag
                         ) != nil
                     }
                     if hasOnlineAuthority {
@@ -85,7 +81,11 @@ extension MobileShellComposite {
     ) async -> Bool {
         guard let routes = instance.routes, await isScopeCurrent(scope) else { return false }
         let deviceId = instance.deviceId
-        guard await !isForgottenMacDeviceID(deviceId, scope: scope) else { return false }
+        guard await !isForgottenMacDeviceID(
+            deviceId,
+            instanceTag: instance.tag,
+            scope: scope
+        ) else { return false }
         if let deviceIndex = registryDevices.firstIndex(where: { $0.deviceId == deviceId }),
            let instanceIndex = registryDevices[deviceIndex].instances
                .firstIndex(where: { $0.tag == instance.tag }) {
@@ -117,7 +117,11 @@ extension MobileShellComposite {
             )
             guard wrote else { return false }
             guard await isScopeCurrent(scope) else { return true }
-            _ = await removeStoredPairedMacIfForgotten(mac.macDeviceID, scope: scope)
+            _ = await removeStoredPairedMacIfForgotten(
+                mac.macDeviceID,
+                instanceTag: mac.instanceTag,
+                scope: scope
+            )
             return true
         } catch {
             presenceRouteSyncLog.debug(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ReconnectRoutes.swift
@@ -63,7 +63,11 @@ extension MobileShellComposite {
             ), let self else { return }
             await self.performSerializedPairedMacWrite(ifStillCurrent: nil) {
                 guard await self.isScopeCurrent(scope),
-                      await !self.isForgottenMacDeviceID(macDeviceID, scope: scope) else { return }
+                      await !self.isForgottenMacDeviceID(
+                        macDeviceID,
+                        instanceTag: capturedInstanceTag,
+                        scope: scope
+                      ) else { return }
                 let activeMac: MobilePairedMac?
                 do {
                     activeMac = try await pairedMacStore.activeMac(
@@ -75,7 +79,11 @@ extension MobileShellComposite {
                     return
                 }
                 guard await self.isScopeCurrent(scope),
-                      await !self.isForgottenMacDeviceID(macDeviceID, scope: scope),
+                      await !self.isForgottenMacDeviceID(
+                        macDeviceID,
+                        instanceTag: capturedInstanceTag,
+                        scope: scope
+                      ),
                       DeviceRegistryService.shouldApplyRegistryRefresh(
                         isSignedIn: self.isSignedIn,
                         capturedUserID: scope.userID,
@@ -101,9 +109,14 @@ extension MobileShellComposite {
                     reconnectRouteLog.debug("registry refresh upsert failed: \(String(describing: error), privacy: .public)")
                     return
                 }
-                if await self.isForgottenMacDeviceID(macDeviceID, scope: scope) {
+                if await self.isForgottenMacDeviceID(
+                    macDeviceID,
+                    instanceTag: capturedInstanceTag,
+                    scope: scope
+                ) {
                     try? await pairedMacStore.remove(
                         macDeviceID: macDeviceID,
+                        instanceTag: capturedInstanceTag,
                         stackUserID: scope.userID,
                         teamID: scope.teamID
                     )
@@ -177,7 +190,11 @@ extension MobileShellComposite {
         let requiresIroh = localRoutes.contains { $0.kind == .iroh }
         guard let deviceRegistry,
               await isScopeCurrent(scope),
-              await !isForgottenMacDeviceID(mac.macDeviceID, scope: scope),
+              await !isForgottenMacDeviceID(
+                mac.macDeviceID,
+                instanceTag: mac.instanceTag,
+                scope: scope
+              ),
               let registryRoutes = await deviceRegistry.freshRoutes(
                   forMacDeviceID: mac.macDeviceID,
                   instanceTag: mac.instanceTag

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+SecondaryPromotion.swift
@@ -91,7 +91,10 @@ extension MobileShellComposite {
         startTerminalRefreshPolling()
         syncSelectedTerminalForWorkspace()
         enqueueActivePairedMacWrite(
-            macDeviceID: macID, scope: scope, reloadAfterWrite: false
+            macDeviceID: macID,
+            instanceTag: activeMacInstanceTag,
+            scope: scope,
+            reloadAfterWrite: false
         )
         scheduleSecondaryAggregation()
         return true

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -1867,6 +1867,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         return nil
     }
 
+    /// Authenticated app-instance tag for the live foreground Mac.
+    public var connectedMacInstanceTag: String? {
+        guard connectionState == .connected else { return nil }
+        return activeMacInstanceTag
+    }
+
     /// Reload ``registryDevices`` from the team-scoped device registry.
     ///
     /// Best-effort and failure-tolerant: a missing registry, an unauthorized
@@ -2071,13 +2077,13 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
-        let aliasIDsByMacID = macDeviceIDAliasesByPairedMacID(
+        let aliasIDsByPairingID = macDeviceIDAliasesByPairedMacID(
             in: visibleLoaded,
             supportedKinds: supportedRouteKinds,
             preferNonLoopback: Self.prefersNonLoopbackRoutes
         )
         pairedMacAliasIDsByRepresentativeID = coalesced.reduce(into: [String: [String]]()) { result, mac in
-            result[mac.macDeviceID] = aliasIDsByMacID[mac.macDeviceID] ?? [mac.macDeviceID]
+            result[mac.id] = aliasIDsByPairingID[mac.id] ?? [mac.macDeviceID]
         }
         pairedMacs = visibleLoaded
     }
@@ -2096,14 +2102,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     ///   `openWorkspace` can avoid selecting a workspace whose Mac is not live.
     /// Switch the foreground connection to another paired Mac.
     @discardableResult
-    public func switchToMac(macDeviceID: String) async -> Bool {
+    public func switchToMac(
+        macDeviceID: String,
+        instanceTag: String? = nil
+    ) async -> Bool {
         guard let pairedMacStore else { return false }
         let switchAttemptID = beginMacSwitchAttempt()
         let liveForegroundRestoreBaseline = liveForegroundMacForSwitchRestore()
         defer { finishMacSwitchAttempt(switchAttemptID) }
         // FAST PATH: if a live read-only connection to this Mac already exists,
         // promote it to the foreground (reuse the client) instead of re-dialing.
-        if await promoteSecondaryToForeground(macDeviceID, switchAttemptID: switchAttemptID) {
+        if instanceTag == nil,
+           await promoteSecondaryToForeground(macDeviceID, switchAttemptID: switchAttemptID) {
             macSwitchRestoreBaseline = nil
             return true
         }
@@ -2138,8 +2148,12 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             await restoreMacSwitchBaselineIfCancelled(switchAttemptID)
             return false
         }
-        guard let refreshedTarget = storeMacs.first(where: { $0.macDeviceID == macDeviceID })
-            ?? pairedMacs.first(where: { $0.macDeviceID == macDeviceID }) else {
+        let matchesTarget: (MobilePairedMac) -> Bool = { mac in
+            mac.macDeviceID == macDeviceID
+                && (instanceTag == nil || mac.instanceTag == instanceTag)
+        }
+        guard let refreshedTarget = storeMacs.first(where: matchesTarget)
+            ?? pairedMacs.first(where: matchesTarget) else {
             if !hasActiveMacConnection,
                await restorePreviousMacIfNeeded(macSwitchRestoreBaseline, switchAttemptID: switchAttemptID) {
                 macSwitchRestoreBaseline = nil
@@ -2217,11 +2231,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let switched = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID == macDeviceID
+            && (refreshedTarget.instanceTag == nil
+                || MobileMacInstanceTagAuthority.sameStoredAuthority(
+                    refreshedTarget.instanceTag,
+                    activeMacInstanceTag
+                ))
         if switched {
             macSwitchRestoreBaseline = nil
             finishMacSwitchAttempt(switchAttemptID)
             if let task = enqueueActivePairedMacWrite(
                 macDeviceID: macDeviceID,
+                instanceTag: refreshedTarget.instanceTag,
                 scope: scope,
                 reloadAfterWrite: true
             ) {
@@ -2230,6 +2250,11 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return connectionState == .connected
                 && remoteClient != nil
                 && foregroundMacDeviceID == macDeviceID
+                && (refreshedTarget.instanceTag == nil
+                    || MobileMacInstanceTagAuthority.sameStoredAuthority(
+                        refreshedTarget.instanceTag,
+                        activeMacInstanceTag
+                    ))
         } else if macSwitchRestoreBaseline != nil || previousForegroundMac != nil, !hasActiveMacConnection {
             // The switch did not connect and the destructive connect path dropped
             // the previous session; reconnect to the still-active previous Mac so
@@ -2265,10 +2290,18 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard let previousActive else { return false }
         guard let restoreScope = await currentScopeSnapshot() else { return false }
         guard await isScopeCurrent(restoreScope), isRestoreCurrent() else { return false }
-        let previousIDs = Set(pairedMacAliasIDs(for: previousActive.macDeviceID))
+        let previousIDs = Set(pairedMacAliasIDs(
+            for: previousActive.macDeviceID,
+            instanceTag: previousActive.instanceTag
+        ))
         let previousStillForeground = connectionState == .connected
             && remoteClient != nil
             && foregroundMacDeviceID.map { previousIDs.contains($0) } == true
+            && (previousActive.instanceTag == nil
+                || MobileMacInstanceTagAuthority.sameStoredAuthority(
+                    previousActive.instanceTag,
+                    activeMacInstanceTag
+                ))
         guard !previousStillForeground else { return true }
         let supportedKinds = runtime?.supportedRouteKinds ?? []
         let candidateRoutes = Self.storedReconnectRoutes(
@@ -2308,6 +2341,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         guard await isScopeCurrent(restoreScope), isRestoreCurrent() else { return restored }
         if let task = enqueueActivePairedMacWrite(
             macDeviceID: previousActive.macDeviceID,
+            instanceTag: previousActive.instanceTag,
             scope: restoreScope,
             reloadAfterWrite: true
         ) {
@@ -2389,6 +2423,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     @discardableResult
     func enqueueActivePairedMacWrite(
         macDeviceID: String,
+        instanceTag: String? = nil,
         scope: MobileShellScopeSnapshot?,
         reloadAfterWrite: Bool
     ) -> Task<Void, Never>? {
@@ -2400,10 +2435,15 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             }
             guard self.connectionState == .connected,
                   self.remoteClient != nil,
-                  self.foregroundMacDeviceID == macDeviceID else { return }
+                  self.foregroundMacDeviceID == macDeviceID,
+                  instanceTag == nil || MobileMacInstanceTagAuthority.sameStoredAuthority(
+                    instanceTag,
+                    self.activeMacInstanceTag
+                  ) else { return }
             do {
                 try await pairedMacStore.setActive(
                     macDeviceID: macDeviceID,
+                    instanceTag: instanceTag,
                     stackUserID: scope?.userID,
                     teamID: scope?.teamID
                 )
@@ -3499,6 +3539,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// Empty strings are normalized to `nil` (cleared).
     public func updateMacCustomization(
         macDeviceID: String,
+        instanceTag: String? = nil,
         customName: String?,
         customColor: String?,
         customIcon: String?
@@ -3508,9 +3549,20 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             return (t?.isEmpty == false) ? t : nil
         }
         guard let scope = await currentScopeSnapshot() else { return }
+        let targetInstanceTag = instanceTag
+            ?? displayPairedMacs.first(where: { $0.macDeviceID == macDeviceID })?.instanceTag
         let name = normalized(customName), color = normalized(customColor), icon = normalized(customIcon), now = Date()
         do {
-            try await pairedMacStore?.setCustomization(macDeviceID: macDeviceID, customName: name, customColor: color, customIcon: icon, stackUserID: scope.userID, teamID: scope.teamID, now: now)
+            try await pairedMacStore?.setCustomization(
+                macDeviceID: macDeviceID,
+                instanceTag: targetInstanceTag,
+                customName: name,
+                customColor: color,
+                customIcon: icon,
+                stackUserID: scope.userID,
+                teamID: scope.teamID,
+                now: now
+            )
         } catch {
             mobileShellLog.error("setCustomization failed mac=\(macDeviceID, privacy: .public) error=\(String(describing: error), privacy: .public)")
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupOp.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupOp.swift
@@ -32,4 +32,6 @@ public enum PairedMacBackupOp: Sendable, Equatable {
     )
     /// Tombstone the record with the given Mac device id.
     case delete(macDeviceID: String)
+    /// Tombstone one exact tagged app-instance record.
+    case deleteInstance(macDeviceID: String, instanceTag: String)
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupOpWire.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupOpWire.swift
@@ -3,6 +3,7 @@ import Foundation
 /// `{ macDeviceID, deleted?, record? }` matching the server's parse.
 struct PairedMacBackupOpWire: Encodable {
     let macDeviceID: String
+    let instanceTag: String?
     let deleted: Bool?
     let reviveDeleted: Bool?
     let record: PairedMacBackupRecordWire?
@@ -11,6 +12,7 @@ struct PairedMacBackupOpWire: Encodable {
         switch op {
         case .upsert(let record, let instanceAuthority):
             self.macDeviceID = record.macDeviceID
+            self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = nil
             self.record = PairedMacBackupRecordWire(
@@ -21,6 +23,7 @@ struct PairedMacBackupOpWire: Encodable {
             )
         case .upsertPreservingCustomizations(let record, let instanceAuthority):
             self.macDeviceID = record.macDeviceID
+            self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = nil
             self.record = PairedMacBackupRecordWire(
@@ -31,6 +34,7 @@ struct PairedMacBackupOpWire: Encodable {
             )
         case .revive(let record, let instanceAuthority):
             self.macDeviceID = record.macDeviceID
+            self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = true
             self.record = PairedMacBackupRecordWire(
@@ -41,6 +45,7 @@ struct PairedMacBackupOpWire: Encodable {
             )
         case .revivePreservingCustomizations(let record, let instanceAuthority):
             self.macDeviceID = record.macDeviceID
+            self.instanceTag = record.instanceTag
             self.deleted = nil
             self.reviveDeleted = true
             self.record = PairedMacBackupRecordWire(
@@ -51,6 +56,13 @@ struct PairedMacBackupOpWire: Encodable {
             )
         case .delete(let macDeviceID):
             self.macDeviceID = macDeviceID
+            self.instanceTag = nil
+            self.deleted = true
+            self.reviveDeleted = nil
+            self.record = nil
+        case .deleteInstance(let macDeviceID, let instanceTag):
+            self.macDeviceID = macDeviceID
+            self.instanceTag = instanceTag
             self.deleted = true
             self.reviveDeleted = nil
             self.record = nil

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupSnapshot.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacBackupSnapshot.swift
@@ -1,13 +1,13 @@
 /// A complete paired-Mac restore snapshot from the presence backup service.
 ///
-/// `records` contains live saved Macs. `deletedMacDeviceIDs` contains retained
-/// delete tombstones that should remove matching local rows before live records
-/// are merged.
+/// `records` contains live saved Macs. `deletedMacDeviceIDs` retains the legacy
+/// wire name but values are pairing identities (`macDeviceID` plus optional
+/// instance tag) that remove matching local rows before live records are merged.
 public struct PairedMacBackupSnapshot: Sendable, Equatable {
     /// Live paired-Mac records, newest-first by the server's restore ordering.
     public var records: [PairedMacBackupRecord]
 
-    /// Mac device IDs with retained delete tombstones in this restore scope.
+    /// Pairing identities with retained delete tombstones in this restore scope.
     public var deletedMacDeviceIDs: [String]
 
     /// Create a restore snapshot from live records and retained delete IDs.

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacRestore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PairedMacRestore.swift
@@ -64,7 +64,12 @@ public struct PairedMacRestore: Sendable {
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
             .filter { !$0.isEmpty })
             .union(locallyDeletedMacDeviceIDs)
-        let liveRecords = snapshot.records.filter { !tombstoneIDs.contains($0.macDeviceID) }
+        let liveRecords = snapshot.records.filter { record in
+            !tombstoneIDs.contains(MobilePairedMac.pairingID(
+                macDeviceID: record.macDeviceID,
+                instanceTag: record.instanceTag
+            ))
+        }
         guard !liveRecords.isEmpty || !tombstoneIDs.isEmpty else {
             return RestoreOutcome(completed: true, restored: 0)
         }
@@ -76,15 +81,29 @@ public struct PairedMacRestore: Sendable {
         if !isCurrent() {
             return RestoreOutcome(completed: false, restored: 0)
         }
-        for macDeviceID in tombstoneIDs {
+        for pairingID in tombstoneIDs {
             if !isCurrent() {
                 return RestoreOutcome(completed: false, restored: 0)
             }
             do {
-                try await store.remove(macDeviceID: macDeviceID, stackUserID: accountID, teamID: teamID)
+                let identity = MobilePairedMac.pairingIdentity(from: pairingID)
+                if let instanceTag = identity.instanceTag {
+                    try await store.remove(
+                        macDeviceID: identity.macDeviceID,
+                        instanceTag: instanceTag,
+                        stackUserID: accountID,
+                        teamID: teamID
+                    )
+                } else {
+                    try await store.remove(
+                        macDeviceID: identity.macDeviceID,
+                        stackUserID: accountID,
+                        teamID: teamID
+                    )
+                }
             } catch {
                 pairedMacRestoreLog.warning(
-                    "failed to apply paired mac tombstone \(macDeviceID, privacy: .public): \(String(describing: error), privacy: .public)"
+                    "failed to apply paired mac tombstone \(pairingID, privacy: .public): \(String(describing: error), privacy: .public)"
                 )
             }
         }
@@ -95,7 +114,7 @@ public struct PairedMacRestore: Sendable {
             return RestoreOutcome(completed: false, restored: 0)
         }
         var localByID: [String: MobilePairedMac] = [:]
-        for mac in local { localByID[mac.macDeviceID] = mac }
+        for mac in local { localByID[mac.id] = mac }
         // On a fresh install (no local active host) honor the backup's active
         // flag so auto-reconnect targets the last host; otherwise never disturb
         // the device's current active selection.
@@ -109,8 +128,12 @@ public struct PairedMacRestore: Sendable {
             if !isCurrent() {
                 return RestoreOutcome(completed: false, restored: restored)
             }
+            let pairingID = MobilePairedMac.pairingID(
+                macDeviceID: record.macDeviceID,
+                instanceTag: record.instanceTag
+            )
             let backupSeconds = record.lastSeenAt / 1000.0
-            if let existing = localByID[record.macDeviceID],
+            if let existing = localByID[pairingID],
                existing.lastSeenAt.timeIntervalSince1970 >= backupSeconds {
                 continue // local is at least as fresh: keep it (local authoritative)
             }
@@ -123,7 +146,7 @@ public struct PairedMacRestore: Sendable {
             // only on a fresh install (no local active host); never hijack an
             // existing active selection.
             let markActive: Bool
-            if let existing = localByID[record.macDeviceID] {
+            if let existing = localByID[pairingID] {
                 markActive = existing.isActive
             } else {
                 markActive = hasLocalActive ? false : record.isActive
@@ -145,9 +168,10 @@ public struct PairedMacRestore: Sendable {
                 )
                 guard restoredThisRecord else { continue }
                 if !isCurrent() {
-                    if localByID[record.macDeviceID] == nil {
+                    if localByID[pairingID] == nil {
                         try? await store.remove(
                             macDeviceID: record.macDeviceID,
+                            instanceTag: record.instanceTag,
                             stackUserID: accountID,
                             teamID: teamID
                         )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TeamScopedPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/TeamScopedPairedMacStore.swift
@@ -118,12 +118,41 @@ public struct TeamScopedPairedMacStore: MobilePairedMacStoring {
     /// Mark one paired Mac active in the selected team scope.
     public func setActive(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
         let team = await resolvedTeam(teamID)
-        let scope = try await visibleScope(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: team)
+        let visible = try await visibleMac(
+            macDeviceID: macDeviceID,
+            instanceTag: nil,
+            stackUserID: stackUserID,
+            teamID: team,
+            requiresExactInstanceTag: false
+        )
+        try await setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: visible?.instanceTag,
+            stackUserID: stackUserID,
+            teamID: team
+        )
+    }
+
+    /// Mark one exact tagged Mac app instance active in the selected team scope.
+    public func setActive(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        let team = await resolvedTeam(teamID)
+        let scope = try await visibleScope(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: team
+        )
         if scope.teamID != team {
             try await inner.clearActive(stackUserID: scope.stackUserID, teamID: team)
         }
         try await inner.setActive(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             stackUserID: scope.stackUserID,
             teamID: scope.teamID
         )
@@ -145,9 +174,46 @@ public struct TeamScopedPairedMacStore: MobilePairedMacStoring {
         now: Date
     ) async throws {
         let team = await resolvedTeam(teamID)
-        let scope = try await visibleScope(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: team)
+        let visible = try await visibleMac(
+            macDeviceID: macDeviceID,
+            instanceTag: nil,
+            stackUserID: stackUserID,
+            teamID: team,
+            requiresExactInstanceTag: false
+        )
+        try await setCustomization(
+            macDeviceID: macDeviceID,
+            instanceTag: visible?.instanceTag,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            stackUserID: stackUserID,
+            teamID: team,
+            now: now
+        )
+    }
+
+    /// Persist local customizations for one exact tagged app instance.
+    public func setCustomization(
+        macDeviceID: String,
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {
+        let team = await resolvedTeam(teamID)
+        let scope = try await visibleScope(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: team
+        )
         try await inner.setCustomization(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             customName: customName,
             customColor: customColor,
             customIcon: customIcon,
@@ -160,9 +226,38 @@ public struct TeamScopedPairedMacStore: MobilePairedMacStoring {
     /// Remove one paired Mac in the selected team scope.
     public func remove(macDeviceID: String, stackUserID: String?, teamID: String?) async throws {
         let team = await resolvedTeam(teamID)
-        let scope = try await visibleScope(macDeviceID: macDeviceID, stackUserID: stackUserID, teamID: team)
+        let visible = try await visibleMac(
+            macDeviceID: macDeviceID,
+            instanceTag: nil,
+            stackUserID: stackUserID,
+            teamID: team,
+            requiresExactInstanceTag: false
+        )
+        try await remove(
+            macDeviceID: macDeviceID,
+            instanceTag: visible?.instanceTag,
+            stackUserID: stackUserID,
+            teamID: team
+        )
+    }
+
+    /// Remove one exact tagged app instance in the selected team scope.
+    public func remove(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        let team = await resolvedTeam(teamID)
+        let scope = try await visibleScope(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: team
+        )
         try await inner.remove(
             macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
             stackUserID: scope.stackUserID,
             teamID: scope.teamID
         )
@@ -180,14 +275,34 @@ public struct TeamScopedPairedMacStore: MobilePairedMacStoring {
 
     private func visibleScope(
         macDeviceID: String,
+        instanceTag: String?,
         stackUserID: String?,
         teamID: String?
     ) async throws -> (stackUserID: String?, teamID: String?) {
-        let visibleMac = try await inner.loadAll(stackUserID: stackUserID, teamID: teamID)
-            .first { $0.macDeviceID == macDeviceID }
+        let visibleMac = try await visibleMac(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            requiresExactInstanceTag: true
+        )
         guard let visibleMac else {
             return (stackUserID, teamID)
         }
         return (visibleMac.stackUserID, visibleMac.teamID)
+    }
+
+    private func visibleMac(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?,
+        requiresExactInstanceTag: Bool
+    ) async throws -> MobilePairedMac? {
+        try await inner.loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first {
+                $0.macDeviceID == macDeviceID
+                    && (!requiresExactInstanceTag || $0.instanceTag == instanceTag)
+            }
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
@@ -107,7 +107,7 @@ import Testing
         #expect(rows.first?.teamID == nil)
     }
 
-    @Test func newerTeamlessDuplicateKeepsLogicalActiveSelection() async throws {
+    @Test func newerTeamlessSiblingTagDoesNotReplaceActiveSelectedTag() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
         let feature = IOSBuildScopedPairedMacStore(
@@ -138,15 +138,18 @@ import Testing
         let rows = try await feature.loadAll(
             stackUserID: "user-1", teamID: "team-a"
         )
-        let row = try #require(rows.first)
-        #expect(rows.count == 1)
-        #expect(row.teamID == nil)
-        #expect(row.instanceTag == "feature-b")
-        #expect(row.routes == [try route("10.0.0.2")])
-        #expect(row.isActive)
+        #expect(rows.count == 2)
+        let selected = try #require(rows.first { $0.instanceTag == "feature-a" })
+        let fallback = try #require(rows.first { $0.instanceTag == "feature-b" })
+        #expect(selected.teamID == "team-a")
+        #expect(selected.routes == [try route("10.0.0.1")])
+        #expect(selected.isActive)
+        #expect(fallback.teamID == nil)
+        #expect(fallback.routes == [try route("10.0.0.2")])
+        #expect(!fallback.isActive)
         #expect(try await feature.activeMac(
             stackUserID: "user-1", teamID: "team-a"
-        )?.instanceTag == "feature-b")
+        )?.instanceTag == "feature-a")
     }
 
     @Test func selectedTeamUpsertClaimsTeamlessScopedRow() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MacBuildChannelTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MacBuildChannelTests.swift
@@ -24,8 +24,20 @@ struct MacBuildChannelTests {
         #expect(MacBuildChannel().label(bundleID: "com.cmuxterm.app.rc.candidate1", tag: nil) == "RC")
     }
 
+    @Test func canonicalTagIdentifiesAppWithoutLivePresenceBundleMetadata() {
+        let channel = MacBuildChannel()
+
+        #expect(channel.label(bundleID: nil, tag: "default") == "Stable")
+        #expect(channel.label(bundleID: nil, tag: "nightly") == "Nightly")
+        #expect(channel.label(bundleID: nil, tag: "staging") == "Staging")
+        #expect(channel.label(bundleID: nil, tag: "rc") == "RC")
+        #expect(channel.label(bundleID: nil, tag: "future-one") == "DEV · future-one")
+        #expect(channel.appDisplayName(bundleID: nil, tag: "default") == "cmux")
+        #expect(channel.appDisplayName(bundleID: nil, tag: "nightly") == "cmux Nightly")
+        #expect(channel.appDisplayName(bundleID: nil, tag: "future-one") == "cmux DEV future-one")
+    }
+
     @Test func nilWhenNotIdentifiable() {
-        #expect(MacBuildChannel().label(bundleID: nil, tag: "default") == nil)
         #expect(MacBuildChannel().label(bundleID: nil, tag: nil) == nil)
         #expect(MacBuildChannel().label(bundleID: "com.example.other", tag: "default") == nil)
         // Unknown future channel component is not guessed at.

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacInstanceConnectionAuthorityTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacInstanceConnectionAuthorityTests.swift
@@ -149,6 +149,51 @@ import Testing
         #expect(!mac.routes.contains(routeA))
     }
 
+    @Test func scanningStableAndNightlyPairingCodesKeepsBothTaggedInstances() async throws {
+        let directory = try makeDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let pairedStore = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired.sqlite3")
+        )
+        let router = LivenessHostRouter()
+        let clock = TestClock()
+        let shell = makeShell(
+            store: pairedStore,
+            router: router,
+            userID: "user-1",
+            clock: clock
+        )
+
+        await router.setHostIdentity(
+            deviceID: "test-mac",
+            instanceTag: "default",
+            displayName: "Studio"
+        )
+        let stableConnected = await shell.connectPairingURL(
+            try attachURL(for: makeTicket(clock: clock))
+        )
+
+        await router.setHostIdentity(
+            deviceID: "test-mac",
+            instanceTag: "nightly",
+            displayName: "Studio"
+        )
+        let nightlyConnected = await shell.connectPairingURL(
+            try attachURL(for: makeTicket(clock: clock))
+        )
+
+        #expect(stableConnected)
+        #expect(nightlyConnected)
+        let records = try await pairedStore.loadAll(
+            stackUserID: "user-1",
+            teamID: "team-a"
+        )
+        #expect(records.count == 2)
+        #expect(Set(records.compactMap(\.instanceTag)) == Set(["default", "nightly"]))
+        #expect(records.first(where: { $0.instanceTag == "default" })?.isActive == false)
+        #expect(records.first(where: { $0.instanceTag == "nightly" })?.isActive == true)
+    }
+
     @Test func explicitRegistryBWithoutReportedTagCannotReplaceA() async throws {
         let directory = try makeDirectory()
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PairedMacBackupTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PairedMacBackupTests.swift
@@ -37,7 +37,7 @@ private let backupRouteDisclosureDate = Date(timeIntervalSince1970: 2_000_000_00
         case .upsert(let record, _), .upsertPreservingCustomizations(let record, _),
              .revive(let record, _), .revivePreservingCustomizations(let record, _):
             return record
-        case .delete:
+        case .delete, .deleteInstance:
             return nil
         }
     }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PairedMacInstanceTagBackupTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/PairedMacInstanceTagBackupTests.swift
@@ -28,7 +28,7 @@ import Testing
         case .upsert(let record, _), .upsertPreservingCustomizations(let record, _),
              .revive(let record, _), .revivePreservingCustomizations(let record, _):
             return record
-        case .delete:
+        case .delete, .deleteInstance:
             return nil
         }
     }
@@ -61,6 +61,40 @@ import Testing
         let uploaded = uploadedRecord(from: first)
         #expect(uploaded?.instanceTag == "feature-a")
         #expect(try encodedRecordObject(from: first)["instanceTagWriteMode"] == nil)
+    }
+
+    @Test func deletingOneTaggedInstanceKeepsAndBacksUpItsSibling() async throws {
+        let (inner, directory) = try makeInnerStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let backup = FakeBackup()
+        let store = BackingUpPairedMacStore(inner: inner, backup: backup)
+
+        for tag in ["stable", "nightly"] {
+            try await store.upsert(
+                macDeviceID: "mac-a",
+                displayName: "Studio",
+                routes: [try route()],
+                instanceTag: tag,
+                markActive: tag == "nightly",
+                stackUserID: "user-1",
+                now: Date()
+            )
+        }
+        try await store.remove(
+            macDeviceID: "mac-a",
+            instanceTag: "stable",
+            stackUserID: "user-1",
+            teamID: nil
+        )
+
+        let remaining = try await inner.loadAll(stackUserID: "user-1", teamID: nil)
+        #expect(remaining.map(\.instanceTag) == ["nightly"])
+        #expect(await backup.uploadedOps().contains {
+            if case .deleteInstance(let macDeviceID, let instanceTag) = $0 {
+                return macDeviceID == "mac-a" && instanceTag == "stable"
+            }
+            return false
+        })
     }
 
     @Test func restoreAppliesInstanceTagFromBackup() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TaggedBuildPresenceRouteIsolationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TaggedBuildPresenceRouteIsolationTests.swift
@@ -181,7 +181,7 @@ import Testing
         #expect(await pairedStore.currentUpsertCount() == 1)
         #expect(try await storedRoutes(in: pairedStore) == [defaultRoute])
         let recoveryRan = try await pollUntil(attempts: 50) {
-            store.connectionRecoveryFailed
+            store.isRecoveringConnection || store.connectionRecoveryFailed
         }
         #expect(recoveryRan)
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DeviceTreeView.swift
@@ -54,7 +54,7 @@ struct DeviceTreeView: View {
                             MacComputerRow(
                                 computer: computer,
                                 requestRemove: requestComputerRemoval,
-                                isConfirmingRemove: removalConfirmationBinding(for: computer.deviceId),
+                                isConfirmingRemove: removalConfirmationBinding(for: computer.id),
                                 confirmRemove: { _ in confirmComputerRemoval() }
                             )
                         }
@@ -70,8 +70,14 @@ struct DeviceTreeView: View {
                 }
             }
             .listStyle(.insetGrouped)
-            .navigationDestination(for: String.self) { deviceId in
-                MacComputerDetailView(store: store, macDeviceID: deviceId)
+            .navigationDestination(for: String.self) { pairingID in
+                if let computer = computers.first(where: { $0.id == pairingID }) {
+                    MacComputerDetailView(
+                        store: store,
+                        macDeviceID: computer.deviceId,
+                        instanceTag: computer.instanceTag
+                    )
+                }
             }
             .navigationTitle(L10n.string("mobile.computers.title", defaultValue: "Computers"))
             .navigationBarTitleDisplayMode(.inline)
@@ -143,8 +149,8 @@ struct DeviceTreeView: View {
         }
     }
 
-    private func requestComputerRemoval(_ deviceID: String) {
-        computerPendingRemovalID = deviceID
+    private func requestComputerRemoval(_ pairingID: String) {
+        computerPendingRemovalID = pairingID
     }
 
     private func removalConfirmationBinding(for deviceID: String) -> Binding<Bool> {
@@ -161,12 +167,16 @@ struct DeviceTreeView: View {
     }
 
     private func confirmComputerRemoval() {
-        guard let deviceID = computerPendingRemovalID else {
+        guard let pairingID = computerPendingRemovalID,
+              let computer = computers.first(where: { $0.id == pairingID }) else {
             return
         }
         computerPendingRemovalID = nil
         Task {
-            await store.forgetMac(macDeviceID: deviceID)
+            await store.forgetMac(
+                macDeviceID: computer.deviceId,
+                instanceTag: computer.instanceTag
+            )
             await reload()
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DisconnectedWorkspaceShellView.swift
@@ -157,11 +157,11 @@ struct DisconnectedWorkspaceShellView: View {
                     MacComputerRow(
                         computer: computer,
                         requestRemove: { computerPendingRemovalID = $0 },
-                        isConfirmingRemove: removalConfirmationBinding(for: computer.deviceId),
+                        isConfirmingRemove: removalConfirmationBinding(for: computer.id),
                         confirmRemove: { _ in confirmComputerRemoval() },
                         style: .reconnect,
-                        connect: { connect(to: $0, named: computer.title) },
-                        isConnecting: connectingMacID == computer.deviceId
+                        connect: { _ in connect(to: computer) },
+                        isConnecting: connectingMacID == computer.id
                     )
                 }
             } header: {
@@ -238,16 +238,19 @@ struct DisconnectedWorkspaceShellView: View {
     /// switch (e.g. from the Settings sheet's host picker) supersedes this one;
     /// in that case the newer attempt is still in flight or has already
     /// connected, and alerting "couldn't connect" would be wrong — skip it.
-    private func connect(to macDeviceID: String, named name: String) {
+    private func connect(to computer: MacComputerSnapshot) {
         guard connectingMacID == nil, let store else { return }
-        connectingMacID = macDeviceID
+        connectingMacID = computer.id
         Task {
-            let connected = await store.switchToMac(macDeviceID: macDeviceID)
+            let connected = await store.switchToMac(
+                macDeviceID: computer.deviceId,
+                instanceTag: computer.instanceTag
+            )
             connectingMacID = nil
             if !connected,
                store.connectionState != .connected,
                !store.isMacSwitchInFlight {
-                connectFailedComputerName = name
+                connectFailedComputerName = computer.title
             }
         }
     }
@@ -276,12 +279,16 @@ struct DisconnectedWorkspaceShellView: View {
     }
 
     private func confirmComputerRemoval() {
-        guard let deviceID = computerPendingRemovalID else {
+        guard let pairingID = computerPendingRemovalID,
+              let computer = savedComputers.first(where: { $0.id == pairingID }) else {
             return
         }
         computerPendingRemovalID = nil
         Task {
-            await store?.forgetMac(macDeviceID: deviceID)
+            await store?.forgetMac(
+                macDeviceID: computer.deviceId,
+                instanceTag: computer.instanceTag
+            )
             await store?.loadPairedMacs()
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerDetailView.swift
@@ -18,6 +18,7 @@ import SwiftUI
 struct MacComputerDetailView: View {
     @Bindable var store: CMUXMobileShellStore
     let macDeviceID: String
+    let instanceTag: String?
     @Environment(\.dismiss) private var dismiss
 
     @State private var pendingRemoval = false
@@ -44,7 +45,9 @@ struct MacComputerDetailView: View {
     private static let emojiChoices = ["💻", "🖥️", "⚡️", "🔥", "⭐️", "🚀", "🐧", "🍎", "🎮", "👾"]
 
     private var pairedMac: MobilePairedMac? {
-        store.displayPairedMacs.first { $0.macDeviceID == macDeviceID }
+        store.displayPairedMacs.first {
+            $0.macDeviceID == macDeviceID && $0.instanceTag == instanceTag
+        }
     }
     private var connectionStatus: MobileMacConnectionStatus? {
         store.macConnectionStatuses[macDeviceID]
@@ -55,7 +58,10 @@ struct MacComputerDetailView: View {
             instanceTag: pairedMac?.instanceTag
         )
     }
-    private var isForeground: Bool { store.connectedMacDeviceID == macDeviceID }
+    private var isForeground: Bool {
+        store.connectedMacDeviceID == macDeviceID
+            && (instanceTag == nil || store.connectedMacInstanceTag == instanceTag)
+    }
     private var displayTitle: String {
         let baseName = pairedMac?.resolvedName ?? macDeviceID
         return MobileIOSBuildScope.current()?.computerDisplayName(baseName) ?? baseName
@@ -93,7 +99,10 @@ struct MacComputerDetailView: View {
         ) {
             Button(L10n.string("mobile.computers.remove", defaultValue: "Remove"), role: .destructive) {
                 let id = macDeviceID
-                Task { await store.forgetMac(macDeviceID: id); await store.loadPairedMacs() }
+                Task {
+                    await store.forgetMac(macDeviceID: id, instanceTag: instanceTag)
+                    await store.loadPairedMacs()
+                }
                 dismiss()
             }
             Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {}
@@ -224,6 +233,7 @@ struct MacComputerDetailView: View {
         Task {
             await store.updateMacCustomization(
                 macDeviceID: macDeviceID,
+                instanceTag: instanceTag,
                 customName: name,
                 customColor: color,
                 customIcon: icon
@@ -437,7 +447,12 @@ struct MacComputerDetailView: View {
                 // re-dials it specifically. `reconnectOrRefresh()` would instead
                 // refresh/redial the foreground/active Mac and leave the computer
                 // shown here untouched.
-                Task { await store.switchToMac(macDeviceID: macDeviceID) }
+                Task {
+                    await store.switchToMac(
+                        macDeviceID: macDeviceID,
+                        instanceTag: instanceTag
+                    )
+                }
             } label: {
                 Label(L10n.string("mobile.workspace.reconnect", defaultValue: "Reconnect"), systemImage: "arrow.clockwise")
             }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerRow.swift
@@ -49,7 +49,7 @@ struct MacComputerRow: View {
             removeSwipeButton
         }
         .accessibilityElement(children: .combine)
-        .accessibilityIdentifier("MobileComputerRow-\(computer.deviceId)")
+        .accessibilityIdentifier("MobileComputerRow-\(computer.id)")
         .confirmationDialog(
             removeTitle,
             isPresented: isConfirmingRemove,
@@ -60,9 +60,9 @@ struct MacComputerRow: View {
                     L10n.string("mobile.computers.remove", defaultValue: "Remove"),
                     role: .destructive
                 ) {
-                    confirmRemove(computer.deviceId)
+                    confirmRemove(computer.id)
                 }
-                .accessibilityIdentifier("MobileComputerRemoveConfirm-\(computer.deviceId)")
+                .accessibilityIdentifier("MobileComputerRemoveConfirm-\(computer.id)")
             }
             Button(L10n.string("mobile.common.cancel", defaultValue: "Cancel"), role: .cancel) {
                 isConfirmingRemove.wrappedValue = false
@@ -76,12 +76,12 @@ struct MacComputerRow: View {
     private var rowContainer: some View {
         switch style {
         case .computers:
-            NavigationLink(value: computer.deviceId) {
+            NavigationLink(value: computer.id) {
                 rowLabel
             }
         case .reconnect:
             Button {
-                connect?(computer.deviceId)
+                connect?(computer.id)
             } label: {
                 rowLabel
             }
@@ -135,7 +135,7 @@ struct MacComputerRow: View {
     private var removeSwipeButton: some View {
         if let requestRemove {
             Button {
-                requestRemove(computer.deviceId)
+                requestRemove(computer.id)
             } label: {
                 Label(
                     L10n.string("mobile.computers.remove", defaultValue: "Remove"),
@@ -143,7 +143,7 @@ struct MacComputerRow: View {
                 )
             }
             .tint(.red)
-            .accessibilityIdentifier("MobileComputerRemoveSwipeButton-\(computer.deviceId)")
+            .accessibilityIdentifier("MobileComputerRemoveSwipeButton-\(computer.id)")
         }
     }
 
@@ -151,14 +151,14 @@ struct MacComputerRow: View {
     private var removeMenuButton: some View {
         if let requestRemove {
             Button(role: .destructive) {
-                requestRemove(computer.deviceId)
+                requestRemove(computer.id)
             } label: {
                 Label(
                     L10n.string("mobile.computers.remove", defaultValue: "Remove"),
                     systemImage: "trash"
                 )
             }
-            .accessibilityIdentifier("MobileComputerRemoveMenuButton-\(computer.deviceId)")
+            .accessibilityIdentifier("MobileComputerRemoveMenuButton-\(computer.id)")
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot+Store.swift
@@ -33,16 +33,25 @@ extension MacComputerSnapshot {
             )
             let presence: DeviceTreePresence? = summary
                 .map { $0.online ? .online : .offline(lastSeenAt: $0.lastSeenAt) }
+            let connectionStatus = connectionStatuses[mac.macDeviceID]
+            let exactConnectionStatus = connectionStatus == .connected
+                && store.connectedMacDeviceID == mac.macDeviceID
+                && mac.instanceTag != nil
+                && store.connectedMacInstanceTag != mac.instanceTag
+                ? nil
+                : connectionStatus
             return MacComputerSnapshot(
                 deviceId: mac.macDeviceID,
+                instanceTag: mac.instanceTag,
                 title: buildScope?.computerDisplayName(mac.resolvedName) ?? mac.resolvedName,
                 platform: "mac",
                 colorIndex: aliases.compactMap { colorIndex[$0] }.first,
                 customColor: mac.customColor,
                 customIcon: mac.customIcon,
-                connectionStatus: connectionStatuses[mac.macDeviceID],
+                connectionStatus: exactConnectionStatus,
                 presence: presence,
-                buildLabel: summary?.buildLabel,
+                buildLabel: summary?.buildLabel
+                    ?? MacBuildChannel().label(bundleID: nil, tag: mac.instanceTag),
                 routeDescription: CmxAttachRoute.deviceTreeRouteDescription(for: mac.routes),
                 lastSeenAt: mac.lastSeenAt,
                 workspaceCount: store.workspaceCount(for: mac.macDeviceID),

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MacComputerSnapshot.swift
@@ -1,9 +1,11 @@
+import CmuxMobilePairedMac
 import CmuxMobileShellModel
 import Foundation
 
 /// Immutable per-computer snapshot for the Computers screen.
 struct MacComputerSnapshot: Equatable, Identifiable {
     let deviceId: String
+    let instanceTag: String?
     let title: String
     let platform: String
     /// The Mac's distinct color index.
@@ -34,5 +36,7 @@ struct MacComputerSnapshot: Equatable, Identifiable {
     /// entries stop looking interchangeable.
     var isOlderDuplicate: Bool = false
 
-    var id: String { deviceId }
+    var id: String {
+        MobilePairedMac.pairingID(macDeviceID: deviceId, instanceTag: instanceTag)
+    }
 }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
@@ -103,7 +103,12 @@ struct MobileHostPickerView: View {
     private func macRow(_ mac: MobilePairedMac) -> some View {
         let isActive = mac.isActive
         Button {
-            Task { await store.switchToMac(macDeviceID: mac.macDeviceID) }
+            Task {
+                await store.switchToMac(
+                    macDeviceID: mac.macDeviceID,
+                    instanceTag: mac.instanceTag
+                )
+            }
         } label: {
             HStack(spacing: 12) {
                 Image(systemName: "desktopcomputer")
@@ -111,6 +116,13 @@ struct MobileHostPickerView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(scopedDisplayName(mac.resolvedName))
                         .foregroundStyle(.primary)
+                    if store.pairedMacs.filter({
+                        $0.macDeviceID == mac.macDeviceID
+                    }).count > 1 {
+                        Text(mac.instanceTag ?? "Legacy")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
                     Text(mac.lastSeenAt, format: .relative(presentation: .named))
                         .font(.caption)
                         .foregroundStyle(.secondary)
@@ -125,14 +137,19 @@ struct MobileHostPickerView: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
-        .accessibilityIdentifier("MobileHostPickerRow-\(mac.macDeviceID)")
+        .accessibilityIdentifier("MobileHostPickerRow-\(mac.id)")
         .swipeActions(edge: .trailing) {
             Button(role: .destructive) {
-                Task { await store.forgetStoredMac(macDeviceID: mac.macDeviceID) }
+                Task {
+                    await store.forgetStoredMac(
+                        macDeviceID: mac.macDeviceID,
+                        instanceTag: mac.instanceTag
+                    )
+                }
             } label: {
                 Label(L10n.string("mobile.hostPicker.forget", defaultValue: "Forget"), systemImage: "trash")
             }
-            .accessibilityIdentifier("MobileHostPickerForget-\(mac.macDeviceID)")
+            .accessibilityIdentifier("MobileHostPickerForget-\(mac.id)")
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileHostPickerView.swift
@@ -102,6 +102,10 @@ struct MobileHostPickerView: View {
     @ViewBuilder
     private func macRow(_ mac: MobilePairedMac) -> some View {
         let isActive = mac.isActive
+        let appDisplayName = localizedAppDisplayName(for: mac)
+        let hasSiblingInstance = store.pairedMacs.contains {
+            $0.id != mac.id && $0.macDeviceID == mac.macDeviceID
+        }
         Button {
             Task {
                 await store.switchToMac(
@@ -116,10 +120,12 @@ struct MobileHostPickerView: View {
                 VStack(alignment: .leading, spacing: 2) {
                     Text(scopedDisplayName(mac.resolvedName))
                         .foregroundStyle(.primary)
-                    if store.pairedMacs.filter({
-                        $0.macDeviceID == mac.macDeviceID
-                    }).count > 1 {
-                        Text(mac.instanceTag ?? "Legacy")
+                    if let appDisplayName {
+                        Text(appDisplayName)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    } else if hasSiblingInstance {
+                        Text(L10n.string("mobile.hostPicker.app.legacy", defaultValue: "Legacy"))
                             .font(.caption)
                             .foregroundStyle(.secondary)
                     }
@@ -155,6 +161,36 @@ struct MobileHostPickerView: View {
 
     private func scopedDisplayName(_ baseName: String) -> String {
         MobileIOSBuildScope.current()?.computerDisplayName(baseName) ?? baseName
+    }
+
+    private func localizedAppDisplayName(for mac: MobilePairedMac) -> String? {
+        guard let appName = MacBuildChannel().appDisplayName(
+            bundleID: nil,
+            tag: mac.instanceTag
+        ) else {
+            return nil
+        }
+        switch appName {
+        case "cmux":
+            return L10n.string("mobile.hostPicker.app.stable", defaultValue: "cmux")
+        case "cmux Nightly":
+            return L10n.string("mobile.hostPicker.app.nightly", defaultValue: "cmux Nightly")
+        case "cmux RC":
+            return L10n.string("mobile.hostPicker.app.rc", defaultValue: "cmux RC")
+        case "cmux Staging":
+            return L10n.string("mobile.hostPicker.app.staging", defaultValue: "cmux Staging")
+        case "cmux DEV":
+            return L10n.string("mobile.hostPicker.app.dev", defaultValue: "cmux DEV")
+        default:
+            let prefix = "cmux DEV "
+            guard appName.hasPrefix(prefix) else { return appName }
+            let tag = appName.dropFirst(prefix.count)
+            let format = L10n.string(
+                "mobile.hostPicker.app.devTaggedFormat",
+                defaultValue: "cmux DEV %@"
+            )
+            return String(format: format, String(tag))
+        }
     }
 }
 #endif

--- a/Sources/Mobile/MobileHostIdentity.swift
+++ b/Sources/Mobile/MobileHostIdentity.swift
@@ -178,9 +178,52 @@ enum MobileHostIdentity {
     }
 
     /// Canonical app-instance tag used by registry and presence. This is the
-    /// same launch tag that owns the tagged socket and bundle identity.
+    /// same launch tag or release channel that owns the socket and bundle
+    /// identity.
     static func instanceTag() -> String {
-        SocketControlSettings.launchTag() ?? "default"
+        instanceTag(
+            environment: ProcessInfo.processInfo.environment,
+            bundleIdentifier: Bundle.main.bundleIdentifier
+        )
+    }
+
+    /// Resolves the app-instance tag from explicit launch metadata first, then
+    /// from the bundle channel. Stable keeps the historical `"default"` tag;
+    /// Nightly and Staging must be distinct now that every app bundle on one
+    /// Mac intentionally shares the same physical device identifier.
+    static func instanceTag(
+        environment: [String: String],
+        bundleIdentifier: String?
+    ) -> String {
+        if let launchTag = SocketControlSettings.launchTag(environment: environment) {
+            return launchTag
+        }
+
+        let normalizedBundleID = bundleIdentifier?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        let releaseCandidateBundleID = stableBundleIdentifier + ".rc"
+        if normalizedBundleID == releaseCandidateBundleID {
+            return "rc"
+        }
+        if normalizedBundleID.hasPrefix(releaseCandidateBundleID + ".") {
+            let suffix = String(normalizedBundleID.dropFirst(releaseCandidateBundleID.count + 1))
+            return SocketPathMarkerFiles.sanitizeSocketSlug(suffix) ?? "rc"
+        }
+
+        switch SocketPathMarkerFiles.variant(
+            bundleIdentifier: normalizedBundleID,
+            environment: environment
+        ) {
+        case .stable:
+            return "default"
+        case .nightly(let slug):
+            return slug ?? "nightly"
+        case .staging(let slug):
+            return slug ?? "staging"
+        case .dev(let slug):
+            return slug ?? "dev"
+        }
     }
 
     /// Returns the longest whole-character prefix that fits a UTF-16 wire limit.

--- a/cmuxTests/MobileHostIdentityTests.swift
+++ b/cmuxTests/MobileHostIdentityTests.swift
@@ -11,6 +11,25 @@ import Testing
 @Suite(.serialized)
 @MainActor
 struct MobileHostIdentityTests {
+    @Test func appInstanceTagDistinguishesReleaseChannelsAndTaggedDevBuilds() {
+        #expect(MobileHostIdentity.instanceTag(
+            environment: [:],
+            bundleIdentifier: "com.cmuxterm.app"
+        ) == "default")
+        #expect(MobileHostIdentity.instanceTag(
+            environment: [:],
+            bundleIdentifier: "com.cmuxterm.app.nightly"
+        ) == "nightly")
+        #expect(MobileHostIdentity.instanceTag(
+            environment: [:],
+            bundleIdentifier: "com.cmuxterm.app.staging"
+        ) == "staging")
+        #expect(MobileHostIdentity.instanceTag(
+            environment: ["CMUX_TAG": "future-one"],
+            bundleIdentifier: "com.cmuxterm.app.debug.future-one"
+        ) == "future-one")
+    }
+
     @Test func authenticatedStatusIncludesAuthoritativeInstanceTag() {
         let previousTag = ProcessInfo.processInfo.environment["CMUX_TAG"]
         setenv("CMUX_TAG", "future-one", 1)

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2534,6 +2534,125 @@
         }
       }
     },
+    "mobile.hostPicker.app.dev": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux DEV"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux DEV"
+          }
+        }
+      }
+    },
+    "mobile.hostPicker.app.devTaggedFormat": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux DEV %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux DEV %@"
+          }
+        }
+      }
+    },
+    "mobile.hostPicker.app.legacy": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Legacy"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "旧形式"
+          }
+        }
+      }
+    },
+    "mobile.hostPicker.app.nightly": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Nightly"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Nightly"
+          }
+        }
+      }
+    },
+    "mobile.hostPicker.app.rc": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux RC"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux RC"
+          }
+        }
+      }
+    },
+    "mobile.hostPicker.app.stable": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux"
+          }
+        }
+      }
+    },
+    "mobile.hostPicker.app.staging": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Staging"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "cmux Staging"
+          }
+        }
+      }
+    },
     "mobile.hostPicker.active": {
       "extractionState": "manual",
       "localizations": {

--- a/workers/presence/src/syncPairedMacs.ts
+++ b/workers/presence/src/syncPairedMacs.ts
@@ -72,6 +72,14 @@ export const MAX_DISPLAY_NAME_LENGTH = 128;
 export const MAX_INSTANCE_TAG_LENGTH = 64;
 export const MAX_CLIENT_SCOPE_LENGTH = 128;
 const SYNC_HEAD_PREFIX = "synchead:";
+const PAIRED_MAC_INSTANCE_SEPARATOR = "\u001f";
+
+/** Storage identity for one physical Mac app instance. Legacy untagged records
+ * keep their historical physical-device id. */
+export function pairedMacBackupID(macDeviceID: string, instanceTag?: string | null): string {
+  const tag = trimmedString(instanceTag);
+  return tag ? `${macDeviceID}${PAIRED_MAC_INSTANCE_SEPARATOR}${tag}` : macDeviceID;
+}
 /** Route bounds mirror validate.ts so the backup payload can't exceed what a
  * heartbeat could push. */
 export const MAX_ROUTES = 16;
@@ -217,8 +225,13 @@ export function parsePairedMacBackup(body: Record<string, unknown>): PairedMacBa
       return { ok: false, error: "invalid_op" };
     }
     const e = entry as Record<string, unknown>;
-    const id = trimmedString(e.macDeviceID);
-    if (!id || id.length > MAX_MAC_ID_LENGTH) return { ok: false, error: "invalid_mac_id" };
+    const macDeviceID = trimmedString(e.macDeviceID);
+    if (!macDeviceID || macDeviceID.length > MAX_MAC_ID_LENGTH) return { ok: false, error: "invalid_mac_id" };
+    const opInstanceTag = trimmedString(e.instanceTag);
+    if (opInstanceTag.length > MAX_INSTANCE_TAG_LENGTH) {
+      return { ok: false, error: "invalid_instance_tag" };
+    }
+    const id = pairedMacBackupID(macDeviceID, opInstanceTag);
     // The last op for an id wins within a request, but a single request should
     // not carry the same id twice; dedup defensively, keeping the last.
     if (seen.has(id)) {
@@ -245,6 +258,9 @@ export function parsePairedMacBackup(body: Record<string, unknown>): PairedMacBa
     const instanceTag = trimmedString(r.instanceTag);
     if (instanceTag.length > MAX_INSTANCE_TAG_LENGTH) {
       return { ok: false, error: "invalid_instance_tag" };
+    }
+    if (opInstanceTag && opInstanceTag !== instanceTag) {
+      return { ok: false, error: "instance_tag_mismatch" };
     }
     const rawInstanceTagWriteMode = r.instanceTagWriteMode;
     if (
@@ -300,7 +316,7 @@ export function parsePairedMacBackup(body: Record<string, unknown>): PairedMacBa
       instanceTagWriteMode: rawInstanceTagWriteMode,
       allowTombstoneRevive: e.reviveDeleted === true,
       record: {
-        macDeviceID: id,
+        macDeviceID,
         displayName: displayName || undefined,
         instanceTag: instanceTag || undefined,
         routes: sanitizePublishedRoutes(routes) ?? [],
@@ -416,9 +432,27 @@ export async function applyBackupOps(
       }
       continue;
     }
-    const existing = await readRecord<PairedMacBackupRecord>(storage, collection, op.id);
+    const exactExisting = await readRecord<PairedMacBackupRecord>(storage, collection, op.id);
+    let existing = exactExisting;
+    let migratingLegacyID: string | null = null;
+    if (existing === undefined && op.id !== op.record.macDeviceID) {
+      const legacy = await readRecord<PairedMacBackupRecord>(
+        storage,
+        collection,
+        op.record.macDeviceID,
+      );
+      if (
+        legacy !== undefined &&
+        !legacy.deleted &&
+        (legacy.payload.instanceTag ?? "") === (op.record.instanceTag ?? "")
+      ) {
+        existing = legacy;
+        migratingLegacyID = op.record.macDeviceID;
+      }
+    }
     const isBrandNew = existing === undefined;
-    const isReviving = existing !== undefined && existing.deleted;
+    const isReviving = exactExisting !== undefined && exactExisting.deleted;
+    const createsStorageSlot = exactExisting === undefined;
     if (isReviving && op.allowTombstoneRevive !== true) {
       // A delete tombstone is the authoritative "forget" operation. Stale
       // devices can republish ordinary upserts with newer lastSeenAt values, so
@@ -433,7 +467,7 @@ export async function applyBackupOps(
       // mirroring the preferred-first leniency elsewhere. Existing records update.
       continue;
     }
-    if (isBrandNew && totalCount >= MAX_PAIRED_MAC_RECORDS_PER_USER) {
+    if (createsStorageSlot && totalCount >= MAX_PAIRED_MAC_RECORDS_PER_USER) {
       // At the cumulative (live + retained-tombstone) cap: refuse a truly-new id
       // until GC frees tombstones, so create/delete churn cannot amplify storage.
       continue;
@@ -498,8 +532,14 @@ export async function applyBackupOps(
     );
     if (res.delta !== null) {
       if (addsLive) liveCount += 1;
-      if (isBrandNew) totalCount += 1;
+      if (createsStorageSlot) totalCount += 1;
       deltas.push(relabelDelta(res.delta));
+    }
+    if (migratingLegacyID !== null) {
+      const retired = await tombstoneRecord(storage, collection, migratingLegacyID, nowMs);
+      if (retired.delta !== null) {
+        deltas.push(relabelDelta(retired.delta));
+      }
     }
   }
 

--- a/workers/presence/test/syncPairedMacs.test.ts
+++ b/workers/presence/test/syncPairedMacs.test.ts
@@ -88,6 +88,20 @@ describe("parsePairedMacBackup", () => {
     expect(parsed.ops[1]).toEqual({ kind: "delete", id: "gone" });
   });
 
+  it("keys tagged operations by physical Mac plus app-instance tag", () => {
+    const tagged = { ...record("mac-a", "10.0.0.1", 22), instanceTag: "nightly" };
+    const parsed = parsePairedMacBackup({
+      ops: [
+        { macDeviceID: "mac-a", instanceTag: "nightly", record: tagged },
+        { macDeviceID: "mac-a", instanceTag: "stable", deleted: true },
+      ],
+    });
+    expect(parsed.ok).toBe(true);
+    if (!parsed.ok) return;
+    expect(parsed.ops[0]).toMatchObject({ kind: "upsert", id: "mac-a\u001fnightly" });
+    expect(parsed.ops[1]).toEqual({ kind: "delete", id: "mac-a\u001fstable" });
+  });
+
   it("rejects a non-array ops, missing id, and bad timestamps", () => {
     expect(parsePairedMacBackup({ ops: "nope" }).ok).toBe(false);
     expect(parsePairedMacBackup({ ops: [{ record: record("x", "h", 1) }] }).ok).toBe(false);
@@ -611,6 +625,33 @@ describe("applyBackupOps", () => {
     const live = await listLiveBackup(storage, "user-1");
     expect(live.filter((r) => r.isActive).map((r) => r.macDeviceID)).toEqual(["mac-b"]);
     expect(live.find((r) => r.macDeviceID === "mac-a")?.isActive).toBe(false);
+  });
+
+  it("stores and deletes two tagged instances on one physical Mac independently", async () => {
+    const storage = new FakeStorage();
+    const stable = { ...record("mac-a", "10.0.0.1", 22), instanceTag: "stable" };
+    const nightly = {
+      ...record("mac-a", "10.0.0.2", 22),
+      instanceTag: "nightly",
+      lastSeenAt: T0 + 1000,
+    };
+    await applyBackupOps(storage, "user-1", [
+      { kind: "upsert", id: "mac-a\u001fstable", record: stable },
+      { kind: "upsert", id: "mac-a\u001fnightly", record: nightly },
+    ], T0);
+
+    let snapshot = await listBackupSnapshot(storage, "user-1");
+    expect(snapshot.records.map((item) => item.instanceTag).sort()).toEqual(["nightly", "stable"]);
+
+    await applyBackupOps(
+      storage,
+      "user-1",
+      [{ kind: "delete", id: "mac-a\u001fstable" }],
+      T0 + 2000,
+    );
+    snapshot = await listBackupSnapshot(storage, "user-1");
+    expect(snapshot.records.map((item) => item.instanceTag)).toEqual(["nightly"]);
+    expect(snapshot.deletedMacDeviceIDs).toEqual(["mac-a\u001fstable"]);
   });
 
   it("a customization-only change syncs (not a same-shape no-op)", async () => {


### PR DESCRIPTION
## Summary
- key saved Mac pairings by physical Mac ID plus authenticated app-instance tag
- derive Stable, Nightly, Staging, RC, and tagged DEV identities from Mac bundle metadata
- show localized app names such as `cmux Nightly` and `cmux DEV <tag>` in the mobile computer picker
- preserve exact-instance switching, forgetting, backup, restore, and presence routing

## Regression
PR #6772 intentionally moved all cmux bundles on one Mac to a shared physical device ID, but the iOS paired-Mac store still allowed only one row per physical ID. PR #7864 later exposed the app-instance tag without making it part of persisted identity, so scanning another app replaced the first.

## Test plan
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MacBuildChannelTests`
- `xcodebuild ... -scheme cmux-unit ... -only-testing:cmuxTests/MobileHostIdentityTests` (14 tests passed)
- `CMUX_SKIP_ZIG_BUILD=1 ./scripts/reload.sh --tag ios-multi-tag --swift-frontend-workaround`
- `ios/scripts/reload.sh --tag ios-multi-tag --no-launch --no-setup`
- localization catalog JSON audit for English and Japanese app-label keys
- `python3 scripts/check-package-resolved-policy.py`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8232"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786766465&installation_id=133855650&pr_number=8232&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8232&signature=f48d79ce9c89dc705f83c234425464967a2ed7d7c777f9334c0c90788d1d405a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes iOS pairing when multiple `cmux` app instances run on the same Mac by keying saved pairings by physical Mac ID plus the authenticated app-instance tag. This stops one scan from replacing another and enables exact switching, forgetting, backup/restore, and presence routing per instance.

- Bug Fixes
  - Persist and identify pairings by pairing identity (`macDeviceID` + `instanceTag`); store migrates to schema v6 and adds APIs to target an exact instance.
  - Extend backup/restore and presence sync to carry `instanceTag`; per-instance delete is supported; `workers/presence` keys ops by pairing identity.
  - Preserve active selection and reconnect routes for the selected tagged instance; aliasing, coalescing, and "forgotten" logic use pairing identity.
  - Derive canonical instance tags for Stable/Nightly/Staging/RC and tagged DEV from bundle/env; used across presence and UI.
  - Show localized app names like "cmux Nightly" and "cmux DEV <tag>"; picker and detail views operate on exact instances.

- Migration
  - Database auto-migrates to v6; no user action.
  - Legacy untagged hosts keep device-only IDs; backup protocol remains compatible.

<sup>Written for commit ec085035b1ad7e1c36b604928711cade5094ed6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8232?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

