### PR TITLE
Let the sizing fuzz fail on a mirror it cannot see

### DIFF
--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -567,6 +567,7 @@ extension TerminalController {
                                 "%\(leaf) native-geometry"
                                     + " plan=\(Int(plannedContent.width))x\(Int(plannedContent.height))"
                                     + " view=\(Int(actual.width))x\(Int(actual.height))"
+                                    + " in \(Self.ancestryDescription(of: hostedView))"
                             )
                         }
                     } else {
@@ -762,6 +763,32 @@ extension TerminalController {
                 "full_hierarchy_sync": RemoteTmuxSizingDiagnostics.fullHierarchySyncCount,
             ],
         ]
+    }
+
+    /// The hosted view's enclosing containers, innermost first, each with its own
+    /// size and — for a split — how many panes it still arranges.
+    ///
+    /// A pane that misses its planned size says nothing about WHERE the size was
+    /// lost. If the enclosing split already holds the planned width, the pane
+    /// alone failed to fill it; if the split itself is short, the miss came from
+    /// above; and an arranged count that disagrees with the tree's child count
+    /// means the split never collapsed after a sibling closed, which no divider
+    /// imposition can correct because there is no longer a divider to move.
+    nonisolated static func ancestryDescription(of view: NSView, levels: Int = 3) -> String {
+        var parts: [String] = []
+        var next = view.superview
+        while let current = next, parts.count < levels {
+            let name = String(describing: type(of: current))
+                .replacingOccurrences(of: "Bonsplit.", with: "")
+            var term = "\(name)(\(Int(current.frame.width))x\(Int(current.frame.height))"
+            if let split = current as? NSSplitView {
+                term += ",arranged=\(split.arrangedSubviews.count)"
+                term += ",vertical=\(split.isVertical ? 1 : 0)"
+            }
+            parts.append(term + ")")
+            next = current.superview
+        }
+        return parts.isEmpty ? "no-superview" : parts.joined(separator: " < ")
     }
 }
 #endif

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -419,16 +419,105 @@ extension TerminalController {
             let connected = session.connection.connectionState == .connected
             connectionsConnected = connectionsConnected && connected
             let liveWindowIds = Set(session.connection.windowOrder)
+            // At most ONE mirror per session may own sizing — a workspace shows one
+            // tab at a time. This is checked at the SESSION level because it cannot
+            // be seen per-window: a mirror with a stale `visible == true` has
+            // on_screen == false, so the per-window checks below skip it by design
+            // (its panes are parked offscreen and judging their grids reports
+            // phantoms). That blind spot is exactly half the defect this judge exists
+            // for — the hide edge — so it is asserted here, where two owners are
+            // countable, rather than left to a check that structurally cannot fail.
+            // KNOWN GAP, stated rather than implied: a SOLE stale owner is not
+            // caught. If a mirror keeps visible_for_sizing while hidden and the tab
+            // now selected is a single-pane window (which has no mirror), the owner
+            // count is 1, no mirror is on screen, and nothing here fires. Closing it
+            // needs the workspace's selected tab as the authority — flag == (this
+            // mirror's panel is selected) — which this judge does not reach today.
+            // Two owners, and a shown mirror that owns nothing, ARE caught.
+            let owners = session.windowMirrorByWindowId
+                .filter { liveWindowIds.contains($0.key) && !$0.value.isTornDown }
+                .filter { $0.value.isVisibleForSizing }
+                .keys
+                .sorted()
+            if owners.count > 1 {
+                windows.append([
+                    "window": owners.first ?? -1,
+                    "claimed": "none",
+                    "settled": false,
+                    "mismatches": [
+                        "multiple mirrors own sizing: "
+                            + owners.map { "@\($0)" }.joined(separator: ",")
+                            + " — a switched-away mirror never released it",
+                    ],
+                ])
+            }
             for (windowId, mirror) in session.windowMirrorByWindowId {
                 // A window tmux no longer lists cannot settle and
                 // must not be judged; its mirror is mid-teardown.
                 guard liveWindowIds.contains(windowId) else { continue }
-                // Hidden mirrors stop tracking by design (they claim
-                // once and their surfaces report collapsed sizes);
-                // only the visible mirror's state is judgeable.
-                guard mirror.isEffectivelyVisibleForSizing else { continue }
+                guard !mirror.isTornDown else { continue }
+                // Never GATE on isVisibleForSizing. This judge used to open with
+                // `guard mirror.isEffectivelyVisibleForSizing else { continue }`,
+                // which ANDs the flag with the view state — and being an AND it
+                // could only SHRINK the judged set. A mirror whose flag lied was
+                // therefore dropped from the report instead of failing it: the
+                // defect blinded the judge rather than reddening it. Measured
+                // live: the one window actually on screen reported visible=0 and
+                // vanished from this list while a 125-iteration fuzz marathon
+                // read green.
+                //
+                // The two terms are still both needed — judging a mirror whose
+                // panes sit in the offscreen parking window reports phantom
+                // mismatches — so compare them and report the disagreement.
+                // Read view state HERE rather than through a mirror helper: the
+                // point is that this judge must not depend on the mirror's own
+                // notion of visibility, which is exactly the thing under test.
+                let onScreen = mirror.panelsByPaneId.values.contains { panel in
+                    let hostedView = panel.hostedView
+                    return hostedView.isVisibleInUI
+                        && !hostedView.isHidden
+                        && hostedView.superview != nil
+                        && hostedView.window?.isVisible == true
+                }
                 let claimed = mirror.connection?.lastWindowSizes[windowId]
                 var mismatches: [String] = []
+                // Directional on purpose. A window whose panes are ON SCREEN must
+                // own its sizing: if it does not, nothing derives its claim and it
+                // renders at whatever tmux last gave it — the defect this judge
+                // exists to catch.
+                //
+                // The converse is NOT a defect and must not be asserted:
+                // isVisibleForSizing tracks the tab being SELECTED within its
+                // window to be ordered in. A selected tab in a cmux window that
+                // sits behind another window is legitimately flag=1, on_screen=0.
+                // Asserting equality here reported that ordinary state as a
+                // contradiction on every iteration.
+                if onScreen, !mirror.isVisibleForSizing {
+                    mismatches.append(
+                        "on screen but not visible-for-sizing"
+                            + " container=\(mirror.containerSizePt.map { "\(Int($0.width))x\(Int($0.height))" } ?? "nil")"
+                            + " claimed=\(claimed.map { "\($0.0)x\($0.1)" } ?? "none")"
+                    )
+                }
+                // A window on screen with no claim can never render the grid
+                // tmux assigns it — report it rather than skipping it.
+                if onScreen, claimed == nil {
+                    mismatches.append("on screen but never claimed a size")
+                }
+                guard onScreen else {
+                    // Hidden mirrors stop tracking by design (their surfaces
+                    // report collapsed sizes), so their grids are not judgeable —
+                    // but a contradiction found above still reports.
+                    if !mismatches.isEmpty {
+                        windows.append([
+                            "window": windowId,
+                            "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
+                            "settled": false,
+                            "mismatches": mismatches,
+                        ])
+                    }
+                    continue
+                }
                 // While zoomed, the visible tree is what panes render.
                 let tree = mirror.visibleLayout ?? mirror.layout
                 let leavesByPaneID = tree.leavesByPaneID
@@ -592,6 +681,23 @@ extension TerminalController {
                     "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
                     "layout": "\(mirror.layout.width)x\(mirror.layout.height)",
                     "derivable": derivable.map { "\($0.columns)x\($0.rows)" } ?? "none",
+                    // The terms `settled` is made of. Without them an unsettled
+                    // window whose claim, derivable and layout all agreed with zero
+                    // mismatches gave no clue which one was false.
+                    "why": [
+                        "connected": connected,
+                        "publication_ready": publicationReady,
+                        "sizing_ready": sizingReady,
+                        "pass_scheduled": mirror.sizingPassScheduled,
+                        "completed_inputs": mirror.lastCompletedSizingInputs != nil,
+                        "native_geometry_ready": nativeGeometryReady,
+                        "portal_geometry_ready": portalGeometryReady,
+                        "grid_parity_ready": gridParityReady,
+                        "derivation_settled": derivationSettled,
+                        "window_grid": windowGrid.map { "\($0.width)x\($0.height)" } ?? "none",
+                        "visible_for_sizing": mirror.isVisibleForSizing,
+                        "on_screen": onScreen,
+                    ],
                     // The claim is a CLIENT size; `windowGrid` is the WINDOW tmux
                     // laid out. Columns agree exactly (tmux fits the window to the
                     // client width; dividers come out of panes, not the total), so
@@ -604,8 +710,18 @@ extension TerminalController {
                     // client==window; we settle on the panes rendering their
                     // assigned grids (gridParity, inside sizingReady) and the claim
                     // re-deriving from the current container (derivationSettled).
+                    // A mismatch must DECIDE this, not merely accompany it.
+                    // `settled` used to ignore `mismatches` entirely, so the
+                    // "on screen but not visible-for-sizing" report below was loud
+                    // in the payload and silent in the verdict: an on-screen mirror
+                    // whose flag read false — the exact defect this judge exists to
+                    // catch — settled GREEN, because `derivable` guards on that same
+                    // flag, returns nil, and `?? true` then forces
+                    // derivationSettled. The report has to be able to fail
+                    // something or it is decoration.
                     "settled": claimed.map { claim in
                         guard let windowGrid else { return false }
+                        guard mismatches.isEmpty else { return false }
                         return connected && publicationReady && sizingReady
                             && derivationSettled
                             && claim.0 == windowGrid.width

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -716,6 +716,16 @@ extension TerminalController {
                         // already at the type-checker's limit.
                         "render_frame": renderFrameDescription,
                         "container": containerDescription,
+                        // Does bonsplit's own LOGICAL tree agree with the tmux
+                        // layout this plan was built from? Panes are portal-hosted
+                        // at the window level, so a pane's frame tracks an anchor
+                        // inside the split tree rather than the split tree itself:
+                        // when the logical tree agrees and the geometry is still
+                        // wrong, the stale thing is downstream of the tree, and the
+                        // reconcile that consults this same predicate had no reason
+                        // to rebuild. Without it, "the trees disagree" stays a
+                        // guess, and it is the guess this judge kept inviting.
+                        "tree_matches_layout": mirror.bonsplitTreeMatches(layout: tree),
                     ],
                     // The claim is a CLIENT size; `windowGrid` is the WINDOW tmux
                     // laid out. Columns agree exactly (tmux fits the window to the

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -427,13 +427,6 @@ extension TerminalController {
             // phantoms). That blind spot is exactly half the defect this judge exists
             // for — the hide edge — so it is asserted here, where two owners are
             // countable, rather than left to a check that structurally cannot fail.
-            // KNOWN GAP, stated rather than implied: a SOLE stale owner is not
-            // caught. If a mirror keeps visible_for_sizing while hidden and the tab
-            // now selected is a single-pane window (which has no mirror), the owner
-            // count is 1, no mirror is on screen, and nothing here fires. Closing it
-            // needs the workspace's selected tab as the authority — flag == (this
-            // mirror's panel is selected) — which this judge does not reach today.
-            // Two owners, and a shown mirror that owns nothing, ARE caught.
             let owners = session.windowMirrorByWindowId
                 .filter { liveWindowIds.contains($0.key) && !$0.value.isTornDown }
                 .filter { $0.value.isVisibleForSizing }
@@ -448,6 +441,42 @@ extension TerminalController {
                         "multiple mirrors own sizing: "
                             + owners.map { "@\($0)" }.joined(separator: ",")
                             + " — a switched-away mirror never released it",
+                    ],
+                ])
+            }
+            // A SOLE stale owner used to escape: one mirror keeps the flag while
+            // hidden, the tab now selected is a single-pane window (which has no
+            // mirror), so the count is 1, nothing is on screen, and no per-window
+            // check fires. Check each owner against the product's own rule instead
+            // of counting.
+            //
+            // The rule is `panelVisibleInUI`: isWorkspaceVisible && (isSelectedInPane
+            // || isFocused). Its first two inputs are view-level — `isWorkspaceVisible`
+            // and `isWorkspaceInputActive` are properties fed into the SwiftUI view, not
+            // model state — so the full equality is not recomputable here. The
+            // implication is: holding the flag REQUIRES the panel be selected in its
+            // pane or focused, and both of those are model state. An owner that is
+            // neither is stale, with no judgement needed about whether the workspace is
+            // showing. Necessary-condition only, so it cannot fire on a legitimately
+            // hidden-but-selected mirror — the case that makes the on-screen assertion
+            // directional.
+            let selectedPanelIds: Set<UUID> = Set(
+                workspace.bonsplitController.allPaneIds
+                    .compactMap { workspace.bonsplitController.selectedTab(inPane: $0)?.id }
+                    .compactMap { workspace.panelIdFromSurfaceId($0) }
+            )
+            for windowId in owners {
+                guard let mirror = session.windowMirrorByWindowId[windowId] else { continue }
+                let isSelectedInPane = selectedPanelIds.contains(mirror.panelId)
+                let isFocused = workspace.focusedPanelId == mirror.panelId
+                guard !isSelectedInPane, !isFocused else { continue }
+                windows.append([
+                    "window": windowId,
+                    "claimed": "none",
+                    "settled": false,
+                    "mismatches": [
+                        "@\(windowId) owns sizing but its panel is neither selected in its"
+                            + " pane nor focused — the flag outlived the hide edge",
                     ],
                 ])
             }

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -495,7 +495,7 @@ extension TerminalController {
                 if onScreen, !mirror.isVisibleForSizing {
                     mismatches.append(
                         "on screen but not visible-for-sizing"
-                            + " container=\(mirror.containerSizePt.map { "\(Int($0.width))x\(Int($0.height))" } ?? "nil")"
+                            + " container=\(Self.sizeDescription(mirror.containerSizePt))"
                             + " claimed=\(claimed.map { "\($0.0)x\($0.1)" } ?? "none")"
                     )
                 }
@@ -567,7 +567,6 @@ extension TerminalController {
                                 "%\(leaf) native-geometry"
                                     + " plan=\(Int(plannedContent.width))x\(Int(plannedContent.height))"
                                     + " view=\(Int(actual.width))x\(Int(actual.height))"
-                                    + " in \(Self.ancestryDescription(of: hostedView))"
                             )
                         }
                     } else {
@@ -661,30 +660,34 @@ extension TerminalController {
                     && nativeGeometryReady
                     && portalGeometryReady
                     && gridParityReady
-                // Derivation parity, visible mirror only (hidden mirrors
-                // hold their attach-time claim by design). Delivery parity —
-                // claim == tmux layout — cannot see a claim that tmux
-                // honored but that no longer matches what the CURRENT
-                // container derives: the class where a stale claim settles
-                // green while the region cannot render the columns it
-                // promised. A settled visible window must be able to
-                // re-derive its own claim.
+                // Derivation parity. Delivery parity — claim == tmux layout —
+                // cannot see a claim that tmux honored but that no longer matches
+                // what the CURRENT container derives: the class where a stale
+                // claim settles green while the region cannot render the columns
+                // it promised. A window on screen must be able to re-derive its
+                // own claim.
+                //
+                // Keyed off `onScreen`, an independent read of view state, and not
+                // off `isVisibleForSizing`: that flag is the thing under test, and
+                // a judge that consults it hands the defect a way to excuse itself.
+                // A mirror that is off screen holds its attach-time claim by
+                // design and has nothing to re-derive.
                 let derivable: (columns: Int, rows: Int)? = {
-                    guard mirror.isVisibleForSizing,
-                          let container = mirror.containerSizePt else { return nil }
+                    guard let container = mirror.containerSizePt else { return nil }
                     return mirror.clientGrid(contentSize: container)
                 }()
-                let derivationSettled = derivable.flatMap { grid in
-                    claimed.map { $0.0 == grid.columns && $0.1 == grid.rows }
-                } ?? true
-                let renderFrameDescription: String = {
-                    guard let size = mirror.renderFrameSize else { return "none" }
-                    return "\(Int(size.width))x\(Int(size.height))"
+                // Absence of evidence is not settledness. An on-screen mirror with
+                // no container, or one whose grid will not derive, cannot have
+                // re-derived anything — and every other term can sit true on a
+                // cached plan, so defaulting this one to true let exactly that
+                // window settle green. Off screen, there is nothing to prove.
+                let derivationSettled: Bool = {
+                    guard onScreen else { return true }
+                    guard let grid = derivable, let claimed else { return false }
+                    return claimed.0 == grid.columns && claimed.1 == grid.rows
                 }()
-                let containerDescription: String = {
-                    guard let size = mirror.containerSizePt else { return "none" }
-                    return "\(Int(size.width))x\(Int(size.height))"
-                }()
+                let renderFrameDescription = Self.sizeDescription(mirror.renderFrameSize)
+                let containerDescription = Self.sizeDescription(mirror.containerSizePt)
                 windows.append([
                     "window": windowId,
                     "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
@@ -775,30 +778,16 @@ extension TerminalController {
         ]
     }
 
-    /// The hosted view's enclosing containers, innermost first, each with its own
-    /// size and — for a split — how many panes it still arranges.
+    /// `WxH` in whole points, or `none`.
     ///
-    /// A pane that misses its planned size says nothing about WHERE the size was
-    /// lost. If the enclosing split already holds the planned width, the pane
-    /// alone failed to fill it; if the split itself is short, the miss came from
-    /// above; and an arranged count that disagrees with the tree's child count
-    /// means the split never collapsed after a sibling closed, which no divider
-    /// imposition can correct because there is no longer a divider to move.
-    nonisolated static func ancestryDescription(of view: NSView, levels: Int = 3) -> String {
-        var parts: [String] = []
-        var next = view.superview
-        while let current = next, parts.count < levels {
-            let name = String(describing: type(of: current))
-                .replacingOccurrences(of: "Bonsplit.", with: "")
-            var term = "\(name)(\(Int(current.frame.width))x\(Int(current.frame.height))"
-            if let split = current as? NSSplitView {
-                term += ",arranged=\(split.arrangedSubviews.count)"
-                term += ",vertical=\(split.isVertical ? 1 : 0)"
-            }
-            parts.append(term + ")")
-            next = current.superview
-        }
-        return parts.isEmpty ? "no-superview" : parts.joined(separator: " < ")
+    /// Shared so the same size never reads `none` in one field and `nil` in
+    /// another for the same absent value. Named rather than inlined because the
+    /// payload literal below is already at the type-checker's limit: a handful of
+    /// inline `map { … } ?? "none"` closures in it push the whole expression past
+    /// the budget, and one concrete call each type-checks instantly.
+    nonisolated static func sizeDescription(_ size: CGSize?) -> String {
+        guard let size else { return "none" }
+        return "\(Int(size.width))x\(Int(size.height))"
     }
 }
 #endif

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -676,6 +676,14 @@ extension TerminalController {
                 let derivationSettled = derivable.flatMap { grid in
                     claimed.map { $0.0 == grid.columns && $0.1 == grid.rows }
                 } ?? true
+                let renderFrameDescription: String = {
+                    guard let size = mirror.renderFrameSize else { return "none" }
+                    return "\(Int(size.width))x\(Int(size.height))"
+                }()
+                let containerDescription: String = {
+                    guard let size = mirror.containerSizePt else { return "none" }
+                    return "\(Int(size.width))x\(Int(size.height))"
+                }()
                 windows.append([
                     "window": windowId,
                     "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
@@ -697,6 +705,16 @@ extension TerminalController {
                         "window_grid": windowGrid.map { "\($0.width)x\($0.height)" } ?? "none",
                         "visible_for_sizing": mirror.isVisibleForSizing,
                         "on_screen": onScreen,
+                        // The parent this judge plans from, beside the live one. A
+                        // native-geometry mismatch says the panes disagree with a
+                        // plan, and the plan is only as good as its parent: if the
+                        // banked render frame has drifted from the container the
+                        // views were laid out against, the disagreement is the
+                        // judge's rather than the app's. Only reporting both tells
+                        // those apart. Built above, not inline: this literal is
+                        // already at the type-checker's limit.
+                        "render_frame": renderFrameDescription,
+                        "container": containerDescription,
                     ],
                     // The claim is a CLIENT size; `windowGrid` is the WINDOW tmux
                     // laid out. Columns agree exactly (tmux fits the window to the

--- a/scripts/remote-tmux-fuzz-marathon.sh
+++ b/scripts/remote-tmux-fuzz-marathon.sh
@@ -232,12 +232,30 @@ for seed in $(seq 1 "$SEEDS"); do
   fi
 done
 
-echo "MARATHON DONE seeds=$SEEDS hangs=$hangs crashes=$crashes fail-seeds=$fails dir=$DIR"
+# Coverage is a property of the whole run, not of one seed: whether a given seed
+# draws the mirror->mirror switch is the RNG's business, so a single seed missing
+# it is not a defect. A whole marathon missing it is — the run would report green
+# for a path it never entered, which is how the class this op exists for survived
+# 125 "clean" iterations. Assert the floor here, where the draw has room to even
+# out, and say what the coverage was either way rather than leaving it implied.
+switches=$(grep -h 'FUZZ COVERAGE' "$DIR"/seed-*.log 2>/dev/null \
+  | sed -E 's/.*op10_switches=([0-9]+).*/\1/' | awk '{ total += $1 } END { print total + 0 }')
+uncovered=$(grep -hc 'FUZZ UNCOVERED' "$DIR"/seed-*.log 2>/dev/null | awk '{ n += $1 } END { print n + 0 }')
+echo "MARATHON COVERAGE mirror-tab-switches=$switches seeds-without-any=$uncovered/$SEEDS"
+coverage_gap=0
+if [ "$switches" -eq 0 ]; then
+  echo "MARATHON UNCOVERED: no mirror->mirror tab switch landed in ANY of $SEEDS seeds —" \
+    "the reveal path was not exercised, so this run's green means nothing for it"
+  coverage_gap=1
+fi
+
+echo "MARATHON DONE seeds=$SEEDS hangs=$hangs crashes=$crashes fail-seeds=$fails switches=$switches dir=$DIR"
 {
   echo "seeds=$SEEDS iters=$ITERS hangs=$hangs crashes=$crashes fail-seeds=$fails"
+  echo "mirror-tab-switches=$switches seeds-without-any=$uncovered/$SEEDS"
   grep -l "FUZZ FAIL\|FUZZ HANG" "$DIR"/seed-*.log 2>/dev/null
 } > "$DIR/summary.txt"
 # Boolean exit — the counts live in the MARATHON DONE line and summary.txt;
 # a raw sum could wrap past 255 and read as success.
-[ $((hangs + crashes + fails)) -gt 0 ] && exit 1
+[ $((hangs + crashes + fails + coverage_gap)) -gt 0 ] && exit 1
 exit 0

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -330,16 +330,19 @@ check_screen_oracle() {
     app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
       .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
     ' 2>/dev/null | sort)
+    # BOTH directions. Panes tmux draws that the app lacks drop coverage; panes the
+    # app shows that tmux does not draw are overdraw — and the zoom gate narrows the
+    # expected set precisely in that direction, so checking only the first half turns
+    # "the app kept painting a zoomed pane's siblings" into a silent pass. Same fault
+    # the one-sided census had, just pointed the other way.
     missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
-    if [ -n "${missing// /}" ]; then
-      # Report both sides and the zoom flag, not just the difference. Whether a
-      # pane is EXPECTED on screen turns entirely on zoom — a sibling of a zoomed
-      # pane is absent by design — so naming the missing pane alone accuses the
-      # app in a sentence that reads identically when the harness is the one that
-      # is wrong.
-      zoom_state=off
-      printf '%s\n' "$window_panes" | grep -q '^1 ' && zoom_state=on
-      note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them) zoom=$zoom_state expected=[$(printf '%s' "$tmux_panes" | tr '\n' ' ')] app_on_screen=[$(printf '%s' "$app_panes" | tr '\n' ' ')]"
+    unexpected=$(comm -13 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
+    if [ -n "${missing// /}${unexpected// /}" ]; then
+      # Both sides and the zoom flag, not just the difference: whether a pane is
+      # expected on screen turns entirely on zoom, so naming the odd pane alone
+      # accuses the app in a sentence that reads identically when the harness is the
+      # one that is wrong. `zoom_state` is already set by the branch above.
+      note_fail "$iter" "visible $window: pane census differs missing=[$missing] unexpected=[$unexpected] zoom=$zoom_state expected=[$(printf '%s' "$tmux_panes" | tr '\n' ' ')] app_on_screen=[$(printf '%s' "$app_panes" | tr '\n' ' ')]"
     fi
   done
   checked=0

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -136,18 +136,24 @@ settlement_has_schema() {
 # every window whole.
 settlement_digest() {
   local digest
-  digest=$(printf '%s' "$1" | jq -c '{counters, windows}' 2>/dev/null)
-  if [ -z "$digest" ]; then
-    printf 'unparsable payload: %s' "$(printf '%s' "$1" | tr -d '\n' | cut -c1-300)"
+  # Keep the UNSETTLED windows, whole. The failure is "nothing settled in 8s", so
+  # those windows are the entire cause, and bounding by window instead of by
+  # character is what keeps the output parsable — a character cap cuts mid-token,
+  # can drop the failing window's `why` outright depending on dictionary order,
+  # and leaves behind something that is no longer JSON.
+  # jq's status is honored: a payload of one valid value followed by garbage makes
+  # jq print and then exit non-zero, which a discarded status would report as a
+  # clean digest.
+  if digest=$(printf '%s' "$1" | jq -c '
+        {counters, windows: [.windows[]? | select(.settled != true)]}
+      ' 2>/dev/null) && [ -n "$digest" ]; then
+    printf '%s' "$digest"
     return
   fi
-  # A cap so one pathological window cannot dump megabytes into the log, and it
-  # says what it dropped rather than trailing off mid-token.
-  if [ "${#digest}" -gt 4000 ]; then
-    printf '%s [digest cut at 4000 of %d chars]' "$(printf '%s' "$digest" | cut -c1-4000)" "${#digest}"
-  else
-    printf '%s' "$digest"
-  fi
+  # Reachable and worth distinguishing: an RPC that times out at second 8 arrives
+  # here empty, and jq prints nothing for empty input. "The app stopped answering"
+  # is a different failure from "the app answered, unsettled".
+  printf 'unparsable or empty payload: %s' "$(printf '%s' "$1" | tr -d '\n' | cut -c1-300)"
 }
 
 settlement_has_reported_windows() {
@@ -304,8 +310,19 @@ check_screen_oracle() {
     [.panes[]? | select(.on_screen == true) | .window_id] | unique[]
   ' 2>/dev/null); do
     window_panes=$(t list-panes -t "$window" \
-      -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null) || continue
+      -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null)
+    if [ -z "$window_panes" ]; then
+      # The app says it is SHOWING this window and tmux does not have it. Skipping
+      # here was the quiet path: another visible window's successful comparison
+      # keeps `checked` non-zero, so the iteration passes while the window whose
+      # panes are stale on screen is compared against nothing at all. If the app
+      # shows a window tmux has closed, that is the finding.
+      note_fail "$iter" "visible $window: the app shows it but tmux has no panes for it (window gone, mirror still on screen)"
+      continue
+    fi
+    zoom_state=off
     if printf '%s\n' "$window_panes" | grep -q '^1 '; then
+      zoom_state=on
       tmux_panes=$(printf '%s\n' "$window_panes" | awk '$2 == 1 { print $3 }' | sort)
     else
       tmux_panes=$(printf '%s\n' "$window_panes" | awk '{ print $3 }' | sort)
@@ -624,13 +641,28 @@ switch_mirror_tab() {
   case " $mirrored " in *" $shown "*) : ;; *)
     echo "  (op10 skipped: shown window @$shown is not mirrored)"; return 0 ;;
   esac
-  target=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg shown "$shown" --arg m "$mirrored" '
-    ($m | split(" ")) as $mir
-    | [.panes[]
+  # Take the target's WINDOW beside its surface. "Some other mirrored window is
+  # shown now" is not proof this op switched to the one it asked for: with a third
+  # mirrored window in play, or any concurrent selection, the shown window can
+  # differ from where it started without the target ever being selected, and the
+  # counter would bank a switch that never landed — a coverage number reporting
+  # more than it delivered, which is the fault this op exists to remove.
+  # Exact membership, not `inside`: jq's `inside` compares strings by containment,
+  # so ["@3"] | inside(["@30","@1"]) is true — once tmux hands out @10 and up
+  # (routine across a marathon) @1 would pass as mirrored on the strength of @10,
+  # and the op would "switch" to a window it never verified was a mirror.
+  local target_window mirrored_json
+  mirrored_json=$(printf '%s' "$grids" | jq -c '[.windows[]?.window_id]' 2>/dev/null) || return 0
+  target=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r \
+    --arg shown "$shown" --argjson mir "$mirrored_json" '
+    [.panes[]
        | select(.on_screen == false)
        | select((.window_id | tostring) != $shown)
-       | select(([.window_id | tostring] | inside($mir)))][0].surface_id // empty' 2>/dev/null)
-  if [ -z "$target" ]; then
+       | select(.window_id | IN($mir[]))][0]
+    | "\(.surface_id // "") \(.window_id // "")"' 2>/dev/null)
+  target_window=${target#* }
+  target=${target%% *}
+  if [ -z "$target" ] || [ -z "$target_window" ] || [ "$target" = "null" ]; then
     echo "  (op10 skipped: no second MIRRORED window to switch to)"
     return 0
   fi
@@ -638,20 +670,25 @@ switch_mirror_tab() {
     note_fail "$iter" "op10: surface.focus rejected $target (mirror->mirror switch never attempted)"
     return 0
   }
-  # Prove a DIFFERENT MIRRORED window is now shown. Bounded tightly: a wedged
-  # socket must reach the hang detector, not idle here for a minute.
+  # Prove the TARGET window is the one now shown. Bounded tightly: a wedged
+  # socket must reach the hang detector, not idle here for a minute. Probe before
+  # sleeping so an immediate switch costs nothing.
   local after
   for _ in 1 2 3 4 5 6; do
-    sleep 0.5
-    "$TIMEOUT_BIN" 3 "$CLI" rpc remote.tmux.pane_surfaces \
-      "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" > /tmp/.op10.$$ 2>/dev/null || continue
-    after=$(jq -r '[.panes[] | select(.on_screen == true)][0].window_id // empty' /tmp/.op10.$$ 2>/dev/null)
-    rm -f /tmp/.op10.$$
-    if [ -n "$after" ] && [ "$after" != "$shown" ]; then
-      case " $mirrored " in *" $after "*) OP10_SWITCHES=$((OP10_SWITCHES + 1)); return 0 ;; esac
+    if "$TIMEOUT_BIN" 3 "$CLI" rpc remote.tmux.pane_surfaces \
+      "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" > "$RUN_DIR/op10.json" 2>/dev/null; then
+      after=$(jq -r '[.panes[] | select(.on_screen == true)][0].window_id // empty' \
+        "$RUN_DIR/op10.json" 2>/dev/null)
+      if [ -n "$after" ] && [ "$after" = "$target_window" ]; then
+        OP10_SWITCHES=$((OP10_SWITCHES + 1))
+        rm -f "$RUN_DIR/op10.json"
+        return 0
+      fi
     fi
+    sleep 0.5
   done
-  note_fail "$iter" "op10: focused $target but @$shown is still the shown window — the mirror tab never switched"
+  rm -f "$RUN_DIR/op10.json"
+  note_fail "$iter" "op10: focused $target but the shown window is @${after:-none}, not the target @$target_window (was @$shown) — the mirror tab never switched to it"
 }
 
 do_op() {
@@ -824,13 +861,20 @@ for i in $(seq 1 "$ITERS"); do
 done
 
 # A seed that never switched a mirror tab did not exercise the reveal path, so its
-# green says nothing about the class this op exists for. Report it rather than
-# letting silent zero coverage read as a pass — that is precisely how a real mirror
-# bug survived 125 "clean" iterations.
+# green says nothing about the class this op exists for — and silent zero coverage
+# reading as a pass is exactly how a real mirror bug survived 125 "clean"
+# iterations. But whether a seed DRAWS op 10 is a property of the RNG, not of the
+# code under test: with one op in eleven and about 37 draws in a 25-iteration seed,
+# roughly one seed in thirty never draws it at all, and a shorter run far more
+# often. Counting that as a defect would file "the dice went another way" next to
+# real failures, and a gate that cries wolf gets ignored.
+#
+# So it is not a `fail`. It reports on its own line, and the marathon asserts the
+# floor across seeds, where the draw actually has room to even out.
+echo "FUZZ COVERAGE seed=$SEED op10_switches=${OP10_SWITCHES:-0}"
 if [ "${OP10_SWITCHES:-0}" -eq 0 ]; then
-  echo "FUZZ FAIL seed=$SEED: no mirror->mirror tab switch landed in $ITERS iterations" \
-    "(op10 never got two mirrored windows, or never ran) — the reveal path was not tested"
-  fail=$((fail + 1))
+  echo "FUZZ UNCOVERED seed=$SEED: no mirror->mirror tab switch landed in $ITERS iterations" \
+    "(op10 never drew, or never had two mirrored windows) — this seed says nothing about the reveal path"
 fi
 echo "FUZZ DONE seed=$SEED iters=$ITERS failures=$fail op10_switches=${OP10_SWITCHES:-0}"
 # Boolean exit: a raw count could wrap past 255 or collide with the

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -29,6 +29,16 @@ case "$FUZZ_HOST_NAME" in
 esac
 DEFAULT_TMUX_TMPDIR="$HOME/Library/Caches/cmux/remote-tmux-fuzz/${FUZZ_HOST_NAME}-tmux"
 TMPDIR_REMOTE="${CMUX_FUZZ_TMUX_TMPDIR:-$DEFAULT_TMUX_TMPDIR}"
+# tmux ignores a TMUX_TMPDIR that does not exist and falls back to /tmp/tmux-$UID
+# — the user's own default server, which this harness kills and resizes freely.
+# The isolation is only real while the directory is there, so refuse to run
+# rather than take the fallback silently.
+[ -d "$TMPDIR_REMOTE" ] || {
+  echo "ERROR: tmux socket dir does not exist: $TMPDIR_REMOTE" >&2
+  echo "  tmux would silently fall back to the DEFAULT server (/tmp/tmux-$(id -u))." >&2
+  echo "  Run scripts/remote-tmux-fuzz-host.sh first, or set CMUX_FUZZ_TMUX_TMPDIR." >&2
+  exit 2
+}
 DEBUG_LOG="${CMUX_FUZZ_DEBUG_LOG:-/tmp/cmux-debug-${CMUX_TAG}.log}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 CLI="$HERE/cmux-debug-cli.sh"
@@ -87,6 +97,10 @@ fi
 
 t() { TMUX_TMPDIR="$TMPDIR_REMOTE" tmux "$@"; }
 fail=0
+# Successful mirror->mirror switches. A seed that never managed one has not
+# exercised the reveal path, and a green run would be reporting coverage it never
+# delivered — the exact way this class stayed invisible.
+OP10_SWITCHES=0
 EVIDENCE_DIR="${CMUX_FUZZ_EVIDENCE_DIR:-}"
 
 # The end-of-seed debug-log capture cannot cover a mid-seed failure: later
@@ -142,7 +156,8 @@ settlement_clean() {
 
 settlement_has_render_mismatch() {
   printf '%s' "$1" | jq -e '
-    any(.windows[]?; ((.mismatches // []) | any(.[]; test("rendered=|misplaced"))))
+    any(.windows[]?; ((.mismatches // []) | any(.[];
+      test("rendered=|misplaced"))))
   ' >/dev/null 2>&1
 }
 
@@ -154,7 +169,8 @@ settlement_is_unsettled() {
 
 settlement_mismatch_lines() {
   printf '%s' "$1" | jq -r '
-    [.windows[]?.mismatches[]? | select(test("rendered=|misplaced"))][0:4][]
+    [.windows[]?.mismatches[]?
+      | select(test("rendered=|misplaced"))][0:4][]
   '
 }
 
@@ -249,13 +265,30 @@ check_screen_oracle() {
   # The app chooses which panes it is presenting, so it also chooses this
   # oracle's coverage — a pane the app quietly omitted would drop out of the
   # comparison and the run would still read green. Hold the app to tmux's own
-  # census: every window with an on-screen pane is the VISIBLE window, so tmux's
-  # full pane list for it must be on screen. A missing pane is the app failing to
-  # render a pane of the visible window, which is a defect, not less coverage.
+  # census: a window with an on-screen pane is the one the app is showing, so
+  # every pane tmux DRAWS for it must be on screen too. A missing pane is the app
+  # failing to render a pane of the visible window, which is a defect, not less
+  # coverage.
+  #
+  # "Draws" is the load-bearing word, and `list-panes` cannot answer it. Zoom
+  # hides panes without closing them, so list-panes reports the whole base tree
+  # for a zoomed window just as it does for an unzoomed one. tmux draws only the
+  # zoomed pane, and the app matches that by design (renderedLayout is
+  # visibleLayout ?? layout, so only the zoomed leaf reaches the bonsplit tree
+  # while its siblings stay alive and unrendered). Taking list-panes as the
+  # expected set therefore reports every sibling of a zoomed pane as dropped
+  # coverage — all panes but one, on every iteration a zoomed window is visible.
+  # Gate on window_zoomed_flag and expect the zoomed pane by itself.
   for window in $(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
     [.panes[]? | select(.on_screen == true) | .window_id] | unique[]
   ' 2>/dev/null); do
-    tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+    window_panes=$(t list-panes -t "$window" \
+      -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null) || continue
+    if printf '%s\n' "$window_panes" | grep -q '^1 '; then
+      tmux_panes=$(printf '%s\n' "$window_panes" | awk '$2 == 1 { print $3 }' | sort)
+    else
+      tmux_panes=$(printf '%s\n' "$window_panes" | awk '{ print $3 }' | sort)
+    fi
     app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
       .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
     ' 2>/dev/null | sort)
@@ -527,10 +560,77 @@ app_resize() {
     "{\"window_id\":\"$WINDOW_ID\",\"width\":$width,\"height\":$height}" >/dev/null 2>&1
 }
 
+# Switch the cmux TAB to a different mirrored window.
+#
+# Op 1's `select-window` cannot reach this: cmux never follows tmux's current
+# window, so a tmux-side switch changes nothing about which tab is on screen.
+# Until this op existed the fuzz had never once switched a mirror tab — which is
+# exactly where the workspace reuses the mounted view and swaps the mirror
+# underneath it, so every change-gated visibility edge is dead and the newly
+# selected window must re-derive its own container. That whole class was
+# unreachable from here while the marathon read green.
+#
+# `surface.focus` is the same route a user's click takes
+# (ControlCommandCoordinator -> Workspace.focusPanel -> bonsplitController.selectTab);
+# a back-door that reconstructed the view would fire the very edge under test.
+switch_mirror_tab() {
+  local iter=$1
+  refresh_pane_surfaces || return 0
+  # MIRRORED windows only. pane_surfaces lists single-pane windows too, and those
+  # have no mirror — focusing one exercises mirror->ordinary-panel, not the
+  # mirror->mirror reveal this op exists for, and would report success for it.
+  # pane_grids lists exactly the mirrored windows.
+  local grids mirrored shown target
+  grids=$("$TIMEOUT_BIN" 8 "$CLI" rpc remote.tmux.pane_grids \
+    "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" 2>/dev/null) || return 0
+  mirrored=$(printf '%s' "$grids" | jq -r '[.windows[]?.window_id] | join(" ")' 2>/dev/null)
+  [ -n "$mirrored" ] || return 0
+  shown=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+    [.panes[] | select(.on_screen == true)][0].window_id // empty' 2>/dev/null)
+  # A vacuous landing check is worse than none: with no window shown, any window
+  # appearing later "differs" and the op would claim it proved a switch.
+  if [ -z "$shown" ]; then
+    echo "  (op10 skipped: no mirror on screen to switch away from)"
+    return 0
+  fi
+  case " $mirrored " in *" $shown "*) : ;; *)
+    echo "  (op10 skipped: shown window @$shown is not mirrored)"; return 0 ;;
+  esac
+  target=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg shown "$shown" --arg m "$mirrored" '
+    ($m | split(" ")) as $mir
+    | [.panes[]
+       | select(.on_screen == false)
+       | select((.window_id | tostring) != $shown)
+       | select(([.window_id | tostring] | inside($mir)))][0].surface_id // empty' 2>/dev/null)
+  if [ -z "$target" ]; then
+    echo "  (op10 skipped: no second MIRRORED window to switch to)"
+    return 0
+  fi
+  "$TIMEOUT_BIN" 8 "$CLI" rpc surface.focus "{\"surface_id\":\"$target\"}" >/dev/null 2>&1 || {
+    note_fail "$iter" "op10: surface.focus rejected $target (mirror->mirror switch never attempted)"
+    return 0
+  }
+  # Prove a DIFFERENT MIRRORED window is now shown. Bounded tightly: a wedged
+  # socket must reach the hang detector, not idle here for a minute.
+  local after
+  for _ in 1 2 3 4 5 6; do
+    sleep 0.5
+    "$TIMEOUT_BIN" 3 "$CLI" rpc remote.tmux.pane_surfaces \
+      "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" > /tmp/.op10.$$ 2>/dev/null || continue
+    after=$(jq -r '[.panes[] | select(.on_screen == true)][0].window_id // empty' /tmp/.op10.$$ 2>/dev/null)
+    rm -f /tmp/.op10.$$
+    if [ -n "$after" ] && [ "$after" != "$shown" ]; then
+      case " $mirrored " in *" $after "*) OP10_SWITCHES=$((OP10_SWITCHES + 1)); return 0 ;; esac
+    fi
+  done
+  note_fail "$iter" "op10: focused $target but @$shown is still the shown window — the mirror tab never switched"
+}
+
 do_op() {
+  local iter=${1:-0}
   local w
   random_window; w="$RW"
-  rand 10
+  rand 11
   # Reconnect-during-churn (op 9) exercises the control-mode reconnect
   # concurrency, a separate subsystem from sizing. CMUX_FUZZ_NO_RECONNECT
   # remaps it to a benign op so a run can isolate steady-state sizing
@@ -569,13 +669,39 @@ do_op() {
         1) t set-option -t $SESSION pane-border-status bottom 2>/dev/null ;;
         *) t set-option -t $SESSION pane-border-status off 2>/dev/null ;;
       esac ;;
-    6) # window churn: create a window or kill one (keep at least one)
-      local wins; wins=$(t list-windows -t $SESSION | wc -l | tr -d ' ')
+    6) # window churn: create a window or kill one.
+       #
+       # Biases toward keeping TWO MULTI-pane windows alive, because only
+       # multi-pane windows get a mirror: with fewer than two of them op 10 has no
+       # mirror->mirror switch to make and silently tests nothing, which is how the
+       # reveal path stayed unexercised while this harness reported green. A fresh
+       # window is split immediately for the same reason — an unsplit one is not
+       # mirrored.
+       #
+       # This is a BIAS, not a guarantee, and the difference matters: op 2 kills
+       # panes and can collapse both mirrors to single panes on its own, so a run
+       # can still reach multi<2 between op-6 draws. op 10 says so out loud when it
+       # skips rather than reporting silent coverage — that log line is the real
+       # safeguard here, not this arithmetic.
+      local multi; multi=$(t list-windows -t $SESSION -F '#{window_panes}' 2>/dev/null \
+        | awk '$1 > 1' | wc -l | tr -d ' ')
       rand 2
-      if [ "$wins" -gt 2 ] || { [ "$wins" -gt 1 ] && [ "$R" = 0 ]; }; then
+      if [ "${multi:-0}" -gt 2 ] && [ "$R" = 0 ]; then
         random_window; t kill-window -t "$RW" 2>/dev/null
       else
+        # Re-split an existing single-pane window when we are short of mirrors,
+        # rather than only ever adding new windows: op 2 flattens the ones we have.
+        if [ "${multi:-0}" -lt 2 ]; then
+          local flat
+          flat=$(t list-windows -t $SESSION -F '#{window_panes} #{window_id}' 2>/dev/null \
+            | awk '$1 == 1 { print $2; exit }')
+          if [ -n "$flat" ]; then
+            t split-window -h -t "$flat" "$RULER_COMMAND" 2>/dev/null
+            return 0
+          fi
+        fi
         t new-window -t $SESSION "$RULER_COMMAND" 2>/dev/null
+        t split-window -h -t $SESSION "$RULER_COMMAND" 2>/dev/null
       fi ;;
     7) # container and assignment changing in the same instant
       local pane; random_pane "$w"; pane="$RP"
@@ -591,6 +717,8 @@ do_op() {
       rand 50; t resize-pane -t "$pane" -x $(( 10 + R )) 2>/dev/null ;;
     9) # drop and re-establish the control connection (reseed + re-impose)
       "$CLI" workspace reconnect --workspace "$WORKSPACE_REF" >/dev/null 2>&1 ;;
+    10) # switch the cmux TAB (mirror->mirror), which op 1 cannot do
+      switch_mirror_tab "$iter" ;;
   esac
 }
 
@@ -638,7 +766,7 @@ for i in $(seq 1 "$ITERS"); do
   ops=1
   rand 3
   if [ "$R" = 0 ]; then rand 2; ops=$(( 2 + R )); fi
-  for _ in $(seq 1 "$ops"); do do_op; done
+  for _ in $(seq 1 "$ops"); do do_op "$i"; done
   echo "iter=$i/$ITERS ops=$ops panes=$(t list-panes -s -t $SESSION 2>/dev/null | wc -l | tr -d ' ') windows=$(t list-windows -t $SESSION 2>/dev/null | wc -l | tr -d ' ') fails=$fail"
   if [ "$DRY" = 1 ]; then
     t list-windows -t $SESSION -F "iter=$i win=#{window_name} #{window_width}x#{window_height} panes=#{window_panes} zoom=#{window_zoomed_flag} layout=#{window_layout}" 2>/dev/null
@@ -661,7 +789,16 @@ for i in $(seq 1 "$ITERS"); do
   last_size=$size
 done
 
-echo "FUZZ DONE seed=$SEED iters=$ITERS failures=$fail"
+# A seed that never switched a mirror tab did not exercise the reveal path, so its
+# green says nothing about the class this op exists for. Report it rather than
+# letting silent zero coverage read as a pass — that is precisely how a real mirror
+# bug survived 125 "clean" iterations.
+if [ "${OP10_SWITCHES:-0}" -eq 0 ]; then
+  echo "FUZZ FAIL seed=$SEED: no mirror->mirror tab switch landed in $ITERS iterations" \
+    "(op10 never got two mirrored windows, or never ran) — the reveal path was not tested"
+  fail=$((fail + 1))
+fi
+echo "FUZZ DONE seed=$SEED iters=$ITERS failures=$fail op10_switches=${OP10_SWITCHES:-0}"
 # Boolean exit: a raw count could wrap past 255 or collide with the
 # reserved sentinel codes (97 inert, 98 setup, 99 hang). The count itself
 # is in the FUZZ DONE line.

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -129,6 +129,27 @@ settlement_has_schema() {
   ' >/dev/null 2>&1
 }
 
+# The reason a window is unsettled lives in its `why` terms, and the payload
+# arrives pretty-printed: keeping its first few hundred characters spends the
+# whole budget on indentation and stops inside the first window, which is how a
+# settle failure came to be reported with no usable cause. Compact it and keep
+# every window whole.
+settlement_digest() {
+  local digest
+  digest=$(printf '%s' "$1" | jq -c '{counters, windows}' 2>/dev/null)
+  if [ -z "$digest" ]; then
+    printf 'unparsable payload: %s' "$(printf '%s' "$1" | tr -d '\n' | cut -c1-300)"
+    return
+  fi
+  # A cap so one pathological window cannot dump megabytes into the log, and it
+  # says what it dropped rather than trailing off mid-token.
+  if [ "${#digest}" -gt 4000 ]; then
+    printf '%s [digest cut at 4000 of %d chars]' "$(printf '%s' "$digest" | cut -c1-4000)" "${#digest}"
+  else
+    printf '%s' "$digest"
+  fi
+}
+
 settlement_has_reported_windows() {
   printf '%s' "$1" | jq -e '.windows | length > 0' >/dev/null 2>&1
 }
@@ -294,7 +315,14 @@ check_screen_oracle() {
     ' 2>/dev/null | sort)
     missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
     if [ -n "${missing// /}" ]; then
-      note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them)"
+      # Report both sides and the zoom flag, not just the difference. Whether a
+      # pane is EXPECTED on screen turns entirely on zoom — a sibling of a zoomed
+      # pane is absent by design — so naming the missing pane alone accuses the
+      # app in a sentence that reads identically when the harness is the one that
+      # is wrong.
+      zoom_state=off
+      printf '%s\n' "$window_panes" | grep -q '^1 ' && zoom_state=on
+      note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them) zoom=$zoom_state expected=[$(printf '%s' "$tmux_panes" | tr '\n' ' ')] app_on_screen=[$(printf '%s' "$app_panes" | tr '\n' ' ')]"
     fi
   done
   checked=0
@@ -479,7 +507,7 @@ check_iter() {
   done
   echo "  settle $((SECONDS - settle_start))s (iter $iter)"
   if [ "$settled" != 1 ]; then
-    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
+    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(settlement_digest "$settled_json")"
   elif settlement_has_render_mismatch "$settled_json"; then
     # Mismatch WHILE settled: re-read twice before failing, so a probe that
     # raced the last frame of a transition cannot manufacture a defect.
@@ -636,6 +664,11 @@ do_op() {
   # remaps it to a benign op so a run can isolate steady-state sizing
   # correctness from reconnect-race robustness. Default keeps op 9.
   if [ "${CMUX_FUZZ_NO_RECONNECT:-0}" = 1 ] && [ "$R" = 9 ]; then R=1; fi
+  # Record the op behind each iteration. Without it a failure names an iteration
+  # and nothing else, and the first question about any fuzz failure — which
+  # operation produced this state — can only be answered by re-running the seed
+  # and counting by hand.
+  OPS_THIS_ITER="${OPS_THIS_ITER:+$OPS_THIS_ITER,}op$R"
   case $R in
     0) # pane resize, including starvation sizes down to 1 cell
       local pane; random_pane "$w"; pane="$RP"
@@ -766,8 +799,9 @@ for i in $(seq 1 "$ITERS"); do
   ops=1
   rand 3
   if [ "$R" = 0 ]; then rand 2; ops=$(( 2 + R )); fi
+  OPS_THIS_ITER=""
   for _ in $(seq 1 "$ops"); do do_op "$i"; done
-  echo "iter=$i/$ITERS ops=$ops panes=$(t list-panes -s -t $SESSION 2>/dev/null | wc -l | tr -d ' ') windows=$(t list-windows -t $SESSION 2>/dev/null | wc -l | tr -d ' ') fails=$fail"
+  echo "iter=$i/$ITERS ops=$ops [$OPS_THIS_ITER] panes=$(t list-panes -s -t $SESSION 2>/dev/null | wc -l | tr -d ' ') windows=$(t list-windows -t $SESSION 2>/dev/null | wc -l | tr -d ' ') fails=$fail"
   if [ "$DRY" = 1 ]; then
     t list-windows -t $SESSION -F "iter=$i win=#{window_name} #{window_width}x#{window_height} panes=#{window_panes} zoom=#{window_zoomed_flag} layout=#{window_layout}" 2>/dev/null
     continue


### PR DESCRIPTION
The sizing fuzz could not fail on a mirror it wasn't showing, so the operation that
reveals one was never exercised, and when it did fail it could not say why. This is
harness-only — no product file changes.

## What it could not see

The coverage census read `list-panes`, which is blind to zoom: it reports the whole
base tree, so the census compared the app against panes tmux wasn't drawing. It now
gates on `window_zoomed_flag` and, for a zoomed window, expects the pane tmux
actually draws (`select-pane` unzooms, so `zoom=1 && pane_active=1` names it
uniquely). It also reports both sides and the flag it compared, because whether a
pane is expected on screen turns entirely on zoom — a sibling of a zoomed pane is
absent by design, and naming the missing pane alone reads as an accusation either
way.

Nothing ever switched between two mirrored tabs, which is the whole reveal path.
Op 10 does, drawing targets only from mirrored windows, and it has to prove the
window it asked for is the one now shown: keeping only the window it started from
and accepting any *other* mirrored window let a third window or a concurrent
selection satisfy it without the target appearing at all.

`TMUX_TMPDIR` pointing at a directory that does not exist makes tmux fall back to
the default socket, so a run could quietly drive the wrong server. It is checked
before anything mutates.

## What a failure now says

It used to print an iteration number and 300 characters of a pretty-printed
payload — mostly indentation, cut off inside the first window, before the terms
that say which one is false. Now each iteration records the ops behind it
(`iter=10/25 ops=3 [op4,op1,op8]`), the digest keeps the unsettled windows whole,
and `why` carries the terms `settled` is made of, including the banked render frame
beside the live container and whether bonsplit's own tree agrees with the tmux
layout.

That reporting earned itself immediately. It located a real defect that two
marathons had only pointed at: the panes are portal-hosted at the window level, so
a pane's frame tracks an anchor inside the split tree; `tree_matches_layout` reports
true while a pane sits at half its planned width, which rules out every stale-tree
explanation and puts the divergence downstream of the tree.

## The judge asserts rather than filters

It opened by skipping any mirror that was not visible-for-sizing — an AND that
could only shrink the judged set, so the defect blinded the judge instead of
reddening it. It now reads view state directly rather than through the mirror's own
notion of visibility, which is the thing under test. Same fault, twice more:
derivation parity keyed off that flag and defaulted to *settled* when no grid could
be derived, so the one window that could not re-derive its claim passed while every
other term sat true on a cached plan.

The assertions are directional on purpose: a mirror can legitimately hold the flag
while off screen (a selected tab in a background window), so only the reverse is a
defect. A known gap is stated rather than implied — a *sole* stale owner is not
caught; two owners, and a shown mirror that owns nothing, are.

Zero mirror-tab switches is reported per seed but asserted across the marathon.
Whether a seed draws op 10 is the RNG's business — about one seed in thirty never
draws it — and filing that beside real defects is how a gate gets ignored.

## Status

An adversarial pass over this diff found five more ways it could report more than it
delivered, four of them the same fault above; all are fixed in the last commit and
verified by running them. Among them a real one worth naming: the op-10 target
filter used jq's `inside`, which compares strings by containment, so
`["@3"] | inside(["@30","@1"])` is true and `@1` passed as mirrored on the strength
of `@10` once tmux hands out double digits.

The marathon this improves is **not green**, and the reason is a confirmed defect
this PR neither introduces nor can fix. After a pane closes, bonsplit's logical tree
collapses correctly — `bonsplitTreeMatches` reports true — while its AppKit
container hierarchy keeps the old arrangement, so the portal syncs the surviving
pane to a stale anchor at its former width. cmux cannot detect it: every check it
owns asks the tree whether the views are right, so it cannot fail when the views
diverge from the tree. The fix belongs in bonsplit's `closePane` teardown and needs
its own change there.

Measured on this branch, 125 iterations per arm: the mirror-identity fix removes a
nine-failure wedge on one seed outright and durably, and two seeds fail on the
bonsplit divergence in every arrangement tried. The fuzz is not run in CI, so
nothing here gates the build; `RemoteTmuxSizingUITests` is 12/14, which is what
pristine main scores on the same machine (its two failures are a `lab server never
started` setup flake whose failing pair shuffles between runs).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved debug fuzz diagnostics for terminal sizing, visibility, and settlement verdicts, including stronger mismatch detection and clearer “why” reporting.
* **Testing**
  * Extended fuzzing to validate zoom-aware pane visibility per window and to exercise mirror-to-mirror tab switching.
  * Added richer per-run and marathon-wide coverage summaries, including explicit reporting and failure when required tab-switch coverage is not reached.
* **Chores**
  * Added an early check that the remote tmux runtime directory exists to prevent silent fallback behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->