### PR TITLE
Scope Codex hooks per launch and serialize delivery

### DIFF
--- a/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
+++ b/CLI/CMUXCLI+CodexFireAndForgetHooks.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 extension CMUXCLI {
+    private static let codexPersistentHookOptInFileName = ".cmux-persistent-hooks-opt-in"
+
     /// The per-invocation Codex hook events the wrapper injects, paired with the
     /// cmux subcommand they call and the codex hook timeout (ms). Lifecycle
     /// events are short; feed events (`PreToolUse`/`PermissionRequest`) are long
@@ -23,11 +25,16 @@ extension CMUXCLI {
     ///   -c\0hooks.SessionStart=[{hooks=[{type="command",command='''<ff>''',timeout=10000}]}]\0
     ///   -c\0hooks.UserPromptSubmit=...\0 ... (one `-c` pair per event)
     /// where `<ff>` is `codexFireAndForgetAgentHookShellCommand(...)` so each
-    /// hook returns `{}` to codex instantly and backgrounds the real cmux call.
+    /// hook returns `{}` to codex instantly and queues the real cmux call behind
+    /// a per-session file lock.
     /// Requires no live socket: pure string construction from the agent def.
     func emitCodexWrapperInjectArgs() throws {
         guard let codexDef = Self.agentDef(named: "codex") else {
             throw CLIError(message: "Codex hook integration is unavailable.")
+        }
+        if try prepareCodexWrapperHookOwnership(codexDef) {
+            writeCodexWrapperArguments(["--enable", "hooks"])
+            return
         }
         // Prefer a #!/bin/sh SCRIPT FILE as the hook command over an inline shell
         // snippet. Some codex-compatible runtimes (subrouters, proxies) exec the
@@ -69,12 +76,83 @@ extension CMUXCLI {
         // `while IFS= read -r -d '' arg` loop captures every element including
         // the final one — a separator-only stream drops the unterminated last
         // arg at EOF.
+        writeCodexWrapperArguments(args)
+    }
+
+    /// Returns true when the user explicitly selected persistent Codex hooks.
+    /// Otherwise, removes legacy cmux-owned global hooks before the wrapper
+    /// injects its invocation-scoped replacements. User-owned hooks survive the
+    /// existing uninstall transform unchanged.
+    private func prepareCodexWrapperHookOwnership(_ def: AgentHookDef) throws -> Bool {
+        if Self.codexPersistentHooksAreOptedIn(for: def) {
+            return true
+        }
+        Self.removeCodexPersistentHookOptIn(for: def)
+        if Self.codexPersistentHooksAreInstalled(for: def) {
+            try uninstallAgentHooks(def, quiet: true)
+        }
+        return false
+    }
+
+    private func writeCodexWrapperArguments(_ arguments: [String]) {
         var out = Data()
-        for arg in args {
-            out.append(Data(arg.utf8))
+        for argument in arguments {
+            out.append(Data(argument.utf8))
             out.append(0)
         }
         FileHandle.standardOutput.write(out)
+    }
+
+    static func recordCodexPersistentHookOptIn(for def: AgentHookDef) throws {
+        let markerURL = codexPersistentHookOptInURL(for: def)
+        try Data("1\n".utf8).write(to: markerURL, options: .atomic)
+    }
+
+    static func removeCodexPersistentHookOptIn(for def: AgentHookDef) {
+        try? FileManager.default.removeItem(at: codexPersistentHookOptInURL(for: def))
+    }
+
+    static func codexPersistentHooksAreOptedIn(for def: AgentHookDef) -> Bool {
+        let markerURL = codexPersistentHookOptInURL(for: def)
+        guard FileManager.default.fileExists(atPath: markerURL.path) else {
+            return false
+        }
+        guard codexPersistentHooksAreInstalled(for: def) else {
+            try? FileManager.default.removeItem(at: markerURL)
+            return false
+        }
+        return true
+    }
+
+    static func codexPersistentHooksAreInstalled(for def: AgentHookDef) -> Bool {
+        let hooksURL = URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
+            .appendingPathComponent(def.configFile, isDirectory: false)
+        guard let data = try? Data(contentsOf: hooksURL),
+              let root = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let hooks = root["hooks"]
+        else {
+            return false
+        }
+        return codexHookValueContainsOwnedCommand(hooks, def: def)
+    }
+
+    private static func codexHookValueContainsOwnedCommand(_ value: Any, def: AgentHookDef) -> Bool {
+        if let array = value as? [Any] {
+            return array.contains { codexHookValueContainsOwnedCommand($0, def: def) }
+        }
+        if let object = value as? [String: Any] {
+            if let command = object["command"] as? String,
+               isCmuxOwnedHookCommand(command, for: def) {
+                return true
+            }
+            return object.values.contains { codexHookValueContainsOwnedCommand($0, def: def) }
+        }
+        return false
+    }
+
+    private static func codexPersistentHookOptInURL(for def: AgentHookDef) -> URL {
+        URL(fileURLWithPath: def.resolvedConfigDir(), isDirectory: true)
+            .appendingPathComponent(codexPersistentHookOptInFileName, isDirectory: false)
     }
 
     /// The cmux-owned directory holding the generated codex hook scripts.
@@ -122,12 +200,14 @@ extension CMUXCLI {
 
     static func codexFireAndForgetAgentHookShellCommand(_ command: String, for def: AgentHookDef) -> String {
         let routedArguments = command.hasPrefix("cmux ") ? String(command.dropFirst("cmux ".count)) : command
-        let runner = "payload=\"$1\"; shift; \"$@\" <\"$payload\" >/dev/null 2>&1 & child=\"$!\"; ( sleep 30; kill \"$child\" 2>/dev/null || true ) & watchdog=\"$!\"; wait \"$child\" 2>/dev/null || true; kill \"$watchdog\" 2>/dev/null || true; rm -f \"$payload\""
+        let runner = "payload=\"$1\"; queue_lock=\"$2\"; shift 2; /usr/bin/lockf -k -t 30 \"$queue_lock\" \"$@\" <\"$payload\" >/dev/null 2>&1 & child=\"$!\"; ( sleep 30; kill \"$child\" 2>/dev/null || true ) & watchdog=\"$!\"; wait \"$child\" 2>/dev/null || true; kill \"$watchdog\" 2>/dev/null || true; rm -f \"$payload\""
         return [
             "cmux_cli=\"${CMUX_BUNDLED_CLI_PATH:-}\"",
             "if [ -z \"$cmux_cli\" ] || [ ! -x \"$cmux_cli\" ]; then cmux_cli=\"$(command -v cmux 2>/dev/null || true)\"; fi",
             "agent_pid=\"${CMUX_CODEX_PID:-${PPID:-}}\"",
-            "if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then payload=\"$(mktemp \"${TMPDIR:-/tmp}/cmux-codex-hook.XXXXXX\" 2>/dev/null || mktemp -t cmux-codex-hook 2>/dev/null)\" || { echo '{}'; exit 0; }; cat >\"$payload\" || true; if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then CMUX_CODEX_PID=\"$agent_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments) >/dev/null 2>&1 & else CMUX_CODEX_PID=\"$agent_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$cmux_cli\" \(routedArguments) >/dev/null 2>&1 & fi; echo '{}'; else echo '{}'; fi",
+            "case \"$agent_pid\" in *[!0-9]*) agent_pid=\"${PPID:-$$}\" ;; esac",
+            "queue_lock=\"${TMPDIR:-/tmp}/cmux-codex-hook-${agent_pid}.lock\"",
+            "if [ -n \"$CMUX_SURFACE_ID\" ] && [ \"$\(def.disableEnvVar)\" != \"1\" ] && [ -n \"$cmux_cli\" ]; then payload=\"$(mktemp \"${TMPDIR:-/tmp}/cmux-codex-hook.XXXXXX\" 2>/dev/null || mktemp -t cmux-codex-hook 2>/dev/null)\" || { echo '{}'; exit 0; }; cat >\"$payload\" || true; if [ -n \"${CMUX_SOCKET_PATH:-}\" ]; then CMUX_CODEX_PID=\"$agent_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$queue_lock\" \"$cmux_cli\" --socket \"$CMUX_SOCKET_PATH\" \(routedArguments) >/dev/null 2>&1 & else CMUX_CODEX_PID=\"$agent_pid\" nohup sh -c '\(runner)' cmux-codex-hook \"$payload\" \"$queue_lock\" \"$cmux_cli\" \(routedArguments) >/dev/null 2>&1 & fi; echo '{}'; else echo '{}'; fi",
         ].joined(separator: "; ")
     }
 }

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -29226,7 +29226,7 @@ export default CMUXSessionRestore;
         print("Removed \(removed) legacy \(def.displayName) cmux hook(s) from \(legacyURL.path)")
     }
 
-    private func uninstallAgentHooks(_ def: AgentHookDef) throws {
+    func uninstallAgentHooks(_ def: AgentHookDef, quiet: Bool = false) throws {
         if def.name == "opencode" { try uninstallOpenCodePluginHooks(def); return }
         if def.name == "pi" { try uninstallPiExtensionHooks(def); return }
         if def.name == "omp" { try uninstallOmpExtensionHooks(def); return }
@@ -29258,7 +29258,9 @@ export default CMUXSessionRestore;
 
         guard let data = fm.contents(atPath: filePath),
               var json = try? JSONSerialization.jsonObject(with: data) as? [String: Any] else {
-            print("No \(def.configFile) found at \(filePath)")
+            if !quiet {
+                print("No \(def.configFile) found at \(filePath)")
+            }
             return
         }
 
@@ -29323,7 +29325,9 @@ export default CMUXSessionRestore;
         json["hooks"] = hooks
         let newData = try JSONSerialization.data(withJSONObject: json, options: [.prettyPrinted, .sortedKeys])
         try newData.write(to: URL(fileURLWithPath: filePath), options: .atomic)
-        print("Removed \(removed) cmux hook(s) from \(filePath)")
+        if !quiet {
+            print("Removed \(removed) cmux hook(s) from \(filePath)")
+        }
 
         // Post-uninstall actions
         if let action = def.postInstallAction {
@@ -29345,7 +29349,9 @@ export default CMUXSessionRestore;
                 )
                 if newContent != content {
                     try newContent.write(toFile: configPath, atomically: true, encoding: .utf8)
-                    print("Removed Codex hooks feature from \(configPath)")
+                    if !quiet {
+                        print("Removed Codex hooks feature from \(configPath)")
+                    }
                 }
             }
         }
@@ -34636,6 +34642,9 @@ export default CMUXSessionRestore;
             return
         }
         try installAgentHooks(def)
+        if def.name == "codex", Self.codexPersistentHooksAreInstalled(for: def) {
+            try Self.recordCodexPersistentHookOptIn(for: def)
+        }
     }
 
     private func uninstallHooksForAgent(_ def: AgentHookDef, arguments: [String]) throws {
@@ -34650,6 +34659,9 @@ export default CMUXSessionRestore;
             return
         }
         try uninstallAgentHooks(def)
+        if def.name == "codex" {
+            Self.removeCodexPersistentHookOptIn(for: def)
+        }
     }
 
     private func runHooksSocketCommand(
@@ -34770,6 +34782,10 @@ export default CMUXSessionRestore;
 
         for def in Self.agentDefs {
             if let agentFilterDef, agentFilterDef.name != def.name { continue }
+            if !isUninstall, agentFilterDef == nil, def.name == "codex" {
+                skipped += 1
+                continue
+            }
             let configDir = def.resolvedConfigDir()
             let canUseMissingConfigDir = def.createConfigDirIfMissing
                 || def.name == "opencode"

--- a/Resources/bin/cmux-codex-wrapper
+++ b/Resources/bin/cmux-codex-wrapper
@@ -320,9 +320,10 @@ fi
 # command for each event. Fire-and-forget is critical: codex runs hooks
 # synchronously and BLOCKS until they return, so a synchronous `cmux hooks codex
 # <sub>` made every launch hang ~35s on "Running SessionStart hook". The emitted
-# command captures codex's stdin payload to a temp file, nohup-backgrounds the
-# real cmux call with a 30s watchdog, and `echo '{}'` returns to codex instantly,
-# so detection still binds the real session id while codex never blocks.
+# command captures codex's stdin payload to a temp file, queues background
+# delivery behind a per-session file lock with a 30s watchdog, and `echo '{}'`
+# returns to codex instantly. Detection keeps the real session id and event
+# order while codex never blocks.
 #
 # Resolving the args via the CLI (instead of re-deriving fragile shell here)
 # avoids quoting bugs in the fire-and-forget command (it contains single quotes

--- a/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
+++ b/cmuxTests/CLICodexHookTimeoutRegressionTests.swift
@@ -3,6 +3,187 @@ import Testing
 
 @Suite(.serialized)
 struct CLICodexHookTimeoutRegressionTests {
+    @Test func codexWrapperInjectionMigratesLegacyPersistentHooks() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-wrapper-migration-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let hookURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
+        let userCommand = "printf user-hook"
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let userHookJSON: [String: Any] = [
+            "hooks": [
+                "PreToolUse": [
+                    ["hooks": [["command": userCommand, "timeout": 5, "type": "command"]]],
+                ],
+            ],
+        ]
+        try JSONSerialization.data(withJSONObject: userHookJSON, options: [.prettyPrinted, .sortedKeys])
+            .write(to: hookURL, options: .atomic)
+
+        let install = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: codexHookTestEnvironment(root: root, codexHome: codexHome),
+            timeout: 10
+        )
+        #expect(install.status == 0, Comment(rawValue: install.stderr))
+        #expect(try codexHookEntries(in: codexHome).count > 1)
+
+        try? FileManager.default.removeItem(
+            at: codexHome.appendingPathComponent(".cmux-persistent-hooks-opt-in", isDirectory: false)
+        )
+        let injection = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "inject-args"],
+            environment: codexHookTestEnvironment(root: root, codexHome: codexHome),
+            timeout: 10
+        )
+
+        #expect(injection.status == 0, Comment(rawValue: injection.stderr))
+        #expect(injection.stdout.contains("--enable\0hooks\0"))
+        let remainingHooks = try codexHookEntries(in: codexHome)
+        #expect(remainingHooks.count == 1)
+        #expect(remainingHooks.first?.command == userCommand)
+    }
+
+    @Test func codexWrapperInjectionDefersToExplicitPersistentHooks() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-wrapper-opt-in-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let install = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "install", "--yes"],
+            environment: codexHookTestEnvironment(root: root, codexHome: codexHome),
+            timeout: 10
+        )
+        #expect(install.status == 0, Comment(rawValue: install.stderr))
+        let installedHooks = try codexHookEntries(in: codexHome)
+        #expect(!installedHooks.isEmpty)
+
+        let injection = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "inject-args"],
+            environment: codexHookTestEnvironment(root: root, codexHome: codexHome),
+            timeout: 10
+        )
+
+        #expect(injection.status == 0, Comment(rawValue: injection.stderr))
+        #expect(injection.stdout == "--enable\0hooks\0")
+        #expect(try codexHookEntries(in: codexHome).count == installedHooks.count)
+    }
+
+    @Test func codexDefaultSetupLeavesCodexToTheWrapper() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-default-setup-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let binDir = root.appendingPathComponent("bin", isDirectory: true)
+        let fakeCodex = binDir.appendingPathComponent("codex", isDirectory: false)
+        let hookURL = codexHome.appendingPathComponent("hooks.json", isDirectory: false)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: binDir, withIntermediateDirectories: true)
+        try makeCodexHookExecutableShellFile(at: fakeCodex, lines: ["#!/bin/sh", "exit 0"])
+        try Data(#"{"hooks":{}}"#.utf8).write(to: hookURL, options: .atomic)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var environment = codexHookTestEnvironment(root: root, codexHome: codexHome)
+        environment["PATH"] = "\(binDir.path):/usr/bin:/bin:/usr/sbin:/sbin"
+        let setup = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "setup", "--yes"],
+            environment: environment,
+            timeout: 10
+        )
+
+        #expect(setup.status == 0, Comment(rawValue: setup.stderr))
+        #expect(try codexHookEntries(in: codexHome).isEmpty)
+    }
+
+    @Test func codexWrapperSerializesBackgroundHookDelivery() throws {
+        let cliPath = try bundledCLIPath()
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-codex-wrapper-order-\(UUID().uuidString)", isDirectory: true)
+        let codexHome = root.appendingPathComponent(".codex", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux", isDirectory: false)
+        let deliveryLog = root.appendingPathComponent("delivery.log", isDirectory: false)
+        try FileManager.default.createDirectory(at: codexHome, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try makeCodexHookExecutableShellFile(at: fakeCLI, lines: [
+            "#!/bin/sh",
+            "cat >/dev/null",
+            "case \"$*\" in",
+            "  *pre-tool-use*) printf 'pre-start\\n' >> \"$CMUX_TEST_DELIVERY_LOG\"; sleep 1; printf 'pre-end\\n' >> \"$CMUX_TEST_DELIVERY_LOG\" ;;",
+            "  *post-tool-use*) printf 'post\\n' >> \"$CMUX_TEST_DELIVERY_LOG\" ;;",
+            "esac",
+        ])
+
+        let injection = runCodexHookProcess(
+            executablePath: cliPath,
+            arguments: ["hooks", "codex", "inject-args"],
+            environment: codexHookTestEnvironment(root: root, codexHome: codexHome),
+            timeout: 10
+        )
+        #expect(injection.status == 0, Comment(rawValue: injection.stderr))
+
+        let arguments = injection.stdout
+            .split(separator: "\0", omittingEmptySubsequences: true)
+            .map(String.init)
+        func injectedCommand(for eventName: String) throws -> String {
+            let argument = try #require(arguments.first { $0.hasPrefix("hooks.\(eventName)=") })
+            let commandPrefix = "command='''"
+            let commandStart = try #require(argument.range(of: commandPrefix)?.upperBound)
+            let commandTail = argument[commandStart...]
+            let commandEnd = try #require(commandTail.range(of: "'''")?.lowerBound)
+            return String(commandTail[..<commandEnd])
+        }
+        let preToolUse = try injectedCommand(for: "PreToolUse")
+        let postToolUse = try injectedCommand(for: "PostToolUse")
+        let environment = [
+            "HOME": root.path,
+            "PATH": "/usr/bin:/bin:/usr/sbin:/sbin",
+            "TMPDIR": root.path,
+            "CMUX_SURFACE_ID": "surface-123",
+            "CMUX_SOCKET_PATH": "/tmp/cmux-test.sock",
+            "CMUX_BUNDLED_CLI_PATH": fakeCLI.path,
+            "CMUX_CODEX_PID": "4242",
+            "CMUX_TEST_DELIVERY_LOG": deliveryLog.path,
+        ]
+
+        let preRun = runCodexHookProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", preToolUse],
+            environment: environment,
+            standardInput: #"{"hook_event_name":"PreToolUse"}"#,
+            timeout: 2
+        )
+        #expect(preRun.status == 0, Comment(rawValue: preRun.stderr))
+        #expect(waitForFile(deliveryLog, containing: "pre-start", timeout: 2))
+
+        let postRun = runCodexHookProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", postToolUse],
+            environment: environment,
+            standardInput: #"{"hook_event_name":"PostToolUse"}"#,
+            timeout: 2
+        )
+        #expect(postRun.status == 0, Comment(rawValue: postRun.stderr))
+        #expect(waitForFile(deliveryLog, containing: "post", timeout: 4))
+        #expect(waitForFile(deliveryLog, containing: "pre-end", timeout: 4))
+
+        let deliveries = try String(contentsOf: deliveryLog, encoding: .utf8)
+            .split(separator: "\n")
+            .map(String.init)
+        #expect(deliveries == ["pre-start", "pre-end", "post"])
+    }
+
     @Test func codexHookInstallReplacesSynchronousBundledHook() throws {
         let cliPath = try bundledCLIPath()
         let root = FileManager.default.temporaryDirectory


### PR DESCRIPTION
Fixes https://github.com/manaflow-ai/cmux/issues/8230

## What changed

- `cmux hooks setup` leaves Codex to the per-launch wrapper by default.
- The wrapper migrates unmarked cmux-owned hooks out of `~/.codex/hooks.json` before Codex reads it, while preserving user-owned hooks.
- Explicit `cmux hooks codex install` records persistent mode for custom launchers; the wrapper then enables hooks without injecting duplicates.
- Background hook deliveries use a per-Codex-PID `lockf` queue, preserving event order while hook commands return `{}` immediately.

## Root cause

Persistent global registration and wrapper injection both owned the same Codex events. The global scripts ran in standalone sessions even when `CMUX_SURFACE_ID` was absent, and wrapped sessions could load both producers. Transport was already fire-and-forget, but separate background processes had no ordering primitive.

## Verification

- First commit adds four behavioral CLI regressions; second commit fixes them.
- Tagged macOS app and bundled CLI built on Blacksmith: https://github.com/manaflow-ai/cmux/actions/runs/29471644334
- Isolated CLI verification: explicit mode installed 10 hooks and emitted only `--enable hooks`; migration removed all 10 cmux hooks and emitted one 15-argument scoped hook set.
- 100 wrapper hook invocations returned in 2.52s total, 25.2ms mean, against a disposable receiver.
- `swiftc -parse`, `bash -n`, and `git diff --check` pass.
- No user-facing strings changed, so localization catalogs are unchanged.

## Design

This is a process-ownership fix, not a language-runtime optimization. Rust would still pay process launch and IPC costs. The existing shell producer now returns quickly, and the OS file lock supplies a bounded FIFO queue without another daemon.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786769315&installation_id=133855650&pr_number=8243&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8243&signature=f8f29fda457f2cf725cfe7a8b8ec43f696b7fb4f2d388e0fab4eb7e9d5c02523"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope Codex hooks to each launch and queue background deliveries per Codex process to keep events ordered and avoid blocking. This removes duplicate producers and stabilizes hook execution.

- **New Features**
  - `cmux hooks setup` now leaves Codex to the per-launch wrapper by default; the wrapper migrates cmux-owned entries out of `~/.codex/hooks.json` and keeps user hooks.
  - Explicit installs via `cmux hooks codex install` persist hooks and create a `.cmux-persistent-hooks-opt-in` marker; wrapper then emits only `--enable hooks` without injecting duplicates.
  - Background delivery uses a per-Codex-PID `lockf` queue so hooks return `{}` immediately while events run in FIFO order.
  - Quiet uninstall path added to support seamless migration during wrapper injection.

- **Migration**
  - No action needed for default Codex launches; migration runs automatically.
  - For custom launchers that want persistent hooks, run: `cmux hooks codex install`.

<sup>Written for commit 98464debdd1857a49eacfb51a429ebee56c94a6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8243?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added persistent Codex hook support with opt-in tracking.
  * Added serialized background hook delivery to preserve execution order.
  * Improved Codex hook setup and migration behavior.

* **Bug Fixes**
  * Prevented duplicate or legacy hooks from being retained.
  * Improved quiet uninstallation behavior and deferred Codex setup handling.
  * Ensured pre- and post-tool hooks execute in the correct sequence.

* **Tests**
  * Added coverage for persistent hook migration, setup, delivery ordering, and timeout-related behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->