### PR TITLE
Revert temporary ios-hotfix-chip-top TestFlight gate and branch dispatch input

### DIFF
--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -14,10 +14,6 @@ on:
   # release flow. See nightly.yml for the rolling dogfood lane.
   workflow_dispatch:
     inputs:
-      branch:
-        description: Optional branch to checkout (for hotfix releases; defaults to main)
-        required: false
-        default: ""
       build_number:
         description: CFBundleVersion to stamp (defaults to UTC yyyyMMddHHmmss)
         required: false
@@ -347,7 +343,6 @@ jobs:
           # range since the last beta.
           fetch-depth: 0
           fetch-tags: true
-          ref: ${{ github.event.inputs.branch || github.ref_name }}
 
       - name: Select Xcode
         run: |

--- a/.github/workflows/ios-testflight.yml
+++ b/.github/workflows/ios-testflight.yml
@@ -314,11 +314,10 @@ jobs:
   upload:
     name: Upload to TestFlight
     needs: decide
-    # Only ever publish from main (or ios-hotfix-chip-top for targeted beta hotfixes).
-    # push/schedule always run on main; this also blocks publishing arbitrary code by
-    # dispatching the workflow against a feature branch (the ASC secrets are only meant
-    # to ship reviewed main). TEMPORARY: gate for ios-hotfix-chip-top hotfix release only.
-    if: needs.decide.outputs.should_build == 'true' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ios-hotfix-chip-top')
+    # Only ever publish from main. push/schedule always run on main; this also
+    # blocks publishing arbitrary code by dispatching the workflow against a
+    # feature branch (the ASC secrets are only meant to ship reviewed main).
+    if: needs.decide.outputs.should_build == 'true' && github.ref == 'refs/heads/main'
     runs-on: ${{ vars.MACOS_RUNNER_IOS || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 60
     outputs:
@@ -609,7 +608,7 @@ jobs:
   assign-internal-group:
     name: Assign build to internal TestFlight group
     needs: [decide, upload]
-    if: (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/ios-hotfix-chip-top') && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
+    if: (needs.decide.outputs.should_build == 'true' || needs.decide.outputs.should_assign_only == 'true') && github.ref == 'refs/heads/main' && (needs.upload.result == 'success' || needs.decide.outputs.should_assign_only == 'true')
     runs-on: ${{ vars.LINUX_RUNNER || 'blacksmith-4vcpu-ubuntu-2404' }}
     timeout-minutes: 40
     env:


### PR DESCRIPTION
The chip-top hotfix shipped to the founders group (build 20260716041132, v1.0.4, verified on ASC in 'cmux founders edition'), so the temporary loosenings on main's TestFlight lane are no longer needed:

- drop `|| refs/heads/ios-hotfix-chip-top` from the upload and internal-assign gates (reverts https://github.com/manaflow-ai/cmux/pull/8216)
- drop the `branch` workflow_dispatch input and the checkout `ref` override, which let a main dispatch ship arbitrary branch code with the ASC secrets

Future rebuilds of this hotfix still work: the branch carries its own workflow copy with its own gate, so dispatching `ios-testflight.yml` with `--ref ios-hotfix-chip-top` is unaffected. The external-assign job conflict resolved in favor of current main (that job was removed by https://github.com/manaflow-ai/cmux/pull/8235 because this lane uploads to dev.cmux.app.internal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8238"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786768705&installation_id=133855650&pr_number=8238&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8238&signature=5d7962359287b335256b91b416c8cde3dcb4515423ca1c9ed1128808ee3fc907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts the temporary `ios-hotfix-chip-top` allowance and removes the `branch` dispatch input, restoring main-only publishing and internal assignment for the iOS TestFlight lane.

- **Refactors**
  - Gate `upload` and `assign-internal-group` jobs to `refs/heads/main` only (remove `ios-hotfix-chip-top` exception).
  - Remove `workflow_dispatch.inputs.branch` and the `actions/checkout` `ref` override.
  - Hotfix builds remain available via the branch’s own workflow; dispatching with `--ref ios-hotfix-chip-top` still works.

<sup>Written for commit f0260730bb810831be3184426824a432839c215c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8238?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Restricted iOS TestFlight uploads and internal distribution assignments to the `main` branch.
  * Removed the option to select a different branch when manually running the TestFlight workflow.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->