### PR TITLE
Fix coalesceLatest demand-contract crash introduced by #8211

### DIFF
--- a/Sources/CoalesceLatestPublisher.swift
+++ b/Sources/CoalesceLatestPublisher.swift
@@ -30,8 +30,15 @@ extension Publisher where Failure == Never {
     ///   is emitted when the window closes (on `scheduler`), which opens the
     ///   next window.
     ///
+    /// Downstream demand is honored: a value reaching an emission point while
+    /// the downstream has zero outstanding demand is conflated into a
+    /// latest-value slot and delivered from `request(_:)` when demand
+    /// arrives. Demand-driven subscribers such as `AsyncPublisher`
+    /// (`.values`) request one value at a time; forwarding past zero demand
+    /// trips Combine's "received an unexpected value" trap, which crashes in
+    /// every build configuration.
+    ///
     /// Not thread-safe: intended for main-thread streams with `RunLoop.main`.
-    /// Downstream demand is ignored (sink-style subscribers only).
     func coalesceLatest<Context: Scheduler>(
         for interval: Context.SchedulerTimeType.Stride,
         scheduler: Context
@@ -73,6 +80,11 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
     private var pendingValue: Input?
     private var trailingScheduled = false
     private var isCancelled = false
+    private var demand: Subscribers.Demand = .none
+    /// Latest value that reached an emission point while downstream demand
+    /// was zero; conflated (newer emissions overwrite it) and delivered from
+    /// `request(_:)` when demand arrives.
+    private var undeliveredValue: Input?
 
     init(downstream: Downstream, interval: Context.SchedulerTimeType.Stride, scheduler: Context) {
         self.downstream = downstream
@@ -90,7 +102,7 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
         guard !isCancelled else { return .none }
         if !hasReceivedReplay {
             hasReceivedReplay = true
-            _ = downstream.receive(input)
+            deliver(input)
             return .none
         }
         let now = scheduler.now
@@ -104,7 +116,7 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
             // callback cannot emit it out of order after this value.
             pendingValue = nil
             windowStart = now
-            _ = downstream.receive(input)
+            deliver(input)
         }
         return .none
     }
@@ -113,7 +125,7 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
         guard !isCancelled else { return }
         if let value = pendingValue {
             pendingValue = nil
-            _ = downstream.receive(value)
+            deliver(value)
         }
         downstream.receive(completion: completion)
     }
@@ -141,17 +153,33 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
         }
         pendingValue = nil
         windowStart = scheduler.now
-        _ = downstream.receive(value)
+        deliver(value)
     }
 
-    func request(_ demand: Subscribers.Demand) {
-        // Downstream demand is intentionally ignored; this operator backs
-        // sink-style Void observation streams with unlimited demand.
+    /// Hands a value to the downstream only when it has outstanding demand;
+    /// otherwise conflates it into the latest-value slot for `request(_:)`.
+    private func deliver(_ value: Input) {
+        guard demand > .none else {
+            undeliveredValue = value
+            return
+        }
+        demand -= 1
+        demand += downstream.receive(value)
+    }
+
+    func request(_ additionalDemand: Subscribers.Demand) {
+        guard !isCancelled else { return }
+        demand += additionalDemand
+        guard demand > .none, let value = undeliveredValue else { return }
+        undeliveredValue = nil
+        demand -= 1
+        demand += downstream.receive(value)
     }
 
     func cancel() {
         isCancelled = true
         pendingValue = nil
+        undeliveredValue = nil
         upstreamSubscription?.cancel()
         upstreamSubscription = nil
     }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -659,6 +659,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A6AC72080000000000000001 /* CMUXWorkspaceLoadingCLIRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC72080000000000000002 /* CMUXWorkspaceLoadingCLIRegressionTests.swift */; };
 		E3B7A3000000000000000103 /* CmuxWorkspaces in Frameworks */ = {isa = PBXBuildFile; productRef = E3B7A3000000000000000102 /* CmuxWorkspaces */; };
 		C0A1E5CE01C0A1E5CE01A001 /* CoalesceLatestPublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0A1E5CE01C0A1E5CE01A002 /* CoalesceLatestPublisher.swift */; };
+		AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 43BEE8C1CB174E3AB4F89EDE /* CoalesceLatestPublisherDemandTests.swift */; };
 		A9F200000000000000000016 /* CodexAppServerQueuedInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */; };
 		A9E02000000000000000000E /* CodexAppServerSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E01000000000000000000E /* CodexAppServerSession.swift */; };
 		A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E040000000000000000001 /* CodexAppServerSessionTests.swift */; };
@@ -2624,6 +2625,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		E30750000000000000000003 /* CmuxWorkspaceDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CmuxWorkspaceDefinition.swift; sourceTree = "<group>"; };
 		A6AC72080000000000000002 /* CMUXWorkspaceLoadingCLIRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXWorkspaceLoadingCLIRegressionTests.swift; sourceTree = "<group>"; };
 		C0A1E5CE01C0A1E5CE01A002 /* CoalesceLatestPublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoalesceLatestPublisher.swift; sourceTree = "<group>"; };
+		43BEE8C1CB174E3AB4F89EDE /* CoalesceLatestPublisherDemandTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoalesceLatestPublisherDemandTests.swift; sourceTree = "<group>"; };
 		A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerQueuedInput.swift; sourceTree = "<group>"; };
 		A9E01000000000000000000E /* CodexAppServerSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/CodexAppServerSession.swift; sourceTree = "<group>"; };
 		A9E040000000000000000001 /* CodexAppServerSessionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CodexAppServerSessionTests.swift; sourceTree = "<group>"; };
@@ -5702,6 +5704,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D41A7C02D41A7C02D41A7C02 /* SidebarLazyLayoutScaleTests.swift */,
 				6707F0186707F0186707F018 /* SidebarWorkspaceContextMenuWindowTargetsTests.swift */,
 				6707F0246707F0246707F024 /* SidebarWorkspaceNotificationIndexTests.swift */,
+				43BEE8C1CB174E3AB4F89EDE /* CoalesceLatestPublisherDemandTests.swift */,
 				A80070020000000000000001 /* SidebarPointerInteractionMonitorTests.swift */,
 				A80040120000000000000001 /* SidebarPointerInteractionScaleTests.swift */,
 				C4A570030000000000000002 /* CanvasShortcutContextTests.swift */,
@@ -7968,6 +7971,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE58990000000000000004 /* CmuxWebViewKeyDownReentryTests.swift in Sources */,
 				7D5DA4DC51454ECDBF9AC978 /* CmuxWebViewMouseNavigationButtonTests.swift in Sources */,
 					A6AC72080000000000000001 /* CMUXWorkspaceLoadingCLIRegressionTests.swift in Sources */,
+				AAE06C3AEC68484DA33D42A1 /* CoalesceLatestPublisherDemandTests.swift in Sources */,
 				A9E040000000000000000002 /* CodexAppServerSessionTests.swift in Sources */,
 				C0DECAFE0000000000000003 /* CodexTeamsApprovalBridge.swift in Sources */,
 				C0DE7100C0DE7100C0DE7100 /* CodexTerminalErrorNotificationTests.swift in Sources */,

--- a/cmuxTests/CoalesceLatestPublisherDemandTests.swift
+++ b/cmuxTests/CoalesceLatestPublisherDemandTests.swift
@@ -1,0 +1,147 @@
+import Combine
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Records every Combine `Subscriber` contract violation instead of trapping.
+///
+/// `AsyncPublisher` (`.values`) requests one value at a time and hard-crashes
+/// ("received an unexpected value") when an upstream forwards a value while
+/// its outstanding demand is zero. The sidebar consumes `coalesceLatest`
+/// through `.values`, so the operator must never emit past zero demand
+/// (https://github.com/manaflow-ai/cmux/pull/8211 startup crash).
+private final class DemandTrackingSubscriber<Input>: Subscriber {
+    typealias Failure = Never
+
+    private(set) var receivedValues: [Input] = []
+    private(set) var valuesReceivedWithZeroDemand = 0
+    private var outstandingDemand: Subscribers.Demand = .none
+    private var subscription: Subscription?
+    private let initialDemand: Subscribers.Demand
+
+    init(initialDemand: Subscribers.Demand) {
+        self.initialDemand = initialDemand
+    }
+
+    func receive(subscription: Subscription) {
+        self.subscription = subscription
+        if initialDemand > .none {
+            outstandingDemand += initialDemand
+            subscription.request(initialDemand)
+        }
+    }
+
+    func receive(_ input: Input) -> Subscribers.Demand {
+        if outstandingDemand == .none {
+            valuesReceivedWithZeroDemand += 1
+        } else {
+            outstandingDemand -= 1
+        }
+        receivedValues.append(input)
+        return .none
+    }
+
+    func receive(completion: Subscribers.Completion<Never>) {}
+
+    func requestMore(_ demand: Subscribers.Demand) {
+        outstandingDemand += demand
+        subscription?.request(demand)
+    }
+
+    func cancel() {
+        subscription?.cancel()
+    }
+}
+
+@MainActor
+@Suite
+struct CoalesceLatestPublisherDemandTests {
+    @Test
+    func replayIsHeldUntilDownstreamRequestsDemand() {
+        let upstream = CurrentValueSubject<Int, Never>(7)
+        let subscriber = DemandTrackingSubscriber<Int>(initialDemand: .none)
+        upstream
+            .coalesceLatest(for: .zero, scheduler: RunLoop.main)
+            .subscribe(subscriber)
+
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        #expect(subscriber.receivedValues.isEmpty)
+
+        subscriber.requestMore(.max(1))
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        #expect(subscriber.receivedValues == [7])
+        subscriber.cancel()
+    }
+
+    @Test
+    func zeroDemandBurstConflatesToLatestValue() {
+        let upstream = CurrentValueSubject<Int, Never>(0)
+        let subscriber = DemandTrackingSubscriber<Int>(initialDemand: .none)
+        upstream
+            .coalesceLatest(for: .zero, scheduler: RunLoop.main)
+            .subscribe(subscriber)
+
+        upstream.send(1)
+        upstream.send(2)
+        upstream.send(3)
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        #expect(subscriber.receivedValues.isEmpty)
+
+        subscriber.requestMore(.max(1))
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        #expect(subscriber.receivedValues == [3])
+        subscriber.cancel()
+    }
+
+    @Test
+    func demandOneAtATimeNeverReceivesUnrequestedValues() {
+        // AsyncPublisher's exact pattern: one value of demand outstanding at
+        // a time, with upstream emissions arriving between requests.
+        let upstream = CurrentValueSubject<Int, Never>(0)
+        let subscriber = DemandTrackingSubscriber<Int>(initialDemand: .max(1))
+        upstream
+            .coalesceLatest(for: .zero, scheduler: RunLoop.main)
+            .subscribe(subscriber)
+
+        #expect(subscriber.receivedValues == [0])
+
+        upstream.send(1)
+        upstream.send(2)
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        #expect(subscriber.receivedValues == [0])
+
+        subscriber.requestMore(.max(1))
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        #expect(subscriber.receivedValues == [0, 2])
+
+        upstream.send(3)
+        subscriber.requestMore(.max(1))
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        #expect(subscriber.receivedValues == [0, 2, 3])
+        subscriber.cancel()
+    }
+
+    @Test
+    func unlimitedDemandKeepsLeadingEdgeSynchronous() {
+        // Sink-style subscribers (unlimited demand) must keep the original
+        // synchronous leading-edge behavior.
+        let upstream = CurrentValueSubject<Int, Never>(0)
+        let subscriber = DemandTrackingSubscriber<Int>(initialDemand: .unlimited)
+        upstream
+            .coalesceLatest(for: .zero, scheduler: RunLoop.main)
+            .subscribe(subscriber)
+
+        #expect(subscriber.receivedValues == [0])
+        upstream.send(1)
+        #expect(subscriber.receivedValues == [0, 1])
+        upstream.send(2)
+        #expect(subscriber.receivedValues == [0, 1, 2])
+        #expect(subscriber.valuesReceivedWithZeroDemand == 0)
+        subscriber.cancel()
+    }
+}


### PR DESCRIPTION
Fixes a hard startup/runtime crash introduced by https://github.com/manaflow-ai/cmux/pull/8211.

## Crash

`coalesceLatest` ignored downstream demand by design ("sink-style subscribers only"), but `WorkspaceSidebarObservation` consumes it through `.values` (Combine's `AsyncPublisher`), which requests exactly one value at a time and traps with "received an unexpected value" when a value arrives at zero demand. That trap is inside the system Combine binary, so it fires in Release/nightly builds too, not just Debug.

The `@Published` replay is forwarded synchronously from `receive(subscription:)` before the async iterator has requested anything, so the crash window opens at subscription time; any later emission racing the iterator's next request also crashes. Two crash reports on this machine on 2026-07-15 (`com.cmuxterm.app.debug` 21:06, `com.cmuxterm.app.debug.sbver` 21:21) show the identical stack: `AsyncPublisher.Iterator.Inner.receive` assertion fed by `CoalesceLatestInner.receive` under a `PublishedSubject` replay.

## Fix

`CoalesceLatestInner` now tracks outstanding demand. A value reaching an emission point while demand is zero is conflated into a latest-value slot and delivered from `request(_:)` when demand arrives. Values are never dropped silently within a subscription's lifetime (latest wins, which is this operator's semantic anyway) and never forwarded past zero demand. Sink-style subscribers request `.unlimited` upfront, so the synchronous leading-edge behavior the sidebar relies on is unchanged for them.

## Tests

Two-commit red/green: the first commit adds `CoalesceLatestPublisherDemandTests` with a `DemandTrackingSubscriber` that records zero-demand deliveries instead of trapping — replay-before-demand, zero-demand burst conflation, the exact `AsyncPublisher` demand-1 request pattern, and unchanged unlimited-demand leading-edge behavior. The second commit adds the fix.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8236"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786768597&installation_id=133855650&pr_number=8236&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8236&signature=31920a7e69f8802d08f81a2dc81a69ab030e2928adcc689c68623eb5e21fe02f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a startup/runtime crash in `coalesceLatest` when used via Combine `AsyncPublisher` (`.values`) by honoring downstream demand and never emitting at zero demand. This prevents the "received an unexpected value" trap and stabilizes sidebar startup.

- **Bug Fixes**
  - Track downstream demand; hold the latest value when demand is zero and deliver it from `request(_:)`.
  - Keep synchronous leading-edge behavior for `.unlimited` sink-style subscribers.
  - Add `CoalesceLatestPublisherDemandTests` to cover replay-before-demand, zero-demand conflation, demand-1 pattern, and unlimited-demand paths.

<sup>Written for commit f91f662099deb11348a9016fd0c7053285ecb59e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8236?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved `coalesceLatest` demand handling so values are delivered only when requested.
  * Preserved the latest pending value when downstream demand is temporarily unavailable.
  * Ensured cancellation clears undelivered values.

* **Tests**
  * Added coverage for replay, burst coalescing, one-at-a-time demand, and unlimited-demand behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->