### PR TITLE
Fix capped session pane interaction paths

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7196,15 +7196,35 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 
     override func menu(for event: NSEvent) -> NSMenu? {
+        makeContextMenu(for: event, sendsTerminalPointerEvent: true)
+    }
+
+    /// Builds the terminal's cmux context menu for pane chrome outside the
+    /// terminal viewport without sending an out-of-bounds mouse event to Ghostty.
+    func paneContextMenu(for event: NSEvent) -> NSMenu? {
+        makeContextMenu(for: event, sendsTerminalPointerEvent: false)
+    }
+
+    private func makeContextMenu(
+        for event: NSEvent,
+        sendsTerminalPointerEvent: Bool
+    ) -> NSMenu? {
         guard let surface = surface else { return nil }
         if ghostty_surface_mouse_captured(surface) {
             return nil
         }
 
         window?.makeFirstResponder(self)
-        let point = convert(event.locationInWindow, from: nil)
-        ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, mouseModsFromEvent(event))
-        _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_PRESS, GHOSTTY_MOUSE_RIGHT, mouseModsFromEvent(event))
+        if sendsTerminalPointerEvent {
+            let point = convert(event.locationInWindow, from: nil)
+            ghostty_surface_mouse_pos(surface, point.x, bounds.height - point.y, mouseModsFromEvent(event))
+            _ = ghostty_surface_mouse_button(
+                surface,
+                GHOSTTY_MOUSE_PRESS,
+                GHOSTTY_MOUSE_RIGHT,
+                mouseModsFromEvent(event)
+            )
+        }
 
         let menu = NSMenu()
         if onTriggerFlash != nil {
@@ -7869,15 +7889,12 @@ private final class TerminalPaneBackgroundView: NSView {
     }
 
     override func rightMouseDown(with event: NSEvent) {
-        terminalSurfaceView?.rightMouseDown(with: event)
-    }
-
-    override func rightMouseUp(with event: NSEvent) {
-        terminalSurfaceView?.rightMouseUp(with: event)
+        terminalSurfaceView?.focusFromPointerDown()
+        super.rightMouseDown(with: event)
     }
 
     override func menu(for event: NSEvent) -> NSMenu? {
-        terminalSurfaceView?.menu(for: event)
+        terminalSurfaceView?.paneContextMenu(for: event)
     }
 
     override func scrollWheel(with event: NSEvent) {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7857,15 +7857,31 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 }
 
 private final class TerminalPaneBackgroundView: NSView {
-    var onPointerDown: (() -> Void)?
-    var onScrollWheel: ((NSEvent) -> Void)?
+    weak var terminalSurfaceView: GhosttyNSView?
+    weak var terminalScrollView: GhosttyScrollView?
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        terminalSurfaceView?.acceptsFirstMouse(for: event) ?? false
+    }
 
     override func mouseDown(with event: NSEvent) {
-        onPointerDown?()
+        terminalSurfaceView?.focusFromPointerDown()
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        terminalSurfaceView?.rightMouseDown(with: event)
+    }
+
+    override func rightMouseUp(with event: NSEvent) {
+        terminalSurfaceView?.rightMouseUp(with: event)
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        terminalSurfaceView?.menu(for: event)
     }
 
     override func scrollWheel(with event: NSEvent) {
-        onScrollWheel?(event)
+        terminalScrollView?.scrollWheel(with: event)
     }
 }
 
@@ -8423,12 +8439,8 @@ final class GhosttySurfaceScrollView: NSView {
         backgroundView.wantsLayer = true
         backgroundView.layer?.backgroundColor = NSColor.clear.cgColor
         backgroundView.layer?.isOpaque = false
-        backgroundView.onPointerDown = { [weak surfaceView] in
-            surfaceView?.focusFromPointerDown()
-        }
-        backgroundView.onScrollWheel = { [weak scrollView] event in
-            scrollView?.scrollWheel(with: event)
-        }
+        backgroundView.terminalSurfaceView = surfaceView
+        backgroundView.terminalScrollView = scrollView
         addSubview(backgroundView)
         addSubview(scrollView)
         mobileViewportBorderOverlayView.isHidden = true

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7210,7 +7210,7 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         sendsTerminalPointerEvent: Bool
     ) -> NSMenu? {
         guard let surface = surface else { return nil }
-        if ghostty_surface_mouse_captured(surface) {
+        if sendsTerminalPointerEvent, ghostty_surface_mouse_captured(surface) {
             return nil
         }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7876,32 +7876,6 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
     }
 }
 
-private final class TerminalPaneBackgroundView: NSView {
-    weak var terminalSurfaceView: GhosttyNSView?
-    weak var terminalScrollView: GhosttyScrollView?
-
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
-        terminalSurfaceView?.acceptsFirstMouse(for: event) ?? false
-    }
-
-    override func mouseDown(with event: NSEvent) {
-        terminalSurfaceView?.focusFromPointerDown()
-    }
-
-    override func rightMouseDown(with event: NSEvent) {
-        terminalSurfaceView?.focusFromPointerDown()
-        super.rightMouseDown(with: event)
-    }
-
-    override func menu(for event: NSEvent) -> NSMenu? {
-        terminalSurfaceView?.paneContextMenu(for: event)
-    }
-
-    override func scrollWheel(with event: NSEvent) {
-        terminalScrollView?.scrollWheel(with: event)
-    }
-}
-
 private extension NSScreen {
     var displayID: UInt32? {
         let key = NSDeviceDescriptionKey("NSScreenNumber")

--- a/Sources/Panels/AgentSessionPanelView.swift
+++ b/Sources/Panels/AgentSessionPanelView.swift
@@ -1,6 +1,11 @@
 import SwiftUI
+import CmuxSettings
 
 struct AgentSessionPanelView: View {
+    @AppStorage(SessionContentWidthSettings.maxWidthKey)
+    private var storedSessionContentMaximumWidth = SessionContentWidthSettings.noMaximumWidth
+    @AppStorage(SessionContentWidthSettings.alignmentKey)
+    private var storedSessionContentAlignment = SessionContentAlignment.center.rawValue
     let panel: AgentSessionPanel
     let isFocused: Bool
     let isVisibleInUI: Bool
@@ -16,6 +21,7 @@ struct AgentSessionPanelView: View {
                     isFocused: isFocused,
                     backgroundColor: appearance.contentBackgroundColor,
                     theme: AgentSessionWebTheme.resolve(appearance: appearance),
+                    sessionContentWidthPresentation: sessionContentWidthPresentation,
                     onRequestPanelFocus: onRequestPanelFocus
                 )
                 .id(panel.id)
@@ -25,7 +31,13 @@ struct AgentSessionPanelView: View {
                 Color.clear
             }
         }
-        .sessionContentWidth()
         .background(Color(nsColor: appearance.contentBackgroundColor))
+    }
+
+    private var sessionContentWidthPresentation: SessionContentWidthPresentation {
+        SessionContentWidthPresentation(
+            storedMaximumWidth: storedSessionContentMaximumWidth,
+            storedAlignment: storedSessionContentAlignment
+        )
     }
 }

--- a/Sources/Panels/AgentSessionWebHostView.swift
+++ b/Sources/Panels/AgentSessionWebHostView.swift
@@ -9,6 +9,7 @@ final class AgentSessionWebHostView: NSView {
     private var lastReportedAgentSessionWebHostGeometryState: AgentSessionWebHostGeometryState?
     private var hasPendingGeometryNotification = false
     private weak var hostedWebView: WKWebView?
+    private var sessionContentWidthPresentation = SessionContentWidthPresentation.disabled
 
     override var isOpaque: Bool { false }
 
@@ -26,9 +27,23 @@ final class AgentSessionWebHostView: NSView {
     override func layout() {
         super.layout()
         if let hostedWebView, hostedWebView.superview === self {
-            hostedWebView.frame = bounds
+            hostedWebView.frame = sessionContentWidthPresentation.contentFrame(in: bounds)
         }
         notifyGeometryChangedIfNeeded()
+    }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        hostedWebView?.acceptsFirstMouse(for: event) ?? false
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        guard let webView = hostedWebView as? AgentSessionWebView else { return }
+        webView.onPointerDown?()
+        window?.makeFirstResponder(webView)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        hostedWebView?.scrollWheel(with: event)
     }
 
     override func setFrameOrigin(_ newOrigin: NSPoint) {
@@ -76,8 +91,15 @@ final class AgentSessionWebHostView: NSView {
         }
         hostedWebView = webView
         webView.translatesAutoresizingMaskIntoConstraints = true
-        webView.autoresizingMask = [.width, .height]
-        webView.frame = bounds
+        webView.autoresizingMask = []
+        webView.frame = sessionContentWidthPresentation.contentFrame(in: bounds)
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+    }
+
+    func setSessionContentWidthPresentation(_ presentation: SessionContentWidthPresentation) {
+        guard sessionContentWidthPresentation != presentation else { return }
+        sessionContentWidthPresentation = presentation
         needsLayout = true
         layoutSubtreeIfNeeded()
     }

--- a/Sources/Panels/AgentSessionWebHostView.swift
+++ b/Sources/Panels/AgentSessionWebHostView.swift
@@ -10,6 +10,11 @@ final class AgentSessionWebHostView: NSView {
     private var hasPendingGeometryNotification = false
     private weak var hostedWebView: WKWebView?
     private var sessionContentWidthPresentation = SessionContentWidthPresentation.disabled
+    private var pendingScrollDelta = CGPoint.zero
+    private var scrollFlushTask: Task<Void, Never>?
+    private var isScrollJavaScriptInFlight = false
+    private var scrollGeneration: UInt64 = 0
+    private static let maximumPendingScrollDelta: CGFloat = 2400
 
     override var isOpaque: Bool { false }
 
@@ -49,15 +54,62 @@ final class AgentSessionWebHostView: NSView {
         let deltaY = event.scrollingDeltaY * pointScale
         guard deltaX.isFinite, deltaY.isFinite else { return }
 
+        pendingScrollDelta.x = Self.clampedScrollDelta(pendingScrollDelta.x + deltaX)
+        pendingScrollDelta.y = Self.clampedScrollDelta(pendingScrollDelta.y + deltaY)
+        scheduleScrollFlush()
+    }
+
+    private static func clampedScrollDelta(_ value: CGFloat) -> CGFloat {
+        min(max(value, -maximumPendingScrollDelta), maximumPendingScrollDelta)
+    }
+
+    private func scheduleScrollFlush() {
+        guard pendingScrollDelta != .zero,
+              scrollFlushTask == nil,
+              !isScrollJavaScriptInFlight else { return }
+        scrollFlushTask = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled, let self else { return }
+            self.scrollFlushTask = nil
+            self.flushPendingScroll()
+        }
+    }
+
+    private func flushPendingScroll() {
+        guard !isScrollJavaScriptInFlight,
+              let hostedWebView,
+              pendingScrollDelta != .zero else { return }
+
+        let delta = pendingScrollDelta
+        pendingScrollDelta = .zero
+        isScrollJavaScriptInFlight = true
+        let generation = scrollGeneration
+
         let script = """
         (() => {
           const thread = document.querySelector('.agent-thread');
           if (!(thread instanceof HTMLElement)) return false;
-          thread.scrollBy(\(-Double(deltaX)), \(-Double(deltaY)));
+          thread.scrollBy(\(-Double(delta.x)), \(-Double(delta.y)));
           return true;
         })()
         """
-        hostedWebView.evaluateJavaScript(script, completionHandler: nil)
+        hostedWebView.evaluateJavaScript(script) { [weak self, weak hostedWebView] _, _ in
+            Task { @MainActor in
+                guard let self,
+                      self.scrollGeneration == generation,
+                      self.hostedWebView === hostedWebView else { return }
+                self.isScrollJavaScriptInFlight = false
+                self.scheduleScrollFlush()
+            }
+        }
+    }
+
+    private func resetPendingScroll() {
+        scrollGeneration &+= 1
+        scrollFlushTask?.cancel()
+        scrollFlushTask = nil
+        pendingScrollDelta = .zero
+        isScrollJavaScriptInFlight = false
     }
 
     override func setFrameOrigin(_ newOrigin: NSPoint) {
@@ -99,6 +151,9 @@ final class AgentSessionWebHostView: NSView {
     }
 
     func attachWebView(_ webView: WKWebView) {
+        if hostedWebView !== webView {
+            resetPendingScroll()
+        }
         if webView.superview !== self {
             webView.removeFromSuperview()
             addSubview(webView, positioned: .above, relativeTo: nil)
@@ -125,6 +180,7 @@ final class AgentSessionWebHostView: NSView {
         }
         webView.removeFromSuperview()
         if hostedWebView === webView {
+            resetPendingScroll()
             hostedWebView = nil
         }
     }

--- a/Sources/Panels/AgentSessionWebHostView.swift
+++ b/Sources/Panels/AgentSessionWebHostView.swift
@@ -43,7 +43,30 @@ final class AgentSessionWebHostView: NSView {
     }
 
     override func scrollWheel(with event: NSEvent) {
-        hostedWebView?.scrollWheel(with: event)
+        guard let hostedWebView else { return }
+        guard let cgEvent = event.cgEvent?.copy() else {
+            hostedWebView.scrollWheel(with: event)
+            return
+        }
+
+        let targetInWindow = hostedWebView.convert(
+            NSPoint(x: hostedWebView.bounds.midX, y: hostedWebView.bounds.midY),
+            to: nil
+        )
+        let windowDelta = NSPoint(
+            x: targetInWindow.x - event.locationInWindow.x,
+            y: targetInWindow.y - event.locationInWindow.y
+        )
+        var targetInQuartz = cgEvent.location
+        targetInQuartz.x += windowDelta.x
+        targetInQuartz.y -= windowDelta.y
+        cgEvent.location = targetInQuartz
+
+        guard let retargetedEvent = NSEvent(cgEvent: cgEvent) else {
+            hostedWebView.scrollWheel(with: event)
+            return
+        }
+        hostedWebView.scrollWheel(with: retargetedEvent)
     }
 
     override func setFrameOrigin(_ newOrigin: NSPoint) {

--- a/Sources/Panels/AgentSessionWebHostView.swift
+++ b/Sources/Panels/AgentSessionWebHostView.swift
@@ -42,17 +42,26 @@ final class AgentSessionWebHostView: NSView {
     }
 
     override func mouseDown(with event: NSEvent) {
-        guard let webView = hostedWebView as? AgentSessionWebView else { return }
+        guard let webView = hostedWebView as? AgentSessionWebView else {
+            super.mouseDown(with: event)
+            return
+        }
         webView.onPointerDown?()
         window?.makeFirstResponder(webView)
     }
 
     override func scrollWheel(with event: NSEvent) {
-        guard let hostedWebView else { return }
+        guard let hostedWebView else {
+            super.scrollWheel(with: event)
+            return
+        }
         let pointScale: CGFloat = event.hasPreciseScrollingDeltas ? 1 : 20
         let deltaX = event.scrollingDeltaX * pointScale
         let deltaY = event.scrollingDeltaY * pointScale
-        guard deltaX.isFinite, deltaY.isFinite else { return }
+        guard deltaX.isFinite, deltaY.isFinite else {
+            super.scrollWheel(with: event)
+            return
+        }
 
         pendingScrollDelta.x = Self.clampedScrollDelta(pendingScrollDelta.x + deltaX)
         pendingScrollDelta.y = Self.clampedScrollDelta(pendingScrollDelta.y + deltaY)

--- a/Sources/Panels/AgentSessionWebHostView.swift
+++ b/Sources/Panels/AgentSessionWebHostView.swift
@@ -44,29 +44,20 @@ final class AgentSessionWebHostView: NSView {
 
     override func scrollWheel(with event: NSEvent) {
         guard let hostedWebView else { return }
-        guard let cgEvent = event.cgEvent?.copy() else {
-            hostedWebView.scrollWheel(with: event)
-            return
-        }
+        let pointScale: CGFloat = event.hasPreciseScrollingDeltas ? 1 : 20
+        let deltaX = event.scrollingDeltaX * pointScale
+        let deltaY = event.scrollingDeltaY * pointScale
+        guard deltaX.isFinite, deltaY.isFinite else { return }
 
-        let targetInWindow = hostedWebView.convert(
-            NSPoint(x: hostedWebView.bounds.midX, y: hostedWebView.bounds.midY),
-            to: nil
-        )
-        let windowDelta = NSPoint(
-            x: targetInWindow.x - event.locationInWindow.x,
-            y: targetInWindow.y - event.locationInWindow.y
-        )
-        var targetInQuartz = cgEvent.location
-        targetInQuartz.x += windowDelta.x
-        targetInQuartz.y -= windowDelta.y
-        cgEvent.location = targetInQuartz
-
-        guard let retargetedEvent = NSEvent(cgEvent: cgEvent) else {
-            hostedWebView.scrollWheel(with: event)
-            return
-        }
-        hostedWebView.scrollWheel(with: retargetedEvent)
+        let script = """
+        (() => {
+          const thread = document.querySelector('.agent-thread');
+          if (!(thread instanceof HTMLElement)) return false;
+          thread.scrollBy(\(-Double(deltaX)), \(-Double(deltaY)));
+          return true;
+        })()
+        """
+        hostedWebView.evaluateJavaScript(script, completionHandler: nil)
     }
 
     override func setFrameOrigin(_ newOrigin: NSPoint) {

--- a/Sources/Panels/AgentSessionWebRenderer.swift
+++ b/Sources/Panels/AgentSessionWebRenderer.swift
@@ -8,6 +8,7 @@ struct AgentSessionWebRenderer: NSViewRepresentable {
     let isFocused: Bool
     let backgroundColor: NSColor
     let theme: AgentSessionWebTheme
+    let sessionContentWidthPresentation: SessionContentWidthPresentation
     let onRequestPanelFocus: () -> Void
 
     func makeCoordinator() -> AgentSessionWebRendererCoordinator {
@@ -47,6 +48,7 @@ struct AgentSessionWebRenderer: NSViewRepresentable {
         applyBackground(to: host)
         applyBackground(to: webView)
         applyAppearance(to: webView)
+        host.setSessionContentWidthPresentation(sessionContentWidthPresentation)
         host.attachWebView(webView)
         host.onDidMoveToWindow = { [weak coordinator = context.coordinator] in
             coordinator?.loadShellIfNeeded()

--- a/Sources/Panels/SessionContentWidthModifier.swift
+++ b/Sources/Panels/SessionContentWidthModifier.swift
@@ -1,39 +1,7 @@
 import CmuxSettings
 import SwiftUI
 
-/// Resolved session-width values shared by SwiftUI and direct AppKit terminal hosts.
-struct SessionContentWidthPresentation: Equatable, Sendable {
-    static let disabled = SessionContentWidthPresentation(
-        storedMaximumWidth: SessionContentWidthSettings.noMaximumWidth,
-        storedAlignment: SessionContentAlignment.center.rawValue
-    )
-
-    let maximumWidth: CGFloat?
-    let alignment: SessionContentAlignment
-
-    init(storedMaximumWidth: Double, storedAlignment: String) {
-        maximumWidth = SessionContentWidthSettings()
-            .configuredMaximumWidth(from: storedMaximumWidth)
-            .map { CGFloat($0) }
-        alignment = SessionContentAlignment(rawValue: storedAlignment) ?? .center
-    }
-
-    /// Returns the content rectangle inside full-pane bounds.
-    func contentFrame(in bounds: CGRect) -> CGRect {
-        guard let maximumWidth, bounds.width > maximumWidth else { return bounds }
-
-        let x: CGFloat
-        switch alignment {
-        case .left:
-            x = bounds.minX
-        case .center:
-            x = bounds.minX + (bounds.width - maximumWidth) / 2
-        case .right:
-            x = bounds.maxX - maximumWidth
-        }
-        return CGRect(x: x, y: bounds.minY, width: maximumWidth, height: bounds.height)
-    }
-
+private extension SessionContentWidthPresentation {
     var swiftUIAlignment: Alignment {
         switch alignment {
         case .left:

--- a/Sources/Panels/SessionContentWidthPresentation.swift
+++ b/Sources/Panels/SessionContentWidthPresentation.swift
@@ -1,0 +1,36 @@
+import CmuxSettings
+import CoreGraphics
+
+/// Resolved session-width values shared by SwiftUI and direct AppKit terminal hosts.
+struct SessionContentWidthPresentation: Equatable, Sendable {
+    static let disabled = SessionContentWidthPresentation(
+        storedMaximumWidth: SessionContentWidthSettings.noMaximumWidth,
+        storedAlignment: SessionContentAlignment.center.rawValue
+    )
+
+    let maximumWidth: CGFloat?
+    let alignment: SessionContentAlignment
+
+    init(storedMaximumWidth: Double, storedAlignment: String) {
+        maximumWidth = SessionContentWidthSettings()
+            .configuredMaximumWidth(from: storedMaximumWidth)
+            .map { CGFloat($0) }
+        alignment = SessionContentAlignment(rawValue: storedAlignment) ?? .center
+    }
+
+    /// Returns the content rectangle inside full-pane bounds.
+    func contentFrame(in bounds: CGRect) -> CGRect {
+        guard let maximumWidth, bounds.width > maximumWidth else { return bounds }
+
+        let x: CGFloat
+        switch alignment {
+        case .left:
+            x = bounds.minX
+        case .center:
+            x = bounds.minX + (bounds.width - maximumWidth) / 2
+        case .right:
+            x = bounds.maxX - maximumWidth
+        }
+        return CGRect(x: x, y: bounds.minY, width: maximumWidth, height: bounds.height)
+    }
+}

--- a/Sources/TerminalPaneBackgroundView.swift
+++ b/Sources/TerminalPaneBackgroundView.swift
@@ -1,0 +1,28 @@
+import AppKit
+
+/// Preserves terminal interaction semantics in empty space around capped content.
+final class TerminalPaneBackgroundView: NSView {
+    weak var terminalSurfaceView: GhosttyNSView?
+    weak var terminalScrollView: GhosttyScrollView?
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        terminalSurfaceView?.acceptsFirstMouse(for: event) ?? false
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        terminalSurfaceView?.focusFromPointerDown()
+    }
+
+    override func rightMouseDown(with event: NSEvent) {
+        terminalSurfaceView?.focusFromPointerDown()
+        super.rightMouseDown(with: event)
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        terminalSurfaceView?.paneContextMenu(for: event)
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        terminalScrollView?.scrollWheel(with: event)
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1371,6 +1371,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A74770010000000000000005 /* SessionConfigFrameEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74770010000000000000006 /* SessionConfigFrameEntry.swift */; };
 		A74770010000000000000007 /* SessionConfigFrameRing.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74770010000000000000008 /* SessionConfigFrameRing.swift */; };
 		C71500020000000000000001 /* SessionContentWidthModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71500010000000000000001 /* SessionContentWidthModifier.swift */; };
+		C71500040000000000000001 /* SessionContentWidthPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71500030000000000000001 /* SessionContentWidthPresentation.swift */; };
 		C71510010000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71510020000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift */; };
 		A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74770010000000000000004 /* SessionDisplaySnapshot.swift */; };
 		B3575000000000000000000C /* SessionIndexModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3575000000000000000000B /* SessionIndexModels.swift */; };
@@ -3331,6 +3332,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A74770010000000000000006 /* SessionConfigFrameEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionConfigFrameEntry.swift; sourceTree = "<group>"; };
 		A74770010000000000000008 /* SessionConfigFrameRing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionConfigFrameRing.swift; sourceTree = "<group>"; };
 		C71500010000000000000001 /* SessionContentWidthModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/SessionContentWidthModifier.swift; sourceTree = "<group>"; };
+		C71500030000000000000001 /* SessionContentWidthPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/SessionContentWidthPresentation.swift; sourceTree = "<group>"; };
 		C71510020000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContentWidthSettingsFileStoreTests.swift; sourceTree = "<group>"; };
 		A74770010000000000000004 /* SessionDisplaySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplaySnapshot.swift; sourceTree = "<group>"; };
 		B3575000000000000000000B /* SessionIndexModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexModels.swift; sourceTree = "<group>"; };
@@ -5013,6 +5015,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A500RG00 /* ReactGrab.swift */,
 				A5001413 /* TerminalPanelView.swift */,
 				C71500010000000000000001 /* SessionContentWidthModifier.swift */,
+				C71500030000000000000001 /* SessionContentWidthPresentation.swift */,
 				BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */,
 				048DACB3F8147BCBDD266297 /* BrowserSystemProxyMirror.swift */,
 				109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */,
@@ -7278,6 +7281,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A74770010000000000000005 /* SessionConfigFrameEntry.swift in Sources */,
 				A74770010000000000000007 /* SessionConfigFrameRing.swift in Sources */,
 				C71500020000000000000001 /* SessionContentWidthModifier.swift in Sources */,
+				C71500040000000000000001 /* SessionContentWidthPresentation.swift in Sources */,
 				A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */,
 				B3575000000000000000000C /* SessionIndexModels.swift in Sources */,
 				B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1728,6 +1728,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5001095 /* TerminalNotificationStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001092 /* TerminalNotificationStore.swift */; };
 		0A110711000000000000001C /* TerminalOutputTeeCallback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A110711000000000000001D /* TerminalOutputTeeCallback.swift */; };
 		0A110711000000000000001E /* TerminalOutputTeeContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A110711000000000000001F /* TerminalOutputTeeContext.swift */; };
+		C71500060000000000000001 /* TerminalPaneBackgroundView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71500050000000000000001 /* TerminalPaneBackgroundView.swift */; };
 		D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */; };
 		A5F100000000000000000007 /* TerminalPanel+NotificationScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F100000000000000000008 /* TerminalPanel+NotificationScroll.swift */; };
 		791101010000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 791101020000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift */; };
@@ -3681,6 +3682,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001092 /* TerminalNotificationStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalNotificationStore.swift; sourceTree = "<group>"; };
 		0A110711000000000000001D /* TerminalOutputTeeCallback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalOutputTeeCallback.swift; sourceTree = "<group>"; };
 		0A110711000000000000001F /* TerminalOutputTeeContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalOutputTeeContext.swift; sourceTree = "<group>"; };
+		C71500050000000000000001 /* TerminalPaneBackgroundView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneBackgroundView.swift; sourceTree = "<group>"; };
 		D0B10001A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalPaneDropTargetView.swift; sourceTree = "<group>"; };
 		A5F100000000000000000008 /* TerminalPanel+NotificationScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/TerminalPanel+NotificationScroll.swift"; sourceTree = "<group>"; };
 		791101020000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/TerminalPanel+SessionScrollbackReplay.swift"; sourceTree = "<group>"; };
@@ -5016,6 +5018,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001413 /* TerminalPanelView.swift */,
 				C71500010000000000000001 /* SessionContentWidthModifier.swift */,
 				C71500030000000000000001 /* SessionContentWidthPresentation.swift */,
+				C71500050000000000000001 /* TerminalPaneBackgroundView.swift */,
 				BCBC0A0E0000000000000C02 /* BrowserChromeMetrics.swift */,
 				048DACB3F8147BCBDD266297 /* BrowserSystemProxyMirror.swift */,
 				109D0E38E29A8779FA0BAE82 /* BrowserRemoteWorkspaceStatus.swift */,
@@ -7527,6 +7530,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001095 /* TerminalNotificationStore.swift in Sources */,
 				0A110711000000000000001C /* TerminalOutputTeeCallback.swift in Sources */,
 				0A110711000000000000001E /* TerminalOutputTeeContext.swift in Sources */,
+				C71500060000000000000001 /* TerminalPaneBackgroundView.swift in Sources */,
 				D0B10000A1B2C3D4E5F60001 /* TerminalPaneDropTargetView.swift in Sources */,
 				A5F100000000000000000007 /* TerminalPanel+NotificationScroll.swift in Sources */,
 				791101010000000000000001 /* TerminalPanel+SessionScrollbackReplay.swift in Sources */,


### PR DESCRIPTION
Follow-up to https://github.com/manaflow-ai/cmux/pull/8222.

Preserves full-pane terminal overlays and Canvas width caps, keeps terminal gutter focus, scrolling, and context menus on existing interaction paths, and keeps agent-chat gutter scrolling active. Splits shared geometry and gutter-host types into policy-compliant files.

Verification:
- canonical autoreview clean
- CmuxSettings: 258 tests passed
- CmuxSettingsUI: 112 tests passed
- tagged macOS cloud build passed on the reviewed implementation

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8250"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786773024&installation_id=133855650&pr_number=8250&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8250&signature=863ab24d4fd87f5852b4d9027be301a556db2fccefc2a2379770a948eeb92409"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes interaction gaps around capped session content so clicking, scrolling, and context menus work in terminal and agent chat panes. Keeps full‑pane overlays and Canvas width caps while retargeting gutter events to the right surface and coalescing agent gutter scrolls.

- **Bug Fixes**
  - Routes gutter scrolling in agent chat panes to the transcript and coalesces/clamps deltas for smoother scroll.
  - Clicking gutters focuses the webview; right‑click shows a pane‑chrome menu without sending terminal events.
  - Preserves terminal focus, first‑click, and scrolling from empty space around capped content; agent web content respects max width and alignment.

- **Refactors**
  - Extracts `SessionContentWidthPresentation` for shared width/alignment logic across SwiftUI and AppKit hosts.
  - Moves the terminal gutter host into `TerminalPaneBackgroundView` and wires it into the Ghostty surface scroll view.

<sup>Written for commit 005ca307c62e2d470f697705836eec6f4c9ccc90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8250?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added persisted controls to limit agent session content width and choose horizontal alignment.
- **Bug Fixes**
  - Improved terminal background interactions by forwarding focus, context menus, and scroll/pointer events to the correct terminal views.
  - Corrected hosted session web view sizing and layout to respect the selected content width presentation.
- **Usability**
  - Refined right-click and pointer interaction behavior so context menus and first-interaction handling work more consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->