### PR TITLE
Fix workspace group-create RPC auth test route

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCGroupActionAuthTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCGroupActionAuthTests.swift
@@ -130,7 +130,7 @@ import Testing
     }
 
     @Test func workspaceGroupCreateCarriesWorkspaceScopedAttachTicketContext() async throws {
-        let route = try hostPortRoute(kind: .tailscale, host: "100.64.0.5", port: 58465)
+        let route = try hostPortRoute(kind: .debugLoopback, host: "127.0.0.1", port: 58465)
         let transport = QueuedCancellationProbeTransport()
         let runtime = TestMobileSyncRuntime(
             transportFactory: QueuedCancellationProbeTransportFactory(transport: transport),


### PR DESCRIPTION
## Summary
- run the workspace group-create auth-context test over trusted loopback, matching the production Stack bearer policy
- retain fail-closed raw Tailscale behavior while restoring full CmuxMobileRPC coverage

## Testing
- `swift test --package-path Packages/iOS/CmuxMobileRPC --scratch-path /tmp/cmux-rpcauth-spm --filter workspaceGroupCreateCarriesWorkspaceScopedAttachTicketContext`
- `swift test --package-path Packages/iOS/CmuxMobileRPC --scratch-path /tmp/cmux-rpcauth-spm`
- `swift test --package-path Packages/iOS/CmuxMobileShellModel --scratch-path /tmp/cmux-rpcauth-shellmodel --filter MobileShellRouteAuthPolicyTests`

## Context
The authenticated-Iroh migration converted the neighboring RPC authorization tests from plaintext Tailscale to loopback but missed the later workspace group-create case. Production correctly rejects Stack bearer transmission over raw Tailscale TCP, so this test must exercise its attach-ticket assertions through the trusted loopback route.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786768707&installation_id=133855650&pr_number=8239&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8239&signature=eecdc53b54c517e7cf424a371e94d8bda672458375e56aecbf6318acb577fdcb"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the workspace group-create RPC auth test to run over the trusted `debugLoopback` (`127.0.0.1`) route instead of Tailscale. This aligns with production Stack bearer policy and restores attach-ticket verification in `CmuxMobileRPC` tests.

<sup>Written for commit 787f771c80ba62b3b8ea0454e941896efa9650a8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8239?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated workspace group creation coverage to use a local debug loopback connection.
  * Continued verifying that attach ticket and stack access tokens are included in the transmitted request.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->