### PR TITLE
Add privacy-safe mobile dial diagnostics

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -73,20 +73,11 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             connectAttemptRegistry: connectAttemptRegistry,
             abandonedConnectCleanupTimeoutNanoseconds: abandonedConnectCleanupTimeoutNanoseconds,
             lateAbandonedConnectCloseTimeoutNanoseconds: lateAbandonedConnectCloseTimeoutNanoseconds,
-35:             makeTransport: { [runtime, transportRequest] in
+            makeTransport: { [runtime, transportRequest] in
                 try runtime.transportFactory.makeTransport(for: transportRequest)
             },
             makeIndependentEventByteStream: independentEventFactory,
             transportConnectObserver: transportConnectObserver
-36:         makeIndependentEventByteStream: IndependentEventByteStreamFactory? = nil,
-        didReceiveConnectedCandidate: ConnectedCandidateHook? = nil,
-        transportConnectObserver: TransportConnectObserver? = nil
-37:             mobileShellLog.info("pairing trying route kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)")
-            let attemptIndex = routeIndex + 1
-            let routeID = route.id
-            let routeKind = route.kind.rawValue
-            let endpointSummary = Self.mobileDialEndpointSummary(route.endpoint)
-            let dialLog = dialLog
         )
     }
 

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -30,6 +30,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     ///   - ticket: The attach ticket authorizing requests.
     ///   - allowsStackAuthFallback: When `true`, falls back to a Stack Auth token
     ///     on routes that allow it once the attach ticket no longer covers a request.
+    ///   - transportConnectObserver: Optional observer for the underlying transport
+    ///     attempt, success, and failure lifecycle.
     public init(
         runtime: any MobileSyncRuntime,
         route: CmxAttachRoute,
@@ -40,7 +42,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         stackTokenForceRefreshGate: RPCStackTokenGate? = nil,
         abandonedConnectCleanupTimeoutNanoseconds: UInt64 = 1_000_000_000,
         lateAbandonedConnectCloseTimeoutNanoseconds: UInt64 = 5_000_000_000,
-        stackTokenGateResetNanoseconds: UInt64 = 30_000_000_000
+        stackTokenGateResetNanoseconds: UInt64 = 30_000_000_000,
+        transportConnectObserver: (@Sendable (MobileRPCTransportConnectEvent) async -> Void)? = nil
     ) {
         self.runtime = runtime
         self.route = route
@@ -70,10 +73,20 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             connectAttemptRegistry: connectAttemptRegistry,
             abandonedConnectCleanupTimeoutNanoseconds: abandonedConnectCleanupTimeoutNanoseconds,
             lateAbandonedConnectCloseTimeoutNanoseconds: lateAbandonedConnectCloseTimeoutNanoseconds,
-            makeTransport: { [runtime, transportRequest] in
+35:             makeTransport: { [runtime, transportRequest] in
                 try runtime.transportFactory.makeTransport(for: transportRequest)
             },
-            makeIndependentEventByteStream: independentEventFactory
+            makeIndependentEventByteStream: independentEventFactory,
+            transportConnectObserver: transportConnectObserver
+36:         makeIndependentEventByteStream: IndependentEventByteStreamFactory? = nil,
+        didReceiveConnectedCandidate: ConnectedCandidateHook? = nil,
+        transportConnectObserver: TransportConnectObserver? = nil
+37:             mobileShellLog.info("pairing trying route kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)")
+            let attemptIndex = routeIndex + 1
+            let routeID = route.id
+            let routeKind = route.kind.rawValue
+            let endpointSummary = Self.mobileDialEndpointSummary(route.endpoint)
+            let dialLog = dialLog
         )
     }
 

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -5,6 +5,7 @@ actor MobileCoreRPCSession {
     typealias TransportFactory = @Sendable () throws -> any CmxByteTransport
     typealias IndependentEventByteStreamFactory = @Sendable () async throws -> CmxIndependentEventByteStream
     typealias ConnectedCandidateHook = @Sendable (_ candidate: any CmxByteTransport) async -> Void
+    typealias TransportConnectObserver = @Sendable (MobileRPCTransportConnectEvent) async -> Void
     typealias PendingContinuation = CheckedContinuation<Result<Data, MobileShellConnectionError>, Never>
     typealias ConnectingTask = (id: UUID, lease: MobileRPCConnectAttemptLease?, task: Task<any CmxByteTransport, any Error>, waiters: Set<UUID>, completed: Bool)
     static let defaultAbandonedConnectCleanupTimeoutNanoseconds: UInt64 = 1_000_000_000
@@ -48,6 +49,7 @@ actor MobileCoreRPCSession {
     private let makeTransport: TransportFactory
     let makeIndependentEventByteStream: IndependentEventByteStreamFactory?
     private let didReceiveConnectedCandidate: ConnectedCandidateHook?
+    private let transportConnectObserver: TransportConnectObserver?
     private var transport: (any CmxByteTransport)?
     private var connectionTask: ConnectingTask?
     private var installedConnectionID: UUID?
@@ -72,8 +74,20 @@ actor MobileCoreRPCSession {
         abandonedConnectCleanupTimeoutNanoseconds: UInt64 = 1_000_000_000,
         lateAbandonedConnectCloseTimeoutNanoseconds: UInt64 = 5_000_000_000,
         makeTransport: @escaping TransportFactory,
-        makeIndependentEventByteStream: IndependentEventByteStreamFactory? = nil,
-        didReceiveConnectedCandidate: ConnectedCandidateHook? = nil
+35:             makeTransport: { [runtime, transportRequest] in
+                try runtime.transportFactory.makeTransport(for: transportRequest)
+            },
+            makeIndependentEventByteStream: independentEventFactory,
+            transportConnectObserver: transportConnectObserver
+36:         makeIndependentEventByteStream: IndependentEventByteStreamFactory? = nil,
+        didReceiveConnectedCandidate: ConnectedCandidateHook? = nil,
+        transportConnectObserver: TransportConnectObserver? = nil
+37:             mobileShellLog.info("pairing trying route kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)")
+            let attemptIndex = routeIndex + 1
+            let routeID = route.id
+            let routeKind = route.kind.rawValue
+            let endpointSummary = Self.mobileDialEndpointSummary(route.endpoint)
+            let dialLog = dialLog
     ) {
         self.connectAttemptKey = connectAttemptKey
         self.connectAttemptRegistry = connectAttemptRegistry
@@ -82,6 +96,7 @@ actor MobileCoreRPCSession {
         self.makeTransport = makeTransport
         self.makeIndependentEventByteStream = makeIndependentEventByteStream
         self.didReceiveConnectedCandidate = didReceiveConnectedCandidate
+        self.transportConnectObserver = transportConnectObserver
     }
 
     deinit {
@@ -228,22 +243,45 @@ actor MobileCoreRPCSession {
             } else {
                 connectLease = .untracked
             }
+            let connectStartedAt = ContinuousClock.now
+            await transportConnectObserver?(.attempt)
             let candidate: any CmxByteTransport
             do {
                 candidate = try makeTransport()
             } catch {
+                await transportConnectObserver?(
+                    .failed(
+                        error: error,
+                        elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt)
+                    )
+                )
                 await connectAttemptRegistry.clearFinishedConnect(lease: connectLease)
                 throw error
             }
             connectionID = UUID()
+            let transportConnectObserver = transportConnectObserver
             task = Task.detached {
-                try await withTaskCancellationHandler {
-                    try await candidate.connect()
-                    return candidate
-                } onCancel: {
-                    Task {
-                        await candidate.close()
+                do {
+                    let connected = try await withTaskCancellationHandler {
+                        try await candidate.connect()
+                        return candidate
+                    } onCancel: {
+                        Task {
+                            await candidate.close()
+                        }
                     }
+                    await transportConnectObserver?(
+                        .connected(elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt))
+                    )
+                    return connected
+                } catch {
+                    await transportConnectObserver?(
+                        .failed(
+                            error: error,
+                            elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt)
+                        )
+                    )
+                    throw error
                 }
             }
             connectionTask = (id: connectionID, lease: connectLease, task: task, waiters: [waiterID], completed: false)
@@ -323,6 +361,13 @@ actor MobileCoreRPCSession {
             throw CancellationError()
         }
         return candidate
+    }
+
+    private static func elapsedMilliseconds(since start: ContinuousClock.Instant) -> Int {
+        let components = start.duration(to: .now).components
+        let milliseconds = components.seconds * 1_000
+            + components.attoseconds / 1_000_000_000_000_000
+        return max(0, Int(milliseconds))
     }
 
     private func cancelConnectingWaiter(id connectionID: UUID, waiterID: UUID) async {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -74,20 +74,9 @@ actor MobileCoreRPCSession {
         abandonedConnectCleanupTimeoutNanoseconds: UInt64 = 1_000_000_000,
         lateAbandonedConnectCloseTimeoutNanoseconds: UInt64 = 5_000_000_000,
         makeTransport: @escaping TransportFactory,
-35:             makeTransport: { [runtime, transportRequest] in
-                try runtime.transportFactory.makeTransport(for: transportRequest)
-            },
-            makeIndependentEventByteStream: independentEventFactory,
-            transportConnectObserver: transportConnectObserver
-36:         makeIndependentEventByteStream: IndependentEventByteStreamFactory? = nil,
+        makeIndependentEventByteStream: IndependentEventByteStreamFactory? = nil,
         didReceiveConnectedCandidate: ConnectedCandidateHook? = nil,
         transportConnectObserver: TransportConnectObserver? = nil
-37:             mobileShellLog.info("pairing trying route kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)")
-            let attemptIndex = routeIndex + 1
-            let routeID = route.id
-            let routeKind = route.kind.rawValue
-            let endpointSummary = Self.mobileDialEndpointSummary(route.endpoint)
-            let dialLog = dialLog
     ) {
         self.connectAttemptKey = connectAttemptKey
         self.connectAttemptRegistry = connectAttemptRegistry
@@ -244,24 +233,14 @@ actor MobileCoreRPCSession {
                 connectLease = .untracked
             }
             let connectStartedAt = ContinuousClock.now
-            await transportConnectObserver?(.attempt)
-            let candidate: any CmxByteTransport
-            do {
-                candidate = try makeTransport()
-            } catch {
-                await transportConnectObserver?(
-                    .failed(
-                        error: error,
-                        elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt)
-                    )
-                )
-                await connectAttemptRegistry.clearFinishedConnect(lease: connectLease)
-                throw error
-            }
-            connectionID = UUID()
+            let makeTransport = makeTransport
             let transportConnectObserver = transportConnectObserver
+            connectionID = UUID()
             task = Task.detached {
+                await transportConnectObserver?(.attempt)
                 do {
+                    try Task.checkCancellation()
+                    let candidate = try makeTransport()
                     let connected = try await withTaskCancellationHandler {
                         try await candidate.connect()
                         return candidate

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -256,6 +256,9 @@ actor MobileCoreRPCSession {
                 } catch is CancellationError {
                     throw CancellationError()
                 } catch {
+                    if Task.isCancelled {
+                        throw CancellationError()
+                    }
                     await transportConnectObserver?(
                         .failed(
                             error: error,

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCSession.swift
@@ -253,6 +253,8 @@ actor MobileCoreRPCSession {
                         .connected(elapsedMilliseconds: Self.elapsedMilliseconds(since: connectStartedAt))
                     )
                     return connected
+                } catch is CancellationError {
+                    throw CancellationError()
                 } catch {
                     await transportConnectObserver?(
                         .failed(

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCTransportConnectEvent.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileRPCTransportConnectEvent.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// A lifecycle event for one underlying mobile transport connection attempt.
+public enum MobileRPCTransportConnectEvent: Sendable {
+    /// The transport factory is about to build and dial its route.
+    case attempt
+    /// The underlying byte transport connected successfully.
+    /// - Parameter elapsedMilliseconds: Whole milliseconds since the attempt began.
+    case connected(elapsedMilliseconds: Int)
+    /// The transport factory or underlying byte transport failed.
+    /// - Parameters:
+    ///   - error: The transport construction or connection error.
+    ///   - elapsedMilliseconds: Whole milliseconds since the attempt began.
+    case failed(error: any Error, elapsedMilliseconds: Int)
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/FirstConnectClosedErrorThenSucceedsTransport.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/FirstConnectClosedErrorThenSucceedsTransport.swift
@@ -1,0 +1,119 @@
+import CMUXMobileCore
+import Foundation
+@testable import CmuxMobileRPC
+
+actor FirstConnectClosedErrorThenSucceedsTransport: CmxByteTransport {
+    private struct SyntheticClosedError: Error {}
+
+    private var sentPayloads: [Data] = []
+    private var receiveWaiters: [CheckedContinuation<Data?, Never>] = []
+    private var queuedResponses: [Data] = []
+    private var firstConnectRelease: CheckedContinuation<Void, Never>?
+    private var firstConnectStartedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstConnectFinishedWaiters: [CheckedContinuation<Void, Never>] = []
+    private var firstConnectStarted = false
+    private var firstConnectFinished = false
+    private var connects = 0
+    private var isClosed = false
+
+    func connect() async throws {
+        connects += 1
+        if connects == 1 {
+            firstConnectStarted = true
+            let startedWaiters = firstConnectStartedWaiters
+            firstConnectStartedWaiters = []
+            for waiter in startedWaiters {
+                waiter.resume()
+            }
+            await withCheckedContinuation { continuation in
+                firstConnectRelease = continuation
+            }
+            firstConnectFinished = true
+            let finishedWaiters = firstConnectFinishedWaiters
+            firstConnectFinishedWaiters = []
+            for waiter in finishedWaiters {
+                waiter.resume()
+            }
+            throw SyntheticClosedError()
+        }
+        isClosed = false
+    }
+
+    func receive() async throws -> Data? {
+        if isClosed {
+            return nil
+        }
+        if !queuedResponses.isEmpty {
+            return queuedResponses.removeFirst()
+        }
+        return await withCheckedContinuation { continuation in
+            receiveWaiters.append(continuation)
+        }
+    }
+
+    func send(_ data: Data) async throws {
+        var buffer = data
+        let payloads = try MobileSyncFrameCodec.decodeFrames(from: &buffer)
+        sentPayloads.append(contentsOf: payloads)
+        for payload in payloads {
+            let request = try recordedRPCRequest(from: payload)
+            try enqueueResponse(id: request.id)
+        }
+    }
+
+    func close() async {
+        isClosed = true
+        if connects == 1 {
+            firstConnectRelease?.resume()
+            firstConnectRelease = nil
+            return
+        }
+        let waiters = receiveWaiters
+        receiveWaiters = []
+        for waiter in waiters {
+            waiter.resume(returning: nil)
+        }
+    }
+
+    func waitUntilFirstConnectStarted() async {
+        if firstConnectStarted {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            firstConnectStartedWaiters.append(continuation)
+        }
+    }
+
+    func waitUntilFirstConnectFinished() async {
+        if firstConnectFinished {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            firstConnectFinishedWaiters.append(continuation)
+        }
+    }
+
+    func connectCount() -> Int {
+        connects
+    }
+
+    func sentRequests() throws -> [RecordedRPCRequest] {
+        try sentPayloads.map(recordedRPCRequest(from:))
+    }
+
+    private func enqueueResponse(id: String?) throws {
+        let response: [String: Any] = [
+            "id": id ?? "",
+            "ok": true,
+            "result": ["status": "ok"],
+        ]
+        let payload = try JSONSerialization.data(withJSONObject: response)
+        let frame = try MobileSyncFrameCodec.encodeFrame(payload)
+        if let waiter = receiveWaiters.first {
+            receiveWaiters.removeFirst()
+            waiter.resume(returning: frame)
+        } else {
+            queuedResponses.append(frame)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
@@ -132,11 +132,16 @@ import Testing
             expiresAt: Date().addingTimeInterval(60),
             authToken: "ticket-secret"
         )
+        let (connectEvents, connectEventContinuation) =
+            AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
         let client = MobileCoreRPCClient(
             runtime: runtime,
             route: route,
             ticket: ticket,
-            allowsStackAuthFallback: true
+            allowsStackAuthFallback: true,
+            transportConnectObserver: { event in
+                connectEventContinuation.yield(event)
+            }
         )
         let first = try MobileCoreRPCClient.requestData(
             method: "terminal.input",
@@ -163,6 +168,18 @@ import Testing
         } catch is CancellationError {
         } catch {
             Issue.record("Expected CancellationError, got \(error)")
+        }
+        connectEventContinuation.finish()
+        var recordedConnectEvents: [MobileRPCTransportConnectEvent] = []
+        for await event in connectEvents {
+            recordedConnectEvents.append(event)
+        }
+        #expect(recordedConnectEvents.count == 1)
+        if let firstEvent = recordedConnectEvents.first {
+            guard case .attempt = firstEvent else {
+                Issue.record("Expected only an attempt event for a cancelled connect")
+                return
+            }
         }
 
         let data = try await client.sendRequest(second)

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCAbandonedConnectTests.swift
@@ -189,6 +189,75 @@ import Testing
         #expect(try await transport.sentRequests().map(\.id) == ["second-after-connect-cancellation"])
     }
 
+    @Test func callerCancellationClosedErrorDoesNotEmitFailedAndAllowsRetry() async throws {
+        let transport = FirstConnectClosedErrorThenSucceedsTransport()
+        let (connectEvents, connectEventContinuation) =
+            AsyncStream<MobileRPCTransportConnectEvent>.makeStream()
+        let session = MobileCoreRPCSession(
+            makeTransport: { transport },
+            transportConnectObserver: { event in
+                connectEventContinuation.yield(event)
+            }
+        )
+        let first = try MobileCoreRPCClient.requestData(
+            method: "mobile.host.status",
+            params: [:],
+            id: "cancelled-closed-connect"
+        )
+        let second = try MobileCoreRPCClient.requestData(
+            method: "mobile.host.status",
+            params: [:],
+            id: "retry-after-closed-connect"
+        )
+        let deadline = DispatchTime.now().uptimeNanoseconds + 60 * 1_000_000_000
+        let firstTask = Task {
+            try await session.send(
+                payload: first,
+                requestID: "cancelled-closed-connect",
+                deadlineUptimeNanoseconds: deadline
+            )
+        }
+
+        await transport.waitUntilFirstConnectStarted()
+        firstTask.cancel()
+        do {
+            _ = try await firstTask.value
+            Issue.record("Expected first RPC request to throw CancellationError")
+        } catch is CancellationError {
+        } catch {
+            Issue.record("Expected CancellationError, got \(error)")
+        }
+        await transport.waitUntilFirstConnectFinished()
+
+        let data = try await session.send(
+            payload: second,
+            requestID: "retry-after-closed-connect",
+            deadlineUptimeNanoseconds: deadline
+        )
+        let response = try #require(JSONSerialization.jsonObject(with: data) as? [String: String])
+        #expect(response["status"] == "ok")
+        #expect(await transport.connectCount() == 2)
+        #expect(try await transport.sentRequests().map(\.id) == ["retry-after-closed-connect"])
+
+        connectEventContinuation.finish()
+        var attemptCount = 0
+        var connectedCount = 0
+        var failedCount = 0
+        for await event in connectEvents {
+            switch event {
+            case .attempt:
+                attemptCount += 1
+            case .connected:
+                connectedCount += 1
+            case .failed:
+                failedCount += 1
+            }
+        }
+        #expect(attemptCount == 2)
+        #expect(connectedCount == 1)
+        #expect(failedCount == 0)
+    }
+
     @Test func repeatedConnectTimeoutsDoNotFanOutWhileCleanupIsStuck() async throws {
         let transport = CancellationIgnoringConnectTransport()
         let route = try hostPortRoute(kind: .debugLoopback, host: "127.0.0.1", port: 59127)

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -611,6 +611,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     /// The injected, fire-and-forget product-analytics emitter. Defaults to
     /// ``NoopAnalytics`` so previews/tests inject nothing.
     let analytics: any AnalyticsEmitting
+    let dialLog: @Sendable (String) async -> Void
     let connectAttemptRegistry = MobileRPCConnectAttemptRegistry()
     let stackTokenGate = RPCStackTokenGate()
     let stackTokenForceRefreshGate = RPCStackTokenGate()
@@ -875,6 +876,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     /// Create a mobile shell store with injectable runtime services for app
     /// composition, previews, and package tests.
+    /// - Parameter dialLog: Optional ordered dial-log sink. The production
+    ///   default writes through ``MobileDebugLog/anchormux(_:)``.
     public init(
         runtime: (any MobileSyncRuntime)? = nil,
         isSignedIn: Bool = false,
@@ -898,6 +901,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         forgottenMacStore: any PairedMacForgottenStoring = InMemoryPairedMacForgottenStore(),
         analytics: any AnalyticsEmitting = NoopAnalytics(),
         diagnosticLog: DiagnosticLog? = nil,
+        dialLog: (@Sendable (String) async -> Void)? = nil,
         feedbackEmailSubmitter: (any MobileFeedbackEmailSubmitting)? = nil,
         feedbackStampProvider: @escaping @MainActor () -> MobileFeedbackStamp = { MobileShellComposite.emptyFeedbackStamp },
         draftStore: (any TerminalDraftStoring)? = nil,
@@ -921,6 +925,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.forgottenMacStore = forgottenMacStore
         self.analytics = analytics
         self.diagnosticLog = diagnosticLog
+        self.dialLog = dialLog ?? { message in MobileDebugLog.anchormux(message) }
         self.feedbackEmailSubmitter = feedbackEmailSubmitter
         self.feedbackStampProvider = feedbackStampProvider
         // Distinguish "key absent" (an install that predates the hint and may
@@ -4622,9 +4627,14 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let routeAllowsStackAuthFallbackOverride = allowsStackAuthFallback
         let connectionAttemptStartedAt = pairingAttemptStartedAt
         var lastError: (any Error)?
-        routeLoop: for route in supportedRoutes {
+        routeLoop: for (routeIndex, route) in supportedRoutes.enumerated() {
             activeRoute = route
             mobileShellLog.info("pairing trying route kind=\(route.kind.rawValue, privacy: .public) endpoint=\(route.endpoint.logDescription, privacy: .private)")
+            let attemptIndex = routeIndex + 1
+            let routeID = route.id
+            let routeKind = route.kind.rawValue
+            let endpointSummary = Self.mobileDialEndpointSummary(route.endpoint)
+            let dialLog = dialLog
             let client = MobileCoreRPCClient(
                 runtime: runtime,
                 route: route,
@@ -4633,7 +4643,19 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     ?? MobileShellRouteAuthPolicy.routeAllowsStackAuth(route),
                 connectAttemptRegistry: connectAttemptRegistry,
                 stackTokenGate: stackTokenGate,
-                stackTokenForceRefreshGate: stackTokenForceRefreshGate
+                stackTokenForceRefreshGate: stackTokenForceRefreshGate,
+                transportConnectObserver: { event in
+                    let line: String
+                    switch event {
+                    case .attempt:
+                        line = "mobile.dial.attempt index=\(attemptIndex) route_id=\(routeID) kind=\(routeKind) endpoint=\(endpointSummary)"
+                    case .connected(let elapsedMilliseconds):
+                        line = "mobile.dial.connected index=\(attemptIndex) route_id=\(routeID) kind=\(routeKind) elapsed_ms=\(elapsedMilliseconds)"
+                    case let .failed(error, elapsedMilliseconds):
+                        line = "mobile.dial.failed index=\(attemptIndex) route_id=\(routeID) kind=\(routeKind) failure_kind=\(Self.mobileDialFailureKind(error)) elapsed_ms=\(elapsedMilliseconds)"
+                    }
+                    await dialLog(line)
+                }
             )
             for workspaceListRequest in workspaceListRequests {
                 do {
@@ -4864,6 +4886,44 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
         diagnosticLog?.record(DiagnosticEvent(.pairFail))
         throw lastError ?? MobileShellConnectionError.connectionClosed
+    }
+
+    nonisolated private static func mobileDialEndpointSummary(_ endpoint: CmxAttachEndpoint) -> String {
+        switch endpoint {
+        case let .hostPort(host, port):
+            return "\(host):\(port)"
+        case let .peer(identity, pathHints):
+            let endpointPrefix = String(identity.endpointID.prefix(8))
+            return "peer:\(endpointPrefix),hints:\(pathHints.count)"
+        case .url:
+            return "url:redacted"
+        }
+    }
+
+    nonisolated private static func mobileDialFailureKind(_ error: any Error) -> String {
+        if let error = error as? CmxNetworkByteTransportError {
+            switch error {
+            case .connectionTimedOut:
+                return "timedOut"
+            case .connectionFailed(_, let kind):
+                return mobileDialFailureKind(kind)
+            default:
+                return "transport_error:\(String(describing: type(of: error)))"
+            }
+        }
+        return "transport_error:\(String(describing: type(of: error)))"
+    }
+
+    nonisolated private static func mobileDialFailureKind(_ kind: CmxConnectFailureKind) -> String {
+        switch kind {
+        case .connectionRefused: "connectionRefused"
+        case .hostUnreachable: "hostUnreachable"
+        case .timedOut: "timedOut"
+        case .permissionDenied: "permissionDenied"
+        case .dnsFailed: "dnsFailed"
+        case .secureChannelFailed: "secureChannelFailed"
+        case .generic: "generic"
+        }
     }
 
     private struct WorkspaceListRequest {

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4890,8 +4890,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     nonisolated private static func mobileDialEndpointSummary(_ endpoint: CmxAttachEndpoint) -> String {
         switch endpoint {
-        case let .hostPort(host, port):
-            return "\(host):\(port)"
+        case let .hostPort(_, port):
+            return "host_port:redacted,port:\(port)"
         case let .peer(identity, pathHints):
             let endpointPrefix = String(identity.endpointID.prefix(8))
             return "peer:\(endpointPrefix),hints:\(pathHints.count)"

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticFailingTransport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticFailingTransport.swift
@@ -1,0 +1,13 @@
+import CMUXMobileCore
+import CmuxMobileTransport
+import Foundation
+
+actor DialDiagnosticFailingTransport: CmxByteTransport {
+    func connect() async throws {
+        throw CmxIrohByteTransportError.connectionFailed("sensitive transport detail", .hostUnreachable)
+    }
+
+    func receive() async throws -> Data? { nil }
+    func send(_ data: Data) async throws {}
+    func close() async {}
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticFailingTransport.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticFailingTransport.swift
@@ -4,7 +4,7 @@ import Foundation
 
 actor DialDiagnosticFailingTransport: CmxByteTransport {
     func connect() async throws {
-        throw CmxIrohByteTransportError.connectionFailed("sensitive transport detail", .hostUnreachable)
+        throw CmxNetworkByteTransportError.connectionFailed("sensitive transport detail", .hostUnreachable)
     }
 
     func receive() async throws -> Data? { nil }

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticRecorder.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticRecorder.swift
@@ -1,0 +1,11 @@
+actor DialDiagnosticRecorder {
+    private var recordedLines: [String] = []
+
+    func record(_ line: String) {
+        recordedLines.append(line)
+    }
+
+    func lines() -> [String] {
+        recordedLines
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticTransportFactory.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DialDiagnosticTransportFactory.swift
@@ -1,0 +1,13 @@
+import CMUXMobileCore
+
+struct DialDiagnosticTransportFactory: CmxByteTransportFactory {
+    let router: LivenessHostRouter
+    let failingRouteID: String
+
+    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        if route.id == failingRouteID {
+            return DialDiagnosticFailingTransport()
+        }
+        return LivenessTransport(router: router)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileDialDiagnosticsTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileDialDiagnosticsTests.swift
@@ -1,0 +1,67 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+@Suite struct MobileDialDiagnosticsTests {
+    @Test func diagnosticsFollowIrohThenTailscalePriorityOrder() async throws {
+        let irohRoute = try CmxAttachRoute(
+            id: "iroh-primary",
+            kind: .iroh,
+            endpoint: .peer(
+                id: "1234567890-full-endpoint-id",
+                relayHint: nil,
+                directAddrs: [],
+                relayURL: "https://relay.example.com/path?token=never-log-this"
+            ),
+            priority: 1
+        )
+        let tailscaleRoute = try CmxAttachRoute(
+            id: "tailscale-fallback",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.71.210.41", port: CmxMobileDefaults.defaultHostPort),
+            priority: 2
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [tailscaleRoute, irohRoute]
+        )
+        let router = LivenessHostRouter()
+        let recorder = DialDiagnosticRecorder()
+        let runtime = LivenessTestRuntime(
+            transportFactory: DialDiagnosticTransportFactory(
+                router: router,
+                failingRouteID: irohRoute.id
+            ),
+            now: Date.init,
+            supportedRouteKinds: [.iroh, .tailscale]
+        )
+        let store = MobileShellComposite(
+            runtime: runtime,
+            isSignedIn: true,
+            dialLog: { line in await recorder.record(line) }
+        )
+
+        _ = try await store.connect(ticket: ticket)
+
+        let lines = await recorder.lines()
+        #expect(lines.count == 4)
+        guard lines.count == 4 else {
+            Issue.record("unexpected dial diagnostics: \(lines)")
+            return
+        }
+        #expect(lines[0] == "mobile.dial.attempt index=1 route_id=iroh-primary kind=iroh endpoint=peer:12345678,relay:relay.example.com")
+        #expect(lines[1].hasPrefix("mobile.dial.failed index=1 route_id=iroh-primary kind=iroh failure_kind=hostUnreachable elapsed_ms="))
+        #expect(lines[2] == "mobile.dial.attempt index=2 route_id=tailscale-fallback kind=tailscale endpoint=100.71.210.41:\(CmxMobileDefaults.defaultHostPort)")
+        #expect(lines[3].hasPrefix("mobile.dial.connected index=2 route_id=tailscale-fallback kind=tailscale elapsed_ms="))
+        let combined = lines.joined(separator: "\n")
+        #expect(!combined.contains("1234567890-full-endpoint-id"))
+        #expect(!combined.contains("never-log-this"))
+        #expect(!combined.contains("sensitive transport detail"))
+        #expect(store.connectionState == .connected)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileDialDiagnosticsTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileDialDiagnosticsTests.swift
@@ -1,16 +1,18 @@
 import CMUXMobileCore
+import CmuxMobileTransport
 import Foundation
 import Testing
 @testable import CmuxMobileShell
 
 @MainActor
 @Suite struct MobileDialDiagnosticsTests {
-    @Test func diagnosticsFollowIrohThenTailscalePriorityOrder() async throws {
+    @Test func diagnosticsDoNotDowngradeFromIrohToRawTailscale() async throws {
+        let endpointID = String(repeating: "1", count: 64)
         let irohRoute = try CmxAttachRoute(
             id: "iroh-primary",
             kind: .iroh,
             endpoint: .peer(
-                id: "1234567890-full-endpoint-id",
+                id: endpointID,
                 relayHint: nil,
                 directAddrs: [],
                 relayURL: "https://relay.example.com/path?token=never-log-this"
@@ -30,15 +32,69 @@ import Testing
             macDisplayName: "Test Mac",
             routes: [tailscaleRoute, irohRoute]
         )
-        let router = LivenessHostRouter()
         let recorder = DialDiagnosticRecorder()
         let runtime = LivenessTestRuntime(
             transportFactory: DialDiagnosticTransportFactory(
-                router: router,
+                router: LivenessHostRouter(),
                 failingRouteID: irohRoute.id
             ),
             now: Date.init,
             supportedRouteKinds: [.iroh, .tailscale]
+        )
+        let store = MobileShellComposite(
+            runtime: runtime,
+            isSignedIn: true,
+            dialLog: { line in await recorder.record(line) }
+        )
+
+        await #expect(throws: CmxNetworkByteTransportError.self) {
+            _ = try await store.connect(ticket: ticket)
+        }
+
+        let lines = await recorder.lines()
+        #expect(lines.count == 2)
+        guard lines.count == 2 else {
+            Issue.record("unexpected dial diagnostics: \(lines)")
+            return
+        }
+        #expect(lines[0] == "mobile.dial.attempt index=1 route_id=iroh-primary kind=iroh endpoint=peer:11111111,hints:1")
+        #expect(lines[1].hasPrefix("mobile.dial.failed index=1 route_id=iroh-primary kind=iroh failure_kind=hostUnreachable elapsed_ms="))
+        let combined = lines.joined(separator: "\n")
+        #expect(!combined.contains(endpointID))
+        #expect(!combined.contains("never-log-this"))
+        #expect(!combined.contains("sensitive transport detail"))
+        #expect(!combined.contains("tailscale-fallback"))
+        #expect(!combined.contains("100.71.210.41"))
+    }
+
+    @Test func diagnosticsFollowFallbackRouteOrder() async throws {
+        let firstRoute = try CmxAttachRoute(
+            id: "debug-primary",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: 44_001),
+            priority: 1
+        )
+        let fallbackRoute = try CmxAttachRoute(
+            id: "debug-fallback",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: 44_002),
+            priority: 2
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "",
+            terminalID: nil,
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [fallbackRoute, firstRoute]
+        )
+        let recorder = DialDiagnosticRecorder()
+        let runtime = LivenessTestRuntime(
+            transportFactory: DialDiagnosticTransportFactory(
+                router: LivenessHostRouter(),
+                failingRouteID: firstRoute.id
+            ),
+            now: Date.init,
+            supportedRouteKinds: [.debugLoopback]
         )
         let store = MobileShellComposite(
             runtime: runtime,
@@ -54,14 +110,11 @@ import Testing
             Issue.record("unexpected dial diagnostics: \(lines)")
             return
         }
-        #expect(lines[0] == "mobile.dial.attempt index=1 route_id=iroh-primary kind=iroh endpoint=peer:12345678,relay:relay.example.com")
-        #expect(lines[1].hasPrefix("mobile.dial.failed index=1 route_id=iroh-primary kind=iroh failure_kind=hostUnreachable elapsed_ms="))
-        #expect(lines[2] == "mobile.dial.attempt index=2 route_id=tailscale-fallback kind=tailscale endpoint=100.71.210.41:\(CmxMobileDefaults.defaultHostPort)")
-        #expect(lines[3].hasPrefix("mobile.dial.connected index=2 route_id=tailscale-fallback kind=tailscale elapsed_ms="))
-        let combined = lines.joined(separator: "\n")
-        #expect(!combined.contains("1234567890-full-endpoint-id"))
-        #expect(!combined.contains("never-log-this"))
-        #expect(!combined.contains("sensitive transport detail"))
+        #expect(lines[0] == "mobile.dial.attempt index=1 route_id=debug-primary kind=debug_loopback endpoint=host_port:redacted,port:44001")
+        #expect(lines[1].hasPrefix("mobile.dial.failed index=1 route_id=debug-primary kind=debug_loopback failure_kind=hostUnreachable elapsed_ms="))
+        #expect(lines[2] == "mobile.dial.attempt index=2 route_id=debug-fallback kind=debug_loopback endpoint=host_port:redacted,port:44002")
+        #expect(lines[3].hasPrefix("mobile.dial.connected index=2 route_id=debug-fallback kind=debug_loopback elapsed_ms="))
+        #expect(!lines.joined(separator: "\n").contains("127.0.0.1"))
         #expect(store.connectionState == .connected)
     }
 }

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/cmuxFeatureTests.swift
@@ -2293,6 +2293,7 @@ struct TerminalStreamTests {
 
 @MainActor
 @Test func terminalInputResyncsOutputWhenMacSequenceIsAhead() async throws {
+    let now = Date()
     let route = try CmxAttachRoute(
         id: "debug_loopback",
         kind: .debugLoopback,
@@ -2304,52 +2305,52 @@ struct TerminalStreamTests {
         macDeviceID: "test-mac",
         macDisplayName: "Test Mac",
         routes: [route],
-        expiresAt: Date().addingTimeInterval(60)
+        expiresAt: now.addingTimeInterval(60)
     )
     let router = TerminalOutputSelfHealingRouter()
     let runtime = testRuntime(
         supportedRouteKinds: [.debugLoopback],
         transportFactory: RequestAwareTransportFactory(router: router),
+        now: { now },
         supportsServerPushEvents: true
     )
     let store = CMUXMobileShellStore.preview(runtime: runtime)
-    let collector = TerminalOutputCollector()
 
     store.signIn()
     await store.connectPairingURL(try attachURL(for: ticket).absoluteString)
-    collector.mount(store: store, surfaceID: "live-terminal")
+    // The initial subscription request proves host capabilities have been
+    // applied before the surface mounts. Otherwise the cold replay can start
+    // unbarriered and be superseded by its capability-upgrade replay, which is
+    // a different lifecycle than the input-resync race this test owns.
+    _ = try await waitForRequestCount("mobile.events.subscribe", count: 1, router: router)
+    var output = store.terminalOutputStream(surfaceID: "live-terminal").makeAsyncIterator()
     let oldGridText = try terminalRenderGridReplacementText(seq: 4, text: "old")
     let currentGridText = try terminalRenderGridReplacementText(seq: 12, text: "current")
 
     _ = try await waitForRequestCount("mobile.terminal.replay", count: 1, router: router)
-    // Anchor on the cold replay's DELIVERY, not just its request: submitting
-    // input while the first replay's response is still in flight races the
-    // input-triggered resync against the in-flight replay's barrier state,
-    // and one interleaving legitimately skips the second replay (the flaky
-    // iPad failure in https://github.com/manaflow-ai/cmux/issues/7820). The
-    // scenario under test is a phone SETTLED at stale content learning from
-    // an input ack that the mac is ahead.
-    for _ in 0..<4000 where !collector.lines.contains(oldGridText) {
-        try await Task.sleep(nanoseconds: 1_000_000)
-    }
-    #expect(collector.lines.last == oldGridText)
+    let oldChunk = try #require(await output.next())
+    try #require(String(data: oldChunk.data, encoding: .utf8) == oldGridText)
 
+    // Keep the cold replay unacknowledged while the input response reports a
+    // newer Mac sequence. The resync must remain owned by that replay barrier
+    // and run as its follow-up instead of racing it with a stale token.
     await store.submitTerminalRawInput(Data("x".utf8), surfaceID: "live-terminal")
+    let requestsBeforeAcknowledgement = await router.sentRequests()
+    try #require(requestsBeforeAcknowledgement.count { $0.method == "mobile.terminal.replay" } == 1)
+    store.terminalOutputDidProcess(
+        surfaceID: "live-terminal",
+        streamToken: oldChunk.streamToken
+    )
 
     let replayRequests = try await waitForRequestCount("mobile.terminal.replay", count: 2, router: router)
     #expect(replayRequests.count >= 2)
     _ = try await waitForRequestCount("mobile.events.subscribe", count: 2, router: router)
-    // The request-count waits only prove the second replay was REQUESTED; its
-    // response still has to round-trip and deliver. The slower CI iPad leg
-    // regularly needs more than the file's usual 200ms here.
-    for _ in 0..<4000 where !collector.lines.contains(currentGridText) {
-        try await Task.sleep(nanoseconds: 1_000_000)
-    }
-
-    #expect(collector.lines.last == currentGridText)
-    #expect(Set(collector.lines).isSubset(of: [oldGridText, currentGridText]))
-    #expect(collector.lines.count <= 2)
-    collector.unmount()
+    let currentChunk = try #require(await output.next())
+    #expect(String(data: currentChunk.data, encoding: .utf8) == currentGridText)
+    store.terminalOutputDidProcess(
+        surfaceID: "live-terminal",
+        streamToken: currentChunk.streamToken
+    )
 }
 
 @MainActor


### PR DESCRIPTION
## Summary
- add ordered `mobile.dial.attempt`, `mobile.dial.connected`, and `mobile.dial.failed` diagnostics around the underlying transport connect lifecycle
- report route order, redacted endpoint shape, stable failure kind, and elapsed time without logging host addresses, full EndpointIds, relay URLs/tokens, or raw transport errors
- suppress failure diagnostics for every cancelled connect, including production-shaped cases where closing the transport causes `connect()` to finish with a domain error instead of `CancellationError`
- make the terminal input/resync replay regression deterministic by freezing ticket time and explicitly sequencing subscription, replay, input, and replay acknowledgement
- preserve `main`'s authoritative authenticated `CmuxIrohTransport` implementation from #7908; an authenticated Iroh route remains fail-closed and never downgrades to raw Tailscale

The earlier duplicate native-FFI transport implementation was dropped during the rebase because #7908 now owns production Iroh transport, broker admission, relay policy, and authenticated path-hint fallback.

## Regression evidence
- test-only commit `baa62fdfb4`: `callerCancellationClosedErrorDoesNotEmitFailedAndAllowsRetry` failed exactly because the cancelled closed connect emitted one `.failed` event
- fix commit `8fb97e2648`: normalizes `Task.isCancelled` before observer notification; the new regression and existing cancellation retry test both pass

## Verification
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobileDialDiagnosticsTests` — 2 tests passed
- focused MobileRPC cancellation run — 2 tests passed, including the production-shaped closed-error regression
- `xcodebuild test ... -only-testing:cmuxFeatureTests` on an iOS Simulator at `051310aebb` — 188 tests passed, including `terminalInputResyncsOutputWhenMacSequenceIsAhead`; final commits touch only MobileRPC cancellation diagnostics and their focused tests
- `scripts/reload.sh --tag iroh-rebase --launch` at `8fb97e2648` — tagged macOS build succeeded; tag-bound CLI workspace smoke test passed
- Release iPhone build at `8fb97e2648` succeeded, was signed, and installed on a physical iPhone 16 Pro Max; automatic launch awaits device unlock
- phone metadata verified `CMUXAuthEnvironment=production`, display name `cmux BETA Iroh`, and Stack OAuth callback scheme `stack-auth-mobile-oauth-url`

## Review
- Greptile final review: 5/5, safe to merge, no files requiring attention on the reduced diagnostics diff
- CodeRabbit and Socket Security checks completed successfully on the prior stable head
- fresh internal integration review of `origin/main...8fb97e2648` found no concrete blockers
- no host publication, pairing persistence/backup, reconnect-route, endpoint-pinning, or settings paths are changed