### PR TITLE
Add reversible Zen Mode

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction+Defaults.swift
@@ -19,6 +19,11 @@ extension ShortcutAction {
                 first: ShortcutStroke(key: "["),
                 second: ShortcutStroke(key: "f")
             )
+        case .toggleZenMode:
+            return StoredShortcut(
+                first: ShortcutStroke(key: "k", command: true),
+                second: ShortcutStroke(key: "z")
+            )
         default:
             return defaultStroke.map { StoredShortcut(first: $0) }
         }
@@ -41,6 +46,7 @@ extension ShortcutAction {
         case .newWindow: return ShortcutStroke(key: "n", command: true, shift: true)
         case .closeWindow: return ShortcutStroke(key: "w", command: true, control: true)
         case .toggleFullScreen: return ShortcutStroke(key: "f", command: true, control: true)
+        case .toggleZenMode: return nil
         case .quit: return ShortcutStroke(key: "q", command: true)
         case .toggleSidebar: return ShortcutStroke(key: "b", command: true)
         case .newTab: return ShortcutStroke(key: "n", command: true)

--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Values/ShortcutAction.swift
@@ -15,6 +15,7 @@ public enum ShortcutAction: String, CaseIterable, Sendable, Hashable, SettingCod
     case newWindow
     case closeWindow
     case toggleFullScreen
+    case toggleZenMode
     case quit
 
     // MARK: Workspace
@@ -177,7 +178,7 @@ extension ShortcutAction {
     public var group: Group {
         switch self {
         case .openSettings, .reloadConfiguration, .showHideAllWindows, .globalSearch,
-             .newWindow, .closeWindow, .toggleFullScreen, .quit:
+             .newWindow, .closeWindow, .toggleFullScreen, .toggleZenMode, .quit:
             return .app
         case .toggleSidebar, .newTab, .newBrowserWorkspace, .saveLayoutTemplate, .openFolder, .reopenPreviousSession, .goToWorkspace,
              .commandPalette, .commandPaletteNext, .commandPalettePrevious, .sendFeedback,
@@ -333,6 +334,8 @@ extension ShortcutAction {
         case .newWindow: return "New Window"
         case .closeWindow: return "Close Window"
         case .toggleFullScreen: return "Toggle Full Screen"
+        case .toggleZenMode:
+            return String(localized: "command.toggleZenMode.title", defaultValue: "Toggle Zen Mode")
         case .quit: return "Quit cmux"
         case .toggleSidebar: return "Toggle Left Sidebar"
         case .newTab: return "New Workspace"

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -813,6 +813,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var ghosttyCrashBreadcrumbTask: Task<Void, Never>?
     private static let configuredShortcutChordTimeout: TimeInterval = 1
     private struct PendingConfiguredShortcutChord {
+        let id: UUID
         let firstStroke: ShortcutStroke
         let secondStrokes: [ShortcutStroke]
         let expiresAt: TimeInterval
@@ -820,6 +821,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let fallbackEvent: NSEvent
     }
     private var pendingConfiguredShortcutChord: PendingConfiguredShortcutChord?
+    private var configuredShortcutChordExpirationTimer: Timer?
     var activeConfiguredShortcutChordPrefixForCurrentEvent: ShortcutStroke?
     var shortcutEventFocusContextCache: ShortcutEventFocusContextCache?
     private var ghosttyConfigObserver: NSObjectProtocol?
@@ -12587,6 +12589,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func clearConfiguredShortcutChordState() {
+        configuredShortcutChordExpirationTimer?.invalidate()
+        configuredShortcutChordExpirationTimer = nil
         pendingConfiguredShortcutChord = nil
         activeConfiguredShortcutChordPrefixForCurrentEvent = nil
     }
@@ -13329,6 +13333,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
+        let configuredCmuxShortcutContext = preferredMainWindowContextForShortcutRouting(event: event)
+        let configuredCmuxShortcutActions = configuredCmuxShortcutActions(for: configuredCmuxShortcutContext)
+
         if activeConfiguredShortcutChordPrefixForCurrentEvent == nil {
             let shortcutContext = shortcutEventFocusContext(event).shortcutContext
             let availableChordActions = currentConfiguredShortcutChordActions().filter { action in
@@ -13338,21 +13345,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
                 // one does not swallow its first stroke elsewhere (issue #5189).
                 KeyboardShortcutSettings.effectiveWhenClause(for: action).evaluate(shortcutContext)
             }
-            if armConfiguredShortcutChordIfNeeded(event: event, actions: availableChordActions) {
+            if armConfiguredShortcutChordIfNeeded(
+                event: event,
+                actions: availableChordActions,
+                shortcuts: configuredCmuxShortcutActions.compactMap(\.shortcut)
+            ) {
                 return true
             }
-        }
-
-        let configuredCmuxShortcutContext = preferredMainWindowContextForShortcutRouting(event: event)
-        let configuredCmuxShortcutActions = configuredCmuxShortcutActions(for: configuredCmuxShortcutContext)
-
-        if activeConfiguredShortcutChordPrefixForCurrentEvent == nil,
-           armConfiguredShortcutChordIfNeeded(
-               event: event,
-               actions: [],
-               shortcuts: configuredCmuxShortcutActions.compactMap(\.shortcut)
-           ) {
-            return true
         }
 
         // Focused browser web content owns document-editing command equivalents
@@ -15243,6 +15242,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         guard let firstStroke else { return false }
 
         let pending = PendingConfiguredShortcutChord(
+            id: UUID(),
             firstStroke: firstStroke,
             secondStrokes: secondStrokes,
             expiresAt: event.timestamp + Self.configuredShortcutChordTimeout,
@@ -15250,11 +15250,23 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             fallbackEvent: event
         )
         pendingConfiguredShortcutChord = pending
+        configuredShortcutChordExpirationTimer?.invalidate()
+        let timer = Timer(timeInterval: Self.configuredShortcutChordTimeout, repeats: false) { [weak self] timer in
+            MainActor.assumeIsolated {
+                guard let self, self.configuredShortcutChordExpirationTimer === timer else { return }
+                self.configuredShortcutChordExpirationTimer = nil
+                self.expireConfiguredShortcutChord(id: pending.id)
+            }
+        }
+        configuredShortcutChordExpirationTimer = timer
+        RunLoop.main.add(timer, forMode: .common)
         return true
     }
 
     private func resolvePendingConfiguredShortcutChord(for event: NSEvent) -> ShortcutStroke? {
         guard let pending = pendingConfiguredShortcutChord else { return nil }
+        configuredShortcutChordExpirationTimer?.invalidate()
+        configuredShortcutChordExpirationTimer = nil
         pendingConfiguredShortcutChord = nil
 
         let sameWindow = pending.windowNumber == configuredShortcutChordWindowNumber(for: event)
@@ -15266,6 +15278,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
         deliverConfiguredShortcutChordFallback(pending)
         return nil
+    }
+
+    private func expireConfiguredShortcutChord(id: UUID) {
+        guard let pending = pendingConfiguredShortcutChord, pending.id == id else { return }
+        pendingConfiguredShortcutChord = nil
+        deliverConfiguredShortcutChordFallback(pending)
     }
 
     private func deliverConfiguredShortcutChordFallback(_ pending: PendingConfiguredShortcutChord) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -811,15 +811,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var splitButtonTooltipRefreshScheduled = false
     private var didScheduleGhosttyCrashBreadcrumbCheck = false
     private var ghosttyCrashBreadcrumbTask: Task<Void, Never>?
+    private static let configuredShortcutChordTimeout: TimeInterval = 1
     private struct PendingConfiguredShortcutChord {
-        let id: UUID
         let firstStroke: ShortcutStroke
         let secondStrokes: [ShortcutStroke]
+        let expiresAt: TimeInterval
         let windowNumber: Int?
         let fallbackEvent: NSEvent
     }
     private var pendingConfiguredShortcutChord: PendingConfiguredShortcutChord?
-    private var configuredShortcutChordTimeoutTask: Task<Void, Never>?
     var activeConfiguredShortcutChordPrefixForCurrentEvent: ShortcutStroke?
     var shortcutEventFocusContextCache: ShortcutEventFocusContextCache?
     private var ghosttyConfigObserver: NSObjectProtocol?
@@ -1860,6 +1860,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     private func prepareForConfirmedAppTermination() {
+        restoreZenModeForTermination()
         isTerminatingApp = true
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
         ClosedItemHistoryStore.shared.flushPendingSaves()
@@ -1982,9 +1983,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         StartupBreadcrumbLog.append("appDelegate.willTerminate.begin")
-        if let session = zenModeController.restoreForTermination() {
-            restoreZenModeWindowState(session)
-        }
+        restoreZenModeForTermination()
         // Backstop for any terminate path that did not route through
         // prepareForConfirmedAppTermination() (idempotent with the primary arm).
         // Apple's promised-pasteboard observer can fire before this delegate
@@ -2018,6 +2017,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         enableSuddenTerminationIfNeeded()
     }
 
+    private func restoreZenModeForTermination() {
+        if let session = zenModeController.restoreForTermination() {
+            restoreZenModeWindowState(session)
+        }
+    }
+
     func applicationWillResignActive(_ notification: Notification) {
         guard !isTerminatingApp else { return }
         PortScanner.shared.setTrackedAgentScanningPaused(true)
@@ -2028,6 +2033,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func persistSessionForUpdateRelaunch() {
+        restoreZenModeForTermination()
         isTerminatingApp = true
         _ = saveSessionSnapshotIncludingProcessDetectedIndexes(includeScrollback: true, removeWhenEmpty: false)
         ClosedItemHistoryStore.shared.flushPendingSaves()
@@ -12581,8 +12587,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func clearConfiguredShortcutChordState() {
-        configuredShortcutChordTimeoutTask?.cancel()
-        configuredShortcutChordTimeoutTask = nil
         pendingConfiguredShortcutChord = nil
         activeConfiguredShortcutChordPrefixForCurrentEvent = nil
     }
@@ -15238,47 +15242,30 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
         guard let firstStroke else { return false }
 
-        configuredShortcutChordTimeoutTask?.cancel()
         let pending = PendingConfiguredShortcutChord(
-            id: UUID(),
             firstStroke: firstStroke,
             secondStrokes: secondStrokes,
+            expiresAt: event.timestamp + Self.configuredShortcutChordTimeout,
             windowNumber: configuredShortcutChordWindowNumber(for: event),
             fallbackEvent: event
         )
         pendingConfiguredShortcutChord = pending
-        configuredShortcutChordTimeoutTask = Task { @MainActor [weak self] in
-            do {
-                try await Task.sleep(for: .seconds(1))
-            } catch {
-                return
-            }
-            self?.expireConfiguredShortcutChord(id: pending.id)
-        }
         return true
     }
 
     private func resolvePendingConfiguredShortcutChord(for event: NSEvent) -> ShortcutStroke? {
         guard let pending = pendingConfiguredShortcutChord else { return nil }
-        configuredShortcutChordTimeoutTask?.cancel()
-        configuredShortcutChordTimeoutTask = nil
         pendingConfiguredShortcutChord = nil
 
         let sameWindow = pending.windowNumber == configuredShortcutChordWindowNumber(for: event)
-        if sameWindow,
+        if event.timestamp <= pending.expiresAt,
+           sameWindow,
            pending.secondStrokes.contains(where: { matchShortcutStroke(event: event, stroke: $0) }) {
             return pending.firstStroke
         }
 
         deliverConfiguredShortcutChordFallback(pending)
         return nil
-    }
-
-    private func expireConfiguredShortcutChord(id: UUID) {
-        guard let pending = pendingConfiguredShortcutChord, pending.id == id else { return }
-        pendingConfiguredShortcutChord = nil
-        configuredShortcutChordTimeoutTask = nil
-        deliverConfiguredShortcutChordFallback(pending)
     }
 
     private func deliverConfiguredShortcutChordFallback(_ pending: PendingConfiguredShortcutChord) {

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -512,6 +512,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     var aboutTitlebarDebugStore: AboutTitlebarDebugStore { debugWindowsCoordinator.aboutTitlebarStore }
     /// Coordinates remote tmux (`ssh … tmux -CC`) mirroring; composition-root owned.
     let remoteTmuxController = RemoteTmuxController()
+    /// Coordinates the reversible app-wide Zen Mode session.
+    private let zenModeController = ZenModeController()
     private let systemAppearanceObserver = SystemAppearanceObserver()
     private static let reloadConfigurationMenuItemIdentifier = NSUserInterfaceItemIdentifier("com.cmux.reloadConfiguration")
     private static let cachedIsRunningUnderXCTest = detectRunningUnderXCTest(ProcessInfo.processInfo.environment)
@@ -1976,6 +1978,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         StartupBreadcrumbLog.append("appDelegate.willTerminate.begin")
+        zenModeController.restoreForTermination()
         // Backstop for any terminate path that did not route through
         // prepareForConfirmedAppTermination() (idempotent with the primary arm).
         // Apple's promised-pasteboard observer can fire before this delegate
@@ -5868,6 +5871,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func unregisterMainWindowContext(for window: NSWindow) -> MainWindowContext? {
         guard let removed = contextForMainTerminalWindow(window, reindex: false) else { return nil }
+        _ = zenModeController.endIfTargeting(windowID: removed.windowId)
         removed.teardownWindowDock()
         let removedKeys = mainWindowContexts.compactMap { key, value in
             value === removed ? key : nil
@@ -5883,6 +5887,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     // Internal (not private): see notifyMainWindowContextsDidChange.
     func discardOrphanedMainWindowContext(_ context: MainWindowContext, allowWindowlessFallback: Bool = false) {
+        _ = zenModeController.endIfTargeting(windowID: context.windowId)
         context.teardownWindowDock()
         let contextKeys = mainWindowContexts.compactMap { key, value in
             value === context ? key : nil
@@ -6519,6 +6524,46 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return true
         }
         return false
+    }
+
+    /// Toggles app-wide Zen Mode while restoring only state changed on entry.
+    @discardableResult
+    func toggleZenMode(preferredWindow: NSWindow? = nil) -> Bool {
+        if zenModeController.isActive {
+            guard let session = zenModeController.end() else { return false }
+            guard let context = mainWindowContexts.values.first(where: { $0.windowId == session.windowID }) else {
+                return true
+            }
+
+            if session.restoresSidebarVisibility, !context.sidebarState.isVisible {
+                context.sidebarState.isVisible = true
+            }
+            if session.exitsFullScreen,
+               let window = resolvedWindow(for: context),
+               window.styleMask.contains(.fullScreen) {
+                window.toggleFullScreen(nil)
+            }
+            return true
+        }
+
+        guard let context = preferredRegisteredMainWindowContext(preferredWindow: preferredWindow),
+              let window = resolvedWindow(for: context),
+              let session = zenModeController.begin(
+                  windowID: context.windowId,
+                  isSidebarVisible: context.sidebarState.isVisible,
+                  isFullScreen: window.styleMask.contains(.fullScreen)
+              ) else {
+            return false
+        }
+
+        setActiveMainWindow(window)
+        if session.restoresSidebarVisibility {
+            context.sidebarState.isVisible = false
+        }
+        if session.exitsFullScreen {
+            window.toggleFullScreen(nil)
+        }
+        return true
     }
 
     @discardableResult
@@ -13357,6 +13402,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             }
             targetWindow.toggleFullScreen(nil)
             return true
+        }
+
+        if matchConfiguredShortcut(event: event, action: .toggleZenMode) {
+            return toggleZenMode(preferredWindow: mainWindowForShortcutEvent(event))
         }
 
         if handleConfiguredCmuxShortcut(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -812,10 +812,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     private var didScheduleGhosttyCrashBreadcrumbCheck = false
     private var ghosttyCrashBreadcrumbTask: Task<Void, Never>?
     private struct PendingConfiguredShortcutChord {
+        let id: UUID
         let firstStroke: ShortcutStroke
+        let secondStrokes: [ShortcutStroke]
         let windowNumber: Int?
+        let fallbackEvent: NSEvent
     }
     private var pendingConfiguredShortcutChord: PendingConfiguredShortcutChord?
+    private var configuredShortcutChordTimeoutTask: Task<Void, Never>?
     var activeConfiguredShortcutChordPrefixForCurrentEvent: ShortcutStroke?
     var shortcutEventFocusContextCache: ShortcutEventFocusContextCache?
     private var ghosttyConfigObserver: NSObjectProtocol?
@@ -1978,7 +1982,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     func applicationWillTerminate(_ notification: Notification) {
         StartupBreadcrumbLog.append("appDelegate.willTerminate.begin")
-        zenModeController.restoreForTermination()
+        if let session = zenModeController.restoreForTermination() {
+            restoreZenModeWindowState(session)
+        }
         // Backstop for any terminate path that did not route through
         // prepareForConfirmedAppTermination() (idempotent with the primary arm).
         // Apple's promised-pasteboard observer can fire before this delegate
@@ -6531,18 +6537,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     func toggleZenMode(preferredWindow: NSWindow? = nil) -> Bool {
         if zenModeController.isActive {
             guard let session = zenModeController.end() else { return false }
-            guard let context = mainWindowContexts.values.first(where: { $0.windowId == session.windowID }) else {
-                return true
-            }
-
-            if session.restoresSidebarVisibility, !context.sidebarState.isVisible {
-                context.sidebarState.isVisible = true
-            }
-            if session.exitsFullScreen,
-               let window = resolvedWindow(for: context),
-               window.styleMask.contains(.fullScreen) {
-                window.toggleFullScreen(nil)
-            }
+            restoreZenModeWindowState(session)
             return true
         }
 
@@ -6564,6 +6559,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             window.toggleFullScreen(nil)
         }
         return true
+    }
+
+    private func restoreZenModeWindowState(_ session: ZenModeController.Session) {
+        guard let context = mainWindowContexts.values.first(where: { $0.windowId == session.windowID }) else {
+            return
+        }
+        if session.restoresSidebarVisibility, !context.sidebarState.isVisible {
+            context.sidebarState.isVisible = true
+        }
+        if session.exitsFullScreen,
+           let window = resolvedWindow(for: context),
+           window.styleMask.contains(.fullScreen) {
+            window.toggleFullScreen(nil)
+        }
     }
 
     @discardableResult
@@ -12570,6 +12579,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     }
 
     func clearConfiguredShortcutChordState() {
+        configuredShortcutChordTimeoutTask?.cancel()
+        configuredShortcutChordTimeoutTask = nil
         pendingConfiguredShortcutChord = nil
         activeConfiguredShortcutChordPrefixForCurrentEvent = nil
     }
@@ -12850,14 +12861,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         let isControlOnly = hasControl && !hasCommand && !hasOption
         let controlDChar = chars == "d" || event.characters == "\u{04}"
         let isControlD = isControlOnly && (controlDChar || event.keyCode == 2)
-        let configuredShortcutEventWindowNumber = configuredShortcutChordWindowNumber(for: event)
-        if let pendingConfiguredShortcutChord,
-           pendingConfiguredShortcutChord.windowNumber == configuredShortcutEventWindowNumber {
-            activeConfiguredShortcutChordPrefixForCurrentEvent = pendingConfiguredShortcutChord.firstStroke
-        } else {
-            activeConfiguredShortcutChordPrefixForCurrentEvent = nil
-        }
-        pendingConfiguredShortcutChord = nil
+        activeConfiguredShortcutChordPrefixForCurrentEvent = resolvePendingConfiguredShortcutChord(for: event)
         defer { activeConfiguredShortcutChordPrefixForCurrentEvent = nil; clearShortcutEventFocusContextCache(for: event) }
 #if DEBUG
         if isControlD {
@@ -15056,14 +15060,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             return false
         }
 
-        let configuredShortcutEventWindowNumber = configuredShortcutChordWindowNumber(for: event)
-        if let pendingConfiguredShortcutChord,
-           pendingConfiguredShortcutChord.windowNumber == configuredShortcutEventWindowNumber {
-            activeConfiguredShortcutChordPrefixForCurrentEvent = pendingConfiguredShortcutChord.firstStroke
-        } else {
-            activeConfiguredShortcutChordPrefixForCurrentEvent = nil
-        }
-        pendingConfiguredShortcutChord = nil
+        activeConfiguredShortcutChordPrefixForCurrentEvent = resolvePendingConfiguredShortcutChord(for: event)
         defer {
             activeConfiguredShortcutChordPrefixForCurrentEvent = nil
             clearShortcutEventFocusContextCache(for: event)
@@ -15222,21 +15219,70 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         shortcuts: [StoredShortcut] = []
     ) -> Bool {
         var seen = Set<StoredShortcut>()
+        var firstStroke: ShortcutStroke?
+        var secondStrokes: [ShortcutStroke] = []
         let configuredShortcuts = actions.map {
             KeyboardShortcutSettings.shortcut(for: $0)
         } + shortcuts
         for shortcut in configuredShortcuts {
             guard seen.insert(shortcut).inserted else { continue }
-            guard shortcut.hasChord else { continue }
+            guard let secondStroke = shortcut.secondStroke else { continue }
             if matchShortcutStroke(event: event, stroke: shortcut.firstStroke) {
-                pendingConfiguredShortcutChord = PendingConfiguredShortcutChord(
-                    firstStroke: shortcut.firstStroke,
-                    windowNumber: configuredShortcutChordWindowNumber(for: event)
-                )
-                return true
+                firstStroke = shortcut.firstStroke
+                if !secondStrokes.contains(secondStroke) {
+                    secondStrokes.append(secondStroke)
+                }
             }
         }
-        return false
+        guard let firstStroke else { return false }
+
+        configuredShortcutChordTimeoutTask?.cancel()
+        let pending = PendingConfiguredShortcutChord(
+            id: UUID(),
+            firstStroke: firstStroke,
+            secondStrokes: secondStrokes,
+            windowNumber: configuredShortcutChordWindowNumber(for: event),
+            fallbackEvent: event
+        )
+        pendingConfiguredShortcutChord = pending
+        configuredShortcutChordTimeoutTask = Task { @MainActor [weak self] in
+            do {
+                try await Task.sleep(for: .seconds(1))
+            } catch {
+                return
+            }
+            self?.expireConfiguredShortcutChord(id: pending.id)
+        }
+        return true
+    }
+
+    private func resolvePendingConfiguredShortcutChord(for event: NSEvent) -> ShortcutStroke? {
+        guard let pending = pendingConfiguredShortcutChord else { return nil }
+        configuredShortcutChordTimeoutTask?.cancel()
+        configuredShortcutChordTimeoutTask = nil
+        pendingConfiguredShortcutChord = nil
+
+        let sameWindow = pending.windowNumber == configuredShortcutChordWindowNumber(for: event)
+        if sameWindow,
+           pending.secondStrokes.contains(where: { matchShortcutStroke(event: event, stroke: $0) }) {
+            return pending.firstStroke
+        }
+
+        deliverConfiguredShortcutChordFallback(pending)
+        return nil
+    }
+
+    private func expireConfiguredShortcutChord(id: UUID) {
+        guard let pending = pendingConfiguredShortcutChord, pending.id == id else { return }
+        pendingConfiguredShortcutChord = nil
+        configuredShortcutChordTimeoutTask = nil
+        deliverConfiguredShortcutChordFallback(pending)
+    }
+
+    private func deliverConfiguredShortcutChordFallback(_ pending: PendingConfiguredShortcutChord) {
+        let targetWindow = pending.fallbackEvent.window
+            ?? pending.windowNumber.flatMap { NSApp.window(withWindowNumber: $0) }
+        targetWindow?.sendEvent(pending.fallbackEvent)
     }
 
     func configuredCmuxShortcutActions(

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -3467,7 +3467,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             ClosedItemHistoryStore.shared.remapWorkspaceWindowIds(from: originalWindowId, to: context.windowId)
             ClosedItemHistoryStore.shared.flushPendingSaves()
         }
-        context.sidebarState.isVisible = snapshot.sidebar.isVisible
+        context.sidebarState.isVisible = zenModeController.consumeInterruptedSidebarVisibilityRecovery(
+            windowID: snapshot.windowId ?? context.windowId
+        ) ? true : snapshot.sidebar.isVisible
         context.sidebarState.persistedWidth = CGFloat(
             SessionPersistencePolicy.sanitizedSidebarWidth(snapshot.sidebar.width)
         )

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6403,6 +6403,14 @@ struct ContentView: View {
         )
         contributions.append(
             CommandPaletteCommandContribution(
+                commandId: "palette.toggleZenMode",
+                title: constant(String(localized: "command.toggleZenMode.title", defaultValue: "Toggle Zen Mode")),
+                subtitle: constant(String(localized: "command.toggleSidebar.subtitle", defaultValue: "Layout")),
+                keywords: ["zen", "focus", "minimal", "fullscreen", "sidebar", "width"]
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
                 commandId: "palette.reopenClosedBrowserTab",
                 title: constant(String(localized: "menu.history.reopenLastClosed", defaultValue: "Reopen Last Closed")),
                 subtitle: constant(String(localized: "menu.history.title", defaultValue: "History")),
@@ -7589,6 +7597,11 @@ struct ContentView: View {
                 return
             }
             window.toggleFullScreen(nil)
+        }
+        registry.register(commandId: "palette.toggleZenMode") {
+            if AppDelegate.shared?.toggleZenMode(preferredWindow: observedWindow ?? NSApp.keyWindow ?? NSApp.mainWindow) != true {
+                NSSound.beep()
+            }
         }
         registry.register(commandId: "palette.reopenClosedBrowserTab") {
             if let appDelegate = AppDelegate.shared {

--- a/Sources/KeyboardShortcutSettings.swift
+++ b/Sources/KeyboardShortcutSettings.swift
@@ -70,6 +70,7 @@ enum KeyboardShortcutSettings {
         case newWindow
         case closeWindow
         case toggleFullScreen
+        case toggleZenMode
         case quit
 
         // Titlebar / primary UI
@@ -204,6 +205,7 @@ enum KeyboardShortcutSettings {
             case .newWindow: return String(localized: "shortcut.newWindow.label", defaultValue: "New Window")
             case .closeWindow: return String(localized: "shortcut.closeWindow.label", defaultValue: "Close Window")
             case .toggleFullScreen: return String(localized: "command.toggleFullScreen.title", defaultValue: "Toggle Full Screen")
+            case .toggleZenMode: return String(localized: "command.toggleZenMode.title", defaultValue: "Toggle Zen Mode")
             case .quit: return String(localized: "menu.quitCmux", defaultValue: "Quit cmux")
             case .toggleSidebar: return String(localized: "shortcut.toggleLeftSidebar.label", defaultValue: "Toggle Left Sidebar")
             case .newTab: return String(localized: "shortcut.newWorkspace.label", defaultValue: "New Workspace")
@@ -347,6 +349,11 @@ enum KeyboardShortcutSettings {
                 return StoredShortcut(key: "w", command: true, shift: false, option: false, control: true)
             case .toggleFullScreen:
                 return StoredShortcut(key: "f", command: true, shift: false, option: false, control: true)
+            case .toggleZenMode:
+                return StoredShortcut(
+                    first: ShortcutStroke(key: "k", command: true, shift: false, option: false, control: false),
+                    second: ShortcutStroke(key: "z", command: false, shift: false, option: false, control: false)
+                )
             case .quit:
                 return StoredShortcut(key: "q", command: true, shift: false, option: false, control: false)
             case .toggleSidebar:

--- a/Sources/ZenModeController.swift
+++ b/Sources/ZenModeController.swift
@@ -109,6 +109,8 @@ final class ZenModeController {
     func consumeInterruptedSidebarVisibilityRecovery(windowID: UUID) -> Bool {
         guard interruptedSidebarRecoveryWindowID == windowID else { return false }
         interruptedSidebarRecoveryWindowID = nil
+        defaults.removeObject(forKey: Self.recoverySidebarVisibilityChangedKey)
+        defaults.removeObject(forKey: Self.recoveryWindowIDKey)
         return true
     }
 
@@ -147,13 +149,16 @@ final class ZenModeController {
     }
 
     private func restoreInterruptedSettingsIfNeeded(captureSidebarRecovery: Bool) {
-        guard defaults.bool(forKey: Self.recoveryActiveKey) else { return }
-
+        var capturedSidebarRecovery = false
         if captureSidebarRecovery,
            defaults.bool(forKey: Self.recoverySidebarVisibilityChangedKey),
-           let rawWindowID = defaults.string(forKey: Self.recoveryWindowIDKey) {
-            interruptedSidebarRecoveryWindowID = UUID(uuidString: rawWindowID)
+           let rawWindowID = defaults.string(forKey: Self.recoveryWindowIDKey),
+           let windowID = UUID(uuidString: rawWindowID) {
+            interruptedSidebarRecoveryWindowID = windowID
+            capturedSidebarRecovery = true
         }
+
+        guard defaults.bool(forKey: Self.recoveryActiveKey) else { return }
 
         if defaults.bool(forKey: Self.recoveryPresentationModeChangedKey),
            WorkspacePresentationModeSettings.isMinimal(defaults: defaults) {
@@ -178,7 +183,7 @@ final class ZenModeController {
             }
         }
 
-        clearRecoveryState()
+        clearRecoveryState(preservingSidebarRecovery: capturedSidebarRecovery)
     }
 
     private func restorePreviousValue(key: String, wasPresentKey: String, valueKey: String) {
@@ -189,8 +194,8 @@ final class ZenModeController {
         }
     }
 
-    private func clearRecoveryState() {
-        [
+    private func clearRecoveryState(preservingSidebarRecovery: Bool = false) {
+        var keys = [
             Self.recoveryActiveKey,
             Self.recoveryPresentationModeChangedKey,
             Self.recoveryPresentationModeWasPresentKey,
@@ -199,8 +204,11 @@ final class ZenModeController {
             Self.recoveryContentWidthWasPresentKey,
             Self.recoveryContentWidthValueKey,
             Self.recoveryAppliedContentWidthKey,
-            Self.recoverySidebarVisibilityChangedKey,
-            Self.recoveryWindowIDKey,
-        ].forEach(defaults.removeObject(forKey:))
+        ]
+        if !preservingSidebarRecovery {
+            keys.append(Self.recoverySidebarVisibilityChangedKey)
+            keys.append(Self.recoveryWindowIDKey)
+        }
+        keys.forEach(defaults.removeObject(forKey:))
     }
 }

--- a/Sources/ZenModeController.swift
+++ b/Sources/ZenModeController.swift
@@ -1,0 +1,181 @@
+import CmuxSettings
+import Foundation
+
+/// Owns the reversible settings ledger for the app-wide Zen Mode session.
+@MainActor
+final class ZenModeController {
+    struct Session: Equatable {
+        let windowID: UUID
+        let restoresSidebarVisibility: Bool
+        let exitsFullScreen: Bool
+    }
+
+    private static let recoveryActiveKey = "zenMode.recovery.active"
+    private static let recoveryPresentationModeChangedKey = "zenMode.recovery.presentationModeChanged"
+    private static let recoveryPresentationModeWasPresentKey = "zenMode.recovery.presentationModeWasPresent"
+    private static let recoveryPresentationModeValueKey = "zenMode.recovery.presentationModeValue"
+    private static let recoveryContentWidthChangedKey = "zenMode.recovery.contentWidthChanged"
+    private static let recoveryContentWidthWasPresentKey = "zenMode.recovery.contentWidthWasPresent"
+    private static let recoveryContentWidthValueKey = "zenMode.recovery.contentWidthValue"
+    private static let recoveryAppliedContentWidthKey = "zenMode.recovery.appliedContentWidth"
+
+    private let defaults: UserDefaults
+    private let contentWidthSettings: SessionContentWidthSettings
+    private(set) var activeSession: Session?
+
+    var isActive: Bool { activeSession != nil }
+
+    init(
+        defaults: UserDefaults = .standard,
+        contentWidthSettings: SessionContentWidthSettings = SessionContentWidthSettings()
+    ) {
+        self.defaults = defaults
+        self.contentWidthSettings = contentWidthSettings
+        restoreInterruptedGlobalSettingsIfNeeded()
+    }
+
+    /// Begins Zen Mode and records only state that must be restored later.
+    func begin(
+        windowID: UUID,
+        isSidebarVisible: Bool,
+        isFullScreen: Bool
+    ) -> Session? {
+        guard activeSession == nil else { return nil }
+
+        let presentationModeChanged = !WorkspacePresentationModeSettings.isMinimal(defaults: defaults)
+        let storedContentWidth = defaults.object(forKey: SessionContentWidthSettings.maxWidthKey)
+            .flatMap { ($0 as? NSNumber)?.doubleValue }
+            ?? SessionContentWidthSettings.noMaximumWidth
+        let contentWidthChanged = contentWidthSettings.configuredMaximumWidth(from: storedContentWidth) == nil
+
+        recordGlobalSettingsRecovery(
+            presentationModeChanged: presentationModeChanged,
+            contentWidthChanged: contentWidthChanged
+        )
+
+        if presentationModeChanged {
+            defaults.set(
+                WorkspacePresentationModeSettings.Mode.minimal.rawValue,
+                forKey: WorkspacePresentationModeSettings.modeKey
+            )
+        }
+
+        if contentWidthChanged {
+            let rememberedWidth = defaults.object(forKey: SessionContentWidthSettings.rememberedMaxWidthKey)
+                .flatMap { ($0 as? NSNumber)?.doubleValue }
+                ?? SessionContentWidthSettings.defaultConfiguredMaximumWidth
+            let zenWidth = contentWidthSettings.editorMaximumWidth(
+                activeStoredValue: storedContentWidth,
+                rememberedStoredValue: rememberedWidth
+            )
+            defaults.set(zenWidth, forKey: SessionContentWidthSettings.maxWidthKey)
+            defaults.set(zenWidth, forKey: Self.recoveryAppliedContentWidthKey)
+        }
+
+        let session = Session(
+            windowID: windowID,
+            restoresSidebarVisibility: isSidebarVisible,
+            exitsFullScreen: !isFullScreen
+        )
+        activeSession = session
+        return session
+    }
+
+    /// Ends Zen Mode and restores global settings that still have Zen's values.
+    func end() -> Session? {
+        guard let activeSession else { return nil }
+        restoreInterruptedGlobalSettingsIfNeeded()
+        self.activeSession = nil
+        return activeSession
+    }
+
+    /// Ends Zen Mode when its target window closes.
+    func endIfTargeting(windowID: UUID) -> Session? {
+        guard activeSession?.windowID == windowID else { return nil }
+        return end()
+    }
+
+    /// Restores temporary global settings before normal application termination.
+    func restoreForTermination() {
+        restoreInterruptedGlobalSettingsIfNeeded()
+        activeSession = nil
+    }
+
+    private func recordGlobalSettingsRecovery(
+        presentationModeChanged: Bool,
+        contentWidthChanged: Bool
+    ) {
+        guard presentationModeChanged || contentWidthChanged else { return }
+
+        defaults.set(true, forKey: Self.recoveryActiveKey)
+        defaults.set(presentationModeChanged, forKey: Self.recoveryPresentationModeChangedKey)
+        defaults.set(contentWidthChanged, forKey: Self.recoveryContentWidthChangedKey)
+
+        if presentationModeChanged {
+            let previousValue = defaults.string(forKey: WorkspacePresentationModeSettings.modeKey)
+            defaults.set(previousValue != nil, forKey: Self.recoveryPresentationModeWasPresentKey)
+            if let previousValue {
+                defaults.set(previousValue, forKey: Self.recoveryPresentationModeValueKey)
+            }
+        }
+
+        if contentWidthChanged {
+            let previousValue = defaults.object(forKey: SessionContentWidthSettings.maxWidthKey)
+                .flatMap { ($0 as? NSNumber)?.doubleValue }
+            defaults.set(previousValue != nil, forKey: Self.recoveryContentWidthWasPresentKey)
+            if let previousValue {
+                defaults.set(previousValue, forKey: Self.recoveryContentWidthValueKey)
+            }
+        }
+    }
+
+    private func restoreInterruptedGlobalSettingsIfNeeded() {
+        guard defaults.bool(forKey: Self.recoveryActiveKey) else { return }
+
+        if defaults.bool(forKey: Self.recoveryPresentationModeChangedKey),
+           WorkspacePresentationModeSettings.isMinimal(defaults: defaults) {
+            restorePreviousValue(
+                key: WorkspacePresentationModeSettings.modeKey,
+                wasPresentKey: Self.recoveryPresentationModeWasPresentKey,
+                valueKey: Self.recoveryPresentationModeValueKey
+            )
+        }
+
+        if defaults.bool(forKey: Self.recoveryContentWidthChangedKey),
+           let currentWidth = defaults.object(forKey: SessionContentWidthSettings.maxWidthKey)
+               .flatMap({ ($0 as? NSNumber)?.doubleValue }),
+           currentWidth == defaults.double(forKey: Self.recoveryAppliedContentWidthKey) {
+            if defaults.bool(forKey: Self.recoveryContentWidthWasPresentKey) {
+                defaults.set(
+                    defaults.double(forKey: Self.recoveryContentWidthValueKey),
+                    forKey: SessionContentWidthSettings.maxWidthKey
+                )
+            } else {
+                defaults.removeObject(forKey: SessionContentWidthSettings.maxWidthKey)
+            }
+        }
+
+        clearRecoveryState()
+    }
+
+    private func restorePreviousValue(key: String, wasPresentKey: String, valueKey: String) {
+        if defaults.bool(forKey: wasPresentKey), let previousValue = defaults.string(forKey: valueKey) {
+            defaults.set(previousValue, forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
+
+    private func clearRecoveryState() {
+        [
+            Self.recoveryActiveKey,
+            Self.recoveryPresentationModeChangedKey,
+            Self.recoveryPresentationModeWasPresentKey,
+            Self.recoveryPresentationModeValueKey,
+            Self.recoveryContentWidthChangedKey,
+            Self.recoveryContentWidthWasPresentKey,
+            Self.recoveryContentWidthValueKey,
+            Self.recoveryAppliedContentWidthKey,
+        ].forEach(defaults.removeObject(forKey:))
+    }
+}

--- a/Sources/ZenModeController.swift
+++ b/Sources/ZenModeController.swift
@@ -96,9 +96,8 @@ final class ZenModeController {
     }
 
     /// Restores temporary global settings before normal application termination.
-    func restoreForTermination() {
-        restoreInterruptedGlobalSettingsIfNeeded()
-        activeSession = nil
+    func restoreForTermination() -> Session? {
+        end()
     }
 
     private func recordGlobalSettingsRecovery(

--- a/Sources/ZenModeController.swift
+++ b/Sources/ZenModeController.swift
@@ -18,10 +18,13 @@ final class ZenModeController {
     private static let recoveryContentWidthWasPresentKey = "zenMode.recovery.contentWidthWasPresent"
     private static let recoveryContentWidthValueKey = "zenMode.recovery.contentWidthValue"
     private static let recoveryAppliedContentWidthKey = "zenMode.recovery.appliedContentWidth"
+    private static let recoverySidebarVisibilityChangedKey = "zenMode.recovery.sidebarVisibilityChanged"
+    private static let recoveryWindowIDKey = "zenMode.recovery.windowID"
 
     private let defaults: UserDefaults
     private let contentWidthSettings: SessionContentWidthSettings
     private(set) var activeSession: Session?
+    private var interruptedSidebarRecoveryWindowID: UUID?
 
     var isActive: Bool { activeSession != nil }
 
@@ -31,7 +34,7 @@ final class ZenModeController {
     ) {
         self.defaults = defaults
         self.contentWidthSettings = contentWidthSettings
-        restoreInterruptedGlobalSettingsIfNeeded()
+        restoreInterruptedSettingsIfNeeded(captureSidebarRecovery: true)
     }
 
     /// Begins Zen Mode and records only state that must be restored later.
@@ -49,8 +52,10 @@ final class ZenModeController {
         let contentWidthChanged = contentWidthSettings.configuredMaximumWidth(from: storedContentWidth) == nil
 
         recordGlobalSettingsRecovery(
+            windowID: windowID,
             presentationModeChanged: presentationModeChanged,
-            contentWidthChanged: contentWidthChanged
+            contentWidthChanged: contentWidthChanged,
+            sidebarVisibilityChanged: isSidebarVisible
         )
 
         if presentationModeChanged {
@@ -84,7 +89,7 @@ final class ZenModeController {
     /// Ends Zen Mode and restores global settings that still have Zen's values.
     func end() -> Session? {
         guard let activeSession else { return nil }
-        restoreInterruptedGlobalSettingsIfNeeded()
+        restoreInterruptedSettingsIfNeeded(captureSidebarRecovery: false)
         self.activeSession = nil
         return activeSession
     }
@@ -100,15 +105,28 @@ final class ZenModeController {
         end()
     }
 
+    /// Consumes crash recovery after session restoration has recreated the target window.
+    func consumeInterruptedSidebarVisibilityRecovery(windowID: UUID) -> Bool {
+        guard interruptedSidebarRecoveryWindowID == windowID else { return false }
+        interruptedSidebarRecoveryWindowID = nil
+        return true
+    }
+
     private func recordGlobalSettingsRecovery(
+        windowID: UUID,
         presentationModeChanged: Bool,
-        contentWidthChanged: Bool
+        contentWidthChanged: Bool,
+        sidebarVisibilityChanged: Bool
     ) {
-        guard presentationModeChanged || contentWidthChanged else { return }
+        guard presentationModeChanged || contentWidthChanged || sidebarVisibilityChanged else { return }
 
         defaults.set(true, forKey: Self.recoveryActiveKey)
         defaults.set(presentationModeChanged, forKey: Self.recoveryPresentationModeChangedKey)
         defaults.set(contentWidthChanged, forKey: Self.recoveryContentWidthChangedKey)
+        defaults.set(sidebarVisibilityChanged, forKey: Self.recoverySidebarVisibilityChangedKey)
+        if sidebarVisibilityChanged {
+            defaults.set(windowID.uuidString, forKey: Self.recoveryWindowIDKey)
+        }
 
         if presentationModeChanged {
             let previousValue = defaults.string(forKey: WorkspacePresentationModeSettings.modeKey)
@@ -128,8 +146,14 @@ final class ZenModeController {
         }
     }
 
-    private func restoreInterruptedGlobalSettingsIfNeeded() {
+    private func restoreInterruptedSettingsIfNeeded(captureSidebarRecovery: Bool) {
         guard defaults.bool(forKey: Self.recoveryActiveKey) else { return }
+
+        if captureSidebarRecovery,
+           defaults.bool(forKey: Self.recoverySidebarVisibilityChangedKey),
+           let rawWindowID = defaults.string(forKey: Self.recoveryWindowIDKey) {
+            interruptedSidebarRecoveryWindowID = UUID(uuidString: rawWindowID)
+        }
 
         if defaults.bool(forKey: Self.recoveryPresentationModeChangedKey),
            WorkspacePresentationModeSettings.isMinimal(defaults: defaults) {
@@ -175,6 +199,8 @@ final class ZenModeController {
             Self.recoveryContentWidthWasPresentKey,
             Self.recoveryContentWidthValueKey,
             Self.recoveryAppliedContentWidthKey,
+            Self.recoverySidebarVisibilityChangedKey,
+            Self.recoveryWindowIDKey,
         ].forEach(defaults.removeObject(forKey:))
     }
 }

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1021,6 +1021,12 @@ struct cmuxApp: App {
                 targetWindow.toggleFullScreen(nil)
             }
 
+            splitCommandButton(title: String(localized: "command.toggleZenMode.title", defaultValue: "Toggle Zen Mode"), shortcut: menuShortcut(for: .toggleZenMode)) {
+                if AppDelegate.shared?.toggleZenMode(preferredWindow: NSApp.keyWindow ?? NSApp.mainWindow) != true {
+                    NSSound.beep()
+                }
+            }
+
             Divider()
 
             splitCommandButton(title: String(localized: "menu.view.splitRight", defaultValue: "Split Right"), shortcut: menuShortcut(for: .splitRight)) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1967,6 +1967,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		39EF42EF23A2F751429718CE /* WorkspaceTodoState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9A243534CEB9E9A49B44453 /* WorkspaceTodoState.swift */; };
 		6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */; };
 		84E00D47E4584162AE53BC8D /* xterm-ghostty in Resources */ = {isa = PBXBuildFile; fileRef = B2E7294509CC42FE9191870E /* xterm-ghostty */; };
+		C71600010000000000000001 /* ZenModeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71600020000000000000001 /* ZenModeController.swift */; };
+		C71610010000000000000001 /* ZenModeControllerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71610020000000000000001 /* ZenModeControllerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -3918,6 +3920,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		E9A243534CEB9E9A49B44453 /* WorkspaceTodoState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceTodoState.swift; sourceTree = "<group>"; };
 		71F8ED91A4B55D34BE6A0668 /* WorkspaceUnitTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceUnitTests.swift; sourceTree = "<group>"; };
 		B2E7294509CC42FE9191870E /* xterm-ghostty */ = {isa = PBXFileReference; lastKnownFileType = file; path = "ghostty/terminfo/78/xterm-ghostty"; sourceTree = "<group>"; };
+		C71600020000000000000001 /* ZenModeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenModeController.swift; sourceTree = "<group>"; };
+		C71610020000000000000001 /* ZenModeControllerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ZenModeControllerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -4317,6 +4321,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					5732B0065732B0065732B006 /* WorkspacePresentationModeContentTopPaddingModifier.swift */,
 					5732B0105732B0105732B010 /* WorkspacePresentationModeRuntimeCache.swift */,
 					5732B0075732B0075732B007 /* WorkspaceTitlebarModeLayer.swift */,
+					C71600020000000000000001 /* ZenModeController.swift */,
 					C0DE46010000000000000002 /* CMUXInstalledExtensionSidebarHostView.swift */,
 				C0DE46030000000000000002 /* CMUXSidebarExtensionBrowserPanel.swift */,
 				E4C001000000000000000002 /* ExtensionSidebarWorkspaceRowView.swift */,
@@ -5734,6 +5739,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6042B0026042B0026042B002 /* KeyboardShortcutModifierHoldHintsSettingsFileTests.swift */,
 				D5671102D5671102D5671102 /* TerminalScrollSpeedSettingsFileStoreTests.swift */,
 				C71510020000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift */,
+				C71610020000000000000001 /* ZenModeControllerTests.swift */,
 				6042B0036042B0036042B003 /* ShortcutHintDebugSettingsBindingTests.swift */,
 				E3309A0C /* KeyboardShortcutSettingsEqualizeSplitsTests.swift */,
 				A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */,
@@ -7692,6 +7698,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				249969F7EAC03A99E20C753B /* WorkspaceTodoPanel.swift in Sources */,
 				78F17D618B657B6CF929E327 /* WorkspaceTodoPanelView.swift in Sources */,
 				39EF42EF23A2F751429718CE /* WorkspaceTodoState.swift in Sources */,
+					C71600010000000000000001 /* ZenModeController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -8377,6 +8384,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				41ECF85FFD13D233A0AC75A6 /* WorkspaceTodoSidebarModelTests.swift in Sources */,
 				5B38DFE53BE108F4DA2BDBB7 /* WorkspaceTodoSnapshotTests.swift in Sources */,
 				6B524A0BA34FD46A771335AB /* WorkspaceUnitTests.swift in Sources */,
+				C71610010000000000000001 /* ZenModeControllerTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1059,7 +1059,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertTrue(window.receivedEvents.first === prefixEvent)
     }
 
-    func testChordedShortcutTimeoutReplaysPrefixToOriginalWindow() {
+    func testExpiredChordReplaysPrefixBeforeRoutingNextEvent() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -1079,14 +1079,24 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             key: "k",
             modifiers: [.command],
             keyCode: 40,
-            windowNumber: window.windowNumber
+            windowNumber: window.windowNumber,
+            timestamp: 100
+        ),
+        let expiredSuffixEvent = makeKeyDownEvent(
+            key: "z",
+            modifiers: [],
+            keyCode: 6,
+            windowNumber: window.windowNumber,
+            timestamp: 102
         ) else {
-            XCTFail("Failed to construct chord prefix event")
+            XCTFail("Failed to construct chord events")
             return
         }
 
         XCTAssertTrue(appDelegate.armConfiguredShortcutChordIfNeeded(event: prefixEvent, actions: [.toggleZenMode]))
-        waitFor(timeout: 1.5) { window.receivedEvents.count == 1 }
+#if DEBUG
+        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: expiredSuffixEvent))
+#endif
         XCTAssertEqual(window.receivedEvents.count, 1)
         XCTAssertTrue(window.receivedEvents.first === prefixEvent)
     }

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1124,8 +1124,20 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         }
 
         let customShortcut = StoredShortcut(
-            first: ShortcutStroke(key: "k", command: true),
-            second: ShortcutStroke(key: "c")
+            first: ShortcutStroke(
+                key: "k",
+                command: true,
+                shift: false,
+                option: false,
+                control: false
+            ),
+            second: ShortcutStroke(
+                key: "c",
+                command: false,
+                shift: false,
+                option: false,
+                control: false
+            )
         )
         XCTAssertTrue(appDelegate.armConfiguredShortcutChordIfNeeded(
             event: prefixEvent,

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -1059,7 +1059,7 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
         XCTAssertTrue(window.receivedEvents.first === prefixEvent)
     }
 
-    func testExpiredChordReplaysPrefixBeforeRoutingNextEvent() {
+    func testChordTimeoutReplaysPrefixToOriginalWindow() {
         guard let appDelegate = AppDelegate.shared else {
             XCTFail("Expected AppDelegate.shared")
             return
@@ -1079,26 +1079,63 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
             key: "k",
             modifiers: [.command],
             keyCode: 40,
-            windowNumber: window.windowNumber,
-            timestamp: 100
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct chord prefix event")
+            return
+        }
+
+        XCTAssertTrue(appDelegate.armConfiguredShortcutChordIfNeeded(event: prefixEvent, actions: [.toggleZenMode]))
+        waitFor(timeout: 1.5) { window.receivedEvents.count == 1 }
+        XCTAssertEqual(window.receivedEvents.count, 1)
+        XCTAssertTrue(window.receivedEvents.first === prefixEvent)
+    }
+
+    func testBuiltInAndCustomChordsSharingPrefixAcceptEitherSuffix() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let window = ShortcutFallbackRecordingWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+
+        guard let prefixEvent = makeKeyDownEvent(
+            key: "k",
+            modifiers: [.command],
+            keyCode: 40,
+            windowNumber: window.windowNumber
         ),
-        let expiredSuffixEvent = makeKeyDownEvent(
-            key: "z",
+        let customSuffixEvent = makeKeyDownEvent(
+            key: "c",
             modifiers: [],
-            keyCode: 6,
-            windowNumber: window.windowNumber,
-            timestamp: 102
+            keyCode: 8,
+            windowNumber: window.windowNumber
         ) else {
             XCTFail("Failed to construct chord events")
             return
         }
 
-        XCTAssertTrue(appDelegate.armConfiguredShortcutChordIfNeeded(event: prefixEvent, actions: [.toggleZenMode]))
+        let customShortcut = StoredShortcut(
+            first: ShortcutStroke(key: "k", command: true),
+            second: ShortcutStroke(key: "c")
+        )
+        XCTAssertTrue(appDelegate.armConfiguredShortcutChordIfNeeded(
+            event: prefixEvent,
+            actions: [.toggleZenMode],
+            shortcuts: [customShortcut]
+        ))
 #if DEBUG
-        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: expiredSuffixEvent))
+        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: customSuffixEvent))
 #endif
-        XCTAssertEqual(window.receivedEvents.count, 1)
-        XCTAssertTrue(window.receivedEvents.first === prefixEvent)
+        XCTAssertTrue(window.receivedEvents.isEmpty)
     }
 
     func testCreateMainWindowDoesNotDisallowFullScreenTilingByDefault() {

--- a/cmuxTests/AppDelegateShortcutRoutingTests.swift
+++ b/cmuxTests/AppDelegateShortcutRoutingTests.swift
@@ -16,6 +16,13 @@ private final class FakeWKInspectorContainerView: NSView {}
 private final class FocusableTestView: NSView {
     override var acceptsFirstResponder: Bool { true }
 }
+private final class ShortcutFallbackRecordingWindow: NSWindow {
+    private(set) var receivedEvents: [NSEvent] = []
+
+    override func sendEvent(_ event: NSEvent) {
+        receivedEvents.append(event)
+    }
+}
 private final class FakeTextBoxSubmitSurface: TextBoxSubmitSurfaceControlling {
     var clipboardReadGeneration = 0
     var textBoxSubmitObservationWindow: NSWindow?
@@ -1010,6 +1017,78 @@ final class AppDelegateShortcutRoutingTests: XCTestCase {
 
         RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
         XCTAssertEqual(workspace.panels.count, initialPanelCount, "Unmatched chord suffix must not trigger the action")
+    }
+
+    func testChordedShortcutMismatchReplaysPrefixToOriginalWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let window = ShortcutFallbackRecordingWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+
+        guard let prefixEvent = makeKeyDownEvent(
+            key: "k",
+            modifiers: [.command],
+            keyCode: 40,
+            windowNumber: window.windowNumber
+        ),
+        let mismatchEvent = makeKeyDownEvent(
+            key: "x",
+            modifiers: [],
+            keyCode: 7,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct chord events")
+            return
+        }
+
+        XCTAssertTrue(appDelegate.armConfiguredShortcutChordIfNeeded(event: prefixEvent, actions: [.toggleZenMode]))
+#if DEBUG
+        XCTAssertFalse(appDelegate.debugHandleCustomShortcut(event: mismatchEvent))
+#endif
+        XCTAssertEqual(window.receivedEvents.count, 1)
+        XCTAssertTrue(window.receivedEvents.first === prefixEvent)
+    }
+
+    func testChordedShortcutTimeoutReplaysPrefixToOriginalWindow() {
+        guard let appDelegate = AppDelegate.shared else {
+            XCTFail("Expected AppDelegate.shared")
+            return
+        }
+
+        let window = ShortcutFallbackRecordingWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 320, height: 240),
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.orderFront(nil)
+        defer { window.orderOut(nil) }
+
+        guard let prefixEvent = makeKeyDownEvent(
+            key: "k",
+            modifiers: [.command],
+            keyCode: 40,
+            windowNumber: window.windowNumber
+        ) else {
+            XCTFail("Failed to construct chord prefix event")
+            return
+        }
+
+        XCTAssertTrue(appDelegate.armConfiguredShortcutChordIfNeeded(event: prefixEvent, actions: [.toggleZenMode]))
+        waitFor(timeout: 1.5) { window.receivedEvents.count == 1 }
+        XCTAssertEqual(window.receivedEvents.count, 1)
+        XCTAssertTrue(window.receivedEvents.first === prefixEvent)
     }
 
     func testCreateMainWindowDoesNotDisallowFullScreenTilingByDefault() {

--- a/cmuxTests/ZenModeControllerTests.swift
+++ b/cmuxTests/ZenModeControllerTests.swift
@@ -152,7 +152,10 @@ final class ZenModeControllerTests {
         ))
         #expect(KeyboardShortcutSettings.settingsVisibleActions.contains(.toggleZenMode))
         #expect(ShortcutAction.settingsVisibleActions.contains(.toggleZenMode))
-        #expect(ShortcutAction.toggleZenMode.defaultShortcut == shortcut)
+        #expect(ShortcutAction.toggleZenMode.defaultShortcut == CmuxSettings.StoredShortcut(
+            first: CmuxSettings.ShortcutStroke(key: "k", command: true),
+            second: CmuxSettings.ShortcutStroke(key: "z")
+        ))
     }
 
     private func resetDefaults() -> UserDefaults {

--- a/cmuxTests/ZenModeControllerTests.swift
+++ b/cmuxTests/ZenModeControllerTests.swift
@@ -1,0 +1,133 @@
+import CmuxSettings
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("ZenModeController")
+@MainActor
+struct ZenModeControllerTests {
+    @Test
+    func entersAndRestoresOnlyStateItChanges() {
+        let defaults = makeDefaults()
+        defaults.set(1120.0, forKey: SessionContentWidthSettings.rememberedMaxWidthKey)
+        let controller = ZenModeController(defaults: defaults)
+        let windowID = UUID()
+
+        let session = controller.begin(
+            windowID: windowID,
+            isSidebarVisible: true,
+            isFullScreen: false
+        )
+
+        #expect(session == ZenModeController.Session(
+            windowID: windowID,
+            restoresSidebarVisibility: true,
+            exitsFullScreen: true
+        ))
+        #expect(WorkspacePresentationModeSettings.isMinimal(defaults: defaults))
+        #expect(defaults.double(forKey: SessionContentWidthSettings.maxWidthKey) == 1120)
+
+        #expect(controller.end() == session)
+        #expect(defaults.object(forKey: WorkspacePresentationModeSettings.modeKey) == nil)
+        #expect(defaults.object(forKey: SessionContentWidthSettings.maxWidthKey) == nil)
+    }
+
+    @Test
+    func preservesStateAlreadyMatchingZenMode() {
+        let defaults = makeDefaults()
+        defaults.set(
+            WorkspacePresentationModeSettings.Mode.minimal.rawValue,
+            forKey: WorkspacePresentationModeSettings.modeKey
+        )
+        defaults.set(760.0, forKey: SessionContentWidthSettings.maxWidthKey)
+        let controller = ZenModeController(defaults: defaults)
+
+        let session = controller.begin(
+            windowID: UUID(),
+            isSidebarVisible: false,
+            isFullScreen: true
+        )
+
+        #expect(session?.restoresSidebarVisibility == false)
+        #expect(session?.exitsFullScreen == false)
+        _ = controller.end()
+        #expect(WorkspacePresentationModeSettings.isMinimal(defaults: defaults))
+        #expect(defaults.double(forKey: SessionContentWidthSettings.maxWidthKey) == 760)
+    }
+
+    @Test
+    func doesNotOverwriteSettingsChangedWhileZenModeIsActive() {
+        let defaults = makeDefaults()
+        let controller = ZenModeController(defaults: defaults)
+        _ = controller.begin(windowID: UUID(), isSidebarVisible: true, isFullScreen: false)
+
+        defaults.set(
+            WorkspacePresentationModeSettings.Mode.standard.rawValue,
+            forKey: WorkspacePresentationModeSettings.modeKey
+        )
+        defaults.set(1400.0, forKey: SessionContentWidthSettings.maxWidthKey)
+        _ = controller.end()
+
+        #expect(!WorkspacePresentationModeSettings.isMinimal(defaults: defaults))
+        #expect(defaults.double(forKey: SessionContentWidthSettings.maxWidthKey) == 1400)
+    }
+
+    @Test
+    func restoresTemporaryGlobalSettingsAfterInterruptedSession() {
+        let defaults = makeDefaults()
+        defaults.set(
+            WorkspacePresentationModeSettings.Mode.standard.rawValue,
+            forKey: WorkspacePresentationModeSettings.modeKey
+        )
+        defaults.set(
+            SessionContentWidthSettings.noMaximumWidth,
+            forKey: SessionContentWidthSettings.maxWidthKey
+        )
+        let interruptedController = ZenModeController(defaults: defaults)
+        _ = interruptedController.begin(windowID: UUID(), isSidebarVisible: true, isFullScreen: false)
+
+        _ = ZenModeController(defaults: defaults)
+
+        #expect(
+            defaults.string(forKey: WorkspacePresentationModeSettings.modeKey) ==
+                WorkspacePresentationModeSettings.Mode.standard.rawValue
+        )
+        #expect(
+            defaults.double(forKey: SessionContentWidthSettings.maxWidthKey) ==
+                SessionContentWidthSettings.noMaximumWidth
+        )
+    }
+
+    @Test
+    func usesVSCodeZenModeShortcutAndPublishesItInSettings() {
+        let shortcut = KeyboardShortcutSettings.Action.toggleZenMode.defaultShortcut
+
+        #expect(shortcut.firstStroke == ShortcutStroke(
+            key: "k",
+            command: true,
+            shift: false,
+            option: false,
+            control: false
+        ))
+        #expect(shortcut.secondStroke == ShortcutStroke(
+            key: "z",
+            command: false,
+            shift: false,
+            option: false,
+            control: false
+        ))
+        #expect(KeyboardShortcutSettings.settingsVisibleActions.contains(.toggleZenMode))
+    }
+
+    private func makeDefaults() -> UserDefaults {
+        let suiteName = "ZenModeControllerTests.\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suiteName)!
+        defaults.removePersistentDomain(forName: suiteName)
+        return defaults
+    }
+}

--- a/cmuxTests/ZenModeControllerTests.swift
+++ b/cmuxTests/ZenModeControllerTests.swift
@@ -104,6 +104,17 @@ struct ZenModeControllerTests {
     }
 
     @Test
+    func terminationReturnsWindowStateLedgerForSynchronousRestoration() {
+        let defaults = makeDefaults()
+        let controller = ZenModeController(defaults: defaults)
+        let session = controller.begin(windowID: UUID(), isSidebarVisible: true, isFullScreen: false)
+
+        #expect(controller.restoreForTermination() == session)
+        #expect(defaults.object(forKey: WorkspacePresentationModeSettings.modeKey) == nil)
+        #expect(defaults.object(forKey: SessionContentWidthSettings.maxWidthKey) == nil)
+    }
+
+    @Test
     func usesVSCodeZenModeShortcutAndPublishesItInSettings() {
         let shortcut = KeyboardShortcutSettings.Action.toggleZenMode.defaultShortcut
 
@@ -122,6 +133,8 @@ struct ZenModeControllerTests {
             control: false
         ))
         #expect(KeyboardShortcutSettings.settingsVisibleActions.contains(.toggleZenMode))
+        #expect(ShortcutAction.settingsVisibleActions.contains(.toggleZenMode))
+        #expect(ShortcutAction.toggleZenMode.defaultShortcut == shortcut)
     }
 
     private func makeDefaults() -> UserDefaults {

--- a/cmuxTests/ZenModeControllerTests.swift
+++ b/cmuxTests/ZenModeControllerTests.swift
@@ -105,7 +105,7 @@ final class ZenModeControllerTests {
         let interruptedController = ZenModeController(defaults: defaults)
         _ = interruptedController.begin(windowID: windowID, isSidebarVisible: true, isFullScreen: false)
 
-        let recoveredController = ZenModeController(defaults: defaults)
+        _ = ZenModeController(defaults: defaults)
 
         #expect(
             defaults.string(forKey: WorkspacePresentationModeSettings.modeKey) ==
@@ -115,8 +115,13 @@ final class ZenModeControllerTests {
             defaults.double(forKey: SessionContentWidthSettings.maxWidthKey) ==
                 SessionContentWidthSettings.noMaximumWidth
         )
-        #expect(recoveredController.consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
-        #expect(!recoveredController.consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
+
+        // A second startup crash before session restoration must not lose the
+        // pending sidebar repair.
+        let secondRecoveredController = ZenModeController(defaults: defaults)
+        #expect(secondRecoveredController.consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
+        #expect(!secondRecoveredController.consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
+        #expect(!ZenModeController(defaults: defaults).consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
     }
 
     @Test

--- a/cmuxTests/ZenModeControllerTests.swift
+++ b/cmuxTests/ZenModeControllerTests.swift
@@ -8,12 +8,25 @@ import Testing
 @testable import cmux
 #endif
 
-@Suite("ZenModeController")
+@Suite("ZenModeController", .serialized)
 @MainActor
-struct ZenModeControllerTests {
+final class ZenModeControllerTests {
+    private let defaultsSuiteName: String
+    private let defaults: UserDefaults
+
+    init() {
+        defaultsSuiteName = "ZenModeControllerTests.\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: defaultsSuiteName)!
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+    }
+
+    deinit {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+    }
+
     @Test
     func entersAndRestoresOnlyStateItChanges() {
-        let defaults = makeDefaults()
+        let defaults = resetDefaults()
         defaults.set(1120.0, forKey: SessionContentWidthSettings.rememberedMaxWidthKey)
         let controller = ZenModeController(defaults: defaults)
         let windowID = UUID()
@@ -39,7 +52,7 @@ struct ZenModeControllerTests {
 
     @Test
     func preservesStateAlreadyMatchingZenMode() {
-        let defaults = makeDefaults()
+        let defaults = resetDefaults()
         defaults.set(
             WorkspacePresentationModeSettings.Mode.minimal.rawValue,
             forKey: WorkspacePresentationModeSettings.modeKey
@@ -62,7 +75,7 @@ struct ZenModeControllerTests {
 
     @Test
     func doesNotOverwriteSettingsChangedWhileZenModeIsActive() {
-        let defaults = makeDefaults()
+        let defaults = resetDefaults()
         let controller = ZenModeController(defaults: defaults)
         _ = controller.begin(windowID: UUID(), isSidebarVisible: true, isFullScreen: false)
 
@@ -79,7 +92,8 @@ struct ZenModeControllerTests {
 
     @Test
     func restoresTemporaryGlobalSettingsAfterInterruptedSession() {
-        let defaults = makeDefaults()
+        let defaults = resetDefaults()
+        let windowID = UUID()
         defaults.set(
             WorkspacePresentationModeSettings.Mode.standard.rawValue,
             forKey: WorkspacePresentationModeSettings.modeKey
@@ -89,9 +103,9 @@ struct ZenModeControllerTests {
             forKey: SessionContentWidthSettings.maxWidthKey
         )
         let interruptedController = ZenModeController(defaults: defaults)
-        _ = interruptedController.begin(windowID: UUID(), isSidebarVisible: true, isFullScreen: false)
+        _ = interruptedController.begin(windowID: windowID, isSidebarVisible: true, isFullScreen: false)
 
-        _ = ZenModeController(defaults: defaults)
+        let recoveredController = ZenModeController(defaults: defaults)
 
         #expect(
             defaults.string(forKey: WorkspacePresentationModeSettings.modeKey) ==
@@ -101,17 +115,21 @@ struct ZenModeControllerTests {
             defaults.double(forKey: SessionContentWidthSettings.maxWidthKey) ==
                 SessionContentWidthSettings.noMaximumWidth
         )
+        #expect(recoveredController.consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
+        #expect(!recoveredController.consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
     }
 
     @Test
     func terminationReturnsWindowStateLedgerForSynchronousRestoration() {
-        let defaults = makeDefaults()
+        let defaults = resetDefaults()
         let controller = ZenModeController(defaults: defaults)
-        let session = controller.begin(windowID: UUID(), isSidebarVisible: true, isFullScreen: false)
+        let windowID = UUID()
+        let session = controller.begin(windowID: windowID, isSidebarVisible: true, isFullScreen: false)
 
         #expect(controller.restoreForTermination() == session)
         #expect(defaults.object(forKey: WorkspacePresentationModeSettings.modeKey) == nil)
         #expect(defaults.object(forKey: SessionContentWidthSettings.maxWidthKey) == nil)
+        #expect(!ZenModeController(defaults: defaults).consumeInterruptedSidebarVisibilityRecovery(windowID: windowID))
     }
 
     @Test
@@ -137,10 +155,8 @@ struct ZenModeControllerTests {
         #expect(ShortcutAction.toggleZenMode.defaultShortcut == shortcut)
     }
 
-    private func makeDefaults() -> UserDefaults {
-        let suiteName = "ZenModeControllerTests.\(UUID().uuidString)"
-        let defaults = UserDefaults(suiteName: suiteName)!
-        defaults.removePersistentDomain(forName: suiteName)
+    private func resetDefaults() -> UserDefaults {
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
         return defaults
     }
 }

--- a/web/data/cmux-shortcuts.ts
+++ b/web/data/cmux-shortcuts.ts
@@ -61,6 +61,16 @@ export const shortcutCategories: ShortcutCategory[] = [
       { id: "closeWindow", combos: [["⌃", "⌘", "W"]], description: { en: "Close window", ja: "ウインドウを閉じる" } },
       { id: "toggleFullScreen", combos: [["⌃", "⌘", "F"]], description: { en: "Toggle full screen", ja: "フルスクリーンを切り替え" } },
       {
+        id: "toggleZenMode",
+        combos: [["⌘", "K"], ["Z"]],
+        description: { en: "Toggle Zen Mode", ja: "Zenモードを切り替え" },
+        note: {
+          en: "Hides the left sidebar, enables Minimal Mode and the session content width cap, and enters full screen; toggle again to restore only the settings Zen Mode changed.",
+          ja: "左サイドバーを隠し、ミニマルモードとセッションコンテンツの最大幅を有効にしてフルスクリーンにします。もう一度切り替えると、Zenモードが変更した設定だけを元に戻します。",
+        },
+        configValue: '["cmd+k", "z"]',
+      },
+      {
         id: "sendFeedback",
         combos: [],
         description: { en: "Send feedback", ja: "フィードバックを送信" },

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -1571,6 +1571,7 @@
               "newWindow",
               "closeWindow",
               "toggleFullScreen",
+              "toggleZenMode",
               "quit",
               "toggleSidebar",
               "newTab",


### PR DESCRIPTION
## Summary
- add VS Code-compatible `⌘K Z` Zen Mode across shortcuts, Settings, View menu, and command palette
- hide the left sidebar, enable Minimal Mode and the remembered session width cap, then enter native full screen
- restore only state changed by Zen Mode, including interrupted-session recovery
- document the configurable shortcut and localize English and Japanese UI

Depends on and includes https://github.com/manaflow-ai/cmux/pull/8222.

## Verification
- final tagged cloud build passed: https://github.com/manaflow-ai/cmux/actions/runs/29479037091 (`zenmd`)
- `swift test --package-path Packages/macOS/CmuxSettings`: 258 tests passed
- `bun run typecheck`
- `bunx eslint data/cmux-shortcuts.ts`
- `scripts/check-pbxproj.sh`
- `scripts/lint-pbxproj-test-wiring.sh`
- final `cmux-unit` target compiled the app and Zen tests, then the existing `main` app-host crash stopped test bootstrap: https://github.com/manaflow-ai/cmux/actions/runs/29479023129

UI preflight is **UNVERIFIED**. Launching the final `zenmd` build with session restore disabled reproduces `Combine/Publisher+AsyncSequence.swift:112: Received an output without requesting demand` before the Zen shortcut can run. The merged dependency tag `swcap` reproduces it, and the fix is tracked in https://github.com/manaflow-ai/cmux/pull/8231.

The required Vercel preview remains queued with no reported build error.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8249"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786772987&installation_id=133855650&pr_number=8249&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8249&signature=7625f4ba503500edb70b4160adf242101a87d0a824d7aed4ac957ec4b2ad70dd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reversible Zen Mode matching VS Code’s ⌘K, Z. It hides the left sidebar, enables Minimal Mode and a content width cap, and enters full screen; on toggle, quit, or relaunch it restores only what Zen changed, with durable crash recovery that restores the sidebar when the original window returns.

- **New Features**
  - Adds ZenModeController to toggle Zen Mode and track only the state it changes; restores on quit/window close and before termination/relaunch; durably captures sidebar recovery across restarts until the target window is recreated.
  - Adds “Toggle Zen Mode” in the Command Palette and View menu; default shortcut is ⌘K, Z and is configurable in Settings.
  - Improves chorded shortcut lifecycle: 1s timeout; mismatched or expired chords replay the prefix to the original window; supports shared prefixes across built‑in and custom chords; keeps Quit responsive.
  - Adds English and Japanese labels, plus web shortcut docs and `cmux.schema.json` updates.

<sup>Written for commit 188ff44931f5fe2296fa5c3eac7dabae91782ff4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8249?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Zen Mode with reversible “focus” presentation, restoring full-screen/sidebar state and editor/content width when applicable.
  * Added “Toggle Zen Mode” to the app menu and Command Palette, including Settings support and a default two-step shortcut (Cmd+K, then Z).
* **Bug Fixes**
  * Improved two-stroke shortcut chord handling: on mismatch or timeout, the app now replays the correct prefix event to the intended window.
* **Documentation**
  * Added English/Japanese localized command and shortcut labels, plus restore-behavior guidance.
* **Tests**
  * Added Zen Mode and shortcut-routing test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->