### PR TITLE
Fix Intel macOS 14 compatibility verification

### DIFF
--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -17,22 +17,6 @@ jobs:
             skip_zig: false
             expected_arch: x86_64
             expected_os_major: "14"
-          - os: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-            timeout: 30
-            run_unit_tests: true
-            startup_smoke: true
-            virtual_display: true
-            skip_zig: false
-            expected_arch: ""
-            expected_os_major: ""
-          - os: ${{ vars.MACOS_RUNNER_26 || 'blacksmith-6vcpu-macos-26' }}
-            timeout: 30
-            run_unit_tests: true
-            startup_smoke: true
-            virtual_display: false
-            skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26
-            expected_arch: ""
-            expected_os_major: ""
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     steps:
@@ -150,8 +134,8 @@ jobs:
       - name: Run mobile transport package tests on Intel Sonoma
         if: matrix.expected_arch == 'x86_64'
         run: |
-          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CMUXMobileCore
-          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CmuxIrohTransport
+          swift test --package-path Packages/Shared/CmuxIrohTransport \
+            --filter CmxIrohPersistenceLifecycleRaceTests
 
       - name: Run unit tests
         if: matrix.run_unit_tests

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -150,8 +150,8 @@ jobs:
       - name: Run mobile transport package tests on Intel Sonoma
         if: matrix.expected_arch == 'x86_64'
         run: |
-          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CMUXMobileCore
-          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CmuxIrohTransport
+          swift test --package-path Packages/Shared/CmuxIrohTransport \
+            --filter CmxIrohPersistenceLifecycleRaceTests
 
       - name: Run unit tests
         if: matrix.run_unit_tests

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -150,8 +150,8 @@ jobs:
       - name: Run mobile transport package tests on Intel Sonoma
         if: matrix.expected_arch == 'x86_64'
         run: |
-          swift test --package-path Packages/Shared/CmuxIrohTransport \
-            --filter CmxIrohPersistenceLifecycleRaceTests
+          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CMUXMobileCore
+          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CmuxIrohTransport
 
       - name: Run unit tests
         if: matrix.run_unit_tests

--- a/.github/workflows/ci-macos-compat.yml
+++ b/.github/workflows/ci-macos-compat.yml
@@ -17,6 +17,22 @@ jobs:
             skip_zig: false
             expected_arch: x86_64
             expected_os_major: "14"
+          - os: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
+            timeout: 30
+            run_unit_tests: true
+            startup_smoke: true
+            virtual_display: true
+            skip_zig: false
+            expected_arch: ""
+            expected_os_major: ""
+          - os: ${{ vars.MACOS_RUNNER_26 || 'blacksmith-6vcpu-macos-26' }}
+            timeout: 30
+            run_unit_tests: true
+            startup_smoke: true
+            virtual_display: false
+            skip_zig: true  # zig 0.15.2 MachO linker can't resolve libSystem on macOS 26
+            expected_arch: ""
+            expected_os_major: ""
     runs-on: ${{ matrix.os }}
     timeout-minutes: ${{ matrix.timeout }}
     steps:
@@ -134,8 +150,8 @@ jobs:
       - name: Run mobile transport package tests on Intel Sonoma
         if: matrix.expected_arch == 'x86_64'
         run: |
-          swift test --package-path Packages/Shared/CmuxIrohTransport \
-            --filter CmxIrohPersistenceLifecycleRaceTests
+          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CMUXMobileCore
+          ./scripts/ci/run-swift-testing-suites.sh Packages/Shared/CmuxIrohTransport
 
       - name: Run unit tests
         if: matrix.run_unit_tests

--- a/CLI/cmux_open.swift
+++ b/CLI/cmux_open.swift
@@ -4035,7 +4035,7 @@ extension CMUXCLI {
             to: openingFileURL,
             title: title,
             message: message,
-            appearance: appearance,
+            appearance: appearance
         )
         let allowedFiles = [try mapper.allowedFile(fileURL: openingFileURL, mimeType: "text/html")]
         try writeDiffViewerHTTPManifest(

--- a/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPersistenceLifecycleRaceTests.swift
+++ b/Packages/Shared/CmuxIrohTransport/Tests/CmuxIrohTransportTests/CmxIrohPersistenceLifecycleRaceTests.swift
@@ -66,11 +66,12 @@ struct CmxIrohPersistenceLifecycleRaceTests {
         }
         await store.waitUntilWriteIsSuspended()
         await store.suspendNextDeleteAll()
+        let now = fixture.now
 
         let deactivate = Task { try await cache.deactivate() }
         #expect(
             await waitsForLifecycleCancellation {
-                _ = try await cache.load(for: expectation, now: fixture.now)
+                _ = try await cache.load(for: expectation, now: now)
             }
         )
         await store.resumeSuspendedWrite()

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+WorkspaceActions.swift
@@ -282,7 +282,7 @@ extension MobileShellComposite {
         let policy = MobileShellWorkspaceMutationTicketPolicy(now: now)
         if target.isForeground {
             return policy.allowsMacScopedWorkspaceMutations(
-                activeTicket ?? client.attachTicket,
+                activeTicket ?? client.attachTicket
             )
         }
         let ticket = target.macDeviceID.flatMap { secondaryMacSubscriptions[$0]?.ticket }

--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Interaction/CommandPaletteInteractionMonitor.swift
@@ -39,8 +39,14 @@ public final class CommandPaletteInteractionMonitor {
         self.mainMenuProvider = mainMenuProvider
     }
 
-    isolated deinit {
-        deactivate()
+    deinit {
+        // This AppKit-owned object is created and released on the main actor.
+        // `isolated deinit` cannot be compiled by Xcode 16.4, which cmux uses
+        // for Intel macOS 14 verification, so keep the synchronous teardown
+        // contract while asserting that owner invariant at runtime.
+        MainActor.assumeIsolated {
+            deactivate()
+        }
     }
 
     /// Starts observation for `window`, or refreshes the callbacks when already active.

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketClientCapabilityAuthority.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Transport/SocketClientCapabilityAuthority.swift
@@ -6,7 +6,10 @@ public import Foundation
 /// An authority is immutable and contains no session registry. Tokens issued
 /// from the same secret and audience remain valid across listener and app
 /// restarts, while a different app variant derives an independent signing key.
-public struct SocketClientCapabilityAuthority: Sendable {
+// CryptoKit only declared `SymmetricKey` as `Sendable` in newer SDKs. The key
+// is an immutable value and this authority never exposes or mutates it, so the
+// same concurrency contract is safe when compiling with Xcode 16.2.
+public struct SocketClientCapabilityAuthority: @unchecked Sendable {
     /// Required byte count for master secrets and per-token nonces.
     public static let secureByteCount = 32
 

--- a/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Model/WorkspaceGitSnapshotTaskContext.swift
+++ b/Packages/macOS/CmuxSidebarGit/Sources/CmuxSidebarGit/Model/WorkspaceGitSnapshotTaskContext.swift
@@ -1,6 +1,6 @@
 import CmuxGit
 
 /// The cache-reuse inputs captured when a per-directory snapshot task starts.
-nonisolated struct WorkspaceGitSnapshotTaskContext: Equatable, Sendable {
+struct WorkspaceGitSnapshotTaskContext: Equatable, Sendable {
     let trackedPathEventGeneration: GitTrackedPathEventGeneration?
 }

--- a/Sources/AgentDeliveryTargetResolution.swift
+++ b/Sources/AgentDeliveryTargetResolution.swift
@@ -24,7 +24,7 @@ import Foundation
 /// method; in-app notification delivery reaches it through
 /// `agentNotificationDeliveryTarget` so stale-addressed notifications are
 /// retargeted rather than dropped or misfiled.
-nonisolated struct AgentDeliveryTargetCandidate: Equatable {
+struct AgentDeliveryTargetCandidate: Equatable {
     let workspaceId: UUID
     let surfaceId: UUID
 }

--- a/Sources/AppDelegate+SocketConfiguration.swift
+++ b/Sources/AppDelegate+SocketConfiguration.swift
@@ -102,7 +102,7 @@ extension AppDelegate {
         TerminalController.shared.startSocketTransport(
             config,
             socketPath: restartPath,
-            preferredTabManager: manager,
+            preferredTabManager: manager
         )
     }
 }

--- a/Sources/BackgroundWorkspacePrimeCoordinator.swift
+++ b/Sources/BackgroundWorkspacePrimeCoordinator.swift
@@ -2,99 +2,101 @@ import Foundation
 import Combine
 import CmuxTerminal
 
+// Swift 6.0 cannot mark nested type declarations `nonisolated`. File scope
+// keeps these concurrency helpers outside the coordinator's main-actor domain.
+private enum PrimeCompletionReason: String {
+    case alreadyCleared = "already_cleared"
+    case cancelled
+    case noSurfaceWork = "no_surface_work"
+    case surfaceReady = "surface_ready"
+    case timeout
+    case workspaceRemoved = "workspace_removed"
+}
+
+private enum PrimeState {
+    case pending
+    case completed(reason: PrimeCompletionReason)
+}
+
+private enum Policy {
+    static let timeoutSeconds: TimeInterval = 2.0
+}
+
+private final class Waiter: @unchecked Sendable {
+    // Cancellation handlers cannot await an actor hop; this lock keeps continuation
+    // and cleanup state synchronous across task cancellation and readiness callbacks.
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<PrimeCompletionReason, Never>?
+    private var cleanupActions: [() -> Void] = []
+    private var resolvedReason: PrimeCompletionReason?
+
+    var isResolved: Bool {
+        lock.lock()
+        defer { lock.unlock() }
+        return resolvedReason != nil
+    }
+
+    deinit {
+        finish(reason: .cancelled)
+    }
+
+    func start(continuation: CheckedContinuation<PrimeCompletionReason, Never>) {
+        let reason: PrimeCompletionReason?
+        lock.lock()
+        reason = resolvedReason
+        if reason == nil {
+            self.continuation = continuation
+        }
+        lock.unlock()
+        if let reason {
+            continuation.resume(returning: reason)
+        }
+    }
+
+    func addObserver(_ observer: NSObjectProtocol) {
+        addCleanup { NotificationCenter.default.removeObserver(observer) }
+    }
+
+    func addCancellable(_ cancellable: AnyCancellable) {
+        addCleanup { cancellable.cancel() }
+    }
+
+    func addTask(_ task: Task<Void, Never>) {
+        addCleanup { task.cancel() }
+    }
+
+    func finish(reason: PrimeCompletionReason) {
+        let drained: (CheckedContinuation<PrimeCompletionReason, Never>?, [() -> Void])?
+        lock.lock()
+        if resolvedReason == nil {
+            resolvedReason = reason
+            drained = (continuation, cleanupActions)
+            continuation = nil
+            cleanupActions.removeAll()
+        } else {
+            drained = nil
+        }
+        lock.unlock()
+
+        guard let (continuation, cleanupActions) = drained else { return }
+        cleanupActions.forEach { $0() }
+        continuation?.resume(returning: reason)
+    }
+
+    private func addCleanup(_ action: @escaping () -> Void) {
+        lock.lock()
+        guard resolvedReason == nil else {
+            lock.unlock()
+            action()
+            return
+        }
+        cleanupActions.append(action)
+        lock.unlock()
+    }
+}
+
 @MainActor
 final class BackgroundWorkspacePrimeCoordinator {
-    private nonisolated enum PrimeCompletionReason: String {
-        case alreadyCleared = "already_cleared"
-        case cancelled
-        case noSurfaceWork = "no_surface_work"
-        case surfaceReady = "surface_ready"
-        case timeout
-        case workspaceRemoved = "workspace_removed"
-    }
-
-    private nonisolated enum PrimeState {
-        case pending
-        case completed(reason: PrimeCompletionReason)
-    }
-
-    private nonisolated enum Policy {
-        static let timeoutSeconds: TimeInterval = 2.0
-    }
-
-    private nonisolated final class Waiter: @unchecked Sendable {
-        // Cancellation handlers cannot await an actor hop; this lock keeps continuation
-        // and cleanup state synchronous across task cancellation and readiness callbacks.
-        private let lock = NSLock()
-        private var continuation: CheckedContinuation<PrimeCompletionReason, Never>?
-        private var cleanupActions: [() -> Void] = []
-        private var resolvedReason: PrimeCompletionReason?
-
-        var isResolved: Bool {
-            lock.lock()
-            defer { lock.unlock() }
-            return resolvedReason != nil
-        }
-
-        deinit {
-            finish(reason: .cancelled)
-        }
-
-        func start(continuation: CheckedContinuation<PrimeCompletionReason, Never>) {
-            let reason: PrimeCompletionReason?
-            lock.lock()
-            reason = resolvedReason
-            if reason == nil {
-                self.continuation = continuation
-            }
-            lock.unlock()
-            if let reason {
-                continuation.resume(returning: reason)
-            }
-        }
-
-        func addObserver(_ observer: NSObjectProtocol) {
-            addCleanup { NotificationCenter.default.removeObserver(observer) }
-        }
-
-        func addCancellable(_ cancellable: AnyCancellable) {
-            addCleanup { cancellable.cancel() }
-        }
-
-        func addTask(_ task: Task<Void, Never>) {
-            addCleanup { task.cancel() }
-        }
-
-        func finish(reason: PrimeCompletionReason) {
-            let drained: (CheckedContinuation<PrimeCompletionReason, Never>?, [() -> Void])?
-            lock.lock()
-            if resolvedReason == nil {
-                resolvedReason = reason
-                drained = (continuation, cleanupActions)
-                continuation = nil
-                cleanupActions.removeAll()
-            } else {
-                drained = nil
-            }
-            lock.unlock()
-
-            guard let (continuation, cleanupActions) = drained else { return }
-            cleanupActions.forEach { $0() }
-            continuation?.resume(returning: reason)
-        }
-
-        private func addCleanup(_ action: @escaping () -> Void) {
-            lock.lock()
-            guard resolvedReason == nil else {
-                lock.unlock()
-                action()
-                return
-            }
-            cleanupActions.append(action)
-            lock.unlock()
-        }
-    }
-
     deinit {
         // Explicit for the required_deinit lint; per-prime resources live on Waiter.
     }

--- a/Sources/CmuxTopProcessEnumeration.swift
+++ b/Sources/CmuxTopProcessEnumeration.swift
@@ -3,7 +3,7 @@ import Foundation
 
 private nonisolated let cmuxTopPIDPathBufferSize = 4096
 
-nonisolated extension CmuxTopProcessSnapshot {
+extension CmuxTopProcessSnapshot {
     static func allProcesses(includeProcessDetails: Bool, includeCMUXScope: Bool) -> [CmuxTopProcessInfo] {
         let sampledProcesses = allBSDProcesses()
         guard !sampledProcesses.isEmpty else { return [] }

--- a/Sources/CmuxTopProcessSnapshotCache.swift
+++ b/Sources/CmuxTopProcessSnapshotCache.swift
@@ -1,7 +1,7 @@
 import Foundation
 import os
 
-private nonisolated struct CmuxTopProcessSnapshotCacheState {
+private struct CmuxTopProcessSnapshotCacheState {
     var snapshot: CmuxTopProcessSnapshot?
     var includeProcessDetails = false
     var includeCMUXScope = true

--- a/Sources/CmuxTopProcessSnapshotCache.swift
+++ b/Sources/CmuxTopProcessSnapshotCache.swift
@@ -13,7 +13,7 @@ private nonisolated let cmuxTopProcessSnapshotCache = OSAllocatedUnfairLock(
     initialState: CmuxTopProcessSnapshotCacheState()
 )
 
-nonisolated extension CmuxTopProcessSnapshot {
+extension CmuxTopProcessSnapshot {
     static func captureCached(
         includeProcessDetails: Bool = false,
         includeCMUXScope: Bool = true,

--- a/Sources/GhosttyDesktopNotificationRequest.swift
+++ b/Sources/GhosttyDesktopNotificationRequest.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Sendable payload copied at the synchronous Ghostty callback boundary.
-nonisolated struct GhosttyDesktopNotificationRequest: Equatable, Sendable {
+struct GhosttyDesktopNotificationRequest: Equatable, Sendable {
     let tabId: UUID
     let surfaceId: UUID?
     let hookDirectory: String?

--- a/Sources/GhosttyTitleUpdateSurfaceKey.swift
+++ b/Sources/GhosttyTitleUpdateSurfaceKey.swift
@@ -3,7 +3,7 @@ import Foundation
 /// Identifies title-publication state for one concrete Ghostty surface lifetime.
 /// The owning tab is routing metadata and is intentionally excluded because a
 /// live surface can move between workspaces without changing its lifetime.
-nonisolated struct GhosttyTitleUpdateSurfaceKey: Hashable, Sendable {
+struct GhosttyTitleUpdateSurfaceKey: Hashable, Sendable {
     let surfaceId: UUID
     let sourceSurfaceIdentifier: ObjectIdentifier
 

--- a/Sources/Panels/BrowserWebViewLifecycleState.swift
+++ b/Sources/Panels/BrowserWebViewLifecycleState.swift
@@ -1,4 +1,4 @@
-nonisolated enum BrowserWebViewLifecycleState: String {
+enum BrowserWebViewLifecycleState: String {
     case newTab = "new_tab"
     case deferredURL = "deferred_url"
     case liveVisible = "live_visible"

--- a/Sources/Panels/DiffSidecarBridge.swift
+++ b/Sources/Panels/DiffSidecarBridge.swift
@@ -1,6 +1,21 @@
 import Foundation
 import WebKit
 
+// Swift 6.0 cannot mark nested type declarations `nonisolated`. File scope
+// keeps these process-result values outside the bridge's main-actor domain.
+private enum InvocationCompletion: Sendable {
+    case ready(Bool)
+    case terminated(Int32)
+    case timedOut
+    case missingTermination
+    case cancelled
+}
+
+private enum InvocationError: Error {
+    case timedOut
+    case missingTermination
+}
+
 /// Reply-capable transport for the Rust diff sidecar. Each request is a bounded
 /// stdin/stdout exchange with a short-lived child process. The sidecar never
 /// opens a socket, and WebKit never receives filesystem paths or process access.
@@ -8,19 +23,6 @@ import WebKit
 final class DiffSidecarBridge: NSObject, WKScriptMessageHandlerWithReply {
     static let handlerName = "cmuxDiff"
     static let shared = DiffSidecarBridge()
-
-    nonisolated private enum InvocationCompletion: Sendable {
-        case ready(Bool)
-        case terminated(Int32)
-        case timedOut
-        case missingTermination
-        case cancelled
-    }
-
-    nonisolated private enum InvocationError: Error {
-        case timedOut
-        case missingTermination
-    }
 
     private static var handlerInstalledKey: UInt8 = 0
     private static let maximumRequestBytes = 1024 * 1024

--- a/Sources/TerminalNotificationClickAction.swift
+++ b/Sources/TerminalNotificationClickAction.swift
@@ -1,6 +1,6 @@
 import Foundation
 
-nonisolated enum TerminalNotificationClickAction: Codable, Hashable, Sendable {
+enum TerminalNotificationClickAction: Codable, Hashable, Sendable {
     case revealInFinder(path: String)
 
     private static let kindUserInfoKey = "cmuxClickAction"

--- a/Sources/TerminalSelectionAccessibilityNotifier.swift
+++ b/Sources/TerminalSelectionAccessibilityNotifier.swift
@@ -3,7 +3,7 @@ import AppKit
 /// Thread-safe, bounded ingress from Ghostty's renderer callback into the UI.
 /// `bufferingNewest(1)` keeps at most one undelivered event per surface, so a
 /// stalled main actor cannot accumulate one task per drag update.
-nonisolated final class TerminalSelectionAccessibilitySignal: Sendable {
+final class TerminalSelectionAccessibilitySignal: Sendable {
     let events: AsyncStream<Void>
     private let continuation: AsyncStream<Void>.Continuation
 


### PR DESCRIPTION
## Summary
- keep command-palette observer teardown compatible with Xcode 16.4 by asserting its existing main-actor owner invariant synchronously instead of using unavailable `isolated deinit`
- avoid capturing the non-Sendable Iroh policy fixture in a Sendable test closure

## Verification
- `swift test --package-path Packages/Shared/CmuxIrohTransport --filter CmxIrohPersistenceLifecycleRaceTests` (2 passed)
- `swift test --package-path Packages/macOS/CmuxCommandPalette --filter CommandPaletteInteractionMonitorTests` (5 passed)
- `swift test --package-path Packages/iOS/CmuxMobileShell --filter MobilePairingFailureTests` (23 passed)

This closes compiler blockers found by the x86_64 macOS 14 compatibility workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved persistence lifecycle stability during cancellation/deactivation races by keeping timing consistent during the test flow.
  * Improved command palette shutdown teardown to ensure deactivation runs safely with correct actor isolation.
* **Maintenance**
  * Refined Swift concurrency isolation usage across internal types for more consistent runtime behavior.
  * Updated socket capability authority concurrency handling to use `@unchecked Sendable`, with added documentation clarifying its immutability expectations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->