### PR TITLE
Isolate CmuxAgentChat package test suites

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1197,7 +1197,7 @@ jobs:
             fi
             echo "::group::swift test $pkgdir"
             case "$pkg" in
-            CmuxAuthRuntime|CmuxIrohTransport)
+            CmuxAgentChat|CmuxAuthRuntime|CmuxIrohTransport)
               ./scripts/ci/run-swift-testing-suites.sh "$pkgdir"
               ;;
             CmuxTerminal|CmuxTerminalCore)

--- a/scripts/ci/run-swift-testing-suites.sh
+++ b/scripts/ci/run-swift-testing-suites.sh
@@ -22,5 +22,5 @@ fi
 while IFS= read -r suite; do
   [ -n "$suite" ] || continue
   echo "swift test $package_path --filter $suite"
-  swift test --package-path "$package_path" --filter "$suite"
-done <<< "$suite_list"
+  swift test --package-path "$package_path" --filter "$suite" </dev/null
+done < <(printf '%s\n' "$suite_list")


### PR DESCRIPTION
Fixes Swift package CI where the CmuxAgentChat aggregate Swift Testing runner finishes its assertions and then aborts or hangs under Xcode 26.3.

- Routes CmuxAgentChat through the existing per-suite test runner.
- Streams suite names through process substitution and gives each test process /dev/null stdin, preventing the helper from deadlocking with 25 suites.

Verification:
- The helper passed all 274 CmuxAgentChat tests across 25 isolated suite processes on Xcode 26.6.
- bash syntax and git diff checks passed.
- The focused Swift-package workflow topology guard passed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8261"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786783110&installation_id=133855650&pr_number=8261&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8261&signature=fce5b858b27f7f3e5716caf7d7696688f16e3bef92905e6d1f35c7cc53bfe044"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Isolated `CmuxAgentChat` test suites in CI to prevent the aggregate Swift Testing runner from hanging/aborting on Xcode 26.x. Tests now run per suite with stdin closed to avoid deadlocks.

- **Bug Fixes**
  - Route `CmuxAgentChat` through `scripts/ci/run-swift-testing-suites.sh` in the workflow.
  - Stream suite names via process substitution and pass /dev/null to each `swift test` stdin.

<sup>Written for commit 45a2a830b6eb992a3117aafae7e93f90223e1e19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8261?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Swift test execution reliability by preventing suite input from interfering with individual test runs.
  * Expanded handling for a known diagnostic so the relevant package tests can complete successfully while genuine failures still fail the CI job.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->