### PR TITLE
Strip any embedded framework without a valid dynamic-library executable

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -151,14 +151,22 @@ verify_ipa_framework_minimum_os_versions() {
   while IFS= read -r -d '' framework; do
     framework_name="$(basename "$framework")"
     # ASC validates the framework BINARY, not just Info.plist: an embedded
-    # framework whose binary is a static archive has no Mach-O minimum-OS load
-    # command and is rejected in processing (ITMS-90208) even when its
-    # Info.plist declares MinimumOSVersion. Static code is already linked into
-    # the app executable; the manual re-sign path strips these, so reaching
-    # this check with one still embedded is a hard error.
-    framework_binary="$framework/$(basename "$framework" .framework)"
-    if [[ -f "$framework_binary" ]] && file -b "$framework_binary" | grep -q 'ar archive'; then
-      echo "error: $framework_name is embedded in the app bundle but its binary is a static archive; ASC rejects this (ITMS-90208). It must be stripped from Frameworks/ (its code is already statically linked into the app executable)." >&2
+    # framework whose executable is a static archive, a stripped-out shell
+    # (Info.plist with no binary — Xcode's export processing leaves these
+    # behind for static SPM binaryTargets), or any other non-dylib blob is
+    # rejected in processing (ITMS-90208) even when its Info.plist declares
+    # MinimumOSVersion. The manual re-sign path strips those, so reaching
+    # this check with one still embedded is a hard error: an embedded
+    # framework must be a dynamically linked Mach-O, full stop.
+    framework_exec_name="$("$PLISTBUDDY" -c 'Print :CFBundleExecutable' "$framework/Info.plist" 2>/dev/null || basename "$framework" .framework)"
+    framework_binary="$framework/$framework_exec_name"
+    if [[ ! -f "$framework_binary" ]]; then
+      echo "error: $framework_name is embedded in the app bundle but has no executable ($framework_exec_name); ASC rejects invalid framework shells (ITMS-90208). Strip it from Frameworks/." >&2
+      rm -rf "$workdir"
+      return 1
+    fi
+    if ! file -b "$framework_binary" | grep -q 'dynamically linked shared library'; then
+      echo "error: $framework_name is embedded in the app bundle but its executable is not a dynamic library ($(file -b "$framework_binary")); ASC rejects this (ITMS-90208). Strip it from Frameworks/ (static code is already linked into the app executable)." >&2
       rm -rf "$workdir"
       return 1
     fi
@@ -1007,27 +1015,46 @@ if [[ "$SIGNING" == "manual" ]]; then
   # Xcode embeds SPM binaryTarget frameworks into Frameworks/ even when the
   # framework's binary is a STATIC archive (ar), e.g. iroh-ffi's Iroh.framework.
   # The linker already folded that code into the app executable, so the embedded
-  # copy is inert dead weight — and App Store Connect rejects it in processing
-  # (ITMS-90208: a static archive has no Mach-O minimum-OS load command, so ASC
-  # reads "does not support the minimum OS Version" regardless of the
-  # deployment target or the framework's Info.plist). Strip such frameworks
-  # before re-signing. Gate: prove the app executable does not reference a
-  # stripped framework in its dynamic load commands (it cannot, for an ar
-  # archive, but verify rather than assume).
+  # copy is inert — and App Store Connect rejects it in processing with
+  # ITMS-90208 regardless of the app's deployment target or the framework's
+  # Info.plist. Depending on the Xcode version, export-time distribution
+  # processing may also strip the static executable and leave an INVALID SHELL
+  # (Info.plist with no binary), which ASC rejects the same way; build
+  # 20260716043221 shipped exactly that past an ar-archive-only check here.
+  # So the keep policy is a whitelist, not a blacklist: an embedded framework
+  # stays ONLY if its executable exists and is a dynamically linked Mach-O.
+  # Everything else is stripped, gated on the app executable not referencing
+  # the framework in its dynamic load commands. Every framework's state is
+  # logged first so a future ASC rejection comes with ground truth.
   RESIGN_APP_EXECUTABLE="$RESIGN_APP/$("$PLISTBUDDY" -c 'Print :CFBundleExecutable' "$RESIGN_APP/Info.plist")"
+  if [[ -d "$RESIGN_APP/Frameworks" ]]; then
+    echo "embedded Frameworks/ contents before static-framework strip:"
+    find "$RESIGN_APP/Frameworks" -maxdepth 2 -print | sed "s|$RESIGN_APP/||"
+  fi
   while IFS= read -r -d '' embedded_fw; do
     embedded_fw_name="$(basename "$embedded_fw" .framework)"
-    embedded_fw_bin="$embedded_fw/$embedded_fw_name"
-    [[ -f "$embedded_fw_bin" ]] || continue
-    if file -b "$embedded_fw_bin" | grep -q 'ar archive'; then
-      if otool -L "$RESIGN_APP_EXECUTABLE" | grep -qF "/${embedded_fw_name}.framework/"; then
-        echo "error: app executable dynamically links ${embedded_fw_name}.framework but the embedded binary is a static archive; refusing to strip or upload" >&2
-        exit 1
-      fi
-      echo "stripping embedded static-archive framework (already statically linked into the app executable; ASC rejects it as an embedded framework): Frameworks/${embedded_fw_name}.framework"
-      rm -rf "$embedded_fw"
+    embedded_fw_exec_name="$("$PLISTBUDDY" -c 'Print :CFBundleExecutable' "$embedded_fw/Info.plist" 2>/dev/null || echo "$embedded_fw_name")"
+    embedded_fw_bin="$embedded_fw/$embedded_fw_exec_name"
+    if [[ -f "$embedded_fw_bin" ]]; then
+      embedded_fw_kind="$(file -b "$embedded_fw_bin")"
+    else
+      embedded_fw_kind="<executable missing>"
     fi
+    echo "embedded framework ${embedded_fw_name}.framework binary: $embedded_fw_kind"
+    if [[ "$embedded_fw_kind" == *"dynamically linked shared library"* ]]; then
+      xcrun vtool -show-build "$embedded_fw_bin" 2>/dev/null | sed -n '1,8p' || true
+      continue
+    fi
+    if otool -L "$RESIGN_APP_EXECUTABLE" | grep -qF "/${embedded_fw_name}.framework/"; then
+      echo "error: app executable dynamically links ${embedded_fw_name}.framework but the embedded copy is not a valid dynamic library ($embedded_fw_kind); refusing to strip or upload" >&2
+      exit 1
+    fi
+    echo "stripping embedded framework without a valid dynamic-library executable ($embedded_fw_kind); its code is statically linked into the app executable and ASC rejects the leftover bundle (ITMS-90208): Frameworks/${embedded_fw_name}.framework"
+    rm -rf "$embedded_fw"
   done < <(find "$RESIGN_APP/Frameworks" -maxdepth 1 -type d -name '*.framework' -print0 2>/dev/null)
+  # An empty Frameworks/ dir after stripping is pointless; remove it so the
+  # bundle matches the historical no-Frameworks layout.
+  rmdir "$RESIGN_APP/Frameworks" 2>/dev/null || true
 
   # Start from the exported app's current (profile-baseline) entitlements, then
   # MERGE the profile's authorized Entitlements dict, then every key from the


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/8235. Build 20260716043221 (run https://github.com/manaflow-ai/cmux/actions/runs/29471458156, which contained the ar-archive-only strip) was still rejected with ITMS-90208: Xcode's export-time processing can remove a static SPM binaryTarget's executable and leave an invalid framework shell (Info.plist, no binary) in `Frameworks/`, which the `[[ -f ]]` guard skipped.

The keep policy is now a whitelist: an embedded framework stays only if its executable exists and is a dynamically linked Mach-O. Static archives, stripped shells, and anything else are removed (gated on the app executable not referencing the framework in its load commands), the pre-strip `Frameworks/` state is logged for ground truth, and the final-IPA verifier enforces the same whitelist for the automatic-signing path. Verified locally against the real iroh-ffi `1.0.2-cmux.2` static artifact, a binary-less shell, and a real dylib.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8245"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786770228&installation_id=133855650&pr_number=8245&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8245&signature=a8ed17613a3a10801952ddf9d9f1ee3cb496725c4ee7c5847b0766bb1ef09e71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent App Store Connect ITMS-90208 by only keeping embedded frameworks that have a valid, dynamically linked executable; everything else is stripped with clear logging. The same whitelist is enforced during IPA verification to catch issues in both manual and automatic signing paths.

- **Bug Fixes**
  - Keep an embedded framework only if its `CFBundleExecutable` exists and is a Mach-O dynamic library; strip static archives, binary-less shells, and other non-dylib blobs.
  - Before stripping, log `Frameworks/` contents and each framework’s `file` type; remove an empty `Frameworks/` directory afterward.
  - Check the app binary with `otool -L` and fail if it links an invalid framework we would otherwise strip.
  - Apply the same whitelist in the final IPA verifier for automatic-signing uploads.

<sup>Written for commit 834874dcd674d7c6d9a61202147ea464502cb422. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8245?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of embedded iOS frameworks during TestFlight uploads.
  * Uploads now fail clearly when framework executables are missing or invalid.
  * Manual re-signing removes unsupported frameworks more reliably while preventing removal of frameworks required by the app.
  * Added clearer validation logging and cleanup of empty framework directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->