### PR TITLE
Share OpenCode server across Agent Session surfaces

### DIFF
--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -1995,6 +1995,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         stopSessionAutosaveTimer()
         CloudVMActionLauncher.shared.terminateAll()
         CmuxSSHURLProcessLauncher.shared.terminateAll()
+        tabManager?.agentSessionOpenCodeServer.terminateImmediately()
         MobileHostService.shared.stop()
         TerminalController.shared.stop()
         GhosttyApp.terminalPasteboard.cleanupAllOwnedTemporaryImageFiles()

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -8568,7 +8568,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
             initialWorkingDirectory: initialWorkingDirectory,
             initialTerminalInput: initialTerminalInput,
             autoWelcomeIfNeeded: initialTerminalInput == nil,
-            pullRequestProbeService: self.tabManager?.pullRequestProbeService
+            pullRequestProbeService: self.tabManager?.pullRequestProbeService,
+            agentSessionOpenCodeServer: self.tabManager?.agentSessionOpenCodeServer ?? OpenCodeServerService()
         )
         tabManager.windowId = windowId
         if let sessionWindowSnapshot {

--- a/Sources/Panels/AgentSessionAssetSchemeHandler.swift
+++ b/Sources/Panels/AgentSessionAssetSchemeHandler.swift
@@ -1,0 +1,71 @@
+import Foundation
+import WebKit
+
+final class AgentSessionAssetSchemeHandler: NSObject, WKURLSchemeHandler {
+    static let scheme = "cmux-agent-session"
+    static let shared = AgentSessionAssetSchemeHandler()
+    static let shellURL = URL(string: "\(scheme)://app/agent-session.html")!
+
+    private struct Asset {
+        let pathComponents: [String]
+        let mimeType: String
+    }
+
+    private static let assetsByRequestPath: [String: Asset] = [
+        "/agent-session.html": Asset(
+            pathComponents: ["markdown-viewer", "webviews-app", "agent-session.html"],
+            mimeType: "text/html"
+        ),
+        "/main.mjs": Asset(
+            pathComponents: ["markdown-viewer", "webviews-app", "main.mjs"],
+            mimeType: "text/javascript"
+        ),
+        "/chunks/agentSessionSurface.mjs": Asset(
+            pathComponents: ["markdown-viewer", "webviews-app", "chunks", "agentSessionSurface.mjs"],
+            mimeType: "text/javascript"
+        ),
+        "/chunks/installWebviewStyles.mjs": Asset(
+            pathComponents: ["markdown-viewer", "webviews-app", "chunks", "installWebviewStyles.mjs"],
+            mimeType: "text/javascript"
+        ),
+        "/chunks/vendor.mjs": Asset(
+            pathComponents: ["markdown-viewer", "webviews-app", "chunks", "vendor.mjs"],
+            mimeType: "text/javascript"
+        ),
+    ]
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        guard let requestURL = urlSchemeTask.request.url,
+              requestURL.scheme == Self.scheme,
+              requestURL.host == "app",
+              requestURL.query == nil,
+              let asset = Self.assetsByRequestPath[requestURL.path],
+              let resourceURL = Bundle.main.resourceURL else {
+            urlSchemeTask.didFailWithError(URLError(.fileDoesNotExist))
+            return
+        }
+
+        let fileURL = asset.pathComponents.reduce(resourceURL) {
+            $0.appendingPathComponent($1, isDirectory: false)
+        }
+        do {
+            let data = try Data(contentsOf: fileURL, options: .mappedIfSafe)
+            let response = URLResponse(
+                url: requestURL,
+                mimeType: asset.mimeType,
+                expectedContentLength: data.count,
+                textEncodingName: "utf-8"
+            )
+            urlSchemeTask.didReceive(response)
+            urlSchemeTask.didReceive(data)
+            urlSchemeTask.didFinish()
+        } catch {
+            urlSchemeTask.didFailWithError(error)
+        }
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+        _ = webView
+        _ = urlSchemeTask
+    }
+}

--- a/Sources/Panels/AgentSessionPanel.swift
+++ b/Sources/Panels/AgentSessionPanel.swift
@@ -10,7 +10,7 @@ final class AgentSessionPanel: Panel {
     let rendererKind: AgentSessionRendererKind
     let initialProviderID: AgentSessionProviderID
     private(set) var workingDirectory: String?
-    let rendererSession = AgentSessionWebRendererSession()
+    let rendererSession: AgentSessionWebRendererSession
 
     private(set) var currentProviderID: AgentSessionProviderID
     private(set) var displayTitle: String
@@ -26,7 +26,8 @@ final class AgentSessionPanel: Panel {
         workspaceId: UUID,
         rendererKind: AgentSessionRendererKind,
         initialProviderID: AgentSessionProviderID = .codex,
-        workingDirectory: String? = nil
+        workingDirectory: String? = nil,
+        openCodeServer: any OpenCodeServerServing
     ) {
         self.id = UUID()
         self.workspaceId = workspaceId
@@ -34,6 +35,7 @@ final class AgentSessionPanel: Panel {
         self.initialProviderID = initialProviderID
         self.currentProviderID = initialProviderID
         self.workingDirectory = workingDirectory
+        self.rendererSession = AgentSessionWebRendererSession(openCodeServer: openCodeServer)
         self.displayTitle = Self.title(provider: initialProviderID, rendererKind: rendererKind)
         self.rendererSession.onHasActiveProviderChanged = { [weak self] hasActiveProvider in
             self?.setHasActiveProvider(hasActiveProvider)

--- a/Sources/Panels/AgentSessionProcessStore.swift
+++ b/Sources/Panels/AgentSessionProcessStore.swift
@@ -14,11 +14,19 @@ final class AgentSessionProcessStore {
     }
     private var sessions: [String: AgentSessionRunningSession] = [:]
     private var lastEmittedHasActiveProviderSession: Bool?
+    private let openCodeServer: any OpenCodeServerServing
     private static let terminationEscalationInterval: DispatchTimeInterval = .seconds(3)
+
+    init(openCodeServer: any OpenCodeServerServing = OpenCodeServerService()) {
+        self.openCodeServer = openCodeServer
+    }
 
     func start(plan: AgentSessionLaunchPlan, workingDirectory: String?) async throws -> AgentSessionStartedSession {
         guard sessions.isEmpty else {
             throw AgentSessionBridgeError.sessionAlreadyRunning
+        }
+        if plan.provider == .opencode {
+            return try await startOpenCodeSession(plan: plan, workingDirectory: workingDirectory)
         }
         let sessionId = UUID().uuidString
         let process = Process()
@@ -37,7 +45,6 @@ final class AgentSessionProcessStore {
         let stdout = Pipe()
         let stderr = Pipe()
         let inputWriter = AgentSessionInputWriter(fileHandle: stdin.fileHandleForWriting)
-        let openCodeAuth = OpenCodeServerAuth(environment: launchEnvironment)
         process.standardInput = stdin
         process.standardOutput = stdout
         process.standardError = stderr
@@ -48,9 +55,8 @@ final class AgentSessionProcessStore {
             arguments: launchArguments,
             workingDirectory: workingDirectory,
             process: process,
-            stdin: stdin,
             inputWriter: inputWriter,
-            openCodeAuthorizationHeader: openCodeAuth?.authorizationHeader
+            openCodeAuthorizationHeader: nil
         )
         if plan.provider == .codex {
             running.codexAppServerSession = CodexAppServerSession(
@@ -113,9 +119,7 @@ final class AgentSessionProcessStore {
             throw error
         }
 
-        if plan.provider != .opencode {
-            emitStarted(session: running)
-        }
+        emitStarted(session: running)
         return AgentSessionStartedSession(sessionId: sessionId)
     }
 
@@ -135,22 +139,91 @@ final class AgentSessionProcessStore {
             }
             try await codexAppServerSession.submit(text, permissionMode: permissionMode)
         case .claude:
-            try await writeClaudeStreamJSON(text, to: session.inputWriter)
+            guard let inputWriter = session.inputWriter else {
+                throw AgentSessionBridgeError.providerNotReady(session.providerID.displayName)
+            }
+            try await writeClaudeStreamJSON(text, to: inputWriter)
         case .opencode:
             try await postOpenCodePrompt(text, session: session)
         }
     }
 
-    func stop(sessionId: String) throws {
+    func stop(sessionId: String) async throws {
         guard let session = sessions[sessionId] else {
             throw AgentSessionBridgeError.sessionNotFound(sessionId)
+        }
+        if session.providerID == .opencode {
+            await stopOpenCodeSession(session, status: 0)
+            return
         }
         requestTermination(for: session)
     }
 
     func closeAll() {
-        for session in sessions.values {
-            requestTermination(for: session)
+        for session in Array(sessions.values) {
+            if session.providerID == .opencode {
+                sessions.removeValue(forKey: session.sessionId)
+                cancelSessionTasks(session)
+                scheduleOpenCodeServerLeaseRelease(for: session)
+            } else {
+                requestTermination(for: session)
+            }
+        }
+        emitActiveProviderStateIfNeeded()
+    }
+
+    private func startOpenCodeSession(
+        plan: AgentSessionLaunchPlan,
+        workingDirectory: String?
+    ) async throws -> AgentSessionStartedSession {
+        let sessionId = UUID().uuidString
+        let connection = try await openCodeServer.acquireConnection(plan: plan)
+        let running = AgentSessionRunningSession(
+            sessionId: sessionId,
+            providerID: plan.provider,
+            executablePath: plan.executableURL.path,
+            arguments: plan.arguments,
+            workingDirectory: workingDirectory,
+            process: nil,
+            inputWriter: nil,
+            openCodeAuthorizationHeader: connection.authorizationHeader,
+            holdsOpenCodeServerLease: true
+        )
+        running.openCodeBaseURL = connection.baseURL
+        sessions[sessionId] = running
+
+        do {
+            let response = try await postJSON(
+                to: openCodeURL(
+                    baseURL: connection.baseURL,
+                    path: "session",
+                    workingDirectory: workingDirectory
+                ),
+                body: [
+                    "metadata": [
+                        "cmuxAgentSessionId": sessionId,
+                    ],
+                ],
+                authorizationHeader: connection.authorizationHeader
+            )
+            guard let openCodeSessionID = response["id"] as? String,
+                  !openCodeSessionID.isEmpty else {
+                throw AgentSessionBridgeError.providerNotReady(plan.provider.displayName)
+            }
+            guard sessions[sessionId] === running else {
+                throw AgentSessionBridgeError.sessionNotFound(sessionId)
+            }
+            running.openCodeSessionID = openCodeSessionID
+            startOpenCodeEventStream(running)
+            emitActiveProviderStateIfNeeded()
+            emitStarted(session: running)
+            return AgentSessionStartedSession(sessionId: sessionId)
+        } catch {
+            sessions.removeValue(forKey: sessionId)
+            cancelSessionTasks(running)
+            await releaseOpenCodeServerLease(for: running)
+            emitActiveProviderStateIfNeeded()
+            throw error
         }
     }
 
@@ -211,7 +284,11 @@ final class AgentSessionProcessStore {
         }
         emitActiveProviderStateIfNeeded()
         cancelSessionTasks(session)
-        requestTermination(for: session)
+        if session.providerID == .opencode {
+            scheduleOpenCodeServerLeaseRelease(for: session)
+        } else {
+            requestTermination(for: session)
+        }
         emitExit(
             sessionId: session.sessionId,
             providerID: session.providerID,
@@ -221,8 +298,9 @@ final class AgentSessionProcessStore {
 
     private func requestTermination(for session: AgentSessionRunningSession) {
         session.openCodeEventTask?.cancel()
-        if session.process.isRunning {
-            session.process.terminate()
+        guard let process = session.process else { return }
+        if process.isRunning {
+            process.terminate()
         }
         installTerminationEscalationTimer(for: session)
     }
@@ -238,8 +316,12 @@ final class AgentSessionProcessStore {
         )
         timer.setEventHandler { [weak self, session] in
             Task { @MainActor in
-                if session.process.isRunning {
-                    _ = kill(session.process.processIdentifier, SIGKILL)
+                guard let process = session.process else {
+                    timer.cancel()
+                    return
+                }
+                if process.isRunning {
+                    _ = kill(process.processIdentifier, SIGKILL)
                     return
                 }
                 guard let self,
@@ -265,29 +347,51 @@ final class AgentSessionProcessStore {
         session.stdoutReadTask = nil
         session.stderrReadTask?.cancel()
         session.stderrReadTask = nil
-        Task {
-            await session.inputWriter.close()
+        if let inputWriter = session.inputWriter {
+            Task {
+                await inputWriter.close()
+            }
         }
         session.openCodeEventTask?.cancel()
         session.openCodeEventTask = nil
     }
 
-    private func handleOutputLine(_ text: String, session: AgentSessionRunningSession, stream: String) {
-        if session.providerID == .opencode {
-            switch Self.openCodeProcessOutputDisposition(text: text, stream: stream) {
-            case .serverURL(let baseURL):
-                if session.openCodeBaseURL == nil {
-                    session.openCodeBaseURL = baseURL
-                    createOpenCodeSession(session)
-                }
-                return
-            case .suppress:
-                return
-            case .emit:
-                break
-            }
+    private func stopOpenCodeSession(_ session: AgentSessionRunningSession, status: Int32) async {
+        guard sessions.removeValue(forKey: session.sessionId) === session else { return }
+        cancelSessionTasks(session)
+        if let baseURL = session.openCodeBaseURL,
+           let openCodeSessionID = session.openCodeSessionID {
+            await deleteOpenCodeSession(
+                baseURL: baseURL,
+                openCodeSessionID: openCodeSessionID,
+                workingDirectory: session.workingDirectory,
+                authorizationHeader: session.openCodeAuthorizationHeader
+            )
         }
+        await releaseOpenCodeServerLease(for: session)
+        emitActiveProviderStateIfNeeded()
+        emitExit(
+            sessionId: session.sessionId,
+            providerID: session.providerID,
+            status: status
+        )
+    }
 
+    private func scheduleOpenCodeServerLeaseRelease(for session: AgentSessionRunningSession) {
+        guard session.holdsOpenCodeServerLease else { return }
+        session.holdsOpenCodeServerLease = false
+        Task {
+            await openCodeServer.releaseConnection()
+        }
+    }
+
+    private func releaseOpenCodeServerLease(for session: AgentSessionRunningSession) async {
+        guard session.holdsOpenCodeServerLease else { return }
+        session.holdsOpenCodeServerLease = false
+        await openCodeServer.releaseConnection()
+    }
+
+    private func handleOutputLine(_ text: String, session: AgentSessionRunningSession, stream: String) {
         if stream == "stdout",
            let codexAppServerSession = session.codexAppServerSession {
             codexAppServerSession.consumeStdout(text)
@@ -320,82 +424,6 @@ final class AgentSessionProcessStore {
             stream: stream,
             text: text
         )
-    }
-
-    static func openCodeProcessOutputDisposition(text: String, stream: String) -> OpenCodeProcessOutputDisposition {
-        if let baseURL = openCodeServerURL(from: text) {
-            return .serverURL(baseURL)
-        }
-        if stream == "stdout" {
-            return .suppress
-        }
-        return .emit
-    }
-
-    private static func openCodeServerURL(from text: String) -> URL? {
-        let marker = "opencode server listening on "
-        guard let range = text.range(of: marker) else { return nil }
-        let rawURL = text[range.upperBound...]
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-            .split(separator: " ")
-            .first
-            .map(String.init)
-        guard let url = rawURL.flatMap(URL.init(string:)),
-              agentSessionIsLoopbackURL(url) else {
-            return nil
-        }
-        return url
-    }
-
-    private func createOpenCodeSession(_ session: AgentSessionRunningSession) {
-        guard !session.isOpenCodeSessionCreateInFlight,
-              session.openCodeSessionID == nil,
-              let baseURL = session.openCodeBaseURL else {
-            return
-        }
-        session.isOpenCodeSessionCreateInFlight = true
-        Task { @MainActor in
-            do {
-                let response = try await self.postJSON(
-                    to: self.openCodeURL(baseURL: baseURL, path: "session", workingDirectory: session.workingDirectory),
-                    body: [:],
-                    authorizationHeader: session.openCodeAuthorizationHeader
-                )
-                guard let id = response["id"] as? String, !id.isEmpty else {
-                    throw AgentSessionBridgeError.providerNotReady(session.providerID.displayName)
-                }
-                guard self.sessions[session.sessionId] === session else { return }
-                session.openCodeSessionID = id
-                session.isOpenCodeSessionCreateInFlight = false
-                self.startOpenCodeEventStream(session)
-                self.emitStarted(session: session)
-            } catch {
-                session.isOpenCodeSessionCreateInFlight = false
-                guard let removedSession = self.sessions.removeValue(forKey: session.sessionId),
-                      removedSession === session else {
-                    return
-                }
-                self.emitActiveProviderStateIfNeeded()
-                self.cancelSessionTasks(session)
-                self.requestTermination(for: session)
-                let message = (error as? AgentSessionBridgeError)?.localizedDescription
-                    ?? String(
-                        localized: "agentSession.opencode.error.sessionCreateFailed",
-                        defaultValue: "OpenCode session could not be created."
-                    )
-                self.emitOutput(
-                    sessionId: session.sessionId,
-                    providerID: session.providerID,
-                    stream: "stderr",
-                    text: "\(message)\n"
-                )
-                self.emitExit(
-                    sessionId: session.sessionId,
-                    providerID: session.providerID,
-                    status: 1
-                )
-            }
-        }
     }
 
     private func postOpenCodePrompt(_ text: String, session: AgentSessionRunningSession) async throws {
@@ -507,12 +535,12 @@ final class AgentSessionProcessStore {
     private func openCodeEventStreamEOFRequiresFailure(sessionId: String) -> Bool {
         Self.openCodeEventStreamEOFRequiresFailure(
             isCancelled: false,
-            processIsRunning: sessions[sessionId]?.process.isRunning == true
+            sessionIsActive: sessions[sessionId] != nil
         )
     }
 
-    static func openCodeEventStreamEOFRequiresFailure(isCancelled: Bool, processIsRunning: Bool) -> Bool {
-        !isCancelled && processIsRunning
+    static func openCodeEventStreamEOFRequiresFailure(isCancelled: Bool, sessionIsActive: Bool) -> Bool {
+        !isCancelled && sessionIsActive
     }
 
     private func failOpenCodeEventStream(sessionId: String, openCodeSessionID: String) {
@@ -568,6 +596,26 @@ final class AgentSessionProcessStore {
             components?.queryItems = [URLQueryItem(name: "directory", value: workingDirectory)]
         }
         return components?.url ?? url
+    }
+
+    private func deleteOpenCodeSession(
+        baseURL: URL,
+        openCodeSessionID: String,
+        workingDirectory: String?,
+        authorizationHeader: String?
+    ) async {
+        let url = openCodeURL(
+            baseURL: baseURL,
+            path: "session/\(openCodeSessionID)",
+            workingDirectory: workingDirectory
+        )
+        var request = URLRequest(url: url)
+        request.httpMethod = "DELETE"
+        request.timeoutInterval = 10
+        if let authorizationHeader {
+            request.setValue(authorizationHeader, forHTTPHeaderField: "Authorization")
+        }
+        _ = try? await URLSession.shared.data(for: request)
     }
 
     private func postJSON(

--- a/Sources/Panels/AgentSessionRunningSession.swift
+++ b/Sources/Panels/AgentSessionRunningSession.swift
@@ -6,15 +6,14 @@ final class AgentSessionRunningSession {
     let executablePath: String
     let arguments: [String]
     let workingDirectory: String?
-    let process: Process
-    let stdin: Pipe
-    let inputWriter: AgentSessionInputWriter
+    let process: Process?
+    let inputWriter: AgentSessionInputWriter?
     let openCodeAuthorizationHeader: String?
+    var holdsOpenCodeServerLease: Bool
     var codexAppServerSession: CodexAppServerSession?
     private var claudeStreamJSONAccumulator = ClaudeStreamJSONAccumulator()
     var openCodeBaseURL: URL?
     var openCodeSessionID: String?
-    var isOpenCodeSessionCreateInFlight = false
     var stdoutReadTask: Task<Void, Never>?
     var stderrReadTask: Task<Void, Never>?
     var openCodeEventTask: Task<Void, Never>?
@@ -31,10 +30,10 @@ final class AgentSessionRunningSession {
         executablePath: String,
         arguments: [String],
         workingDirectory: String?,
-        process: Process,
-        stdin: Pipe,
-        inputWriter: AgentSessionInputWriter,
-        openCodeAuthorizationHeader: String?
+        process: Process?,
+        inputWriter: AgentSessionInputWriter?,
+        openCodeAuthorizationHeader: String?,
+        holdsOpenCodeServerLease: Bool = false
     ) {
         self.sessionId = sessionId
         self.providerID = providerID
@@ -42,9 +41,9 @@ final class AgentSessionRunningSession {
         self.arguments = arguments
         self.workingDirectory = workingDirectory
         self.process = process
-        self.stdin = stdin
         self.inputWriter = inputWriter
         self.openCodeAuthorizationHeader = openCodeAuthorizationHeader
+        self.holdsOpenCodeServerLease = holdsOpenCodeServerLease
     }
 
     func appendOutputData(_ data: Data, stream: String) -> [String] {

--- a/Sources/Panels/AgentSessionWebRendererCoordinator.swift
+++ b/Sources/Panels/AgentSessionWebRendererCoordinator.swift
@@ -20,7 +20,7 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
     private var isPanelFocused = false
     private var isClosed = false
     private var isProviderStartPending = false
-    private var processStore = AgentSessionProcessStore()
+    private let processStore: AgentSessionProcessStore
     nonisolated private static let imagePreviewMaxBytes = 512 * 1024
     nonisolated private static let imagePreviewTotalMaxBytes = 2 * 1024 * 1024
     var onHasActiveProviderChanged: ((Bool) -> Void)? {
@@ -29,6 +29,11 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
         }
     }
     var onProviderIDChanged: ((AgentSessionProviderID) -> Void)?
+
+    init(openCodeServer: any OpenCodeServerServing) {
+        processStore = AgentSessionProcessStore(openCodeServer: openCodeServer)
+        super.init()
+    }
 
     func bind(
         panelId: UUID,
@@ -610,7 +615,7 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
             )
             return ["sent": true]
         case "provider.stop":
-            try processStore.stop(sessionId: request.requiredString("sessionId"))
+            try await processStore.stop(sessionId: request.requiredString("sessionId"))
             return ["stopped": true]
         default:
             throw AgentSessionBridgeError.unsupportedMethod(request.method)

--- a/Sources/Panels/AgentSessionWebRendererCoordinator.swift
+++ b/Sources/Panels/AgentSessionWebRendererCoordinator.swift
@@ -82,6 +82,10 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
             contentWorld: .page,
             name: AgentSessionBridgeContract.handlerName
         )
+        configuration.setURLSchemeHandler(
+            AgentSessionAssetSchemeHandler.shared,
+            forURLScheme: AgentSessionAssetSchemeHandler.scheme
+        )
         let webView = AgentSessionWebView(frame: .zero, configuration: configuration)
         isClosed = false
         webView.onPointerDown = onPointerDown
@@ -108,21 +112,18 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
         guard let webView, webView.window != nil else {
             return
         }
-        guard let resourceDirectoryURL = Bundle.main.resourceURL else {
-            return
-        }
         let indexURL = Self.shellURL(
             rendererKind: rendererKind,
-            resourceDirectoryURL: resourceDirectoryURL
+            resourceDirectoryURL: Bundle.main.resourceURL ?? URL(fileURLWithPath: "/")
         )
-        trustedShellURL = Self.normalizedTrustedFileURL(indexURL)
+        trustedShellURL = indexURL
 #if DEBUG
         cmuxDebugLog(
             "agentSession.web.load renderer=\(rendererKind.rawValue) " +
             "index=\(indexURL.path)"
         )
 #endif
-        webView.loadFileURL(indexURL, allowingReadAccessTo: Bundle.main.resourceURL ?? resourceDirectoryURL)
+        webView.load(URLRequest(url: indexURL))
         loadedRendererKind = rendererKind
         hasFinishedNavigation = false
         hasCompletedVisiblePaintFlush = false
@@ -325,12 +326,15 @@ final class AgentSessionWebRendererCoordinator: NSObject, WKNavigationDelegate, 
         rendererKind: AgentSessionRendererKind,
         resourceDirectoryURL: URL
     ) -> URL {
-        rendererKind.resourceHTMLPathComponents.reduce(resourceDirectoryURL) {
-            $0.appendingPathComponent($1, isDirectory: false)
-        }
+        _ = rendererKind
+        _ = resourceDirectoryURL
+        return AgentSessionAssetSchemeHandler.shellURL
     }
 
     nonisolated static func isTrustedShellURL(_ candidate: URL?, expected: URL?) -> Bool {
+        if expected?.scheme == AgentSessionAssetSchemeHandler.scheme {
+            return candidate == expected
+        }
         guard let candidate = normalizedTrustedFileURL(candidate),
               let expected = normalizedTrustedFileURL(expected) else {
             return false

--- a/Sources/Panels/AgentSessionWebRendererSession.swift
+++ b/Sources/Panels/AgentSessionWebRendererSession.swift
@@ -2,7 +2,11 @@ import Foundation
 
 @MainActor
 final class AgentSessionWebRendererSession {
-    private let ownedCoordinator = AgentSessionWebRendererCoordinator()
+    private let ownedCoordinator: AgentSessionWebRendererCoordinator
+
+    init(openCodeServer: any OpenCodeServerServing) {
+        ownedCoordinator = AgentSessionWebRendererCoordinator(openCodeServer: openCodeServer)
+    }
     var onHasActiveProviderChanged: ((Bool) -> Void)? {
         didSet {
             ownedCoordinator.onHasActiveProviderChanged = onHasActiveProviderChanged

--- a/Sources/Panels/OpenCodeProcessOutputDisposition.swift
+++ b/Sources/Panels/OpenCodeProcessOutputDisposition.swift
@@ -1,7 +1,0 @@
-import Foundation
-
-enum OpenCodeProcessOutputDisposition: Equatable {
-    case emit
-    case suppress
-    case serverURL(URL)
-}

--- a/Sources/Panels/OpenCodeServerConnection.swift
+++ b/Sources/Panels/OpenCodeServerConnection.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct OpenCodeServerConnection: Equatable, Sendable {
+    let baseURL: URL
+    let authorizationHeader: String
+    let processIdentifier: Int32
+}

--- a/Sources/Panels/OpenCodeServerService.swift
+++ b/Sources/Panels/OpenCodeServerService.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+actor OpenCodeServerService: OpenCodeServerServing {
+    private struct PendingConnection {
+        let continuation: CheckedContinuation<OpenCodeServerConnection, Error>
+    }
+
+    private var process: Process?
+    private var connection: OpenCodeServerConnection?
+    private var pendingConnections: [PendingConnection] = []
+    private var stdoutHandle: FileHandle?
+    private var stderrHandle: FileHandle?
+    private var outputBuffers: [String: Data] = [:]
+    private var leaseCount = 0
+
+    func acquireConnection(plan: AgentSessionLaunchPlan) async throws -> OpenCodeServerConnection {
+        guard plan.provider == .opencode else {
+            throw AgentSessionBridgeError.invalidRequest
+        }
+        if let connection {
+            leaseCount += 1
+            return connection
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            pendingConnections.append(PendingConnection(continuation: continuation))
+            guard process == nil else { return }
+            do {
+                try launch(plan: plan)
+            } catch {
+                failPendingConnections(error)
+            }
+        }
+    }
+
+    func releaseConnection() {
+        guard leaseCount > 0 else { return }
+        leaseCount -= 1
+        guard leaseCount == 0, pendingConnections.isEmpty else { return }
+        stopServer()
+    }
+
+    nonisolated static func serverURL(from text: String) -> URL? {
+        let marker = "opencode server listening on "
+        guard let range = text.range(of: marker) else { return nil }
+        let rawURL = text[range.upperBound...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: " ")
+            .first
+            .map(String.init)
+        guard let url = rawURL.flatMap(URL.init(string:)),
+              agentSessionIsLoopbackURL(url) else {
+            return nil
+        }
+        return url
+    }
+
+    private func launch(plan: AgentSessionLaunchPlan) throws {
+        let launchEnvironment = plan.environment(overridingWorkingDirectory: nil)
+        guard OpenCodeServerAuth(environment: launchEnvironment) != nil else {
+            throw AgentSessionBridgeError.providerNotReady(plan.provider.displayName)
+        }
+
+        let process = Process()
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.executableURL = plan.executableURL
+        process.arguments = plan.arguments
+        process.environment = launchEnvironment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = stdout
+        process.standardError = stderr
+        process.terminationHandler = { [weak self] process in
+            Task {
+                await self?.serverExited(
+                    processIdentifier: process.processIdentifier,
+                    status: process.terminationStatus
+                )
+            }
+        }
+
+        self.process = process
+        stdoutHandle = stdout.fileHandleForReading
+        stderrHandle = stderr.fileHandleForReading
+        installReadHandler(stdout.fileHandleForReading, stream: "stdout")
+        installReadHandler(stderr.fileHandleForReading, stream: "stderr")
+
+        do {
+            try process.run()
+        } catch {
+            stopServer()
+            throw error
+        }
+    }
+
+    private func installReadHandler(_ fileHandle: FileHandle, stream: String) {
+        fileHandle.readabilityHandler = { [weak self] handle in
+            let data = handle.availableData
+            if data.isEmpty {
+                handle.readabilityHandler = nil
+            }
+            Task {
+                await self?.consumeOutputData(data, stream: stream)
+            }
+        }
+    }
+
+    private func consumeOutputData(_ data: Data, stream: String) {
+        var buffer = outputBuffers.removeValue(forKey: stream) ?? Data()
+        buffer.append(data)
+        while let newline = buffer.firstIndex(of: 0x0A) {
+            let line = buffer[..<newline]
+            buffer.removeSubrange(...newline)
+            consumeOutputLine(String(decoding: line, as: UTF8.self))
+        }
+        if data.isEmpty, !buffer.isEmpty {
+            consumeOutputLine(String(decoding: buffer, as: UTF8.self))
+            buffer.removeAll()
+        }
+        if !buffer.isEmpty {
+            outputBuffers[stream] = buffer
+        }
+    }
+
+    private func consumeOutputLine(_ text: String) {
+        guard connection == nil,
+              let process,
+              let baseURL = Self.serverURL(from: text),
+              let auth = OpenCodeServerAuth(environment: process.environment ?? [:]) else {
+            return
+        }
+        let connection = OpenCodeServerConnection(
+            baseURL: baseURL,
+            authorizationHeader: auth.authorizationHeader,
+            processIdentifier: process.processIdentifier
+        )
+        self.connection = connection
+        let pending = pendingConnections
+        pendingConnections.removeAll(keepingCapacity: false)
+        leaseCount += pending.count
+        for waiter in pending {
+            waiter.continuation.resume(returning: connection)
+        }
+    }
+
+    private func serverExited(processIdentifier: Int32, status: Int32) {
+        guard process?.processIdentifier == processIdentifier else { return }
+        let error = AgentSessionBridgeError.providerNotReady(
+            "\(AgentSessionProviderID.opencode.displayName) (exit \(status))"
+        )
+        failPendingConnections(error)
+        clearServerState()
+    }
+
+    private func failPendingConnections(_ error: Error) {
+        let pending = pendingConnections
+        pendingConnections.removeAll(keepingCapacity: false)
+        for waiter in pending {
+            waiter.continuation.resume(throwing: error)
+        }
+    }
+
+    private func stopServer() {
+        if let process, process.isRunning {
+            process.terminate()
+        }
+        clearServerState()
+    }
+
+    private func clearServerState() {
+        stdoutHandle?.readabilityHandler = nil
+        stdoutHandle = nil
+        stderrHandle?.readabilityHandler = nil
+        stderrHandle = nil
+        outputBuffers.removeAll(keepingCapacity: false)
+        process = nil
+        connection = nil
+        leaseCount = 0
+    }
+}

--- a/Sources/Panels/OpenCodeServerService.swift
+++ b/Sources/Panels/OpenCodeServerService.swift
@@ -1,5 +1,34 @@
 import Foundation
 
+private final class OpenCodeServerProcessOwner: @unchecked Sendable {
+    private let lock = NSLock()
+    private var process: Process?
+
+    func store(_ process: Process) {
+        lock.withLock {
+            self.process = process
+        }
+    }
+
+    func clear(processIdentifier: Int32) {
+        lock.withLock {
+            guard process?.processIdentifier == processIdentifier else { return }
+            process = nil
+        }
+    }
+
+    func terminate() {
+        let process = lock.withLock {
+            let process = self.process
+            self.process = nil
+            return process
+        }
+        if let process, process.isRunning {
+            process.terminate()
+        }
+    }
+}
+
 actor OpenCodeServerService: OpenCodeServerServing {
     private struct PendingConnection {
         let continuation: CheckedContinuation<OpenCodeServerConnection, Error>
@@ -12,6 +41,7 @@ actor OpenCodeServerService: OpenCodeServerServing {
     private var stderrHandle: FileHandle?
     private var outputBuffers: [String: Data] = [:]
     private var leaseCount = 0
+    private nonisolated let processOwner = OpenCodeServerProcessOwner()
 
     func acquireConnection(plan: AgentSessionLaunchPlan) async throws -> OpenCodeServerConnection {
         guard plan.provider == .opencode else {
@@ -38,6 +68,10 @@ actor OpenCodeServerService: OpenCodeServerServing {
         leaseCount -= 1
         guard leaseCount == 0, pendingConnections.isEmpty else { return }
         stopServer()
+    }
+
+    nonisolated func terminateImmediately() {
+        processOwner.terminate()
     }
 
     nonisolated static func serverURL(from text: String) -> URL? {
@@ -80,6 +114,7 @@ actor OpenCodeServerService: OpenCodeServerServing {
         }
 
         self.process = process
+        processOwner.store(process)
         stdoutHandle = stdout.fileHandleForReading
         stderrHandle = stderr.fileHandleForReading
         installReadHandler(stdout.fileHandleForReading, stream: "stdout")
@@ -168,6 +203,9 @@ actor OpenCodeServerService: OpenCodeServerServing {
     }
 
     private func clearServerState() {
+        if let process {
+            processOwner.clear(processIdentifier: process.processIdentifier)
+        }
         stdoutHandle?.readabilityHandler = nil
         stdoutHandle = nil
         stderrHandle?.readabilityHandler = nil

--- a/Sources/Panels/OpenCodeServerServing.swift
+++ b/Sources/Panels/OpenCodeServerServing.swift
@@ -1,0 +1,4 @@
+protocol OpenCodeServerServing: Sendable {
+    func acquireConnection(plan: AgentSessionLaunchPlan) async throws -> OpenCodeServerConnection
+    func releaseConnection() async
+}

--- a/Sources/Panels/OpenCodeServerServing.swift
+++ b/Sources/Panels/OpenCodeServerServing.swift
@@ -1,4 +1,5 @@
 protocol OpenCodeServerServing: Sendable {
     func acquireConnection(plan: AgentSessionLaunchPlan) async throws -> OpenCodeServerConnection
     func releaseConnection() async
+    func terminateImmediately()
 }

--- a/Sources/TabManager+DetachedWorkspace.swift
+++ b/Sources/TabManager+DetachedWorkspace.swift
@@ -65,7 +65,8 @@ extension TabManager {
                 workingDirectory: normalizedWorkingDirectory(detached.directory) ?? snapshot.preferredWorkingDirectory,
                 portOrdinal: ordinal,
                 configTemplate: inheritedConfig,
-                initialDetachedSurface: detached
+                initialDetachedSurface: detached,
+                agentSessionOpenCodeServer: agentSessionOpenCodeServer
             )
             guard newWorkspace.panels[detached.panelId] != nil,
                   newWorkspace.paneId(forPanelId: detached.panelId) != nil else {

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -456,6 +456,7 @@ class TabManager: ObservableObject {
     // entry points.
     let sidebarGitMetadataService: any SidebarGitMetadataServing
     let pullRequestProbing: any PullRequestProbing
+    let agentSessionOpenCodeServer: any OpenCodeServerServing
     /// Process-scoped GitHub transport state. AppDelegate passes this same
     /// value to every subsequently-created window so their pollers share one
     /// session, ETag cache, backoff deadline, and request queue.
@@ -474,9 +475,11 @@ class TabManager: ObservableObject {
         gitProbeLimiter: WorkspaceGitMetadataProbeLimiter? = nil,
         panelTitleUpdateCoalescer: NotificationBurstCoalescer? = nil,
         settings: any SettingsWriting = UserDefaultsSettingsClient(defaults: .standard),
-        closeTabWarningDefaults: UserDefaults = .standard
+        closeTabWarningDefaults: UserDefaults = .standard,
+        agentSessionOpenCodeServer: any OpenCodeServerServing = OpenCodeServerService()
     ) {
         self.settings = settings
+        self.agentSessionOpenCodeServer = agentSessionOpenCodeServer
         self.panelTitleUpdateCoalescer = panelTitleUpdateCoalescer ?? NotificationBurstCoalescer()
         self.closeTabWarningDefaults = closeTabWarningDefaults
         workspaceReordering = WorkspaceReorderCoordinator(model: workspaces)
@@ -957,7 +960,8 @@ class TabManager: ObservableObject {
             initialBrowserTransparentBackground: initialBrowserTransparentBackground,
             workspaceEnvironment: workspaceEnvironment,
             allowTextBoxFocusDefault: allowTextBoxFocusDefault,
-            closeTabWarningDefaults: closeTabWarningDefaults
+            closeTabWarningDefaults: closeTabWarningDefaults,
+            agentSessionOpenCodeServer: agentSessionOpenCodeServer
         )
     }
 
@@ -5985,7 +5989,8 @@ extension TabManager {
                 title: workspaceSnapshot.processTitle,
                 workingDirectory: workspaceSnapshot.currentDirectory,
                 portOrdinal: ordinal,
-                closeTabWarningDefaults: closeTabWarningDefaults
+                closeTabWarningDefaults: closeTabWarningDefaults,
+                agentSessionOpenCodeServer: agentSessionOpenCodeServer
             )
             workspace.owningTabManager = self
             let restoredPanelIds = workspace.restoreSessionSnapshot(workspaceSnapshot, excludingStableIdentities: excludingStableIdentities)
@@ -5998,7 +6003,12 @@ extension TabManager {
         if newTabs.isEmpty {
             let ordinal = Self.nextPortOrdinal
             Self.nextPortOrdinal += 1
-            let fallback = Workspace(title: "Terminal 1", portOrdinal: ordinal, closeTabWarningDefaults: closeTabWarningDefaults)
+            let fallback = Workspace(
+                title: "Terminal 1",
+                portOrdinal: ordinal,
+                closeTabWarningDefaults: closeTabWarningDefaults,
+                agentSessionOpenCodeServer: agentSessionOpenCodeServer
+            )
             fallback.owningTabManager = self
             wireClosedBrowserTracking(for: fallback)
             newTabs.append(fallback)

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -2400,6 +2400,7 @@ final class Workspace: Identifiable, ObservableObject {
     }
     private var pendingTerminalInputObserversByPanelId: [UUID: [WorkspacePendingTerminalInputObserver]] = [:]
     private let sessionRestorePolicy: WorkspaceSessionRestorePolicyService<SurfaceResumeBindingSnapshot>
+    let agentSessionOpenCodeServer: any OpenCodeServerServing
 
     typealias SurfaceResumeStartupLaunch = WorkspaceSurfaceResumeStartupLaunch
 
@@ -2896,11 +2897,13 @@ final class Workspace: Identifiable, ObservableObject {
         agentSessionAutoResumeDefaults: UserDefaults = .standard,
         initialDetachedSurface: DetachedSurfaceTransfer? = nil,
         sessionRestorePolicy: WorkspaceSessionRestorePolicyService<SurfaceResumeBindingSnapshot>? = nil,
-        sidebarProcessTitleObservation: WorkspaceSidebarProcessTitleObservationModel? = nil
+        sidebarProcessTitleObservation: WorkspaceSidebarProcessTitleObservationModel? = nil,
+        agentSessionOpenCodeServer: any OpenCodeServerServing = OpenCodeServerService()
     ) {
         self.id = UUID()
         self.sessionRestorePolicy = sessionRestorePolicy ?? Self.makeSessionRestorePolicyService()
         self.sidebarProcessTitleObservation = sidebarProcessTitleObservation ?? WorkspaceSidebarProcessTitleObservationModel()
+        self.agentSessionOpenCodeServer = agentSessionOpenCodeServer
         self.closeTabWarningDefaults = closeTabWarningDefaults
         self.agentSessionAutoResumeDefaults = agentSessionAutoResumeDefaults
         let sanitizedWorkspaceEnvironment = Self.sanitizedWorkspaceEnvironment(workspaceEnvironment)
@@ -8511,7 +8514,8 @@ final class Workspace: Identifiable, ObservableObject {
             workspaceId: id,
             rendererKind: rendererKind,
             initialProviderID: providerID,
-            workingDirectory: directory
+            workingDirectory: directory,
+            openCodeServer: agentSessionOpenCodeServer
         )
         panels[agentPanel.id] = agentPanel
         panelTitles[agentPanel.id] = agentPanel.displayTitle

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -194,7 +194,10 @@ struct cmuxApp: App {
         KeyboardShortcutSettings.settingsFileStore.applyDeferredManagedDefaultSideEffects()
         StartupBreadcrumbLog.append("app.init.keyboardShortcuts.sideEffectsApplied")
         StartupBreadcrumbLog.append("app.init.tabManager.begin")
-        _tabManager = StateObject(wrappedValue: TabManager())
+        let agentSessionOpenCodeServer = OpenCodeServerService()
+        _tabManager = StateObject(wrappedValue: TabManager(
+            agentSessionOpenCodeServer: agentSessionOpenCodeServer
+        ))
         StartupBreadcrumbLog.append("app.init.tabManager.complete")
         // Migrate legacy and old-format socket mode values to the new enum.
         if let stored = defaults.string(forKey: SocketControlSettings.appStorageKey) {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1110,7 +1110,9 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A9F200000000000000000017 /* OpenCodeEventStreamParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000017 /* OpenCodeEventStreamParser.swift */; };
 		A9F200000000000000000018 /* OpenCodeEventTextAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000018 /* OpenCodeEventTextAccumulator.swift */; };
 		A5E01203A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5E01204A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift */; };
-		A9F200000000000000000019 /* OpenCodeProcessOutputDisposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9F100000000000000000019 /* OpenCodeProcessOutputDisposition.swift */; };
+		0C5E00010000000000000002 /* OpenCodeServerConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5E00010000000000000001 /* OpenCodeServerConnection.swift */; };
+		0C5E00010000000000000006 /* OpenCodeServerService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5E00010000000000000005 /* OpenCodeServerService.swift */; };
+		0C5E00010000000000000004 /* OpenCodeServerServing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5E00010000000000000003 /* OpenCodeServerServing.swift */; };
 		ODBG00010000000000000001 /* OpenDiffViewerAgentBaselineLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = ODBG00010000000000000002 /* OpenDiffViewerAgentBaselineLookup.swift */; };
 		ODBG00020000000000000001 /* OpenDiffViewerAgentContextRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = ODBG00020000000000000002 /* OpenDiffViewerAgentContextRequest.swift */; };
 		A6AC72040000000000000001 /* OverlayComparison.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC72040000000000000002 /* OverlayComparison.swift */; };
@@ -3079,7 +3081,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A9F100000000000000000017 /* OpenCodeEventStreamParser.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/OpenCodeEventStreamParser.swift; sourceTree = "<group>"; };
 		A9F100000000000000000018 /* OpenCodeEventTextAccumulator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/OpenCodeEventTextAccumulator.swift; sourceTree = "<group>"; };
 		A5E01204A1B2C3D4E5F60718 /* OpenCodeHookRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenCodeHookRegressionTests.swift; sourceTree = "<group>"; };
-		A9F100000000000000000019 /* OpenCodeProcessOutputDisposition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/OpenCodeProcessOutputDisposition.swift; sourceTree = "<group>"; };
+		0C5E00010000000000000001 /* OpenCodeServerConnection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/OpenCodeServerConnection.swift; sourceTree = "<group>"; };
+		0C5E00010000000000000005 /* OpenCodeServerService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/OpenCodeServerService.swift; sourceTree = "<group>"; };
+		0C5E00010000000000000003 /* OpenCodeServerServing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/OpenCodeServerServing.swift; sourceTree = "<group>"; };
 		ODBG00010000000000000002 /* OpenDiffViewerAgentBaselineLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenDiffViewerAgentBaselineLookup.swift; sourceTree = "<group>"; };
 		ODBG00020000000000000002 /* OpenDiffViewerAgentContextRequest.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenDiffViewerAgentContextRequest.swift; sourceTree = "<group>"; };
 		A6AC72040000000000000002 /* OverlayComparison.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OverlayComparison.swift; sourceTree = "<group>"; };
@@ -5059,7 +5063,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A9F100000000000000000016 /* CodexAppServerQueuedInput.swift */,
 				A9F100000000000000000017 /* OpenCodeEventStreamParser.swift */,
 				A9F100000000000000000018 /* OpenCodeEventTextAccumulator.swift */,
-				A9F100000000000000000019 /* OpenCodeProcessOutputDisposition.swift */,
+				0C5E00010000000000000001 /* OpenCodeServerConnection.swift */,
+				0C5E00010000000000000003 /* OpenCodeServerServing.swift */,
+				0C5E00010000000000000005 /* OpenCodeServerService.swift */,
 				A9E01000000000000000000F /* AgentSessionRendererKind.swift */,
 				A9E010000000000000000002 /* AgentSessionPanel.swift */,
 				A9E010000000000000000008 /* AgentSessionBridge.swift */,
@@ -7113,7 +7119,9 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C67540090000000000000001 /* OmnibarAddressButtonStyle.swift in Sources */,
 				A9F200000000000000000017 /* OpenCodeEventStreamParser.swift in Sources */,
 				A9F200000000000000000018 /* OpenCodeEventTextAccumulator.swift in Sources */,
-				A9F200000000000000000019 /* OpenCodeProcessOutputDisposition.swift in Sources */,
+				0C5E00010000000000000002 /* OpenCodeServerConnection.swift in Sources */,
+				0C5E00010000000000000006 /* OpenCodeServerService.swift in Sources */,
+				0C5E00010000000000000004 /* OpenCodeServerServing.swift in Sources */,
 				ODBG00010000000000000001 /* OpenDiffViewerAgentBaselineLookup.swift in Sources */,
 				ODBG00020000000000000001 /* OpenDiffViewerAgentContextRequest.swift in Sources */,
 					A6AC72040000000000000001 /* OverlayComparison.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -90,6 +90,7 @@
 		B79500110000000000000001 /* AgentPortTrackingState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B79500110000000000000002 /* AgentPortTrackingState.swift */; };
 		0A1107110000000000000012 /* AgentRelaunchCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1107110000000000000013 /* AgentRelaunchCommandBuilder.swift */; };
 		0A1107110000000000000014 /* AgentRestoreMode.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A1107110000000000000015 /* AgentRestoreMode.swift */; };
+		0C5E00010000000000000008 /* AgentSessionAssetSchemeHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C5E00010000000000000007 /* AgentSessionAssetSchemeHandler.swift */; };
 		D3610B010000000000000001 /* AgentSessionAutoResumeSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */; };
 		D3610B020000000000000001 /* AgentSessionAutoResumeSwiftTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */; };
 		A9E020000000000000000008 /* AgentSessionBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9E010000000000000000008 /* AgentSessionBridge.swift */; };
@@ -2128,6 +2129,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B79500110000000000000002 /* AgentPortTrackingState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentPortTrackingState.swift; sourceTree = "<group>"; };
 		0A1107110000000000000013 /* AgentRelaunchCommandBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRelaunchCommandBuilder.swift; sourceTree = "<group>"; };
 		0A1107110000000000000015 /* AgentRestoreMode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentRestoreMode.swift; sourceTree = "<group>"; };
+		0C5E00010000000000000007 /* AgentSessionAssetSchemeHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionAssetSchemeHandler.swift; sourceTree = "<group>"; };
 		D3610B010000000000000002 /* AgentSessionAutoResumeSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionAutoResumeSettingsTests.swift; sourceTree = "<group>"; };
 		D3610B020000000000000002 /* AgentSessionAutoResumeSwiftTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSessionAutoResumeSwiftTests.swift; sourceTree = "<group>"; };
 		A9E010000000000000000008 /* AgentSessionBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/AgentSessionBridge.swift; sourceTree = "<group>"; };
@@ -5066,6 +5068,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				0C5E00010000000000000001 /* OpenCodeServerConnection.swift */,
 				0C5E00010000000000000003 /* OpenCodeServerServing.swift */,
 				0C5E00010000000000000005 /* OpenCodeServerService.swift */,
+				0C5E00010000000000000007 /* AgentSessionAssetSchemeHandler.swift */,
 				A9E01000000000000000000F /* AgentSessionRendererKind.swift */,
 				A9E010000000000000000002 /* AgentSessionPanel.swift */,
 				A9E010000000000000000008 /* AgentSessionBridge.swift */,
@@ -6552,6 +6555,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B79500110000000000000001 /* AgentPortTrackingState.swift in Sources */,
 				0A1107110000000000000012 /* AgentRelaunchCommandBuilder.swift in Sources */,
 				0A1107110000000000000014 /* AgentRestoreMode.swift in Sources */,
+				0C5E00010000000000000008 /* AgentSessionAssetSchemeHandler.swift in Sources */,
 				A9E020000000000000000008 /* AgentSessionBridge.swift in Sources */,
 				A9F20000000000000000000B /* AgentSessionBridgeError.swift in Sources */,
 				A9F20000000000000000000C /* AgentSessionBridgeRequest.swift in Sources */,

--- a/cmuxTests/AgentSessionWebRendererTests.swift
+++ b/cmuxTests/AgentSessionWebRendererTests.swift
@@ -10,22 +10,14 @@ import Testing
 @Suite(.serialized)
 struct AgentSessionWebRendererTests {
     @Test
-    func testTrustedShellURLAcceptsOnlyMatchingFileURL() {
+    func testTrustedShellURLAcceptsOnlyMatchingAgentSessionURL() {
         let resources = URL(fileURLWithPath: "/tmp/cmux DEV test.app/Contents/Resources", isDirectory: true)
         let expected = AgentSessionWebRendererCoordinator.shellURL(
             rendererKind: .react,
             resourceDirectoryURL: resources
         )
-        let equivalent = resources
-            .appendingPathComponent("markdown-viewer", isDirectory: true)
-            .appendingPathComponent("webviews-app", isDirectory: true)
-            .appendingPathComponent("..", isDirectory: true)
-            .appendingPathComponent("webviews-app", isDirectory: true)
-            .appendingPathComponent("agent-session.html", isDirectory: false)
-        let otherBundledFile = resources
-            .appendingPathComponent("markdown-viewer", isDirectory: true)
-            .appendingPathComponent("webviews-app", isDirectory: true)
-            .appendingPathComponent("diff-viewer.html", isDirectory: false)
+        let equivalent = URL(string: "cmux-agent-session://app/agent-session.html")
+        let otherBundledFile = URL(string: "cmux-agent-session://app/main.mjs")
 
         expectTrue(AgentSessionWebRendererCoordinator.isTrustedShellURL(expected, expected: expected))
         expectTrue(AgentSessionWebRendererCoordinator.isTrustedShellURL(equivalent, expected: expected))

--- a/cmuxTests/CodexAppServerSessionTests.swift
+++ b/cmuxTests/CodexAppServerSessionTests.swift
@@ -90,30 +90,68 @@ struct CodexAppServerSessionTests {
     }
 
     @Test
-    func testOpenCodeProcessStdoutLogsAreNotAssistantOutput() throws {
+    func testOpenCodeServerURLParserAcceptsOnlyLoopbackListenerOutput() throws {
         let serverURL = try #require(URL(string: "http://127.0.0.1:49211"))
 
         expectEqual(
-            AgentSessionProcessStore.openCodeProcessOutputDisposition(
-                text: "opencode server listening on http://127.0.0.1:49211\n",
-                stream: "stdout"
+            OpenCodeServerService.serverURL(
+                from: "opencode server listening on http://127.0.0.1:49211\n"
             ),
-            .serverURL(serverURL)
+            serverURL
         )
+        expectNil(OpenCodeServerService.serverURL(from: "INFO request completed\n"))
+        expectNil(OpenCodeServerService.serverURL(
+            from: "opencode server listening on http://192.0.2.1:49211\n"
+        ))
+    }
+
+    @Test
+    func testOpenCodeServerServiceSharesOneProcessAcrossConcurrentLeases() async throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-opencode-server-\(UUID().uuidString)", isDirectory: true)
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: root)
+        }
+        let launchCountURL = root.appendingPathComponent("launch-count")
+        let scriptURL = root.appendingPathComponent("opencode-server-fixture.sh")
+        let script = """
+        #!/bin/sh
+        printf 'launch\\n' >> "$CMUX_TEST_OPENCODE_LAUNCH_COUNT"
+        printf 'opencode server listening on http://127.0.0.1:49211\\n'
+        exec /usr/bin/tail -f /dev/null
+        """
+        try script.write(to: scriptURL, atomically: true, encoding: .utf8)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: scriptURL.path)
+
+        let plan = AgentSessionLaunchPlan(
+            provider: .opencode,
+            executableURL: scriptURL,
+            arguments: [],
+            environment: [
+                "CMUX_TEST_OPENCODE_LAUNCH_COUNT": launchCountURL.path,
+                "OPENCODE_SERVER_USERNAME": "cmux",
+                "OPENCODE_SERVER_PASSWORD": "secret",
+                "PATH": "/usr/bin:/bin",
+            ]
+        )
+        let service = OpenCodeServerService()
+
+        async let first = service.acquireConnection(plan: plan)
+        async let second = service.acquireConnection(plan: plan)
+        let (firstConnection, secondConnection) = try await (first, second)
+
+        expectEqual(firstConnection, secondConnection)
         expectEqual(
-            AgentSessionProcessStore.openCodeProcessOutputDisposition(
-                text: "INFO request completed\n",
-                stream: "stdout"
-            ),
-            .suppress
+            try String(contentsOf: launchCountURL, encoding: .utf8)
+                .split(separator: "\n")
+                .count,
+            1
         )
-        expectEqual(
-            AgentSessionProcessStore.openCodeProcessOutputDisposition(
-                text: "OpenCode session could not be created.\n",
-                stream: "stderr"
-            ),
-            .emit
-        )
+
+        await service.releaseConnection()
+        await service.releaseConnection()
     }
 
     @Test
@@ -121,19 +159,19 @@ struct CodexAppServerSessionTests {
         expectTrue(
             AgentSessionProcessStore.openCodeEventStreamEOFRequiresFailure(
                 isCancelled: false,
-                processIsRunning: true
+                sessionIsActive: true
             )
         )
         expectFalse(
             AgentSessionProcessStore.openCodeEventStreamEOFRequiresFailure(
                 isCancelled: true,
-                processIsRunning: true
+                sessionIsActive: true
             )
         )
         expectFalse(
             AgentSessionProcessStore.openCodeEventStreamEOFRequiresFailure(
                 isCancelled: false,
-                processIsRunning: false
+                sessionIsActive: false
             )
         )
     }

--- a/scripts/compress-markdown-viewer-assets.sh
+++ b/scripts/compress-markdown-viewer-assets.sh
@@ -18,6 +18,12 @@ import sys
 import zlib
 
 root = pathlib.Path(sys.argv[1])
+file_url_assets = {
+    "webviews-app/main.mjs",
+    "webviews-app/chunks/agentSessionSurface.mjs",
+    "webviews-app/chunks/installWebviewStyles.mjs",
+    "webviews-app/chunks/vendor.mjs",
+}
 
 for path in sorted(root.rglob("*")):
     if path.suffix not in {".js", ".mjs"}:
@@ -28,6 +34,11 @@ for path in sorted(root.rglob("*")):
     compressed = zlib.compress(raw, level=9)
     output = path.with_name(path.name + ".deflate")
     output.write_bytes(compressed)
-    path.unlink()
-    print(f"compressed markdown viewer asset: {path.name} -> {output.name} ({len(raw)} -> {len(compressed)} bytes)")
+    relative_path = path.relative_to(root).as_posix()
+    if relative_path not in file_url_assets:
+        path.unlink()
+    print(
+        f"compressed markdown viewer asset: {relative_path} -> "
+        f"{output.name} ({len(raw)} -> {len(compressed)} bytes)"
+    )
 PY

--- a/tests/test_compress_markdown_viewer_assets.sh
+++ b/tests/test_compress_markdown_viewer_assets.sh
@@ -5,11 +5,19 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 TMP_DIR="$(mktemp -d)"
 trap 'rm -rf "$TMP_DIR"' EXIT
 
-mkdir -p "$TMP_DIR/markdown-viewer/chunks" "$TMP_DIR/markdown-viewer/nested"
+mkdir -p \
+  "$TMP_DIR/markdown-viewer/chunks" \
+  "$TMP_DIR/markdown-viewer/nested" \
+  "$TMP_DIR/markdown-viewer/webviews-app/chunks"
 printf 'const top = "top";\n' > "$TMP_DIR/markdown-viewer/top.js"
 printf 'export const chunk = "chunk";\n' > "$TMP_DIR/markdown-viewer/chunks/chunk.mjs"
 printf 'already compressed\n' > "$TMP_DIR/markdown-viewer/nested/keep.js.deflate"
 printf 'body { color: red; }\n' > "$TMP_DIR/markdown-viewer/style.css"
+printf 'import "./chunks/agentSessionSurface.mjs";\n' > "$TMP_DIR/markdown-viewer/webviews-app/main.mjs"
+printf 'export const vendor = true;\n' > "$TMP_DIR/markdown-viewer/webviews-app/chunks/vendor.mjs"
+printf 'export const agent = true;\n' > "$TMP_DIR/markdown-viewer/webviews-app/chunks/agentSessionSurface.mjs"
+printf 'export const styles = true;\n' > "$TMP_DIR/markdown-viewer/webviews-app/chunks/installWebviewStyles.mjs"
+printf 'export const diff = true;\n' > "$TMP_DIR/markdown-viewer/webviews-app/chunks/diffSurface.mjs"
 
 "$ROOT/scripts/compress-markdown-viewer-assets.sh" "$TMP_DIR/markdown-viewer" >/tmp/cmux-compress-assets.log
 
@@ -25,13 +33,34 @@ done
 
 for path in \
   "$TMP_DIR/markdown-viewer/top.js.deflate" \
-  "$TMP_DIR/markdown-viewer/chunks/chunk.mjs.deflate"
+  "$TMP_DIR/markdown-viewer/chunks/chunk.mjs.deflate" \
+  "$TMP_DIR/markdown-viewer/webviews-app/main.mjs.deflate" \
+  "$TMP_DIR/markdown-viewer/webviews-app/chunks/vendor.mjs.deflate" \
+  "$TMP_DIR/markdown-viewer/webviews-app/chunks/agentSessionSurface.mjs.deflate" \
+  "$TMP_DIR/markdown-viewer/webviews-app/chunks/installWebviewStyles.mjs.deflate"
 do
   if [ ! -s "$path" ]; then
     echo "compressed asset missing or empty: $path" >&2
     exit 1
   fi
 done
+
+for path in \
+  "$TMP_DIR/markdown-viewer/webviews-app/main.mjs" \
+  "$TMP_DIR/markdown-viewer/webviews-app/chunks/vendor.mjs" \
+  "$TMP_DIR/markdown-viewer/webviews-app/chunks/agentSessionSurface.mjs" \
+  "$TMP_DIR/markdown-viewer/webviews-app/chunks/installWebviewStyles.mjs"
+do
+  if [ ! -s "$path" ]; then
+    echo "agent session file URL asset missing or empty: $path" >&2
+    exit 1
+  fi
+done
+
+if [ -e "$TMP_DIR/markdown-viewer/webviews-app/chunks/diffSurface.mjs" ]; then
+  echo "raw diff viewer asset was not removed" >&2
+  exit 1
+fi
 
 if [ "$(cat "$TMP_DIR/markdown-viewer/nested/keep.js.deflate")" != "already compressed" ]; then
   echo "existing .deflate asset was rewritten" >&2


### PR DESCRIPTION
OpenCode Agent Session panels now lease one app-scoped `opencode serve` process while retaining independent HTTP sessions and event streams. The server exits after the final lease and during app termination.

This also fixes Agent Session web modules after bundle compression by preserving the required modules and serving them through an allowlisted `cmux-agent-session://` loader.

Verification:
- `tests/test_compress_markdown_viewer_assets.sh`
- strict-concurrency typecheck for the OpenCode service and asset loader
- tagged cloud build: https://github.com/manaflow-ai/cmux/actions/runs/29488768112
- two visible React/Solid OpenCode panels, two server sessions, one `opencode serve` child
- Quit menu removed both the cmux and OpenCode PIDs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8265"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786788178&installation_id=133855650&pr_number=8265&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8265&signature=13225f30b06092698a6fb895c9e9f02e86d73a73bf1e0bd91d814a7749a3a243"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added improved OpenCode session support, including shared server connections and smoother session startup and shutdown.
  * Added secure loading for bundled agent-session web assets.
* **Bug Fixes**
  * Improved handling of interrupted, failed, and stopped sessions.
  * Prevented unrelated web assets from being retained during markdown viewer packaging.
* **Tests**
  * Expanded coverage for trusted asset URLs, server reuse, loopback validation, session failures, and compressed viewer assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Agent Session panels now share a single app-scoped OpenCode server, cutting duplicate processes and improving cleanup. Agent Session web assets are now served via a secure `cmux-agent-session://` scheme so compressed bundles still load.

- **New Features**
  - Lease-based OpenCode server reuse across panels; independent HTTP sessions and event streams; server exits after the final lease and on app quit.
  - Added `cmux-agent-session://` URL scheme to serve an allowlisted set of Agent Session assets for reliable loading after compression.

- **Bug Fixes**
  - OpenCode sessions stop cleanly: the remote session is deleted, the lease is released, and event stream EOF only triggers failure while a session is active.
  - Trusted URL checks and webview loading updated to the new scheme to prevent unintended asset access.

<sup>Written for commit dcf2df0955183f4d8a8e093760b5008a61de8e1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8265?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

