### PR TITLE
Fix CmuxTerminal package test linking

### DIFF
--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/GhosttyRuntimeTestStubs.c
@@ -1,5 +1,19 @@
 #include "include/GhosttyRuntimeTestStubs.h"
+#include <stdlib.h>
 #include <string.h>
+#include <strings.h>
+
+typedef struct {
+    uint8_t r;
+    uint8_t g;
+    uint8_t b;
+} GhosttyRuntimeTestColor;
+
+typedef struct {
+    GhosttyRuntimeTestColor foreground;
+    bool has_foreground;
+    uint32_t diagnostics_count;
+} GhosttyRuntimeTestConfig;
 
 static bool cmux_test_needs_confirm_quit = false;
 static uint64_t cmux_test_foreground_pid = 0;
@@ -20,6 +34,51 @@ void cmux_test_ghostty_runtime_stubs_set_close_state(bool needs_confirm, uint64_
 bool ghostty_surface_clear_selection(void *surface) {
     (void)surface;
     return false;
+}
+
+void *ghostty_config_new(void) {
+    return calloc(1, sizeof(GhosttyRuntimeTestConfig));
+}
+
+void ghostty_config_free(void *config) {
+    free(config);
+}
+
+void ghostty_config_load_string(
+    void *raw_config,
+    const char *contents,
+    uintptr_t contents_len,
+    const char *path
+) {
+    (void)contents_len;
+    (void)path;
+    GhosttyRuntimeTestConfig *config = raw_config;
+    const char *value = strchr(contents, '=');
+    if (config == NULL || value == NULL) return;
+    do { value++; } while (*value == ' ' || *value == '\t');
+
+    if (strcasecmp(value, "black") == 0) {
+        config->foreground = (GhosttyRuntimeTestColor){0, 0, 0};
+        config->has_foreground = true;
+        return;
+    }
+
+    config->diagnostics_count = 1;
+}
+
+bool ghostty_config_get(
+    void *raw_config,
+    void *raw_value,
+    const char *key,
+    uintptr_t key_len
+) {
+    GhosttyRuntimeTestConfig *config = raw_config;
+    if (config == NULL || raw_value == NULL || !config->has_foreground ||
+        key_len != strlen("foreground") || strncmp(key, "foreground", key_len) != 0) {
+        return false;
+    }
+    *(GhosttyRuntimeTestColor *)raw_value = config->foreground;
+    return true;
 }
 
 void ghostty_config_diagnostics_count(void) {}

--- a/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
+++ b/Packages/macOS/CmuxTerminal/Tests/GhosttyRuntimeTestStubs/include/GhosttyRuntimeTestStubs.h
@@ -17,6 +17,18 @@ typedef struct {
 
 bool ghostty_surface_clear_selection(void *surface);
 
+void *ghostty_config_new(void);
+void ghostty_config_free(void *config);
+void ghostty_config_load_string(
+    void *config,
+    const char *contents,
+    uintptr_t contents_len,
+    const char *path);
+bool ghostty_config_get(
+    void *config,
+    void *value,
+    const char *key,
+    uintptr_t key_len);
 void ghostty_config_diagnostics_count(void);
 void ghostty_config_get_diagnostic(void);
 void ghostty_string_free(ghostty_string_s string);


### PR DESCRIPTION
The standalone `CmuxTerminal` SwiftPM test runner failed to link after `CmuxTerminalCore` began referencing Ghostty config parsing symbols.

This adds test-only implementations and declarations for `ghostty_config_new`, `ghostty_config_free`, `ghostty_config_load_string`, and `ghostty_config_get`, matching the existing `CmuxTerminalCore` fallback behavior. Production linking is unchanged.

Verification:
- Before: `swift test` failed with all four symbols undefined
- After: `swift test` passed 89 tests across 13 suites
- `git diff --check`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8234"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786767873&installation_id=133855650&pr_number=8234&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8234&signature=55afef86d7fe01b1c0d7d952f651b35b9a69e96f2bb517b99e56dcb4cbcd9301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes link failures in the `CmuxTerminal` SwiftPM tests by adding Ghostty config runtime stubs used by `CmuxTerminalCore`. `swift test` builds and runs again; production builds are unchanged.

- **Bug Fixes**
  - Added test-only implementations for `ghostty_config_new`, `ghostty_config_free`, `ghostty_config_load_string`, and `ghostty_config_get`.
  - Declared these in the test header and implemented minimal parsing for the "foreground" key and basic diagnostics to match core fallback behavior.

<sup>Written for commit db8a62557555a4d7745bdfec46c3dbfa80fbec2f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8234?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added in-memory configuration support for runtime tests.
  * Runtime tests can now create, load, retrieve, and release configuration data.
  * Added support for parsing a foreground color setting from simple configuration text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->