### PR TITLE
Reconcile embedded framework MinimumOSVersion with its binary's minos

### DIFF
--- a/ios/scripts/upload-testflight.sh
+++ b/ios/scripts/upload-testflight.sh
@@ -193,6 +193,21 @@ verify_ipa_framework_minimum_os_versions() {
       rm -rf "$workdir"
       return 1
     fi
+    # The plist must not claim a LOWER minimum than the binary actually
+    # supports: ASC rejects that internal inconsistency as ITMS-90208 ("the
+    # bundle does not support the minimum OS Version specified in the
+    # Info.plist"). This is exactly how Xcode-synthesized dylibs for static
+    # SPM binaryTargets shipped broken (binary minos = app deployment target,
+    # plist copied from the xcframework).
+    binary_minos="$(xcrun vtool -show-build "$framework_binary" 2>/dev/null | awk '/^ *minos /{print $2; exit}')"
+    if [[ -n "$binary_minos" && "$binary_minos" != "$minimum" ]]; then
+      lowest="$(printf '%s\n%s\n' "$minimum" "$binary_minos" | sort -V | head -n 1)"
+      if [[ "$lowest" == "$minimum" ]]; then
+        echo "error: $framework_name Info.plist MinimumOSVersion '$minimum' is lower than its binary's minos '$binary_minos'; ASC rejects this (ITMS-90208)" >&2
+        rm -rf "$workdir"
+        return 1
+      fi
+    fi
   done < <(find "$app" -type d -name '*.framework' -print0)
 
   rm -rf "$workdir"
@@ -1042,7 +1057,30 @@ if [[ "$SIGNING" == "manual" ]]; then
     fi
     echo "embedded framework ${embedded_fw_name}.framework binary: $embedded_fw_kind"
     if [[ "$embedded_fw_kind" == *"dynamically linked shared library"* ]]; then
-      xcrun vtool -show-build "$embedded_fw_bin" 2>/dev/null | sed -n '1,8p' || true
+      # ROOT CAUSE of the ITMS-90208 rejections (proven by build
+      # 20260716050845's diagnostics): Xcode synthesizes the embedded dylib
+      # for a static SPM binaryTarget at build time and stamps it with the
+      # APP's deployment target (minos 18.4), but copies the xcframework's
+      # Info.plist unchanged (MinimumOSVersion 17.5). ASC rejects the
+      # internally inconsistent bundle: its binary cannot run on the minimum
+      # OS its own Info.plist declares. Reconcile the plist to the binary's
+      # actual minos, then re-sign the framework (its seal covers Info.plist);
+      # the app itself is force-re-signed right after this block.
+      embedded_fw_minos="$(xcrun vtool -show-build "$embedded_fw_bin" 2>/dev/null | awk '/^ *minos /{print $2; exit}')"
+      embedded_fw_plist_min="$("$PLISTBUDDY" -c 'Print :MinimumOSVersion' "$embedded_fw/Info.plist" 2>/dev/null || true)"
+      echo "embedded framework ${embedded_fw_name}.framework: binary minos=${embedded_fw_minos:-<none>} Info.plist MinimumOSVersion=${embedded_fw_plist_min:-<absent>}"
+      if [[ -n "$embedded_fw_minos" ]]; then
+        embedded_fw_lowest="$(printf '%s\n%s\n' "${embedded_fw_plist_min:-0}" "$embedded_fw_minos" | sort -V | head -n 1)"
+        if [[ -z "$embedded_fw_plist_min" || ( "$embedded_fw_plist_min" != "$embedded_fw_minos" && "$embedded_fw_lowest" == "$embedded_fw_plist_min" ) ]]; then
+          echo "reconciling ${embedded_fw_name}.framework Info.plist MinimumOSVersion ${embedded_fw_plist_min:-<absent>} -> $embedded_fw_minos (must match the binary or ASC rejects with ITMS-90208)"
+          if [[ -z "$embedded_fw_plist_min" ]]; then
+            "$PLISTBUDDY" -c "Add :MinimumOSVersion string $embedded_fw_minos" "$embedded_fw/Info.plist"
+          else
+            "$PLISTBUDDY" -c "Set :MinimumOSVersion $embedded_fw_minos" "$embedded_fw/Info.plist"
+          fi
+          codesign --force --sign "$RESIGN_IDENTITY" --timestamp "$embedded_fw"
+        fi
+      fi
       continue
     fi
     if otool -L "$RESIGN_APP_EXECUTABLE" | grep -qF "/${embedded_fw_name}.framework/"; then


### PR DESCRIPTION
Root cause of every internal-beta ITMS-90208 rejection, proven by the `Frameworks/` diagnostics added in https://github.com/manaflow-ai/cmux/pull/8245 (run https://github.com/manaflow-ai/cmux/actions/runs/29472962671, build 20260716050845):

```
embedded framework Iroh.framework binary: Mach-O 64-bit dynamically linked shared library arm64
  LC_BUILD_VERSION: platform IOS, minos 18.4, sdk 26.5
  Info.plist MinimumOSVersion: 17.5
```

Xcode synthesizes the embedded dylib for a static SPM binaryTarget (iroh-ffi) at build time and stamps it with the app's deployment target, but copies the xcframework's Info.plist unchanged. The framework claims to support iOS 17.5 while its binary requires 18.4 — ASC rejects that internal inconsistency ("the bundle does not support the minimum OS Version specified in the Info.plist"). The mismatch existed at every deployment target tried, which is why the 18.4→18.0→17.5 changes never helped.

The re-sign path now reconciles each kept dynamic framework's Info.plist `MinimumOSVersion` to its binary's actual minos and force-re-signs the framework (the app re-sign right after seals the new nested cdhash). The final-IPA verifier fails on any remaining plist-lower-than-binary mismatch on both signing paths. Verified locally on a real dylib framework, including idempotency.

Follow-up: make manaflow-ai/iroh-ffi ship a real dynamic framework with consistent metadata so Xcode stops synthesizing one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8248"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786772555&installation_id=133855650&pr_number=8248&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8248&signature=bde1d9ad6c93e35c009d4c00467f01a815c907b33aaf6cdadff19a677e762239"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes ITMS-90208 by aligning each embedded dynamic framework’s Info.plist MinimumOSVersion with the binary’s minos during resign, preventing TestFlight processing failures for synthesized dylibs (e.g., `Iroh.framework` from `iroh-ffi`). Adds a verifier that fails if any framework’s plist claims a lower OS than its binary.

- **Bug Fixes**
  - During manual resign, read framework binary minos via `vtool`; if Info.plist MinimumOSVersion is absent or lower, set it to the minos and re-sign the framework (app is re-signed after).
  - IPA verification now errors when a framework’s plist is lower than its binary’s minos, with clear ITMS-90208 messaging.

<sup>Written for commit d5ca0e647cb7ca1ab7a5268772ae54143215e619. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8248?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved iOS package verification to detect mismatches between embedded framework binaries and their declared minimum supported OS versions.
  * Automatically corrects outdated framework metadata during manual signing and re-signs affected frameworks.
  * Helps prevent distribution upload failures caused by minimum OS version inconsistencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->