### PR TITLE
Honor downstream demand in coalesceLatest (fixes launch trap)

### DIFF
--- a/Sources/CoalesceLatestPublisher.swift
+++ b/Sources/CoalesceLatestPublisher.swift
@@ -31,7 +31,13 @@ extension Publisher where Failure == Never {
     ///   next window.
     ///
     /// Not thread-safe: intended for main-thread streams with `RunLoop.main`.
-    /// Downstream demand is ignored (sink-style subscribers only).
+    ///
+    /// A value is forwarded only against outstanding downstream demand. `sink`
+    /// requests unlimited demand and so never observes the difference, but
+    /// `.values` requests one value at a time and Combine traps an
+    /// AsyncPublisher handed a value it did not request. A value with no demand
+    /// behind it is therefore held as the coalesced latest and forwarded once
+    /// demand arrives.
     func coalesceLatest<Context: Scheduler>(
         for interval: Context.SchedulerTimeType.Stride,
         scheduler: Context
@@ -68,6 +74,7 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
     private let interval: Context.SchedulerTimeType.Stride
     private let scheduler: Context
     private var upstreamSubscription: Subscription?
+    private var downstreamDemand: Subscribers.Demand = .none
     private var hasReceivedReplay = false
     private var windowStart: Context.SchedulerTimeType?
     private var pendingValue: Input?
@@ -90,7 +97,7 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
         guard !isCancelled else { return .none }
         if !hasReceivedReplay {
             hasReceivedReplay = true
-            _ = downstream.receive(input)
+            forward(input)
             return .none
         }
         let now = scheduler.now
@@ -104,7 +111,7 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
             // callback cannot emit it out of order after this value.
             pendingValue = nil
             windowStart = now
-            _ = downstream.receive(input)
+            forward(input)
         }
         return .none
     }
@@ -113,7 +120,7 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
         guard !isCancelled else { return }
         if let value = pendingValue {
             pendingValue = nil
-            _ = downstream.receive(value)
+            forward(value)
         }
         downstream.receive(completion: completion)
     }
@@ -141,12 +148,31 @@ private final class CoalesceLatestInner<Downstream: Subscriber, Context: Schedul
         }
         pendingValue = nil
         windowStart = scheduler.now
-        _ = downstream.receive(value)
+        forward(value)
     }
 
-    func request(_ demand: Subscribers.Demand) {
-        // Downstream demand is intentionally ignored; this operator backs
-        // sink-style Void observation streams with unlimited demand.
+    /// Forwards a value only against outstanding demand. Combine traps a
+    /// publisher that hands a subscriber a value it never requested, so a value
+    /// with no demand behind it becomes the coalesced pending value and waits
+    /// for `request(_:)` instead.
+    private func forward(_ input: Input) {
+        guard downstreamDemand > 0 else {
+            pendingValue = input
+            return
+        }
+        downstreamDemand -= 1
+        downstreamDemand += downstream.receive(input)
+    }
+
+    func request(_ additional: Subscribers.Demand) {
+        guard !isCancelled, additional > 0 else { return }
+        downstreamDemand += additional
+        // The window was stamped when the value arrived, so forwarding a value
+        // that was only waiting for demand must not re-stamp it: the coalesce
+        // interval paces upstream bursts, not the consumer's pull rate.
+        guard let value = pendingValue else { return }
+        pendingValue = nil
+        forward(value)
     }
 
     func cancel() {

--- a/cmuxTests/WorkspaceSidebarObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarObservationTests.swift
@@ -228,6 +228,46 @@ struct WorkspaceSidebarObservationTests {
         )
     }
 
+    @Test func coalesceLatestDeliversNoMoreValuesThanDownstreamDemanded() {
+        let scheduler = VirtualCoalesceScheduler()
+        let subject = PassthroughSubject<Int, Never>()
+        let subscriber = DemandLimitedSubscriber<Int>(initialDemand: .max(1))
+        subject
+            .coalesceLatest(for: .milliseconds(50), scheduler: scheduler)
+            .subscribe(subscriber)
+
+        subject.send(1) // replay: forwarded, and consumes the only demand
+        #expect(subscriber.received == [1])
+
+        subject.send(2) // leading edge, but downstream has asked for nothing more
+
+        #expect(
+            subscriber.received == [1],
+            "A value must not be forwarded while downstream demand is zero: the sidebar observes this operator through `.values`, and an AsyncPublisher traps on a value it never requested."
+        )
+    }
+
+    @Test func coalesceLatestForwardsValueHeldForDemandOnceDemandArrives() {
+        let scheduler = VirtualCoalesceScheduler()
+        let subject = PassthroughSubject<Int, Never>()
+        let subscriber = DemandLimitedSubscriber<Int>(initialDemand: .max(1))
+        subject
+            .coalesceLatest(for: .milliseconds(50), scheduler: scheduler)
+            .subscribe(subscriber)
+
+        subject.send(1) // replay: consumes the only demand
+        subject.send(2) // held: no demand to forward it with
+        subject.send(3) // supersedes 2 as the latest held value
+        #expect(subscriber.received == [1])
+
+        subscriber.request(.max(1))
+
+        #expect(
+            subscriber.received == [1, 3],
+            "Withholding a value for want of demand must defer it, not drop it, and the coalesced latest is the one that survives."
+        )
+    }
+
     @Test func sidebarObservationPublisherIgnoresRemoteHeartbeatOnlyChanges() {
         let workspace = Workspace()
 
@@ -376,6 +416,37 @@ private final class ObservationChangeFlag: @unchecked Sendable {
     func mark() {
         fired = true
     }
+}
+
+// A subscriber whose demand is bounded and explicit. `sink` requests unlimited
+// demand, so it can never observe whether an operator forwards a value nobody
+// asked for; this records what arrives and asks for more only when told to.
+private final class DemandLimitedSubscriber<Input>: Subscriber, @unchecked Sendable {
+    typealias Failure = Never
+
+    private(set) var received: [Input] = []
+    private var subscription: Subscription?
+    private let initialDemand: Subscribers.Demand
+
+    init(initialDemand: Subscribers.Demand) {
+        self.initialDemand = initialDemand
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        subscription?.request(demand)
+    }
+
+    func receive(subscription: Subscription) {
+        self.subscription = subscription
+        subscription.request(initialDemand)
+    }
+
+    func receive(_ input: Input) -> Subscribers.Demand {
+        received.append(input)
+        return .none
+    }
+
+    func receive(completion: Subscribers.Completion<Never>) {}
 }
 
 // Deterministic Combine scheduler for coalesceLatest tests: `now` only moves


### PR DESCRIPTION
cmux traps on launch as soon as the sidebar starts observing a workspace:

```
Combine/Publisher+AsyncSequence.swift:112: Fatal error: Received an output without requesting demand
```

Three launches out of three here, dead within five seconds. The `cmux-unit` test
host dies the same way before a single test runs, so the suite can't be run
either.

## Root cause

`sidebarImmediateObservationPublisher` ends in `coalesceLatest`, and the sidebar
reads it through `.values`. An AsyncPublisher requests one value at a time and
traps on any value it did not request, while `coalesceLatest` forwards every
value the moment it arrives.

`receive(subscription:)` hands the subscription downstream and then requests
unlimited demand upstream. `@Published` replays current state synchronously
inside that request, when downstream demand is still zero, so the replay traps on
arrival. The operator has forwarded without demand since #6807 added it; the
sidebar moved onto `.values` in #8211, which is when it started mattering.

## Fix

Track downstream demand and forward only against it. A value with no demand
behind it becomes the coalesced pending value and is forwarded once demand
arrives, which is already what the operator does with a value that lands inside
an open window, and it holds at most one value either way. Forwarding on demand
does not re-stamp the window: the interval paces upstream bursts, not the
consumer's pull rate.

`sink` requests unlimited demand, so every existing subscriber behaves exactly as
before, and the sixteen tests that were already here pass untouched.

## Why nothing caught it

The precondition was a comment — "sink-style subscribers only", "downstream
demand is ignored" — and nothing enforced it. Every existing test subscribed with
`sink`, whose unlimited demand is the one subscriber shape that cannot observe
the violation, so the operator's own tests were green by construction. Moving the
sidebar onto `.values` broke launch rather than failing a test. Honoring demand
puts the contract in the code, where a future subscriber can't quietly void it.

## Tests

The failing test lands first, then the fix. `coalesceLatestDeliversNoMoreValuesThanDownstreamDemanded`
subscribes with an explicit demand of one value and records what arrives; against
the operator as it stands today:

```
✘ Expectation failed: (subscriber.received → [1, 2]) == [1]
```

`coalesceLatestForwardsValueHeldForDemandOnceDemandArrives` pins the other half,
so a fix that simply drops the undemanded value doesn't pass either.

With the fix, `WorkspaceSidebarObservationTests` is 18/18 and the app launches
and stays up.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8260"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786782591&installation_id=133855650&pr_number=8260&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8260&signature=2bac04181b166516e503f1415ca92f50e43f5f24136ea267997d3bf87c07f5de"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a launch crash by honoring downstream demand in `coalesceLatest`. This prevents “Received an output without requesting demand” when the sidebar consumes the stream via `.values`.

- **Bug Fixes**
  - Track downstream demand in `coalesceLatest`; forward only when there is demand. If none, hold the latest and deliver once demand arrives without re-stamping the window.
  - `sink` behavior is unchanged (unlimited demand).
  - Added demand-limited tests to cover this path; sidebar tests pass and the app now launches reliably.

<sup>Written for commit 16e2af512efe76f295f722d0fdb02669923afe3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8260?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

