### PR TITLE
Coalesce terminal resizes during split-divider drags

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
@@ -1,15 +1,26 @@
-extension TerminalSurface {
-    /// Returns whether same-grid pixel changes should be coalesced for the current resize interaction.
+/// Decides whether a surface should defer a same-grid pixel-size update during an interaction.
+public struct TerminalSurfaceResizeCoalescingPolicy: Sendable {
+    private let windowLiveResizeActive: Bool
+    private let interactiveGeometryResizeActive: Bool
+    private let bypass: Bool
+
+    /// Creates a policy evaluation for the current resize state.
     ///
     /// - Parameter windowLiveResizeActive: Whether AppKit is tracking a window-edge resize.
     /// - Parameter interactiveGeometryResizeActive: Whether a pane or sidebar geometry transaction is active.
     /// - Parameter bypass: Whether the caller requires the exact candidate size to be applied immediately.
-    /// - Returns: `true` when pixel-only surface size changes should be withheld.
-    public static func shouldCoalesceSurfacePixelResize(
+    public init(
         windowLiveResizeActive: Bool,
         interactiveGeometryResizeActive: Bool,
         bypass: Bool
-    ) -> Bool {
+    ) {
+        self.windowLiveResizeActive = windowLiveResizeActive
+        self.interactiveGeometryResizeActive = interactiveGeometryResizeActive
+        self.bypass = bypass
+    }
+
+    /// Whether pixel-only surface size changes should be withheld.
+    public var shouldCoalescePixelOnlyResize: Bool {
         (windowLiveResizeActive || interactiveGeometryResizeActive) && !bypass
     }
 }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
@@ -1,0 +1,16 @@
+extension TerminalSurface {
+    /// Returns whether same-grid pixel changes should be coalesced for the current resize interaction.
+    ///
+    /// - Parameter windowLiveResizeActive: Whether AppKit is tracking a window-edge resize.
+    /// - Parameter interactiveGeometryResizeActive: Whether a pane or sidebar geometry transaction is active.
+    /// - Parameter bypass: Whether the caller requires the exact candidate size to be applied immediately.
+    /// - Returns: `true` when pixel-only surface size changes should be withheld.
+    public static func shouldCoalesceSurfacePixelResize(
+        windowLiveResizeActive: Bool,
+        interactiveGeometryResizeActive: Bool,
+        bypass: Bool
+    ) -> Bool {
+        _ = interactiveGeometryResizeActive
+        return windowLiveResizeActive && !bypass
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurfaceResizeCoalescingPolicy.swift
@@ -10,7 +10,6 @@ extension TerminalSurface {
         interactiveGeometryResizeActive: Bool,
         bypass: Bool
     ) -> Bool {
-        _ = interactiveGeometryResizeActive
-        return windowLiveResizeActive && !bypass
+        (windowLiveResizeActive || interactiveGeometryResizeActive) && !bypass
     }
 }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
@@ -1,0 +1,30 @@
+import Testing
+@testable import CmuxTerminal
+
+@Suite
+struct TerminalSurfaceResizeCoalescingPolicyTests {
+    @Test
+    func interactivePaneResizeUsesPixelOnlyCoalescing() {
+        #expect(
+            TerminalSurface.shouldCoalesceSurfacePixelResize(
+                windowLiveResizeActive: false,
+                interactiveGeometryResizeActive: true,
+                bypass: false
+            )
+        )
+        #expect(
+            TerminalSurface.shouldCoalesceSurfacePixelResize(
+                windowLiveResizeActive: true,
+                interactiveGeometryResizeActive: false,
+                bypass: false
+            )
+        )
+        #expect(
+            !TerminalSurface.shouldCoalesceSurfacePixelResize(
+                windowLiveResizeActive: false,
+                interactiveGeometryResizeActive: true,
+                bypass: true
+            )
+        )
+    }
+}

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfaceResizeCoalescingPolicyTests.swift
@@ -6,25 +6,25 @@ struct TerminalSurfaceResizeCoalescingPolicyTests {
     @Test
     func interactivePaneResizeUsesPixelOnlyCoalescing() {
         #expect(
-            TerminalSurface.shouldCoalesceSurfacePixelResize(
+            TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: false,
                 interactiveGeometryResizeActive: true,
                 bypass: false
-            )
+            ).shouldCoalescePixelOnlyResize
         )
         #expect(
-            TerminalSurface.shouldCoalesceSurfacePixelResize(
+            TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: true,
                 interactiveGeometryResizeActive: false,
                 bypass: false
-            )
+            ).shouldCoalescePixelOnlyResize
         )
         #expect(
-            !TerminalSurface.shouldCoalesceSurfacePixelResize(
+            !TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: false,
                 interactiveGeometryResizeActive: true,
                 bypass: true
-            )
+            ).shouldCoalescePixelOnlyResize
         )
     }
 }

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1508,7 +1508,7 @@ struct ContentView: View {
             .onDisappear {
                 hoveredResizerHandles.remove(handle)
                 if isResizerDragging {
-                    TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                    TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: tabManager)
                     isResizerDragging = false
                 }
                 sidebarDragStartWidth = nil
@@ -1520,7 +1520,10 @@ struct ContentView: View {
                     .onChanged { value in
                         let config = resizerConfig(for: handle, availableWidth: availableWidth)
                         if !isResizerDragging {
-                            TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+                            TerminalWindowPortalRegistry.beginInteractiveGeometryResize(
+                                owner: tabManager,
+                                in: observedWindow
+                            )
                             isResizerDragging = true
                             config.captureStart()
                         }
@@ -1529,7 +1532,7 @@ struct ContentView: View {
                     }
                     .onEnded { _ in
                         if isResizerDragging {
-                            TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                            TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: tabManager)
                             isResizerDragging = false
                             let config = resizerConfig(for: handle, availableWidth: availableWidth)
                             config.finishDrag()
@@ -3080,7 +3083,7 @@ struct ContentView: View {
 
         view = AnyView(view.onDisappear {
             if isResizerDragging {
-                TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: tabManager)
                 isResizerDragging = false
                 sidebarDragStartWidth = nil
             }

--- a/Sources/DockSplitStore+PaneFocus.swift
+++ b/Sources/DockSplitStore+PaneFocus.swift
@@ -139,6 +139,24 @@ extension DockSplitStore {
         selectedPanel.focus()
     }
 
+    func splitTabBarDividerDragDidBegin(_ controller: BonsplitController) {
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(
+            owner: controller,
+            in: terminalResizeInteractionWindow()
+        )
+    }
+
+    func splitTabBarDividerDragDidEnd(_ controller: BonsplitController) {
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: controller)
+    }
+
+    private func terminalResizeInteractionWindow() -> NSWindow? {
+        if let eventWindow = NSApp.currentEvent?.window { return eventWindow }
+        return panels.values.lazy.compactMap { panel in
+            (panel as? TerminalPanel)?.hostedView.window
+        }.first
+    }
+
     func splitTabBar(_ controller: BonsplitController, didSelectTab tab: Bonsplit.Tab, inPane pane: PaneID) {
         applyDockSelection(tabId: tab.id, inPane: pane)
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4001,13 +4001,13 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         }
     }
 
-    private static func shouldDeferSurfaceResizeForActiveDrag() -> Bool {
+    private static func shouldDeferSurfaceResizeForActiveDrag(in window: NSWindow?) -> Bool {
         // The drag pasteboard can retain tab-transfer UTIs briefly after a split command
         // or other layout churn. Only defer terminal resizes while an actual drag event
         // is in flight; otherwise pre-existing panes can stay stuck at their old size.
         // Interactive geometry resize already has an explicit fast path for sidebar and
         // split-divider drags. Do not let stale drag-pasteboard state suppress those updates.
-        if TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive {
+        if TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window) {
             return false
         }
         guard hasTabDragPasteboardTypes() else { return false }
@@ -4016,7 +4016,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     private func activeSurfaceResizeDeferralReason() -> String? {
         if isWindowLiveResizeActive { return nil }
-        return Self.shouldDeferSurfaceResizeForActiveDrag() ? "tabDrag" : nil
+        return Self.shouldDeferSurfaceResizeForActiveDrag(in: window) ? "tabDrag" : nil
     }
 
     private var isWindowLiveResizeActive: Bool {
@@ -4162,14 +4162,14 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             backingSize: backingSize,
             coalescePixelOnlyResize: TerminalSurface.shouldCoalesceSurfacePixelResize(
                 windowLiveResizeActive: isWindowLiveResizeActive,
-                interactiveGeometryResizeActive: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive,
+                interactiveGeometryResizeActive: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window),
                 bypass: bypassLiveResizeCoalescing
             ),
             // Don't pin the surface to the tmux-assigned grid mid-drag: the pin
             // would hold it at the pre-drag (larger) size and paint past the
             // shrinking pane. Re-pins at rest when the interactive flag clears.
             suppressAssignedGridPin: isWindowLiveResizeActive
-                || TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
+                || TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window)
         )
         return didChange || surfaceSizeChanged
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4160,7 +4160,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             yScale: yScale,
             layerScale: layerScale,
             backingSize: backingSize,
-            coalescePixelOnlyResize: isWindowLiveResizeActive && !bypassLiveResizeCoalescing,
+            coalescePixelOnlyResize: TerminalSurface.shouldCoalesceSurfacePixelResize(
+                windowLiveResizeActive: isWindowLiveResizeActive,
+                interactiveGeometryResizeActive: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive,
+                bypass: bypassLiveResizeCoalescing
+            ),
             // Don't pin the surface to the tmux-assigned grid mid-drag: the pin
             // would hold it at the pre-drag (larger) size and paint past the
             // shrinking pane. Re-pins at rest when the interactive flag clears.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -4160,11 +4160,11 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
             yScale: yScale,
             layerScale: layerScale,
             backingSize: backingSize,
-            coalescePixelOnlyResize: TerminalSurface.shouldCoalesceSurfacePixelResize(
+            coalescePixelOnlyResize: TerminalSurfaceResizeCoalescingPolicy(
                 windowLiveResizeActive: isWindowLiveResizeActive,
                 interactiveGeometryResizeActive: TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window),
                 bypass: bypassLiveResizeCoalescing
-            ),
+            ).shouldCoalescePixelOnlyResize,
             // Don't pin the surface to the tmux-assigned grid mid-drag: the pin
             // would hold it at the pre-drag (larger) size and paint past the
             // shrinking pane. Re-pins at rest when the interactive flag clears.

--- a/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
+++ b/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
@@ -627,6 +627,7 @@ extension RemoteTmuxWindowMirror: BonsplitDelegate {
     }
 
     func splitTabBarDividerDragDidBegin(_ controller: BonsplitController) {
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
         dividerResizeSentSinceDragBegan = false
         // An imposition that moved a divider parks its baseline at nil,
         // waiting for a post-layout geometry callback to record the clamped
@@ -651,6 +652,7 @@ extension RemoteTmuxWindowMirror: BonsplitDelegate {
     }
 
     func splitTabBarDividerDragDidEnd(_ controller: BonsplitController) {
+        defer { TerminalWindowPortalRegistry.endInteractiveGeometryResize() }
         // A drag ending while a remote layout is being applied cannot run the
         // divider sync mid-apply: the apply is rewriting the tree this send
         // would diff against. Skipping the send outright loses the user's final

--- a/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
+++ b/Sources/RemoteTmuxWindowMirror+Bonsplit.swift
@@ -1,5 +1,6 @@
-import CmuxRemoteSession
+import AppKit
 import Bonsplit
+import CmuxRemoteSession
 import Foundation
 
 @MainActor
@@ -627,7 +628,10 @@ extension RemoteTmuxWindowMirror: BonsplitDelegate {
     }
 
     func splitTabBarDividerDragDidBegin(_ controller: BonsplitController) {
-        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(
+            owner: controller,
+            in: NSApp.currentEvent?.window ?? visibleHostingContext()?.window
+        )
         dividerResizeSentSinceDragBegan = false
         // An imposition that moved a divider parks its baseline at nil,
         // waiting for a post-layout geometry callback to record the clamped
@@ -652,7 +656,7 @@ extension RemoteTmuxWindowMirror: BonsplitDelegate {
     }
 
     func splitTabBarDividerDragDidEnd(_ controller: BonsplitController) {
-        defer { TerminalWindowPortalRegistry.endInteractiveGeometryResize() }
+        defer { TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: controller) }
         // A drag ending while a remote layout is being applied cannot run the
         // divider sync mid-apply: the apply is rewriting the tree this send
         // would diff against. Skipping the send outright loses the user's final

--- a/Sources/RemoteTmuxWindowMirror+SizingTransaction.swift
+++ b/Sources/RemoteTmuxWindowMirror+SizingTransaction.swift
@@ -241,8 +241,9 @@ extension RemoteTmuxWindowMirror {
         // at the top of performSizingPassNow does NOT cover a window resize,
         // so gate the stale re-pin here. The fresh setAssignedGrid below is
         // left alone: it applies tmux's own assignment, never a stale one.
-        let suppressPin = visibleHostingContext()?.window?.inLiveResize == true
-            || TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
+        let hostingWindow = visibleHostingContext()?.window
+        let suppressPin = hostingWindow?.inLiveResize == true
+            || TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: hostingWindow)
         var panesToRepaint: [Int] = []
         for (paneId, panel) in panelsByPaneId {
             // Under zoom the visible tree is the single zoomed leaf, but the

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -2243,10 +2243,6 @@ final class WindowTerminalPortal: NSObject {
 
 @MainActor
 enum TerminalWindowPortalRegistry {
-    private struct InteractiveGeometryResizeOwnerState {
-        let windowId: ObjectIdentifier?
-    }
-
 #if DEBUG
     static var isPointerDragActiveForTesting = false
 #endif
@@ -2256,7 +2252,8 @@ enum TerminalWindowPortalRegistry {
     private static var externalGeometrySyncForAllWindowsGeneration: UInt64 = 0
     private static var interactiveGeometryResizeCountsByWindowId: [ObjectIdentifier: Int] = [:]
     private static var unscopedInteractiveGeometryResizeCount = 0
-    private static var interactiveGeometryResizeOwners: [ObjectIdentifier: InteractiveGeometryResizeOwnerState] = [:]
+    private static var interactiveGeometryResizeOwnerWindowIds: [ObjectIdentifier: ObjectIdentifier] = [:]
+    private static var unscopedInteractiveGeometryResizeOwnerIds: Set<ObjectIdentifier> = []
     private static var activeSplitDividerDragWindowId: ObjectIdentifier?
     private static var activeSplitDividerDragEventNumber: Int?
 #if DEBUG
@@ -2419,7 +2416,7 @@ enum TerminalWindowPortalRegistry {
         }
         hostedToWindowId = hostedToWindowId.filter { $0.value != windowId }
         interactiveGeometryResizeCountsByWindowId.removeValue(forKey: windowId)
-        interactiveGeometryResizeOwners = interactiveGeometryResizeOwners.filter { $0.value.windowId != windowId }
+        interactiveGeometryResizeOwnerWindowIds = interactiveGeometryResizeOwnerWindowIds.filter { $0.value != windowId }
 
         guard let window else { return }
         if let observer = objc_getAssociatedObject(window, &cmuxWindowTerminalPortalCloseObserverKey) {
@@ -2543,16 +2540,24 @@ enum TerminalWindowPortalRegistry {
 
     static func beginInteractiveGeometryResize(owner: AnyObject, in window: NSWindow?) {
         let ownerId = ObjectIdentifier(owner)
-        guard interactiveGeometryResizeOwners[ownerId] == nil else { return }
-        let windowId = window.map(ObjectIdentifier.init)
-        interactiveGeometryResizeOwners[ownerId] = InteractiveGeometryResizeOwnerState(windowId: windowId)
-        beginInteractiveGeometryResize(windowId: windowId)
+        guard interactiveGeometryResizeOwnerWindowIds[ownerId] == nil,
+              !unscopedInteractiveGeometryResizeOwnerIds.contains(ownerId) else { return }
+        if let windowId = window.map(ObjectIdentifier.init) {
+            interactiveGeometryResizeOwnerWindowIds[ownerId] = windowId
+            beginInteractiveGeometryResize(windowId: windowId)
+        } else {
+            unscopedInteractiveGeometryResizeOwnerIds.insert(ownerId)
+            beginInteractiveGeometryResize(windowId: nil)
+        }
     }
 
     static func endInteractiveGeometryResize(owner: AnyObject) {
         let ownerId = ObjectIdentifier(owner)
-        guard let state = interactiveGeometryResizeOwners.removeValue(forKey: ownerId) else { return }
-        endInteractiveGeometryResize(windowId: state.windowId)
+        if let windowId = interactiveGeometryResizeOwnerWindowIds.removeValue(forKey: ownerId) {
+            endInteractiveGeometryResize(windowId: windowId)
+        } else if unscopedInteractiveGeometryResizeOwnerIds.remove(ownerId) != nil {
+            endInteractiveGeometryResize(windowId: nil)
+        }
     }
 
     private static func beginInteractiveGeometryResize(windowId: ObjectIdentifier?) {
@@ -2595,7 +2600,8 @@ enum TerminalWindowPortalRegistry {
     static func resetInteractiveGeometryStateForTesting() {
         interactiveGeometryResizeCountsByWindowId.removeAll()
         unscopedInteractiveGeometryResizeCount = 0
-        interactiveGeometryResizeOwners.removeAll()
+        interactiveGeometryResizeOwnerWindowIds.removeAll()
+        unscopedInteractiveGeometryResizeOwnerIds.removeAll()
         clearActiveSplitDividerDrag()
         isPointerDragActiveForTesting = false
     }

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -2517,7 +2517,13 @@ enum TerminalWindowPortalRegistry {
     }
 
     static func endInteractiveGeometryResize() {
-        interactiveGeometryResizeCount = max(0, interactiveGeometryResizeCount - 1)
+        guard interactiveGeometryResizeCount > 0 else { return }
+        interactiveGeometryResizeCount -= 1
+        if interactiveGeometryResizeCount == 0 {
+            // Apply the final exact renderer and PTY dimensions after the
+            // interaction-wide pixel-only coalescing gate has cleared.
+            scheduleExternalGeometrySynchronizeForAllWindows(forceImmediate: false)
+        }
     }
 
 #if DEBUG

--- a/Sources/TerminalWindowPortal.swift
+++ b/Sources/TerminalWindowPortal.swift
@@ -936,7 +936,7 @@ final class WindowTerminalPortal: NSObject {
                     shouldFlushLatestNow = self.window?.inLiveResize == true
                 }
                 if !shouldFlushLatestNow {
-                    shouldFlushLatestNow = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
+                    shouldFlushLatestNow = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: self.window)
                 }
                 // During sidebar/split drags, new geometry requests can arrive
                 // faster than this queued sync runs. Flush the latest visible
@@ -974,7 +974,7 @@ final class WindowTerminalPortal: NSObject {
                 shouldPerformNow = self.window?.inLiveResize == true
             }
             if !shouldPerformNow {
-                shouldPerformNow = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive
+                shouldPerformNow = TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: self.window)
             }
             if shouldPerformNow {
                 performSync()
@@ -1645,7 +1645,7 @@ final class WindowTerminalPortal: NSObject {
         // window-relative position changed without their own frame
         // changing, and the end-of-resize sync (windowDidEndLiveResize →
         // scheduleExternalGeometrySynchronize) stays unconditional.
-        guard TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive else {
+        guard TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window) else {
             if !isWindowLiveResizeActive {
                 pruneDeadEntries()
             }
@@ -2243,6 +2243,10 @@ final class WindowTerminalPortal: NSObject {
 
 @MainActor
 enum TerminalWindowPortalRegistry {
+    private struct InteractiveGeometryResizeOwnerState {
+        let windowId: ObjectIdentifier?
+    }
+
 #if DEBUG
     static var isPointerDragActiveForTesting = false
 #endif
@@ -2250,7 +2254,9 @@ enum TerminalWindowPortalRegistry {
     static var hostedToWindowId: [ObjectIdentifier: ObjectIdentifier] = [:]
     private static var hasPendingExternalGeometrySyncForAllWindows = false
     private static var externalGeometrySyncForAllWindowsGeneration: UInt64 = 0
-    private static var interactiveGeometryResizeCount = 0
+    private static var interactiveGeometryResizeCountsByWindowId: [ObjectIdentifier: Int] = [:]
+    private static var unscopedInteractiveGeometryResizeCount = 0
+    private static var interactiveGeometryResizeOwners: [ObjectIdentifier: InteractiveGeometryResizeOwnerState] = [:]
     private static var activeSplitDividerDragWindowId: ObjectIdentifier?
     private static var activeSplitDividerDragEventNumber: Int?
 #if DEBUG
@@ -2258,11 +2264,24 @@ enum TerminalWindowPortalRegistry {
     static var blockedBindReasons: [String: Int] = [:]
 #endif
 
-    static var isInteractiveGeometryResizeActive: Bool {
+    static func isInteractiveGeometryResizeActive(in window: NSWindow?) -> Bool {
 #if DEBUG
         if Self.isPointerDragActiveForTesting { return true }
 #endif
-        if Self.interactiveGeometryResizeCount > 0 { return true }
+        if Self.unscopedInteractiveGeometryResizeCount > 0 { return true }
+        if let window,
+           Self.interactiveGeometryResizeCountsByWindowId[ObjectIdentifier(window), default: 0] > 0 {
+            return true
+        }
+        return isSplitDividerDragActive(in: window)
+    }
+
+    private static var isAnyInteractiveGeometryResizeActive: Bool {
+#if DEBUG
+        if Self.isPointerDragActiveForTesting { return true }
+#endif
+        if Self.unscopedInteractiveGeometryResizeCount > 0 { return true }
+        if Self.interactiveGeometryResizeCountsByWindowId.values.contains(where: { $0 > 0 }) { return true }
         return isCurrentEventSplitDividerDrag()
     }
 
@@ -2399,6 +2418,8 @@ enum TerminalWindowPortalRegistry {
             portal.tearDown()
         }
         hostedToWindowId = hostedToWindowId.filter { $0.value != windowId }
+        interactiveGeometryResizeCountsByWindowId.removeValue(forKey: windowId)
+        interactiveGeometryResizeOwners = interactiveGeometryResizeOwners.filter { $0.value.windowId != windowId }
 
         guard let window else { return }
         if let observer = objc_getAssociatedObject(window, &cmuxWindowTerminalPortalCloseObserverKey) {
@@ -2512,30 +2533,69 @@ enum TerminalWindowPortalRegistry {
     }
 #endif
 
-    static func beginInteractiveGeometryResize() {
-        interactiveGeometryResizeCount += 1
+    static func beginInteractiveGeometryResize(in window: NSWindow?) {
+        beginInteractiveGeometryResize(windowId: window.map(ObjectIdentifier.init))
     }
 
-    static func endInteractiveGeometryResize() {
-        guard interactiveGeometryResizeCount > 0 else { return }
-        interactiveGeometryResizeCount -= 1
-        if interactiveGeometryResizeCount == 0 {
-            // Apply the final exact renderer and PTY dimensions after the
-            // interaction-wide pixel-only coalescing gate has cleared.
-            scheduleExternalGeometrySynchronizeForAllWindows(forceImmediate: false)
+    static func endInteractiveGeometryResize(in window: NSWindow?) {
+        endInteractiveGeometryResize(windowId: window.map(ObjectIdentifier.init))
+    }
+
+    static func beginInteractiveGeometryResize(owner: AnyObject, in window: NSWindow?) {
+        let ownerId = ObjectIdentifier(owner)
+        guard interactiveGeometryResizeOwners[ownerId] == nil else { return }
+        let windowId = window.map(ObjectIdentifier.init)
+        interactiveGeometryResizeOwners[ownerId] = InteractiveGeometryResizeOwnerState(windowId: windowId)
+        beginInteractiveGeometryResize(windowId: windowId)
+    }
+
+    static func endInteractiveGeometryResize(owner: AnyObject) {
+        let ownerId = ObjectIdentifier(owner)
+        guard let state = interactiveGeometryResizeOwners.removeValue(forKey: ownerId) else { return }
+        endInteractiveGeometryResize(windowId: state.windowId)
+    }
+
+    private static func beginInteractiveGeometryResize(windowId: ObjectIdentifier?) {
+        guard let windowId else {
+            unscopedInteractiveGeometryResizeCount += 1
+            return
+        }
+        interactiveGeometryResizeCountsByWindowId[windowId, default: 0] += 1
+    }
+
+    private static func endInteractiveGeometryResize(windowId: ObjectIdentifier?) {
+        guard let windowId else {
+            guard unscopedInteractiveGeometryResizeCount > 0 else { return }
+            unscopedInteractiveGeometryResizeCount -= 1
+            if unscopedInteractiveGeometryResizeCount == 0 {
+                for (portalWindowId, portal) in portalsByWindowId
+                where interactiveGeometryResizeCountsByWindowId[portalWindowId, default: 0] == 0 {
+                    portal.scheduleExternalGeometrySynchronize(forceImmediate: false)
+                }
+            }
+            return
+        }
+
+        guard let count = interactiveGeometryResizeCountsByWindowId[windowId], count > 0 else { return }
+        if count == 1 {
+            interactiveGeometryResizeCountsByWindowId.removeValue(forKey: windowId)
+            // Apply the final exact renderer and PTY dimensions only in the
+            // window whose pixel-only coalescing gate just cleared.
+            if unscopedInteractiveGeometryResizeCount == 0 {
+                portalsByWindowId[windowId]?.scheduleExternalGeometrySynchronize(forceImmediate: false)
+            }
+        } else {
+            interactiveGeometryResizeCountsByWindowId[windowId] = count - 1
         }
     }
 
 #if DEBUG
-    /// Test support: clears the interactive-geometry state the production API
-    /// cannot reach. beginInteractiveGeometryResize is refcounted with no
-    /// owner handle, so a test that fails (or wedges) before its balancing
-    /// end call would leave the flag latched for every later test — and a
-    /// latched flag turns each anchor geometry callback into a synchronous
-    /// full-layout pass, which re-dirties layout when it runs inside a
-    /// SwiftUI layout pass. Suites that touch this state call it in tearDown.
+    /// Test support: clears interactive geometry state after a failed test
+    /// whose balancing end call may not have run.
     static func resetInteractiveGeometryStateForTesting() {
-        interactiveGeometryResizeCount = 0
+        interactiveGeometryResizeCountsByWindowId.removeAll()
+        unscopedInteractiveGeometryResizeCount = 0
+        interactiveGeometryResizeOwners.removeAll()
         clearActiveSplitDividerDrag()
         isPointerDragActiveForTesting = false
     }
@@ -2548,12 +2608,12 @@ enum TerminalWindowPortalRegistry {
         let generation = Self.externalGeometrySyncForAllWindowsGeneration
         guard !Self.hasPendingExternalGeometrySyncForAllWindows else { return }
         Self.hasPendingExternalGeometrySyncForAllWindows = true
-        let isDragEvent = forceImmediate || Self.isInteractiveGeometryResizeActive
+        let isDragEvent = forceImmediate || Self.isAnyInteractiveGeometryResizeActive
         DispatchQueue.main.async {
             let performSync = {
                 var shouldFlushLatestNow = isDragEvent
                 if !shouldFlushLatestNow {
-                    shouldFlushLatestNow = Self.isInteractiveGeometryResizeActive
+                    shouldFlushLatestNow = Self.isAnyInteractiveGeometryResizeActive
                 }
                 if Self.externalGeometrySyncForAllWindowsGeneration != generation, !shouldFlushLatestNow {
                     Self.hasPendingExternalGeometrySyncForAllWindows = false
@@ -2567,7 +2627,7 @@ enum TerminalWindowPortalRegistry {
             }
             var shouldPerformNow = isDragEvent
             if !shouldPerformNow {
-                shouldPerformNow = Self.isInteractiveGeometryResizeActive
+                shouldPerformNow = Self.isAnyInteractiveGeometryResizeActive
             }
             if shouldPerformNow {
                 performSync()

--- a/Sources/Workspace+TerminalResizeInteraction.swift
+++ b/Sources/Workspace+TerminalResizeInteraction.swift
@@ -1,11 +1,22 @@
+import AppKit
 import Bonsplit
 
 extension Workspace {
     func splitTabBarDividerDragDidBegin(_ controller: BonsplitController) {
-        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(
+            owner: controller,
+            in: terminalResizeInteractionWindow()
+        )
     }
 
     func splitTabBarDividerDragDidEnd(_ controller: BonsplitController) {
-        TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: controller)
+    }
+
+    private func terminalResizeInteractionWindow() -> NSWindow? {
+        if let eventWindow = NSApp.currentEvent?.window { return eventWindow }
+        return panels.values.lazy.compactMap { panel in
+            (panel as? TerminalPanel)?.hostedView.window
+        }.first
     }
 }

--- a/Sources/Workspace+TerminalResizeInteraction.swift
+++ b/Sources/Workspace+TerminalResizeInteraction.swift
@@ -1,0 +1,11 @@
+import Bonsplit
+
+extension Workspace {
+    func splitTabBarDividerDragDidBegin(_ controller: BonsplitController) {
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+    }
+
+    func splitTabBarDividerDragDidEnd(_ controller: BonsplitController) {
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1878,6 +1878,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C7268002000000000000001 /* Workspace+SidebarDirectories.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7268002000000000000002 /* Workspace+SidebarDirectories.swift */; };
 		C3744E100000000000000001 /* Workspace+SidebarStatusVisibility.swift in Sources */ = {isa = PBXBuildFile; fileRef = C3744E100000000000000002 /* Workspace+SidebarStatusVisibility.swift */; };
 		CA52B0170000000000000000 /* Workspace+SurfaceNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA52C0170000000000000000 /* Workspace+SurfaceNavigation.swift */; };
+		822900000000000000000001 /* Workspace+TerminalResizeInteraction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 822900000000000000000002 /* Workspace+TerminalResizeInteraction.swift */; };
 		4DF302A0C8164672B8547449 /* Workspace+TitleOwnership.swift in Sources */ = {isa = PBXBuildFile; fileRef = D21553D9A12B4EE4974E1943 /* Workspace+TitleOwnership.swift */; };
 		9ACC298766940729D65B3651 /* Workspace+TodoNotifications.swift in Sources */ = {isa = PBXBuildFile; fileRef = 97A8F8FE70450C596AE80D94 /* Workspace+TodoNotifications.swift */; };
 		B8C2E4B811F31AEDF14C7FF0 /* Workspace+TodoPane.swift in Sources */ = {isa = PBXBuildFile; fileRef = C30350CE2602EEAFBD873DC9 /* Workspace+TodoPane.swift */; };
@@ -3823,6 +3824,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C7268002000000000000002 /* Workspace+SidebarDirectories.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SidebarDirectories.swift"; sourceTree = "<group>"; };
 		C3744E100000000000000002 /* Workspace+SidebarStatusVisibility.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SidebarStatusVisibility.swift"; sourceTree = "<group>"; };
 		CA52C0170000000000000000 /* Workspace+SurfaceNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+SurfaceNavigation.swift"; sourceTree = "<group>"; };
+		822900000000000000000002 /* Workspace+TerminalResizeInteraction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+TerminalResizeInteraction.swift"; sourceTree = "<group>"; };
 		D21553D9A12B4EE4974E1943 /* Workspace+TitleOwnership.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+TitleOwnership.swift"; sourceTree = "<group>"; };
 		97A8F8FE70450C596AE80D94 /* Workspace+TodoNotifications.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+TodoNotifications.swift"; sourceTree = "<group>"; };
 		C30350CE2602EEAFBD873DC9 /* Workspace+TodoPane.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+TodoPane.swift"; sourceTree = "<group>"; };
@@ -4553,6 +4555,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				804100000000000000000002 /* TabManager+AdjacentWorkspaceReordering.swift */,
 				E3B7A400000000000000020B /* Workspace+WorkspaceSurfaceTreeReading.swift */,
 				CA52C0170000000000000000 /* Workspace+SurfaceNavigation.swift */,
+				822900000000000000000002 /* Workspace+TerminalResizeInteraction.swift */,
 				A5001511 /* UITestRecorder.swift */,
 				A5001520 /* PostHogAnalytics.swift */,
 				A5001416 /* Workspace.swift */,
@@ -7589,6 +7592,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C7268002000000000000001 /* Workspace+SidebarDirectories.swift in Sources */,
 				C3744E100000000000000001 /* Workspace+SidebarStatusVisibility.swift in Sources */,
 				CA52B0170000000000000000 /* Workspace+SurfaceNavigation.swift in Sources */,
+				822900000000000000000001 /* Workspace+TerminalResizeInteraction.swift in Sources */,
 				4DF302A0C8164672B8547449 /* Workspace+TitleOwnership.swift in Sources */,
 				9ACC298766940729D65B3651 /* Workspace+TodoNotifications.swift in Sources */,
 				B8C2E4B811F31AEDF14C7FF0 /* Workspace+TodoPane.swift in Sources */,

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5448,9 +5448,9 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
             "Initial hit-testing should resolve the portal-hosted terminal at its original window position"
         )
 
-        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(in: window)
         defer {
-            TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+            TerminalWindowPortalRegistry.endInteractiveGeometryResize(in: window)
         }
 
         do {
@@ -5519,9 +5519,9 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         realizeWindowLayout(window)
         let originalHostedFrame = hosted.frame
 
-        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(in: window)
         defer {
-            TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+            TerminalWindowPortalRegistry.endInteractiveGeometryResize(in: window)
         }
 
         shiftedContainer.frame.origin.x += 72
@@ -5591,17 +5591,17 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         // With frame notifications disabled, only the interaction zero
         // crossing can discover and apply this final geometry.
         anchor.postsFrameChangedNotifications = false
-        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(in: window)
         var interactionIsActive = true
         defer {
             if interactionIsActive {
-                TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize(in: window)
             }
         }
         anchor.frame.size.width -= 120
         XCTAssertEqual(surface.debugCurrentPixelSize().width, initialPixelSize.width)
 
-        TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize(in: window)
         interactionIsActive = false
         drainMainQueue()
         drainMainQueue()
@@ -5610,6 +5610,163 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
             surface.debugCurrentPixelSize().width,
             initialPixelSize.width,
             "Ending the resize interaction should flush the final exact terminal width"
+        )
+    }
+
+    func testInteractiveGeometryResizeIsScopedToOwningWindow() {
+        let firstWindow = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 420)
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: firstWindow)
+            firstWindow.orderOut(nil)
+        }
+        let secondWindow = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 420)
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: secondWindow)
+            secondWindow.orderOut(nil)
+        }
+
+        let firstSurface = makeTrackedTerminalSurface()
+        let secondSurface = makeTrackedTerminalSurface()
+        guard let firstContentView = firstWindow.contentView,
+              let secondContentView = secondWindow.contentView else {
+            XCTFail("Expected content views")
+            return
+        }
+
+        let firstAnchor = NSView(frame: NSRect(x: 40, y: 60, width: 420, height: 220))
+        firstContentView.addSubview(firstAnchor)
+        let secondAnchor = NSView(frame: NSRect(x: 40, y: 60, width: 420, height: 220))
+        secondContentView.addSubview(secondAnchor)
+        TerminalWindowPortalRegistry.bind(
+            hostedView: firstSurface.hostedView,
+            to: firstAnchor,
+            visibleInUI: true,
+            expectedSurfaceId: firstSurface.id,
+            expectedGeneration: firstSurface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.bind(
+            hostedView: secondSurface.hostedView,
+            to: secondAnchor,
+            visibleInUI: true,
+            expectedSurfaceId: secondSurface.id,
+            expectedGeneration: secondSurface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(firstAnchor)
+        TerminalWindowPortalRegistry.synchronizeForAnchor(secondAnchor)
+        realizeWindowLayout(firstWindow)
+        realizeWindowLayout(secondWindow)
+        for _ in 0..<4 { drainMainQueue() }
+
+        let initialFirstWidth = firstSurface.debugCurrentPixelSize().width
+        let initialSecondWidth = secondSurface.debugCurrentPixelSize().width
+        XCTAssertGreaterThan(initialFirstWidth, 0)
+        XCTAssertGreaterThan(initialSecondWidth, 0)
+
+        firstAnchor.postsFrameChangedNotifications = false
+        secondAnchor.postsFrameChangedNotifications = false
+        let outerInteractionOwner = NSObject()
+        let nestedInteractionOwner = NSObject()
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(
+            owner: outerInteractionOwner,
+            in: firstWindow
+        )
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(
+            owner: nestedInteractionOwner,
+            in: firstWindow
+        )
+        var outerInteractionIsActive = true
+        var nestedInteractionIsActive = true
+        defer {
+            if outerInteractionIsActive {
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: outerInteractionOwner)
+            }
+            if nestedInteractionIsActive {
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: nestedInteractionOwner)
+            }
+        }
+
+        XCTAssertTrue(TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: firstWindow))
+        XCTAssertFalse(TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: secondWindow))
+        firstAnchor.frame.size.width -= 120
+        secondAnchor.frame.size.width -= 120
+
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: outerInteractionOwner)
+        outerInteractionIsActive = false
+        XCTAssertTrue(
+            TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: firstWindow),
+            "Nested resize ownership should keep the window coalescing until every owner ends"
+        )
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: nestedInteractionOwner)
+        nestedInteractionIsActive = false
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertLess(
+            firstSurface.debugCurrentPixelSize().width,
+            initialFirstWidth,
+            "Drag end should flush the owning window's final terminal width"
+        )
+        XCTAssertEqual(
+            secondSurface.debugCurrentPixelSize().width,
+            initialSecondWidth,
+            "One window's drag end must not flush unrelated terminal portals"
+        )
+
+        TerminalWindowPortalRegistry.scheduleExternalGeometrySynchronize(
+            for: secondWindow,
+            forceImmediate: false
+        )
+        drainMainQueue()
+        drainMainQueue()
+        XCTAssertLess(
+            secondSurface.debugCurrentPixelSize().width,
+            initialSecondWidth,
+            "The unrelated window should still adopt its geometry when explicitly synchronized"
+        )
+    }
+
+    func testDockDividerLifecycleScopesTerminalResizeToHostingWindow() {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 420)
+        )
+        defer {
+            NotificationCenter.default.post(name: NSWindow.willCloseNotification, object: window)
+            window.orderOut(nil)
+        }
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let store = DockSplitStore(workspaceId: UUID(), baseDirectoryProvider: { nil })
+        let panel = TerminalPanel(workspaceId: store.workspaceId)
+        store.panels[panel.id] = panel
+        defer { store.closeAllPanels() }
+        let anchor = NSView(frame: NSRect(x: 40, y: 60, width: 420, height: 220))
+        contentView.addSubview(anchor)
+        TerminalWindowPortalRegistry.bind(
+            hostedView: panel.hostedView,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: panel.surface.id,
+            expectedGeneration: panel.surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+        realizeWindowLayout(window)
+
+        store.bonsplitController.noteDividerDragSession(true)
+        XCTAssertTrue(
+            TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window),
+            "Dock split drags should enter the same window-scoped terminal resize transaction"
+        )
+        store.bonsplitController.noteDividerDragSession(false)
+        XCTAssertFalse(
+            TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in: window),
+            "Dock drag end should balance the terminal resize transaction"
         )
     }
 

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5561,6 +5561,58 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
     }
 
+    func testInteractiveGeometryResizeEndFlushesFinalTerminalSize() {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 420)
+        )
+        let surface = makeTrackedTerminalSurface()
+        guard let contentView = window.contentView else {
+            XCTFail("Expected content view")
+            return
+        }
+
+        let container = NSView(frame: NSRect(x: 40, y: 60, width: 420, height: 220))
+        contentView.addSubview(container)
+        let anchor = NSView(frame: container.bounds)
+        container.addSubview(anchor)
+
+        TerminalWindowPortalRegistry.bind(
+            hostedView: surface.hostedView,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: surface.id,
+            expectedGeneration: surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+        realizeWindowLayout(window)
+        let initialPixelSize = surface.debugCurrentPixelSize()
+        XCTAssertGreaterThan(initialPixelSize.width, 0)
+
+        // With frame notifications disabled, only the interaction zero
+        // crossing can discover and apply this final geometry.
+        anchor.postsFrameChangedNotifications = false
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize()
+        var interactionIsActive = true
+        defer {
+            if interactionIsActive {
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+            }
+        }
+        anchor.frame.size.width -= 120
+        XCTAssertEqual(surface.debugCurrentPixelSize().width, initialPixelSize.width)
+
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize()
+        interactionIsActive = false
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertLess(
+            surface.debugCurrentPixelSize().width,
+            initialPixelSize.width,
+            "Ending the resize interaction should flush the final exact terminal width"
+        )
+    }
+
     func testWindowScopedExternalGeometrySyncDoesNotRefreshOtherWindows() {
         let firstWindow = makeTestWindow(
             contentRect: NSRect(x: 0, y: 0, width: 700, height: 420)

--- a/cmuxTests/TerminalAndGhosttyTests.swift
+++ b/cmuxTests/TerminalAndGhosttyTests.swift
@@ -5606,7 +5606,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         drainMainQueue()
         drainMainQueue()
 
-        XCTAssertLess(
+        XCTAssertLessThan(
             surface.debugCurrentPixelSize().width,
             initialPixelSize.width,
             "Ending the resize interaction should flush the final exact terminal width"
@@ -5705,7 +5705,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         drainMainQueue()
         drainMainQueue()
 
-        XCTAssertLess(
+        XCTAssertLessThan(
             firstSurface.debugCurrentPixelSize().width,
             initialFirstWidth,
             "Drag end should flush the owning window's final terminal width"
@@ -5722,7 +5722,7 @@ final class TerminalWindowPortalLifecycleTests: XCTestCase {
         )
         drainMainQueue()
         drainMainQueue()
-        XCTAssertLess(
+        XCTAssertLessThan(
             secondSurface.debugCurrentPixelSize().width,
             initialSecondWidth,
             "The unrelated window should still adopt its geometry when explicitly synchronized"

--- a/cmuxTests/TerminalSurfaceResizePolicyTests.swift
+++ b/cmuxTests/TerminalSurfaceResizePolicyTests.swift
@@ -4,31 +4,6 @@ import CmuxTerminal
 @Suite
 struct TerminalSurfaceResizePolicyTests {
     @Test
-    func interactivePaneResizeUsesPixelOnlyCoalescing() {
-        #expect(
-            TerminalSurface.shouldCoalesceSurfacePixelResize(
-                windowLiveResizeActive: false,
-                interactiveGeometryResizeActive: true,
-                bypass: false
-            )
-        )
-        #expect(
-            TerminalSurface.shouldCoalesceSurfacePixelResize(
-                windowLiveResizeActive: true,
-                interactiveGeometryResizeActive: false,
-                bypass: false
-            )
-        )
-        #expect(
-            !TerminalSurface.shouldCoalesceSurfacePixelResize(
-                windowLiveResizeActive: false,
-                interactiveGeometryResizeActive: true,
-                bypass: true
-            )
-        )
-    }
-
-    @Test
     func pixelOnlyResizeWithinExistingGridIsCoalesced() {
         #expect(
             !TerminalSurface.shouldApplySurfacePixelSizeChange(

--- a/cmuxTests/TerminalSurfaceResizePolicyTests.swift
+++ b/cmuxTests/TerminalSurfaceResizePolicyTests.swift
@@ -4,6 +4,31 @@ import CmuxTerminal
 @Suite
 struct TerminalSurfaceResizePolicyTests {
     @Test
+    func interactivePaneResizeUsesPixelOnlyCoalescing() {
+        #expect(
+            TerminalSurface.shouldCoalesceSurfacePixelResize(
+                windowLiveResizeActive: false,
+                interactiveGeometryResizeActive: true,
+                bypass: false
+            )
+        )
+        #expect(
+            TerminalSurface.shouldCoalesceSurfacePixelResize(
+                windowLiveResizeActive: true,
+                interactiveGeometryResizeActive: false,
+                bypass: false
+            )
+        )
+        #expect(
+            !TerminalSurface.shouldCoalesceSurfacePixelResize(
+                windowLiveResizeActive: false,
+                interactiveGeometryResizeActive: true,
+                bypass: true
+            )
+        )
+    }
+
+    @Test
     func pixelOnlyResizeWithinExistingGridIsCoalesced() {
         #expect(
             !TerminalSurface.shouldApplySurfacePixelSizeChange(


### PR DESCRIPTION
## Summary

- extend terminal pixel-only resize coalescing from AppKit window-edge live resize to pane/sidebar geometry interactions
- drive the shared portal resize transaction from Bonsplit's authoritative divider begin/end callbacks for both ordinary workspaces and mirrored tmux panes
- flush one deferred, exact renderer/PTY size after the interaction-wide transaction reaches zero

## Root cause

Ghostty exposes one `set_size` operation for both renderer pixels and PTY geometry. PR #6386 already avoids forwarding sub-cell pixel churn during AppKit window-edge live resize because each forwarded size can generate another `SIGWINCH` and another TUI paint.

Pane and sidebar resizing took a different path. The coalescing gate checked only `isWindowLiveResizeActive`, while the portal's `interactiveGeometryResizeActive` state was ignored. In addition, Bonsplit's authoritative divider-drag begin/end callbacks (added with the sizing work in #7938) were not connected to the ordinary workspace portal transaction; mirrored tmux splits used them only for tmux sizing. A narrow split drag therefore forwarded renderer/PTY sizes at intermediate pixel widths outside the live-resize protection. A busy full-screen TUI could repaint at several wrap widths while Ghostty was reflowing the same screen, producing the duplicated/interleaved signature from #8229.

The fix is at the shared sizing boundary rather than a repaint workaround: all interactive geometry owners enter the same refcounted transaction, same-grid pixel changes are withheld during it, and the zero crossing schedules one settled pass after the gate clears so the exact final dimensions are always applied.

## Compression investigation

The Ghostty scrollback compression change in #7758 is not the reproducer here. A temporary differential Zig test created identical 197-column screens with 900 Claude-like lines, compressed the cold history in one screen, resized both to 10 columns, and compared their complete logical dumps. They matched:

```bash
cd ghostty
zig build test -Dtest-filter='compressed scrollback narrow reflow' -Demit-macos-app=false
```

The same window-only coalescing predicate is also present before #7758, after #7758, and after #7938. No Ghostty fork change or submodule bump is needed.

## Regression coverage

The regression test is isolated in the `CmuxTerminal` package. Against the test-only commit it fails specifically at the pane-interaction expectation:

```text
Expectation failed: TerminalSurface.shouldCoalesceSurfacePixelResize(
  windowLiveResizeActive: false,
  interactiveGeometryResizeActive: true,
  bypass: false
)
SWIFT_TEST_EXIT=1
```

With the fix, the identical AWS Mac command passes one test:

```bash
cd Packages/macOS/CmuxTerminal
swift test --filter TerminalSurfaceResizeCoalescingPolicyTests
# Test run with 1 test in 1 suite passed
# SWIFT_TEST_EXIT=0
```

This was reconfirmed on `aws-m4pro-5` against exact commit `d3a6bcb63bd5ed7b049e04e58ea13efd9e4bfc19`. The standalone SwiftPM run used a disposable builder-only normalization for GhosttyKit's non-`lib`-prefixed macOS archive and overlapping test stubs; no repository file or PR commit was changed for that harness.

A behavior test also verifies that ending an interactive geometry transaction discovers otherwise-unreported final anchor geometry and applies the final terminal pixel width.

## App-host test infrastructure

The app lifecycle suite compiled on three GitHub-hosted attempts at exact HEAD, but the app exited before XCTest bootstrapped and each run executed zero tests:

- [Warp macOS 15, run 29473408507](https://github.com/manaflow-ai/cmux/actions/runs/29473408507): app-host crash in `Combine/Publisher+AsyncSequence.swift:112` (`Received an output without requesting demand`), exit code 6.
- [Blacksmith macOS 26, run 29474626486](https://github.com/manaflow-ai/cmux/actions/runs/29474626486): early app-host exit before the XCTest connection; [artifact report](https://github.com/manaflow-ai/cmux-dev-artifacts/issues/4202).
- [Blacksmith macOS 15, run 29475084011](https://github.com/manaflow-ai/cmux/actions/runs/29475084011): the build completed, then `cmux DEV` exited with code 6 while preparing to run tests after 9.405 seconds; [artifact report](https://github.com/manaflow-ai/cmux-dev-artifacts/issues/4203).

A separate AWS M4 Pro attempt on Xcode 26.2 reached the app linker without a source/compiler error, then failed with `ld: write() failed, errno=28` because the builder disk was full. These infrastructure failures do not supply a nonzero app-host test count; the executable package-level policy test above remains the focused regression proof.

Non-build validation completed:

- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- `git diff --check`

No user-facing strings changed. Current `main` no longer contains the legacy Swift budget TSV/checker, and this PR does not restore or modify either budget.

Closes #8229

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8240"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786768795&installation_id=133855650&pr_number=8240&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8240&signature=0079ddf2fd92db96dd3c4444f6dd55a13798cf3a2ba51418b4cb941dd94b2963"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesces terminal pixel-only resizes during pane/sidebar divider drags to prevent mid-drag reflow garbling (fixes #8229). Unifies live window and interactive geometry resizes under window-scoped, owner-refcounted transactions, and applies a final exact renderer/PTY size to the owning window at drag end.

- **Bug Fixes**
  - Added window-scoped interactive resize transactions with owner refcounts; begin/end driven by `Bonsplit` in `Workspace`, `DockSplitStore`, `ContentView`, and `RemoteTmuxWindowMirror`; per-window queries and end-of-drag flush in `TerminalWindowPortalRegistry`.
  - Centralized coalescing via `TerminalSurfaceResizeCoalescingPolicy` in `CmuxTerminal`; `GhosttyTerminalView` now gates pixel-only updates with `TerminalWindowPortalRegistry.isInteractiveGeometryResizeActive(in:)` and supports bypass.
  - Tests cover policy, per-window scoping, nested ownership, dock divider lifecycle, and final-size flush; assertions fixed for stability.

<sup>Written for commit d3a6bcb63bd5ed7b049e04e58ea13efd9e4bfc19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8240?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved terminal resizing behavior during window live-resize and split-pane divider drags.
  * Enhanced coordination so resize-collapsing rules apply consistently during interactive resize, with correct bypass handling.

* **Bug Fixes**
  * Prevented premature pixel-size updates while interactive geometry resizing is active.
  * Improved window-scoped resize synchronization, including mirrored panes.

* **Tests**
  * Added and expanded tests covering interactive resize scoping, lifecycle flush behavior, and bypass/collapsing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
