### PR TITLE
Fix agent session host warning

### DIFF
--- a/Sources/Panels/AgentSessionWebHostView.swift
+++ b/Sources/Panels/AgentSessionWebHostView.swift
@@ -51,7 +51,7 @@ final class AgentSessionWebHostView: NSView {
     }
 
     override func scrollWheel(with event: NSEvent) {
-        guard let hostedWebView else {
+        guard hostedWebView != nil else {
             super.scrollWheel(with: event)
             return
         }


### PR DESCRIPTION
PR https://github.com/manaflow-ai/cmux/pull/8250 added a non-nil guard that bound `hostedWebView` without using the local value. The Swift warning budget therefore failed on current main.

Check the weak property directly instead. Runtime behavior is unchanged: scrolling still falls back to `super` when no web view is attached.

Verification:
- `git diff --check`
- Current-main composite failure: https://github.com/manaflow-ai/cmux/actions/runs/29477222885
- Final composite and tagged build will cover this head before merge.

No user-facing strings changed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8256"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786776866&installation_id=133855650&pr_number=8256&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8256&signature=8f244514ce9fcd930545ddebadba21df1fbe7ff24338aec6589a4525c6501699"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Swift compiler warning in AgentSessionWebHostView by checking the weak hostedWebView for nil instead of binding an unused value. Runtime behavior is unchanged: scrollWheel still falls back to super when no web view is attached.

<sup>Written for commit 5a676cba873f31e5ebe3b2d5cfefe8d869818bd2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8256?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved standard scrolling behavior when no hosted web content is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->