### PR TITLE
Rewrite built-in sidebar in AppKit

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -1604,6 +1604,9 @@ struct ContentView: View {
                 )
             },
             observedWindow: observedWindow,
+            tabManager: tabManager,
+            sidebarUnread: sidebarUnread,
+            cmuxConfigStore: cmuxConfigStore,
             selection: $sidebarSelectionState.selection,
             selectedTabIds: $selectedTabIds, lastSidebarSelectionIndex: $lastSidebarSelectionIndex, sidebarRenderWorkerClient: $sidebarRenderWorkerClient
         )
@@ -9865,11 +9868,9 @@ extension SidebarDragState {
     }
 }
 
-/// Freezes `showsModifierShortcutHints` for the row whose context menu is open,
-/// so pressing/releasing the modifier key while the menu is up does not flip
-/// the underlying row's shortcut badges (which would be visible around the
-/// open context menu). All other rows transition live.
-struct VerticalTabsSidebar: View {
+/// Existing SwiftUI sidebar retained as the default during the staged AppKit
+/// rollout and as the host for custom and installed extension providers.
+struct LegacyVerticalTabsSidebar: View {
     var updateViewModel: UpdateStateModel
     @ObservedObject var fileExplorerState: FileExplorerState
     let windowId: UUID
@@ -10270,9 +10271,6 @@ struct VerticalTabsSidebar: View {
     }
 
     var body: some View {
-#if DEBUG
-        let _ = { minimalModeInvalidationProbe.verticalTabsSidebarBody?() }()
-#endif
         let signpost = SidebarProfilingSignposts.begin("vertical-sidebar-body", "workspaces=\(tabManager.tabs.count) selected=\(sidebarShortTabId(tabManager.selectedTabId))")
         let tabs = tabManager.tabs
         let workspaceCount = tabs.count

--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -46,6 +46,7 @@ final class CmuxFeatureFlags {
     #endif
     private static let agentChatUIDefault = false
     private static let sidebarWorkspaceAgentSpinnerDefault = false
+    private static let appKitSidebarDefault = false
 
     private static let overrideKeyPrefix = "cmux.flags.override."
 
@@ -132,6 +133,24 @@ final class CmuxFeatureFlags {
                 ),
                 defaultWhenUnavailable: CmuxFeatureFlags.sidebarWorkspaceAgentSpinnerDefault
             ),
+
+            // FLAG(key: appkit-sidebar-enabled-experiment, owner: lawrencecchen,
+            //      reviewBy: 2026-10-01, defaultWhenUnavailable: false)
+            // Routes the built-in workspace sidebar to its native AppKit
+            // implementation. The existing sidebar remains the default until
+            // the native implementation finishes staged dogfood.
+            CmuxFeatureFlagDefinition(
+                key: "appkit-sidebar-enabled-experiment",
+                title: String(
+                    localized: "featureFlags.appKitSidebar.title",
+                    defaultValue: "AppKit sidebar"
+                ),
+                flagDescription: String(
+                    localized: "featureFlags.appKitSidebar.description",
+                    defaultValue: "Uses the native AppKit implementation for the built-in workspace sidebar."
+                ),
+                defaultWhenUnavailable: CmuxFeatureFlags.appKitSidebarDefault
+            ),
         ]
     }()
 
@@ -153,6 +172,10 @@ final class CmuxFeatureFlags {
 
     var isSidebarWorkspaceAgentSpinnerEnabled: Bool {
         effectiveValue(for: Self.allFlags[4])
+    }
+
+    var isAppKitSidebarEnabled: Bool {
+        effectiveValue(for: Self.allFlags[5])
     }
 
     @ObservationIgnored

--- a/Sources/Sidebar/AppKit/SidebarAppKitBadgeView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitBadgeView.swift
@@ -1,0 +1,93 @@
+import AppKit
+import QuartzCore
+
+/// Fixed-hierarchy unread badge shared by the native workspace and group cells.
+/// The label is retained across reuse; configuration only changes its value and
+/// colors, avoiding per-update view allocation.
+@MainActor
+final class SidebarAppKitBadgeView: NSView {
+    private let label = NSTextField(labelWithString: "")
+    private var fillColor: NSColor = .controlAccentColor
+    private var badgeHeight: CGFloat = SidebarAppKitCellMetrics.accessorySide
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+        wantsLayer = true
+        setAccessibilityElement(false)
+
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.alignment = .center
+        label.lineBreakMode = .byClipping
+        label.maximumNumberOfLines = 1
+        label.setContentCompressionResistancePriority(.required, for: .horizontal)
+        addSubview(label)
+
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 5),
+            label.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -5),
+            label.centerYAnchor.constraint(equalTo: centerYAnchor),
+        ])
+        isHidden = true
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var intrinsicContentSize: NSSize {
+        guard !isHidden else { return .zero }
+        return NSSize(
+            width: max(badgeHeight, ceil(label.intrinsicContentSize.width) + 10),
+            height: badgeHeight
+        )
+    }
+
+    func configure(
+        count: Int,
+        fillColor: NSColor,
+        textColor: NSColor,
+        font: NSFont,
+        height: CGFloat
+    ) {
+        guard count > 0 else {
+            resetForReuse()
+            return
+        }
+        self.fillColor = fillColor
+        badgeHeight = max(12, height)
+        label.stringValue = String(count)
+        label.font = font
+        label.textColor = textColor
+        isHidden = false
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+        applyFillColor()
+    }
+
+    func resetForReuse() {
+        label.stringValue = ""
+        isHidden = true
+        invalidateIntrinsicContentSize()
+        layer?.backgroundColor = nil
+    }
+
+    override func layout() {
+        super.layout()
+        layer?.cornerRadius = min(bounds.height, badgeHeight) / 2
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        applyFillColor()
+    }
+
+    private func applyFillColor() {
+        guard !isHidden else { return }
+        var resolved = fillColor.cgColor
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            resolved = fillColor.usingColorSpace(.deviceRGB)?.cgColor ?? fillColor.cgColor
+        }
+        layer?.backgroundColor = resolved
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitCellSupport.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitCellSupport.swift
@@ -1,0 +1,48 @@
+import AppKit
+
+@MainActor
+enum SidebarAppKitCellMetrics {
+    static let outerHorizontalInset: CGFloat = 6
+    static let innerHorizontalInset: CGFloat = 10
+    static let verticalInset: CGFloat = 8
+    static let rowSpacing: CGFloat = 4
+    static let minimumWorkspaceHeight: CGFloat = 36
+    static let minimumGroupHeight: CGFloat = 30
+    static let cornerRadius: CGFloat = 6
+    static let groupCornerRadius: CGFloat = 4
+    static let accessorySide: CGFloat = 16
+    static let groupAccessorySide: CGFloat = 14
+    static let railWidth: CGFloat = 3
+    static let maximumDetailLines = 6
+}
+
+@MainActor
+enum SidebarAppKitCellText {
+    static func bounded(
+        _ value: String?,
+        maximumCharacters: Int,
+        maximumLines: Int
+    ) -> String? {
+        guard let value else { return nil }
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+
+        let lines = trimmed
+            .split(whereSeparator: { $0.isNewline })
+            .prefix(max(1, maximumLines))
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !lines.isEmpty else { return nil }
+        let flattened = lines.joined(separator: " ")
+        guard flattened.count > maximumCharacters else { return flattened }
+        return String(flattened.prefix(maximumCharacters))
+    }
+
+    static func joined(_ values: [String], maximumLines: Int) -> String? {
+        let lines = values
+            .compactMap { bounded($0, maximumCharacters: 1024, maximumLines: 1) }
+            .prefix(maximumLines)
+        guard !lines.isEmpty else { return nil }
+        return lines.joined(separator: "\n")
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitChecklistController.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitChecklistController.swift
@@ -1,0 +1,985 @@
+import AppKit
+import CmuxFoundation
+import CmuxWorkspaces
+import Combine
+
+/// Lazily presents one workspace checklist in native AppKit.
+///
+/// Collapsed rows do not create this hierarchy or read checklist items. The
+/// view starts its single workspace observation only while it is attached as
+/// an inline expansion or shown in an `NSPopover`.
+@MainActor
+final class SidebarAppKitChecklistView: NSView, NSTableViewDataSource, NSTableViewDelegate,
+    NSTextFieldDelegate
+{
+    enum PresentationMode: Equatable {
+        case inline
+        case popover
+    }
+
+    private enum Metrics {
+        static let rowHeight: CGFloat = 28
+        static let visibleRowLimit = 6
+        static let popoverWidth: CGFloat = 320
+        static let horizontalInset: CGFloat = 8
+        static let verticalInset: CGFloat = 8
+        static let addIconSide: CGFloat = 16
+        static let auxiliaryRowHeight: CGFloat = 24
+    }
+
+    private enum Identifier {
+        static let column = NSUserInterfaceItemIdentifier("SidebarAppKitChecklistColumn")
+        static let itemCell = NSUserInterfaceItemIdentifier("SidebarAppKitChecklistItemCell")
+    }
+
+    private let contentStack = NSStackView()
+    private let headerStack = NSStackView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let progressLabel = NSTextField(labelWithString: "")
+    private let scrollView = NSScrollView()
+    private let tableView = NSTableView()
+    private let addStack = NSStackView()
+    private let addImageView = NSImageView()
+    private let addField = NSTextField(string: "")
+    private let separator = NSBox()
+    private let openPaneButton = NSButton()
+    private var scrollHeightConstraint: NSLayoutConstraint!
+    private var addImageWidthConstraint: NSLayoutConstraint!
+    private var addImageHeightConstraint: NSLayoutConstraint!
+    private var addStackHeightConstraint: NSLayoutConstraint!
+    private var openPaneHeightConstraint: NSLayoutConstraint!
+
+    private weak var workspace: Workspace?
+    private var mode: PresentationMode = .popover
+    private var items: [WorkspaceChecklistItem] = []
+    private var checklistObservationTask: Task<Void, Never>?
+    private var fontMagnificationObserver: GlobalFontMagnificationChangeObserver?
+    private var onPreferredHeightChange: (() -> Void)?
+    private var onRequestClose: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setUpHierarchy()
+        setUpAccessibility()
+        fontMagnificationObserver = GlobalFontMagnificationChangeObserver { [weak self] in
+            self?.refreshFontMagnification(notifyPreferredHeightChange: true)
+        }
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    deinit {
+        checklistObservationTask?.cancel()
+    }
+
+    func configure(
+        workspace: Workspace,
+        mode: PresentationMode,
+        onPreferredHeightChange: @escaping () -> Void,
+        onRequestClose: @escaping () -> Void
+    ) {
+        let identityChanged = self.workspace !== workspace || self.mode != mode
+        if identityChanged {
+            stopObserving()
+        }
+        self.onPreferredHeightChange = onPreferredHeightChange
+        self.onRequestClose = onRequestClose
+        self.mode = mode
+        titleLabel.stringValue = workspace.title
+        applyMode()
+        guard identityChanged else { return }
+
+        self.workspace = workspace
+        applyItems(workspace.todoState.checklist, notifyHeightChange: false)
+
+        checklistObservationTask = Task { @MainActor [weak self, weak workspace] in
+            guard let workspace else { return }
+            for await nextItems in workspace.todoState.$checklist.dropFirst().values {
+                guard !Task.isCancelled, let self, self.workspace === workspace else { return }
+                self.applyItems(nextItems, notifyHeightChange: true)
+            }
+        }
+    }
+
+    func stopObserving(clearItems: Bool = true) {
+        checklistObservationTask?.cancel()
+        checklistObservationTask = nil
+        workspace = nil
+        onPreferredHeightChange = nil
+        onRequestClose = nil
+        if clearItems {
+            items = []
+            tableView.reloadData()
+            scrollHeightConstraint.constant = 0
+            scrollView.isHidden = true
+            titleLabel.stringValue = ""
+            progressLabel.stringValue = ""
+            addField.stringValue = ""
+        }
+    }
+
+    func focusAddField() {
+        Task { @MainActor [weak self] in
+            guard let self else { return }
+            self.window?.makeFirstResponder(self.addField)
+            self.addField.selectText(nil)
+        }
+    }
+
+    var preferredContentSize: NSSize {
+        frame.size.width = Metrics.popoverWidth
+        layoutSubtreeIfNeeded()
+        return NSSize(
+            width: Metrics.popoverWidth,
+            height: ceil(contentStack.fittingSize.height + 2 * Metrics.verticalInset)
+        )
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        items.count
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        viewFor tableColumn: NSTableColumn?,
+        row: Int
+    ) -> NSView? {
+        guard items.indices.contains(row), let workspace else { return nil }
+        let item = items[row]
+        let cell: SidebarAppKitChecklistItemCellView
+        if let reusable = tableView.makeView(
+            withIdentifier: Identifier.itemCell,
+            owner: nil
+        ) as? SidebarAppKitChecklistItemCellView {
+            cell = reusable
+        } else {
+            cell = SidebarAppKitChecklistItemCellView(frame: .zero)
+            cell.identifier = Identifier.itemCell
+        }
+
+        let isCompleted = item.state == .completed
+        let canMoveUp = row > 0 && (items[row - 1].state == .completed) == isCompleted
+        let canMoveDown = row + 1 < items.count
+            && (items[row + 1].state == .completed) == isCompleted
+        cell.configure(
+            item: item,
+            canMoveUp: canMoveUp,
+            canMoveDown: canMoveDown,
+            onSetState: { [weak workspace] state in
+                guard let workspace else { return }
+                WorkspaceTodoActions.setChecklistItemState(
+                    id: item.id,
+                    state: state,
+                    in: workspace
+                )
+            },
+            onEdit: { [weak workspace] text in
+                guard let workspace else { return }
+                WorkspaceTodoActions.editChecklistItem(
+                    id: item.id,
+                    text: text,
+                    in: workspace
+                )
+            },
+            onRemove: { [weak workspace] in
+                guard let workspace else { return }
+                WorkspaceTodoActions.removeChecklistItem(id: item.id, from: workspace)
+            },
+            onMove: { [weak workspace] delta in
+                guard let workspace else { return }
+                WorkspaceTodoActions.moveChecklistItem(
+                    id: item.id,
+                    toIndex: row + delta,
+                    in: workspace
+                )
+            }
+        )
+        return cell
+    }
+
+    func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        doCommandBy commandSelector: Selector
+    ) -> Bool {
+        guard control === addField, !textView.hasMarkedText() else { return false }
+        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            addPendingItem()
+            return true
+        }
+        if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+            addField.stringValue = ""
+            onRequestClose?()
+            return true
+        }
+        return false
+    }
+
+    private func setUpHierarchy() {
+        translatesAutoresizingMaskIntoConstraints = false
+
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.distribution = .fill
+        contentStack.spacing = 4
+        addSubview(contentStack)
+
+        setUpHeader()
+        setUpTable()
+        setUpAddRow()
+        setUpFooter()
+
+        for arrangedView in [headerStack, scrollView, addStack, separator, openPaneButton] {
+            contentStack.addArrangedSubview(arrangedView)
+            arrangedView.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
+        }
+
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: Metrics.horizontalInset
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -Metrics.horizontalInset
+            ),
+            contentStack.topAnchor.constraint(
+                equalTo: topAnchor,
+                constant: Metrics.verticalInset
+            ),
+            contentStack.bottomAnchor.constraint(
+                equalTo: bottomAnchor,
+                constant: -Metrics.verticalInset
+            ),
+        ])
+    }
+
+    private func setUpHeader() {
+        headerStack.translatesAutoresizingMaskIntoConstraints = false
+        headerStack.orientation = .horizontal
+        headerStack.alignment = .firstBaseline
+        headerStack.distribution = .fill
+        headerStack.spacing = 8
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 13,
+            weight: .semibold
+        )
+        titleLabel.lineBreakMode = .byTruncatingTail
+        titleLabel.maximumNumberOfLines = 1
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        progressLabel.translatesAutoresizingMaskIntoConstraints = false
+        progressLabel.font = GlobalFontMagnification.monospacedDigitSystemFont(
+            ofSize: 11,
+            weight: .regular
+        )
+        progressLabel.textColor = .secondaryLabelColor
+        progressLabel.alignment = .right
+        progressLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        headerStack.addArrangedSubview(titleLabel)
+        headerStack.addArrangedSubview(progressLabel)
+    }
+
+    private func setUpTable() {
+        let column = NSTableColumn(identifier: Identifier.column)
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.backgroundColor = .clear
+        tableView.gridStyleMask = []
+        tableView.intercellSpacing = .zero
+        tableView.rowHeight = magnifiedRowHeight
+        tableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
+        tableView.selectionHighlightStyle = .none
+        tableView.allowsEmptySelection = true
+        tableView.focusRingType = .none
+        tableView.dataSource = self
+        tableView.delegate = self
+
+        scrollView.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.drawsBackground = false
+        scrollView.borderType = .noBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.documentView = tableView
+        scrollHeightConstraint = scrollView.heightAnchor.constraint(equalToConstant: 0)
+        scrollHeightConstraint.isActive = true
+    }
+
+    private func setUpAddRow() {
+        addStack.translatesAutoresizingMaskIntoConstraints = false
+        addStack.orientation = .horizontal
+        addStack.alignment = .centerY
+        addStack.distribution = .fill
+        addStack.spacing = 6
+
+        addImageView.translatesAutoresizingMaskIntoConstraints = false
+        addImageView.image = NSImage(systemSymbolName: "plus.circle", accessibilityDescription: nil)
+        addImageView.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11),
+            weight: .regular
+        )
+        addImageView.contentTintColor = .secondaryLabelColor
+        addImageView.imageScaling = .scaleProportionallyDown
+        addImageView.setAccessibilityElement(false)
+
+        addField.translatesAutoresizingMaskIntoConstraints = false
+        addField.isBordered = false
+        addField.drawsBackground = false
+        addField.focusRingType = .none
+        addField.usesSingleLineMode = true
+        addField.font = GlobalFontMagnification.systemFont(ofSize: 12)
+        addField.placeholderString = String(
+            localized: "sidebar.checklist.addItemPlaceholder",
+            defaultValue: "New checklist item"
+        )
+        addField.delegate = self
+        addField.setAccessibilityIdentifier("SidebarChecklistAppKitAddItemField")
+
+        addStack.addArrangedSubview(addImageView)
+        addStack.addArrangedSubview(addField)
+        addImageWidthConstraint = addImageView.widthAnchor.constraint(
+            equalToConstant: GlobalFontMagnification.scaledSize(Metrics.addIconSide)
+        )
+        addImageHeightConstraint = addImageView.heightAnchor.constraint(
+            equalToConstant: GlobalFontMagnification.scaledSize(Metrics.addIconSide)
+        )
+        addStackHeightConstraint = addStack.heightAnchor.constraint(
+            greaterThanOrEqualToConstant: GlobalFontMagnification.scaledSize(
+                Metrics.auxiliaryRowHeight
+            )
+        )
+        NSLayoutConstraint.activate([
+            addImageWidthConstraint,
+            addImageHeightConstraint,
+            addStackHeightConstraint,
+        ])
+    }
+
+    private func setUpFooter() {
+        separator.translatesAutoresizingMaskIntoConstraints = false
+        separator.boxType = .separator
+
+        openPaneButton.translatesAutoresizingMaskIntoConstraints = false
+        openPaneButton.isBordered = false
+        openPaneButton.imagePosition = .imageLeading
+        openPaneButton.imageHugsTitle = true
+        openPaneButton.alignment = .left
+        openPaneButton.title = String(
+            localized: "sidebar.checklist.openAsPane",
+            defaultValue: "Open as Pane"
+        )
+        openPaneButton.image = NSImage(
+            systemSymbolName: "rectangle.split.2x1",
+            accessibilityDescription: nil
+        )
+        openPaneButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11),
+            weight: .regular
+        )
+        openPaneButton.font = GlobalFontMagnification.systemFont(ofSize: 12)
+        openPaneButton.target = self
+        openPaneButton.action = #selector(openAsPane)
+        openPaneButton.setAccessibilityIdentifier("SidebarChecklistAppKitOpenAsPane")
+        openPaneHeightConstraint = openPaneButton.heightAnchor.constraint(
+            greaterThanOrEqualToConstant: GlobalFontMagnification.scaledSize(
+                Metrics.auxiliaryRowHeight
+            )
+        )
+        openPaneHeightConstraint.isActive = true
+    }
+
+    private func setUpAccessibility() {
+        setAccessibilityElement(true)
+        setAccessibilityRole(.group)
+        setAccessibilityIdentifier("SidebarWorkspaceChecklistAppKit")
+        addField.setAccessibilityLabel(String(
+            localized: "sidebar.checklist.addItemPlaceholder",
+            defaultValue: "New checklist item"
+        ))
+        openPaneButton.setAccessibilityLabel(openPaneButton.title)
+    }
+
+    private func applyMode() {
+        headerStack.isHidden = mode == .inline
+    }
+
+    private func applyItems(
+        _ nextItems: [WorkspaceChecklistItem],
+        notifyHeightChange: Bool
+    ) {
+        let ordered = SidebarWorkspaceChecklistDisplayPolicy.orderedItems(nextItems)
+        guard ordered != items else {
+            updateProgressLabel()
+            return
+        }
+        let previousHeight = scrollHeightConstraint.constant
+        items = ordered
+        tableView.reloadData()
+        scrollView.isHidden = items.isEmpty
+        scrollView.hasVerticalScroller = items.count > Metrics.visibleRowLimit
+        scrollHeightConstraint.constant = magnifiedRowHeight
+            * CGFloat(min(items.count, Metrics.visibleRowLimit))
+        updateProgressLabel()
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+        if notifyHeightChange, previousHeight != scrollHeightConstraint.constant {
+            onPreferredHeightChange?()
+        }
+    }
+
+    private func updateProgressLabel() {
+        let completedCount = items.count { $0.state == .completed }
+        progressLabel.stringValue = "\(completedCount)/\(items.count)"
+    }
+
+    private var magnifiedRowHeight: CGFloat {
+        GlobalFontMagnification.scaledSize(Metrics.rowHeight)
+    }
+
+    /// Reapplies magnification-derived presentation to the retained hierarchy.
+    ///
+    /// The checklist's workspace observation task is deliberately untouched:
+    /// live font changes restyle the existing controls and visible row views.
+    private func refreshFontMagnification(notifyPreferredHeightChange: Bool) {
+        titleLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 13,
+            weight: .semibold
+        )
+        progressLabel.font = GlobalFontMagnification.monospacedDigitSystemFont(
+            ofSize: 11,
+            weight: .regular
+        )
+        addField.font = GlobalFontMagnification.systemFont(ofSize: 12)
+        openPaneButton.font = GlobalFontMagnification.systemFont(ofSize: 12)
+
+        let symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11),
+            weight: .regular
+        )
+        addImageView.symbolConfiguration = symbolConfiguration
+        openPaneButton.symbolConfiguration = symbolConfiguration
+
+        addImageWidthConstraint.constant = GlobalFontMagnification.scaledSize(
+            Metrics.addIconSide
+        )
+        addImageHeightConstraint.constant = GlobalFontMagnification.scaledSize(
+            Metrics.addIconSide
+        )
+        addStackHeightConstraint.constant = GlobalFontMagnification.scaledSize(
+            Metrics.auxiliaryRowHeight
+        )
+        openPaneHeightConstraint.constant = GlobalFontMagnification.scaledSize(
+            Metrics.auxiliaryRowHeight
+        )
+
+        let rowHeight = magnifiedRowHeight
+        tableView.rowHeight = rowHeight
+        scrollHeightConstraint.constant = rowHeight
+            * CGFloat(min(items.count, Metrics.visibleRowLimit))
+        refreshVisibleItemCells()
+
+        titleLabel.invalidateIntrinsicContentSize()
+        progressLabel.invalidateIntrinsicContentSize()
+        addField.invalidateIntrinsicContentSize()
+        openPaneButton.invalidateIntrinsicContentSize()
+        contentStack.needsLayout = true
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+
+        if notifyPreferredHeightChange {
+            onPreferredHeightChange?()
+        }
+    }
+
+    /// At most the six-row viewport is visited, regardless of checklist size.
+    private func refreshVisibleItemCells() {
+        let visibleRows = tableView.rows(in: tableView.visibleRect)
+        guard visibleRows.location != NSNotFound else { return }
+        let upperBound = min(tableView.numberOfRows, NSMaxRange(visibleRows))
+        guard visibleRows.location < upperBound else { return }
+        for row in visibleRows.location..<upperBound {
+            let cell = tableView.view(
+                atColumn: 0,
+                row: row,
+                makeIfNecessary: false
+            ) as? SidebarAppKitChecklistItemCellView
+            cell?.refreshFontMagnification()
+        }
+    }
+
+    private func addPendingItem() {
+        guard let workspace else { return }
+        let text = addField.stringValue
+        addField.stringValue = ""
+        if !WorkspaceTodoActions.addChecklistItem(text: text, to: workspace) {
+            NSSound.beep()
+        }
+        focusAddField()
+    }
+
+    @objc private func openAsPane() {
+        guard let workspace else { return }
+        if mode == .popover {
+            onRequestClose?()
+        }
+        if WorkspaceTodoActions.openTodoPane(for: workspace) == nil {
+            NSSound.beep()
+        }
+    }
+}
+
+/// Native, reusable row for one checklist item.
+@MainActor
+private final class SidebarAppKitChecklistItemCellView: NSTableCellView, NSTextFieldDelegate {
+    private enum Metrics {
+        static let controlSide: CGFloat = 20
+    }
+
+    private let stack = NSStackView()
+    private let stateButton = NSButton()
+    private let itemField = NSTextField(string: "")
+    private let moveUpButton = NSButton()
+    private let moveDownButton = NSButton()
+    private let removeButton = NSButton()
+
+    private var item: WorkspaceChecklistItem?
+    private var baselineText = ""
+    private var onSetState: ((WorkspaceChecklistItem.State) -> Void)?
+    private var onEdit: ((String) -> Void)?
+    private var onRemove: (() -> Void)?
+    private var onMove: ((Int) -> Void)?
+    private var canMoveUp = false
+    private var canMoveDown = false
+    private var imageButtonSizeConstraints: [(
+        button: NSButton,
+        width: NSLayoutConstraint,
+        height: NSLayoutConstraint
+    )] = []
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setUpHierarchy()
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func configure(
+        item: WorkspaceChecklistItem,
+        canMoveUp: Bool,
+        canMoveDown: Bool,
+        onSetState: @escaping (WorkspaceChecklistItem.State) -> Void,
+        onEdit: @escaping (String) -> Void,
+        onRemove: @escaping () -> Void,
+        onMove: @escaping (Int) -> Void
+    ) {
+        self.item = item
+        baselineText = item.text
+        self.onSetState = onSetState
+        self.onEdit = onEdit
+        self.onRemove = onRemove
+        self.onMove = onMove
+        self.canMoveUp = canMoveUp
+        self.canMoveDown = canMoveDown
+
+        itemField.stringValue = item.text
+        itemField.textColor = item.state == .completed ? .secondaryLabelColor : .labelColor
+        let attributes: [NSAttributedString.Key: Any] = item.state == .completed
+            ? [.strikethroughStyle: NSUnderlineStyle.single.rawValue]
+            : [:]
+        itemField.attributedStringValue = NSAttributedString(string: item.text, attributes: attributes)
+
+        let symbolName: String
+        let stateHelp: String
+        switch item.state {
+        case .pending:
+            symbolName = "square"
+            stateHelp = String(
+                localized: "sidebar.checklist.checkTooltip",
+                defaultValue: "Mark as completed"
+            )
+        case .inProgress:
+            symbolName = "minus.square"
+            stateHelp = String(
+                localized: "sidebar.checklist.checkTooltip",
+                defaultValue: "Mark as completed"
+            )
+        case .completed:
+            symbolName = "checkmark.square.fill"
+            stateHelp = String(
+                localized: "sidebar.checklist.uncheckTooltip",
+                defaultValue: "Mark as pending"
+            )
+        }
+        stateButton.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+        stateButton.toolTip = stateHelp
+        stateButton.setAccessibilityLabel(stateHelp)
+        moveUpButton.isEnabled = canMoveUp
+        moveDownButton.isEnabled = canMoveDown
+        refreshFontMagnification()
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        guard let item else { return nil }
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        addMenuItem(
+            to: menu,
+            title: String(
+                localized: "sidebar.checklist.uncheckTooltip",
+                defaultValue: "Mark as pending"
+            ),
+            action: #selector(markPending),
+            state: item.state == .pending ? .on : .off
+        )
+        addMenuItem(
+            to: menu,
+            title: String(
+                localized: "sidebar.checklist.markInProgress",
+                defaultValue: "Mark In Progress"
+            ),
+            action: #selector(markInProgress),
+            state: item.state == .inProgress ? .on : .off
+        )
+        addMenuItem(
+            to: menu,
+            title: String(
+                localized: "sidebar.checklist.checkTooltip",
+                defaultValue: "Mark as completed"
+            ),
+            action: #selector(markCompleted),
+            state: item.state == .completed ? .on : .off
+        )
+        menu.addItem(.separator())
+        addMenuItem(
+            to: menu,
+            title: String(localized: "sidebar.checklist.editItem", defaultValue: "Edit"),
+            action: #selector(beginEditing)
+        )
+        addMenuItem(
+            to: menu,
+            title: String(localized: "contextMenu.moveUp", defaultValue: "Move Up"),
+            action: #selector(moveUp),
+            enabled: canMoveUp
+        )
+        addMenuItem(
+            to: menu,
+            title: String(localized: "contextMenu.moveDown", defaultValue: "Move Down"),
+            action: #selector(moveDown),
+            enabled: canMoveDown
+        )
+        menu.addItem(.separator())
+        addMenuItem(
+            to: menu,
+            title: String(
+                localized: "sidebar.checklist.removeItem",
+                defaultValue: "Remove"
+            ),
+            action: #selector(removeItem)
+        )
+        return menu
+    }
+
+    func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        doCommandBy commandSelector: Selector
+    ) -> Bool {
+        guard control === itemField, !textView.hasMarkedText() else { return false }
+        if commandSelector == #selector(NSResponder.insertNewline(_:)) {
+            commitEdit()
+            window?.makeFirstResponder(enclosingScrollView?.documentView)
+            return true
+        }
+        if commandSelector == #selector(NSResponder.cancelOperation(_:)) {
+            itemField.stringValue = baselineText
+            window?.makeFirstResponder(enclosingScrollView?.documentView)
+            return true
+        }
+        return false
+    }
+
+    func controlTextDidEndEditing(_ notification: Notification) {
+        guard notification.object as? NSTextField === itemField else { return }
+        commitEdit()
+    }
+
+    private func setUpHierarchy() {
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.distribution = .fill
+        stack.spacing = 4
+        addSubview(stack)
+
+        configureImageButton(stateButton, symbolName: "square", action: #selector(cycleState))
+
+        itemField.translatesAutoresizingMaskIntoConstraints = false
+        itemField.isBordered = false
+        itemField.drawsBackground = false
+        itemField.focusRingType = .none
+        itemField.usesSingleLineMode = true
+        itemField.lineBreakMode = .byTruncatingTail
+        itemField.font = GlobalFontMagnification.systemFont(ofSize: 12)
+        itemField.placeholderString = String(
+            localized: "sidebar.checklist.editItemPlaceholder",
+            defaultValue: "Item text"
+        )
+        itemField.delegate = self
+        itemField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        itemField.setAccessibilityIdentifier("SidebarChecklistAppKitEditItemField")
+
+        configureImageButton(moveUpButton, symbolName: "chevron.up", action: #selector(moveUp))
+        moveUpButton.toolTip = String(localized: "contextMenu.moveUp", defaultValue: "Move Up")
+        moveUpButton.setAccessibilityLabel(moveUpButton.toolTip)
+
+        configureImageButton(moveDownButton, symbolName: "chevron.down", action: #selector(moveDown))
+        moveDownButton.toolTip = String(localized: "contextMenu.moveDown", defaultValue: "Move Down")
+        moveDownButton.setAccessibilityLabel(moveDownButton.toolTip)
+
+        configureImageButton(removeButton, symbolName: "xmark.circle.fill", action: #selector(removeItem))
+        removeButton.toolTip = String(
+            localized: "sidebar.checklist.removeItemTooltip",
+            defaultValue: "Remove item"
+        )
+        removeButton.setAccessibilityLabel(removeButton.toolTip)
+
+        [stateButton, itemField, moveUpButton, moveDownButton, removeButton]
+            .forEach(stack.addArrangedSubview)
+
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: 2),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor, constant: -2),
+            stack.topAnchor.constraint(equalTo: topAnchor, constant: 2),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -2),
+        ])
+    }
+
+    private func configureImageButton(
+        _ button: NSButton,
+        symbolName: String,
+        action: Selector
+    ) {
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isBordered = false
+        button.imagePosition = .imageOnly
+        button.image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+        button.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11),
+            weight: .regular
+        )
+        button.target = self
+        button.action = action
+        let widthConstraint = button.widthAnchor.constraint(
+            equalToConstant: GlobalFontMagnification.scaledSize(
+                Metrics.controlSide
+            )
+        )
+        let heightConstraint = button.heightAnchor.constraint(
+            equalToConstant: GlobalFontMagnification.scaledSize(
+                Metrics.controlSide
+            )
+        )
+        NSLayoutConstraint.activate([widthConstraint, heightConstraint])
+        imageButtonSizeConstraints.append((
+            button: button,
+            width: widthConstraint,
+            height: heightConstraint
+        ))
+    }
+
+    func refreshFontMagnification() {
+        itemField.font = GlobalFontMagnification.systemFont(ofSize: 12)
+        let symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11),
+            weight: .regular
+        )
+        let controlSide = GlobalFontMagnification.scaledSize(
+            Metrics.controlSide
+        )
+        for constraints in imageButtonSizeConstraints {
+            constraints.button.symbolConfiguration = symbolConfiguration
+            constraints.width.constant = controlSide
+            constraints.height.constant = controlSide
+            constraints.button.invalidateIntrinsicContentSize()
+        }
+        itemField.invalidateIntrinsicContentSize()
+        stack.needsLayout = true
+        needsLayout = true
+    }
+
+    private func addMenuItem(
+        to menu: NSMenu,
+        title: String,
+        action: Selector,
+        state: NSControl.StateValue = .off,
+        enabled: Bool = true
+    ) {
+        let menuItem = NSMenuItem(title: title, action: action, keyEquivalent: "")
+        menuItem.target = self
+        menuItem.state = state
+        menuItem.isEnabled = enabled
+        menu.addItem(menuItem)
+    }
+
+    private func commitEdit() {
+        let text = itemField.stringValue
+        guard text != baselineText else { return }
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            itemField.stringValue = baselineText
+            return
+        }
+        baselineText = text
+        onEdit?(text)
+    }
+
+    @objc private func cycleState() {
+        guard let item else { return }
+        let next: WorkspaceChecklistItem.State = item.state == .completed
+            ? .pending
+            : .completed
+        onSetState?(next)
+    }
+
+    @objc private func markPending() {
+        onSetState?(.pending)
+    }
+
+    @objc private func markInProgress() {
+        onSetState?(.inProgress)
+    }
+
+    @objc private func markCompleted() {
+        onSetState?(.completed)
+    }
+
+    @objc private func beginEditing() {
+        window?.makeFirstResponder(itemField)
+        itemField.selectText(nil)
+    }
+
+    @objc private func moveUp() {
+        onMove?(-1)
+    }
+
+    @objc private func moveDown() {
+        onMove?(1)
+    }
+
+    @objc private func removeItem() {
+        onRemove?()
+    }
+}
+
+/// Owns the one native checklist popover used by the sidebar.
+@MainActor
+final class SidebarAppKitChecklistPopoverController: NSObject, NSPopoverDelegate {
+    private var popover: NSPopover?
+    private var checklistView: SidebarAppKitChecklistView?
+    private weak var presentedWorkspace: Workspace?
+
+    @discardableResult
+    func toggle(
+        workspace: Workspace,
+        relativeTo anchorView: NSView,
+        focusAddField: Bool
+    ) -> Bool {
+        if let popover, popover.isShown, presentedWorkspace === workspace {
+            if focusAddField {
+                checklistView?.focusAddField()
+            } else {
+                close()
+            }
+            return true
+        }
+        return present(
+            workspace: workspace,
+            relativeTo: anchorView,
+            focusAddField: focusAddField
+        )
+    }
+
+    @discardableResult
+    func present(
+        workspace: Workspace,
+        relativeTo anchorView: NSView,
+        focusAddField: Bool
+    ) -> Bool {
+        guard anchorView.window != nil else { return false }
+        close()
+
+        let checklistView = SidebarAppKitChecklistView(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: 320,
+            height: 1
+        ))
+        let viewController = NSViewController()
+        viewController.view = checklistView
+
+        let popover = NSPopover()
+        popover.animates = false
+        popover.behavior = .transient
+        popover.delegate = self
+        popover.contentViewController = viewController
+
+        self.popover = popover
+        self.checklistView = checklistView
+        presentedWorkspace = workspace
+        checklistView.configure(
+            workspace: workspace,
+            mode: .popover,
+            onPreferredHeightChange: { [weak self] in
+                self?.refreshPopoverSize()
+            },
+            onRequestClose: { [weak self] in
+                self?.close()
+            }
+        )
+        refreshPopoverSize()
+        popover.show(relativeTo: anchorView.bounds, of: anchorView, preferredEdge: .maxX)
+        if focusAddField {
+            checklistView.focusAddField()
+        }
+        return true
+    }
+
+    func close() {
+        let closingPopover = popover
+        closingPopover?.delegate = nil
+        if closingPopover?.isShown == true {
+            closingPopover?.performClose(nil)
+        }
+        tearDown()
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        tearDown()
+    }
+
+    private func refreshPopoverSize() {
+        guard let checklistView else { return }
+        let size = checklistView.preferredContentSize
+        popover?.contentSize = size
+        popover?.contentViewController?.preferredContentSize = size
+    }
+
+    private func tearDown() {
+        checklistView?.stopObserving()
+        popover?.delegate = nil
+        popover?.contentViewController = nil
+        popover = nil
+        checklistView = nil
+        presentedWorkspace = nil
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitChecklistController.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitChecklistController.swift
@@ -669,13 +669,13 @@ private final class SidebarAppKitChecklistItemCellView: NSTableCellView, NSTextF
         addMenuItem(
             to: menu,
             title: String(localized: "contextMenu.moveUp", defaultValue: "Move Up"),
-            action: #selector(moveUp),
+            action: #selector(moveChecklistItemUp),
             enabled: canMoveUp
         )
         addMenuItem(
             to: menu,
             title: String(localized: "contextMenu.moveDown", defaultValue: "Move Down"),
-            action: #selector(moveDown),
+            action: #selector(moveChecklistItemDown),
             enabled: canMoveDown
         )
         menu.addItem(.separator())
@@ -739,11 +739,19 @@ private final class SidebarAppKitChecklistItemCellView: NSTableCellView, NSTextF
         itemField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
         itemField.setAccessibilityIdentifier("SidebarChecklistAppKitEditItemField")
 
-        configureImageButton(moveUpButton, symbolName: "chevron.up", action: #selector(moveUp))
+        configureImageButton(
+            moveUpButton,
+            symbolName: "chevron.up",
+            action: #selector(moveChecklistItemUp)
+        )
         moveUpButton.toolTip = String(localized: "contextMenu.moveUp", defaultValue: "Move Up")
         moveUpButton.setAccessibilityLabel(moveUpButton.toolTip)
 
-        configureImageButton(moveDownButton, symbolName: "chevron.down", action: #selector(moveDown))
+        configureImageButton(
+            moveDownButton,
+            symbolName: "chevron.down",
+            action: #selector(moveChecklistItemDown)
+        )
         moveDownButton.toolTip = String(localized: "contextMenu.moveDown", defaultValue: "Move Down")
         moveDownButton.setAccessibilityLabel(moveDownButton.toolTip)
 
@@ -868,11 +876,11 @@ private final class SidebarAppKitChecklistItemCellView: NSTableCellView, NSTextF
         itemField.selectText(nil)
     }
 
-    @objc private func moveUp() {
+    @objc private func moveChecklistItemUp() {
         onMove?(-1)
     }
 
-    @objc private func moveDown() {
+    @objc private func moveChecklistItemDown() {
         onMove?(1)
     }
 

--- a/Sources/Sidebar/AppKit/SidebarAppKitConfiguration.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitConfiguration.swift
@@ -1,0 +1,187 @@
+import AppKit
+import Foundation
+
+/// Replaceable, parent-owned input for the native workspace sidebar.
+///
+/// Production callers should use the resolver initializer. Resolvers are only
+/// invoked when `NSTableView` asks for a reusable row, so an update does not
+/// project every workspace before the virtualization boundary. The dictionary
+/// initializer is a convenience for tests and migration call sites that already
+/// own immutable row snapshots.
+@MainActor
+struct SidebarAppKitConfiguration {
+    typealias WorkspaceSnapshotResolver = @MainActor (UUID) -> SidebarWorkspaceRowSnapshot?
+    typealias GroupSnapshotResolver = @MainActor (UUID) -> SidebarWorkspaceGroupRowSnapshot?
+    typealias WorkspaceActionsResolver = @MainActor (UUID) -> SidebarAppKitWorkspaceCellView.Actions
+    typealias GroupActionsResolver = @MainActor (UUID) -> SidebarAppKitGroupCellView.Actions
+
+    struct InteractionHandlers {
+        typealias SelectionHandler = @MainActor (
+            UUID?,
+            NSEvent.ModifierFlags
+        ) -> Void
+        typealias HoverHandler = @MainActor (SidebarWorkspaceRenderItemID?) -> Void
+        typealias MiddleClickHandler = @MainActor (SidebarWorkspaceRenderItem, NSEvent) -> Void
+        typealias ContextMenuProvider = @MainActor (SidebarWorkspaceRenderItem, NSEvent) -> NSMenu?
+        typealias EmptyAreaHandler = @MainActor () -> Void
+        typealias EmptyAreaContextMenuProvider = @MainActor (NSEvent) -> NSMenu?
+        typealias VisibleWorkspaceHandler = @MainActor (Set<UUID>) -> Void
+
+        let onSelectionChanged: SelectionHandler
+        let onHoveredItemChanged: HoverHandler
+        let onMiddleClick: MiddleClickHandler?
+        let contextMenuProvider: ContextMenuProvider?
+        let onEmptyAreaDoubleClick: EmptyAreaHandler?
+        let emptyAreaContextMenuProvider: EmptyAreaContextMenuProvider?
+        let onVisibleWorkspaceIDsChanged: VisibleWorkspaceHandler
+
+        init(
+            onSelectionChanged: @escaping SelectionHandler = { _, _ in },
+            onHoveredItemChanged: @escaping HoverHandler = { _ in },
+            onMiddleClick: MiddleClickHandler? = nil,
+            contextMenuProvider: ContextMenuProvider? = nil,
+            onEmptyAreaDoubleClick: EmptyAreaHandler? = nil,
+            emptyAreaContextMenuProvider: EmptyAreaContextMenuProvider? = nil,
+            onVisibleWorkspaceIDsChanged: @escaping VisibleWorkspaceHandler = { _ in }
+        ) {
+            self.onSelectionChanged = onSelectionChanged
+            self.onHoveredItemChanged = onHoveredItemChanged
+            self.onMiddleClick = onMiddleClick
+            self.contextMenuProvider = contextMenuProvider
+            self.onEmptyAreaDoubleClick = onEmptyAreaDoubleClick
+            self.emptyAreaContextMenuProvider = emptyAreaContextMenuProvider
+            self.onVisibleWorkspaceIDsChanged = onVisibleWorkspaceIDsChanged
+        }
+    }
+
+    struct DragHandlers {
+        typealias PasteboardWriter = @MainActor (
+            SidebarWorkspaceRenderItem
+        ) -> (any NSPasteboardWriting)?
+        typealias ValidateDrop = @MainActor (
+            NSDraggingInfo,
+            SidebarWorkspaceRenderItem?,
+            Int,
+            NSTableView.DropOperation
+        ) -> NSDragOperation
+        typealias AcceptDrop = @MainActor (
+            NSDraggingInfo,
+            SidebarWorkspaceRenderItem?,
+            Int,
+            NSTableView.DropOperation
+        ) -> Bool
+        typealias DragSessionBegan = @MainActor (
+            NSDraggingSession,
+            [SidebarWorkspaceRenderItemID]
+        ) -> Void
+        typealias DragSessionEnded = @MainActor (
+            NSDraggingSession,
+            NSPoint,
+            NSDragOperation
+        ) -> Void
+        typealias UpdateDraggingItems = @MainActor (NSDraggingInfo) -> Void
+
+        let registeredTypes: [NSPasteboard.PasteboardType]
+        let localSourceOperationMask: NSDragOperation
+        let externalSourceOperationMask: NSDragOperation
+        let pasteboardWriter: PasteboardWriter
+        let validateDrop: ValidateDrop
+        let acceptDrop: AcceptDrop
+        let dragSessionBegan: DragSessionBegan?
+        let dragSessionEnded: DragSessionEnded?
+        let updateDraggingItems: UpdateDraggingItems?
+
+        init(
+            registeredTypes: [NSPasteboard.PasteboardType],
+            localSourceOperationMask: NSDragOperation = .move,
+            externalSourceOperationMask: NSDragOperation = [],
+            pasteboardWriter: @escaping PasteboardWriter,
+            validateDrop: @escaping ValidateDrop,
+            acceptDrop: @escaping AcceptDrop,
+            dragSessionBegan: DragSessionBegan? = nil,
+            dragSessionEnded: DragSessionEnded? = nil,
+            updateDraggingItems: UpdateDraggingItems? = nil
+        ) {
+            self.registeredTypes = registeredTypes
+            self.localSourceOperationMask = localSourceOperationMask
+            self.externalSourceOperationMask = externalSourceOperationMask
+            self.pasteboardWriter = pasteboardWriter
+            self.validateDrop = validateDrop
+            self.acceptDrop = acceptDrop
+            self.dragSessionBegan = dragSessionBegan
+            self.dragSessionEnded = dragSessionEnded
+            self.updateDraggingItems = updateDraggingItems
+        }
+    }
+
+    let renderItems: [SidebarWorkspaceRenderItem]
+    let selectedWorkspaceIDs: Set<UUID>
+    let activeWorkspaceID: UUID?
+    let workspaceSnapshot: WorkspaceSnapshotResolver
+    let groupSnapshot: GroupSnapshotResolver
+    let workspaceActions: WorkspaceActionsResolver
+    let groupActions: GroupActionsResolver
+    let interactions: InteractionHandlers
+    let dragHandlers: DragHandlers?
+    let alternateContentView: NSView?
+    let headerView: NSView?
+    let footerView: NSView?
+
+    init(
+        renderItems: [SidebarWorkspaceRenderItem],
+        selectedWorkspaceIDs: Set<UUID>,
+        activeWorkspaceID: UUID?,
+        workspaceSnapshot: @escaping WorkspaceSnapshotResolver,
+        groupSnapshot: @escaping GroupSnapshotResolver,
+        workspaceActions: @escaping WorkspaceActionsResolver,
+        groupActions: @escaping GroupActionsResolver,
+        interactions: InteractionHandlers = InteractionHandlers(),
+        dragHandlers: DragHandlers? = nil,
+        alternateContentView: NSView? = nil,
+        headerView: NSView? = nil,
+        footerView: NSView? = nil
+    ) {
+        self.renderItems = renderItems
+        self.selectedWorkspaceIDs = selectedWorkspaceIDs
+        self.activeWorkspaceID = activeWorkspaceID
+        self.workspaceSnapshot = workspaceSnapshot
+        self.groupSnapshot = groupSnapshot
+        self.workspaceActions = workspaceActions
+        self.groupActions = groupActions
+        self.interactions = interactions
+        self.dragHandlers = dragHandlers
+        self.alternateContentView = alternateContentView
+        self.headerView = headerView
+        self.footerView = footerView
+    }
+
+    init(
+        renderItems: [SidebarWorkspaceRenderItem],
+        workspaceSnapshotsByID: [UUID: SidebarWorkspaceRowSnapshot],
+        groupSnapshotsByID: [UUID: SidebarWorkspaceGroupRowSnapshot],
+        selectedWorkspaceIDs: Set<UUID>,
+        activeWorkspaceID: UUID?,
+        workspaceActions: @escaping WorkspaceActionsResolver,
+        groupActions: @escaping GroupActionsResolver,
+        interactions: InteractionHandlers = InteractionHandlers(),
+        dragHandlers: DragHandlers? = nil,
+        alternateContentView: NSView? = nil,
+        headerView: NSView? = nil,
+        footerView: NSView? = nil
+    ) {
+        self.init(
+            renderItems: renderItems,
+            selectedWorkspaceIDs: selectedWorkspaceIDs,
+            activeWorkspaceID: activeWorkspaceID,
+            workspaceSnapshot: { workspaceSnapshotsByID[$0] },
+            groupSnapshot: { groupSnapshotsByID[$0] },
+            workspaceActions: workspaceActions,
+            groupActions: groupActions,
+            interactions: interactions,
+            dragHandlers: dragHandlers,
+            alternateContentView: alternateContentView,
+            headerView: headerView,
+            footerView: footerView
+        )
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitContextMenuController.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitContextMenuController.swift
@@ -1,0 +1,1522 @@
+import AppKit
+import CmuxSettings
+import CmuxWorkspaces
+import Foundation
+
+/// Builds native sidebar context menus from live state at menu-open time.
+///
+/// No row retains a menu or a live model projection. The table passes stable
+/// render identity here only after a context-click, and every enabled state,
+/// target set, group membership, notification fact, and detail row is resolved
+/// immediately before the `NSMenu` is returned.
+@MainActor
+final class SidebarAppKitContextMenuController: NSObject {
+    private let tabManager: TabManager
+    private let projectionSource: SidebarAppKitProjectionSource
+    private let interactionCoordinator: SidebarAppKitInteractionCoordinator
+    private let notificationStore: TerminalNotificationStore
+
+    init(
+        tabManager: TabManager,
+        projectionSource: SidebarAppKitProjectionSource,
+        interactionCoordinator: SidebarAppKitInteractionCoordinator,
+        notificationStore: TerminalNotificationStore = .shared
+    ) {
+        self.tabManager = tabManager
+        self.projectionSource = projectionSource
+        self.interactionCoordinator = interactionCoordinator
+        self.notificationStore = notificationStore
+        super.init()
+    }
+
+    /// Returns a freshly resolved menu for the clicked render item.
+    func menu(
+        for item: SidebarWorkspaceRenderItem,
+        event _: NSEvent? = nil
+    ) -> NSMenu? {
+        switch item {
+        case .workspace(let workspaceId):
+            return workspaceMenu(workspaceId: workspaceId)
+        case .groupHeader(let groupId, let anchorWorkspaceId):
+            return groupMenu(groupId: groupId, anchorWorkspaceId: anchorWorkspaceId)
+        }
+    }
+
+    /// Naming alias for call sites that prefer factory terminology.
+    func makeMenu(
+        for item: SidebarWorkspaceRenderItem,
+        event: NSEvent? = nil
+    ) -> NSMenu? {
+        menu(for: item, event: event)
+    }
+
+    func emptyAreaMenu() -> NSMenu {
+        let menu = makeBaseMenu()
+        addAction(
+            to: menu,
+            title: String(
+                localized: "contextMenu.workspaceGroup.newEmpty",
+                defaultValue: "New Empty Workspace Group"
+            ),
+            shortcutAction: .newWorkspaceGroup,
+            enabled: tabManager.selectedTab?.isRemoteTmuxMirror != true
+        ) { [weak self] in
+            guard let self else { return }
+            _ = AppDelegate.shared?.createEmptyWorkspaceGroup(tabManager: tabManager)
+        }
+        return menu
+    }
+
+    private func workspaceMenu(workspaceId: UUID) -> NSMenu? {
+        guard let workspace = projectionSource.workspaceById[workspaceId],
+              let index = projectionSource.workspaceIndexById[workspaceId],
+              let rowSnapshot = projectionSource.workspaceSnapshot(workspaceId: workspaceId) else {
+            return nil
+        }
+
+        let targetIds = projectionSource.contextTargetWorkspaceIds(for: workspaceId)
+        let targetSet = Set(targetIds)
+        let isMulti = targetIds.count > 1
+        let menu = makeBaseMenu()
+
+        appendWorkspacePinItem(
+            to: menu,
+            workspaceId: workspaceId,
+            targetIds: targetIds,
+            isMulti: isMulti
+        )
+        appendWorkspaceGroupItems(
+            to: menu,
+            workspaceId: workspaceId,
+            targetIds: targetIds,
+            isMulti: isMulti
+        )
+
+        addSeparator(to: menu)
+        appendWorkspaceTodoItems(
+            to: menu,
+            workspaceId: workspaceId,
+            targetIds: targetIds,
+            isMulti: isMulti,
+            snapshot: rowSnapshot
+        )
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: String(
+                localized: "contextMenu.renameWorkspace",
+                defaultValue: "Rename Workspace…"
+            ),
+            shortcutAction: .renameWorkspace
+        ) { [weak self] in
+            self?.promptWorkspaceRename(workspaceId: workspaceId)
+        }
+        if workspace.hasCustomTitle {
+            addAction(
+                to: menu,
+                title: String(
+                    localized: "contextMenu.removeCustomWorkspaceName",
+                    defaultValue: "Remove Custom Workspace Name"
+                )
+            ) { [weak self] in
+                self?.tabManager.clearCustomTitle(tabId: workspaceId)
+            }
+        }
+        if !isMulti {
+            addAction(
+                to: menu,
+                title: String(
+                    localized: "contextMenu.editWorkspaceDescription",
+                    defaultValue: "Edit Workspace Description…"
+                ),
+                shortcutAction: .editWorkspaceDescription
+            ) { [weak self] in
+                self?.promptWorkspaceDescriptionEdit(workspaceId: workspaceId)
+            }
+            if workspace.hasCustomDescription {
+                addAction(
+                    to: menu,
+                    title: String(
+                        localized: "contextMenu.clearWorkspaceDescription",
+                        defaultValue: "Clear Workspace Description"
+                    )
+                ) { [weak self] in
+                    self?.tabManager.clearCustomDescription(tabId: workspaceId)
+                }
+            }
+        }
+
+        appendWorkspaceRemoteItems(
+            to: menu,
+            targetIds: targetIds,
+            isMulti: isMulti
+        )
+        appendWorkspaceColorMenu(
+            to: menu,
+            targetIds: targetIds,
+            customColorHex: rowSnapshot.workspace.customColorHex,
+            activeTabIndicatorStyle: rowSnapshot.settings.activeTabIndicatorStyle
+        )
+        if let copyableRemoteError = rowSnapshot.workspace.copyableSidebarSSHError {
+            addSeparator(to: menu)
+            addAction(
+                to: menu,
+                title: String(
+                    localized: "contextMenu.copySshError",
+                    defaultValue: "Copy SSH Error"
+                )
+            ) { [weak self] in
+                self?.interactionCoordinator.copyRemoteError(copyableRemoteError)
+            }
+        }
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: String(localized: "contextMenu.moveUp", defaultValue: "Move Up"),
+            enabled: index > 0
+        ) { [weak self] in
+            self?.interactionCoordinator.moveWorkspace(workspaceId, by: -1)
+        }
+        addAction(
+            to: menu,
+            title: String(localized: "contextMenu.moveDown", defaultValue: "Move Down"),
+            enabled: index < tabManager.tabs.count - 1
+        ) { [weak self] in
+            self?.interactionCoordinator.moveWorkspace(workspaceId, by: 1)
+        }
+        addAction(
+            to: menu,
+            title: String(localized: "contextMenu.moveToTop", defaultValue: "Move to Top"),
+            enabled: !targetIds.isEmpty
+        ) { [weak self] in
+            guard let self else { return }
+            tabManager.moveTabsToTop(targetSet)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+        appendWorkspaceWindowMoveMenu(
+            to: menu,
+            targetIds: targetIds,
+            isMulti: isMulti
+        )
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(localized: "contextMenu.closeWorkspaces", defaultValue: "Close Workspaces")
+                : String(localized: "contextMenu.closeWorkspace", defaultValue: "Close Workspace"),
+            shortcutAction: .closeWorkspace,
+            enabled: !targetIds.isEmpty
+        ) { [weak self] in
+            guard let self else { return }
+            tabManager.closeWorkspacesWithConfirmation(targetIds, allowPinned: true)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "contextMenu.closeOtherWorkspaces",
+                defaultValue: "Close Other Workspaces"
+            ),
+            enabled: tabManager.tabs.count > targetIds.count
+        ) { [weak self] in
+            guard let self else { return }
+            let ids = tabManager.tabs.compactMap { targetSet.contains($0.id) ? nil : $0.id }
+            tabManager.closeWorkspacesWithConfirmation(ids, allowPinned: true)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "contextMenu.closeWorkspacesBelow",
+                defaultValue: "Close Workspaces Below"
+            ),
+            enabled: index < tabManager.tabs.count - 1
+        ) { [weak self] in
+            guard let self,
+                  let liveIndex = tabManager.tabs.firstIndex(where: { $0.id == workspaceId }) else {
+                return
+            }
+            let ids = Array(tabManager.tabs.suffix(from: liveIndex + 1).map(\.id))
+            tabManager.closeWorkspacesWithConfirmation(ids, allowPinned: true)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "contextMenu.closeWorkspacesAbove",
+                defaultValue: "Close Workspaces Above"
+            ),
+            enabled: index > 0
+        ) { [weak self] in
+            guard let self,
+                  let liveIndex = tabManager.tabs.firstIndex(where: { $0.id == workspaceId }) else {
+                return
+            }
+            let ids = Array(tabManager.tabs.prefix(upTo: liveIndex).map(\.id))
+            tabManager.closeWorkspacesWithConfirmation(ids, allowPinned: true)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+
+        appendWorkspaceNotificationItems(to: menu, targetIds: targetIds, isMulti: isMulti)
+        appendWorkspaceDetailLinks(
+            to: menu,
+            workspaceId: workspaceId,
+            snapshot: rowSnapshot
+        )
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(localized: "contextMenu.copyWorkspaceIDs", defaultValue: "Copy Workspace IDs")
+                : String(localized: "contextMenu.copyWorkspaceID", defaultValue: "Copy Workspace ID"),
+            enabled: !targetIds.isEmpty
+        ) {
+            WorkspaceSurfaceIdentifierClipboardText.copyWorkspaceIds(
+                targetIds,
+                includeRefs: false
+            )
+        }
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(localized: "contextMenu.copyWorkspaceLinks", defaultValue: "Copy Workspace Links")
+                : String(localized: "contextMenu.copyWorkspaceLink", defaultValue: "Copy Workspace Link"),
+            enabled: !targetIds.isEmpty
+        ) { [weak self] in
+            guard let self else { return }
+            WorkspaceSurfaceIdentifierClipboardText.copyWorkspaceLinks(
+                targetIds,
+                resolvingStableIdsFrom: tabManager.tabs
+            )
+        }
+        if !isMulti {
+            let finderDirectoryPath = WorkspaceFinderDirectoryResolver.path(for: workspace)
+            let finderDirectoryURL = finderDirectoryPath.map {
+                URL(fileURLWithPath: $0, isDirectory: true)
+            }
+            addAction(
+                to: menu,
+                title: String(
+                    localized: "contextMenu.showWorkspaceInFinder",
+                    defaultValue: "Show in Finder"
+                ),
+                enabled: finderDirectoryURL != nil
+            ) {
+                Task { @MainActor in
+                    await WorkspaceFinderDirectoryOpener.openInFinder(finderDirectoryURL)
+                }
+            }
+        }
+
+        removeTrailingSeparator(from: menu)
+        return menu
+    }
+
+    private func appendWorkspacePinItem(
+        to menu: NSMenu,
+        workspaceId: UUID,
+        targetIds: [UUID],
+        isMulti: Bool
+    ) {
+        let pinState = WorkspaceActionDispatcher.pinState(
+            in: tabManager,
+            target: WorkspaceActionDispatcher.Target(
+                workspaceIds: targetIds,
+                anchorWorkspaceId: workspaceId
+            )
+        )
+        let shouldPin = pinState?.pinned ?? true
+        let title: String
+        if shouldPin {
+            title = isMulti
+                ? String(localized: "contextMenu.pinWorkspaces", defaultValue: "Pin Workspaces")
+                : String(localized: "contextMenu.pinWorkspace", defaultValue: "Pin Workspace")
+        } else {
+            title = isMulti
+                ? String(localized: "contextMenu.unpinWorkspaces", defaultValue: "Unpin Workspaces")
+                : String(localized: "contextMenu.unpinWorkspace", defaultValue: "Unpin Workspace")
+        }
+        addAction(to: menu, title: title, enabled: pinState != nil) { [weak self] in
+            guard let self, let pinState else { return }
+            _ = WorkspaceActionDispatcher.performPinAction(pinState, in: tabManager)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+    }
+
+    private func appendWorkspaceGroupItems(
+        to menu: NSMenu,
+        workspaceId: UUID,
+        targetIds: [UUID],
+        isMulti: Bool
+    ) {
+        let canCreateEmpty = tabManager.selectedTab?.isRemoteTmuxMirror != true
+        addAction(
+            to: menu,
+            title: String(
+                localized: "contextMenu.workspaceGroup.newEmpty",
+                defaultValue: "New Empty Workspace Group"
+            ),
+            shortcutAction: .newWorkspaceGroup,
+            enabled: canCreateEmpty
+        ) { [weak self] in
+            guard let self else { return }
+            _ = AppDelegate.shared?.createEmptyWorkspaceGroup(tabManager: tabManager)
+        }
+
+        let anchorIds = Set(tabManager.workspaceGroups.map(\.anchorWorkspaceId))
+        let eligibleIds = targetIds.filter { id in
+            projectionSource.workspaceById[id] != nil && !anchorIds.contains(id)
+        }
+        guard !eligibleIds.isEmpty else { return }
+
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(
+                    localized: "contextMenu.workspaceGroup.newFromSelection",
+                    defaultValue: "New Group from Selection"
+                )
+                : String(
+                    localized: "contextMenu.workspaceGroup.newFromWorkspace",
+                    defaultValue: "New Group from Workspace"
+                ),
+            shortcutAction: .groupSelectedWorkspaces
+        ) { [weak self] in
+            guard let self else { return }
+            tabManager.createWorkspaceGroup(name: "", childWorkspaceIds: eligibleIds)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+
+        let groups = tabManager.workspaceGroups
+        if !groups.isEmpty {
+            let moveMenu = makeBaseMenu()
+            let existingGroupIds = Set(
+                eligibleIds.compactMap { projectionSource.workspaceById[$0]?.groupId }
+            )
+            for group in groups {
+                addAction(
+                    to: moveMenu,
+                    title: group.name,
+                    enabled: existingGroupIds.count != 1 || !existingGroupIds.contains(group.id)
+                ) { [weak self] in
+                    guard let self else { return }
+                    for targetId in eligibleIds {
+                        tabManager.addWorkspaceToGroup(
+                            workspaceId: targetId,
+                            groupId: group.id
+                        )
+                    }
+                    interactionCoordinator.reconcileSelectionAfterMutation()
+                }
+            }
+            addSubmenu(
+                moveMenu,
+                to: menu,
+                title: String(
+                    localized: "contextMenu.workspaceGroup.moveTo",
+                    defaultValue: "Move to Group"
+                )
+            )
+        } else {
+            addAction(
+                to: menu,
+                title: String(
+                    localized: "contextMenu.workspaceGroup.moveTo",
+                    defaultValue: "Move to Group"
+                ),
+                enabled: false
+            ) {}
+        }
+
+        let hasGroupedTarget = eligibleIds.contains {
+            projectionSource.workspaceById[$0]?.groupId != nil
+        }
+        if hasGroupedTarget {
+            addAction(
+                to: menu,
+                title: String(
+                    localized: "contextMenu.workspaceGroup.remove",
+                    defaultValue: "Remove from Group"
+                )
+            ) { [weak self] in
+                guard let self else { return }
+                for targetId in eligibleIds {
+                    tabManager.removeWorkspaceFromGroup(workspaceId: targetId)
+                }
+                interactionCoordinator.reconcileSelectionAfterMutation()
+            }
+        }
+        _ = workspaceId
+    }
+
+    private func appendWorkspaceRemoteItems(
+        to menu: NSMenu,
+        targetIds: [UUID],
+        isMulti: Bool
+    ) {
+        let remoteTargetIds = targetIds.filter { id in
+            guard let workspace = projectionSource.workspaceById[id] else { return false }
+            return workspace.isRemoteWorkspace && !workspace.isManagedCloudVMWorkspace
+        }
+        guard !remoteTargetIds.isEmpty else { return }
+
+        let allConnecting = remoteTargetIds.allSatisfy { id in
+            guard let state = projectionSource.workspaceById[id]?.remoteConnectionState else {
+                return false
+            }
+            return state == .connecting || state == .reconnecting
+        }
+        let allDisconnected = remoteTargetIds.allSatisfy {
+            projectionSource.workspaceById[$0]?.remoteConnectionState == .disconnected
+        }
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(
+                    localized: "contextMenu.reconnectWorkspaces",
+                    defaultValue: "Reconnect Workspaces"
+                )
+                : String(
+                    localized: "contextMenu.reconnectWorkspace",
+                    defaultValue: "Reconnect Workspace"
+                ),
+            enabled: !allConnecting
+        ) { [weak self] in
+            guard let self else { return }
+            for id in remoteTargetIds {
+                interactionCoordinator.reconnectRemoteWorkspace(id)
+            }
+        }
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(
+                    localized: "contextMenu.disconnectWorkspaces",
+                    defaultValue: "Disconnect Workspaces"
+                )
+                : String(
+                    localized: "contextMenu.disconnectWorkspace",
+                    defaultValue: "Disconnect Workspace"
+                ),
+            enabled: !allDisconnected
+        ) { [weak self] in
+            guard let self else { return }
+            for id in remoteTargetIds {
+                tabManager.tabs.first(where: { $0.id == id })?
+                    .disconnectRemoteConnection(clearConfiguration: false)
+            }
+        }
+    }
+
+    private func appendWorkspaceColorMenu(
+        to menu: NSMenu,
+        targetIds: [UUID],
+        customColorHex: String?,
+        activeTabIndicatorStyle: WorkspaceIndicatorStyle
+    ) {
+        let colorMenu = makeBaseMenu()
+        if customColorHex != nil {
+            let title = String(
+                localized: "contextMenu.clearColor",
+                defaultValue: "Clear Color"
+            )
+            let item = addAction(to: colorMenu, title: title) { [weak self] in
+                self?.tabManager.applyWorkspaceColor(nil, toWorkspaceIds: targetIds)
+            }
+            item.image = NSImage(systemSymbolName: "xmark.circle", accessibilityDescription: title)
+        }
+
+        let customTitle = String(
+            localized: "contextMenu.chooseCustomColor",
+            defaultValue: "Choose Custom Color…"
+        )
+        let customItem = addAction(to: colorMenu, title: customTitle) { [weak self] in
+            self?.promptCustomColor(targetIds: targetIds, seedHex: customColorHex)
+        }
+        customItem.image = NSImage(
+            systemSymbolName: "paintpalette",
+            accessibilityDescription: customTitle
+        )
+
+        let palette = WorkspaceTabColorSettings.palette()
+        if !palette.isEmpty {
+            addSeparator(to: colorMenu)
+        }
+        let bestMatch = NSApp?.effectiveAppearance.bestMatch(from: [.darkAqua, .aqua])
+        let colorScheme: ColorScheme = bestMatch == .darkAqua ? .dark : .light
+        for entry in palette {
+            let item = addAction(to: colorMenu, title: entry.name) { [weak self] in
+                self?.tabManager.applyWorkspaceColor(
+                    entry.hex,
+                    toWorkspaceIds: targetIds
+                )
+            }
+            let swatchColor = WorkspaceTabColorSettings.displayNSColor(
+                hex: entry.hex,
+                colorScheme: colorScheme,
+                forceBright: activeTabIndicatorStyle == .leftRail
+            ) ?? NSColor(hex: entry.hex) ?? .gray
+            item.image = coloredCircleImage(color: swatchColor)
+        }
+
+        addSubmenu(
+            colorMenu,
+            to: menu,
+            title: String(
+                localized: "contextMenu.workspaceColor",
+                defaultValue: "Workspace Color"
+            )
+        )
+    }
+
+    private func appendWorkspaceWindowMoveMenu(
+        to menu: NSMenu,
+        targetIds: [UUID],
+        isMulti: Bool
+    ) {
+        let moveMenu = makeBaseMenu()
+        addAction(
+            to: moveMenu,
+            title: String(localized: "contextMenu.newWindow", defaultValue: "New Window"),
+            enabled: !targetIds.isEmpty
+        ) { [weak self] in
+            self?.interactionCoordinator.moveWorkspacesToNewWindow(targetIds)
+        }
+
+        let referenceWindowId = AppDelegate.shared?.windowId(for: tabManager)
+        let windowTargets = AppDelegate.shared?.windowMoveTargets(
+            referenceWindowId: referenceWindowId
+        ) ?? []
+        if !windowTargets.isEmpty {
+            addSeparator(to: moveMenu)
+        }
+        for target in windowTargets {
+            addAction(
+                to: moveMenu,
+                title: target.label,
+                enabled: !target.isCurrentWindow && !targetIds.isEmpty
+            ) { [weak self] in
+                self?.interactionCoordinator.moveWorkspaces(
+                    targetIds,
+                    toWindow: target.windowId
+                )
+            }
+        }
+
+        addSubmenu(
+            moveMenu,
+            to: menu,
+            title: isMulti
+                ? String(
+                    localized: "contextMenu.moveWorkspacesToWindow",
+                    defaultValue: "Move Workspaces to Window"
+                )
+                : String(
+                    localized: "contextMenu.moveWorkspaceToWindow",
+                    defaultValue: "Move Workspace to Window"
+                )
+        )
+    }
+
+    private func promptCustomColor(targetIds: [UUID], seedHex: String?) {
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "alert.customColor.title",
+            defaultValue: "Custom Workspace Color"
+        )
+        alert.informativeText = String(
+            localized: "alert.customColor.message",
+            defaultValue: "Enter a hex color in the format #RRGGBB."
+        )
+
+        let seed = seedHex ?? WorkspaceTabColorSettings.customPaletteEntries().first?.hex ?? ""
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        input.stringValue = seed
+        input.placeholderString = "#1565C0"
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(
+            localized: "alert.customColor.apply",
+            defaultValue: "Apply"
+        ))
+        alert.addButton(withTitle: String(
+            localized: "alert.customColor.cancel",
+            defaultValue: "Cancel"
+        ))
+        alert.window.initialFirstResponder = input
+        input.selectText(nil)
+
+        guard runCmuxModalAlert(alert) == .alertFirstButtonReturn else { return }
+        guard let normalized = WorkspaceTabColorSettings.addCustomColor(input.stringValue) else {
+            showInvalidColorAlert(input.stringValue)
+            return
+        }
+        tabManager.applyWorkspaceColor(normalized, toWorkspaceIds: targetIds)
+    }
+
+    private func showInvalidColorAlert(_ value: String) {
+        let alert = NSAlert()
+        alert.alertStyle = .warning
+        alert.messageText = String(
+            localized: "alert.invalidColor.title",
+            defaultValue: "Invalid Color"
+        )
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty {
+            alert.informativeText = String(
+                localized: "alert.invalidColor.emptyMessage",
+                defaultValue: "Enter a hex color in the format #RRGGBB."
+            )
+        } else {
+            alert.informativeText = String(
+                localized: "alert.invalidColor.invalidMessage",
+                defaultValue: "\"\(trimmed)\" is not a valid hex color. Use #RRGGBB."
+            )
+        }
+        alert.addButton(withTitle: String(
+            localized: "alert.invalidColor.ok",
+            defaultValue: "OK"
+        ))
+        _ = runCmuxModalAlert(alert)
+    }
+
+    /// Resolves todo state only after the native menu opens. The realized row
+    /// keeps an O(1) progress summary, while status targets and checklist items
+    /// are copied only for the workspace the user explicitly invoked.
+    private func appendWorkspaceTodoItems(
+        to menu: NSMenu,
+        workspaceId: UUID,
+        targetIds: [UUID],
+        isMulti: Bool,
+        snapshot: SidebarWorkspaceRowSnapshot
+    ) {
+        let targetWorkspaces = targetIds.compactMap { projectionSource.workspaceById[$0] }
+        let statusMenu = makeBaseMenu()
+        for lane in snapshot.contextMenu.todoStatusLanes {
+            if lane.isNone {
+                addSeparator(to: statusMenu)
+            }
+            addAction(
+                to: statusMenu,
+                title: lane.title,
+                enabled: !targetWorkspaces.isEmpty,
+                state: lane.isSelected ? .on : .off
+            ) {
+                if lane.isNone {
+                    WorkspaceTodoActions.hideStatus(for: targetWorkspaces)
+                } else {
+                    WorkspaceTodoActions.applyStatusOverride(
+                        lane.status,
+                        to: targetWorkspaces
+                    )
+                }
+            }
+            if lane.status == nil, !lane.isNone {
+                addSeparator(to: statusMenu)
+            }
+        }
+        addSubmenu(
+            statusMenu,
+            to: menu,
+            title: String(localized: "contextMenu.workspaceStatus", defaultValue: "Status")
+        )
+
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(
+                    localized: "contextMenu.markWorkspacesDone",
+                    defaultValue: "Mark Workspaces as Done"
+                )
+                : String(
+                    localized: "contextMenu.markWorkspaceDone",
+                    defaultValue: "Mark Workspace as Done"
+                ),
+            shortcutAction: .markWorkspaceDone,
+            enabled: !targetWorkspaces.isEmpty
+        ) {
+            WorkspaceTodoActions.applyStatusOverride(.done, to: targetWorkspaces)
+        }
+
+        addAction(
+            to: menu,
+            title: String(
+                localized: "contextMenu.addChecklistItem",
+                defaultValue: "Add Checklist Item…"
+            )
+        ) {
+            WorkspaceTodoActions.requestChecklistAddField(workspaceId: workspaceId)
+        }
+
+        guard !isMulti,
+              let workspace = projectionSource.workspaceById[workspaceId] else {
+            return
+        }
+
+        if !workspace.todoState.checklist.isEmpty {
+            addSubmenu(
+                checklistMenu(for: workspace),
+                to: menu,
+                title: String(
+                    localized: "sidebar.checklist.popoverTooltip",
+                    defaultValue: "Show checklist"
+                )
+            )
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "sidebar.checklist.openAsPane",
+                defaultValue: "Open as Pane"
+            )
+        ) {
+            if WorkspaceTodoActions.openTodoPane(for: workspace) == nil {
+                NSSound.beep()
+            }
+        }
+    }
+
+    private func checklistMenu(for workspace: Workspace) -> NSMenu {
+        let menu = makeBaseMenu()
+        let orderedItems = SidebarWorkspaceChecklistDisplayPolicy.orderedItems(
+            workspace.todoState.checklist
+        )
+        let display = SidebarWorkspaceChecklistDisplayPolicy.clampedItems(
+            orderedItems,
+            showsAllItems: false
+        )
+        for item in display.visible {
+            let itemMenu = makeBaseMenu()
+            let isCompleted = item.state == .completed
+            addAction(
+                to: itemMenu,
+                title: isCompleted
+                    ? String(
+                        localized: "sidebar.checklist.uncheckTooltip",
+                        defaultValue: "Mark as pending"
+                    )
+                    : String(
+                        localized: "sidebar.checklist.checkTooltip",
+                        defaultValue: "Mark as completed"
+                    )
+            ) {
+                WorkspaceTodoActions.setChecklistItemState(
+                    id: item.id,
+                    state: isCompleted ? .pending : .completed,
+                    in: workspace
+                )
+            }
+            if item.state != .inProgress {
+                addAction(
+                    to: itemMenu,
+                    title: String(
+                        localized: "sidebar.checklist.markInProgress",
+                        defaultValue: "Mark In Progress"
+                    )
+                ) {
+                    WorkspaceTodoActions.setChecklistItemState(
+                        id: item.id,
+                        state: .inProgress,
+                        in: workspace
+                    )
+                }
+            }
+            addSeparator(to: itemMenu)
+            addAction(
+                to: itemMenu,
+                title: String(
+                    localized: "sidebar.checklist.editItem",
+                    defaultValue: "Edit"
+                )
+            ) { [weak self] in
+                self?.promptChecklistItemEdit(item: item, workspace: workspace)
+            }
+            addAction(
+                to: itemMenu,
+                title: String(
+                    localized: "sidebar.checklist.removeItem",
+                    defaultValue: "Remove"
+                )
+            ) {
+                WorkspaceTodoActions.removeChecklistItem(id: item.id, from: workspace)
+            }
+
+            let title = SidebarAppKitCellText.bounded(
+                item.text,
+                maximumCharacters: 256,
+                maximumLines: 1
+            ) ?? item.text
+            let itemEntry = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+            itemEntry.state = isCompleted ? .on : .off
+            itemEntry.submenu = itemMenu
+            menu.addItem(itemEntry)
+        }
+        if display.hiddenCount > 0 {
+            addAction(
+                to: menu,
+                title: String.localizedStringWithFormat(
+                    String(
+                        localized: "sidebar.checklist.moreItems",
+                        defaultValue: "… %lld more"
+                    ),
+                    Int64(display.hiddenCount)
+                ),
+                enabled: false
+            ) {}
+        }
+        return menu
+    }
+
+    /// Shared entry for context-menu and command-palette add requests while
+    /// the AppKit sidebar is mounted.
+    func requestChecklistAdd(workspaceId: UUID) {
+        guard let workspace = projectionSource.workspaceById[workspaceId] else { return }
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "contextMenu.addChecklistItem",
+            defaultValue: "Add Checklist Item…"
+        )
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        input.placeholderString = String(
+            localized: "sidebar.checklist.addItemPlaceholder",
+            defaultValue: "New checklist item"
+        )
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+        alert.window.initialFirstResponder = input
+        guard runCmuxModalAlert(alert) == .alertFirstButtonReturn else { return }
+        if !WorkspaceTodoActions.addChecklistItem(text: input.stringValue, to: workspace) {
+            NSSound.beep()
+        }
+    }
+
+    private func promptChecklistItemEdit(
+        item: WorkspaceChecklistItem,
+        workspace: Workspace
+    ) {
+        guard workspace.todoState.checklist.contains(where: { $0.id == item.id }) else { return }
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "sidebar.checklist.editItem",
+            defaultValue: "Edit"
+        )
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 300, height: 24))
+        input.stringValue = item.text
+        input.placeholderString = String(
+            localized: "sidebar.checklist.editItemPlaceholder",
+            defaultValue: "Item text"
+        )
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+        alert.window.initialFirstResponder = input
+        input.selectText(nil)
+        guard runCmuxModalAlert(alert) == .alertFirstButtonReturn else { return }
+        WorkspaceTodoActions.editChecklistItem(
+            id: item.id,
+            text: input.stringValue,
+            in: workspace
+        )
+    }
+
+    private func appendWorkspaceNotificationItems(
+        to menu: NSMenu,
+        targetIds: [UUID],
+        isMulti: Bool
+    ) {
+        addSeparator(to: menu)
+        let canMarkRead = notificationStore.canMarkWorkspaceRead(forTabIds: targetIds)
+        let canMarkUnread = notificationStore.canMarkWorkspaceUnread(forTabIds: targetIds)
+        let hasLatest = targetIds.contains {
+            notificationStore.latestNotification(forTabId: $0) != nil
+        }
+
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(localized: "contextMenu.markWorkspacesRead", defaultValue: "Mark Workspaces as Read")
+                : String(localized: "contextMenu.markWorkspaceRead", defaultValue: "Mark Workspace as Read"),
+            enabled: canMarkRead
+        ) { [weak self] in
+            guard let self else { return }
+            for id in targetIds where notificationStore.canMarkWorkspaceRead(forTabIds: [id]) {
+                notificationStore.markRead(forTabId: id)
+            }
+        }
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(localized: "contextMenu.markWorkspacesUnread", defaultValue: "Mark Workspaces as Unread")
+                : String(localized: "contextMenu.markWorkspaceUnread", defaultValue: "Mark Workspace as Unread"),
+            enabled: canMarkUnread
+        ) { [weak self] in
+            guard let self else { return }
+            for id in targetIds where notificationStore.canMarkWorkspaceUnread(forTabIds: [id]) {
+                notificationStore.markUnread(forTabId: id)
+            }
+        }
+        addAction(
+            to: menu,
+            title: isMulti
+                ? String(
+                    localized: "contextMenu.clearLatestNotifications",
+                    defaultValue: "Clear Latest Notifications"
+                )
+                : String(
+                    localized: "contextMenu.clearLatestNotification",
+                    defaultValue: "Clear Latest Notification"
+                ),
+            enabled: hasLatest
+        ) { [weak self] in
+            guard let self else { return }
+            for id in targetIds {
+                notificationStore.clearLatestNotification(forTabId: id)
+            }
+        }
+
+        let notificationsMenu = makeBaseMenu()
+        let notifications = notificationStore.notifications(forTabIds: targetIds)
+        if notifications.isEmpty {
+            addAction(
+                to: notificationsMenu,
+                title: String(
+                    localized: "contextMenu.notifications.empty",
+                    defaultValue: "No Notifications"
+                ),
+                enabled: false
+            ) {}
+        } else {
+            for notification in notifications {
+                addAction(
+                    to: notificationsMenu,
+                    title: workspaceNotificationMenuTitle(notification)
+                ) {
+                    if AppDelegate.shared?.openTerminalNotification(notification) != true {
+                        NSSound.beep()
+                    }
+                }
+            }
+        }
+        addSubmenu(
+            notificationsMenu,
+            to: menu,
+            title: String(
+                localized: "contextMenu.notifications",
+                defaultValue: "Notifications"
+            )
+        )
+    }
+
+    private func workspaceNotificationMenuTitle(_ notification: TerminalNotification) -> String {
+        let timeText = notification.createdAt.formatted(date: .abbreviated, time: .shortened)
+        let title = workspaceNotificationMenuText(notification.title, limit: 80)
+        let detail = workspaceNotificationMenuText(
+            notification.body.isEmpty ? notification.subtitle : notification.body,
+            limit: 120
+        )
+        let readPrefix = notification.isRead ? "" : "• "
+        let firstLine = title.isEmpty
+            ? "\(readPrefix)\(timeText)"
+            : "\(readPrefix)\(timeText)  \(title)"
+        guard !detail.isEmpty else { return firstLine }
+        return "\(firstLine)\n\(detail)"
+    }
+
+    private func workspaceNotificationMenuText(_ value: String, limit: Int) -> String {
+        let firstLine = value.split(whereSeparator: \.isNewline).first.map(String.init) ?? value
+        let trimmed = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > limit else { return trimmed }
+        let prefix = String(trimmed.prefix(limit)).trimmingCharacters(in: .whitespacesAndNewlines)
+        return "\(prefix)..."
+    }
+
+    private func appendWorkspaceDetailLinks(
+        to menu: NSMenu,
+        workspaceId: UUID,
+        snapshot: SidebarWorkspaceRowSnapshot
+    ) {
+        let workspace = snapshot.workspace
+        let visibility = snapshot.settings.visibleAuxiliaryDetails
+        var addedLink = false
+
+        if visibility.showsPullRequests {
+            for pullRequest in workspace.pullRequestRows {
+                if !addedLink {
+                    addSeparator(to: menu)
+                    addedLink = true
+                }
+                addAction(
+                    to: menu,
+                    title: String(
+                        localized: "sidebar.pullRequest.openTooltip",
+                        defaultValue: "Open \(pullRequest.label) #\(pullRequest.number)"
+                    )
+                ) { [weak self] in
+                    self?.interactionCoordinator.openURL(
+                        pullRequest.url,
+                        fromWorkspace: workspaceId
+                    )
+                }
+            }
+        }
+
+        if visibility.showsPorts {
+            for port in workspace.listeningPorts {
+                if !addedLink {
+                    addSeparator(to: menu)
+                    addedLink = true
+                }
+                addAction(
+                    to: menu,
+                    title: SidebarPortDisplayText.openTooltip(for: port)
+                ) { [weak self] in
+                    self?.interactionCoordinator.openPort(port, fromWorkspace: workspaceId)
+                }
+            }
+        }
+    }
+
+    /// Builds the plus button's compact menu from live group config only after
+    /// AppKit requests a context menu for that control.
+    func groupAddButtonMenu(
+        groupId: UUID,
+        event _: NSEvent? = nil
+    ) -> NSMenu? {
+        guard let group = projectionSource.groupById[groupId],
+              projectionSource.workspaceById[group.anchorWorkspaceId] != nil else {
+            return nil
+        }
+        let menu = makeBaseMenu()
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.plus.contextMenu.newWorkspace",
+                defaultValue: "New Workspace in Group"
+            )
+        ) { [weak self] in
+            self?.interactionCoordinator.addWorkspace(toGroup: groupId)
+        }
+        appendWorkspaceGroupConfigurationItems(
+            to: menu,
+            groupId: groupId,
+            usesAddButtonLabels: true
+        )
+        removeTrailingSeparator(from: menu)
+        return menu
+    }
+
+    private func groupMenu(groupId: UUID, anchorWorkspaceId: UUID) -> NSMenu? {
+        guard let group = projectionSource.groupById[groupId],
+              projectionSource.workspaceById[anchorWorkspaceId] != nil else {
+            return nil
+        }
+        let memberIds = tabManager.tabs.compactMap {
+            $0.groupId == groupId ? $0.id : nil
+        }
+        let nonAnchorMemberIds = memberIds.filter { $0 != anchorWorkspaceId }
+        let menu = makeBaseMenu()
+
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.plus.contextMenu.newWorkspace",
+                defaultValue: "New Workspace in Group"
+            )
+        ) { [weak self] in
+            self?.interactionCoordinator.addWorkspace(toGroup: groupId)
+        }
+        addAction(
+            to: menu,
+            title: group.isCollapsed
+                ? String(localized: "workspaceGroup.expand.a11y", defaultValue: "Expand group")
+                : String(localized: "workspaceGroup.collapse.a11y", defaultValue: "Collapse group")
+        ) { [weak self] in
+            self?.interactionCoordinator.toggleGroupCollapsed(groupId)
+        }
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.rename",
+                defaultValue: "Rename Group…"
+            )
+        ) { [weak self] in
+            self?.promptGroupRename(groupId: groupId)
+        }
+        addAction(
+            to: menu,
+            title: group.isPinned
+                ? String(
+                    localized: "workspaceGroup.contextMenu.unpin",
+                    defaultValue: "Unpin Group"
+                )
+                : String(
+                    localized: "workspaceGroup.contextMenu.pin",
+                    defaultValue: "Pin Group"
+                )
+        ) { [weak self] in
+            guard let self else { return }
+            tabManager.toggleWorkspaceGroupPinned(groupId: groupId)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.markRead",
+                defaultValue: "Mark Group as Read"
+            ),
+            enabled: notificationStore.canMarkWorkspaceRead(forTabIds: [anchorWorkspaceId])
+        ) { [weak self] in
+            guard let self,
+                  notificationStore.canMarkWorkspaceRead(forTabIds: [anchorWorkspaceId]) else {
+                return
+            }
+            notificationStore.markRead(forTabId: anchorWorkspaceId)
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.markUnread",
+                defaultValue: "Mark Group as Unread"
+            ),
+            enabled: notificationStore.canMarkWorkspaceUnread(forTabIds: [anchorWorkspaceId])
+        ) { [weak self] in
+            guard let self,
+                  notificationStore.canMarkWorkspaceUnread(forTabIds: [anchorWorkspaceId]) else {
+                return
+            }
+            notificationStore.markUnread(forTabId: anchorWorkspaceId)
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.clearLatestNotifications",
+                defaultValue: "Clear Latest Notifications"
+            ),
+            enabled: notificationStore.latestNotification(forTabId: anchorWorkspaceId) != nil
+        ) { [weak self] in
+            self?.notificationStore.clearLatestNotification(forTabId: anchorWorkspaceId)
+        }
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.markAllRead",
+                defaultValue: "Mark All Workspaces in Group as Read"
+            ),
+            enabled: notificationStore.canMarkWorkspaceRead(forTabIds: nonAnchorMemberIds)
+        ) { [weak self] in
+            guard let self else { return }
+            let liveIds = tabManager.tabs.compactMap {
+                $0.groupId == groupId && $0.id != anchorWorkspaceId ? $0.id : nil
+            }
+            for id in liveIds where notificationStore.canMarkWorkspaceRead(forTabIds: [id]) {
+                notificationStore.markRead(forTabId: id)
+            }
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.markAllUnread",
+                defaultValue: "Mark All Workspaces in Group as Unread"
+            ),
+            enabled: notificationStore.canMarkWorkspaceUnread(forTabIds: nonAnchorMemberIds)
+        ) { [weak self] in
+            guard let self else { return }
+            let liveIds = tabManager.tabs.compactMap {
+                $0.groupId == groupId && $0.id != anchorWorkspaceId ? $0.id : nil
+            }
+            for id in liveIds where notificationStore.canMarkWorkspaceUnread(forTabIds: [id]) {
+                notificationStore.markUnread(forTabId: id)
+            }
+        }
+
+        appendWorkspaceGroupConfigurationItems(
+            to: menu,
+            groupId: groupId,
+            usesAddButtonLabels: false
+        )
+
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.ungroup",
+                defaultValue: "Ungroup Workspaces"
+            )
+        ) { [weak self] in
+            guard let self else { return }
+            tabManager.ungroupWorkspaceGroup(groupId: groupId)
+            interactionCoordinator.reconcileSelectionAfterMutation()
+        }
+        addAction(
+            to: menu,
+            title: String(
+                localized: "workspaceGroup.contextMenu.delete",
+                defaultValue: "Delete Group"
+            )
+        ) { [weak self] in
+            self?.deleteGroup(groupId: groupId)
+        }
+
+        removeTrailingSeparator(from: menu)
+        return menu
+    }
+
+    private func appendWorkspaceGroupConfigurationItems(
+        to menu: NSMenu,
+        groupId: UUID,
+        usesAddButtonLabels: Bool
+    ) {
+        appendResolvedWorkspaceGroupActions(to: menu, groupId: groupId)
+        addSeparator(to: menu)
+        addAction(
+            to: menu,
+            title: usesAddButtonLabels
+                ? String(
+                    localized: "workspaceGroup.plus.contextMenu.editConfig",
+                    defaultValue: "Edit Group Config…"
+                )
+                : String(
+                    localized: "workspaceGroup.contextMenu.editConfig",
+                    defaultValue: "Edit Group Config…"
+                )
+        ) {
+            SidebarWorkspaceGroupConfigOpener.openCmuxConfigInEditor()
+        }
+        addAction(
+            to: menu,
+            title: usesAddButtonLabels
+                ? String(
+                    localized: "workspaceGroup.plus.contextMenu.openDocs",
+                    defaultValue: "Open Workspace Groups Docs"
+                )
+                : String(
+                    localized: "workspaceGroup.contextMenu.openDocs",
+                    defaultValue: "Open Workspace Groups Docs"
+                )
+        ) {
+            SidebarWorkspaceGroupConfigOpener.openWorkspaceGroupsDocs()
+        }
+    }
+
+    private func appendResolvedWorkspaceGroupActions(
+        to menu: NSMenu,
+        groupId: UUID
+    ) {
+        guard let snapshot = projectionSource.groupSnapshot(groupId: groupId) else { return }
+        var hasAction = false
+        for item in snapshot.cwdContextMenuItems {
+            switch item {
+            case .separator:
+                guard hasAction else { continue }
+                addSeparator(to: menu)
+            case .action(let action):
+                if !hasAction {
+                    addSeparator(to: menu)
+                    hasAction = true
+                }
+                addAction(to: menu, title: action.title) { [weak self] in
+                    guard let self else { return }
+                    SidebarWorkspaceGroupContextMenuRunner.run(
+                        item: action,
+                        tabManager: tabManager,
+                        groupId: groupId
+                    )
+                }
+            }
+        }
+        if hasAction {
+            removeTrailingSeparator(from: menu)
+        }
+    }
+
+    private func promptWorkspaceRename(workspaceId: UUID) {
+        guard let workspace = projectionSource.workspaceById[workspaceId] else { return }
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "alert.renameWorkspace.title",
+            defaultValue: "Rename Workspace"
+        )
+        alert.informativeText = String(
+            localized: "alert.renameWorkspace.message",
+            defaultValue: "Enter a custom name for this workspace."
+        )
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        input.stringValue = workspace.customTitle ?? workspace.title
+        input.placeholderString = String(
+            localized: "alert.renameWorkspace.placeholder",
+            defaultValue: "Workspace name"
+        )
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(
+            localized: "alert.renameWorkspace.rename",
+            defaultValue: "Rename"
+        ))
+        alert.addButton(withTitle: String(
+            localized: "alert.renameWorkspace.cancel",
+            defaultValue: "Cancel"
+        ))
+        alert.window.initialFirstResponder = input
+        input.selectText(nil)
+        guard runCmuxModalAlert(alert) == .alertFirstButtonReturn else { return }
+        interactionCoordinator.renameWorkspace(workspaceId, to: input.stringValue)
+    }
+
+    private func promptWorkspaceDescriptionEdit(workspaceId: UUID) {
+        guard let workspace = projectionSource.workspaceById[workspaceId] else { return }
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "command.editWorkspaceDescription.title",
+            defaultValue: "Edit Workspace Description…"
+        )
+        alert.informativeText = String(
+            localized: "commandPalette.description.workspaceInputHint",
+            defaultValue: "Press Enter to save. Press Shift-Enter for a new line, or Escape to cancel."
+        )
+
+        let scrollView = NSScrollView(frame: NSRect(x: 0, y: 0, width: 360, height: 120))
+        scrollView.borderType = .bezelBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        let editor = NSTextView(frame: scrollView.contentView.bounds)
+        editor.isRichText = false
+        editor.isAutomaticQuoteSubstitutionEnabled = false
+        editor.isAutomaticDashSubstitutionEnabled = false
+        editor.font = .systemFont(ofSize: 13)
+        editor.string = workspace.customDescription ?? ""
+        editor.autoresizingMask = [.width]
+        scrollView.documentView = editor
+        alert.accessoryView = scrollView
+        alert.addButton(withTitle: String(localized: "common.ok", defaultValue: "OK"))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+        alert.window.initialFirstResponder = editor
+        guard runCmuxModalAlert(alert) == .alertFirstButtonReturn else { return }
+        tabManager.setCustomDescription(tabId: workspaceId, description: editor.string)
+    }
+
+    private func promptGroupRename(groupId: UUID) {
+        guard let group = projectionSource.groupById[groupId] else { return }
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "workspaceGroup.rename.title",
+            defaultValue: "Rename Group"
+        )
+        alert.informativeText = String(
+            localized: "workspaceGroup.rename.message",
+            defaultValue: "Enter a new name for this group."
+        )
+        let input = NSTextField(frame: NSRect(x: 0, y: 0, width: 240, height: 24))
+        input.stringValue = group.name
+        input.placeholderString = String(
+            localized: "workspaceGroup.rename.placeholder",
+            defaultValue: "Group name"
+        )
+        alert.accessoryView = input
+        alert.addButton(withTitle: String(
+            localized: "workspaceGroup.rename.confirm",
+            defaultValue: "Rename"
+        ))
+        alert.addButton(withTitle: String(localized: "common.cancel", defaultValue: "Cancel"))
+        alert.window.initialFirstResponder = input
+        input.selectText(nil)
+        guard runCmuxModalAlert(alert) == .alertFirstButtonReturn else { return }
+        tabManager.renameWorkspaceGroup(groupId: groupId, name: input.stringValue)
+    }
+
+    private func deleteGroup(groupId: UUID) {
+        guard let group = projectionSource.groupById[groupId],
+              let confirmation = tabManager.workspaceGrouping.deletionConfirmation(
+                groupId: groupId,
+                fallbackGroupName: group.name,
+                fallbackAnchorWorkspaceId: group.anchorWorkspaceId
+              ) else {
+            return
+        }
+        if confirmation.containedWorkspaceCount > 0,
+           !confirmDeleteWorkspaceGroup(
+                groupName: confirmation.groupName,
+                memberCount: confirmation.containedWorkspaceCount
+           ) {
+            return
+        }
+        tabManager.workspaceGrouping.deleteWorkspaceGroup(confirmed: confirmation)
+        interactionCoordinator.reconcileSelectionAfterMutation()
+    }
+
+    private func makeBaseMenu() -> NSMenu {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+        return menu
+    }
+
+    @discardableResult
+    private func addAction(
+        to menu: NSMenu,
+        title: String,
+        shortcutAction: KeyboardShortcutSettings.Action? = nil,
+        enabled: Bool = true,
+        state: NSControl.StateValue = .off,
+        action: @escaping @MainActor () -> Void
+    ) -> NSMenuItem {
+        let item = NSMenuItem(
+            title: title,
+            action: #selector(performMenuAction(_:)),
+            keyEquivalent: ""
+        )
+        item.target = self
+        item.representedObject = ActionBox(action)
+        item.isEnabled = enabled
+        item.state = state
+        if let shortcutAction {
+            let shortcut = KeyboardShortcutSettings.shortcut(for: shortcutAction)
+            if let keyEquivalent = shortcut.menuItemKeyEquivalent {
+                item.keyEquivalent = keyEquivalent
+                item.keyEquivalentModifierMask = shortcut.modifierFlags
+            }
+        }
+        menu.addItem(item)
+        return item
+    }
+
+    private func addSubmenu(_ submenu: NSMenu, to menu: NSMenu, title: String) {
+        let item = NSMenuItem(title: title, action: nil, keyEquivalent: "")
+        item.submenu = submenu
+        item.isEnabled = true
+        menu.addItem(item)
+    }
+
+    private func addSeparator(to menu: NSMenu) {
+        guard let last = menu.items.last, !last.isSeparatorItem else { return }
+        menu.addItem(.separator())
+    }
+
+    private func removeTrailingSeparator(from menu: NSMenu) {
+        if menu.items.last?.isSeparatorItem == true {
+            menu.removeItem(at: menu.items.count - 1)
+        }
+    }
+
+    @objc private func performMenuAction(_ sender: NSMenuItem) {
+        (sender.representedObject as? ActionBox)?.action()
+    }
+
+    @MainActor
+    private final class ActionBox: NSObject {
+        let action: @MainActor () -> Void
+
+        init(_ action: @escaping @MainActor () -> Void) {
+            self.action = action
+        }
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitContextMenuController.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitContextMenuController.swift
@@ -2,6 +2,7 @@ import AppKit
 import CmuxSettings
 import CmuxWorkspaces
 import Foundation
+import SwiftUI
 
 /// Builds native sidebar context menus from live state at menu-open time.
 ///

--- a/Sources/Sidebar/AppKit/SidebarAppKitDragCoordinator.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitDragCoordinator.swift
@@ -46,6 +46,7 @@ final class SidebarAppKitDragCoordinator {
     }
 
     /// Immutable model and synthetic row geometry used by one drag session.
+    @MainActor
     private struct SessionSnapshot {
         let workspaces: [SidebarWorkspaceReorderWorkspaceSnapshot]
         let workspaceById: [UUID: SidebarWorkspaceReorderWorkspaceSnapshot]

--- a/Sources/Sidebar/AppKit/SidebarAppKitDragCoordinator.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitDragCoordinator.swift
@@ -1,0 +1,922 @@
+import AppKit
+import CmuxFoundation
+import CmuxSidebar
+import Foundation
+
+/// Owns native table drag/drop without putting live workspace scans on the
+/// pointer-update path.
+///
+/// A native workspace drag snapshots the destination rows once when AppKit
+/// starts the session. Validation then resolves the proposed row through
+/// constant-time dictionaries. The full reorder resolver runs only after
+/// AppKit accepts the drop.
+@MainActor
+final class SidebarAppKitDragCoordinator {
+    struct StateAccess {
+        var selectedWorkspaceIds: () -> Set<UUID>
+        var setSelectedWorkspaceIds: (Set<UUID>) -> Void
+        var lastSelectionIndex: () -> Int?
+        var setLastSelectionIndex: (Int?) -> Void
+        var selectTabsPage: () -> Void
+    }
+
+    private struct MovingWorkspace {
+        let id: UUID
+        let isPinned: Bool
+    }
+
+    @MainActor
+    private final class OriginMetadata {
+        let draggedWorkspaceId: UUID
+        let draggedIsPinned: Bool
+        let isGroupAnchor: Bool
+        let movingWorkspaces: [MovingWorkspace]
+
+        init(
+            draggedWorkspaceId: UUID,
+            draggedIsPinned: Bool,
+            isGroupAnchor: Bool,
+            movingWorkspaces: [MovingWorkspace]
+        ) {
+            self.draggedWorkspaceId = draggedWorkspaceId
+            self.draggedIsPinned = draggedIsPinned
+            self.isGroupAnchor = isGroupAnchor
+            self.movingWorkspaces = movingWorkspaces
+        }
+    }
+
+    /// Immutable model and synthetic row geometry used by one drag session.
+    private struct SessionSnapshot {
+        let workspaces: [SidebarWorkspaceReorderWorkspaceSnapshot]
+        let workspaceById: [UUID: SidebarWorkspaceReorderWorkspaceSnapshot]
+        let workspaceIds: [UUID]
+        let groups: [SidebarWorkspaceReorderGroupSnapshot]
+        let groupAnchorIds: Set<UUID>
+        let targets: [SidebarWorkspaceReorderDropTarget]
+        let targetByItemId: [SidebarWorkspaceRenderItemID: SidebarWorkspaceReorderDropTarget]
+        let targetIndexByItemId: [SidebarWorkspaceRenderItemID: Int]
+        let workspaceIdByItemId: [SidebarWorkspaceRenderItemID: UUID]
+        let visiblePinnedTargetCount: Int
+
+        init(
+            tabManager: TabManager,
+            renderItems: [SidebarWorkspaceRenderItem]
+        ) {
+            let workspaceSnapshots = tabManager.tabs.map {
+                SidebarWorkspaceReorderWorkspaceSnapshot(
+                    id: $0.id,
+                    isPinned: $0.isPinned,
+                    groupId: $0.groupId
+                )
+            }
+            let workspaceById = Dictionary(
+                uniqueKeysWithValues: workspaceSnapshots.map { ($0.id, $0) }
+            )
+            let groupSnapshots = tabManager.workspaceGroups.map {
+                SidebarWorkspaceReorderGroupSnapshot(
+                    id: $0.id,
+                    anchorWorkspaceId: $0.anchorWorkspaceId,
+                    isPinned: $0.isPinned
+                )
+            }
+            let groupById = Dictionary(
+                uniqueKeysWithValues: groupSnapshots.map { ($0.id, $0) }
+            )
+
+            var targets: [SidebarWorkspaceReorderDropTarget] = []
+            targets.reserveCapacity(renderItems.count)
+            var targetByItemId: [
+                SidebarWorkspaceRenderItemID: SidebarWorkspaceReorderDropTarget
+            ] = [:]
+            targetByItemId.reserveCapacity(renderItems.count)
+            var targetIndexByItemId: [SidebarWorkspaceRenderItemID: Int] = [:]
+            targetIndexByItemId.reserveCapacity(renderItems.count)
+            var workspaceIdByItemId: [SidebarWorkspaceRenderItemID: UUID] = [:]
+            workspaceIdByItemId.reserveCapacity(renderItems.count)
+            var visiblePinnedTargetCount = 0
+
+            for (row, item) in renderItems.enumerated() {
+                let workspaceId = item.rowWorkspaceId
+                let groupId: UUID?
+                let isGroupHeader: Bool
+                let isPinned: Bool
+                switch item {
+                case .groupHeader(let itemGroupId, _):
+                    groupId = itemGroupId
+                    isGroupHeader = true
+                    isPinned = groupById[itemGroupId]?.isPinned ?? false
+                case .workspace:
+                    groupId = workspaceById[workspaceId]?.groupId
+                    isGroupHeader = false
+                    isPinned = workspaceById[workspaceId]?.isPinned ?? false
+                }
+
+                let target = SidebarWorkspaceReorderDropTarget(
+                    workspaceId: workspaceId,
+                    groupId: groupId,
+                    isGroupHeader: isGroupHeader,
+                    frame: CGRect(x: 0, y: CGFloat(row), width: 2, height: 1)
+                )
+                targets.append(target)
+                targetByItemId[item.id] = target
+                targetIndexByItemId[item.id] = row
+                workspaceIdByItemId[item.id] = workspaceId
+                if isPinned {
+                    visiblePinnedTargetCount += 1
+                }
+            }
+
+            self.workspaces = workspaceSnapshots
+            self.workspaceById = workspaceById
+            workspaceIds = workspaceSnapshots.map(\.id)
+            groups = groupSnapshots
+            groupAnchorIds = Set(groupSnapshots.map(\.anchorWorkspaceId))
+            self.targets = targets
+            self.targetByItemId = targetByItemId
+            self.targetIndexByItemId = targetIndexByItemId
+            self.workspaceIdByItemId = workspaceIdByItemId
+            self.visiblePinnedTargetCount = visiblePinnedTargetCount
+        }
+    }
+
+    private struct ActiveSession {
+        let draggedWorkspaceId: UUID
+        let snapshot: SessionSnapshot
+        let selectionBeforeReorder: Set<UUID>
+        let preferredAnchorWorkspaceId: UUID?
+    }
+
+    private enum ProposalKind {
+        case workspace(UUID)
+        case bonsplit
+    }
+
+    private struct ProposedDrop {
+        let kind: ProposalKind
+        let itemId: SidebarWorkspaceRenderItemID?
+        let row: Int
+        let operation: NSTableView.DropOperation
+    }
+
+    private static let workspacePasteboardType = NSPasteboard.PasteboardType(
+        SidebarTabDragPayload.typeIdentifier
+    )
+    private static let bonsplitPasteboardType = NSPasteboard.PasteboardType(
+        BonsplitTabDragPayload.typeIdentifier
+    )
+
+    /// The process has at most one sidebar workspace drag at a time. This
+    /// augments the shared id registry with immutable source-window metadata so
+    /// destination validation does not search every window on each pointer tick.
+    private static var originMetadata: OriginMetadata?
+
+    private let tabManager: TabManager
+    private let projectionSource: SidebarAppKitProjectionSource
+    private let windowId: UUID
+    private let workspaceDragRegistry: any SidebarWorkspaceDragRegistering
+    private var state: StateAccess
+    private var activeSession: ActiveSession?
+    private var proposedDrop: ProposedDrop?
+
+    /// Lightweight counters allow scale tests to prove that pointer movement
+    /// neither rebuilds the session snapshot nor invokes the reorder resolver.
+    private(set) var sessionSnapshotBuildCount = 0
+    private(set) var reorderResolverInvocationCount = 0
+
+    init(
+        tabManager: TabManager,
+        projectionSource: SidebarAppKitProjectionSource,
+        windowId: UUID,
+        workspaceDragRegistry: any SidebarWorkspaceDragRegistering,
+        state: StateAccess
+    ) {
+        self.tabManager = tabManager
+        self.projectionSource = projectionSource
+        self.windowId = windowId
+        self.workspaceDragRegistry = workspaceDragRegistry
+        self.state = state
+    }
+
+    func updateStateAccess(_ state: StateAccess) {
+        self.state = state
+    }
+
+    /// Ends a native drag owned by this coordinator. Runtime teardown can call
+    /// this even when no drag is active without disturbing another window's
+    /// source session.
+    func cancelActiveDrag() {
+        guard let draggedWorkspaceId = activeSession?.draggedWorkspaceId else {
+            proposedDrop = nil
+            return
+        }
+        finishWorkspaceDrag(draggedWorkspaceId)
+    }
+
+    func dragHandlers() -> SidebarAppKitConfiguration.DragHandlers {
+        SidebarAppKitConfiguration.DragHandlers(
+            registeredTypes: [
+                Self.workspacePasteboardType,
+                Self.bonsplitPasteboardType,
+            ],
+            localSourceOperationMask: .move,
+            externalSourceOperationMask: [],
+            pasteboardWriter: { [weak self] item in
+                self?.pasteboardWriter(for: item)
+            },
+            validateDrop: { [weak self] info, item, row, operation in
+                self?.validateDrop(
+                    info,
+                    proposedItem: item,
+                    row: row,
+                    operation: operation
+                ) ?? []
+            },
+            acceptDrop: { [weak self] info, item, row, operation in
+                self?.acceptDrop(
+                    info,
+                    proposedItem: item,
+                    row: row,
+                    operation: operation
+                ) ?? false
+            },
+            dragSessionBegan: { [weak self] session, itemIds in
+                self?.dragSessionBegan(session, itemIds: itemIds)
+            },
+            dragSessionEnded: { [weak self] session, point, operation in
+                self?.dragSessionEnded(session, point: point, operation: operation)
+            },
+            updateDraggingItems: { [weak self] info in
+                self?.updateDraggingItems(info)
+            }
+        )
+    }
+
+    private func pasteboardWriter(
+        for item: SidebarWorkspaceRenderItem
+    ) -> (any NSPasteboardWriting)? {
+        let payload = "\(SidebarTabDragPayload.prefix)\(item.rowWorkspaceId.uuidString)"
+        let pasteboardItem = NSPasteboardItem()
+        guard pasteboardItem.setData(
+            Data(payload.utf8),
+            forType: Self.workspacePasteboardType
+        ) else {
+            return nil
+        }
+        return pasteboardItem
+    }
+
+    private func dragSessionBegan(
+        _ session: NSDraggingSession,
+        itemIds: [SidebarWorkspaceRenderItemID]
+    ) {
+        _ = session
+        let snapshot = makeSessionSnapshot()
+        var draggedWorkspaceId: UUID?
+        for itemId in itemIds {
+            if let workspaceId = snapshot.workspaceIdByItemId[itemId] {
+                draggedWorkspaceId = workspaceId
+                break
+            }
+        }
+        guard let draggedWorkspaceId,
+              let draggedWorkspace = snapshot.workspaceById[draggedWorkspaceId] else {
+            return
+        }
+
+        let selectionBeforeReorder = state.selectedWorkspaceIds()
+        let preferredAnchorWorkspaceId = SidebarWorkspaceSelectionSyncPolicy()
+            .anchorWorkspaceId(
+                existingAnchorIndex: state.lastSelectionIndex(),
+                liveWorkspaceIds: snapshot.workspaceIds
+            )
+        activeSession = ActiveSession(
+            draggedWorkspaceId: draggedWorkspaceId,
+            snapshot: snapshot,
+            selectionBeforeReorder: selectionBeforeReorder,
+            preferredAnchorWorkspaceId: preferredAnchorWorkspaceId
+        )
+        Self.originMetadata = makeOriginMetadata(
+            draggedWorkspaceId: draggedWorkspaceId,
+            draggedIsPinned: draggedWorkspace.isPinned,
+            groupAnchorIds: snapshot.groupAnchorIds,
+            workspaces: snapshot.workspaces,
+            selectedWorkspaceIds: selectionBeforeReorder
+        )
+        workspaceDragRegistry.begin(workspaceId: draggedWorkspaceId)
+        SidebarDragLifecycleNotification().postStateDidChange(
+            tabId: draggedWorkspaceId,
+            reason: "appkit_drag_begin"
+        )
+    }
+
+    private func dragSessionEnded(
+        _ session: NSDraggingSession,
+        point: NSPoint,
+        operation: NSDragOperation
+    ) {
+        _ = session
+        _ = point
+        _ = operation
+        guard let draggedWorkspaceId = activeSession?.draggedWorkspaceId else {
+            proposedDrop = nil
+            return
+        }
+        finishWorkspaceDrag(draggedWorkspaceId)
+    }
+
+    private func validateDrop(
+        _ info: NSDraggingInfo,
+        proposedItem: SidebarWorkspaceRenderItem?,
+        row: Int,
+        operation: NSTableView.DropOperation
+    ) -> NSDragOperation {
+        if let proposal = workspaceProposal(
+            info,
+            proposedItem: proposedItem,
+            row: row,
+            operation: operation
+        ) {
+            proposedDrop = proposal
+            return .move
+        }
+        if let proposal = bonsplitProposal(
+            info,
+            proposedItem: proposedItem,
+            row: row,
+            operation: operation
+        ) {
+            proposedDrop = proposal
+            return .move
+        }
+        proposedDrop = nil
+        return []
+    }
+
+    /// NSTableView already carries the proposed row and operation through
+    /// `validateDrop`. Keep this callback constant-time and let AppKit update
+    /// its native insertion marker from the cached proposal.
+    private func updateDraggingItems(_ info: NSDraggingInfo) {
+        _ = info.draggingSequenceNumber
+        _ = proposedDrop
+    }
+
+    private func acceptDrop(
+        _ info: NSDraggingInfo,
+        proposedItem: SidebarWorkspaceRenderItem?,
+        row: Int,
+        operation: NSTableView.DropOperation
+    ) -> Bool {
+        if let proposal = workspaceProposal(
+            info,
+            proposedItem: proposedItem,
+            row: row,
+            operation: operation
+        ) {
+            proposedDrop = proposal
+            return acceptWorkspaceDrop(proposal)
+        }
+        if let proposal = bonsplitProposal(
+            info,
+            proposedItem: proposedItem,
+            row: row,
+            operation: operation
+        ) {
+            proposedDrop = proposal
+            return acceptBonsplitDrop(info, proposal: proposal)
+        }
+        proposedDrop = nil
+        return false
+    }
+
+    private func workspaceProposal(
+        _ info: NSDraggingInfo,
+        proposedItem: SidebarWorkspaceRenderItem?,
+        row: Int,
+        operation: NSTableView.DropOperation
+    ) -> ProposedDrop? {
+        guard info.draggingPasteboard.types?.contains(Self.workspacePasteboardType) == true,
+              let draggedWorkspaceId = activeSession?.draggedWorkspaceId
+                ?? workspaceDragRegistry.currentWorkspaceId else {
+            return nil
+        }
+
+        let isLocalWorkspace = projectionSource.workspaceById[draggedWorkspaceId] != nil
+        if !isLocalWorkspace,
+           let origin = Self.originMetadata,
+           origin.draggedWorkspaceId == draggedWorkspaceId,
+           origin.isGroupAnchor {
+            return nil
+        }
+
+        let sessionSnapshot = activeSession?.draggedWorkspaceId == draggedWorkspaceId
+            ? activeSession?.snapshot
+            : nil
+        guard isValidProposedTarget(
+            proposedItem,
+            row: row,
+            operation: operation,
+            sessionSnapshot: sessionSnapshot
+        ) else {
+            return nil
+        }
+        return ProposedDrop(
+            kind: .workspace(draggedWorkspaceId),
+            itemId: proposedItem?.id,
+            row: row,
+            operation: operation
+        )
+    }
+
+    private func bonsplitProposal(
+        _ info: NSDraggingInfo,
+        proposedItem: SidebarWorkspaceRenderItem?,
+        row: Int,
+        operation: NSTableView.DropOperation
+    ) -> ProposedDrop? {
+        guard BonsplitTabDragPayload.canRouteWorkspaceDrop(
+            pasteboardTypes: info.draggingPasteboard.types
+        ),
+        isValidProposedTarget(
+            proposedItem,
+            row: row,
+            operation: operation,
+            sessionSnapshot: nil
+        ) else {
+            return nil
+        }
+        return ProposedDrop(
+            kind: .bonsplit,
+            itemId: proposedItem?.id,
+            row: row,
+            operation: operation
+        )
+    }
+
+    /// This is called by validation, so it must remain independent of the
+    /// total workspace count.
+    private func isValidProposedTarget(
+        _ item: SidebarWorkspaceRenderItem?,
+        row: Int,
+        operation: NSTableView.DropOperation,
+        sessionSnapshot: SessionSnapshot?
+    ) -> Bool {
+        guard row >= 0 else { return false }
+        switch operation {
+        case .on:
+            guard let item else { return false }
+            if let sessionSnapshot {
+                return sessionSnapshot.targetByItemId[item.id] != nil
+            }
+            return projectionSource.workspaceById[item.rowWorkspaceId] != nil
+        case .above:
+            if let item {
+                if let sessionSnapshot {
+                    return sessionSnapshot.targetByItemId[item.id] != nil
+                }
+                return projectionSource.workspaceById[item.rowWorkspaceId] != nil
+            }
+            let itemCount = sessionSnapshot?.targets.count
+                ?? projectionSource.renderItems.count
+            return row <= itemCount
+        @unknown default:
+            return false
+        }
+    }
+
+    private func acceptWorkspaceDrop(_ proposal: ProposedDrop) -> Bool {
+        guard case .workspace(let draggedWorkspaceId) = proposal.kind else {
+            return false
+        }
+        defer { finishWorkspaceDrag(draggedWorkspaceId) }
+
+        let snapshot: SessionSnapshot
+        if let activeSession,
+           activeSession.draggedWorkspaceId == draggedWorkspaceId {
+            snapshot = activeSession.snapshot
+        } else {
+            snapshot = makeSessionSnapshot()
+        }
+        guard let point = resolverPoint(for: proposal, snapshot: snapshot) else {
+            return false
+        }
+
+        let isCrossWindow = snapshot.workspaceById[draggedWorkspaceId] == nil
+        let origin = matchingOriginMetadata(for: draggedWorkspaceId)
+            ?? (isCrossWindow ? resolveOriginMetadata(for: draggedWorkspaceId) : nil)
+        if isCrossWindow, origin?.isGroupAnchor != false {
+            return false
+        }
+        let foreignDraggedIsPinned = isCrossWindow ? origin?.draggedIsPinned : nil
+        if isCrossWindow, foreignDraggedIsPinned == nil {
+            return false
+        }
+
+        reorderResolverInvocationCount += 1
+        guard let plan = SidebarWorkspaceReorderDropResolver().plan(
+            for: SidebarWorkspaceReorderDropRequest(
+                point: point,
+                draggedWorkspaceId: draggedWorkspaceId,
+                foreignDraggedIsPinned: foreignDraggedIsPinned,
+                workspaces: snapshot.workspaces,
+                groups: snapshot.groups,
+                targets: snapshot.targets
+            )
+        ) else {
+            return false
+        }
+
+        switch plan.action {
+        case .reorder(let targetIndex, let usesTopLevelRows, let explicitGroupId):
+            return acceptSameWindowReorder(
+                plan: plan,
+                targetIndex: targetIndex,
+                usesTopLevelRows: usesTopLevelRows,
+                explicitGroupId: explicitGroupId
+            )
+        case .crossWindow(_, let proposedInsertionIndex):
+            guard let origin else { return false }
+            return acceptCrossWindowMove(
+                plan: plan,
+                proposedInsertionIndex: proposedInsertionIndex,
+                origin: origin
+            )
+        }
+    }
+
+    private func resolverPoint(
+        for proposal: ProposedDrop,
+        snapshot: SessionSnapshot
+    ) -> CGPoint? {
+        if let itemId = proposal.itemId {
+            guard let target = snapshot.targetByItemId[itemId] else { return nil }
+            switch proposal.operation {
+            case .above:
+                return CGPoint(x: target.frame.minX + 0.5, y: target.frame.minY)
+            case .on:
+                return CGPoint(x: target.frame.maxX - 0.5, y: target.frame.midY)
+            @unknown default:
+                return nil
+            }
+        }
+        guard proposal.operation == .above,
+              proposal.row <= snapshot.targets.count else {
+            return nil
+        }
+        return CGPoint(x: 0.5, y: CGFloat(snapshot.targets.count) + 1)
+    }
+
+    private func acceptSameWindowReorder(
+        plan: SidebarWorkspaceReorderDropPlan,
+        targetIndex: Int,
+        usesTopLevelRows: Bool,
+        explicitGroupId: UUID?
+    ) -> Bool {
+        let selectionBeforeReorder: Set<UUID>
+        let preferredAnchorWorkspaceId: UUID?
+        if let activeSession,
+           activeSession.draggedWorkspaceId == plan.draggedWorkspaceId {
+            selectionBeforeReorder = activeSession.selectionBeforeReorder
+            preferredAnchorWorkspaceId = activeSession.preferredAnchorWorkspaceId
+        } else {
+            let liveWorkspaceIds = tabManager.tabs.map(\.id)
+            selectionBeforeReorder = state.selectedWorkspaceIds()
+            preferredAnchorWorkspaceId = SidebarWorkspaceSelectionSyncPolicy()
+                .anchorWorkspaceId(
+                    existingAnchorIndex: state.lastSelectionIndex(),
+                    liveWorkspaceIds: liveWorkspaceIds
+                )
+        }
+
+        let didReorder = tabManager.reorderSidebarWorkspace(
+            tabId: plan.draggedWorkspaceId,
+            toIndex: targetIndex,
+            isDragOperation: true,
+            usesTopLevelRows: usesTopLevelRows,
+            explicitGroupId: explicitGroupId
+        )
+        syncSelectionAfterReorder(
+            preserving: selectionBeforeReorder,
+            preferredAnchorWorkspaceId: preferredAnchorWorkspaceId
+        )
+        return didReorder
+    }
+
+    private func acceptCrossWindowMove(
+        plan: SidebarWorkspaceReorderDropPlan,
+        proposedInsertionIndex: Int,
+        origin: OriginMetadata
+    ) -> Bool {
+        guard !origin.isGroupAnchor,
+              !origin.movingWorkspaces.isEmpty,
+              let app = AppDelegate.shared else {
+            return false
+        }
+
+        var movedIds: [UUID] = []
+        for isPinnedTier in [false, true] {
+            let tierWorkspaces = origin.movingWorkspaces.filter {
+                $0.isPinned == isPinnedTier
+            }
+            guard !tierWorkspaces.isEmpty else { continue }
+
+            let topLevelIds = crossWindowTopLevelWorkspaceIds()
+            let slot = clampedCrossWindowTopLevelSlot(
+                proposedInsertionIndex,
+                draggedIsPinned: isPinnedTier,
+                topLevelIds: topLevelIds,
+                pinnedTopLevelIds: crossWindowTopLevelPinnedWorkspaceIds()
+            )
+            let base = crossWindowRawInsertIndex(
+                forTopLevelSlot: slot,
+                topLevelIds: topLevelIds
+            )
+            var tierOffset = 0
+            for workspace in tierWorkspaces {
+                if app.moveWorkspaceToWindow(
+                    workspaceId: workspace.id,
+                    windowId: windowId,
+                    atIndex: base + tierOffset,
+                    focus: false
+                ) {
+                    movedIds.append(workspace.id)
+                    tierOffset += 1
+                }
+            }
+        }
+
+        guard !movedIds.isEmpty else { return false }
+        let focusId = movedIds.contains(plan.draggedWorkspaceId)
+            ? plan.draggedWorkspaceId
+            : (movedIds.last ?? plan.draggedWorkspaceId)
+        _ = app.moveWorkspaceToWindow(
+            workspaceId: focusId,
+            windowId: windowId,
+            focus: true
+        )
+        applySelection(Set(movedIds), preferredWorkspaceId: focusId)
+        return true
+    }
+
+    private func acceptBonsplitDrop(
+        _ info: NSDraggingInfo,
+        proposal: ProposedDrop
+    ) -> Bool {
+        guard case .bonsplit = proposal.kind,
+              let transfer = BonsplitTabDragPayload.transfer(
+                from: info.draggingPasteboard
+              ),
+              let app = AppDelegate.shared else {
+            return false
+        }
+        let snapshot = makeSessionSnapshot()
+
+        switch proposal.operation {
+        case .on:
+            guard let itemId = proposal.itemId,
+                  let targetWorkspaceId = snapshot.workspaceIdByItemId[itemId] else {
+                return false
+            }
+            let moved: Bool
+            if let source = app.locateBonsplitSurface(tabId: transfer.tab.id),
+               source.workspaceId == targetWorkspaceId {
+                moved = true
+            } else {
+                moved = app.moveBonsplitTab(
+                    tabId: transfer.tab.id,
+                    toWorkspace: targetWorkspaceId,
+                    focus: true,
+                    focusWindow: true
+                )
+            }
+            guard moved else { return false }
+            applySelection(
+                [targetWorkspaceId],
+                preferredWorkspaceId: targetWorkspaceId
+            )
+            return true
+
+        case .above:
+            let proposedInsertion: Int
+            if let itemId = proposal.itemId {
+                guard let index = snapshot.targetIndexByItemId[itemId] else {
+                    return false
+                }
+                proposedInsertion = index
+            } else {
+                proposedInsertion = snapshot.targets.count
+            }
+            let insertionIndex = max(
+                proposedInsertion,
+                snapshot.visiblePinnedTargetCount
+            )
+            guard let result = app.moveBonsplitTabToNewWorkspace(
+                tabId: transfer.tab.id,
+                destinationManager: tabManager,
+                focus: true,
+                focusWindow: true,
+                insertionIndexOverride: insertionIndex
+            ) else {
+                return false
+            }
+            applySelection(
+                [result.destinationWorkspaceId],
+                preferredWorkspaceId: result.destinationWorkspaceId
+            )
+            return true
+
+        @unknown default:
+            return false
+        }
+    }
+
+    private func makeSessionSnapshot() -> SessionSnapshot {
+        sessionSnapshotBuildCount += 1
+        return SessionSnapshot(
+            tabManager: tabManager,
+            renderItems: projectionSource.renderItems
+        )
+    }
+
+    private func makeOriginMetadata(
+        draggedWorkspaceId: UUID,
+        draggedIsPinned: Bool,
+        groupAnchorIds: Set<UUID>,
+        workspaces: [SidebarWorkspaceReorderWorkspaceSnapshot],
+        selectedWorkspaceIds: Set<UUID>
+    ) -> OriginMetadata {
+        let movesSelection = selectedWorkspaceIds.contains(draggedWorkspaceId)
+            && selectedWorkspaceIds.count > 1
+        var movingWorkspaces: [MovingWorkspace] = []
+        movingWorkspaces.reserveCapacity(
+            movesSelection ? selectedWorkspaceIds.count : 1
+        )
+        for workspace in workspaces {
+            let isCandidate = movesSelection
+                ? selectedWorkspaceIds.contains(workspace.id)
+                : workspace.id == draggedWorkspaceId
+            if isCandidate, !groupAnchorIds.contains(workspace.id) {
+                movingWorkspaces.append(MovingWorkspace(
+                    id: workspace.id,
+                    isPinned: workspace.isPinned
+                ))
+            }
+        }
+        return OriginMetadata(
+            draggedWorkspaceId: draggedWorkspaceId,
+            draggedIsPinned: draggedIsPinned,
+            isGroupAnchor: groupAnchorIds.contains(draggedWorkspaceId),
+            movingWorkspaces: movingWorkspaces
+        )
+    }
+
+    private func matchingOriginMetadata(
+        for draggedWorkspaceId: UUID
+    ) -> OriginMetadata? {
+        guard let origin = Self.originMetadata,
+              origin.draggedWorkspaceId == draggedWorkspaceId else {
+            return nil
+        }
+        return origin
+    }
+
+    /// Legacy SwiftUI workspace drags provide only the shared id. Resolve the
+    /// richer source metadata once after drop acceptance, never during hover.
+    private func resolveOriginMetadata(
+        for draggedWorkspaceId: UUID
+    ) -> OriginMetadata? {
+        guard let sourceManager = AppDelegate.shared?.tabManagerFor(
+            tabId: draggedWorkspaceId
+        ),
+        let draggedWorkspace = sourceManager.tabs.first(where: {
+            $0.id == draggedWorkspaceId
+        }) else {
+            return nil
+        }
+
+        let groupAnchorIds = Set(sourceManager.workspaceGroups.map(\.anchorWorkspaceId))
+        let selectedWorkspaceIds = sourceManager.sidebarSelectedWorkspaceIds
+        let movesSelection = selectedWorkspaceIds.contains(draggedWorkspaceId)
+            && selectedWorkspaceIds.count > 1
+        var movingWorkspaces: [MovingWorkspace] = []
+        movingWorkspaces.reserveCapacity(
+            movesSelection ? selectedWorkspaceIds.count : 1
+        )
+        for workspace in sourceManager.tabs {
+            let isCandidate = movesSelection
+                ? selectedWorkspaceIds.contains(workspace.id)
+                : workspace.id == draggedWorkspaceId
+            if isCandidate, !groupAnchorIds.contains(workspace.id) {
+                movingWorkspaces.append(MovingWorkspace(
+                    id: workspace.id,
+                    isPinned: workspace.isPinned
+                ))
+            }
+        }
+        return OriginMetadata(
+            draggedWorkspaceId: draggedWorkspaceId,
+            draggedIsPinned: draggedWorkspace.isPinned,
+            isGroupAnchor: groupAnchorIds.contains(draggedWorkspaceId),
+            movingWorkspaces: movingWorkspaces
+        )
+    }
+
+    private func crossWindowTopLevelWorkspaceIds() -> [UUID] {
+        tabManager.sidebarReorderWorkspaceIds(
+            forDraggedWorkspaceId: nil,
+            targetWorkspaceId: nil,
+            usesTopLevelRows: true
+        )
+    }
+
+    private func crossWindowTopLevelPinnedWorkspaceIds() -> Set<UUID> {
+        tabManager.sidebarReorderPinnedWorkspaceIds(
+            forDraggedWorkspaceId: nil,
+            targetWorkspaceId: nil,
+            usesTopLevelRows: true
+        )
+    }
+
+    private func clampedCrossWindowTopLevelSlot(
+        _ proposedSlot: Int,
+        draggedIsPinned: Bool,
+        topLevelIds: [UUID],
+        pinnedTopLevelIds: Set<UUID>
+    ) -> Int {
+        let clampedSlot = max(0, min(proposedSlot, topLevelIds.count))
+        let pinnedCount = topLevelIds.reduce(into: 0) { count, workspaceId in
+            if pinnedTopLevelIds.contains(workspaceId) {
+                count += 1
+            }
+        }
+        return draggedIsPinned
+            ? min(clampedSlot, pinnedCount)
+            : max(clampedSlot, pinnedCount)
+    }
+
+    private func crossWindowRawInsertIndex(
+        forTopLevelSlot slot: Int,
+        topLevelIds: [UUID]
+    ) -> Int {
+        guard slot < topLevelIds.count else { return tabManager.tabs.count }
+        let topLevelId = topLevelIds[slot]
+        return tabManager.tabs.firstIndex { $0.id == topLevelId }
+            ?? tabManager.tabs.count
+    }
+
+    private func syncSelectionAfterReorder(
+        preserving previousSelectionIds: Set<UUID>,
+        preferredAnchorWorkspaceId: UUID?
+    ) {
+        let liveWorkspaceIds = tabManager.tabs.map(\.id)
+        let nextSelectionIds = SidebarWorkspaceSelectionSyncPolicy()
+            .reconciledSelection(
+                previousSelectionIds: previousSelectionIds,
+                liveWorkspaceIds: liveWorkspaceIds,
+                fallbackSelectedWorkspaceId: tabManager.selectedTabId
+            )
+        state.setSelectedWorkspaceIds(nextSelectionIds)
+        tabManager.setSidebarSelectedWorkspaceIds(nextSelectionIds)
+        state.setLastSelectionIndex(
+            SidebarWorkspaceSelectionSyncPolicy()
+                .anchorIndexAfterWorkspaceReorder(
+                    preferredAnchorWorkspaceId: preferredAnchorWorkspaceId,
+                    selectedWorkspaceIds: nextSelectionIds,
+                    focusedWorkspaceId: tabManager.selectedTabId,
+                    liveWorkspaceIds: liveWorkspaceIds
+                )
+        )
+        state.selectTabsPage()
+    }
+
+    private func applySelection(
+        _ workspaceIds: Set<UUID>,
+        preferredWorkspaceId: UUID?
+    ) {
+        state.setSelectedWorkspaceIds(workspaceIds)
+        tabManager.setSidebarSelectedWorkspaceIds(workspaceIds)
+        state.setLastSelectionIndex(
+            preferredWorkspaceId.flatMap { preferredWorkspaceId in
+                tabManager.tabs.firstIndex { $0.id == preferredWorkspaceId }
+            }
+        )
+        state.selectTabsPage()
+    }
+
+    private func finishWorkspaceDrag(_ draggedWorkspaceId: UUID) {
+        let ownsSourceSession = activeSession?.draggedWorkspaceId
+            == draggedWorkspaceId
+        workspaceDragRegistry.end(workspaceId: draggedWorkspaceId)
+        if ownsSourceSession,
+           Self.originMetadata?.draggedWorkspaceId == draggedWorkspaceId {
+            Self.originMetadata = nil
+        }
+        if ownsSourceSession {
+            activeSession = nil
+            SidebarDragLifecycleNotification().postStateDidChange(
+                tabId: nil,
+                reason: "appkit_drag_end"
+            )
+        }
+        proposedDrop = nil
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitFooterView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitFooterView.swift
@@ -1,0 +1,1181 @@
+import AppKit
+import CmuxFoundation
+import CmuxUpdater
+@preconcurrency import Sparkle
+
+/// Fixed native footer shell for the AppKit workspace sidebar.
+///
+/// Buttons are created once and remain in a stable hierarchy. Callers inject
+/// behavior and update the value presentation; this view owns no app models.
+@MainActor
+final class SidebarAppKitFooterView: NSView {
+    struct Callbacks {
+        let onHelpAction: (SidebarAppKitHelpMenuController.Action) -> Void
+        let onOpenExtensionBrowser: (NSView) -> Void
+        let onOpenPricing: () -> Void
+        let onDismissPro: () -> Void
+        let onCheckForUpdates: () -> Void
+        let onCheckForUpdatesInCustomUI: () -> Void
+        let onAttemptUpdate: () -> Void
+        let updateLogPath: () -> String
+        let onSendFeedback: () -> Void
+    }
+
+    struct Presentation: Equatable {
+        let showsExtensionButton: Bool
+        let showsProButton: Bool
+        let proButtonTitle: String
+        let showsUpdateButton: Bool
+        let updateButtonTitle: String
+        let showsShortcutDiscoveryButton: Bool
+        let showsDevBuildBanner: Bool
+
+        init(
+            showsExtensionButton: Bool = false,
+            showsProButton: Bool = false,
+            proButtonTitle: String = String(
+                localized: "sidebar.pro.badge",
+                defaultValue: "Upgrade"
+            ),
+            showsUpdateButton: Bool = false,
+            updateButtonTitle: String = String(
+                localized: "command.checkForUpdates.title",
+                defaultValue: "Check for Updates"
+            ),
+            showsShortcutDiscoveryButton: Bool = false,
+            showsDevBuildBanner: Bool = false
+        ) {
+            self.showsExtensionButton = showsExtensionButton
+            self.showsProButton = showsProButton
+            self.proButtonTitle = proButtonTitle
+            self.showsUpdateButton = showsUpdateButton
+            self.updateButtonTitle = updateButtonTitle
+            self.showsShortcutDiscoveryButton = showsShortcutDiscoveryButton
+            self.showsDevBuildBanner = showsDevBuildBanner
+        }
+    }
+
+    private enum Metrics {
+        static let iconButtonSize: CGFloat = 22
+        static let controlHeight: CGFloat = 22
+        static let horizontalSpacing: CGFloat = 4
+        static let verticalSpacing: CGFloat = 6
+        static let leadingInset: CGFloat = 6
+        static let trailingInset: CGFloat = 10
+        static let verticalInset: CGFloat = 6
+    }
+
+    let helpButton: NSButton
+    let proButton: NSButton
+    let proDismissButton: NSButton
+    let extensionButton: NSButton
+    let updateButton: NSButton
+    let shortcutDiscoveryButton: NSButton
+    let devBuildBannerLabel: NSTextField
+
+    private let callbacks: Callbacks
+    private let helpMenuController: SidebarAppKitHelpMenuController
+    private let shortcutMenuController = SidebarAppKitShortcutMenuController()
+    private let proBadgeView: SidebarAppKitProBadgeView
+    private let updatePopoverController: SidebarAppKitUpdatePopoverController
+    private let buttonStack: NSStackView
+    private let contentStack: NSStackView
+    private var fontMagnificationObserver: GlobalFontMagnificationChangeObserver?
+    private(set) var presentation: Presentation
+
+    init(
+        updateModel: UpdateStateModel,
+        presentation: Presentation = Presentation(),
+        callbacks: Callbacks
+    ) {
+        let helpTitle = String(localized: "sidebar.help.button", defaultValue: "Help")
+        let extensionTitle = String(
+            localized: "sidebar.extensions.browser.title",
+            defaultValue: "Sidebar Extensions"
+        )
+        let helpButton = Self.makeIconButton(
+            systemSymbolName: "questionmark.circle",
+            accessibilityLabel: helpTitle,
+            accessibilityIdentifier: "SidebarHelpMenuButton"
+        )
+        let extensionButton = Self.makeIconButton(
+            systemSymbolName: "puzzlepiece.extension",
+            accessibilityLabel: extensionTitle,
+            accessibilityIdentifier: "SidebarExtensionMenuButton"
+        )
+        let proButton = Self.makeTextButton(accessibilityIdentifier: "SidebarProButton")
+        let proDismissTitle = String(
+            localized: "sidebar.pro.badge.dismiss",
+            defaultValue: "Hide the Pro badge"
+        )
+        let proDismissButton = Self.makeIconButton(
+            systemSymbolName: "xmark",
+            accessibilityLabel: proDismissTitle,
+            accessibilityIdentifier: "ProBadgeDismissButton"
+        )
+        proDismissButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(8),
+            weight: .bold
+        )
+        let proBadgeView = SidebarAppKitProBadgeView(
+            primaryButton: proButton,
+            dismissButton: proDismissButton
+        )
+        let updateButton = Self.makeTextButton(accessibilityIdentifier: "SidebarUpdateButton")
+        let shortcutTitle = String(
+            localized: "shortcutDiscovery.button.help",
+            defaultValue: "Show all shortcuts"
+        )
+        let shortcutDiscoveryButton = Self.makeIconButton(
+            systemSymbolName: "keyboard",
+            accessibilityLabel: shortcutTitle,
+            accessibilityIdentifier: "SidebarShortcutDiscoveryButton"
+        )
+        let devBuildBannerTitle = String(
+            localized: "debug.devBuildBanner.title",
+            defaultValue: "THIS IS A DEV BUILD"
+        )
+        let devBuildBannerLabel = NSTextField(labelWithString: devBuildBannerTitle)
+        devBuildBannerLabel.translatesAutoresizingMaskIntoConstraints = false
+        devBuildBannerLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 11,
+            weight: .semibold
+        )
+        devBuildBannerLabel.textColor = .systemRed
+        devBuildBannerLabel.lineBreakMode = .byTruncatingTail
+        devBuildBannerLabel.identifier = NSUserInterfaceItemIdentifier("SidebarDevBuildBanner")
+        devBuildBannerLabel.setAccessibilityIdentifier("SidebarDevBuildBanner")
+        devBuildBannerLabel.setAccessibilityLabel(devBuildBannerTitle)
+
+        self.helpButton = helpButton
+        self.proButton = proButton
+        self.proDismissButton = proDismissButton
+        self.extensionButton = extensionButton
+        self.updateButton = updateButton
+        self.shortcutDiscoveryButton = shortcutDiscoveryButton
+        self.devBuildBannerLabel = devBuildBannerLabel
+        self.callbacks = callbacks
+        self.presentation = presentation
+        self.proBadgeView = proBadgeView
+        updatePopoverController = SidebarAppKitUpdatePopoverController(
+            model: updateModel,
+            actions: SidebarAppKitUpdatePopoverController.Actions(
+                checkForUpdatesInCustomUI: callbacks.onCheckForUpdatesInCustomUI,
+                attemptUpdate: callbacks.onAttemptUpdate,
+                updateLogPath: callbacks.updateLogPath
+            )
+        )
+        helpMenuController = SidebarAppKitHelpMenuController(
+            callbacks: SidebarAppKitHelpMenuController.Callbacks(
+                onHelpAction: callbacks.onHelpAction,
+                onCheckForUpdates: callbacks.onCheckForUpdates,
+                onSendFeedback: callbacks.onSendFeedback
+            )
+        )
+        buttonStack = NSStackView(views: [
+            helpButton,
+            proBadgeView,
+            extensionButton,
+            updateButton,
+            shortcutDiscoveryButton,
+        ])
+        contentStack = NSStackView(views: [buttonStack, devBuildBannerLabel])
+
+        super.init(frame: .zero)
+        configureHierarchy()
+        configureActions()
+        apply(presentation: presentation)
+        fontMagnificationObserver = GlobalFontMagnificationChangeObserver { [weak self] in
+            self?.refreshFontMagnification()
+        }
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        let bannerHeight = presentation.showsDevBuildBanner
+            ? Metrics.verticalSpacing + devBuildBannerLabel.intrinsicContentSize.height
+            : 0
+        return NSSize(
+            width: NSView.noIntrinsicMetric,
+            height: max(Metrics.controlHeight, buttonStack.fittingSize.height)
+                + bannerHeight
+                + (Metrics.verticalInset * 2)
+        )
+    }
+
+    /// Updates titles and visibility without replacing any button or stack view.
+    func apply(presentation: Presentation) {
+        updatePopoverController.refresh(
+            allowsPresentation: presentation.showsUpdateButton
+        )
+        guard self.presentation != presentation || proButton.title.isEmpty else { return }
+        let bannerVisibilityChanged = self.presentation.showsDevBuildBanner
+            != presentation.showsDevBuildBanner
+        self.presentation = presentation
+
+        extensionButton.isHidden = !presentation.showsExtensionButton
+        proButton.title = presentation.proButtonTitle
+        proButton.toolTip = presentation.proButtonTitle
+        proButton.setAccessibilityLabel(presentation.proButtonTitle)
+        proBadgeView.isHidden = !presentation.showsProButton
+        if !presentation.showsProButton {
+            proBadgeView.resetHover()
+        }
+        updateButton.title = presentation.updateButtonTitle
+        updateButton.toolTip = presentation.updateButtonTitle
+        updateButton.setAccessibilityLabel(presentation.updateButtonTitle)
+        updateButton.isHidden = !presentation.showsUpdateButton
+        shortcutDiscoveryButton.isHidden = !presentation.showsShortcutDiscoveryButton
+        devBuildBannerLabel.isHidden = !presentation.showsDevBuildBanner
+        if bannerVisibilityChanged {
+            invalidateIntrinsicContentSize()
+        }
+    }
+
+    private func configureHierarchy() {
+        buttonStack.orientation = .horizontal
+        buttonStack.alignment = .centerY
+        buttonStack.distribution = .gravityAreas
+        buttonStack.spacing = Metrics.horizontalSpacing
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.distribution = .fill
+        contentStack.spacing = Metrics.verticalSpacing
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        addSubview(contentStack)
+
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.leadingInset),
+            contentStack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -Metrics.trailingInset),
+            contentStack.topAnchor.constraint(equalTo: topAnchor, constant: Metrics.verticalInset),
+            contentStack.bottomAnchor.constraint(equalTo: bottomAnchor, constant: -Metrics.verticalInset),
+            helpButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+            helpButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+            extensionButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+            extensionButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+            proBadgeView.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.controlHeight),
+            proButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.controlHeight),
+            proDismissButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+            proDismissButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+            updateButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.controlHeight),
+            shortcutDiscoveryButton.widthAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+            shortcutDiscoveryButton.heightAnchor.constraint(greaterThanOrEqualToConstant: Metrics.iconButtonSize),
+        ])
+
+        helpButton.setContentHuggingPriority(.required, for: .horizontal)
+        extensionButton.setContentHuggingPriority(.required, for: .horizontal)
+        proBadgeView.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        proButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        updateButton.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+        shortcutDiscoveryButton.setContentHuggingPriority(.required, for: .horizontal)
+    }
+
+    private func configureActions() {
+        helpButton.target = self
+        helpButton.action = #selector(showHelpMenu(_:))
+        extensionButton.target = self
+        extensionButton.action = #selector(openExtensionBrowser(_:))
+        proButton.target = self
+        proButton.action = #selector(openPricing(_:))
+        proDismissButton.target = self
+        proDismissButton.action = #selector(dismissPro(_:))
+        updateButton.target = self
+        updateButton.action = #selector(showUpdate(_:))
+        shortcutDiscoveryButton.target = self
+        shortcutDiscoveryButton.action = #selector(showShortcutDiscovery(_:))
+    }
+
+    private static func makeIconButton(
+        systemSymbolName: String,
+        accessibilityLabel: String,
+        accessibilityIdentifier: String
+    ) -> NSButton {
+        let button = NSButton(frame: .zero)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.title = ""
+        button.isBordered = false
+        button.bezelStyle = .regularSquare
+        button.focusRingType = .none
+        button.refusesFirstResponder = true
+        button.setButtonType(.momentaryChange)
+        button.imagePosition = .imageOnly
+        button.imageScaling = .scaleProportionallyDown
+        let image = NSImage(
+            systemSymbolName: systemSymbolName,
+            accessibilityDescription: accessibilityLabel
+        )
+        button.image = image
+        button.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(12),
+            weight: .medium
+        )
+        button.contentTintColor = .secondaryLabelColor
+        button.toolTip = accessibilityLabel
+        button.identifier = NSUserInterfaceItemIdentifier(accessibilityIdentifier)
+        button.setAccessibilityIdentifier(accessibilityIdentifier)
+        button.setAccessibilityLabel(accessibilityLabel)
+        button.setAccessibilityRole(.button)
+        return button
+    }
+
+    private static func makeTextButton(accessibilityIdentifier: String) -> NSButton {
+        let button = NSButton(title: "", target: nil, action: nil)
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.bezelStyle = .roundRect
+        button.controlSize = .small
+        button.font = GlobalFontMagnification.systemFont(ofSize: 11, weight: .medium)
+        button.focusRingType = .none
+        button.refusesFirstResponder = true
+        button.setButtonType(.momentaryPushIn)
+        button.identifier = NSUserInterfaceItemIdentifier(accessibilityIdentifier)
+        button.setAccessibilityIdentifier(accessibilityIdentifier)
+        button.setAccessibilityRole(.button)
+        return button
+    }
+
+    private func refreshFontMagnification() {
+        let symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(12),
+            weight: .medium
+        )
+        helpButton.symbolConfiguration = symbolConfiguration
+        extensionButton.symbolConfiguration = symbolConfiguration
+        shortcutDiscoveryButton.symbolConfiguration = symbolConfiguration
+        proDismissButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(8),
+            weight: .bold
+        )
+        proButton.font = GlobalFontMagnification.systemFont(ofSize: 11, weight: .medium)
+        updateButton.font = GlobalFontMagnification.systemFont(ofSize: 11, weight: .medium)
+        devBuildBannerLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 11,
+            weight: .semibold
+        )
+        proButton.invalidateIntrinsicContentSize()
+        updateButton.invalidateIntrinsicContentSize()
+        proBadgeView.invalidateIntrinsicContentSize()
+        buttonStack.needsLayout = true
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+    }
+
+    @objc private func showHelpMenu(_ sender: NSButton) {
+        helpMenuController.present(relativeTo: sender)
+    }
+
+    @objc private func openExtensionBrowser(_ sender: NSButton) {
+        callbacks.onOpenExtensionBrowser(sender)
+    }
+
+    @objc private func openPricing(_ sender: NSButton) {
+        _ = sender
+        callbacks.onOpenPricing()
+    }
+
+    @objc private func dismissPro(_ sender: NSButton) {
+        _ = sender
+        callbacks.onDismissPro()
+    }
+
+    @objc private func showUpdate(_ sender: NSButton) {
+        updatePopoverController.handleTap(relativeTo: sender)
+    }
+
+    @objc private func showShortcutDiscovery(_ sender: NSButton) {
+        shortcutMenuController.present(relativeTo: sender)
+    }
+}
+
+/// Native hover shell for the Pro badge. The pricing button stays the primary
+/// action while an adjacent dismiss affordance is revealed under the pointer,
+/// matching the existing sidebar badge behavior without hosting SwiftUI.
+@MainActor
+private final class SidebarAppKitProBadgeView: NSView {
+    private let stack: NSStackView
+    private let dismissButton: NSButton
+    private var trackingArea: NSTrackingArea?
+
+    init(primaryButton: NSButton, dismissButton: NSButton) {
+        self.dismissButton = dismissButton
+        stack = NSStackView(views: [primaryButton, dismissButton])
+        super.init(frame: .zero)
+
+        translatesAutoresizingMaskIntoConstraints = false
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.orientation = .horizontal
+        stack.alignment = .centerY
+        stack.distribution = .fill
+        stack.spacing = 0
+        addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: trailingAnchor),
+            stack.topAnchor.constraint(equalTo: topAnchor),
+            stack.bottomAnchor.constraint(equalTo: bottomAnchor),
+        ])
+        dismissButton.isHidden = true
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var intrinsicContentSize: NSSize {
+        stack.fittingSize
+    }
+
+    override func updateTrackingAreas() {
+        if let trackingArea {
+            removeTrackingArea(trackingArea)
+        }
+        let next = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(next)
+        trackingArea = next
+        super.updateTrackingAreas()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        setDismissVisible(true)
+        ProUpgradePresenter.prefetch()
+        super.mouseEntered(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        setDismissVisible(false)
+        super.mouseExited(with: event)
+    }
+
+    func resetHover() {
+        setDismissVisible(false)
+    }
+
+    private func setDismissVisible(_ visible: Bool) {
+        guard dismissButton.isHidden == visible else { return }
+        dismissButton.isHidden = !visible
+        invalidateIntrinsicContentSize()
+        superview?.needsLayout = true
+    }
+}
+
+/// Native equivalent of `UpdatePill.handleTap` and its update popover.
+///
+/// The state machine and phase callbacks remain owned by `UpdateStateModel` and
+/// `UpdateController`; this controller only maps the current state to retained
+/// AppKit controls and invokes the same check/install/cancel/retry callbacks.
+@MainActor
+private final class SidebarAppKitUpdatePopoverController: NSObject, NSPopoverDelegate {
+    struct Actions {
+        let checkForUpdatesInCustomUI: () -> Void
+        let attemptUpdate: () -> Void
+        let updateLogPath: () -> String
+    }
+
+    private enum Metrics {
+        static let width: CGFloat = 300
+        static let inset: CGFloat = 16
+        static let maximumHeight: CGFloat = 480
+    }
+
+    private let model: UpdateStateModel
+    private let actions: Actions
+    private let popover = NSPopover()
+    private let contentController = NSViewController()
+    private var allowsPresentation = false
+    private var fontMagnificationObserver: GlobalFontMagnificationChangeObserver?
+
+    init(model: UpdateStateModel, actions: Actions) {
+        self.model = model
+        self.actions = actions
+        super.init()
+        popover.behavior = .semitransient
+        popover.animates = true
+        popover.delegate = self
+        popover.contentViewController = contentController
+        fontMagnificationObserver = GlobalFontMagnificationChangeObserver { [weak self] in
+            guard let self, popover.isShown else { return }
+            installCurrentContent()
+        }
+    }
+
+    /// Matches `UpdatePill.handleTap`: passive detected updates open details
+    /// and hydrate missing appcast metadata; a no-update result acknowledges
+    /// immediately; every other phase toggles the state-specific popover.
+    func handleTap(relativeTo anchorView: NSView) {
+        guard allowsPresentation else { return }
+
+        if model.showsDetectedBackgroundUpdate {
+            if popover.isShown {
+                dismiss()
+                return
+            }
+            present(relativeTo: anchorView)
+            if !model.hasCachedDetectedUpdateDetails {
+                actions.checkForUpdatesInCustomUI()
+            }
+            return
+        }
+
+        if case .notFound(let notFound) = model.state {
+            model.setState(.idle)
+            notFound.acknowledgement()
+            dismiss()
+            return
+        }
+
+        if popover.isShown {
+            dismiss()
+        } else {
+            present(relativeTo: anchorView)
+        }
+    }
+
+    func refresh(allowsPresentation: Bool) {
+        self.allowsPresentation = allowsPresentation
+        guard allowsPresentation else {
+            dismiss()
+            return
+        }
+        if popover.isShown {
+            installCurrentContent()
+        }
+    }
+
+    func popoverDidClose(_ notification: Notification) {
+        _ = notification
+    }
+
+    private func present(relativeTo anchorView: NSView) {
+        installCurrentContent()
+        guard !popover.isShown else { return }
+        popover.show(
+            relativeTo: anchorView.bounds,
+            of: anchorView,
+            preferredEdge: .maxY
+        )
+    }
+
+    private func dismiss() {
+        if popover.isShown {
+            popover.performClose(nil)
+        }
+    }
+
+    private func installCurrentContent() {
+        let content = makeCurrentContent()
+        let size = content.frame.size
+        contentController.view = content
+        contentController.preferredContentSize = size
+        popover.contentSize = size
+    }
+
+    private func makeCurrentContent() -> NSView {
+        let stack: NSStackView
+        switch model.effectiveState {
+        case .idle:
+            stack = makeDetectedUpdateContent()
+        case .permissionRequest(let request):
+            stack = makePermissionContent(request)
+        case .checking(let checking):
+            stack = makeCheckingContent(checking)
+        case .updateAvailable(let update):
+            stack = makeAvailableContent(update)
+        case .downloading(let download):
+            stack = makeDownloadingContent(download)
+        case .extracting(let extracting):
+            stack = makeExtractingContent(extracting)
+        case .installing(let installing):
+            stack = makeInstallingContent(installing)
+        case .notFound(let notFound):
+            stack = makeNotFoundContent(notFound)
+        case .error(let error):
+            stack = makeErrorContent(error)
+        }
+        return wrap(stack)
+    }
+
+    private func makeDetectedUpdateContent() -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(String(
+            localized: "update.popover.updateAvailable",
+            defaultValue: "Update Available"
+        )))
+
+        if let item = model.detectedUpdateItem {
+            stack.addArrangedSubview(metadataView(for: item))
+            stack.addArrangedSubview(buttonRow(
+                leading: [actionButton(
+                    String(localized: "common.later", defaultValue: "Later"),
+                    cancel: true
+                ) { [weak self] in self?.dismiss() }],
+                trailing: [actionButton(
+                    String(
+                        localized: "common.installAndRelaunch",
+                        defaultValue: "Install and Relaunch"
+                    ),
+                    primary: true
+                ) { [weak self] in
+                    self?.actions.attemptUpdate()
+                    self?.dismiss()
+                }]
+            ))
+            if let notes = UpdateState.ReleaseNotes(
+                displayVersionString: item.displayVersionString
+            ) {
+                stack.addArrangedSubview(linkButton(notes.label, url: notes.url))
+            }
+        } else {
+            if let version = model.detectedUpdateVersion {
+                stack.addArrangedSubview(metadataRow(
+                    label: String(
+                        localized: "update.popover.version",
+                        defaultValue: "Version:"
+                    ),
+                    value: version
+                ))
+            }
+            stack.addArrangedSubview(statusRow(
+                String(
+                    localized: "update.popover.checking",
+                    defaultValue: "Checking for updates…"
+                ),
+                progress: nil,
+                indeterminate: true
+            ))
+        }
+        return stack
+    }
+
+    private func makePermissionContent(
+        _ request: UpdateState.PermissionRequest
+    ) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(String(
+            localized: "update.popover.enableAutoUpdates",
+            defaultValue: "Enable automatic updates?"
+        )))
+        stack.addArrangedSubview(detailLabel(String(
+            localized: "update.popover.autoUpdatesDescription",
+            defaultValue: "cmux can automatically check for updates in the background."
+        )))
+        stack.addArrangedSubview(buttonRow(
+            leading: [actionButton(
+                String(localized: "common.notNow", defaultValue: "Not Now"),
+                cancel: true
+            ) { [weak self] in
+                request.reply(SUUpdatePermissionResponse(
+                    automaticUpdateChecks: false,
+                    sendSystemProfile: false
+                ))
+                self?.dismiss()
+            }],
+            trailing: [actionButton(
+                String(localized: "common.allow", defaultValue: "Allow"),
+                primary: true
+            ) { [weak self] in
+                request.reply(SUUpdatePermissionResponse(
+                    automaticUpdateChecks: true,
+                    sendSystemProfile: false
+                ))
+                self?.dismiss()
+            }]
+        ))
+        return stack
+    }
+
+    private func makeCheckingContent(_ checking: UpdateState.Checking) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(statusRow(
+            String(
+                localized: "update.popover.checking",
+                defaultValue: "Checking for updates…"
+            ),
+            progress: nil,
+            indeterminate: true
+        ))
+        stack.addArrangedSubview(buttonRow(
+            leading: [],
+            trailing: [actionButton(
+                String(localized: "common.cancel", defaultValue: "Cancel"),
+                cancel: true
+            ) { [weak self] in
+                checking.cancel()
+                self?.dismiss()
+            }]
+        ))
+        return stack
+    }
+
+    private func makeAvailableContent(
+        _ update: UpdateState.UpdateAvailable
+    ) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(String(
+            localized: "update.popover.updateAvailable",
+            defaultValue: "Update Available"
+        )))
+        stack.addArrangedSubview(metadataView(for: update.appcastItem))
+        stack.addArrangedSubview(buttonRow(
+            leading: [
+                actionButton(String(localized: "common.skip", defaultValue: "Skip")) {
+                    [weak self] in
+                    update.reply(.skip)
+                    self?.dismiss()
+                },
+                actionButton(
+                    String(localized: "common.later", defaultValue: "Later"),
+                    cancel: true
+                ) { [weak self] in
+                    update.reply(.dismiss)
+                    self?.dismiss()
+                },
+            ],
+            trailing: [actionButton(
+                String(
+                    localized: "common.installAndRelaunch",
+                    defaultValue: "Install and Relaunch"
+                ),
+                primary: true
+            ) { [weak self] in
+                self?.actions.attemptUpdate()
+                self?.dismiss()
+            }]
+        ))
+        if let notes = update.releaseNotes {
+            stack.addArrangedSubview(linkButton(notes.label, url: notes.url))
+        }
+        return stack
+    }
+
+    private func makeDownloadingContent(
+        _ download: UpdateState.Downloading
+    ) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(String(
+            localized: "update.popover.downloadingUpdate",
+            defaultValue: "Downloading Update"
+        )))
+        let progress = download.expectedLength.flatMap { expected -> Double? in
+            guard expected > 0 else { return nil }
+            return min(1, max(0, Double(download.progress) / Double(expected)))
+        }
+        stack.addArrangedSubview(progressView(value: progress))
+        stack.addArrangedSubview(buttonRow(
+            leading: [],
+            trailing: [actionButton(
+                String(localized: "common.cancel", defaultValue: "Cancel"),
+                cancel: true
+            ) { [weak self] in
+                download.cancel()
+                self?.dismiss()
+            }]
+        ))
+        return stack
+    }
+
+    private func makeExtractingContent(
+        _ extracting: UpdateState.Extracting
+    ) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(String(
+            localized: "update.popover.preparingUpdate",
+            defaultValue: "Preparing Update"
+        )))
+        stack.addArrangedSubview(progressView(
+            value: min(1, max(0, extracting.progress))
+        ))
+        return stack
+    }
+
+    private func makeInstallingContent(
+        _ installing: UpdateState.Installing
+    ) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(String(
+            localized: "update.popover.restartRequired",
+            defaultValue: "Restart Required"
+        )))
+        stack.addArrangedSubview(detailLabel(String(
+            localized: "update.popover.restartRequired.message",
+            defaultValue: "The update is ready. Please restart the application to complete the installation."
+        )))
+        stack.addArrangedSubview(buttonRow(
+            leading: [actionButton(
+                String(localized: "common.restartLater", defaultValue: "Restart Later"),
+                cancel: true
+            ) { [weak self] in
+                installing.dismiss()
+                self?.dismiss()
+            }],
+            trailing: [actionButton(
+                String(localized: "common.restartNow", defaultValue: "Restart Now"),
+                primary: true
+            ) { [weak self] in
+                installing.retryTerminatingApplication()
+                self?.dismiss()
+            }]
+        ))
+        return stack
+    }
+
+    private func makeNotFoundContent(
+        _ notFound: UpdateState.NotFound
+    ) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(String(
+            localized: "update.popover.noUpdatesFound",
+            defaultValue: "No Updates Found"
+        )))
+        stack.addArrangedSubview(detailLabel(String(
+            localized: "update.popover.noUpdatesFound.message",
+            defaultValue: "You're already running the latest version."
+        )))
+        stack.addArrangedSubview(buttonRow(
+            leading: [],
+            trailing: [actionButton(
+                String(localized: "common.ok", defaultValue: "OK"),
+                primary: true
+            ) { [weak self] in
+                notFound.acknowledgement()
+                self?.dismiss()
+            }]
+        ))
+        return stack
+    }
+
+    private func makeErrorContent(_ error: UpdateState.Error) -> NSStackView {
+        let stack = makeVerticalStack(spacing: 12)
+        stack.addArrangedSubview(titleLabel(
+            UpdateStateModel.userFacingErrorTitle(for: error.error)
+        ))
+        stack.addArrangedSubview(detailLabel(
+            UpdateStateModel.userFacingErrorMessage(for: error.error)
+        ))
+
+        if let downloadURL = UpdateManualDownloadRecovery().url(
+            for: error.error,
+            feedURLString: error.feedURLString
+        ) {
+            stack.addArrangedSubview(actionButton(
+                String(
+                    localized: "update.error.downloadLatest.button",
+                    defaultValue: "Download Latest Version"
+                ),
+                primary: true
+            ) {
+                NSWorkspace.shared.open(downloadURL)
+            })
+        }
+
+        let details = UpdateErrorDetailsFormatter().details(
+            for: error.error,
+            technicalDetails: error.technicalDetails,
+            feedURLString: error.feedURLString,
+            logPath: actions.updateLogPath()
+        )
+        stack.addArrangedSubview(detailTextView(details))
+        stack.addArrangedSubview(buttonRow(
+            leading: [
+                actionButton(
+                    String(localized: "common.copyDetails", defaultValue: "Copy Details")
+                ) {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(details, forType: .string)
+                },
+                actionButton(
+                    String(localized: "common.ok", defaultValue: "OK"),
+                    cancel: true
+                ) { [weak self] in
+                    error.dismiss()
+                    self?.dismiss()
+                },
+            ],
+            trailing: [actionButton(
+                String(localized: "common.retry", defaultValue: "Retry"),
+                primary: true
+            ) { [weak self] in
+                error.retry()
+                self?.dismiss()
+            }]
+        ))
+        return stack
+    }
+
+    private func makeVerticalStack(spacing: CGFloat) -> NSStackView {
+        let stack = NSStackView()
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.distribution = .fill
+        stack.spacing = spacing
+        return stack
+    }
+
+    private func titleLabel(_ text: String) -> NSTextField {
+        let label = wrappingLabel(text, size: 13, weight: .semibold)
+        label.textColor = .labelColor
+        return label
+    }
+
+    private func detailLabel(_ text: String) -> NSTextField {
+        let label = wrappingLabel(text, size: 11, weight: .regular)
+        label.textColor = .secondaryLabelColor
+        return label
+    }
+
+    private func wrappingLabel(
+        _ text: String,
+        size: CGFloat,
+        weight: NSFont.Weight
+    ) -> NSTextField {
+        let label = NSTextField(wrappingLabelWithString: text)
+        label.font = GlobalFontMagnification.systemFont(ofSize: size, weight: weight)
+        label.maximumNumberOfLines = 0
+        label.lineBreakMode = .byWordWrapping
+        label.preferredMaxLayoutWidth = Metrics.width - 2 * Metrics.inset
+        label.isSelectable = true
+        label.setContentCompressionResistancePriority(.required, for: .vertical)
+        return label
+    }
+
+    private func metadataView(for item: SUAppcastItem) -> NSView {
+        let stack = makeVerticalStack(spacing: 4)
+        stack.addArrangedSubview(metadataRow(
+            label: String(localized: "update.popover.version", defaultValue: "Version:"),
+            value: item.displayVersionString
+        ))
+        if item.contentLength > 0 {
+            stack.addArrangedSubview(metadataRow(
+                label: String(localized: "update.popover.size", defaultValue: "Size:"),
+                value: ByteCountFormatter.string(
+                    fromByteCount: Int64(item.contentLength),
+                    countStyle: .file
+                )
+            ))
+        }
+        if let date = item.date {
+            stack.addArrangedSubview(metadataRow(
+                label: String(localized: "update.popover.released", defaultValue: "Released:"),
+                value: date.formatted(date: .abbreviated, time: .omitted)
+            ))
+        }
+        return stack
+    }
+
+    private func metadataRow(label: String, value: String) -> NSView {
+        let labelField = NSTextField(labelWithString: label)
+        labelField.font = GlobalFontMagnification.systemFont(ofSize: 11)
+        labelField.textColor = .secondaryLabelColor
+        labelField.alignment = .right
+        labelField.setContentHuggingPriority(.required, for: .horizontal)
+        labelField.widthAnchor.constraint(equalToConstant: 60).isActive = true
+
+        let valueField = NSTextField(labelWithString: value)
+        valueField.font = GlobalFontMagnification.systemFont(ofSize: 11)
+        valueField.lineBreakMode = .byTruncatingTail
+        valueField.isSelectable = true
+        valueField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: [labelField, valueField])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.distribution = .fill
+        row.spacing = 6
+        return row
+    }
+
+    private func statusRow(
+        _ text: String,
+        progress: Double?,
+        indeterminate: Bool
+    ) -> NSView {
+        let indicator = NSProgressIndicator()
+        indicator.controlSize = .small
+        if indeterminate {
+            indicator.style = .spinning
+            indicator.isIndeterminate = true
+            indicator.startAnimation(nil)
+            indicator.widthAnchor.constraint(equalToConstant: 16).isActive = true
+            indicator.heightAnchor.constraint(equalToConstant: 16).isActive = true
+        } else {
+            indicator.style = .bar
+            indicator.isIndeterminate = false
+            indicator.minValue = 0
+            indicator.maxValue = 1
+            indicator.doubleValue = progress ?? 0
+            indicator.widthAnchor.constraint(equalToConstant: 100).isActive = true
+        }
+        let label = NSTextField(labelWithString: text)
+        label.font = GlobalFontMagnification.systemFont(ofSize: 13)
+        let row = NSStackView(views: [indicator, label])
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.distribution = .fill
+        row.spacing = 10
+        return row
+    }
+
+    private func progressView(value: Double?) -> NSView {
+        guard let value else {
+            return statusRow(
+                String(localized: "update.downloading.status", defaultValue: "Downloading…"),
+                progress: nil,
+                indeterminate: true
+            )
+        }
+        let clamped = min(1, max(0, value))
+        let indicator = NSProgressIndicator()
+        indicator.style = .bar
+        indicator.isIndeterminate = false
+        indicator.minValue = 0
+        indicator.maxValue = 1
+        indicator.doubleValue = clamped
+
+        let percentage = NSTextField(labelWithString: String(format: "%.0f%%", clamped * 100))
+        percentage.font = GlobalFontMagnification.systemFont(ofSize: 11)
+        percentage.textColor = .secondaryLabelColor
+
+        let stack = makeVerticalStack(spacing: 6)
+        stack.addArrangedSubview(indicator)
+        stack.addArrangedSubview(percentage)
+        indicator.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
+        return stack
+    }
+
+    private func detailTextView(_ text: String) -> NSView {
+        let scrollView = NSTextView.scrollableTextView()
+        guard let textView = scrollView.documentView as? NSTextView else {
+            assertionFailure("NSTextView.scrollableTextView() must contain an NSTextView")
+            return scrollView
+        }
+        textView.isEditable = false
+        textView.isSelectable = true
+        textView.drawsBackground = false
+        textView.font = GlobalFontMagnification.monospacedSystemFont(
+            ofSize: 10,
+            weight: .regular
+        )
+        textView.textColor = .secondaryLabelColor
+        textView.string = text
+        textView.textContainerInset = NSSize(width: 4, height: 4)
+        textView.textContainer?.widthTracksTextView = true
+
+        scrollView.borderType = .bezelBorder
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.heightAnchor.constraint(equalToConstant: 150).isActive = true
+        return scrollView
+    }
+
+    private func buttonRow(
+        leading: [NSButton],
+        trailing: [NSButton]
+    ) -> NSView {
+        let spacer = NSView(frame: .zero)
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        spacer.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+
+        let row = NSStackView(views: leading + [spacer] + trailing)
+        row.orientation = .horizontal
+        row.alignment = .centerY
+        row.distribution = .fill
+        row.spacing = 8
+        return row
+    }
+
+    private func actionButton(
+        _ title: String,
+        primary: Bool = false,
+        cancel: Bool = false,
+        action: @escaping @MainActor () -> Void
+    ) -> NSButton {
+        let button = SidebarAppKitActionButton(title: title, action: action)
+        button.controlSize = .small
+        button.bezelStyle = primary ? .texturedRounded : .rounded
+        if primary {
+            button.keyEquivalent = "\r"
+        } else if cancel {
+            button.keyEquivalent = "\u{1b}"
+        }
+        return button
+    }
+
+    private func linkButton(_ title: String, url: URL) -> NSButton {
+        let button = actionButton(title) {
+            NSWorkspace.shared.open(url)
+        }
+        button.image = NSImage(
+            systemSymbolName: "arrow.up.right",
+            accessibilityDescription: nil
+        )
+        button.imagePosition = .imageTrailing
+        button.alignment = .left
+        return button
+    }
+
+    private func wrap(_ contentStack: NSStackView) -> NSView {
+        let contentWidth = Metrics.width - 2 * Metrics.inset
+        contentStack.frame = NSRect(x: 0, y: 0, width: contentWidth, height: 1)
+        contentStack.widthAnchor.constraint(equalToConstant: contentWidth).isActive = true
+        for arrangedSubview in contentStack.arrangedSubviews {
+            arrangedSubview.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
+        }
+        contentStack.layoutSubtreeIfNeeded()
+        let contentHeight = ceil(contentStack.fittingSize.height)
+        let height = min(
+            Metrics.maximumHeight,
+            max(1, contentHeight + 2 * Metrics.inset)
+        )
+        let root = NSView(frame: NSRect(
+            x: 0,
+            y: 0,
+            width: Metrics.width,
+            height: height
+        ))
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        root.addSubview(contentStack)
+        NSLayoutConstraint.activate([
+            contentStack.leadingAnchor.constraint(equalTo: root.leadingAnchor, constant: Metrics.inset),
+            contentStack.trailingAnchor.constraint(equalTo: root.trailingAnchor, constant: -Metrics.inset),
+            contentStack.topAnchor.constraint(equalTo: root.topAnchor, constant: Metrics.inset),
+            contentStack.bottomAnchor.constraint(lessThanOrEqualTo: root.bottomAnchor, constant: -Metrics.inset),
+        ])
+        root.layoutSubtreeIfNeeded()
+        return root
+    }
+}
+
+/// Target-action bridge that owns a main-actor closure without using Objective-C
+/// associated storage or rebuilding the footer's controller hierarchy.
+@MainActor
+private final class SidebarAppKitActionButton: NSButton {
+    private let handler: @MainActor () -> Void
+
+    init(title: String, action: @escaping @MainActor () -> Void) {
+        handler = action
+        super.init(frame: .zero)
+        self.title = title
+        target = self
+        self.action = #selector(performAction(_:))
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    @objc private func performAction(_ sender: NSButton) {
+        _ = sender
+        handler()
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitGroupCellView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitGroupCellView.swift
@@ -1,0 +1,521 @@
+import AppKit
+import CmuxFoundation
+
+/// Resolves its menu only when AppKit receives a context-click.
+@MainActor
+private final class SidebarAppKitDeferredMenuButton: NSButton {
+    var menuProvider: ((NSEvent) -> NSMenu?)?
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        menuProvider?(event) ?? super.menu(for: event)
+    }
+}
+
+/// Reusable native cell for one immutable workspace-group header projection.
+@MainActor
+final class SidebarAppKitGroupCellView: NSTableCellView {
+    struct Actions {
+        let onActivate: () -> Void
+        let onToggleCollapsed: () -> Void
+        let onAddWorkspace: () -> Void
+        let onContextMenu: (NSEvent) -> NSMenu?
+
+        init(
+            onActivate: @escaping () -> Void,
+            onToggleCollapsed: @escaping () -> Void,
+            onAddWorkspace: @escaping () -> Void,
+            onContextMenu: @escaping (NSEvent) -> NSMenu? = { _ in nil }
+        ) {
+            self.onActivate = onActivate
+            self.onToggleCollapsed = onToggleCollapsed
+            self.onAddWorkspace = onAddWorkspace
+            self.onContextMenu = onContextMenu
+        }
+
+        static let none = Self(
+            onActivate: {},
+            onToggleCollapsed: {},
+            onAddWorkspace: {}
+        )
+    }
+
+    private let backgroundView = NSView()
+    private let rowStack = NSStackView()
+    private let pinImageView = NSImageView()
+    private let disclosureButton = NSButton()
+    private let groupImageView = NSImageView()
+    private let nameLabel = NSTextField(labelWithString: "")
+    private let unreadBadge = SidebarAppKitBadgeView()
+    private let shortcutLabel = NSTextField(labelWithString: "")
+    private let addButton = SidebarAppKitDeferredMenuButton()
+    private let topDropIndicator = NSView()
+    private let bottomDropIndicator = NSView()
+
+    private var snapshot: SidebarWorkspaceGroupRowSnapshot?
+    private var actions = Actions.none
+    private var isPointerInside = false
+    private var pointerTrackingArea: NSTrackingArea?
+    private var fontMagnificationObserver: GlobalFontMagnificationChangeObserver?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setUpHierarchy()
+        setUpAccessibility()
+        resetForReuse()
+        fontMagnificationObserver = GlobalFontMagnificationChangeObserver { [weak self] in
+            self?.refreshFontMagnification()
+        }
+    }
+
+    convenience init(identifier: NSUserInterfaceItemIdentifier) {
+        self.init(frame: .zero)
+        self.identifier = identifier
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    /// Applies one immutable projection without replacing any subviews.
+    func configure(snapshot: SidebarWorkspaceGroupRowSnapshot, actions: Actions) {
+        self.snapshot = snapshot
+        self.actions = actions
+
+        let scale = max(0.5, snapshot.fontScale)
+        nameLabel.stringValue = SidebarAppKitCellText.bounded(
+            snapshot.name,
+            maximumCharacters: 2_048,
+            maximumLines: 1
+        ) ?? snapshot.name
+        nameLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 11 * scale,
+            weight: .semibold
+        )
+        nameLabel.toolTip = snapshot.name
+
+        configureDisclosure(snapshot: snapshot, scale: scale)
+        configurePin(snapshot: snapshot, scale: scale)
+        configureGroupIcon(snapshot: snapshot, scale: scale)
+        configureUnread(snapshot: snapshot, scale: scale)
+        configureShortcut(snapshot: snapshot, scale: scale)
+        configureColors(snapshot: snapshot)
+        configureAccessibility(snapshot: snapshot)
+
+        backgroundView.alphaValue = snapshot.isBeingDragged ? 0.6 : 1
+        topDropIndicator.isHidden = !snapshot.topDropIndicatorVisible
+        bottomDropIndicator.isHidden = !snapshot.bottomDropIndicatorVisible
+        isPointerInside = snapshot.isPointerHovering
+        updateAddButtonVisibility()
+        updateDropIndicatorColors()
+        needsLayout = true
+    }
+
+    /// Clears model-derived content and callbacks before a cell enters reuse.
+    func resetForReuse() {
+        snapshot = nil
+        actions = .none
+        isPointerInside = false
+
+        nameLabel.stringValue = ""
+        nameLabel.toolTip = nil
+        pinImageView.isHidden = true
+        pinImageView.toolTip = nil
+        disclosureButton.image = nil
+        disclosureButton.toolTip = nil
+        groupImageView.image = nil
+        groupImageView.isHidden = true
+        unreadBadge.resetForReuse()
+        shortcutLabel.stringValue = ""
+        shortcutLabel.isHidden = true
+        addButton.isHidden = true
+        addButton.setAccessibilityElement(false)
+
+        backgroundView.alphaValue = 1
+        backgroundView.layer?.backgroundColor = nil
+        backgroundView.layer?.borderColor = nil
+        backgroundView.layer?.borderWidth = 0
+        topDropIndicator.isHidden = true
+        bottomDropIndicator.isHidden = true
+        setAccessibilityIdentifier(nil)
+        setAccessibilityLabel(nil)
+        setAccessibilityValue(nil)
+        setAccessibilitySelected(false)
+    }
+
+    /// Returns the Auto Layout fitting height for the proposed table width.
+    func fittingHeight(constrainedTo width: CGFloat) -> CGFloat {
+        let horizontalInsets = 2 * (
+            SidebarAppKitCellMetrics.outerHorizontalInset
+                + SidebarAppKitCellMetrics.innerHorizontalInset
+        )
+        nameLabel.preferredMaxLayoutWidth = max(1, width - horizontalInsets)
+        layoutSubtreeIfNeeded()
+        return ceil(max(
+            SidebarAppKitCellMetrics.minimumGroupHeight,
+            rowStack.fittingSize.height + 10
+        ))
+    }
+
+    override func updateTrackingAreas() {
+        if let pointerTrackingArea {
+            removeTrackingArea(pointerTrackingArea)
+        }
+        let options: NSTrackingArea.Options = [
+            .mouseEnteredAndExited,
+            .activeInKeyWindow,
+            .inVisibleRect,
+        ]
+        let area = NSTrackingArea(rect: .zero, options: options, owner: self, userInfo: nil)
+        addTrackingArea(area)
+        pointerTrackingArea = area
+        super.updateTrackingAreas()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isPointerInside = true
+        updateAddButtonVisibility()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isPointerInside = false
+        updateAddButtonVisibility()
+    }
+
+    /// Buttons keep their own events. Ordinary group-row hits go to the table,
+    /// which owns selection, modifier handling, menus, and native dragging.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let hitView = super.hitTest(point) else { return nil }
+        if belongsToInteractiveSubview(hitView, ancestor: disclosureButton)
+            || belongsToInteractiveSubview(hitView, ancestor: addButton) {
+            return hitView
+        }
+        return enclosingTableView ?? hitView
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        actions.onActivate()
+        return true
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        guard let snapshot else { return }
+        configureColors(snapshot: snapshot)
+        updateDropIndicatorColors()
+    }
+
+    private func setUpHierarchy() {
+        wantsLayer = true
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.wantsLayer = true
+        backgroundView.layer?.cornerRadius = SidebarAppKitCellMetrics.groupCornerRadius
+        addSubview(backgroundView)
+
+        rowStack.translatesAutoresizingMaskIntoConstraints = false
+        rowStack.orientation = .horizontal
+        rowStack.alignment = .centerY
+        rowStack.distribution = .fill
+        rowStack.spacing = 4
+        backgroundView.addSubview(rowStack)
+
+        setUpImageView(pinImageView)
+        setUpButton(disclosureButton, action: #selector(toggleCollapsed))
+        setUpImageView(groupImageView)
+
+        nameLabel.translatesAutoresizingMaskIntoConstraints = false
+        nameLabel.maximumNumberOfLines = 1
+        nameLabel.lineBreakMode = .byTruncatingTail
+        nameLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        nameLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        shortcutLabel.translatesAutoresizingMaskIntoConstraints = false
+        shortcutLabel.maximumNumberOfLines = 1
+        shortcutLabel.lineBreakMode = .byClipping
+        shortcutLabel.alignment = .right
+        shortcutLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        setUpButton(addButton, action: #selector(addWorkspace))
+        addButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: nil)
+        addButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11),
+            weight: .medium
+        )
+        addButton.menuProvider = { [weak self] event in
+            self?.actions.onContextMenu(event)
+        }
+
+        [
+            pinImageView,
+            disclosureButton,
+            groupImageView,
+            nameLabel,
+            unreadBadge,
+            shortcutLabel,
+            addButton,
+        ].forEach(rowStack.addArrangedSubview)
+
+        setUpDropIndicator(topDropIndicator)
+        setUpDropIndicator(bottomDropIndicator)
+        addSubview(topDropIndicator)
+        addSubview(bottomDropIndicator)
+
+        NSLayoutConstraint.activate([
+            backgroundView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: SidebarAppKitCellMetrics.outerHorizontalInset
+            ),
+            backgroundView.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -SidebarAppKitCellMetrics.outerHorizontalInset
+            ),
+            backgroundView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            rowStack.leadingAnchor.constraint(
+                equalTo: backgroundView.leadingAnchor,
+                constant: SidebarAppKitCellMetrics.innerHorizontalInset
+            ),
+            rowStack.trailingAnchor.constraint(
+                equalTo: backgroundView.trailingAnchor,
+                constant: -SidebarAppKitCellMetrics.innerHorizontalInset
+            ),
+            rowStack.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: 5),
+            rowStack.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -5),
+
+            pinImageView.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.groupAccessorySide),
+            pinImageView.heightAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.groupAccessorySide),
+            disclosureButton.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.groupAccessorySide),
+            disclosureButton.heightAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.groupAccessorySide),
+            groupImageView.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.groupAccessorySide),
+            groupImageView.heightAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.groupAccessorySide),
+            addButton.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+            addButton.heightAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+
+            topDropIndicator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topDropIndicator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topDropIndicator.topAnchor.constraint(equalTo: topAnchor),
+            topDropIndicator.heightAnchor.constraint(equalToConstant: 2),
+            bottomDropIndicator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomDropIndicator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomDropIndicator.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomDropIndicator.heightAnchor.constraint(equalToConstant: 2),
+        ])
+    }
+
+    private func belongsToInteractiveSubview(_ view: NSView, ancestor: NSView) -> Bool {
+        var candidate: NSView? = view
+        while let current = candidate {
+            if current === ancestor { return true }
+            if current === self { return false }
+            candidate = current.superview
+        }
+        return false
+    }
+
+    private var enclosingTableView: NSTableView? {
+        var ancestor = superview
+        while let view = ancestor {
+            if let tableView = view as? NSTableView {
+                return tableView
+            }
+            ancestor = view.superview
+        }
+        return nil
+    }
+
+    private func setUpImageView(_ imageView: NSImageView) {
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.imageScaling = .scaleProportionallyDown
+        imageView.setAccessibilityElement(false)
+    }
+
+    private func setUpButton(_ button: NSButton, action: Selector) {
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isBordered = false
+        button.imagePosition = .imageOnly
+        button.target = self
+        button.action = action
+    }
+
+    private func setUpDropIndicator(_ view: NSView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.wantsLayer = true
+        view.layer?.cornerRadius = 1
+        view.isHidden = true
+    }
+
+    private func setUpAccessibility() {
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        nameLabel.setAccessibilityElement(false)
+        pinImageView.setAccessibilityElement(false)
+        groupImageView.setAccessibilityElement(false)
+        disclosureButton.setAccessibilityIdentifier("sidebarWorkspaceGroup.disclosure")
+        addButton.setAccessibilityIdentifier("sidebarWorkspaceGroup.addWorkspace")
+    }
+
+    private func configureDisclosure(snapshot: SidebarWorkspaceGroupRowSnapshot, scale: CGFloat) {
+        let symbol = snapshot.isCollapsed ? "chevron.right" : "chevron.down"
+        disclosureButton.image = NSImage(systemSymbolName: symbol, accessibilityDescription: nil)
+        disclosureButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(9 * scale),
+            weight: .semibold
+        )
+        let label = snapshot.isCollapsed
+            ? String(localized: "workspaceGroup.expand.a11y", defaultValue: "Expand group")
+            : String(localized: "workspaceGroup.collapse.a11y", defaultValue: "Collapse group")
+        disclosureButton.setAccessibilityLabel(label)
+        disclosureButton.toolTip = label
+    }
+
+    private func configurePin(snapshot: SidebarWorkspaceGroupRowSnapshot, scale: CGFloat) {
+        pinImageView.isHidden = !snapshot.isPinned
+        guard snapshot.isPinned else { return }
+        pinImageView.image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: nil)
+        pinImageView.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(9 * scale),
+            weight: .semibold
+        )
+        pinImageView.toolTip = String(
+            localized: "workspaceGroup.pinned.tooltip",
+            defaultValue: "Pinned group"
+        )
+    }
+
+    private func configureGroupIcon(snapshot: SidebarWorkspaceGroupRowSnapshot, scale: CGFloat) {
+        let configured = NSImage(systemSymbolName: snapshot.iconSymbol, accessibilityDescription: nil)
+        groupImageView.image = configured
+            ?? NSImage(systemSymbolName: "folder.fill", accessibilityDescription: nil)
+        groupImageView.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11 * scale),
+            weight: .semibold
+        )
+        groupImageView.isHidden = false
+    }
+
+    private func configureUnread(snapshot: SidebarWorkspaceGroupRowSnapshot, scale: CGFloat) {
+        guard snapshot.anchorUnreadCount > 0 else {
+            unreadBadge.resetForReuse()
+            return
+        }
+        unreadBadge.configure(
+            count: snapshot.anchorUnreadCount,
+            fillColor: cmuxAccentNSColor(for: effectiveAppearance),
+            textColor: .white,
+            font: GlobalFontMagnification.systemFont(
+                ofSize: 10 * scale,
+                weight: .semibold
+            ),
+            height: GlobalFontMagnification.scaledSize(
+                SidebarAppKitCellMetrics.accessorySide * scale
+            )
+        )
+    }
+
+    private func configureShortcut(snapshot: SidebarWorkspaceGroupRowSnapshot, scale: CGFloat) {
+        guard snapshot.showsShortcutHint,
+              let modifier = snapshot.shortcutModifierSymbol,
+              let digit = snapshot.shortcutDigit else {
+            shortcutLabel.stringValue = ""
+            shortcutLabel.isHidden = true
+            return
+        }
+        shortcutLabel.stringValue = "\(modifier)\(digit)"
+        shortcutLabel.font = GlobalFontMagnification.monospacedSystemFont(
+            ofSize: 10 * scale,
+            weight: .semibold
+        )
+        shortcutLabel.isHidden = false
+    }
+
+    private func refreshFontMagnification() {
+        guard let snapshot else { return }
+        let scale = max(0.5, snapshot.fontScale)
+        nameLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 11 * scale,
+            weight: .semibold
+        )
+        configureDisclosure(snapshot: snapshot, scale: scale)
+        configurePin(snapshot: snapshot, scale: scale)
+        configureGroupIcon(snapshot: snapshot, scale: scale)
+        configureUnread(snapshot: snapshot, scale: scale)
+        configureShortcut(snapshot: snapshot, scale: scale)
+        addButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(11),
+            weight: .medium
+        )
+        needsLayout = true
+        if let tableView = enclosingTableView {
+            let row = tableView.row(for: self)
+            if row >= 0 {
+                tableView.noteHeightOfRows(withIndexesChanged: IndexSet(integer: row))
+            }
+        }
+    }
+
+    private func configureColors(snapshot: SidebarWorkspaceGroupRowSnapshot) {
+        let accent = cmuxAccentNSColor(for: effectiveAppearance)
+        let tint = snapshot.tintHex.flatMap(NSColor.init(hex:)) ?? .secondaryLabelColor
+        let activeBackground = snapshot.isAnchorActive ? accent.withAlphaComponent(0.16) : nil
+
+        nameLabel.textColor = snapshot.isAnchorActive ? .labelColor : .labelColor.withAlphaComponent(0.9)
+        disclosureButton.contentTintColor = .secondaryLabelColor
+        pinImageView.contentTintColor = .secondaryLabelColor
+        groupImageView.contentTintColor = tint
+        shortcutLabel.textColor = .secondaryLabelColor
+        addButton.contentTintColor = .secondaryLabelColor
+
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            backgroundView.layer?.backgroundColor = activeBackground?
+                .usingColorSpace(.deviceRGB)?.cgColor
+            backgroundView.layer?.borderWidth = snapshot.isAnchorActive ? 1 : 0
+            backgroundView.layer?.borderColor = snapshot.isAnchorActive
+                ? accent.withAlphaComponent(0.35).usingColorSpace(.deviceRGB)?.cgColor
+                : nil
+        }
+    }
+
+    private func configureAccessibility(snapshot: SidebarWorkspaceGroupRowSnapshot) {
+        setAccessibilityIdentifier("sidebarWorkspaceGroup.\(snapshot.groupId.uuidString)")
+        setAccessibilityLabel(snapshot.name)
+        setAccessibilityHint(String(
+            localized: "workspaceGroup.focusAnchor.a11y",
+            defaultValue: "Focus the group’s anchor workspace"
+        ))
+        setAccessibilitySelected(snapshot.isAnchorActive)
+        if snapshot.anchorUnreadCount > 0 {
+            setAccessibilityValue(String.localizedStringWithFormat(
+                String(localized: "workspaceGroup.unread.a11y", defaultValue: "%lld unread"),
+                Int64(snapshot.anchorUnreadCount)
+            ))
+        } else {
+            setAccessibilityValue(nil)
+        }
+        addButton.setAccessibilityLabel(String(
+            localized: "workspaceGroup.newWorkspaceInGroup.a11y",
+            defaultValue: "New workspace in group"
+        ))
+    }
+
+    private func updateAddButtonVisibility() {
+        let visible = isPointerInside && shortcutLabel.isHidden
+        addButton.isHidden = !visible
+        addButton.setAccessibilityElement(visible)
+    }
+
+    private func updateDropIndicatorColors() {
+        let color = cmuxAccentNSColor(for: effectiveAppearance)
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            topDropIndicator.layer?.backgroundColor = color.usingColorSpace(.deviceRGB)?.cgColor
+            bottomDropIndicator.layer?.backgroundColor = color.usingColorSpace(.deviceRGB)?.cgColor
+        }
+    }
+
+    @objc private func toggleCollapsed() {
+        actions.onToggleCollapsed()
+    }
+
+    @objc private func addWorkspace() {
+        actions.onAddWorkspace()
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitGroupCellView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitGroupCellView.swift
@@ -478,7 +478,7 @@ final class SidebarAppKitGroupCellView: NSTableCellView {
     private func configureAccessibility(snapshot: SidebarWorkspaceGroupRowSnapshot) {
         setAccessibilityIdentifier("sidebarWorkspaceGroup.\(snapshot.groupId.uuidString)")
         setAccessibilityLabel(snapshot.name)
-        setAccessibilityHint(String(
+        setAccessibilityHelp(String(
             localized: "workspaceGroup.focusAnchor.a11y",
             defaultValue: "Focus the group’s anchor workspace"
         ))

--- a/Sources/Sidebar/AppKit/SidebarAppKitHeaderView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitHeaderView.swift
@@ -1,0 +1,598 @@
+import AppKit
+import CmuxFoundation
+import Foundation
+
+/// Native titlebar-height header for the default AppKit workspace sidebar.
+///
+/// The control hierarchy is permanent. Callers replace the small state value
+/// and action bundle as live window state changes; buttons always dispatch
+/// through the latest bundle rather than retaining per-update closures.
+@MainActor
+final class SidebarAppKitHeaderView: NSView {
+    nonisolated enum Control: Int, CaseIterable, Sendable {
+        case toggleSidebar
+        case showNotifications
+        case newWorkspace
+        case cloudVM
+        case focusHistoryBack
+        case focusHistoryForward
+
+        var accessibilityIdentifier: String {
+            switch self {
+            case .toggleSidebar:
+                "titlebarControl.toggleSidebar"
+            case .showNotifications:
+                "titlebarControl.showNotifications"
+            case .newWorkspace:
+                "titlebarControl.newTab"
+            case .cloudVM:
+                "titlebarControl.cloudVM"
+            case .focusHistoryBack:
+                "titlebarControl.focusHistoryBack"
+            case .focusHistoryForward:
+                "titlebarControl.focusHistoryForward"
+            }
+        }
+
+        var accessibilityLabel: String {
+            switch self {
+            case .toggleSidebar:
+                String(
+                    localized: "titlebar.sidebar.accessibilityLabel",
+                    defaultValue: "Toggle Sidebar"
+                )
+            case .showNotifications:
+                String(
+                    localized: "titlebar.notifications.accessibilityLabel",
+                    defaultValue: "Notifications"
+                )
+            case .newWorkspace:
+                String(
+                    localized: "titlebar.newWorkspace.accessibilityLabel",
+                    defaultValue: "New Workspace"
+                )
+            case .cloudVM:
+                String(
+                    localized: "titlebar.cloudVM.accessibilityLabel",
+                    defaultValue: "cloud VM"
+                )
+            case .focusHistoryBack:
+                String(localized: "menu.history.focusBack", defaultValue: "Focus Back")
+            case .focusHistoryForward:
+                String(localized: "menu.history.focusForward", defaultValue: "Focus Forward")
+            }
+        }
+
+        var acceptsContextMenu: Bool {
+            self != .showNotifications
+        }
+    }
+
+    nonisolated struct State: Equatable, Sendable {
+        var canNavigateBack: Bool
+        var canNavigateForward: Bool
+        var unreadNotificationCount: Int
+        var isNotificationsPresented: Bool
+        var showsControls: Bool
+
+        init(
+            canNavigateBack: Bool,
+            canNavigateForward: Bool,
+            unreadNotificationCount: Int,
+            isNotificationsPresented: Bool = false,
+            showsControls: Bool = true
+        ) {
+            self.canNavigateBack = canNavigateBack
+            self.canNavigateForward = canNavigateForward
+            self.unreadNotificationCount = max(0, unreadNotificationCount)
+            self.isNotificationsPresented = isNotificationsPresented
+            self.showsControls = showsControls
+        }
+
+        static let empty = Self(
+            canNavigateBack: false,
+            canNavigateForward: false,
+            unreadNotificationCount: 0
+        )
+    }
+
+    struct Actions {
+        var onToggleSidebar: () -> Void
+        var onToggleNotifications: (NSView) -> Void
+        var onNewWorkspace: () -> Void
+        var onCloudVM: (NSView) -> Void
+        var onFocusHistoryBack: () -> Void
+        var onFocusHistoryForward: () -> Void
+        var onContextMenu: ((Control, NSView, NSEvent) -> Void)?
+
+        init(
+            onToggleSidebar: @escaping () -> Void,
+            onToggleNotifications: @escaping (NSView) -> Void,
+            onNewWorkspace: @escaping () -> Void,
+            onCloudVM: @escaping (NSView) -> Void,
+            onFocusHistoryBack: @escaping () -> Void,
+            onFocusHistoryForward: @escaping () -> Void,
+            onContextMenu: ((Control, NSView, NSEvent) -> Void)? = nil
+        ) {
+            self.onToggleSidebar = onToggleSidebar
+            self.onToggleNotifications = onToggleNotifications
+            self.onNewWorkspace = onNewWorkspace
+            self.onCloudVM = onCloudVM
+            self.onFocusHistoryBack = onFocusHistoryBack
+            self.onFocusHistoryForward = onFocusHistoryForward
+            self.onContextMenu = onContextMenu
+        }
+
+        static let none = Self(
+            onToggleSidebar: {},
+            onToggleNotifications: { _ in },
+            onNewWorkspace: {},
+            onCloudVM: { _ in },
+            onFocusHistoryBack: {},
+            onFocusHistoryForward: {}
+        )
+    }
+
+    private enum Metrics {
+        static let baseHeight = WindowChromeMetrics.appTitlebarHeight
+        static let leadingInset = HeaderChromeControlMetrics.titlebarControlsLeadingPadding
+        static let trailingInset: CGFloat = 4
+        static let baseButtonSide = HeaderChromeControlMetrics.buttonSize
+        static let baseIconSize = HeaderChromeControlMetrics.iconSize
+        static let spacing: CGFloat = 6
+        static let baseBadgeSide: CGFloat = 12
+
+        static var iconSize: CGFloat {
+            GlobalFontMagnification.scaledSize(baseIconSize)
+        }
+
+        static var buttonSide: CGFloat {
+            max(
+                baseButtonSide,
+                HeaderChromeControlMetrics.iconFrameSize(forIconSize: iconSize)
+            )
+        }
+
+        static var height: CGFloat {
+            let baseVerticalInsets = baseHeight - baseButtonSide
+            return max(baseHeight, buttonSide + baseVerticalInsets)
+        }
+
+        static var badgeSide: CGFloat {
+            GlobalFontMagnification.scaledSize(baseBadgeSide)
+        }
+    }
+
+    private let controlsStack = NSStackView()
+    private let toggleSidebarButton = HeaderButton(control: .toggleSidebar)
+    private let notificationsButton = HeaderButton(control: .showNotifications)
+    private let newWorkspaceButton = HeaderButton(control: .newWorkspace)
+    private let cloudVMButton = HeaderButton(control: .cloudVM)
+    private let focusBackButton = HeaderButton(control: .focusHistoryBack)
+    private let focusForwardButton = HeaderButton(control: .focusHistoryForward)
+    private let notificationBadge = SidebarAppKitBadgeView()
+    private var buttonsByControl: [Control: HeaderButton] = [:]
+    private var buttonSizeConstraints: [NSLayoutConstraint] = []
+    private var fontMagnificationObserver: GlobalFontMagnificationChangeObserver?
+
+    private var state = State.empty
+    private var actions = Actions.none
+    private var isPointerInside = false
+    private var pointerTrackingArea: NSTrackingArea?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setUpHierarchy()
+        setUpAccessibility()
+        applyState()
+        fontMagnificationObserver = GlobalFontMagnificationChangeObserver { [weak self] in
+            self?.refreshFontMagnification()
+        }
+    }
+
+    convenience init(state: State, actions: Actions) {
+        self.init(frame: .zero)
+        configure(state: state, actions: actions)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var intrinsicContentSize: NSSize {
+        let controlsWidth = CGFloat(Control.allCases.count) * Metrics.buttonSide
+            + CGFloat(Control.allCases.count - 1) * Metrics.spacing
+        return NSSize(
+            width: Metrics.leadingInset + controlsWidth + Metrics.trailingInset,
+            height: Metrics.height
+        )
+    }
+
+    override var mouseDownCanMoveWindow: Bool { false }
+
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+        true
+    }
+
+    /// Replaces both current presentation state and every live callback.
+    func configure(state: State, actions: Actions) {
+        self.actions = actions
+        update(state: state)
+    }
+
+    /// Updates availability, unread count, and notification presentation.
+    func update(state: State) {
+        self.state = State(
+            canNavigateBack: state.canNavigateBack,
+            canNavigateForward: state.canNavigateForward,
+            unreadNotificationCount: state.unreadNotificationCount,
+            isNotificationsPresented: state.isNotificationsPresented,
+            showsControls: state.showsControls
+        )
+        applyState()
+    }
+
+    /// Replaces callbacks without rebuilding or reconfiguring the controls.
+    func update(actions: Actions) {
+        self.actions = actions
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount >= 2 {
+            let result = handleTitlebarDoubleClick(
+                window: window,
+                behavior: .standardAction
+            )
+            if result.consumesEvent {
+                return
+            }
+        }
+
+        guard !isWindowDragSuppressed(window: window) else { return }
+        if let window {
+            withTemporaryWindowMovableEnabled(window: window) {
+                window.performDrag(with: event)
+            }
+        } else {
+            super.mouseDown(with: event)
+        }
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        for button in buttonsByControl.values {
+            button.refreshAppearance()
+        }
+        applyNotificationBadge()
+    }
+
+    override func updateTrackingAreas() {
+        if let pointerTrackingArea {
+            removeTrackingArea(pointerTrackingArea)
+        }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(area)
+        pointerTrackingArea = area
+        super.updateTrackingAreas()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isPointerInside = true
+        applyControlsVisibility()
+        super.mouseEntered(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isPointerInside = false
+        applyControlsVisibility()
+        super.mouseExited(with: event)
+    }
+
+    private func setUpHierarchy() {
+        wantsLayer = true
+        setAccessibilityElement(false)
+
+        buttonsByControl = [
+            .toggleSidebar: toggleSidebarButton,
+            .showNotifications: notificationsButton,
+            .newWorkspace: newWorkspaceButton,
+            .cloudVM: cloudVMButton,
+            .focusHistoryBack: focusBackButton,
+            .focusHistoryForward: focusForwardButton,
+        ]
+
+        configureButton(toggleSidebarButton, symbol: "sidebar.left", weight: .regular)
+        configureButton(notificationsButton, symbol: "bell", weight: .regular)
+        configureButton(newWorkspaceButton, symbol: "plus", weight: .medium)
+        configureButton(cloudVMButton, symbol: "chevron.down", weight: .medium)
+        configureButton(focusBackButton, symbol: "arrow.left", weight: .regular)
+        configureButton(focusForwardButton, symbol: "arrow.right", weight: .regular)
+
+        controlsStack.translatesAutoresizingMaskIntoConstraints = false
+        controlsStack.orientation = .horizontal
+        controlsStack.alignment = .centerY
+        controlsStack.distribution = .fill
+        controlsStack.spacing = Metrics.spacing
+        addSubview(controlsStack)
+        for control in Control.allCases {
+            guard let button = buttonsByControl[control] else { continue }
+            controlsStack.addArrangedSubview(button)
+            buttonSizeConstraints.append(
+                button.widthAnchor.constraint(equalToConstant: Metrics.buttonSide)
+            )
+            buttonSizeConstraints.append(
+                button.heightAnchor.constraint(equalToConstant: Metrics.buttonSide)
+            )
+        }
+        NSLayoutConstraint.activate(buttonSizeConstraints)
+
+        notificationBadge.setAccessibilityElement(false)
+        notificationsButton.addSubview(notificationBadge)
+
+        NSLayoutConstraint.activate([
+            controlsStack.leadingAnchor.constraint(equalTo: leadingAnchor, constant: Metrics.leadingInset),
+            controlsStack.centerYAnchor.constraint(equalTo: centerYAnchor),
+            controlsStack.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -Metrics.trailingInset),
+            notificationBadge.topAnchor.constraint(equalTo: notificationsButton.topAnchor),
+            notificationBadge.trailingAnchor.constraint(equalTo: notificationsButton.trailingAnchor),
+        ])
+
+        setContentHuggingPriority(.required, for: .vertical)
+        setContentCompressionResistancePriority(.required, for: .vertical)
+    }
+
+    private func configureButton(
+        _ button: HeaderButton,
+        symbol: String,
+        weight: NSFont.Weight
+    ) {
+        button.translatesAutoresizingMaskIntoConstraints = false
+        button.isBordered = false
+        button.bezelStyle = .regularSquare
+        button.focusRingType = .none
+        button.imagePosition = .imageOnly
+        button.configureSymbol(named: symbol, weight: weight)
+        button.target = self
+        button.action = #selector(controlPressed(_:))
+        button.tag = button.control.rawValue
+        button.onRightMouseDown = { [weak self, weak button] event in
+            guard let self, let button else { return }
+            handleContextMenu(for: button.control, anchor: button, event: event)
+        }
+    }
+
+    private func setUpAccessibility() {
+        setAccessibilityIdentifier("SidebarAppKitHeader")
+        for (control, button) in buttonsByControl {
+            button.identifier = NSUserInterfaceItemIdentifier(control.accessibilityIdentifier)
+            button.setAccessibilityIdentifier(control.accessibilityIdentifier)
+            button.setAccessibilityLabel(control.accessibilityLabel)
+            button.setAccessibilityRole(.button)
+        }
+        refreshTooltips()
+    }
+
+    private func refreshTooltips() {
+        toggleSidebarButton.toolTip = KeyboardShortcutSettings.Action.toggleSidebar.tooltip(
+            String(
+                localized: "titlebar.sidebar.tooltip",
+                defaultValue: "Show or hide the sidebar"
+            )
+        )
+        notificationsButton.toolTip = KeyboardShortcutSettings.Action.showNotifications.tooltip(
+            String(
+                localized: "titlebar.notifications.tooltip",
+                defaultValue: "Show notifications"
+            )
+        )
+        newWorkspaceButton.toolTip = KeyboardShortcutSettings.Action.newTab.tooltip(
+            String(
+                localized: "titlebar.newWorkspace.tooltip",
+                defaultValue: "New workspace"
+            )
+        )
+        cloudVMButton.toolTip = String(
+            localized: "titlebar.cloudVM.menu.accessibilityLabel",
+            defaultValue: "Cloud VM Menu"
+        )
+        focusBackButton.toolTip = KeyboardShortcutSettings.Action.focusHistoryBack.tooltip(
+            String(localized: "menu.history.focusBack", defaultValue: "Focus Back")
+        )
+        focusForwardButton.toolTip = KeyboardShortcutSettings.Action.focusHistoryForward.tooltip(
+            String(localized: "menu.history.focusForward", defaultValue: "Focus Forward")
+        )
+    }
+
+    private func applyState() {
+        focusBackButton.isEnabled = state.canNavigateBack
+        focusForwardButton.isEnabled = state.canNavigateForward
+        notificationsButton.isActive = state.isNotificationsPresented
+        applyNotificationBadge()
+        applyControlsVisibility()
+    }
+
+    private func applyControlsVisibility() {
+        let isVisible = state.showsControls
+            && (isPointerInside || state.isNotificationsPresented)
+        controlsStack.isHidden = !isVisible
+        controlsStack.alphaValue = isVisible ? 1 : 0
+    }
+
+    private func applyNotificationBadge() {
+        guard state.unreadNotificationCount > 0 else {
+            notificationBadge.resetForReuse()
+            return
+        }
+        notificationBadge.configure(
+            count: min(state.unreadNotificationCount, 99),
+            fillColor: cmuxAccentNSColor(for: effectiveAppearance),
+            textColor: .white,
+            font: GlobalFontMagnification.systemFont(ofSize: 8, weight: .semibold),
+            height: Metrics.badgeSide
+        )
+    }
+
+    private func refreshFontMagnification() {
+        for constraint in buttonSizeConstraints {
+            constraint.constant = Metrics.buttonSide
+        }
+        for button in buttonsByControl.values {
+            button.refreshSymbolConfiguration()
+        }
+        applyNotificationBadge()
+        invalidateIntrinsicContentSize()
+        needsLayout = true
+        superview?.needsLayout = true
+    }
+
+    @objc private func controlPressed(_ sender: NSButton) {
+        guard let control = Control(rawValue: sender.tag) else { return }
+        switch control {
+        case .toggleSidebar:
+            actions.onToggleSidebar()
+        case .showNotifications:
+            actions.onToggleNotifications(sender)
+        case .newWorkspace:
+            actions.onNewWorkspace()
+        case .cloudVM:
+            actions.onCloudVM(sender)
+        case .focusHistoryBack:
+            guard state.canNavigateBack else { return }
+            actions.onFocusHistoryBack()
+        case .focusHistoryForward:
+            guard state.canNavigateForward else { return }
+            actions.onFocusHistoryForward()
+        }
+    }
+
+    private func handleContextMenu(
+        for control: Control,
+        anchor: NSView,
+        event: NSEvent
+    ) {
+        guard control.acceptsContextMenu else { return }
+        actions.onContextMenu?(control, anchor, event)
+    }
+
+    /// Titlebar-style icon button with native hover/active chrome.
+    private final class HeaderButton: NSButton {
+        let control: Control
+        var onRightMouseDown: ((NSEvent) -> Void)?
+        var isActive = false {
+            didSet { refreshAppearance() }
+        }
+
+        private var isPointerInside = false
+        private var pointerTrackingArea: NSTrackingArea?
+        private var symbolWeight: NSFont.Weight = .regular
+
+        init(control: Control) {
+            self.control = control
+            super.init(frame: .zero)
+            wantsLayer = true
+            layer?.cornerRadius = HeaderChromeControlMetrics.cornerRadius
+            layer?.masksToBounds = false
+            refreshAppearance()
+        }
+
+        required init?(coder: NSCoder) {
+            nil
+        }
+
+        override var mouseDownCanMoveWindow: Bool { false }
+
+        override var isEnabled: Bool {
+            didSet { refreshAppearance() }
+        }
+
+        override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+            true
+        }
+
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            bounds.contains(point) ? self : nil
+        }
+
+        override func updateTrackingAreas() {
+            if let pointerTrackingArea {
+                removeTrackingArea(pointerTrackingArea)
+            }
+            let area = NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            )
+            addTrackingArea(area)
+            pointerTrackingArea = area
+            super.updateTrackingAreas()
+        }
+
+        override func mouseEntered(with event: NSEvent) {
+            isPointerInside = true
+            refreshAppearance()
+        }
+
+        override func mouseExited(with event: NSEvent) {
+            isPointerInside = false
+            refreshAppearance()
+        }
+
+        override func rightMouseDown(with event: NSEvent) {
+            guard control.acceptsContextMenu else {
+                super.rightMouseDown(with: event)
+                return
+            }
+            onRightMouseDown?(event)
+        }
+
+        override func viewDidChangeEffectiveAppearance() {
+            super.viewDidChangeEffectiveAppearance()
+            refreshAppearance()
+        }
+
+        func configureSymbol(named symbolName: String, weight: NSFont.Weight) {
+            image = NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)
+            symbolWeight = weight
+            refreshSymbolConfiguration()
+        }
+
+        func refreshSymbolConfiguration() {
+            symbolConfiguration = NSImage.SymbolConfiguration(
+                pointSize: Metrics.iconSize,
+                weight: symbolWeight
+            )
+        }
+
+        func refreshAppearance() {
+            let foregroundAlpha: CGFloat
+            if !isEnabled {
+                foregroundAlpha = 0.34
+            } else if isPointerInside || isActive {
+                foregroundAlpha = 0.96
+            } else {
+                foregroundAlpha = 0.86
+            }
+            contentTintColor = NSColor.secondaryLabelColor.withAlphaComponent(foregroundAlpha)
+
+            let backgroundAlpha: CGFloat
+            if isActive {
+                backgroundAlpha = 0.14
+            } else if isEnabled && isPointerInside {
+                backgroundAlpha = 0.07
+            } else {
+                backgroundAlpha = 0
+            }
+            effectiveAppearance.performAsCurrentDrawingAppearance {
+                layer?.backgroundColor = NSColor.secondaryLabelColor
+                    .withAlphaComponent(backgroundAlpha)
+                    .usingColorSpace(.deviceRGB)?.cgColor
+            }
+        }
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitHelpMenuController.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitHelpMenuController.swift
@@ -1,0 +1,156 @@
+import AppKit
+
+/// Lazily builds and presents the native menu anchored to the AppKit sidebar footer.
+@MainActor
+final class SidebarAppKitHelpMenuController: NSObject {
+    enum Action: String, CaseIterable {
+        case welcome
+        case keyboardShortcuts
+        case importBrowserData
+        case docs
+        case changelog
+        case github
+        case githubIssues
+        case discord
+    }
+
+    struct Callbacks {
+        let onHelpAction: (Action) -> Void
+        let onCheckForUpdates: () -> Void
+        let onSendFeedback: () -> Void
+    }
+
+    private let callbacks: Callbacks
+    private var cachedMenu: NSMenu?
+
+    private(set) var menuBuildCount = 0
+
+    init(callbacks: Callbacks) {
+        self.callbacks = callbacks
+        super.init()
+    }
+
+    var isMenuLoaded: Bool { cachedMenu != nil }
+
+    /// The same menu instance is reused after its first access.
+    var menu: NSMenu {
+        if let cachedMenu {
+            return cachedMenu
+        }
+        let menu = makeMenu()
+        cachedMenu = menu
+        menuBuildCount += 1
+        return menu
+    }
+
+    func present(relativeTo anchorView: NSView) {
+        menu.popUp(
+            positioning: nil,
+            at: NSPoint(x: 0, y: anchorView.bounds.maxY + 4),
+            in: anchorView
+        )
+    }
+
+    private func makeMenu() -> NSMenu {
+        let menu = NSMenu(
+            title: String(localized: "sidebar.help.button", defaultValue: "Help")
+        )
+        menu.autoenablesItems = false
+
+        menu.addItem(helpItem(
+            title: String(localized: "sidebar.help.welcome", defaultValue: "Welcome to cmux!"),
+            action: .welcome,
+            accessibilityIdentifier: "SidebarHelpMenuOptionWelcome"
+        ))
+        menu.addItem(callbackItem(
+            title: String(localized: "sidebar.help.sendFeedback", defaultValue: "Send Feedback"),
+            selector: #selector(sendFeedback(_:)),
+            accessibilityIdentifier: "SidebarHelpMenuOptionSendFeedback"
+        ))
+        menu.addItem(helpItem(
+            title: String(localized: "settings.section.keyboardShortcuts", defaultValue: "Keyboard Shortcuts"),
+            action: .keyboardShortcuts,
+            accessibilityIdentifier: "SidebarHelpMenuOptionKeyboardShortcuts"
+        ))
+        menu.addItem(helpItem(
+            title: String(localized: "menu.view.importFromBrowser", defaultValue: "Import Browser Data…"),
+            action: .importBrowserData,
+            accessibilityIdentifier: "SidebarHelpMenuOptionImportBrowserData"
+        ))
+        menu.addItem(.separator())
+        menu.addItem(helpItem(
+            title: String(localized: "about.docs", defaultValue: "Docs"),
+            action: .docs,
+            accessibilityIdentifier: "SidebarHelpMenuOptionDocs"
+        ))
+        menu.addItem(helpItem(
+            title: String(localized: "sidebar.help.changelog", defaultValue: "Changelog"),
+            action: .changelog,
+            accessibilityIdentifier: "SidebarHelpMenuOptionChangelog"
+        ))
+        menu.addItem(helpItem(
+            title: String(localized: "about.github", defaultValue: "GitHub"),
+            action: .github,
+            accessibilityIdentifier: "SidebarHelpMenuOptionGitHub"
+        ))
+        menu.addItem(helpItem(
+            title: String(localized: "sidebar.help.githubIssues", defaultValue: "GitHub Issues"),
+            action: .githubIssues,
+            accessibilityIdentifier: "SidebarHelpMenuOptionGitHubIssues"
+        ))
+        menu.addItem(helpItem(
+            title: String(localized: "sidebar.help.discord", defaultValue: "Discord"),
+            action: .discord,
+            accessibilityIdentifier: "SidebarHelpMenuOptionDiscord"
+        ))
+        menu.addItem(.separator())
+        menu.addItem(callbackItem(
+            title: String(localized: "command.checkForUpdates.title", defaultValue: "Check for Updates"),
+            selector: #selector(checkForUpdates(_:)),
+            accessibilityIdentifier: "SidebarHelpMenuOptionCheckForUpdates"
+        ))
+        return menu
+    }
+
+    private func helpItem(
+        title: String,
+        action: Action,
+        accessibilityIdentifier: String
+    ) -> NSMenuItem {
+        let item = callbackItem(
+            title: title,
+            selector: #selector(performHelpAction(_:)),
+            accessibilityIdentifier: accessibilityIdentifier
+        )
+        item.representedObject = action.rawValue
+        return item
+    }
+
+    private func callbackItem(
+        title: String,
+        selector: Selector,
+        accessibilityIdentifier: String
+    ) -> NSMenuItem {
+        let item = NSMenuItem(title: title, action: selector, keyEquivalent: "")
+        item.target = self
+        item.isEnabled = true
+        item.identifier = NSUserInterfaceItemIdentifier(accessibilityIdentifier)
+        return item
+    }
+
+    @objc private func performHelpAction(_ sender: NSMenuItem) {
+        guard let rawValue = sender.representedObject as? String,
+              let action = Action(rawValue: rawValue) else { return }
+        callbacks.onHelpAction(action)
+    }
+
+    @objc private func checkForUpdates(_ sender: NSMenuItem) {
+        _ = sender
+        callbacks.onCheckForUpdates()
+    }
+
+    @objc private func sendFeedback(_ sender: NSMenuItem) {
+        _ = sender
+        callbacks.onSendFeedback()
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitInteractionCoordinator.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitInteractionCoordinator.swift
@@ -1,0 +1,347 @@
+import AppKit
+import CmuxFoundation
+import CmuxSettings
+import CmuxWorkspaces
+import Foundation
+
+/// Resolves native sidebar interactions against live window state.
+///
+/// Cells retain stable ids and call this coordinator only in response to a
+/// user event. Deferred actions never capture a stale workspace array.
+@MainActor
+final class SidebarAppKitInteractionCoordinator {
+    struct StateAccess {
+        var selectedWorkspaceIds: () -> Set<UUID>
+        var setSelectedWorkspaceIds: (Set<UUID>) -> Void
+        var lastSelectionIndex: () -> Int?
+        var setLastSelectionIndex: (Int?) -> Void
+        var selectTabsPage: () -> Void
+        var showsAgentActivity: () -> Bool
+    }
+
+    private let tabManager: TabManager
+    private let projectionSource: SidebarAppKitProjectionSource
+    private let notificationStore: TerminalNotificationStore
+    private var state: StateAccess
+
+    init(
+        tabManager: TabManager,
+        projectionSource: SidebarAppKitProjectionSource,
+        notificationStore: TerminalNotificationStore = .shared,
+        state: StateAccess
+    ) {
+        self.tabManager = tabManager
+        self.projectionSource = projectionSource
+        self.notificationStore = notificationStore
+        self.state = state
+    }
+
+    func updateStateAccess(_ state: StateAccess) {
+        self.state = state
+    }
+
+    func activateWorkspace(_ workspaceId: UUID, modifiers: NSEvent.ModifierFlags) {
+        guard let workspace = projectionSource.workspaceById[workspaceId],
+              let clickedIndex = projectionSource.workspaceIndexById[workspaceId] else {
+            return
+        }
+        let isCommand = modifiers.contains(.command)
+        let isShift = modifiers.contains(.shift)
+        let wasFocused = tabManager.selectedTabId == workspaceId
+        var selectedIds = state.selectedWorkspaceIds()
+
+        let shiftAnchorIndex = isShift
+            ? SidebarWorkspaceSelectionSyncPolicy().shiftClickAnchorIndex(
+                existingAnchorIndex: state.lastSelectionIndex(),
+                selectedWorkspaceIds: selectedIds,
+                focusedWorkspaceId: tabManager.selectedTabId,
+                liveWorkspaceIds: tabManager.tabs.map(\.id)
+            )
+            : nil
+
+        if isShift, let anchorIndex = shiftAnchorIndex {
+            let lower = min(anchorIndex, clickedIndex)
+            let upper = max(anchorIndex, clickedIndex)
+            let collapsedGroupIds = Set(
+                projectionSource.groupById.values.filter(\.isCollapsed).map(\.id)
+            )
+            let anchorIdsByGroup = Dictionary(
+                uniqueKeysWithValues: projectionSource.groupById.values.map {
+                    ($0.id, $0.anchorWorkspaceId)
+                }
+            )
+            let rangeIds = tabManager.tabs[lower...upper].compactMap { candidate -> UUID? in
+                if let groupId = candidate.groupId,
+                   collapsedGroupIds.contains(groupId),
+                   anchorIdsByGroup[groupId] != candidate.id {
+                    return nil
+                }
+                return candidate.id
+            }
+            if isCommand {
+                selectedIds.formUnion(rangeIds)
+            } else {
+                selectedIds = Set(rangeIds)
+            }
+        } else if isCommand {
+            if selectedIds.contains(workspaceId) {
+                selectedIds.remove(workspaceId)
+            } else {
+                selectedIds.insert(workspaceId)
+            }
+        } else {
+            selectedIds = [workspaceId]
+        }
+
+        state.setSelectedWorkspaceIds(selectedIds)
+        state.setLastSelectionIndex(
+            SidebarWorkspaceSelectionSyncPolicy().anchorIndexAfterWorkspaceClick(
+                isShiftClick: isShift,
+                resolvedShiftAnchorIndex: shiftAnchorIndex,
+                clickedIndex: clickedIndex
+            )
+        )
+        tabManager.selectTab(workspace)
+        if wasFocused, !isCommand, !isShift {
+            tabManager.dismissNotificationOnDirectInteraction(
+                tabId: workspaceId,
+                surfaceId: tabManager.focusedSurfaceId(for: workspaceId)
+            )
+        }
+        state.selectTabsPage()
+        projectionSource.updateExternalState(
+            selectedWorkspaceIds: selectedIds,
+            showsAgentActivity: state.showsAgentActivity()
+        )
+    }
+
+    func focusGroupAnchor(_ groupId: UUID) {
+        guard let group = projectionSource.groupById[groupId],
+              let workspace = projectionSource.workspaceById[group.anchorWorkspaceId] else {
+            return
+        }
+        tabManager.selectWorkspace(workspace)
+        state.setSelectedWorkspaceIds([workspace.id])
+        state.setLastSelectionIndex(projectionSource.workspaceIndexById[workspace.id])
+        state.selectTabsPage()
+        projectionSource.updateExternalState(
+            selectedWorkspaceIds: [workspace.id],
+            showsAgentActivity: state.showsAgentActivity()
+        )
+    }
+
+    func toggleGroupCollapsed(_ groupId: UUID) {
+        tabManager.toggleWorkspaceGroupCollapsed(groupId: groupId)
+    }
+
+    func addWorkspace(toGroup groupId: UUID) {
+        let placement = projectionSource.groupSnapshot(groupId: groupId)?.newWorkspacePlacement
+            ?? UserDefaultsSettingsClient(defaults: .standard)
+                .value(for: SettingCatalog().workspaceGroups.newWorkspacePlacement)
+        _ = tabManager.createWorkspaceInGroup(groupId: groupId, placement: placement)
+    }
+
+    func addWorkspaceAtEnd() {
+        if tabManager.selectedTab?.isRemoteTmuxMirror == true {
+            _ = AppDelegate.shared?.performNewWorkspaceAction(
+                tabManager: tabManager,
+                debugSource: "sidebar.appKit.emptyArea.remoteTmux"
+            )
+        } else {
+            tabManager.addWorkspace(placementOverride: .end)
+        }
+        let selectedId = tabManager.selectedTabId
+        state.setSelectedWorkspaceIds(selectedId.map { [$0] } ?? [])
+        state.setLastSelectionIndex(
+            selectedId.flatMap { id in tabManager.tabs.firstIndex { $0.id == id } }
+        )
+        state.selectTabsPage()
+    }
+
+    func renameWorkspace(_ workspaceId: UUID, to title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        tabManager.setCustomTitle(tabId: workspaceId, title: trimmed)
+    }
+
+    func clearWorkspaceTitle(_ workspaceId: UUID) {
+        tabManager.clearCustomTitle(tabId: workspaceId)
+    }
+
+    func closeWorkspace(_ workspaceId: UUID) {
+        guard let workspace = projectionSource.workspaceById[workspaceId] else { return }
+        tabManager.closeWorkspaceFromTabCloseButton(workspace)
+        reconcileSelectionAfterMutation()
+    }
+
+    func closeWorkspaceFromMiddleClick(_ workspaceId: UUID) {
+        guard let workspace = projectionSource.workspaceById[workspaceId] else { return }
+        tabManager.closeWorkspaceWithConfirmation(workspace)
+        reconcileSelectionAfterMutation()
+    }
+
+    func reconnectRemoteWorkspace(_ workspaceId: UUID) {
+        guard let workspace = projectionSource.workspaceById[workspaceId],
+              workspace.isRemoteWorkspace,
+              !workspace.isManagedCloudVMWorkspace else {
+            return
+        }
+        workspace.reconnectRemoteConnection()
+    }
+
+    func copyRemoteError(_ text: String) {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        WorkspaceSurfaceIdentifierClipboardText.copy(text)
+    }
+
+    func moveWorkspace(_ workspaceId: UUID, by delta: Int) {
+        guard tabManager.reorderWorkspace(tabId: workspaceId, by: delta) else { return }
+        state.setSelectedWorkspaceIds([workspaceId])
+        state.setLastSelectionIndex(tabManager.tabs.firstIndex { $0.id == workspaceId })
+        if let workspace = tabManager.tabs.first(where: { $0.id == workspaceId }) {
+            tabManager.selectTab(workspace)
+        }
+        state.selectTabsPage()
+    }
+
+    func moveWorkspaces(_ workspaceIds: [UUID], toWindow windowId: UUID) {
+        guard let app = AppDelegate.shared else { return }
+        let requestedIds = Set(workspaceIds)
+        let orderedIds = tabManager.tabs.compactMap {
+            requestedIds.contains($0.id) ? $0.id : nil
+        }
+        guard !orderedIds.isEmpty else { return }
+
+        var movedIds: [UUID] = []
+        movedIds.reserveCapacity(orderedIds.count)
+        for workspaceId in orderedIds {
+            if app.moveWorkspaceToWindow(
+                workspaceId: workspaceId,
+                windowId: windowId,
+                focus: false
+            ) {
+                movedIds.append(workspaceId)
+            }
+        }
+        guard let focusId = movedIds.last else { return }
+        _ = app.moveWorkspaceToWindow(
+            workspaceId: focusId,
+            windowId: windowId,
+            focus: true
+        )
+        reconcileSelectionAfterMutation()
+    }
+
+    func moveWorkspacesToNewWindow(_ workspaceIds: [UUID]) {
+        guard let app = AppDelegate.shared else { return }
+        let requestedIds = Set(workspaceIds)
+        let orderedIds = tabManager.tabs.compactMap {
+            requestedIds.contains($0.id) ? $0.id : nil
+        }
+        guard let firstId = orderedIds.first,
+              let newWindowId = app.moveWorkspaceToNewWindow(
+                workspaceId: firstId,
+                focus: false
+              ) else {
+            return
+        }
+
+        var movedIds = [firstId]
+        movedIds.reserveCapacity(orderedIds.count)
+        for workspaceId in orderedIds.dropFirst() {
+            if app.moveWorkspaceToWindow(
+                workspaceId: workspaceId,
+                windowId: newWindowId,
+                focus: false
+            ) {
+                movedIds.append(workspaceId)
+            }
+        }
+        if let focusId = movedIds.last {
+            _ = app.moveWorkspaceToWindow(
+                workspaceId: focusId,
+                windowId: newWindowId,
+                focus: true
+            )
+        }
+        reconcileSelectionAfterMutation()
+    }
+
+    func markWorkspaceRead(_ workspaceId: UUID) {
+        guard notificationStore.canMarkWorkspaceRead(forTabIds: [workspaceId]) else { return }
+        notificationStore.markRead(forTabId: workspaceId)
+    }
+
+    func markWorkspaceUnread(_ workspaceId: UUID) {
+        guard notificationStore.canMarkWorkspaceUnread(forTabIds: [workspaceId]) else { return }
+        notificationStore.markUnread(forTabId: workspaceId)
+    }
+
+    func openURL(_ url: URL, fromWorkspace workspaceId: UUID) {
+        let settings = SidebarTabItemSettingsSnapshot()
+        openURL(
+            url,
+            fromWorkspace: workspaceId,
+            prefersCmuxBrowser: settings.openPullRequestLinksInCmuxBrowser
+        )
+    }
+
+    func openMetadataURL(_ url: URL, fromWorkspace workspaceId: UUID) {
+        openURL(url, fromWorkspace: workspaceId, prefersCmuxBrowser: false)
+    }
+
+    func openPort(_ port: Int, fromWorkspace workspaceId: UUID) {
+        guard let url = URL(string: "http://localhost:\(port)") else { return }
+        let settings = SidebarTabItemSettingsSnapshot()
+        openURL(
+            url,
+            fromWorkspace: workspaceId,
+            prefersCmuxBrowser: settings.openPortLinksInCmuxBrowser
+        )
+    }
+
+    private func openURL(
+        _ url: URL,
+        fromWorkspace workspaceId: UUID,
+        prefersCmuxBrowser: Bool
+    ) {
+        guard projectionSource.workspaceById[workspaceId] != nil else { return }
+        activateWorkspace(workspaceId, modifiers: NSEvent.modifierFlags)
+        if prefersCmuxBrowser,
+           tabManager.openBrowser(
+               inWorkspace: workspaceId,
+               url: url,
+               preferSplitRight: true,
+               insertAtEnd: true
+           ) != nil {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+
+    func dragItemProvider(for workspaceId: UUID) -> NSItemProvider {
+        SidebarTabDragPayload(tabId: workspaceId).provider()
+    }
+
+    /// Reconciles the sidebar's multi-selection and shift-click anchor after an
+    /// action mutates ordering or removes workspaces. Context-menu actions use
+    /// the same path as native row buttons so no entrypoint leaves stale ids or
+    /// an anchor index pointing at the previous order.
+    func reconcileSelectionAfterMutation() {
+        let existingIds = Set(tabManager.tabs.map(\.id))
+        var selectedIds = state.selectedWorkspaceIds().intersection(existingIds)
+        if selectedIds.isEmpty, let selectedId = tabManager.selectedTabId {
+            selectedIds = [selectedId]
+        }
+        state.setSelectedWorkspaceIds(selectedIds)
+        state.setLastSelectionIndex(
+            tabManager.selectedTabId.flatMap { selectedId in
+                tabManager.tabs.firstIndex { $0.id == selectedId }
+            }
+        )
+        projectionSource.updateExternalState(
+            selectedWorkspaceIds: selectedIds,
+            showsAgentActivity: state.showsAgentActivity()
+        )
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitModifierMonitor.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitModifierMonitor.swift
@@ -1,0 +1,53 @@
+import AppKit
+
+/// Window-scoped modifier monitor for native shortcut hints.
+///
+/// One local event monitor updates a Boolean. The projection source then
+/// reconfigures only visible native rows when the Command key changes.
+@MainActor
+final class SidebarAppKitModifierMonitor {
+    private weak var window: NSWindow?
+    private var eventMonitor: Any?
+    private(set) var isCommandPressed = false
+    var onChange: ((Bool) -> Void)?
+
+    func start(window: NSWindow?) {
+        self.window = window
+        if eventMonitor == nil {
+            eventMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
+                [weak self] event in
+                MainActor.assumeIsolated {
+                    self?.receive(event)
+                }
+                return event
+            }
+        }
+        setCommandPressed(NSEvent.modifierFlags.contains(.command))
+    }
+
+    func updateWindow(_ window: NSWindow?) {
+        self.window = window
+    }
+
+    func stop() {
+        if let eventMonitor {
+            NSEvent.removeMonitor(eventMonitor)
+            self.eventMonitor = nil
+        }
+        setCommandPressed(false)
+        window = nil
+    }
+
+    private func receive(_ event: NSEvent) {
+        if let window, let eventWindow = event.window, eventWindow !== window {
+            return
+        }
+        setCommandPressed(event.modifierFlags.contains(.command))
+    }
+
+    private func setCommandPressed(_ value: Bool) {
+        guard value != isCommandPressed else { return }
+        isCommandPressed = value
+        onChange?(value)
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitProjectionSource.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitProjectionSource.swift
@@ -1,0 +1,651 @@
+import AppKit
+import Combine
+import CmuxCore
+import CmuxSettings
+import CmuxWorkspaces
+import Foundation
+
+/// Main-actor projection boundary for the native workspace sidebar.
+///
+/// Structural publishers are observed once for the whole table. Row-affecting
+/// workspace publishers are observed only while a workspace is visible. This
+/// keeps the number of long-lived tasks proportional to reusable table cells,
+/// rather than the total number of workspaces.
+@MainActor
+final class SidebarAppKitProjectionSource {
+    private struct GroupAggregate {
+        var totalUnreadCount = 0
+        var nonAnchorMemberCount = 0
+        var unreadNonAnchorMemberCount = 0
+    }
+
+    struct Change {
+        let structureChanged: Bool
+        let itemIds: Set<SidebarWorkspaceRenderItemID>
+        let selectionChanged: Bool
+
+        static let structure = Change(
+            structureChanged: true,
+            itemIds: [],
+            selectionChanged: true
+        )
+
+        static func rows(
+            _ itemIds: Set<SidebarWorkspaceRenderItemID>,
+            selectionChanged: Bool = false
+        ) -> Change {
+            Change(
+                structureChanged: false,
+                itemIds: itemIds,
+                selectionChanged: selectionChanged
+            )
+        }
+    }
+
+    private let tabManager: TabManager
+    private let sidebarUnread: SidebarUnreadModel
+    private let cmuxConfigStore: CmuxConfigStore
+    private let notificationStore: TerminalNotificationStore
+    private let onWorkspaceProjection: () -> Void
+
+    private var tabs: [Workspace]
+    private var groups: [WorkspaceGroup]
+    private var selectedWorkspaceId: UUID?
+    private var selectedWorkspaceIds: Set<UUID>
+    private var unreadSummariesByWorkspaceId: [UUID: SidebarWorkspaceUnreadSummary]
+    private var settings: SidebarTabItemSettingsSnapshot
+    private var showsAgentActivity: Bool
+    private var showsModifierShortcutHints: Bool
+    private var expandedChecklistWorkspaceIds: Set<UUID> = []
+
+    private(set) var renderItems: [SidebarWorkspaceRenderItem] = []
+    private(set) var workspaceById: [UUID: Workspace] = [:]
+    private(set) var workspaceIndexById: [UUID: Int] = [:]
+    private(set) var groupById: [UUID: WorkspaceGroup] = [:]
+    private(set) var memberWorkspaceIdsByGroupId: [UUID: [UUID]] = [:]
+    private var groupAggregateById: [UUID: GroupAggregate] = [:]
+
+    private var detailSnapshotByWorkspaceId: [UUID: SidebarWorkspaceSnapshotBuilder.Snapshot] = [:]
+    private var visibleWorkspaceIds: Set<UUID> = []
+    private var visibleObservationTasks: [UUID: Task<Void, Never>] = [:]
+    private var modelObservationTasks: [Task<Void, Never>] = []
+    private var unreadSummaryChangesCancellable: AnyCancellable?
+    private var settingsObservers: [NSObjectProtocol] = []
+    private var sidebarFontSize: CGFloat
+
+    var onChange: ((Change) -> Void)?
+
+    init(
+        tabManager: TabManager,
+        sidebarUnread: SidebarUnreadModel,
+        cmuxConfigStore: CmuxConfigStore,
+        notificationStore: TerminalNotificationStore = .shared,
+        selectedWorkspaceIds: Set<UUID>,
+        showsAgentActivity: Bool,
+        showsModifierShortcutHints: Bool = false,
+        onWorkspaceProjection: @escaping () -> Void = {}
+    ) {
+        self.tabManager = tabManager
+        self.sidebarUnread = sidebarUnread
+        self.cmuxConfigStore = cmuxConfigStore
+        self.notificationStore = notificationStore
+        self.onWorkspaceProjection = onWorkspaceProjection
+        tabs = tabManager.tabs
+        groups = tabManager.workspaceGroups
+        selectedWorkspaceId = tabManager.selectedTabId
+        self.selectedWorkspaceIds = selectedWorkspaceIds
+        unreadSummariesByWorkspaceId = sidebarUnread.summaryByWorkspaceId
+        sidebarFontSize = GhosttyConfig.load().sidebarFontSize
+        settings = SidebarTabItemSettingsSnapshot(sidebarFontSize: sidebarFontSize)
+        self.showsAgentActivity = showsAgentActivity
+        self.showsModifierShortcutHints = showsModifierShortcutHints
+        rebuildStructure(notify: false)
+        startModelObservations()
+        startSettingsObservations()
+    }
+
+    deinit {
+        for task in modelObservationTasks { task.cancel() }
+        for task in visibleObservationTasks.values { task.cancel() }
+        unreadSummaryChangesCancellable?.cancel()
+        for observer in settingsObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+    }
+
+    func emitCurrentState() {
+        onChange?(.structure)
+    }
+
+    func updateExternalState(
+        selectedWorkspaceIds: Set<UUID>,
+        showsAgentActivity: Bool,
+        showsModifierShortcutHints: Bool? = nil
+    ) {
+        var changedIds: Set<SidebarWorkspaceRenderItemID> = []
+        var selectionChanged = false
+        if self.selectedWorkspaceIds != selectedWorkspaceIds {
+            selectionChanged = true
+            changedIds = changedSelectionItemIds(
+                from: self.selectedWorkspaceIds,
+                to: selectedWorkspaceIds
+            )
+            self.selectedWorkspaceIds = selectedWorkspaceIds
+        }
+
+        if self.showsAgentActivity != showsAgentActivity {
+            self.showsAgentActivity = showsAgentActivity
+            detailSnapshotByWorkspaceId.removeAll(keepingCapacity: true)
+            changedIds.formUnion(visibleWorkspaceIds.map(SidebarWorkspaceRenderItemID.workspace))
+        }
+        if let showsModifierShortcutHints,
+           self.showsModifierShortcutHints != showsModifierShortcutHints {
+            self.showsModifierShortcutHints = showsModifierShortcutHints
+            changedIds.formUnion(visibleWorkspaceIds.map {
+                renderItemId(forWorkspaceId: $0)
+            })
+        }
+        publishRows(changedIds, selectionChanged: selectionChanged)
+    }
+
+    func setVisibleWorkspaceIds(_ ids: Set<UUID>) {
+        let liveVisibleIds = Set(ids.filter { workspaceById[$0] != nil })
+        guard liveVisibleIds != visibleWorkspaceIds else { return }
+
+        let removedIds = visibleWorkspaceIds.subtracting(liveVisibleIds)
+        let addedIds = liveVisibleIds.subtracting(visibleWorkspaceIds)
+        visibleWorkspaceIds = liveVisibleIds
+
+        for id in removedIds {
+            visibleObservationTasks.removeValue(forKey: id)?.cancel()
+        }
+        for id in addedIds {
+            guard let workspace = workspaceById[id] else { continue }
+            visibleObservationTasks[id] = observeVisibleWorkspace(workspace)
+        }
+    }
+
+    func setChecklistExpanded(_ isExpanded: Bool, workspaceId: UUID) {
+        guard workspaceById[workspaceId] != nil else { return }
+        let changed: Bool
+        if isExpanded {
+            changed = expandedChecklistWorkspaceIds.insert(workspaceId).inserted
+        } else {
+            changed = expandedChecklistWorkspaceIds.remove(workspaceId) != nil
+        }
+        guard changed else { return }
+        publishRows([renderItemId(forWorkspaceId: workspaceId)])
+    }
+
+    func isChecklistExpanded(workspaceId: UUID) -> Bool {
+        expandedChecklistWorkspaceIds.contains(workspaceId)
+    }
+
+    func collapseAllChecklists() {
+        guard !expandedChecklistWorkspaceIds.isEmpty else { return }
+        let itemIds = Set(expandedChecklistWorkspaceIds.map(renderItemId(forWorkspaceId:)))
+        expandedChecklistWorkspaceIds.removeAll(keepingCapacity: true)
+        publishRows(itemIds)
+    }
+
+    func workspaceSnapshot(workspaceId: UUID) -> SidebarWorkspaceRowSnapshot? {
+        guard let workspace = workspaceById[workspaceId],
+              let index = workspaceIndexById[workspaceId] else {
+            return nil
+        }
+        onWorkspaceProjection()
+        let detail = detailSnapshot(for: workspace)
+        let unread = unreadSummariesByWorkspaceId[workspaceId]
+            ?? SidebarWorkspaceUnreadSummary(unreadCount: 0, latestNotificationText: nil)
+        let todoResolution = WorkspaceTaskStatusOverride.effectiveStatus(
+            override: workspace.todoState.statusOverride,
+            inferred: workspace.inferredTaskStatus
+        )
+        let activeTodoOverride: WorkspaceTaskStatus? = {
+            guard let override = workspace.todoState.statusOverride,
+                  !todoResolution.shouldClearOverride else {
+                return nil
+            }
+            return override.status
+        }()
+        // Native menus resolve their complete target aggregate only when the
+        // menu opens. The cell snapshot carries a constant-size placeholder so
+        // realizing one row never scans the selected set, all groups, all live
+        // workspace ids, or the notification collection.
+        let contextMenu = SidebarWorkspaceContextMenuSnapshot(
+            targetWorkspaceIds: [workspaceId],
+            remoteTargetWorkspaceIds: [],
+            allRemoteTargetsConnecting: false,
+            allRemoteTargetsDisconnected: false,
+            pinState: nil,
+            groupMenuSnapshot: WorkspaceGroupMenuSnapshot(items: []),
+            canCreateEmptyGroup: selectedWorkspaceId.flatMap { workspaceById[$0] }?.isRemoteTmuxMirror != true,
+            eligibleGroupTargetIds: [],
+            allEligibleTargetsGroupId: nil,
+            hasGroupedEligibleTarget: false,
+            todoStatusLanes: WorkspaceTodoStatusLane.lanes(
+                inferred: workspace.inferredTaskStatus,
+                activeOverride: activeTodoOverride,
+                isHidden: workspace.todoState.statusHidden
+            ),
+            canMarkRead: unread.unreadCount > 0,
+            canMarkUnread: unread.unreadCount == 0,
+            // Native menus resolve notifications when the menu opens. Keeping
+            // them out of every visible-cell snapshot avoids sorting/copying
+            // menu payloads during scroll and hover.
+            hasLatestNotification: false,
+            notifications: []
+        )
+
+        return SidebarWorkspaceRowSnapshot(
+            workspaceId: workspaceId,
+            groupId: workspace.groupId,
+            index: index,
+            workspaceCount: tabs.count,
+            workspace: detail,
+            isActive: selectedWorkspaceId == workspaceId,
+            isMultiSelected: selectedWorkspaceIds.contains(workspaceId),
+            hasUserCustomTitle: workspace.effectiveCustomTitleSource == .user,
+            hasCustomTitle: workspace.hasCustomTitle,
+            hasCustomDescription: workspace.hasCustomDescription,
+            customTitle: workspace.customTitle,
+            workspaceShortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                at: index,
+                workspaceCount: tabs.count
+            ),
+            workspaceShortcutModifierSymbol: KeyboardShortcutSettings
+                .shortcut(for: .selectWorkspaceByNumber)
+                .numberedDigitHintPrefix,
+            canCloseWorkspace: tabs.count > 1,
+            unreadCount: unread.unreadCount,
+            latestNotificationText: settings.showsNotificationMessage
+                ? unread.latestNotificationText
+                : nil,
+            showsAgentActivity: showsAgentActivity,
+            rowSpacing: 2,
+            showsModifierShortcutHints: showsModifierShortcutHints,
+            isPointerHovering: false,
+            isBeingDragged: false,
+            topDropIndicatorVisible: false,
+            bottomDropIndicatorVisible: false,
+            isBonsplitWorkspaceDropActive: false,
+            settings: settings,
+            isChecklistExpanded: expandedChecklistWorkspaceIds.contains(workspaceId),
+            checklistAddFieldActivationToken: 0,
+            isChecklistPopoverPresented: false,
+            contextMenu: contextMenu
+        )
+    }
+
+    func groupSnapshot(groupId: UUID) -> SidebarWorkspaceGroupRowSnapshot? {
+        guard let group = groupById[groupId] else { return nil }
+        let memberIds = memberWorkspaceIdsByGroupId[groupId] ?? []
+        let anchorIndex = workspaceIndexById[group.anchorWorkspaceId] ?? 0
+        let anchorCwd = workspaceById[group.anchorWorkspaceId]?.currentDirectory
+        let resolvedConfig = cmuxConfigStore.resolveWorkspaceGroupConfig(forCwd: anchorCwd)
+        let aggregate = groupAggregateById[groupId] ?? GroupAggregate()
+        let anchorUnreadCount: Int
+        if group.isCollapsed {
+            anchorUnreadCount = aggregate.totalUnreadCount
+        } else {
+            anchorUnreadCount = unreadSummariesByWorkspaceId[group.anchorWorkspaceId]?.unreadCount ?? 0
+        }
+
+        return SidebarWorkspaceGroupRowSnapshot(
+            groupId: group.id,
+            anchorWorkspaceId: group.anchorWorkspaceId,
+            name: group.name,
+            iconSymbol: RenderableSystemSymbol.resolvedWorkspaceGroupIcon(
+                explicit: group.iconSymbol,
+                configured: resolvedConfig?.iconSymbol
+            ),
+            tintHex: group.customColor ?? resolvedConfig?.color,
+            isCollapsed: group.isCollapsed,
+            isPinned: group.isPinned,
+            isAnchorActive: selectedWorkspaceId == group.anchorWorkspaceId,
+            memberCount: memberIds.count,
+            anchorUnreadCount: anchorUnreadCount,
+            canMarkRead: (unreadSummariesByWorkspaceId[group.anchorWorkspaceId]?.unreadCount ?? 0) > 0,
+            canMarkUnread: (unreadSummariesByWorkspaceId[group.anchorWorkspaceId]?.unreadCount ?? 0) == 0,
+            hasLatestNotifications: notificationStore.latestNotification(forTabId: group.anchorWorkspaceId) != nil,
+            canMarkAllRead: aggregate.unreadNonAnchorMemberCount > 0,
+            canMarkAllUnread: aggregate.unreadNonAnchorMemberCount
+                < aggregate.nonAnchorMemberCount,
+            shortcutDigit: WorkspaceShortcutMapper.digitForWorkspace(
+                at: anchorIndex,
+                workspaceCount: tabs.count
+            ),
+            shortcutModifierSymbol: KeyboardShortcutSettings
+                .shortcut(for: .selectWorkspaceByNumber)
+                .numberedDigitHintPrefix,
+            showsShortcutHint: showsModifierShortcutHints,
+            isPointerHovering: false,
+            shortcutHintXOffset: settings.sidebarShortcutHintXOffset,
+            shortcutHintYOffset: settings.sidebarShortcutHintYOffset,
+            fontScale: settings.sidebarFontScale,
+            cwdContextMenuItems: resolvedConfig?.contextMenuItems ?? [],
+            newWorkspacePlacement: resolvedConfig?.newWorkspacePlacement,
+            rowSpacing: 2,
+            isFirstRow: renderItems.first?.rowWorkspaceId == group.anchorWorkspaceId,
+            isBeingDragged: false,
+            topDropIndicatorVisible: false,
+            bottomDropIndicatorVisible: false,
+            shouldCollectWorkspaceDropTargets: false
+        )
+    }
+
+    func contextTargetWorkspaceIds(for workspaceId: UUID) -> [UUID] {
+        guard selectedWorkspaceIds.contains(workspaceId) else { return [workspaceId] }
+        return tabs.compactMap { selectedWorkspaceIds.contains($0.id) ? $0.id : nil }
+    }
+
+    private func startModelObservations() {
+        unreadSummaryChangesCancellable = sidebarUnread.summaryChangesPublisher.sink {
+            [weak self] changes in
+            MainActor.assumeIsolated {
+                self?.receiveUnreadSummaryChanges(changes)
+            }
+        }
+        modelObservationTasks = [
+            Task { @MainActor [weak self, tabManager] in
+                for await nextTabs in tabManager.tabsPublisher.values {
+                    guard !Task.isCancelled, let self else { return }
+                    receiveTabs(nextTabs)
+                }
+            },
+            Task { @MainActor [weak self, tabManager] in
+                for await nextGroups in tabManager.workspaceGroupsPublisher.values {
+                    guard !Task.isCancelled, let self else { return }
+                    receiveGroups(nextGroups)
+                }
+            },
+            Task { @MainActor [weak self, tabManager] in
+                for await nextSelectedId in tabManager.selectedTabIdPublisher.values {
+                    guard !Task.isCancelled, let self else { return }
+                    receiveSelectedWorkspaceId(nextSelectedId)
+                }
+            },
+            Task { @MainActor [weak self, cmuxConfigStore] in
+                for await _ in cmuxConfigStore.$workspaceGroupConfigs.values {
+                    guard !Task.isCancelled, let self else { return }
+                    publishRows(Set(groups.map {
+                        SidebarWorkspaceRenderItemID.group($0.id)
+                    }))
+                }
+            },
+        ]
+    }
+
+    private func startSettingsObservations() {
+        let defaultsObserver = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in self?.refreshSettings() }
+        }
+        let ghosttyObserver = NotificationCenter.default.addObserver(
+            forName: .ghosttyConfigDidReload,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                sidebarFontSize = GhosttyConfig.load().sidebarFontSize
+                refreshSettings()
+            }
+        }
+        settingsObservers = [defaultsObserver, ghosttyObserver]
+    }
+
+    private func receiveTabs(_ nextTabs: [Workspace]) {
+        let previousWorkspaceById = Dictionary(
+            tabs.map { ($0.id, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        let oldIds = tabs.map(\.id)
+        let nextIds = nextTabs.map(\.id)
+        let oldGroupIds = tabs.map(\.groupId)
+        let nextGroupIds = nextTabs.map(\.groupId)
+        let replacedWorkspaceIds = nextTabs.compactMap { next in
+            guard let previous = previousWorkspaceById[next.id], previous !== next else {
+                return nil
+            }
+            return next.id
+        }
+        tabs = nextTabs
+        if !replacedWorkspaceIds.isEmpty {
+            for id in replacedWorkspaceIds { detailSnapshotByWorkspaceId[id] = nil }
+        }
+        guard oldIds != nextIds || oldGroupIds != nextGroupIds || !replacedWorkspaceIds.isEmpty else {
+            return
+        }
+        rebuildStructure(
+            notify: true,
+            replacedWorkspaceIds: Set(replacedWorkspaceIds)
+        )
+    }
+
+    private func receiveGroups(_ nextGroups: [WorkspaceGroup]) {
+        guard groups != nextGroups else { return }
+        groups = nextGroups
+        rebuildStructure(notify: true)
+    }
+
+    private func receiveSelectedWorkspaceId(_ nextId: UUID?) {
+        guard selectedWorkspaceId != nextId else { return }
+        let previousId = selectedWorkspaceId
+        selectedWorkspaceId = nextId
+        var ids: Set<SidebarWorkspaceRenderItemID> = []
+        if let previousId { ids.insert(renderItemId(forWorkspaceId: previousId)) }
+        if let nextId { ids.insert(renderItemId(forWorkspaceId: nextId)) }
+        publishRows(ids)
+    }
+
+    private func receiveUnreadSummaryChanges(
+        _ changes: [SidebarWorkspaceUnreadSummaryChange]
+    ) {
+        guard !changes.isEmpty else { return }
+        var itemIds = Set<SidebarWorkspaceRenderItemID>()
+        itemIds.reserveCapacity(changes.count * 2)
+        for change in changes {
+            let workspaceId = change.workspaceId
+            let previous = unreadSummariesByWorkspaceId[workspaceId]
+            guard previous != change.summary else { continue }
+            if let summary = change.summary {
+                unreadSummariesByWorkspaceId[workspaceId] = summary
+            } else {
+                unreadSummariesByWorkspaceId.removeValue(forKey: workspaceId)
+            }
+            updateGroupAggregate(
+                workspaceId: workspaceId,
+                previous: previous,
+                next: change.summary
+            )
+            itemIds.insert(.workspace(workspaceId))
+            if let groupId = workspaceById[workspaceId]?.groupId {
+                itemIds.insert(.group(groupId))
+            }
+        }
+        publishRows(itemIds)
+    }
+
+    private func rebuildStructure(
+        notify: Bool,
+        replacedWorkspaceIds: Set<UUID> = []
+    ) {
+        let liveIds = Set(tabs.map(\.id))
+        workspaceById = Dictionary(tabs.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        workspaceIndexById = Dictionary(
+            tabs.enumerated().map { ($0.element.id, $0.offset) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        groupById = Dictionary(groups.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        memberWorkspaceIdsByGroupId = SidebarWorkspaceRenderItem.memberWorkspaceIdsByGroupId(tabs: tabs)
+        rebuildGroupAggregates()
+        renderItems = SidebarWorkspaceRenderItem.renderItems(tabs: tabs, groupsById: groupById)
+        detailSnapshotByWorkspaceId = detailSnapshotByWorkspaceId.filter { liveIds.contains($0.key) }
+        expandedChecklistWorkspaceIds.formIntersection(liveIds)
+        setVisibleWorkspaceIds(visibleWorkspaceIds)
+        restartVisibleObservations(for: replacedWorkspaceIds)
+        if notify { onChange?(.structure) }
+    }
+
+    /// A structural publisher may replace a `Workspace` reference without
+    /// changing its stable id. Visible observation tasks capture the reference,
+    /// so transfer those tasks to the replacement instead of treating the
+    /// unchanged visible-id set as a no-op.
+    private func restartVisibleObservations(for workspaceIds: Set<UUID>) {
+        for workspaceId in workspaceIds where visibleWorkspaceIds.contains(workspaceId) {
+            visibleObservationTasks.removeValue(forKey: workspaceId)?.cancel()
+            guard let workspace = workspaceById[workspaceId] else { continue }
+            visibleObservationTasks[workspaceId] = observeVisibleWorkspace(workspace)
+        }
+    }
+
+    private func rebuildGroupAggregates() {
+        var next: [UUID: GroupAggregate] = [:]
+        next.reserveCapacity(groups.count)
+        for group in groups {
+            let memberIds = memberWorkspaceIdsByGroupId[group.id] ?? []
+            var aggregate = GroupAggregate()
+            aggregate.nonAnchorMemberCount = memberIds.reduce(into: 0) { count, workspaceId in
+                if workspaceId != group.anchorWorkspaceId {
+                    count += 1
+                }
+            }
+            for workspaceId in memberIds {
+                let unreadCount = unreadSummariesByWorkspaceId[workspaceId]?.unreadCount ?? 0
+                aggregate.totalUnreadCount += unreadCount
+                if workspaceId != group.anchorWorkspaceId, unreadCount > 0 {
+                    aggregate.unreadNonAnchorMemberCount += 1
+                }
+            }
+            next[group.id] = aggregate
+        }
+        groupAggregateById = next
+    }
+
+    private func updateGroupAggregate(
+        workspaceId: UUID,
+        previous: SidebarWorkspaceUnreadSummary?,
+        next: SidebarWorkspaceUnreadSummary?
+    ) {
+        guard let groupId = workspaceById[workspaceId]?.groupId,
+              let group = groupById[groupId],
+              var aggregate = groupAggregateById[groupId] else {
+            return
+        }
+        let previousCount = previous?.unreadCount ?? 0
+        let nextCount = next?.unreadCount ?? 0
+        aggregate.totalUnreadCount += nextCount - previousCount
+        if workspaceId != group.anchorWorkspaceId {
+            if previousCount == 0, nextCount > 0 {
+                aggregate.unreadNonAnchorMemberCount += 1
+            } else if previousCount > 0, nextCount == 0 {
+                aggregate.unreadNonAnchorMemberCount -= 1
+            }
+        }
+        groupAggregateById[groupId] = aggregate
+    }
+
+    private func observeVisibleWorkspace(_ workspace: Workspace) -> Task<Void, Never> {
+        let id = workspace.id
+        return Task { @MainActor [weak self, weak workspace] in
+            guard let workspace else { return }
+            await withTaskGroup(of: Void.self) { group in
+                group.addTask { @MainActor [weak self, weak workspace] in
+                    guard let workspace else { return }
+                    for await _ in workspace.sidebarImmediateObservationPublisher.values {
+                        guard !Task.isCancelled, let self else { return }
+                        invalidateDetail(workspaceId: id)
+                    }
+                }
+                group.addTask { @MainActor [weak self, weak workspace] in
+                    guard let workspace else { return }
+                    for await _ in workspace.sidebarObservationPublisher.values {
+                        guard !Task.isCancelled, let self else { return }
+                        invalidateDetail(workspaceId: id)
+                    }
+                }
+                group.addTask { @MainActor [weak self, weak workspace] in
+                    guard let workspace else { return }
+                    for await _ in workspace.sidebarProcessTitleObservation.changes() {
+                        guard !Task.isCancelled, let self else { return }
+                        invalidateDetail(workspaceId: id)
+                    }
+                }
+                group.addTask { @MainActor [weak self, weak workspace] in
+                    guard let workspace else { return }
+                    for await _ in workspace.sidebarAgentRuntimeObservation.changes() {
+                        guard !Task.isCancelled, let self else { return }
+                        invalidateDetail(workspaceId: id)
+                    }
+                }
+            }
+        }
+    }
+
+    private func invalidateDetail(workspaceId: UUID) {
+        detailSnapshotByWorkspaceId[workspaceId] = nil
+        var ids: Set<SidebarWorkspaceRenderItemID> = [renderItemId(forWorkspaceId: workspaceId)]
+        if let groupId = workspaceById[workspaceId]?.groupId {
+            ids.insert(.group(groupId))
+        }
+        publishRows(ids)
+    }
+
+    private func detailSnapshot(
+        for workspace: Workspace
+    ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+        let expectedKey = SidebarWorkspaceSnapshotFactory.presentationKey(
+            settings: settings,
+            showsAgentActivity: showsAgentActivity
+        )
+        if let cached = detailSnapshotByWorkspaceId[workspace.id],
+           cached.presentationKey == expectedKey {
+            return cached
+        }
+        let snapshot = SidebarWorkspaceSnapshotFactory(
+            workspace: workspace,
+            settings: settings,
+            showsAgentActivity: showsAgentActivity,
+            includesChecklistItems: false
+        ).makeSnapshot()
+        detailSnapshotByWorkspaceId[workspace.id] = snapshot
+        return snapshot
+    }
+
+    private func refreshSettings() {
+        let next = SidebarTabItemSettingsSnapshot(sidebarFontSize: sidebarFontSize)
+        guard next != settings else { return }
+        settings = next
+        detailSnapshotByWorkspaceId.removeAll(keepingCapacity: true)
+        var ids = Set(visibleWorkspaceIds.map(SidebarWorkspaceRenderItemID.workspace))
+        ids.formUnion(groups.map { SidebarWorkspaceRenderItemID.group($0.id) })
+        publishRows(ids)
+    }
+
+    private func changedSelectionItemIds(
+        from old: Set<UUID>,
+        to new: Set<UUID>
+    ) -> Set<SidebarWorkspaceRenderItemID> {
+        Set(old.symmetricDifference(new).map { renderItemId(forWorkspaceId: $0) })
+    }
+
+    private func renderItemId(forWorkspaceId workspaceId: UUID) -> SidebarWorkspaceRenderItemID {
+        if let groupId = workspaceById[workspaceId]?.groupId,
+           groupById[groupId]?.anchorWorkspaceId == workspaceId {
+            return .group(groupId)
+        }
+        return .workspace(workspaceId)
+    }
+
+    private func publishRows(
+        _ ids: Set<SidebarWorkspaceRenderItemID>,
+        selectionChanged: Bool = false
+    ) {
+        guard !ids.isEmpty else { return }
+        onChange?(.rows(ids, selectionChanged: selectionChanged))
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitProjectionSource.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitProjectionSource.swift
@@ -13,6 +13,22 @@ import Foundation
 /// rather than the total number of workspaces.
 @MainActor
 final class SidebarAppKitProjectionSource {
+    private final class VisibleWorkspaceObservation {
+        var cancellables: Set<AnyCancellable> = []
+        var tasks: [Task<Void, Never>] = []
+
+        func cancel() {
+            for cancellable in cancellables { cancellable.cancel() }
+            cancellables.removeAll()
+            for task in tasks { task.cancel() }
+            tasks.removeAll()
+        }
+
+        deinit {
+            cancel()
+        }
+    }
+
     private struct GroupAggregate {
         var totalUnreadCount = 0
         var nonAnchorMemberCount = 0
@@ -67,7 +83,7 @@ final class SidebarAppKitProjectionSource {
 
     private var detailSnapshotByWorkspaceId: [UUID: SidebarWorkspaceSnapshotBuilder.Snapshot] = [:]
     private var visibleWorkspaceIds: Set<UUID> = []
-    private var visibleObservationTasks: [UUID: Task<Void, Never>] = [:]
+    private var visibleObservations: [UUID: VisibleWorkspaceObservation] = [:]
     private var modelObservationTasks: [Task<Void, Never>] = []
     private var unreadSummaryChangesCancellable: AnyCancellable?
     private var settingsObservers: [NSObjectProtocol] = []
@@ -106,7 +122,7 @@ final class SidebarAppKitProjectionSource {
 
     deinit {
         for task in modelObservationTasks { task.cancel() }
-        for task in visibleObservationTasks.values { task.cancel() }
+        for observation in visibleObservations.values { observation.cancel() }
         unreadSummaryChangesCancellable?.cancel()
         for observer in settingsObservers {
             NotificationCenter.default.removeObserver(observer)
@@ -157,11 +173,11 @@ final class SidebarAppKitProjectionSource {
         visibleWorkspaceIds = liveVisibleIds
 
         for id in removedIds {
-            visibleObservationTasks.removeValue(forKey: id)?.cancel()
+            visibleObservations.removeValue(forKey: id)?.cancel()
         }
         for id in addedIds {
             guard let workspace = workspaceById[id] else { continue }
-            visibleObservationTasks[id] = observeVisibleWorkspace(workspace)
+            visibleObservations[id] = observeVisibleWorkspace(workspace)
         }
     }
 
@@ -407,7 +423,7 @@ final class SidebarAppKitProjectionSource {
         let nextIds = nextTabs.map(\.id)
         let oldGroupIds = tabs.map(\.groupId)
         let nextGroupIds = nextTabs.map(\.groupId)
-        let replacedWorkspaceIds = nextTabs.compactMap { next in
+        let replacedWorkspaceIds: [UUID] = nextTabs.compactMap { next -> UUID? in
             guard let previous = previousWorkspaceById[next.id], previous !== next else {
                 return nil
             }
@@ -497,9 +513,9 @@ final class SidebarAppKitProjectionSource {
     /// unchanged visible-id set as a no-op.
     private func restartVisibleObservations(for workspaceIds: Set<UUID>) {
         for workspaceId in workspaceIds where visibleWorkspaceIds.contains(workspaceId) {
-            visibleObservationTasks.removeValue(forKey: workspaceId)?.cancel()
+            visibleObservations.removeValue(forKey: workspaceId)?.cancel()
             guard let workspace = workspaceById[workspaceId] else { continue }
-            visibleObservationTasks[workspaceId] = observeVisibleWorkspace(workspace)
+            visibleObservations[workspaceId] = observeVisibleWorkspace(workspace)
         }
     }
 
@@ -549,41 +565,40 @@ final class SidebarAppKitProjectionSource {
         groupAggregateById[groupId] = aggregate
     }
 
-    private func observeVisibleWorkspace(_ workspace: Workspace) -> Task<Void, Never> {
+    private func observeVisibleWorkspace(_ workspace: Workspace) -> VisibleWorkspaceObservation {
         let id = workspace.id
-        return Task { @MainActor [weak self, weak workspace] in
-            guard let workspace else { return }
-            await withTaskGroup(of: Void.self) { group in
-                group.addTask { @MainActor [weak self, weak workspace] in
-                    guard let workspace else { return }
-                    for await _ in workspace.sidebarImmediateObservationPublisher.values {
-                        guard !Task.isCancelled, let self else { return }
-                        invalidateDetail(workspaceId: id)
-                    }
-                }
-                group.addTask { @MainActor [weak self, weak workspace] in
-                    guard let workspace else { return }
-                    for await _ in workspace.sidebarObservationPublisher.values {
-                        guard !Task.isCancelled, let self else { return }
-                        invalidateDetail(workspaceId: id)
-                    }
-                }
-                group.addTask { @MainActor [weak self, weak workspace] in
-                    guard let workspace else { return }
-                    for await _ in workspace.sidebarProcessTitleObservation.changes() {
-                        guard !Task.isCancelled, let self else { return }
-                        invalidateDetail(workspaceId: id)
-                    }
-                }
-                group.addTask { @MainActor [weak self, weak workspace] in
-                    guard let workspace else { return }
-                    for await _ in workspace.sidebarAgentRuntimeObservation.changes() {
-                        guard !Task.isCancelled, let self else { return }
-                        invalidateDetail(workspaceId: id)
-                    }
-                }
+        let observation = VisibleWorkspaceObservation()
+
+        workspace.sidebarImmediateObservationPublisher.sink { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.invalidateDetail(workspaceId: id)
             }
-        }
+        }.store(in: &observation.cancellables)
+
+        workspace.sidebarObservationPublisher.sink { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.invalidateDetail(workspaceId: id)
+            }
+        }.store(in: &observation.cancellables)
+
+        observation.tasks = [
+            Task { @MainActor [weak self, weak workspace] in
+                guard let workspace else { return }
+                for await _ in workspace.sidebarProcessTitleObservation.changes() {
+                    guard !Task.isCancelled, let self else { return }
+                    invalidateDetail(workspaceId: id)
+                }
+            },
+            Task { @MainActor [weak self, weak workspace] in
+                guard let workspace else { return }
+                for await _ in workspace.sidebarAgentRuntimeObservation.changes() {
+                    guard !Task.isCancelled, let self else { return }
+                    invalidateDetail(workspaceId: id)
+                }
+            },
+        ]
+
+        return observation
     }
 
     private func invalidateDetail(workspaceId: UUID) {

--- a/Sources/Sidebar/AppKit/SidebarAppKitRuntimeHostRepresentable.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitRuntimeHostRepresentable.swift
@@ -1,0 +1,887 @@
+import AppKit
+import Combine
+import CmuxFoundation
+import CmuxSidebar
+import CmuxUpdater
+import Foundation
+import Observation
+import SwiftUI
+
+/// Production SwiftUI ownership bridge for the native workspace sidebar.
+///
+/// The representable value may be recreated by SwiftUI, but its coordinator
+/// keeps the projection source, interaction router, and native footer alive for
+/// the lifetime of the mounted sidebar.
+@MainActor
+struct SidebarAppKitRuntimeHostRepresentable: NSViewControllerRepresentable {
+    let updateViewModel: UpdateStateModel
+    let fileExplorerState: FileExplorerState
+    let windowId: UUID
+    let onSendFeedback: () -> Void
+    let onToggleSidebar: () -> Void
+    let onNewTab: () -> Void
+    let observedWindow: NSWindow?
+    let tabManager: TabManager
+    let sidebarUnread: SidebarUnreadModel
+    let cmuxConfigStore: CmuxConfigStore
+    @Binding var selection: SidebarSelection
+    @Binding var selectedTabIds: Set<UUID>
+    @Binding var lastSidebarSelectionIndex: Int?
+    let showsAgentActivity: Bool
+    let enablesModifierShortcutHints: Bool
+    let workspaceRowInputProjection: (() -> Void)?
+
+    init(
+        updateViewModel: UpdateStateModel,
+        fileExplorerState: FileExplorerState,
+        windowId: UUID,
+        onSendFeedback: @escaping () -> Void,
+        onToggleSidebar: @escaping () -> Void,
+        onNewTab: @escaping () -> Void,
+        observedWindow: NSWindow?,
+        tabManager: TabManager,
+        sidebarUnread: SidebarUnreadModel,
+        cmuxConfigStore: CmuxConfigStore,
+        selection: Binding<SidebarSelection>,
+        selectedTabIds: Binding<Set<UUID>>,
+        lastSidebarSelectionIndex: Binding<Int?>,
+        showsAgentActivity: Bool,
+        enablesModifierShortcutHints: Bool,
+        workspaceRowInputProjection: (() -> Void)? = nil
+    ) {
+        self.updateViewModel = updateViewModel
+        self.fileExplorerState = fileExplorerState
+        self.windowId = windowId
+        self.onSendFeedback = onSendFeedback
+        self.onToggleSidebar = onToggleSidebar
+        self.onNewTab = onNewTab
+        self.observedWindow = observedWindow
+        self.tabManager = tabManager
+        self.sidebarUnread = sidebarUnread
+        self.cmuxConfigStore = cmuxConfigStore
+        _selection = selection
+        _selectedTabIds = selectedTabIds
+        _lastSidebarSelectionIndex = lastSidebarSelectionIndex
+        self.showsAgentActivity = showsAgentActivity
+        self.enablesModifierShortcutHints = enablesModifierShortcutHints
+        self.workspaceRowInputProjection = workspaceRowInputProjection
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(parent: self)
+    }
+
+    func makeNSViewController(context: Context) -> SidebarAppKitViewController {
+        let controller = SidebarAppKitViewController()
+        context.coordinator.connect(to: controller)
+        return controller
+    }
+
+    func updateNSViewController(
+        _ nsViewController: SidebarAppKitViewController,
+        context: Context
+    ) {
+        context.coordinator.update(parent: self, controller: nsViewController)
+    }
+
+    static func dismantleNSViewController(
+        _ nsViewController: SidebarAppKitViewController,
+        coordinator: Coordinator
+    ) {
+        coordinator.disconnect(from: nsViewController)
+    }
+
+    @MainActor
+    final class Coordinator {
+        private var parent: SidebarAppKitRuntimeHostRepresentable
+        private let projectionSource: SidebarAppKitProjectionSource
+        private weak var controller: SidebarAppKitViewController?
+        private weak var observedUpdateViewModel: UpdateStateModel?
+        private var updateObservationTask: Task<Void, Never>?
+        private var headerUnreadObservationTask: Task<Void, Never>?
+        private var defaultsObserver: NSObjectProtocol?
+        private var checklistAddObserver: NSObjectProtocol?
+        private var dragClearObserver: NSObjectProtocol?
+        private var chromeObservers: [NSObjectProtocol] = []
+        private var selectionObservers: [NSObjectProtocol] = []
+        private var observesFooterPresentation = false
+        private let modifierMonitor = SidebarAppKitModifierMonitor()
+        private let checklistPopoverController = SidebarAppKitChecklistPopoverController()
+        private var checklistStyle = WorkspaceTodoFeature.checklistStyle
+
+        private lazy var interactionCoordinator = SidebarAppKitInteractionCoordinator(
+            tabManager: parent.tabManager,
+            projectionSource: projectionSource,
+            state: makeStateAccess()
+        )
+
+        private lazy var dragCoordinator = SidebarAppKitDragCoordinator(
+            tabManager: parent.tabManager,
+            projectionSource: projectionSource,
+            windowId: parent.windowId,
+            workspaceDragRegistry: AppDelegate.shared?.sidebarWorkspaceDragRegistry
+                ?? SidebarWorkspaceDragRegistry(),
+            state: makeDragStateAccess()
+        )
+
+        private lazy var contextMenuController = SidebarAppKitContextMenuController(
+            tabManager: parent.tabManager,
+            projectionSource: projectionSource,
+            interactionCoordinator: interactionCoordinator
+        )
+
+        private lazy var headerView = SidebarAppKitHeaderView(
+            state: makeHeaderState(),
+            actions: makeHeaderActions()
+        )
+
+        private lazy var footerView = SidebarAppKitFooterView(
+            updateModel: parent.updateViewModel,
+            presentation: makeFooterPresentation(),
+            callbacks: SidebarAppKitFooterView.Callbacks(
+                onHelpAction: { [weak self] action in
+                    self?.performHelpAction(action)
+                },
+                onOpenExtensionBrowser: { [weak self] anchorView in
+                    self?.openExtensionBrowser(from: anchorView)
+                },
+                onOpenPricing: {
+                    ProUpgradePresenter.present()
+                },
+                onDismissPro: {
+                    ProBadgeStyleStore.shared.isDismissed = true
+                },
+                onCheckForUpdates: {
+                    AppDelegate.shared?.checkForUpdates(nil)
+                },
+                onCheckForUpdatesInCustomUI: {
+                    AppDelegate.shared?.checkForUpdatesInCustomUI()
+                },
+                onAttemptUpdate: {
+                    AppDelegate.shared?.attemptUpdate(nil)
+                },
+                updateLogPath: {
+                    AppDelegate.shared?.updateLogPath ?? ""
+                },
+                onSendFeedback: { [weak self] in
+                    self?.parent.onSendFeedback()
+                }
+            )
+        )
+
+        init(parent: SidebarAppKitRuntimeHostRepresentable) {
+            self.parent = parent
+            projectionSource = SidebarAppKitProjectionSource(
+                tabManager: parent.tabManager,
+                sidebarUnread: parent.sidebarUnread,
+                cmuxConfigStore: parent.cmuxConfigStore,
+                selectedWorkspaceIds: parent.selectedTabIds,
+                showsAgentActivity: parent.showsAgentActivity,
+                showsModifierShortcutHints: false
+            )
+        }
+
+        deinit {
+            updateObservationTask?.cancel()
+            headerUnreadObservationTask?.cancel()
+            if let defaultsObserver {
+                NotificationCenter.default.removeObserver(defaultsObserver)
+            }
+            if let checklistAddObserver {
+                NotificationCenter.default.removeObserver(checklistAddObserver)
+            }
+            if let dragClearObserver {
+                NotificationCenter.default.removeObserver(dragClearObserver)
+            }
+            for observer in chromeObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            for observer in selectionObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+        }
+
+        func connect(to controller: SidebarAppKitViewController) {
+            self.controller = controller
+            projectionSource.onChange = { [weak self, weak controller] change in
+                guard let self, let controller else { return }
+                if change.structureChanged {
+                    controller.apply(self.makeConfiguration())
+                } else {
+                    controller.reconfigure(itemIDs: change.itemIds)
+                    if change.selectionChanged {
+                        self.applySelection(to: controller)
+                    }
+                }
+            }
+            installFooterObserversIfNeeded()
+            installChromeObserversIfNeeded()
+            installChecklistAddObserverIfNeeded()
+            installDragClearObserverIfNeeded()
+            installSelectionObserversIfNeeded()
+            startHeaderUnreadObservationIfNeeded()
+            refreshHeaderPresentation()
+            refreshFooterPresentation()
+            modifierMonitor.onChange = { [weak self] isPressed in
+                self?.modifierStateChanged(isPressed: isPressed)
+            }
+            modifierMonitor.start(window: preferredWindow(using: AppDelegate.shared))
+            controller.apply(makeConfiguration())
+        }
+
+        func update(
+            parent: SidebarAppKitRuntimeHostRepresentable,
+            controller: SidebarAppKitViewController
+        ) {
+            self.parent = parent
+            self.controller = controller
+            interactionCoordinator.updateStateAccess(makeStateAccess())
+            dragCoordinator.updateStateAccess(makeDragStateAccess())
+            modifierMonitor.updateWindow(preferredWindow(using: AppDelegate.shared))
+            modifierStateChanged(isPressed: modifierMonitor.isCommandPressed)
+            installFooterObserversIfNeeded()
+            installChromeObserversIfNeeded()
+            installChecklistAddObserverIfNeeded()
+            installDragClearObserverIfNeeded()
+            installSelectionObserversIfNeeded()
+            headerView.update(actions: makeHeaderActions())
+            refreshHeaderPresentation()
+            refreshFooterPresentation()
+            applySelection(to: controller)
+        }
+
+        func disconnect(from controller: SidebarAppKitViewController) {
+            guard self.controller === controller else { return }
+            projectionSource.onChange = nil
+            projectionSource.setVisibleWorkspaceIds([])
+            updateObservationTask?.cancel()
+            updateObservationTask = nil
+            observedUpdateViewModel = nil
+            headerUnreadObservationTask?.cancel()
+            headerUnreadObservationTask = nil
+            if let defaultsObserver {
+                NotificationCenter.default.removeObserver(defaultsObserver)
+                self.defaultsObserver = nil
+            }
+            if let checklistAddObserver {
+                NotificationCenter.default.removeObserver(checklistAddObserver)
+                self.checklistAddObserver = nil
+            }
+            if let dragClearObserver {
+                NotificationCenter.default.removeObserver(dragClearObserver)
+                self.dragClearObserver = nil
+            }
+            for observer in chromeObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            chromeObservers.removeAll()
+            for observer in selectionObservers {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            selectionObservers.removeAll()
+            observesFooterPresentation = false
+            modifierMonitor.stop()
+            dragCoordinator.cancelActiveDrag()
+            checklistPopoverController.close()
+            controller.prepareForRemoval()
+            self.controller = nil
+        }
+
+        private func makeConfiguration() -> SidebarAppKitConfiguration {
+            SidebarAppKitConfiguration(
+                renderItems: projectionSource.renderItems,
+                selectedWorkspaceIDs: parent.selectedTabIds,
+                activeWorkspaceID: parent.tabManager.selectedTabId,
+                workspaceSnapshot: { [weak self] workspaceId in
+                    guard let self else { return nil }
+                    #if DEBUG
+                    self.parent.workspaceRowInputProjection?()
+                    #endif
+                    return self.projectionSource.workspaceSnapshot(workspaceId: workspaceId)
+                },
+                groupSnapshot: { [weak self] groupId in
+                    self?.projectionSource.groupSnapshot(groupId: groupId)
+                },
+                workspaceActions: { [weak self] workspaceId in
+                    self?.makeWorkspaceActions(workspaceId: workspaceId) ?? .none
+                },
+                groupActions: { [weak self] groupId in
+                    self?.makeGroupActions(groupId: groupId) ?? .none
+                },
+                interactions: SidebarAppKitConfiguration.InteractionHandlers(
+                    onSelectionChanged: { [weak self] primaryWorkspaceId, modifiers in
+                        guard let primaryWorkspaceId else { return }
+                        self?.interactionCoordinator.activateWorkspace(
+                            primaryWorkspaceId,
+                            modifiers: modifiers
+                        )
+                    },
+                    onHoveredItemChanged: { _ in },
+                    onMiddleClick: { [weak self] item, _ in
+                        self?.interactionCoordinator.closeWorkspaceFromMiddleClick(
+                            item.rowWorkspaceId
+                        )
+                    },
+                    contextMenuProvider: { [weak self] item, event in
+                        self?.contextMenuController.menu(for: item, event: event)
+                    },
+                    onEmptyAreaDoubleClick: { [weak self] in
+                        self?.interactionCoordinator.addWorkspaceAtEnd()
+                    },
+                    emptyAreaContextMenuProvider: { [weak self] _ in
+                        self?.contextMenuController.emptyAreaMenu()
+                    },
+                    onVisibleWorkspaceIDsChanged: { [weak self] workspaceIds in
+                        self?.projectionSource.setVisibleWorkspaceIds(workspaceIds)
+                    }
+                ),
+                dragHandlers: dragCoordinator.dragHandlers(),
+                headerView: headerView,
+                footerView: footerView
+            )
+        }
+
+        private func makeWorkspaceActions(
+            workspaceId: UUID
+        ) -> SidebarAppKitWorkspaceCellView.Actions {
+            SidebarAppKitWorkspaceCellView.Actions(
+                onActivate: { [weak self] in
+                    self?.interactionCoordinator.activateWorkspace(
+                        workspaceId,
+                        modifiers: NSEvent.modifierFlags
+                    )
+                },
+                onMoveUp: { [weak self] in
+                    self?.interactionCoordinator.moveWorkspace(workspaceId, by: -1)
+                },
+                onMoveDown: { [weak self] in
+                    self?.interactionCoordinator.moveWorkspace(workspaceId, by: 1)
+                },
+                onCommitRename: { [weak self] title in
+                    self?.interactionCoordinator.renameWorkspace(workspaceId, to: title)
+                },
+                onClose: { [weak self] in
+                    self?.interactionCoordinator.closeWorkspace(workspaceId)
+                },
+                onOpenMetadataURL: { [weak self] url in
+                    self?.interactionCoordinator.openMetadataURL(
+                        url,
+                        fromWorkspace: workspaceId
+                    )
+                },
+                onOpenPullRequest: { [weak self] url in
+                    self?.interactionCoordinator.openURL(url, fromWorkspace: workspaceId)
+                },
+                onOpenPort: { [weak self] port in
+                    self?.interactionCoordinator.openPort(port, fromWorkspace: workspaceId)
+                },
+                checklistStyle: WorkspaceTodoFeature.checklistStyle,
+                onOpenChecklist: { [weak self] anchorView in
+                    self?.toggleChecklist(workspaceId: workspaceId, anchorView: anchorView)
+                },
+                resolveChecklistWorkspace: { [weak self] in
+                    self?.projectionSource.workspaceById[workspaceId]
+                },
+                onChecklistHeightChanged: { [weak self] in
+                    self?.controller?.noteChecklistHeightChanged(for: workspaceId)
+                },
+                onReconnectRemote: { [weak self] in
+                    self?.interactionCoordinator.reconnectRemoteWorkspace(workspaceId)
+                },
+                onCopyRemoteError: { [weak self] text in
+                    self?.interactionCoordinator.copyRemoteError(text)
+                }
+            )
+        }
+
+        private func makeGroupActions(
+            groupId: UUID
+        ) -> SidebarAppKitGroupCellView.Actions {
+            SidebarAppKitGroupCellView.Actions(
+                onActivate: { [weak self] in
+                    self?.interactionCoordinator.focusGroupAnchor(groupId)
+                },
+                onToggleCollapsed: { [weak self] in
+                    self?.interactionCoordinator.toggleGroupCollapsed(groupId)
+                },
+                onAddWorkspace: { [weak self] in
+                    self?.interactionCoordinator.addWorkspace(toGroup: groupId)
+                },
+                onContextMenu: { [weak self] event in
+                    self?.contextMenuController.groupAddButtonMenu(
+                        groupId: groupId,
+                        event: event
+                    )
+                }
+            )
+        }
+
+        private func makeStateAccess() -> SidebarAppKitInteractionCoordinator.StateAccess {
+            SidebarAppKitInteractionCoordinator.StateAccess(
+                selectedWorkspaceIds: { [weak self] in
+                    self?.parent.selectedTabIds ?? []
+                },
+                setSelectedWorkspaceIds: { [weak self] ids in
+                    self?.parent.selectedTabIds = ids
+                },
+                lastSelectionIndex: { [weak self] in
+                    self?.parent.lastSidebarSelectionIndex
+                },
+                setLastSelectionIndex: { [weak self] index in
+                    self?.parent.lastSidebarSelectionIndex = index
+                },
+                selectTabsPage: { [weak self] in
+                    self?.parent.selection = .tabs
+                },
+                showsAgentActivity: { [weak self] in
+                    self?.parent.showsAgentActivity ?? false
+                }
+            )
+        }
+
+        private func makeDragStateAccess() -> SidebarAppKitDragCoordinator.StateAccess {
+            SidebarAppKitDragCoordinator.StateAccess(
+                selectedWorkspaceIds: { [weak self] in
+                    self?.parent.selectedTabIds ?? []
+                },
+                setSelectedWorkspaceIds: { [weak self] ids in
+                    self?.parent.selectedTabIds = ids
+                },
+                lastSelectionIndex: { [weak self] in
+                    self?.parent.lastSidebarSelectionIndex
+                },
+                setLastSelectionIndex: { [weak self] index in
+                    self?.parent.lastSidebarSelectionIndex = index
+                },
+                selectTabsPage: { [weak self] in
+                    self?.parent.selection = .tabs
+                }
+            )
+        }
+
+        private func applySelection(to controller: SidebarAppKitViewController) {
+            controller.updateSelection(
+                selectedWorkspaceIDs: parent.selectedTabIds,
+                activeWorkspaceID: parent.tabManager.selectedTabId
+            )
+        }
+
+        private func modifierStateChanged(isPressed: Bool) {
+            projectionSource.updateExternalState(
+                selectedWorkspaceIds: parent.selectedTabIds,
+                showsAgentActivity: parent.showsAgentActivity,
+                showsModifierShortcutHints: parent.enablesModifierShortcutHints && isPressed
+            )
+            refreshFooterPresentation()
+        }
+
+        private func installFooterObserversIfNeeded() {
+            if observedUpdateViewModel !== parent.updateViewModel {
+                updateObservationTask?.cancel()
+                let model = parent.updateViewModel
+                observedUpdateViewModel = model
+                updateObservationTask = Task { @MainActor [weak self, weak model] in
+                    guard let model else { return }
+                    for await _ in model.stateChanges() {
+                        guard !Task.isCancelled, let self else { return }
+                        self.refreshFooterPresentation()
+                    }
+                }
+            }
+
+            if defaultsObserver == nil {
+                defaultsObserver = NotificationCenter.default.addObserver(
+                    forName: UserDefaults.didChangeNotification,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    Task { @MainActor [weak self] in
+                        self?.reconcileChecklistStyle()
+                        self?.refreshHeaderPresentation()
+                        self?.refreshFooterPresentation()
+                    }
+                }
+            }
+
+            if !observesFooterPresentation {
+                observesFooterPresentation = true
+                observeFooterPresentation()
+            }
+        }
+
+        private func reconcileChecklistStyle() {
+            let nextStyle = WorkspaceTodoFeature.checklistStyle
+            guard nextStyle != checklistStyle else { return }
+            checklistStyle = nextStyle
+            checklistPopoverController.close()
+            projectionSource.collapseAllChecklists()
+        }
+
+        private func installChromeObserversIfNeeded() {
+            guard chromeObservers.isEmpty else { return }
+            let center = NotificationCenter.default
+            for name in [
+                Notification.Name.tabManagerFocusHistoryRevisionDidChange,
+                Notification.Name.cmuxNotificationsPopoverVisibilityDidChange,
+                NSWindow.didBecomeKeyNotification,
+            ] {
+                chromeObservers.append(center.addObserver(
+                    forName: name,
+                    object: nil,
+                    queue: .main
+                ) { [weak self] _ in
+                    Task { @MainActor [weak self] in
+                        self?.refreshHeaderPresentation()
+                    }
+                })
+            }
+        }
+
+        private func installChecklistAddObserverIfNeeded() {
+            guard checklistAddObserver == nil else { return }
+            checklistAddObserver = NotificationCenter.default.addObserver(
+                forName: .workspaceChecklistAddItemRequested,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                guard let workspaceId = notification.userInfo?[WorkspaceTodoActions.workspaceIdUserInfoKey]
+                    as? UUID else {
+                    return
+                }
+                Task { @MainActor [weak self] in
+                    guard let self,
+                          self.projectionSource.workspaceById[workspaceId] != nil else {
+                        return
+                    }
+                    self.presentChecklistAddField(workspaceId: workspaceId)
+                }
+            }
+        }
+
+        private func toggleChecklist(workspaceId: UUID, anchorView: NSView) {
+            guard let workspace = projectionSource.workspaceById[workspaceId] else { return }
+            switch WorkspaceTodoFeature.checklistStyle {
+            case .popover:
+                projectionSource.setChecklistExpanded(false, workspaceId: workspaceId)
+                _ = checklistPopoverController.toggle(
+                    workspace: workspace,
+                    relativeTo: anchorView,
+                    focusAddField: false
+                )
+            case .inline:
+                checklistPopoverController.close()
+                let shouldExpand = !projectionSource.isChecklistExpanded(workspaceId: workspaceId)
+                projectionSource.setChecklistExpanded(shouldExpand, workspaceId: workspaceId)
+                if shouldExpand,
+                   controller?.checklistAnchorView(for: workspaceId, makeVisible: false)
+                    is SidebarAppKitGroupCellView {
+                    projectionSource.setChecklistExpanded(false, workspaceId: workspaceId)
+                    if let fallbackAnchor = controller?.checklistAnchorView(for: workspaceId) {
+                        _ = checklistPopoverController.present(
+                            workspace: workspace,
+                            relativeTo: fallbackAnchor,
+                            focusAddField: false
+                        )
+                    }
+                }
+            }
+        }
+
+        private func presentChecklistAddField(workspaceId: UUID) {
+            guard let workspace = projectionSource.workspaceById[workspaceId],
+                  let controller else {
+                return
+            }
+            switch WorkspaceTodoFeature.checklistStyle {
+            case .popover:
+                projectionSource.setChecklistExpanded(false, workspaceId: workspaceId)
+                guard let anchor = controller.checklistAnchorView(for: workspaceId) else {
+                    NSSound.beep()
+                    return
+                }
+                if !checklistPopoverController.present(
+                    workspace: workspace,
+                    relativeTo: anchor,
+                    focusAddField: true
+                ) {
+                    NSSound.beep()
+                }
+            case .inline:
+                checklistPopoverController.close()
+                projectionSource.setChecklistExpanded(true, workspaceId: workspaceId)
+                if !controller.focusInlineChecklistAddField(for: workspaceId) {
+                    projectionSource.setChecklistExpanded(false, workspaceId: workspaceId)
+                    guard let anchor = controller.checklistAnchorView(for: workspaceId),
+                          checklistPopoverController.present(
+                            workspace: workspace,
+                            relativeTo: anchor,
+                            focusAddField: true
+                          ) else {
+                        NSSound.beep()
+                        return
+                    }
+                }
+            }
+        }
+
+        private func installDragClearObserverIfNeeded() {
+            guard dragClearObserver == nil else { return }
+            dragClearObserver = NotificationCenter.default.addObserver(
+                forName: SidebarDragLifecycleNotification.requestClear,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                MainActor.assumeIsolated {
+                    self?.dragCoordinator.cancelActiveDrag()
+                }
+            }
+        }
+
+        private func installSelectionObserversIfNeeded() {
+            guard selectionObservers.isEmpty else { return }
+            let center = NotificationCenter.default
+            selectionObservers.append(center.addObserver(
+                forName: SidebarMultiSelectionDidHideEvent.notificationName,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                MainActor.assumeIsolated {
+                    self?.handleMultiSelectionDidHide(notification)
+                }
+            })
+            selectionObservers.append(center.addObserver(
+                forName: SidebarMultiSelectionShouldCollapseEvent.notificationName,
+                object: nil,
+                queue: .main
+            ) { [weak self] notification in
+                MainActor.assumeIsolated {
+                    self?.handleMultiSelectionShouldCollapse(notification)
+                }
+            })
+        }
+
+        private func handleMultiSelectionDidHide(_ notification: Notification) {
+            guard let model = notification.object as? SidebarMultiSelectionModel,
+                  model === parent.tabManager.sidebarMultiSelection,
+                  let event = SidebarMultiSelectionDidHideEvent(notification) else {
+                return
+            }
+            var next = parent.selectedTabIds.subtracting(event.hiddenWorkspaceIds)
+            if let focusedId = event.focusedWorkspaceId {
+                next.insert(focusedId)
+                parent.lastSidebarSelectionIndex = projectionSource.workspaceIndexById[focusedId]
+            }
+            applyExternalSelection(next)
+        }
+
+        private func handleMultiSelectionShouldCollapse(_ notification: Notification) {
+            guard let model = notification.object as? SidebarMultiSelectionModel,
+                  model === parent.tabManager.sidebarMultiSelection,
+                  let event = SidebarMultiSelectionShouldCollapseEvent(notification) else {
+                return
+            }
+            let focusedId = event.focusedWorkspaceId
+            let next: Set<UUID> = projectionSource.workspaceById[focusedId] == nil
+                ? []
+                : [focusedId]
+            parent.lastSidebarSelectionIndex = projectionSource.workspaceIndexById[focusedId]
+            applyExternalSelection(next)
+        }
+
+        private func applyExternalSelection(_ workspaceIds: Set<UUID>) {
+            guard workspaceIds != parent.selectedTabIds else { return }
+            parent.selectedTabIds = workspaceIds
+            parent.tabManager.setSidebarSelectedWorkspaceIds(workspaceIds)
+            projectionSource.updateExternalState(
+                selectedWorkspaceIds: workspaceIds,
+                showsAgentActivity: parent.showsAgentActivity
+            )
+            if let controller {
+                applySelection(to: controller)
+            }
+        }
+
+        private func startHeaderUnreadObservationIfNeeded() {
+            guard headerUnreadObservationTask == nil else { return }
+            let unread = parent.sidebarUnread
+            headerUnreadObservationTask = Task { @MainActor [weak self, weak unread] in
+                guard let unread else { return }
+                for await _ in unread.$totalUnreadCount.values {
+                    guard !Task.isCancelled, let self else { return }
+                    self.refreshHeaderPresentation()
+                }
+            }
+        }
+
+        private func refreshHeaderPresentation() {
+            headerView.update(state: makeHeaderState())
+        }
+
+        private func makeHeaderState() -> SidebarAppKitHeaderView.State {
+            let window = preferredWindow(using: AppDelegate.shared)
+            let availability = focusHistoryNavigationAvailability(preferredWindow: window)
+            return SidebarAppKitHeaderView.State(
+                canNavigateBack: availability.canNavigateBack,
+                canNavigateForward: availability.canNavigateForward,
+                unreadNotificationCount: parent.sidebarUnread.totalUnreadCount,
+                isNotificationsPresented: NotificationsPopoverVisibilityState.shared.isShown(
+                    in: window?.windowNumber
+                ),
+                showsControls: WorkspacePresentationModeSettings.isMinimal()
+            )
+        }
+
+        private func makeHeaderActions() -> SidebarAppKitHeaderView.Actions {
+            SidebarAppKitHeaderView.Actions(
+                onToggleSidebar: { [weak self] in
+                    self?.parent.onToggleSidebar()
+                },
+                onToggleNotifications: { anchorView in
+                    AppDelegate.shared?.toggleNotificationsPopover(
+                        animated: true,
+                        anchorView: anchorView
+                    )
+                },
+                onNewWorkspace: { [weak self] in
+                    self?.parent.onNewTab()
+                },
+                onCloudVM: { anchorView in
+                    _ = AppDelegate.shared?.showNewWorkspaceContextMenu(
+                        anchorView: anchorView,
+                        debugSource: "sidebar.appKit.header.cloudMenu"
+                    )
+                },
+                onFocusHistoryBack: { [weak self] in
+                    guard self?.parent.tabManager.navigateBack() == true else {
+                        NSSound.beep()
+                        return
+                    }
+                },
+                onFocusHistoryForward: { [weak self] in
+                    guard self?.parent.tabManager.navigateForward() == true else {
+                        NSSound.beep()
+                        return
+                    }
+                },
+                onContextMenu: { control, anchorView, event in
+                    switch control {
+                    case .toggleSidebar:
+                        CmuxExtensionSidebarSelection.showMenu(
+                            anchorView: anchorView,
+                            event: event
+                        )
+                    case .newWorkspace, .cloudVM:
+                        _ = AppDelegate.shared?.showNewWorkspaceContextMenu(
+                            anchorView: anchorView,
+                            event: event,
+                            debugSource: "sidebar.appKit.header.contextMenu"
+                        )
+                    case .focusHistoryBack:
+                        _ = AppDelegate.shared?.showFocusHistoryContextMenu(
+                            anchorView: anchorView,
+                            event: event,
+                            direction: .back
+                        )
+                    case .focusHistoryForward:
+                        _ = AppDelegate.shared?.showFocusHistoryContextMenu(
+                            anchorView: anchorView,
+                            event: event,
+                            direction: .forward
+                        )
+                    case .showNotifications:
+                        break
+                    }
+                }
+            )
+        }
+
+        private func observeFooterPresentation() {
+            withObservationTracking {
+                _ = CmuxFeatureFlags.shared.isProUpgradeUIEnabled
+                _ = ProBadgeStyleStore.shared.current
+                _ = ProBadgeStyleStore.shared.isDismissed
+            } onChange: { [weak self] in
+                Task { @MainActor [weak self] in
+                    guard let self, self.observesFooterPresentation else { return }
+                    self.refreshFooterPresentation()
+                    self.observeFooterPresentation()
+                }
+            }
+        }
+
+        private func refreshFooterPresentation() {
+            guard controller != nil else { return }
+            footerView.apply(presentation: makeFooterPresentation())
+        }
+
+        private func makeFooterPresentation() -> SidebarAppKitFooterView.Presentation {
+            let proStore = ProBadgeStyleStore.shared
+            #if DEBUG
+            let showsDevBuildBanner = DevBuildBannerDebugSettings().showSidebarBanner
+            #else
+            let showsDevBuildBanner = false
+            #endif
+            return SidebarAppKitFooterView.Presentation(
+                showsExtensionButton: CmuxExtensionSidebarSelection.isEnabled,
+                showsProButton: CmuxFeatureFlags.shared.isProUpgradeUIEnabled
+                    && !proStore.isDismissed,
+                proButtonTitle: proStore.current.text ?? String(
+                    localized: "sidebar.pro.badge",
+                    defaultValue: "Upgrade"
+                ),
+                showsUpdateButton: parent.updateViewModel.showsPill,
+                updateButtonTitle: parent.updateViewModel.text,
+                showsShortcutDiscoveryButton: parent.enablesModifierShortcutHints
+                    && modifierMonitor.isCommandPressed,
+                showsDevBuildBanner: showsDevBuildBanner
+            )
+        }
+
+        private func performHelpAction(_ action: SidebarAppKitHelpMenuController.Action) {
+            switch action {
+            case .welcome:
+                AppDelegate.shared?.openWelcomeWorkspace()
+            case .keyboardShortcuts:
+                if let appDelegate = AppDelegate.shared {
+                    appDelegate.openPreferencesWindow(
+                        debugSource: "sidebarAppKit.help.keyboardShortcuts",
+                        navigationTarget: .keyboardShortcuts
+                    )
+                } else {
+                    AppDelegate.presentPreferencesWindow(navigationTarget: .keyboardShortcuts)
+                }
+            case .importBrowserData:
+                BrowserDataImportCoordinator.shared.presentImportDialog()
+            case .docs:
+                openURL("https://cmux.com/docs")
+            case .changelog:
+                openURL("https://cmux.com/docs/changelog")
+            case .github:
+                openURL("https://github.com/manaflow-ai/cmux")
+            case .githubIssues:
+                openURL("https://github.com/manaflow-ai/cmux/issues")
+            case .discord:
+                openURL("https://discord.gg/xsgFEVrWCZ")
+            }
+        }
+
+        private func openExtensionBrowser(from anchorView: NSView) {
+            _ = AppDelegate.shared?.openSidebarExtensionBrowser(
+                from: anchorView,
+                title: String(
+                    localized: "sidebar.extensions.browser.title",
+                    defaultValue: "Sidebar Extensions"
+                )
+            )
+        }
+
+        private func openURL(_ string: String) {
+            guard let url = URL(string: string) else { return }
+            NSWorkspace.shared.open(url)
+        }
+
+        private func preferredWindow(using appDelegate: AppDelegate?) -> NSWindow? {
+            parent.observedWindow ?? appDelegate?.mainWindow(for: parent.windowId)
+        }
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitShortcutMenuController.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitShortcutMenuController.swift
@@ -1,0 +1,37 @@
+import AppKit
+import CmuxSettings
+
+/// Builds the shortcut-discovery menu only when the native footer button opens.
+@MainActor
+final class SidebarAppKitShortcutMenuController {
+    func present(relativeTo anchorView: NSView) {
+        let menu = NSMenu(
+            title: String(
+                localized: "settings.section.keyboardShortcuts",
+                defaultValue: "Keyboard Shortcuts"
+            )
+        )
+        menu.autoenablesItems = false
+        for action in KeyboardShortcutSettings.settingsVisibleActions {
+            let stored = KeyboardShortcutSettings.shortcut(for: action)
+            let shortcut = stored.isUnbound
+                ? String(
+                    localized: "shortcutDiscovery.unassigned",
+                    defaultValue: "Unassigned"
+                )
+                : action.displayedShortcutString(for: stored)
+            let item = NSMenuItem(
+                title: "\(action.label)    \(shortcut)",
+                action: nil,
+                keyEquivalent: ""
+            )
+            item.isEnabled = false
+            menu.addItem(item)
+        }
+        menu.popUp(
+            positioning: nil,
+            at: NSPoint(x: 0, y: anchorView.bounds.maxY + 4),
+            in: anchorView
+        )
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitSnapshotStore.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitSnapshotStore.swift
@@ -1,0 +1,336 @@
+import Foundation
+
+/// One immutable input value with a stable identity in an AppKit sidebar.
+struct SidebarAppKitSnapshotItem<ItemID: Hashable, Input: Equatable>: Equatable {
+    let id: ItemID
+    let input: Input
+}
+
+/// An ordered, immutable input snapshot for ``SidebarAppKitSnapshotStore``.
+///
+/// Item ids must be unique. A presentation update replaces the input associated
+/// with an existing id; structural identity changes only through a new snapshot.
+struct SidebarAppKitSnapshot<ItemID: Hashable, Input: Equatable>: Equatable {
+    let items: [SidebarAppKitSnapshotItem<ItemID, Input>]
+    let itemIDs: [ItemID]
+
+    init(items: [SidebarAppKitSnapshotItem<ItemID, Input>]) {
+        var seen = Set<ItemID>()
+        seen.reserveCapacity(items.count)
+        for item in items {
+            precondition(
+                seen.insert(item.id).inserted,
+                "SidebarAppKitSnapshot item ids must be unique"
+            )
+        }
+        self.items = items
+        itemIDs = items.map(\.id)
+    }
+}
+
+/// Presentation-only context owned by the AppKit sidebar state engine.
+struct SidebarAppKitProjectionContext: Equatable {
+    let isHovered: Bool
+}
+
+/// One identity-preserving row move in a structural snapshot diff.
+struct SidebarAppKitSnapshotMove<ItemID: Hashable>: Equatable {
+    let itemID: ItemID
+    let fromRow: Int
+    let toRow: Int
+}
+
+/// AppKit-ready structural and presentation changes between two snapshots.
+///
+/// Removal rows use the old ordering. Insert, move destinations, and reload
+/// rows use the new ordering, so a table or outline view can apply structural
+/// changes before reloading the final row indexes.
+struct SidebarAppKitSnapshotDiff<ItemID: Hashable>: Equatable {
+    var insertedItemIDs: Set<ItemID> = []
+    var removedItemIDs: Set<ItemID> = []
+    var movedItemIDs: Set<ItemID> = []
+    var reloadedItemIDs: Set<ItemID> = []
+    var insertedRows = IndexSet()
+    var removedRows = IndexSet()
+    var moves: [SidebarAppKitSnapshotMove<ItemID>] = []
+    var reloadedRows = IndexSet()
+
+    var isEmpty: Bool {
+        insertedItemIDs.isEmpty &&
+            removedItemIDs.isEmpty &&
+            movedItemIDs.isEmpty &&
+            reloadedItemIDs.isEmpty
+    }
+}
+
+/// Deterministic work counters for scale tests and signpost adapters.
+struct SidebarAppKitSnapshotStoreInstrumentation: Equatable {
+    var structuralSnapshotApplyCount = 0
+    var keyedPresentationUpdateCount = 0
+    var hoverTransitionCount = 0
+    var totalItemVisitCount = 0
+    var totalProjectionCount = 0
+    var totalReloadCount = 0
+    var lastOperationItemVisitCount = 0
+    var lastOperationProjectionCount = 0
+    var lastOperationReloadCount = 0
+}
+
+/// Main-thread state engine for an AppKit workspace table or outline view.
+///
+/// The store owns no live models and uses no observation framework. Callers
+/// submit immutable input values. Structural snapshots are diffed by stable id,
+/// while a keyed presentation update performs one dictionary lookup and one
+/// projection independent of the total item count.
+@MainActor
+final class SidebarAppKitSnapshotStore<ItemID: Hashable, Input: Equatable, Presentation: Equatable> {
+    typealias Item = SidebarAppKitSnapshotItem<ItemID, Input>
+    typealias Snapshot = SidebarAppKitSnapshot<ItemID, Input>
+    typealias Diff = SidebarAppKitSnapshotDiff<ItemID>
+    typealias Projector = (ItemID, Input, SidebarAppKitProjectionContext) -> Presentation
+
+    private struct Entry {
+        var input: Input
+        var presentation: Presentation
+    }
+
+    private let projector: Projector
+    private var entriesByItemID: [ItemID: Entry] = [:]
+    private var rowIndexByItemID: [ItemID: Int] = [:]
+
+    private(set) var orderedItemIDs: [ItemID] = []
+    private(set) var hoveredItemID: ItemID?
+    private(set) var instrumentation = SidebarAppKitSnapshotStoreInstrumentation()
+    private(set) var lastProjectedItemIDs: Set<ItemID> = []
+
+    init(snapshot: Snapshot, projector: @escaping Projector) {
+        self.projector = projector
+        orderedItemIDs = snapshot.itemIDs
+        entriesByItemID.reserveCapacity(snapshot.items.count)
+        rowIndexByItemID.reserveCapacity(snapshot.items.count)
+
+        for (row, item) in snapshot.items.enumerated() {
+            recordItemVisit()
+            entriesByItemID[item.id] = Entry(
+                input: item.input,
+                presentation: project(itemID: item.id, input: item.input)
+            )
+            rowIndexByItemID[item.id] = row
+        }
+    }
+
+    var itemCount: Int { orderedItemIDs.count }
+
+    func contains(_ itemID: ItemID) -> Bool {
+        entriesByItemID[itemID] != nil
+    }
+
+    func itemID(atRow row: Int) -> ItemID? {
+        guard orderedItemIDs.indices.contains(row) else { return nil }
+        return orderedItemIDs[row]
+    }
+
+    func rowIndex(for itemID: ItemID) -> Int? {
+        rowIndexByItemID[itemID]
+    }
+
+    func input(for itemID: ItemID) -> Input? {
+        entriesByItemID[itemID]?.input
+    }
+
+    func presentation(for itemID: ItemID) -> Presentation? {
+        entriesByItemID[itemID]?.presentation
+    }
+
+    func presentation(atRow row: Int) -> Presentation? {
+        guard let itemID = itemID(atRow: row) else { return nil }
+        return entriesByItemID[itemID]?.presentation
+    }
+
+    /// Applies an ordered immutable snapshot and returns a minimal identity diff.
+    /// Unchanged inputs reuse their existing presentations without projection.
+    @discardableResult
+    func apply(snapshot: Snapshot) -> Diff {
+        beginOperation()
+        instrumentation.structuralSnapshotApplyCount += 1
+
+        var diff = structuralDiff(from: orderedItemIDs, to: snapshot.itemIDs)
+        var nextEntries: [ItemID: Entry] = [:]
+        nextEntries.reserveCapacity(snapshot.items.count)
+        var nextRowIndexByItemID: [ItemID: Int] = [:]
+        nextRowIndexByItemID.reserveCapacity(snapshot.items.count)
+
+        for (row, item) in snapshot.items.enumerated() {
+            recordItemVisit()
+            nextRowIndexByItemID[item.id] = row
+
+            if let existing = entriesByItemID[item.id], existing.input == item.input {
+                nextEntries[item.id] = existing
+                continue
+            }
+
+            let nextPresentation = project(itemID: item.id, input: item.input)
+            if let existing = entriesByItemID[item.id],
+               existing.presentation != nextPresentation {
+                diff.reloadedItemIDs.insert(item.id)
+                diff.reloadedRows.insert(row)
+            }
+            nextEntries[item.id] = Entry(
+                input: item.input,
+                presentation: nextPresentation
+            )
+        }
+
+        if let hoveredItemID, nextEntries[hoveredItemID] == nil {
+            self.hoveredItemID = nil
+        }
+        orderedItemIDs = snapshot.itemIDs
+        entriesByItemID = nextEntries
+        rowIndexByItemID = nextRowIndexByItemID
+        finishOperation(diff: diff)
+        return diff
+    }
+
+    /// Replaces one immutable input and reprojects only its keyed presentation.
+    /// The operation is O(1) apart from caller-owned projection work.
+    @discardableResult
+    func updatePresentation(for itemID: ItemID, input: Input) -> Diff {
+        beginOperation()
+        instrumentation.keyedPresentationUpdateCount += 1
+
+        guard var entry = entriesByItemID[itemID],
+              let row = rowIndexByItemID[itemID] else {
+            let diff = Diff()
+            finishOperation(diff: diff)
+            return diff
+        }
+
+        recordItemVisit()
+        guard entry.input != input else {
+            let diff = Diff()
+            finishOperation(diff: diff)
+            return diff
+        }
+
+        let nextPresentation = project(itemID: itemID, input: input)
+        entry.input = input
+        var diff = Diff()
+        if entry.presentation != nextPresentation {
+            entry.presentation = nextPresentation
+            diff.reloadedItemIDs.insert(itemID)
+            diff.reloadedRows.insert(row)
+        }
+        entriesByItemID[itemID] = entry
+        finishOperation(diff: diff)
+        return diff
+    }
+
+    /// Reprojects only the old and new hovered rows. Unknown ids normalize to nil.
+    @discardableResult
+    func setHoveredItemID(_ requestedItemID: ItemID?) -> Diff {
+        beginOperation()
+        let nextHoveredItemID = requestedItemID.flatMap { itemID in
+            entriesByItemID[itemID] == nil ? nil : itemID
+        }
+        guard nextHoveredItemID != hoveredItemID else {
+            let diff = Diff()
+            finishOperation(diff: diff)
+            return diff
+        }
+
+        instrumentation.hoverTransitionCount += 1
+        let previousHoveredItemID = hoveredItemID
+        hoveredItemID = nextHoveredItemID
+        var affectedItemIDs: [ItemID] = []
+        if let previousHoveredItemID {
+            affectedItemIDs.append(previousHoveredItemID)
+        }
+        if let nextHoveredItemID, nextHoveredItemID != previousHoveredItemID {
+            affectedItemIDs.append(nextHoveredItemID)
+        }
+
+        var diff = Diff()
+        for itemID in affectedItemIDs {
+            guard var entry = entriesByItemID[itemID],
+                  let row = rowIndexByItemID[itemID] else { continue }
+            recordItemVisit()
+            let nextPresentation = project(itemID: itemID, input: entry.input)
+            guard entry.presentation != nextPresentation else { continue }
+            entry.presentation = nextPresentation
+            entriesByItemID[itemID] = entry
+            diff.reloadedItemIDs.insert(itemID)
+            diff.reloadedRows.insert(row)
+        }
+        finishOperation(diff: diff)
+        return diff
+    }
+
+    func resetInstrumentation() {
+        instrumentation = SidebarAppKitSnapshotStoreInstrumentation()
+        lastProjectedItemIDs.removeAll(keepingCapacity: true)
+    }
+
+    private func structuralDiff(from oldItemIDs: [ItemID], to newItemIDs: [ItemID]) -> Diff {
+        let difference = newItemIDs.difference(from: oldItemIDs).inferringMoves()
+        var diff = Diff()
+
+        for change in difference {
+            switch change {
+            case .remove(let offset, let itemID, let associatedWith):
+                if let destination = associatedWith {
+                    diff.movedItemIDs.insert(itemID)
+                    diff.moves.append(
+                        SidebarAppKitSnapshotMove(
+                            itemID: itemID,
+                            fromRow: offset,
+                            toRow: destination
+                        )
+                    )
+                } else {
+                    diff.removedItemIDs.insert(itemID)
+                    diff.removedRows.insert(offset)
+                }
+            case .insert(let offset, let itemID, let associatedWith):
+                guard associatedWith == nil else { continue }
+                diff.insertedItemIDs.insert(itemID)
+                diff.insertedRows.insert(offset)
+            }
+        }
+
+        diff.moves.sort { lhs, rhs in
+            if lhs.fromRow == rhs.fromRow {
+                return lhs.toRow < rhs.toRow
+            }
+            return lhs.fromRow < rhs.fromRow
+        }
+        return diff
+    }
+
+    private func beginOperation() {
+        instrumentation.lastOperationItemVisitCount = 0
+        instrumentation.lastOperationProjectionCount = 0
+        instrumentation.lastOperationReloadCount = 0
+        lastProjectedItemIDs.removeAll(keepingCapacity: true)
+    }
+
+    private func recordItemVisit() {
+        instrumentation.totalItemVisitCount += 1
+        instrumentation.lastOperationItemVisitCount += 1
+    }
+
+    private func project(itemID: ItemID, input: Input) -> Presentation {
+        instrumentation.totalProjectionCount += 1
+        instrumentation.lastOperationProjectionCount += 1
+        lastProjectedItemIDs.insert(itemID)
+        return projector(
+            itemID,
+            input,
+            SidebarAppKitProjectionContext(isHovered: hoveredItemID == itemID)
+        )
+    }
+
+    private func finishOperation(diff: Diff) {
+        instrumentation.lastOperationReloadCount = diff.reloadedItemIDs.count
+        instrumentation.totalReloadCount += diff.reloadedItemIDs.count
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitTableView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitTableView.swift
@@ -1,0 +1,200 @@
+import AppKit
+
+/// Native event surface for the AppKit workspace sidebar.
+///
+/// Row identity and models stay in the controller. This view reports only row
+/// indexes, which keeps pointer movement, context menus, and middle clicks from
+/// resolving snapshots or walking the workspace collection.
+@MainActor
+final class SidebarAppKitTableView: NSTableView {
+    final class RowView: NSTableRowView {
+        var isPointerHovering = false {
+            didSet {
+                guard isPointerHovering != oldValue else { return }
+                needsDisplay = true
+            }
+        }
+
+        override func drawBackground(in dirtyRect: NSRect) {
+            super.drawBackground(in: dirtyRect)
+            guard isPointerHovering, !isSelected else { return }
+            NSColor.labelColor.withAlphaComponent(0.06).setFill()
+            NSBezierPath(
+                roundedRect: bounds.insetBy(dx: 6, dy: 1),
+                xRadius: 4,
+                yRadius: 4
+            ).fill()
+        }
+
+        override func drawSelection(in dirtyRect: NSRect) {
+            guard selectionHighlightStyle != .none else { return }
+            NSColor.selectedContentBackgroundColor.withAlphaComponent(0.24).setFill()
+            NSBezierPath(
+                roundedRect: bounds.insetBy(dx: 6, dy: 1),
+                xRadius: 4,
+                yRadius: 4
+            ).fill()
+        }
+    }
+
+    var onHoveredRowChanged: ((Int?, Int?) -> Void)?
+    var onPrimaryClick: ((Int, NSEvent) -> Void)?
+    var onMiddleClick: ((Int, NSEvent) -> Bool)?
+    var contextMenuProvider: ((Int, NSEvent) -> NSMenu?)?
+    var onEmptyAreaDoubleClick: (() -> Void)?
+    var emptyAreaContextMenuProvider: ((NSEvent) -> NSMenu?)?
+    var onVisibleRowsMayHaveChanged: (() -> Void)?
+
+    private(set) var hoveredRow: Int?
+    private(set) var lastSelectionModifierFlags: NSEvent.ModifierFlags = []
+    private(set) var isHandlingPointerSelection = false
+    private var pointerTrackingArea: NSTrackingArea?
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let pointerTrackingArea {
+            removeTrackingArea(pointerTrackingArea)
+        }
+        let next = NSTrackingArea(
+            rect: .zero,
+            options: [
+                .activeInKeyWindow,
+                .inVisibleRect,
+                .mouseEnteredAndExited,
+                .mouseMoved,
+            ],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(next)
+        pointerTrackingArea = next
+        reconcileHoveredRow()
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        updateHoveredRow(for: event)
+        super.mouseMoved(with: event)
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        updateHoveredRow(for: event)
+        super.mouseEntered(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        setHoveredRow(nil)
+        super.mouseExited(with: event)
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        lastSelectionModifierFlags = event.modifierFlags
+        let row = row(at: convert(event.locationInWindow, from: nil))
+        if row < 0, event.clickCount >= 2, let onEmptyAreaDoubleClick {
+            onEmptyAreaDoubleClick()
+            return
+        }
+        if row >= 0, event.clickCount == 1 {
+            onPrimaryClick?(row, event)
+        }
+        isHandlingPointerSelection = true
+        super.mouseDown(with: event)
+        isHandlingPointerSelection = false
+    }
+
+    override func otherMouseDown(with event: NSEvent) {
+        guard event.buttonNumber == 2 else {
+            super.otherMouseDown(with: event)
+            return
+        }
+        let row = row(at: convert(event.locationInWindow, from: nil))
+        guard row >= 0, onMiddleClick?(row, event) == true else {
+            super.otherMouseDown(with: event)
+            return
+        }
+    }
+
+    override func keyDown(with event: NSEvent) {
+        lastSelectionModifierFlags = event.modifierFlags
+        super.keyDown(with: event)
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        let row = row(at: convert(event.locationInWindow, from: nil))
+        guard row >= 0 else {
+            return emptyAreaContextMenuProvider?(event) ?? super.menu(for: event)
+        }
+        return contextMenuProvider?(row, event) ?? super.menu(for: event)
+    }
+
+    override func layout() {
+        super.layout()
+        reconcileHoveredRow()
+        onVisibleRowsMayHaveChanged?()
+    }
+
+    override func scrollWheel(with event: NSEvent) {
+        super.scrollWheel(with: event)
+        reconcileHoveredRow()
+        onVisibleRowsMayHaveChanged?()
+    }
+
+    override func viewDidEndLiveResize() {
+        super.viewDidEndLiveResize()
+        reconcileHoveredRow()
+        onVisibleRowsMayHaveChanged?()
+    }
+
+    func reconcileHoveredRow() {
+        guard let window else {
+            setHoveredRow(nil)
+            return
+        }
+        let location = convert(window.mouseLocationOutsideOfEventStream, from: nil)
+        guard bounds.contains(location) else {
+            setHoveredRow(nil)
+            return
+        }
+        let row = row(at: location)
+        setHoveredRow(row >= 0 ? row : nil)
+    }
+
+    private func updateHoveredRow(for event: NSEvent) {
+        let row = row(at: convert(event.locationInWindow, from: nil))
+        setHoveredRow(row >= 0 ? row : nil)
+    }
+
+    private func setHoveredRow(_ next: Int?) {
+        guard next != hoveredRow else { return }
+        let previous = hoveredRow
+        hoveredRow = next
+        onHoveredRowChanged?(previous, next)
+    }
+}
+
+/// Handles clicks in the viewport below a short table. NSTableView receives
+/// events over realized row geometry; the clip view owns the remaining empty
+/// area so new-workspace and context-menu behavior does not depend on row count.
+@MainActor
+final class SidebarAppKitClipView: NSClipView {
+    var onEmptyAreaDoubleClick: (() -> Void)?
+    var emptyAreaContextMenuProvider: ((NSEvent) -> NSMenu?)?
+
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount >= 2, pointsToEmptyTableArea(event) {
+            onEmptyAreaDoubleClick?()
+            return
+        }
+        super.mouseDown(with: event)
+    }
+
+    override func menu(for event: NSEvent) -> NSMenu? {
+        guard pointsToEmptyTableArea(event) else { return super.menu(for: event) }
+        return emptyAreaContextMenuProvider?(event) ?? super.menu(for: event)
+    }
+
+    private func pointsToEmptyTableArea(_ event: NSEvent) -> Bool {
+        guard let tableView = documentView as? NSTableView else { return false }
+        let point = tableView.convert(event.locationInWindow, from: nil)
+        return tableView.row(at: point) < 0
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitViewController.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitViewController.swift
@@ -1,0 +1,732 @@
+import AppKit
+import CmuxAppKitSupportUI
+import Foundation
+
+/// Native, reusable workspace-sidebar owner.
+///
+/// The controller owns only stable render identity, AppKit lifecycle, and
+/// interaction routing. Live workspace state stays behind lazy resolvers in
+/// ``SidebarAppKitConfiguration`` and is read only when AppKit requests a row.
+@MainActor
+final class SidebarAppKitViewController: NSViewController {
+    private enum Identifier {
+        static let column = NSUserInterfaceItemIdentifier("SidebarAppKitColumn")
+        static let row = NSUserInterfaceItemIdentifier("SidebarAppKitRow")
+        static let workspaceCell = NSUserInterfaceItemIdentifier("SidebarAppKitWorkspaceCell")
+        static let groupCell = NSUserInterfaceItemIdentifier("SidebarAppKitGroupCell")
+    }
+
+    private enum ItemInput: Equatable {
+        case workspace(workspaceID: UUID)
+        case group(groupID: UUID, anchorWorkspaceID: UUID)
+
+        init(_ item: SidebarWorkspaceRenderItem) {
+            switch item {
+            case .workspace(let workspaceID):
+                self = .workspace(workspaceID: workspaceID)
+            case .groupHeader(let groupID, let anchorWorkspaceID):
+                self = .group(groupID: groupID, anchorWorkspaceID: anchorWorkspaceID)
+            }
+        }
+
+        var renderItem: SidebarWorkspaceRenderItem {
+            switch self {
+            case .workspace(let workspaceID):
+                return .workspace(workspaceId: workspaceID)
+            case .group(let groupID, let anchorWorkspaceID):
+                return .groupHeader(groupId: groupID, anchorWorkspaceId: anchorWorkspaceID)
+            }
+        }
+
+        var workspaceID: UUID {
+            switch self {
+            case .workspace(let workspaceID):
+                return workspaceID
+            case .group(_, let anchorWorkspaceID):
+                return anchorWorkspaceID
+            }
+        }
+    }
+
+    private struct ItemPresentation: Equatable {
+        let input: ItemInput
+        let isHovered: Bool
+    }
+
+    #if DEBUG
+    struct ResolverInvocationCounts: Equatable {
+        var workspaceSnapshots = 0
+        var groupSnapshots = 0
+        var workspaceActions = 0
+        var groupActions = 0
+    }
+
+    private(set) var resolverInvocationCounts = ResolverInvocationCounts()
+    #endif
+
+    let tableView = SidebarAppKitTableView(frame: .zero)
+    let scrollView = NSScrollView(frame: .zero)
+    private let clipView = SidebarAppKitClipView(frame: .zero)
+
+    private let headerContainer = NSView(frame: .zero)
+    private let contentContainer = NSView(frame: .zero)
+    private let footerContainer = NSView(frame: .zero)
+    private let trailingBorderView = SidebarAppKitPassiveBorderView(frame: .zero)
+    private var borderRefreshObserver: NSObjectProtocol?
+    private var installedHeaderView: NSView?
+    private var installedContentView: NSView?
+    private var installedFooterView: NSView?
+    private var configuration: SidebarAppKitConfiguration?
+    private var isApplyingSelection = false
+    private var lastVisibleWorkspaceIDs: Set<UUID> = []
+    private var lastAppliedSelectedWorkspaceIDs: Set<UUID>?
+    private var lastActiveWorkspaceID: UUID?
+    private var lastActiveRow: Int?
+    private var registeredDragTypes: [NSPasteboard.PasteboardType] = []
+    private(set) var rowIndexByWorkspaceID: [UUID: Int] = [:]
+
+    private lazy var snapshotStore = SidebarAppKitSnapshotStore<
+        SidebarWorkspaceRenderItemID,
+        ItemInput,
+        ItemPresentation
+    >(
+        snapshot: SidebarAppKitSnapshot(items: []),
+        projector: { _, input, context in
+            ItemPresentation(input: input, isHovered: context.isHovered)
+        }
+    )
+
+    override func loadView() {
+        let root = NSView(frame: .zero)
+        root.setAccessibilityIdentifier("Sidebar")
+        view = root
+
+        let stack = NSStackView(views: [headerContainer, contentContainer, footerContainer])
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.distribution = .fill
+        stack.spacing = 0
+        root.addSubview(stack)
+        trailingBorderView.translatesAutoresizingMaskIntoConstraints = false
+        trailingBorderView.wantsLayer = true
+        root.addSubview(trailingBorderView)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: root.leadingAnchor),
+            stack.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            stack.topAnchor.constraint(equalTo: root.topAnchor),
+            stack.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+            headerContainer.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            contentContainer.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            footerContainer.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            trailingBorderView.topAnchor.constraint(equalTo: root.topAnchor),
+            trailingBorderView.bottomAnchor.constraint(equalTo: root.bottomAnchor),
+            trailingBorderView.trailingAnchor.constraint(equalTo: root.trailingAnchor),
+            trailingBorderView.widthAnchor.constraint(equalToConstant: 1),
+        ])
+        contentContainer.setContentHuggingPriority(.defaultLow, for: .vertical)
+        contentContainer.setContentCompressionResistancePriority(.defaultLow, for: .vertical)
+        headerContainer.setContentHuggingPriority(.required, for: .vertical)
+        headerContainer.setContentCompressionResistancePriority(.required, for: .vertical)
+        headerContainer.isHidden = true
+        footerContainer.setContentHuggingPriority(.required, for: .vertical)
+        footerContainer.setContentCompressionResistancePriority(.required, for: .vertical)
+        footerContainer.isHidden = true
+
+        configureTableView()
+        configureScrollView()
+        installContentView(scrollView)
+        refreshTrailingBorder()
+        borderRefreshObserver = NotificationCenter.default.addObserver(
+            forName: .ghosttyDefaultBackgroundDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.refreshTrailingBorder()
+            }
+        }
+    }
+
+    deinit {
+        if let borderRefreshObserver {
+            NotificationCenter.default.removeObserver(borderRefreshObserver)
+        }
+    }
+
+    func apply(_ nextConfiguration: SidebarAppKitConfiguration) {
+        loadViewIfNeeded()
+        let previousItemIDs = snapshotStore.orderedItemIDs
+        configuration = nextConfiguration
+
+        let nextSnapshot = SidebarAppKitSnapshot(
+            items: nextConfiguration.renderItems.map { item in
+                SidebarAppKitSnapshotItem(id: item.id, input: ItemInput(item))
+            }
+        )
+        let diff = snapshotStore.apply(snapshot: nextSnapshot)
+        rebuildWorkspaceIndex()
+
+        let isShowingTable = nextConfiguration.alternateContentView == nil
+        let contentChanged = installContentView(
+            nextConfiguration.alternateContentView ?? scrollView
+        )
+        installHeaderView(nextConfiguration.headerView)
+        installFooterView(nextConfiguration.footerView)
+        applyDragConfiguration(nextConfiguration.dragHandlers)
+
+        let structureChanged = previousItemIDs != snapshotStore.orderedItemIDs
+        if structureChanged {
+            lastAppliedSelectedWorkspaceIDs = nil
+        }
+        if isShowingTable {
+            if structureChanged || contentChanged {
+                tableView.reloadData()
+            } else if !diff.reloadedItemIDs.isEmpty {
+                reconfigure(itemIDs: diff.reloadedItemIDs)
+            } else {
+                reconfigureVisibleRows()
+            }
+            applySelection(nextConfiguration.selectedWorkspaceIDs)
+            scrollActiveWorkspaceToVisibleIfNeeded(nextConfiguration.activeWorkspaceID)
+            tableView.reconcileHoveredRow()
+            publishVisibleWorkspaceIDsIfNeeded()
+        } else {
+            if !lastVisibleWorkspaceIDs.isEmpty {
+                lastVisibleWorkspaceIDs = []
+                nextConfiguration.interactions.onVisibleWorkspaceIDsChanged([])
+            }
+        }
+    }
+
+    /// Re-resolves only requested rows that are currently realized or visible.
+    /// Structural identity and all unrelated rows remain untouched.
+    func reconfigure(itemIDs: Set<SidebarWorkspaceRenderItemID>) {
+        guard installedContentView === scrollView, !itemIDs.isEmpty else { return }
+        let visibleRows = visibleRowIndexes()
+        var rows = IndexSet()
+        for itemID in itemIDs {
+            guard let row = snapshotStore.rowIndex(for: itemID),
+                  visibleRows.contains(row) else { continue }
+            rows.insert(row)
+        }
+        reload(rows: rows)
+    }
+
+    /// Updates only native selection and visibility state. This is the hot
+    /// path used when an unrelated SwiftUI ancestor re-evaluates the
+    /// representable; it deliberately avoids an O(n) structural snapshot diff
+    /// and avoids reconfiguring every visible cell.
+    func updateSelection(
+        selectedWorkspaceIDs: Set<UUID>,
+        activeWorkspaceID: UUID?
+    ) {
+        guard installedContentView === scrollView else { return }
+        applySelection(selectedWorkspaceIDs)
+        scrollActiveWorkspaceToVisibleIfNeeded(activeWorkspaceID)
+    }
+
+    func rowIndex(for itemID: SidebarWorkspaceRenderItemID) -> Int? {
+        snapshotStore.rowIndex(for: itemID)
+    }
+
+    func checklistAnchorView(for workspaceID: UUID, makeVisible: Bool = true) -> NSView? {
+        guard let row = rowIndexByWorkspaceID[workspaceID] else {
+            return makeVisible ? scrollView.contentView : nil
+        }
+        if makeVisible {
+            tableView.scrollRowToVisible(row)
+            tableView.layoutSubtreeIfNeeded()
+        }
+        guard let cell = tableView.view(
+            atColumn: 0,
+            row: row,
+            makeIfNecessary: makeVisible
+        ) else {
+            return nil
+        }
+        return (cell as? SidebarAppKitWorkspaceCellView)?.checklistPresentationAnchor ?? cell
+    }
+
+    @discardableResult
+    func focusInlineChecklistAddField(for workspaceID: UUID) -> Bool {
+        guard let row = rowIndexByWorkspaceID[workspaceID] else { return false }
+        tableView.scrollRowToVisible(row)
+        tableView.layoutSubtreeIfNeeded()
+        guard let cell = tableView.view(
+            atColumn: 0,
+            row: row,
+            makeIfNecessary: true
+        ) as? SidebarAppKitWorkspaceCellView else {
+            return false
+        }
+        return cell.focusInlineChecklistAddField()
+    }
+
+    func noteChecklistHeightChanged(for workspaceID: UUID) {
+        guard let row = rowIndexByWorkspaceID[workspaceID] else { return }
+        tableView.noteHeightOfRows(withIndexesChanged: IndexSet(integer: row))
+        publishVisibleWorkspaceIDsIfNeeded()
+    }
+
+    func prepareForRemoval() {
+        if !lastVisibleWorkspaceIDs.isEmpty {
+            configuration?.interactions.onVisibleWorkspaceIDsChanged([])
+        }
+        tableView.onHoveredRowChanged = nil
+        tableView.onPrimaryClick = nil
+        tableView.onMiddleClick = nil
+        tableView.contextMenuProvider = nil
+        tableView.onEmptyAreaDoubleClick = nil
+        tableView.emptyAreaContextMenuProvider = nil
+        clipView.onEmptyAreaDoubleClick = nil
+        clipView.emptyAreaContextMenuProvider = nil
+        tableView.onVisibleRowsMayHaveChanged = nil
+        installedHeaderView?.removeFromSuperview()
+        installedHeaderView = nil
+        headerContainer.isHidden = true
+        configuration = nil
+        lastVisibleWorkspaceIDs = []
+        tableView.unregisterDraggedTypes()
+        registeredDragTypes = []
+        if let borderRefreshObserver {
+            NotificationCenter.default.removeObserver(borderRefreshObserver)
+            self.borderRefreshObserver = nil
+        }
+    }
+
+    #if DEBUG
+    func resetResolverInvocationCounts() {
+        resolverInvocationCounts = ResolverInvocationCounts()
+    }
+    #endif
+
+    private func configureTableView() {
+        let column = NSTableColumn(identifier: Identifier.column)
+        column.resizingMask = .autoresizingMask
+        tableView.addTableColumn(column)
+        tableView.headerView = nil
+        tableView.backgroundColor = .clear
+        tableView.gridStyleMask = []
+        tableView.intercellSpacing = .zero
+        tableView.rowHeight = 38
+        tableView.usesAutomaticRowHeights = true
+        tableView.columnAutoresizingStyle = .lastColumnOnlyAutoresizingStyle
+        tableView.selectionHighlightStyle = .regular
+        tableView.allowsEmptySelection = true
+        tableView.allowsMultipleSelection = true
+        tableView.allowsTypeSelect = false
+        tableView.focusRingType = .none
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.setAccessibilityIdentifier("Sidebar")
+
+        tableView.onHoveredRowChanged = { [weak self] previousRow, nextRow in
+            self?.hoveredRowChanged(from: previousRow, to: nextRow)
+        }
+        tableView.onPrimaryClick = { [weak self] row, event in
+            self?.activateRow(row, modifiers: event.modifierFlags)
+        }
+        tableView.onMiddleClick = { [weak self] row, event in
+            self?.handleMiddleClick(row: row, event: event) ?? false
+        }
+        tableView.contextMenuProvider = { [weak self] row, event in
+            self?.contextMenu(row: row, event: event)
+        }
+        tableView.onEmptyAreaDoubleClick = { [weak self] in
+            self?.configuration?.interactions.onEmptyAreaDoubleClick?()
+        }
+        tableView.emptyAreaContextMenuProvider = { [weak self] event in
+            self?.configuration?.interactions.emptyAreaContextMenuProvider?(event)
+        }
+        clipView.onEmptyAreaDoubleClick = { [weak self] in
+            self?.configuration?.interactions.onEmptyAreaDoubleClick?()
+        }
+        clipView.emptyAreaContextMenuProvider = { [weak self] event in
+            self?.configuration?.interactions.emptyAreaContextMenuProvider?(event)
+        }
+        tableView.onVisibleRowsMayHaveChanged = { [weak self] in
+            self?.publishVisibleWorkspaceIDsIfNeeded()
+        }
+    }
+
+    private func configureScrollView() {
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.hasHorizontalScroller = false
+        scrollView.autohidesScrollers = true
+        scrollView.scrollerStyle = .overlay
+        scrollView.borderType = .noBorder
+        scrollView.contentView = clipView
+        scrollView.documentView = tableView
+        scrollView.contentView.postsBoundsChangedNotifications = true
+    }
+
+    private func refreshTrailingBorder() {
+        let color = WindowChromeColorResolver().separatorColor(
+            forChromeBackground: GhosttyBackgroundTheme.currentColor()
+        )
+        trailingBorderView.layer?.backgroundColor = color
+            .usingColorSpace(.deviceRGB)?
+            .cgColor
+    }
+
+    @discardableResult
+    private func installContentView(_ contentView: NSView) -> Bool {
+        guard installedContentView !== contentView else { return false }
+        installedContentView?.removeFromSuperview()
+        installedContentView = contentView
+        embed(contentView, in: contentContainer)
+        return true
+    }
+
+    private func installFooterView(_ footerView: NSView?) {
+        guard installedFooterView !== footerView else { return }
+        installedFooterView?.removeFromSuperview()
+        installedFooterView = footerView
+        footerContainer.isHidden = footerView == nil
+        if let footerView {
+            embed(footerView, in: footerContainer)
+        }
+    }
+
+    private func installHeaderView(_ headerView: NSView?) {
+        guard installedHeaderView !== headerView else { return }
+        installedHeaderView?.removeFromSuperview()
+        installedHeaderView = headerView
+        headerContainer.isHidden = headerView == nil
+        if let headerView {
+            embed(headerView, in: headerContainer)
+        }
+    }
+
+    private func embed(_ child: NSView, in container: NSView) {
+        child.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(child)
+        NSLayoutConstraint.activate([
+            child.leadingAnchor.constraint(equalTo: container.leadingAnchor),
+            child.trailingAnchor.constraint(equalTo: container.trailingAnchor),
+            child.topAnchor.constraint(equalTo: container.topAnchor),
+            child.bottomAnchor.constraint(equalTo: container.bottomAnchor),
+        ])
+    }
+
+    private func rebuildWorkspaceIndex() {
+        var next: [UUID: Int] = [:]
+        next.reserveCapacity(snapshotStore.itemCount)
+        for row in 0..<snapshotStore.itemCount {
+            guard let input = snapshotStore.input(
+                for: snapshotStore.itemID(atRow: row)!
+            ) else { continue }
+            next[input.workspaceID] = row
+        }
+        rowIndexByWorkspaceID = next
+    }
+
+    private func applySelection(_ workspaceIDs: Set<UUID>) {
+        guard lastAppliedSelectedWorkspaceIDs != workspaceIDs else { return }
+        lastAppliedSelectedWorkspaceIDs = workspaceIDs
+        var rows = IndexSet()
+        for workspaceID in workspaceIDs {
+            if let row = rowIndexByWorkspaceID[workspaceID] {
+                rows.insert(row)
+            }
+        }
+        guard rows != tableView.selectedRowIndexes else { return }
+        isApplyingSelection = true
+        tableView.selectRowIndexes(rows, byExtendingSelection: false)
+        isApplyingSelection = false
+    }
+
+    private func scrollActiveWorkspaceToVisibleIfNeeded(_ workspaceID: UUID?) {
+        defer {
+            lastActiveWorkspaceID = workspaceID
+            lastActiveRow = workspaceID.flatMap { rowIndexByWorkspaceID[$0] }
+        }
+        guard let workspaceID, let row = rowIndexByWorkspaceID[workspaceID] else { return }
+        let rowRect = tableView.rect(ofRow: row)
+        let isFullyVisible = tableView.visibleRect.contains(rowRect)
+        guard workspaceID != lastActiveWorkspaceID || row != lastActiveRow || !isFullyVisible else {
+            return
+        }
+        tableView.scrollRowToVisible(row)
+    }
+
+    private func reconfigureVisibleRows() {
+        reload(rows: visibleRowIndexes())
+    }
+
+    private func reload(rows: IndexSet) {
+        guard !rows.isEmpty, tableView.numberOfColumns > 0 else { return }
+        tableView.reloadData(
+            forRowIndexes: rows,
+            columnIndexes: IndexSet(integer: 0)
+        )
+        tableView.noteHeightOfRows(withIndexesChanged: rows)
+        updateHoveredRowViews(rows: rows)
+        publishVisibleWorkspaceIDsIfNeeded()
+    }
+
+    private func visibleRowIndexes() -> IndexSet {
+        guard tableView.numberOfRows > 0 else { return [] }
+        let range = tableView.rows(in: tableView.visibleRect)
+        guard range.location != NSNotFound, range.length > 0 else { return [] }
+        let upperBound = min(tableView.numberOfRows, range.location + range.length)
+        guard range.location < upperBound else { return [] }
+        return IndexSet(integersIn: range.location..<upperBound)
+    }
+
+    private func publishVisibleWorkspaceIDsIfNeeded() {
+        guard installedContentView === scrollView, let configuration else { return }
+        var visibleWorkspaceIDs = Set<UUID>()
+        for row in visibleRowIndexes() {
+            guard let itemID = snapshotStore.itemID(atRow: row),
+                  let input = snapshotStore.input(for: itemID) else { continue }
+            visibleWorkspaceIDs.insert(input.workspaceID)
+        }
+        guard visibleWorkspaceIDs != lastVisibleWorkspaceIDs else { return }
+        lastVisibleWorkspaceIDs = visibleWorkspaceIDs
+        configuration.interactions.onVisibleWorkspaceIDsChanged(visibleWorkspaceIDs)
+    }
+
+    private func hoveredRowChanged(from previousRow: Int?, to nextRow: Int?) {
+        let nextItemID = nextRow.flatMap { snapshotStore.itemID(atRow: $0) }
+        let diff = snapshotStore.setHoveredItemID(nextItemID)
+        updateHoveredRowViews(rows: diff.reloadedRows)
+        configuration?.interactions.onHoveredItemChanged(nextItemID)
+    }
+
+    private func updateHoveredRowViews(rows: IndexSet) {
+        for row in rows {
+            guard let rowView = tableView.rowView(
+                atRow: row,
+                makeIfNecessary: false
+            ) as? SidebarAppKitTableView.RowView else { continue }
+            rowView.isPointerHovering = row == tableView.hoveredRow
+        }
+    }
+
+    private func handleMiddleClick(row: Int, event: NSEvent) -> Bool {
+        guard let handler = configuration?.interactions.onMiddleClick,
+              let item = renderItem(atRow: row) else { return false }
+        handler(item, event)
+        return true
+    }
+
+    private func activateRow(_ row: Int, modifiers: NSEvent.ModifierFlags) {
+        guard let item = renderItem(atRow: row) else { return }
+        configuration?.interactions.onSelectionChanged(
+            item.rowWorkspaceId,
+            modifiers
+        )
+    }
+
+    private func contextMenu(row: Int, event: NSEvent) -> NSMenu? {
+        guard let provider = configuration?.interactions.contextMenuProvider,
+              let item = renderItem(atRow: row) else { return nil }
+        return provider(item, event)
+    }
+
+    private func renderItem(atRow row: Int) -> SidebarWorkspaceRenderItem? {
+        guard let itemID = snapshotStore.itemID(atRow: row),
+              let input = snapshotStore.input(for: itemID) else { return nil }
+        return input.renderItem
+    }
+
+    private func applyDragConfiguration(_ handlers: SidebarAppKitConfiguration.DragHandlers?) {
+        let nextTypes = handlers?.registeredTypes ?? []
+        if registeredDragTypes != nextTypes {
+            tableView.unregisterDraggedTypes()
+            if !nextTypes.isEmpty {
+                tableView.registerForDraggedTypes(nextTypes)
+            }
+            registeredDragTypes = nextTypes
+        }
+        tableView.setDraggingSourceOperationMask(
+            handlers?.localSourceOperationMask ?? [],
+            forLocal: true
+        )
+        tableView.setDraggingSourceOperationMask(
+            handlers?.externalSourceOperationMask ?? [],
+            forLocal: false
+        )
+    }
+}
+
+private final class SidebarAppKitPassiveBorderView: NSView {
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        nil
+    }
+}
+
+extension SidebarAppKitViewController: NSTableViewDataSource, NSTableViewDelegate {
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        snapshotStore.itemCount
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        viewFor tableColumn: NSTableColumn?,
+        row: Int
+    ) -> NSView? {
+        guard let configuration,
+              let itemID = snapshotStore.itemID(atRow: row),
+              let input = snapshotStore.input(for: itemID) else { return nil }
+
+        switch input {
+        case .workspace(let workspaceID):
+            #if DEBUG
+            resolverInvocationCounts.workspaceSnapshots += 1
+            #endif
+            guard let snapshot = configuration.workspaceSnapshot(workspaceID) else { return nil }
+            let cell = reusableWorkspaceCell(in: tableView)
+            cell.resetForReuse()
+            #if DEBUG
+            resolverInvocationCounts.workspaceActions += 1
+            #endif
+            cell.configure(
+                snapshot: snapshot,
+                actions: configuration.workspaceActions(workspaceID)
+            )
+            cell.setAccessibilityIdentifier("sidebarWorkspace.\(workspaceID.uuidString)")
+            cell.setAccessibilityLabel(String(
+                localized: "accessibility.workspacePosition",
+                defaultValue: "\(snapshot.workspace.title), workspace \(snapshot.index + 1) of \(snapshot.workspaceCount)"
+            ))
+            return cell
+
+        case .group(let groupID, _):
+            #if DEBUG
+            resolverInvocationCounts.groupSnapshots += 1
+            #endif
+            guard let snapshot = configuration.groupSnapshot(groupID) else { return nil }
+            let cell = reusableGroupCell(in: tableView)
+            cell.resetForReuse()
+            #if DEBUG
+            resolverInvocationCounts.groupActions += 1
+            #endif
+            cell.configure(
+                snapshot: snapshot,
+                actions: configuration.groupActions(groupID)
+            )
+            cell.setAccessibilityIdentifier("sidebarWorkspaceGroup.\(groupID.uuidString)")
+            cell.setAccessibilityLabel(snapshot.name)
+            return cell
+        }
+    }
+
+    func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+        let rowView: SidebarAppKitTableView.RowView
+        if let reusable = tableView.makeView(
+            withIdentifier: Identifier.row,
+            owner: nil
+        ) as? SidebarAppKitTableView.RowView {
+            rowView = reusable
+        } else {
+            rowView = SidebarAppKitTableView.RowView(frame: .zero)
+            rowView.identifier = Identifier.row
+        }
+        rowView.isPointerHovering = row == self.tableView.hoveredRow
+        return rowView
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        guard !isApplyingSelection,
+              !tableView.isHandlingPointerSelection,
+              let configuration else {
+            return
+        }
+        let primaryWorkspaceID = tableView.selectedRow >= 0
+            ? renderItem(atRow: tableView.selectedRow)?.rowWorkspaceId
+            : nil
+        configuration.interactions.onSelectionChanged(
+            primaryWorkspaceID,
+            self.tableView.lastSelectionModifierFlags
+        )
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        pasteboardWriterForRow row: Int
+    ) -> (any NSPasteboardWriting)? {
+        guard let handlers = configuration?.dragHandlers,
+              let item = renderItem(atRow: row) else { return nil }
+        return handlers.pasteboardWriter(item)
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        validateDrop info: NSDraggingInfo,
+        proposedRow row: Int,
+        proposedDropOperation dropOperation: NSTableView.DropOperation
+    ) -> NSDragOperation {
+        guard let handlers = configuration?.dragHandlers else { return [] }
+        return handlers.validateDrop(
+            info,
+            renderItem(atRow: row),
+            row,
+            dropOperation
+        )
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        acceptDrop info: NSDraggingInfo,
+        row: Int,
+        dropOperation: NSTableView.DropOperation
+    ) -> Bool {
+        guard let handlers = configuration?.dragHandlers else { return false }
+        return handlers.acceptDrop(
+            info,
+            renderItem(atRow: row),
+            row,
+            dropOperation
+        )
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        draggingSession session: NSDraggingSession,
+        willBeginAt screenPoint: NSPoint,
+        forRowIndexes rowIndexes: IndexSet
+    ) {
+        guard let handler = configuration?.dragHandlers?.dragSessionBegan else { return }
+        handler(session, rowIndexes.compactMap { snapshotStore.itemID(atRow: $0) })
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        draggingSession session: NSDraggingSession,
+        endedAt screenPoint: NSPoint,
+        operation: NSDragOperation
+    ) {
+        configuration?.dragHandlers?.dragSessionEnded?(session, screenPoint, operation)
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        updateDraggingItemsForDrag draggingInfo: NSDraggingInfo
+    ) {
+        configuration?.dragHandlers?.updateDraggingItems?(draggingInfo)
+    }
+
+    private func reusableWorkspaceCell(in tableView: NSTableView) -> SidebarAppKitWorkspaceCellView {
+        if let reusable = tableView.makeView(
+            withIdentifier: Identifier.workspaceCell,
+            owner: nil
+        ) as? SidebarAppKitWorkspaceCellView {
+            return reusable
+        }
+        return SidebarAppKitWorkspaceCellView(identifier: Identifier.workspaceCell)
+    }
+
+    private func reusableGroupCell(in tableView: NSTableView) -> SidebarAppKitGroupCellView {
+        if let reusable = tableView.makeView(
+            withIdentifier: Identifier.groupCell,
+            owner: nil
+        ) as? SidebarAppKitGroupCellView {
+            return reusable
+        }
+        return SidebarAppKitGroupCellView(identifier: Identifier.groupCell)
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceCellView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceCellView.swift
@@ -1171,7 +1171,7 @@ final class SidebarAppKitWorkspaceCellView: NSTableCellView, NSTextFieldDelegate
         )
         setAccessibilityIdentifier("sidebarWorkspace.\(snapshot.workspaceId.uuidString)")
         setAccessibilityLabel(title)
-        setAccessibilityHint(String(
+        setAccessibilityHelp(String(
             localized: "sidebar.workspace.accessibilityHint",
             defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions."
         ))

--- a/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceCellView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceCellView.swift
@@ -1,0 +1,1365 @@
+import AppKit
+import CmuxFoundation
+import CmuxSettings
+import CmuxWorkspaces
+
+/// Reusable native cell for one immutable workspace-row projection.
+///
+/// The view hierarchy is created once. `configure(snapshot:actions:)` only
+/// updates retained AppKit controls, which keeps reuse predictable when the
+/// sidebar contains hundreds of frequently changing workspaces.
+@MainActor
+final class SidebarAppKitWorkspaceCellView: NSTableCellView, NSTextFieldDelegate {
+    struct Actions {
+        let onActivate: () -> Void
+        let onMoveUp: () -> Void
+        let onMoveDown: () -> Void
+        let onCommitRename: (String) -> Void
+        let onClose: () -> Void
+        let onOpenMetadataURL: (URL) -> Void
+        let onOpenPullRequest: (URL) -> Void
+        let onOpenPort: (Int) -> Void
+        let checklistStyle: WorkspaceTodoChecklistStyle
+        let onOpenChecklist: (NSView) -> Void
+        let resolveChecklistWorkspace: () -> Workspace?
+        let onChecklistHeightChanged: () -> Void
+        let onReconnectRemote: () -> Void
+        let onCopyRemoteError: (String) -> Void
+
+        init(
+            onActivate: @escaping () -> Void,
+            onMoveUp: @escaping () -> Void,
+            onMoveDown: @escaping () -> Void,
+            onCommitRename: @escaping (String) -> Void,
+            onClose: @escaping () -> Void,
+            onOpenMetadataURL: @escaping (URL) -> Void,
+            onOpenPullRequest: @escaping (URL) -> Void,
+            onOpenPort: @escaping (Int) -> Void,
+            checklistStyle: WorkspaceTodoChecklistStyle,
+            onOpenChecklist: @escaping (NSView) -> Void,
+            resolveChecklistWorkspace: @escaping () -> Workspace?,
+            onChecklistHeightChanged: @escaping () -> Void,
+            onReconnectRemote: @escaping () -> Void,
+            onCopyRemoteError: @escaping (String) -> Void
+        ) {
+            self.onActivate = onActivate
+            self.onMoveUp = onMoveUp
+            self.onMoveDown = onMoveDown
+            self.onCommitRename = onCommitRename
+            self.onClose = onClose
+            self.onOpenMetadataURL = onOpenMetadataURL
+            self.onOpenPullRequest = onOpenPullRequest
+            self.onOpenPort = onOpenPort
+            self.checklistStyle = checklistStyle
+            self.onOpenChecklist = onOpenChecklist
+            self.resolveChecklistWorkspace = resolveChecklistWorkspace
+            self.onChecklistHeightChanged = onChecklistHeightChanged
+            self.onReconnectRemote = onReconnectRemote
+            self.onCopyRemoteError = onCopyRemoteError
+        }
+
+        static let none = Self(
+            onActivate: {},
+            onMoveUp: {},
+            onMoveDown: {},
+            onCommitRename: { _ in },
+            onClose: {},
+            onOpenMetadataURL: { _ in },
+            onOpenPullRequest: { _ in },
+            onOpenPort: { _ in },
+            checklistStyle: .popover,
+            onOpenChecklist: { _ in },
+            resolveChecklistWorkspace: { nil },
+            onChecklistHeightChanged: {},
+            onReconnectRemote: {},
+            onCopyRemoteError: { _ in }
+        )
+    }
+
+    private struct RenameSession {
+        let workspaceID: UUID
+        let baselineTitle: String
+        let baselineHadUserCustomTitle: Bool
+    }
+
+    private let backgroundView = NSView()
+    private let railView = NSView()
+    private let topDropIndicator = NSView()
+    private let bottomDropIndicator = NSView()
+    private let contentStack = NSStackView()
+    private let titleRow = NSStackView()
+    private let leadingBadge = SidebarAppKitBadgeView()
+    private let leadingSpinner = GPUSpinnerNSView(frame: .zero)
+    private let pinImageView = NSImageView()
+    private let mediaImageView = NSImageView()
+    private let titleLabel = NSTextField(labelWithString: "")
+    private let renameField = NSTextField(string: "")
+    private let trailingSpinner = GPUSpinnerNSView(frame: .zero)
+    private let trailingBadge = SidebarAppKitBadgeView()
+    private let shortcutLabel = NSTextField(labelWithString: "")
+    private let closeButton = NSButton()
+    private let descriptionLabel = NSTextField(labelWithString: "")
+    private let subtitleLabel = NSTextField(labelWithString: "")
+    private let remoteRow = NSStackView()
+    private let remoteLabel = NSTextField(labelWithString: "")
+    private let remoteStatusLabel = NSTextField(labelWithString: "")
+    private let remoteReconnectButton = NSButton()
+    private let detailsView = SidebarAppKitWorkspaceDetailsView(frame: .zero)
+    private let progressStack = NSStackView()
+    private let progressIndicator = NSProgressIndicator()
+    private let progressLabel = NSTextField(labelWithString: "")
+    private let checklistButton = NSButton()
+    private var inlineChecklistView: SidebarAppKitChecklistView?
+
+    private var snapshot: SidebarWorkspaceRowSnapshot?
+    private var actions = Actions.none
+    private var copyableRemoteError: String?
+    private var isPointerInside = false
+    private var pointerTrackingArea: NSTrackingArea?
+    private var selectedBackgroundColor: NSColor?
+    private var badgeFillColor: NSColor = .controlAccentColor
+    private let renameKeyResolver = SidebarInlineRenameKeyResolver()
+    private var renameSession: RenameSession?
+    private var renameHasMovedCaretToStart = false
+    private var fontMagnificationObserver: GlobalFontMagnificationChangeObserver?
+    private lazy var moveUpAccessibilityAction = NSAccessibilityCustomAction(
+        name: String(localized: "sidebar.workspace.moveUpAction", defaultValue: "Move Up"),
+        target: self,
+        selector: #selector(moveUpForAccessibility)
+    )
+    private lazy var moveDownAccessibilityAction = NSAccessibilityCustomAction(
+        name: String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down"),
+        target: self,
+        selector: #selector(moveDownForAccessibility)
+    )
+    private lazy var copyRemoteErrorAccessibilityAction = NSAccessibilityCustomAction(
+        name: String(localized: "contextMenu.copySshError", defaultValue: "Copy SSH Error"),
+        target: self,
+        selector: #selector(copyRemoteErrorForAccessibility)
+    )
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        setUpHierarchy()
+        setUpAccessibility()
+        resetForReuse()
+        fontMagnificationObserver = GlobalFontMagnificationChangeObserver { [weak self] in
+            self?.refreshFontMagnification()
+        }
+    }
+
+    convenience init(identifier: NSUserInterfaceItemIdentifier) {
+        self.init(frame: .zero)
+        self.identifier = identifier
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    /// Applies one immutable projection without replacing any subviews.
+    func configure(snapshot: SidebarWorkspaceRowSnapshot, actions: Actions) {
+        if let renameSession, renameSession.workspaceID != snapshot.workspaceId {
+            discardInlineRename(resignFirstResponder: true)
+        }
+        self.snapshot = snapshot
+        self.actions = actions
+
+        let workspace = snapshot.workspace
+        let scale = max(0.5, snapshot.settings.sidebarFontScale)
+        closeButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(9 * scale),
+            weight: .medium
+        )
+        let titleLineCount = snapshot.settings.wrapsWorkspaceTitles ? 8 : 1
+        let title = SidebarAppKitCellText.bounded(
+            workspace.title,
+            maximumCharacters: 2_048,
+            maximumLines: titleLineCount
+        ) ?? workspace.title
+
+        titleLabel.stringValue = title
+        titleLabel.maximumNumberOfLines = titleLineCount
+        titleLabel.lineBreakMode = snapshot.settings.wrapsWorkspaceTitles ? .byWordWrapping : .byTruncatingTail
+        titleLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 12.5 * scale,
+            weight: .semibold
+        )
+        titleLabel.toolTip = workspace.title
+        renameField.font = titleLabel.font
+
+        configurePin(workspace.isPinned, scale: scale)
+        configureMediaActivity(workspace.mediaActivity, scale: scale)
+        configureSubtitle(snapshot: snapshot, scale: scale)
+        configureRemoteDetail(snapshot: snapshot, scale: scale)
+        configureAuxiliaryDetails(snapshot: snapshot, scale: scale)
+        configureProgress(snapshot: snapshot, scale: scale)
+        configureChecklist(snapshot: snapshot, scale: scale)
+        configureInlineChecklist(snapshot: snapshot)
+        configureStatusAccessories(snapshot: snapshot, scale: scale)
+        configureColors(snapshot: snapshot)
+        configureAccessibility(snapshot: snapshot)
+
+        backgroundView.alphaValue = (snapshot.isBeingDragged || workspace.taskStatus == .done) ? 0.6 : 1
+        topDropIndicator.isHidden = !snapshot.topDropIndicatorVisible
+        bottomDropIndicator.isHidden = !snapshot.bottomDropIndicatorVisible
+        isPointerInside = snapshot.isPointerHovering
+        updateTrailingAccessoryVisibility()
+        updateDropIndicatorColors()
+        needsLayout = true
+    }
+
+    /// Clears model-derived content and callbacks before a cell enters reuse.
+    func resetForReuse() {
+        discardInlineRename(resignFirstResponder: true)
+        snapshot = nil
+        actions = .none
+        copyableRemoteError = nil
+        isPointerInside = false
+        selectedBackgroundColor = nil
+        badgeFillColor = .controlAccentColor
+
+        titleLabel.stringValue = ""
+        titleLabel.toolTip = nil
+        titleLabel.isHidden = false
+        renameField.stringValue = ""
+        renameField.isHidden = true
+        descriptionLabel.stringValue = ""
+        descriptionLabel.isHidden = true
+        subtitleLabel.stringValue = ""
+        subtitleLabel.isHidden = true
+        remoteRow.toolTip = nil
+        remoteRow.isHidden = true
+        remoteRow.setAccessibilityLabel(nil)
+        remoteRow.setAccessibilityValue(nil)
+        remoteLabel.stringValue = ""
+        remoteLabel.toolTip = nil
+        remoteStatusLabel.stringValue = ""
+        remoteStatusLabel.toolTip = nil
+        remoteReconnectButton.toolTip = nil
+        remoteReconnectButton.isHidden = true
+        remoteReconnectButton.setAccessibilityHelp(nil)
+        setAccessibilityCustomActions(nil)
+        detailsView.resetForReuse()
+        progressLabel.stringValue = ""
+        progressLabel.isHidden = true
+        progressIndicator.doubleValue = 0
+        progressStack.isHidden = true
+        checklistButton.title = ""
+        checklistButton.attributedTitle = NSAttributedString(string: "")
+        checklistButton.image = nil
+        checklistButton.toolTip = nil
+        checklistButton.isHidden = true
+        inlineChecklistView?.stopObserving()
+        inlineChecklistView?.isHidden = true
+
+        leadingBadge.resetForReuse()
+        trailingBadge.resetForReuse()
+        leadingSpinner.isHidden = true
+        leadingSpinner.toolTip = nil
+        trailingSpinner.isHidden = true
+        trailingSpinner.toolTip = nil
+        pinImageView.isHidden = true
+        pinImageView.toolTip = nil
+        mediaImageView.isHidden = true
+        mediaImageView.toolTip = nil
+        shortcutLabel.stringValue = ""
+        shortcutLabel.isHidden = true
+        closeButton.isHidden = true
+        closeButton.toolTip = nil
+
+        backgroundView.alphaValue = 1
+        backgroundView.layer?.backgroundColor = nil
+        backgroundView.layer?.borderColor = nil
+        backgroundView.layer?.borderWidth = 0
+        railView.isHidden = true
+        railView.layer?.backgroundColor = nil
+        topDropIndicator.isHidden = true
+        bottomDropIndicator.isHidden = true
+        setAccessibilityIdentifier(nil)
+        setAccessibilityLabel(nil)
+        setAccessibilityValue(nil)
+        setAccessibilitySelected(false)
+    }
+
+    /// Returns the Auto Layout fitting height for the proposed table width.
+    func fittingHeight(constrainedTo width: CGFloat) -> CGFloat {
+        let horizontalInsets = 2 * (
+            SidebarAppKitCellMetrics.outerHorizontalInset
+                + SidebarAppKitCellMetrics.innerHorizontalInset
+        )
+        let available = max(1, width - horizontalInsets)
+        titleLabel.preferredMaxLayoutWidth = available
+        descriptionLabel.preferredMaxLayoutWidth = available
+        subtitleLabel.preferredMaxLayoutWidth = available
+        remoteLabel.preferredMaxLayoutWidth = available
+        layoutSubtreeIfNeeded()
+        return ceil(max(
+            SidebarAppKitCellMetrics.minimumWorkspaceHeight,
+            contentStack.fittingSize.height + 2 * SidebarAppKitCellMetrics.verticalInset
+        ))
+    }
+
+    override func updateTrackingAreas() {
+        if let pointerTrackingArea {
+            removeTrackingArea(pointerTrackingArea)
+        }
+        let options: NSTrackingArea.Options = [
+            .mouseEnteredAndExited,
+            .activeInKeyWindow,
+            .inVisibleRect,
+        ]
+        let area = NSTrackingArea(rect: .zero, options: options, owner: self, userInfo: nil)
+        addTrackingArea(area)
+        pointerTrackingArea = area
+        super.updateTrackingAreas()
+    }
+
+    override func mouseEntered(with event: NSEvent) {
+        isPointerInside = true
+        updateTrailingAccessoryVisibility()
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        isPointerInside = false
+        updateTrailingAccessoryVisibility()
+    }
+
+    /// Interactive descendants keep their own events. Ordinary row hits go to
+    /// `NSTableView`, which owns selection, modifier handling, context menus,
+    /// middle-clicks, and drag-session tracking.
+    override func hitTest(_ point: NSPoint) -> NSView? {
+        guard let hitView = super.hitTest(point) else { return nil }
+        if let currentEvent = NSApp.currentEvent {
+            let routesToRow = currentEvent.type == .rightMouseDown
+                || currentEvent.type == .otherMouseDown
+                || (currentEvent.type == .leftMouseDown
+                    && currentEvent.modifierFlags.contains(.control))
+            if routesToRow {
+                return enclosingTableView ?? hitView
+            }
+        }
+        if belongsToInteractiveSubview(hitView, ancestor: closeButton)
+            || belongsToInteractiveSubview(hitView, ancestor: renameField)
+            || belongsToInteractiveSubview(hitView, ancestor: checklistButton)
+            || inlineChecklistView.map({ belongsToInteractiveSubview(hitView, ancestor: $0) }) == true
+            || belongsToInteractiveSubview(hitView, ancestor: remoteReconnectButton)
+            || detailsView.containsInteractiveDescendant(hitView) {
+            return hitView
+        }
+        if NSApp.currentEvent?.type == .leftMouseDown,
+           (NSApp.currentEvent?.clickCount ?? 0) >= 2 {
+            return self
+        }
+        return enclosingTableView ?? hitView
+    }
+
+    override func mouseDown(with event: NSEvent) {
+        if event.clickCount >= 2 {
+            beginInlineRename()
+            return
+        }
+        if let enclosingTableView {
+            enclosingTableView.mouseDown(with: event)
+        } else {
+            super.mouseDown(with: event)
+        }
+    }
+
+    func control(
+        _ control: NSControl,
+        textView: NSTextView,
+        doCommandBy commandSelector: Selector
+    ) -> Bool {
+        guard control === renameField, renameSession != nil else { return false }
+        guard !textView.hasMarkedText() else { return false }
+
+        switch renameKeyResolver.action(
+            for: commandSelector,
+            hasMovedCaretToStart: renameHasMovedCaretToStart
+        ) {
+        case .commit:
+            commitInlineRename(textView.string, resignFirstResponder: true)
+            return true
+        case .caretToStart:
+            textView.setSelectedRange(NSRange(location: 0, length: 0))
+            renameHasMovedCaretToStart = true
+            return true
+        case .cancel:
+            discardInlineRename(resignFirstResponder: true)
+            return true
+        case .passThrough:
+            return false
+        }
+    }
+
+    func controlTextDidEndEditing(_ notification: Notification) {
+        guard let field = notification.object as? NSTextField,
+              field === renameField else { return }
+        commitInlineRename(renameField.stringValue, resignFirstResponder: false)
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        actions.onActivate()
+        return true
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+        super.viewDidChangeEffectiveAppearance()
+        guard let snapshot else { return }
+        configureAuxiliaryDetails(
+            snapshot: snapshot,
+            scale: max(0.5, snapshot.settings.sidebarFontScale)
+        )
+        configureColors(snapshot: snapshot)
+        updateDropIndicatorColors()
+    }
+
+    private func setUpHierarchy() {
+        wantsLayer = true
+        backgroundView.translatesAutoresizingMaskIntoConstraints = false
+        backgroundView.wantsLayer = true
+        backgroundView.layer?.cornerRadius = SidebarAppKitCellMetrics.cornerRadius
+        backgroundView.layer?.masksToBounds = false
+        addSubview(backgroundView)
+
+        railView.translatesAutoresizingMaskIntoConstraints = false
+        railView.wantsLayer = true
+        railView.layer?.cornerRadius = SidebarAppKitCellMetrics.railWidth / 2
+        backgroundView.addSubview(railView)
+
+        contentStack.translatesAutoresizingMaskIntoConstraints = false
+        contentStack.orientation = .vertical
+        contentStack.alignment = .leading
+        contentStack.distribution = .fill
+        contentStack.spacing = SidebarAppKitCellMetrics.rowSpacing
+        backgroundView.addSubview(contentStack)
+
+        setUpTitleRow()
+        setUpTextLabel(descriptionLabel, maximumLines: 3)
+        setUpTextLabel(subtitleLabel, maximumLines: 2)
+        setUpRemoteRow()
+        setUpProgress()
+        setUpChecklist()
+        detailsView.onHeightChanged = { [weak self] in
+            self?.actions.onChecklistHeightChanged()
+        }
+
+        [
+            titleRow,
+            descriptionLabel,
+            subtitleLabel,
+            remoteRow,
+            detailsView,
+            progressStack,
+            checklistButton,
+        ].forEach {
+            contentStack.addArrangedSubview($0)
+            $0.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
+        }
+
+        setUpDropIndicator(topDropIndicator)
+        setUpDropIndicator(bottomDropIndicator)
+        addSubview(topDropIndicator)
+        addSubview(bottomDropIndicator)
+
+        NSLayoutConstraint.activate([
+            backgroundView.leadingAnchor.constraint(
+                equalTo: leadingAnchor,
+                constant: SidebarAppKitCellMetrics.outerHorizontalInset
+            ),
+            backgroundView.trailingAnchor.constraint(
+                equalTo: trailingAnchor,
+                constant: -SidebarAppKitCellMetrics.outerHorizontalInset
+            ),
+            backgroundView.topAnchor.constraint(equalTo: topAnchor),
+            backgroundView.bottomAnchor.constraint(equalTo: bottomAnchor),
+
+            railView.leadingAnchor.constraint(equalTo: backgroundView.leadingAnchor, constant: 3),
+            railView.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.railWidth),
+            railView.topAnchor.constraint(equalTo: backgroundView.topAnchor, constant: 5),
+            railView.bottomAnchor.constraint(equalTo: backgroundView.bottomAnchor, constant: -5),
+
+            contentStack.leadingAnchor.constraint(
+                equalTo: backgroundView.leadingAnchor,
+                constant: SidebarAppKitCellMetrics.innerHorizontalInset
+            ),
+            contentStack.trailingAnchor.constraint(
+                equalTo: backgroundView.trailingAnchor,
+                constant: -SidebarAppKitCellMetrics.innerHorizontalInset
+            ),
+            contentStack.topAnchor.constraint(
+                equalTo: backgroundView.topAnchor,
+                constant: SidebarAppKitCellMetrics.verticalInset
+            ),
+            contentStack.bottomAnchor.constraint(
+                equalTo: backgroundView.bottomAnchor,
+                constant: -SidebarAppKitCellMetrics.verticalInset
+            ),
+
+            topDropIndicator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            topDropIndicator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            topDropIndicator.topAnchor.constraint(equalTo: topAnchor),
+            topDropIndicator.heightAnchor.constraint(equalToConstant: 2),
+            bottomDropIndicator.leadingAnchor.constraint(equalTo: leadingAnchor),
+            bottomDropIndicator.trailingAnchor.constraint(equalTo: trailingAnchor),
+            bottomDropIndicator.bottomAnchor.constraint(equalTo: bottomAnchor),
+            bottomDropIndicator.heightAnchor.constraint(equalToConstant: 2),
+        ])
+    }
+
+    private func setUpRemoteRow() {
+        remoteRow.translatesAutoresizingMaskIntoConstraints = false
+        remoteRow.orientation = .horizontal
+        remoteRow.alignment = .centerY
+        remoteRow.distribution = .fill
+        remoteRow.spacing = 6
+
+        setUpTextLabel(remoteLabel, maximumLines: 1, monospaced: true)
+        remoteLabel.lineBreakMode = .byTruncatingMiddle
+
+        setUpTextLabel(remoteStatusLabel, maximumLines: 1)
+        remoteStatusLabel.lineBreakMode = .byTruncatingTail
+        remoteStatusLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+        remoteStatusLabel.setContentHuggingPriority(.required, for: .horizontal)
+
+        remoteReconnectButton.translatesAutoresizingMaskIntoConstraints = false
+        remoteReconnectButton.isBordered = false
+        remoteReconnectButton.imagePosition = .imageLeading
+        remoteReconnectButton.imageHugsTitle = true
+        remoteReconnectButton.title = String(
+            localized: "sidebar.remote.reconnect.button",
+            defaultValue: "Reconnect"
+        )
+        remoteReconnectButton.image = NSImage(
+            systemSymbolName: "arrow.clockwise",
+            accessibilityDescription: nil
+        )
+        remoteReconnectButton.target = self
+        remoteReconnectButton.action = #selector(reconnectRemote)
+        remoteReconnectButton.setAccessibilityIdentifier("sidebarWorkspace.remoteReconnect")
+        remoteReconnectButton.setContentCompressionResistancePriority(.required, for: .horizontal)
+        remoteReconnectButton.setContentHuggingPriority(.required, for: .horizontal)
+
+        remoteRow.addArrangedSubview(remoteLabel)
+        remoteRow.addArrangedSubview(remoteStatusLabel)
+        remoteRow.addArrangedSubview(remoteReconnectButton)
+    }
+
+    private func setUpTitleRow() {
+        titleRow.translatesAutoresizingMaskIntoConstraints = false
+        titleRow.orientation = .horizontal
+        titleRow.alignment = .centerY
+        titleRow.distribution = .fill
+        titleRow.spacing = 6
+
+        leadingSpinner.translatesAutoresizingMaskIntoConstraints = false
+        trailingSpinner.translatesAutoresizingMaskIntoConstraints = false
+        leadingSpinner.style = .macOSSpokes
+        trailingSpinner.style = .macOSSpokes
+
+        for imageView in [pinImageView, mediaImageView] {
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            imageView.imageScaling = .scaleProportionallyDown
+            imageView.setAccessibilityElement(false)
+        }
+
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.cell?.wraps = true
+        titleLabel.cell?.usesSingleLineMode = false
+        titleLabel.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        renameField.translatesAutoresizingMaskIntoConstraints = false
+        renameField.isBordered = false
+        renameField.drawsBackground = false
+        renameField.focusRingType = .none
+        renameField.usesSingleLineMode = true
+        renameField.cell?.usesSingleLineMode = true
+        renameField.cell?.wraps = false
+        renameField.maximumNumberOfLines = 1
+        renameField.lineBreakMode = .byTruncatingTail
+        renameField.placeholderString = String(
+            localized: "commandPalette.rename.workspacePlaceholder",
+            defaultValue: "Workspace name"
+        )
+        renameField.setAccessibilityLabel(String(
+            localized: "sidebar.workspace.rename.field.accessibilityLabel",
+            defaultValue: "Rename workspace"
+        ))
+        renameField.delegate = self
+        renameField.isHidden = true
+        renameField.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        renameField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+
+        shortcutLabel.translatesAutoresizingMaskIntoConstraints = false
+        shortcutLabel.alignment = .right
+        shortcutLabel.maximumNumberOfLines = 1
+        shortcutLabel.lineBreakMode = .byClipping
+        shortcutLabel.setContentCompressionResistancePriority(.required, for: .horizontal)
+
+        closeButton.translatesAutoresizingMaskIntoConstraints = false
+        closeButton.isBordered = false
+        closeButton.imagePosition = .imageOnly
+        closeButton.image = NSImage(systemSymbolName: "xmark", accessibilityDescription: nil)
+        closeButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(9),
+            weight: .medium
+        )
+        closeButton.target = self
+        closeButton.action = #selector(closeWorkspace)
+
+        [
+            leadingBadge,
+            leadingSpinner,
+            pinImageView,
+            mediaImageView,
+            titleLabel,
+            renameField,
+            shortcutLabel,
+            trailingSpinner,
+            trailingBadge,
+            closeButton,
+        ].forEach(titleRow.addArrangedSubview)
+
+        NSLayoutConstraint.activate([
+            leadingSpinner.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+            leadingSpinner.heightAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+            trailingSpinner.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+            trailingSpinner.heightAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+            pinImageView.widthAnchor.constraint(equalToConstant: 12),
+            pinImageView.heightAnchor.constraint(equalToConstant: 14),
+            mediaImageView.widthAnchor.constraint(equalToConstant: 13),
+            mediaImageView.heightAnchor.constraint(equalToConstant: 14),
+            closeButton.widthAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+            closeButton.heightAnchor.constraint(equalToConstant: SidebarAppKitCellMetrics.accessorySide),
+        ])
+    }
+
+    private func setUpTextLabel(
+        _ label: NSTextField,
+        maximumLines: Int,
+        monospaced: Bool = false
+    ) {
+        label.translatesAutoresizingMaskIntoConstraints = false
+        label.maximumNumberOfLines = maximumLines
+        label.lineBreakMode = maximumLines == 1 ? .byTruncatingMiddle : .byTruncatingTail
+        label.cell?.wraps = maximumLines > 1
+        label.cell?.usesSingleLineMode = maximumLines == 1
+        label.font = monospaced
+            ? GlobalFontMagnification.monospacedSystemFont(ofSize: 10, weight: .regular)
+            : GlobalFontMagnification.systemFont(ofSize: 10)
+        label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        label.setContentHuggingPriority(.defaultLow, for: .horizontal)
+    }
+
+    private func setUpProgress() {
+        progressStack.translatesAutoresizingMaskIntoConstraints = false
+        progressStack.orientation = .vertical
+        progressStack.alignment = .leading
+        progressStack.distribution = .fill
+        progressStack.spacing = 2
+
+        progressIndicator.translatesAutoresizingMaskIntoConstraints = false
+        progressIndicator.style = .bar
+        progressIndicator.controlSize = .small
+        progressIndicator.isIndeterminate = false
+        progressIndicator.minValue = 0
+        progressIndicator.maxValue = 1
+
+        setUpTextLabel(progressLabel, maximumLines: 1)
+        progressStack.addArrangedSubview(progressIndicator)
+        progressStack.addArrangedSubview(progressLabel)
+        progressIndicator.widthAnchor.constraint(equalTo: progressStack.widthAnchor).isActive = true
+        progressLabel.widthAnchor.constraint(equalTo: progressStack.widthAnchor).isActive = true
+    }
+
+    private func setUpChecklist() {
+        checklistButton.translatesAutoresizingMaskIntoConstraints = false
+        checklistButton.isBordered = false
+        checklistButton.imagePosition = .imageLeading
+        checklistButton.imageHugsTitle = true
+        checklistButton.alignment = .left
+        checklistButton.lineBreakMode = .byTruncatingTail
+        checklistButton.target = self
+        checklistButton.action = #selector(openChecklist)
+        checklistButton.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        checklistButton.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        checklistButton.setAccessibilityIdentifier("SidebarChecklistSummaryLine")
+    }
+
+    private func setUpDropIndicator(_ view: NSView) {
+        view.translatesAutoresizingMaskIntoConstraints = false
+        view.wantsLayer = true
+        view.layer?.cornerRadius = 1
+        view.isHidden = true
+    }
+
+    private func setUpAccessibility() {
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        titleLabel.setAccessibilityElement(false)
+        renameField.setAccessibilityIdentifier("sidebarWorkspace.rename")
+        descriptionLabel.setAccessibilityElement(false)
+        subtitleLabel.setAccessibilityElement(false)
+        remoteRow.setAccessibilityElement(true)
+        remoteRow.setAccessibilityRole(.group)
+        remoteLabel.setAccessibilityElement(false)
+        remoteStatusLabel.setAccessibilityElement(false)
+        remoteReconnectButton.setAccessibilityElement(true)
+        remoteReconnectButton.setAccessibilityRole(.button)
+        remoteReconnectButton.setAccessibilityLabel(remoteReconnectButton.title)
+        progressLabel.setAccessibilityElement(false)
+        checklistButton.setAccessibilityRole(.button)
+        closeButton.setAccessibilityIdentifier("sidebarWorkspace.close")
+    }
+
+    private func configurePin(_ isPinned: Bool, scale: CGFloat) {
+        pinImageView.isHidden = !isPinned
+        guard isPinned else { return }
+        pinImageView.image = NSImage(systemSymbolName: "pin.fill", accessibilityDescription: nil)
+        pinImageView.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(9 * scale),
+            weight: .semibold
+        )
+        pinImageView.toolTip = String(
+            localized: "sidebar.pinnedWorkspaceProtected.tooltip",
+            defaultValue: "Pinned workspace. Closing requires confirmation."
+        )
+    }
+
+    private func configureMediaActivity(_ activity: BrowserMediaActivity, scale: CGFloat) {
+        let symbol: String?
+        let color: NSColor
+        if activity.isUsingCamera {
+            symbol = "video.fill"
+            color = .systemGreen
+        } else if activity.isUsingMicrophone {
+            symbol = "mic.fill"
+            color = .systemOrange
+        } else if activity.isPlayingAudio {
+            symbol = "speaker.wave.2.fill"
+            color = .secondaryLabelColor
+        } else {
+            symbol = nil
+            color = .secondaryLabelColor
+        }
+        mediaImageView.isHidden = symbol == nil
+        mediaImageView.image = symbol.flatMap { NSImage(systemSymbolName: $0, accessibilityDescription: nil) }
+        mediaImageView.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(9 * scale),
+            weight: .semibold
+        )
+        mediaImageView.contentTintColor = color
+    }
+
+    private func configureSubtitle(snapshot: SidebarWorkspaceRowSnapshot, scale: CGFloat) {
+        let workspace = snapshot.workspace
+        let description = snapshot.settings.showsWorkspaceDescription
+            ? SidebarAppKitCellText.bounded(
+                workspace.customDescription,
+                maximumCharacters: 2_048,
+                maximumLines: 3
+            )
+            : nil
+        descriptionLabel.stringValue = description ?? ""
+        descriptionLabel.isHidden = description == nil
+        descriptionLabel.maximumNumberOfLines = 3
+        descriptionLabel.font = GlobalFontMagnification.systemFont(ofSize: 10 * scale)
+
+        let conversationSubtitle = !snapshot.settings.hidesAllDetails && snapshot.settings.iMessageModeEnabled
+            ? workspace.latestConversationMessage
+            : nil
+        let subtitle = snapshot.latestNotificationText ?? conversationSubtitle
+        let lineLimit = snapshot.latestNotificationText == nil
+            ? 2
+            : max(1, snapshot.settings.notificationMessageLineLimit)
+        let bounded = SidebarAppKitCellText.bounded(
+            subtitle,
+            maximumCharacters: 4_096,
+            maximumLines: lineLimit
+        )
+        subtitleLabel.stringValue = bounded ?? ""
+        subtitleLabel.isHidden = bounded == nil
+        subtitleLabel.maximumNumberOfLines = lineLimit
+        subtitleLabel.font = GlobalFontMagnification.systemFont(ofSize: 10 * scale)
+    }
+
+    private func configureRemoteDetail(snapshot: SidebarWorkspaceRowSnapshot, scale: CGFloat) {
+        let workspace = snapshot.workspace
+        guard !snapshot.settings.hidesAllDetails,
+              snapshot.settings.showsSSH,
+              let target = SidebarAppKitCellText.bounded(
+                workspace.remoteWorkspaceSidebarText,
+                maximumCharacters: 1_024,
+                maximumLines: 1
+              ) else {
+            copyableRemoteError = nil
+            remoteRow.toolTip = nil
+            remoteRow.isHidden = true
+            remoteRow.setAccessibilityLabel(nil)
+            remoteRow.setAccessibilityValue(nil)
+            remoteRow.setAccessibilityHelp(nil)
+            remoteLabel.stringValue = ""
+            remoteLabel.toolTip = nil
+            remoteStatusLabel.stringValue = ""
+            remoteStatusLabel.toolTip = nil
+            remoteReconnectButton.toolTip = nil
+            remoteReconnectButton.isHidden = true
+            remoteReconnectButton.setAccessibilityHelp(nil)
+            return
+        }
+        let status = SidebarAppKitCellText.bounded(
+            workspace.remoteConnectionStatusText,
+            maximumCharacters: 256,
+            maximumLines: 1
+        )
+        let help = workspace.remoteStateHelpText
+
+        remoteRow.isHidden = false
+        remoteRow.toolTip = help
+        remoteRow.setAccessibilityLabel(target)
+        remoteRow.setAccessibilityValue(status)
+        remoteRow.setAccessibilityHelp(help)
+
+        remoteLabel.stringValue = target
+        remoteLabel.font = GlobalFontMagnification.monospacedSystemFont(
+            ofSize: 10 * scale,
+            weight: .regular
+        )
+        remoteLabel.toolTip = help
+        remoteStatusLabel.stringValue = status ?? ""
+        remoteStatusLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 9 * scale,
+            weight: .medium
+        )
+        remoteStatusLabel.toolTip = help
+        remoteStatusLabel.isHidden = status == nil
+
+        let reconnectHelp = String(
+            format: String(
+                localized: "sidebar.remote.reconnect.help",
+                defaultValue: "Reconnect to %@"
+            ),
+            locale: .current,
+            target
+        )
+        remoteReconnectButton.font = GlobalFontMagnification.systemFont(
+            ofSize: 9 * scale,
+            weight: .semibold
+        )
+        remoteReconnectButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(8 * scale),
+            weight: .semibold
+        )
+        remoteReconnectButton.toolTip = reconnectHelp
+        remoteReconnectButton.setAccessibilityHelp(reconnectHelp)
+        remoteReconnectButton.isHidden = !workspace.showsRemoteReconnectAffordance
+
+        copyableRemoteError = workspace.copyableSidebarSSHError
+    }
+
+    private func configureAuxiliaryDetails(snapshot: SidebarWorkspaceRowSnapshot, scale: CGFloat) {
+        let selection = resolvedSelectionColor(snapshot: snapshot)
+        let primary = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 1)
+            : NSColor.labelColor
+        let secondary = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 0.75)
+            : NSColor.secondaryLabelColor
+        detailsView.configure(
+            snapshot: snapshot,
+            fontScale: scale,
+            primaryColor: primary,
+            secondaryColor: secondary,
+            actions: SidebarAppKitWorkspaceDetailsView.Actions(
+                onActivate: actions.onActivate,
+                onOpenMetadataURL: actions.onOpenMetadataURL,
+                onOpenPullRequest: actions.onOpenPullRequest,
+                onOpenPort: actions.onOpenPort
+            )
+        )
+    }
+
+    private func configureProgress(snapshot: SidebarWorkspaceRowSnapshot, scale: CGFloat) {
+        guard snapshot.settings.visibleAuxiliaryDetails.showsProgress,
+              let progress = snapshot.workspace.progress else {
+            progressStack.isHidden = true
+            progressIndicator.doubleValue = 0
+            progressLabel.stringValue = ""
+            progressLabel.isHidden = true
+            return
+        }
+        progressStack.isHidden = false
+        progressIndicator.doubleValue = min(1, max(0, progress.value))
+        progressLabel.font = GlobalFontMagnification.systemFont(ofSize: 9 * scale)
+        let label = SidebarAppKitCellText.bounded(
+            progress.label,
+            maximumCharacters: 1_024,
+            maximumLines: 1
+        )
+        progressLabel.stringValue = label ?? ""
+        progressLabel.isHidden = label == nil
+    }
+
+    /// Keeps the collapsed-row checklist projection constant-size. Detailed
+    /// item rendering is resolved only after the native inline expansion or
+    /// popover is explicitly presented.
+    private func configureChecklist(snapshot: SidebarWorkspaceRowSnapshot, scale: CGFloat) {
+        let workspace = snapshot.workspace
+        guard workspace.checklistTotalCount > 0 else {
+            checklistButton.title = ""
+            checklistButton.attributedTitle = NSAttributedString(string: "")
+            checklistButton.image = nil
+            checklistButton.toolTip = nil
+            checklistButton.isHidden = true
+            return
+        }
+
+        let progress = "\(workspace.checklistCompletedCount)/\(workspace.checklistTotalCount)"
+        let firstUnchecked = SidebarAppKitCellText.bounded(
+            workspace.checklistFirstUncheckedText,
+            maximumCharacters: 1_024,
+            maximumLines: 1
+        )
+        checklistButton.title = [progress, firstUnchecked]
+            .compactMap { $0 }
+            .joined(separator: "  ·  ")
+        checklistButton.font = GlobalFontMagnification.monospacedDigitSystemFont(
+            ofSize: 10 * scale,
+            weight: .semibold
+        )
+        checklistButton.image = NSImage(
+            systemSymbolName: workspace.checklistCompletedCount == workspace.checklistTotalCount
+                ? "checkmark.circle.fill"
+                : "checklist",
+            accessibilityDescription: nil
+        )
+        checklistButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(8 * scale),
+            weight: .regular
+        )
+        switch actions.checklistStyle {
+        case .popover:
+            checklistButton.toolTip = String(
+                localized: "sidebar.checklist.popoverTooltip",
+                defaultValue: "Show checklist"
+            )
+        case .inline:
+            checklistButton.toolTip = snapshot.isChecklistExpanded
+                ? String(
+                    localized: "sidebar.checklist.collapseTooltip",
+                    defaultValue: "Collapse checklist"
+                )
+                : String(
+                    localized: "sidebar.checklist.expandTooltip",
+                    defaultValue: "Expand checklist"
+                )
+        }
+        checklistButton.setAccessibilityLabel(checklistButton.title)
+        checklistButton.setAccessibilityHelp(checklistButton.toolTip)
+        checklistButton.isHidden = false
+    }
+
+    private func configureInlineChecklist(snapshot: SidebarWorkspaceRowSnapshot) {
+        guard snapshot.isChecklistExpanded,
+              actions.checklistStyle == .inline,
+              let workspace = actions.resolveChecklistWorkspace() else {
+            inlineChecklistView?.stopObserving()
+            inlineChecklistView?.isHidden = true
+            return
+        }
+
+        let checklistView: SidebarAppKitChecklistView
+        if let inlineChecklistView {
+            checklistView = inlineChecklistView
+        } else {
+            checklistView = SidebarAppKitChecklistView(frame: .zero)
+            inlineChecklistView = checklistView
+            contentStack.addArrangedSubview(checklistView)
+            checklistView.widthAnchor.constraint(equalTo: contentStack.widthAnchor).isActive = true
+        }
+        checklistView.isHidden = false
+        checklistView.configure(
+            workspace: workspace,
+            mode: .inline,
+            onPreferredHeightChange: { [weak self] in
+                self?.actions.onChecklistHeightChanged()
+            },
+            onRequestClose: { [weak self] in
+                guard let self else { return }
+                self.actions.onOpenChecklist(self.checklistButton)
+            }
+        )
+    }
+
+    var checklistPresentationAnchor: NSView {
+        checklistButton.isHidden ? self : checklistButton
+    }
+
+    @discardableResult
+    func focusInlineChecklistAddField() -> Bool {
+        guard let inlineChecklistView, !inlineChecklistView.isHidden else { return false }
+        inlineChecklistView.focusAddField()
+        return true
+    }
+
+    private func configureStatusAccessories(snapshot: SidebarWorkspaceRowSnapshot, scale: CGFloat) {
+        let showsSpinner = snapshot.showsAgentActivity && snapshot.workspace.activeCodingAgentCount > 0
+        let leadingSpinnerVisible = showsSpinner && snapshot.settings.loadingSpinnerPosition == .leading
+        let trailingSpinnerVisible = showsSpinner && snapshot.settings.loadingSpinnerPosition == .trailing
+        let leadingBadgeVisible = snapshot.unreadCount > 0
+            && snapshot.settings.notificationBadgePosition == .leading
+            && !leadingSpinnerVisible
+        let trailingBadgeVisible = snapshot.unreadCount > 0
+            && snapshot.settings.notificationBadgePosition == .trailing
+            && !trailingSpinnerVisible
+
+        let selection = resolvedSelectionColor(snapshot: snapshot)
+        let primary = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 1)
+            : NSColor.white
+        let customBadgeColor = snapshot.settings.notificationBadgeColorHex.flatMap(NSColor.init(hex:))
+        badgeFillColor = customBadgeColor
+            ?? (snapshot.isActive
+                ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 0.25)
+                : cmuxAccentNSColor(for: effectiveAppearance))
+        let badgeText = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 1)
+            : primary
+        let badgeFont = GlobalFontMagnification.systemFont(
+            ofSize: 9 * scale,
+            weight: .semibold
+        )
+        let badgeHeight = GlobalFontMagnification.scaledSize(
+            SidebarAppKitCellMetrics.accessorySide * scale
+        )
+
+        if leadingBadgeVisible {
+            leadingBadge.configure(
+                count: snapshot.unreadCount,
+                fillColor: badgeFillColor,
+                textColor: badgeText,
+                font: badgeFont,
+                height: badgeHeight
+            )
+        } else {
+            leadingBadge.resetForReuse()
+        }
+        if trailingBadgeVisible {
+            trailingBadge.configure(
+                count: snapshot.unreadCount,
+                fillColor: badgeFillColor,
+                textColor: badgeText,
+                font: badgeFont,
+                height: badgeHeight
+            )
+        } else {
+            trailingBadge.resetForReuse()
+        }
+
+        let spinnerColor = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 0.55)
+            : .secondaryLabelColor
+        let spinnerTooltip = SidebarWorkspaceLoadingTooltip.text(
+            count: snapshot.workspace.activeCodingAgentCount
+        )
+        leadingSpinner.isHidden = !leadingSpinnerVisible
+        leadingSpinner.color = spinnerColor
+        leadingSpinner.toolTip = leadingSpinnerVisible ? spinnerTooltip : nil
+        trailingSpinner.isHidden = !trailingSpinnerVisible
+        trailingSpinner.color = spinnerColor
+        trailingSpinner.toolTip = trailingSpinnerVisible ? spinnerTooltip : nil
+
+        let shortcutVisible = (snapshot.showsModifierShortcutHints || snapshot.settings.alwaysShowShortcutHints)
+            && snapshot.workspaceShortcutDigit != nil
+        if shortcutVisible, let digit = snapshot.workspaceShortcutDigit {
+            shortcutLabel.stringValue = "\(snapshot.workspaceShortcutModifierSymbol)\(digit)"
+            shortcutLabel.font = GlobalFontMagnification.monospacedSystemFont(
+                ofSize: 10 * scale,
+                weight: .semibold
+            )
+            shortcutLabel.isHidden = false
+        } else {
+            shortcutLabel.stringValue = ""
+            shortcutLabel.isHidden = true
+        }
+    }
+
+    private func configureColors(snapshot: SidebarWorkspaceRowSnapshot) {
+        let selection = resolvedSelectionColor(snapshot: snapshot)
+        selectedBackgroundColor = selection
+        let accent = cmuxAccentNSColor(for: effectiveAppearance)
+        let custom = snapshot.workspace.customColorHex.flatMap(NSColor.init(hex:))
+
+        let background: NSColor?
+        switch snapshot.settings.activeTabIndicatorStyle {
+        case .leftRail:
+            if snapshot.isActive {
+                background = selection
+            } else if snapshot.isMultiSelected {
+                background = accent.withAlphaComponent(0.25)
+            } else {
+                background = nil
+            }
+        case .solidFill:
+            if snapshot.isActive {
+                background = selection
+            } else if let custom {
+                background = custom.withAlphaComponent(snapshot.isMultiSelected ? 0.35 : 0.7)
+            } else if snapshot.isMultiSelected {
+                background = accent.withAlphaComponent(0.25)
+            } else {
+                background = nil
+            }
+        }
+
+        let primary = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 1)
+            : .labelColor
+        let secondary = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 0.75)
+            : .secondaryLabelColor
+        let tertiary = snapshot.isActive
+            ? sidebarSelectedWorkspaceForegroundNSColor(on: selection, opacity: 0.6)
+            : .tertiaryLabelColor
+
+        titleLabel.textColor = primary
+        renameField.textColor = primary
+        (renameField.currentEditor() as? NSTextView)?.insertionPointColor = primary
+        descriptionLabel.textColor = secondary
+        subtitleLabel.textColor = secondary
+        remoteLabel.textColor = secondary
+        remoteStatusLabel.textColor = tertiary
+        remoteReconnectButton.contentTintColor = secondary
+        progressLabel.textColor = tertiary
+        checklistButton.contentTintColor = secondary
+        checklistButton.attributedTitle = NSAttributedString(
+            string: checklistButton.title,
+            attributes: [
+                .foregroundColor: secondary,
+                .font: checklistButton.font ?? GlobalFontMagnification.systemFont(ofSize: 10),
+            ]
+        )
+        pinImageView.contentTintColor = secondary
+        shortcutLabel.textColor = secondary
+        closeButton.contentTintColor = secondary
+
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            backgroundView.layer?.backgroundColor = background?.usingColorSpace(.deviceRGB)?.cgColor
+            if snapshot.isActive, snapshot.settings.activeTabIndicatorStyle == .solidFill {
+                backgroundView.layer?.borderWidth = 1.5
+                backgroundView.layer?.borderColor = primary.withAlphaComponent(0.5)
+                    .usingColorSpace(.deviceRGB)?.cgColor
+            } else if snapshot.isBonsplitWorkspaceDropActive {
+                backgroundView.layer?.borderWidth = 1.5
+                backgroundView.layer?.borderColor = accent.usingColorSpace(.deviceRGB)?.cgColor
+            } else {
+                backgroundView.layer?.borderWidth = 0
+                backgroundView.layer?.borderColor = nil
+            }
+            railView.layer?.backgroundColor = custom?.withAlphaComponent(0.95)
+                .usingColorSpace(.deviceRGB)?.cgColor
+        }
+        railView.isHidden = snapshot.settings.activeTabIndicatorStyle != .leftRail || custom == nil
+    }
+
+    private func configureAccessibility(snapshot: SidebarWorkspaceRowSnapshot) {
+        let title = String(
+            localized: "accessibility.workspacePosition",
+            defaultValue: "\(snapshot.workspace.title), workspace \(snapshot.index + 1) of \(snapshot.workspaceCount)"
+        )
+        setAccessibilityIdentifier("sidebarWorkspace.\(snapshot.workspaceId.uuidString)")
+        setAccessibilityLabel(title)
+        setAccessibilityHint(String(
+            localized: "sidebar.workspace.accessibilityHint",
+            defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions."
+        ))
+        setAccessibilitySelected(snapshot.isActive || snapshot.isMultiSelected)
+        if snapshot.unreadCount > 0 {
+            setAccessibilityValue(String.localizedStringWithFormat(
+                String(localized: "workspaceGroup.unread.a11y", defaultValue: "%lld unread"),
+                Int64(snapshot.unreadCount)
+            ))
+        } else {
+            setAccessibilityValue(nil)
+        }
+
+        let closeLabel = String(
+            localized: "sidebar.closeWorkspace.tooltip",
+            defaultValue: "Close Workspace"
+        )
+        closeButton.setAccessibilityLabel(closeLabel)
+        closeButton.toolTip = snapshot.workspace.isPinned
+            ? String(
+                localized: "sidebar.pinnedWorkspaceProtected.tooltip",
+                defaultValue: "Pinned workspace. Closing requires confirmation."
+            )
+            : closeLabel
+        var customActions = [moveUpAccessibilityAction, moveDownAccessibilityAction]
+        if copyableRemoteError != nil {
+            customActions.append(copyRemoteErrorAccessibilityAction)
+        }
+        setAccessibilityCustomActions(customActions)
+    }
+
+    private func refreshFontMagnification() {
+        guard let snapshot else { return }
+        let scale = max(0.5, snapshot.settings.sidebarFontScale)
+        closeButton.symbolConfiguration = NSImage.SymbolConfiguration(
+            pointSize: GlobalFontMagnification.scaledSize(9 * scale),
+            weight: .medium
+        )
+        titleLabel.font = GlobalFontMagnification.systemFont(
+            ofSize: 12.5 * scale,
+            weight: .semibold
+        )
+        renameField.font = titleLabel.font
+        configurePin(snapshot.workspace.isPinned, scale: scale)
+        configureMediaActivity(snapshot.workspace.mediaActivity, scale: scale)
+        configureSubtitle(snapshot: snapshot, scale: scale)
+        configureRemoteDetail(snapshot: snapshot, scale: scale)
+        configureAuxiliaryDetails(snapshot: snapshot, scale: scale)
+        configureProgress(snapshot: snapshot, scale: scale)
+        configureChecklist(snapshot: snapshot, scale: scale)
+        configureStatusAccessories(snapshot: snapshot, scale: scale)
+        configureColors(snapshot: snapshot)
+        configureAccessibility(snapshot: snapshot)
+        needsLayout = true
+        actions.onChecklistHeightChanged()
+    }
+
+    private func resolvedSelectionColor(snapshot: SidebarWorkspaceRowSnapshot) -> NSColor {
+        snapshot.settings.selectionColorHex.flatMap(NSColor.init(hex:))
+            ?? cmuxAccentNSColor(for: effectiveAppearance)
+    }
+
+    private func updateTrailingAccessoryVisibility() {
+        guard let snapshot else {
+            closeButton.isHidden = true
+            return
+        }
+        let hasShortcut = !shortcutLabel.isHidden
+        let showsClose = isPointerInside && snapshot.canCloseWorkspace && !hasShortcut
+        closeButton.isHidden = !showsClose
+        if snapshot.settings.loadingSpinnerPosition == .trailing {
+            trailingSpinner.isHidden = showsClose
+                || !snapshot.showsAgentActivity
+                || snapshot.workspace.activeCodingAgentCount == 0
+        }
+        if snapshot.settings.notificationBadgePosition == .trailing {
+            trailingBadge.isHidden = showsClose
+                || snapshot.unreadCount == 0
+                || (!trailingSpinner.isHidden && snapshot.workspace.activeCodingAgentCount > 0)
+        }
+        closeButton.setAccessibilityElement(showsClose)
+    }
+
+    private func updateDropIndicatorColors() {
+        let color = cmuxAccentNSColor(for: effectiveAppearance)
+        effectiveAppearance.performAsCurrentDrawingAppearance {
+            topDropIndicator.layer?.backgroundColor = color.usingColorSpace(.deviceRGB)?.cgColor
+            bottomDropIndicator.layer?.backgroundColor = color.usingColorSpace(.deviceRGB)?.cgColor
+        }
+    }
+
+    private var enclosingTableView: NSTableView? {
+        var ancestor = superview
+        while let view = ancestor {
+            if let tableView = view as? NSTableView {
+                return tableView
+            }
+            ancestor = view.superview
+        }
+        return nil
+    }
+
+    private func belongsToInteractiveSubview(_ view: NSView, ancestor: NSView) -> Bool {
+        view === ancestor || view.isDescendant(of: ancestor)
+    }
+
+    private func beginInlineRename() {
+        guard renameSession == nil, let snapshot else { return }
+        renameSession = RenameSession(
+            workspaceID: snapshot.workspaceId,
+            baselineTitle: snapshot.workspace.title,
+            baselineHadUserCustomTitle: snapshot.hasUserCustomTitle
+        )
+        renameHasMovedCaretToStart = false
+        renameField.stringValue = snapshot.workspace.title
+        titleLabel.isHidden = true
+        renameField.isHidden = false
+        needsLayout = true
+        layoutSubtreeIfNeeded()
+
+        guard window?.makeFirstResponder(renameField) == true else {
+            discardInlineRename(resignFirstResponder: false)
+            return
+        }
+        renameField.currentEditor()?.selectAll(nil)
+        (renameField.currentEditor() as? NSTextView)?.insertionPointColor = renameField.textColor
+    }
+
+    private func commitInlineRename(_ draft: String, resignFirstResponder: Bool) {
+        guard let renameSession else { return }
+        let title = SidebarInlineRenameCommit().titleToCommit(
+            draft: draft,
+            baseline: renameSession.baselineTitle,
+            baselineHadUserCustomTitle: renameSession.baselineHadUserCustomTitle
+        )
+        finishInlineRename(resignFirstResponder: resignFirstResponder)
+        if let title {
+            actions.onCommitRename(title)
+        }
+    }
+
+    private func discardInlineRename(resignFirstResponder: Bool) {
+        guard renameSession != nil else { return }
+        finishInlineRename(resignFirstResponder: resignFirstResponder)
+    }
+
+    private func finishInlineRename(resignFirstResponder: Bool) {
+        renameSession = nil
+        renameHasMovedCaretToStart = false
+        if resignFirstResponder {
+            if let enclosingTableView {
+                window?.makeFirstResponder(enclosingTableView)
+            } else {
+                window?.makeFirstResponder(nil)
+            }
+        }
+        renameField.stringValue = ""
+        renameField.isHidden = true
+        titleLabel.isHidden = false
+        needsLayout = true
+    }
+
+    @objc private func closeWorkspace() {
+        actions.onClose()
+    }
+
+    @objc private func openChecklist() {
+        actions.onOpenChecklist(checklistButton)
+    }
+
+    @objc private func reconnectRemote() {
+        guard snapshot?.workspace.showsRemoteReconnectAffordance == true else { return }
+        actions.onReconnectRemote()
+    }
+
+    @objc private func copyRemoteErrorForAccessibility() -> Bool {
+        guard let copyableRemoteError else { return false }
+        actions.onCopyRemoteError(copyableRemoteError)
+        return true
+    }
+
+    @objc private func moveUpForAccessibility() -> Bool {
+        actions.onMoveUp()
+        return true
+    }
+
+    @objc private func moveDownForAccessibility() -> Bool {
+        actions.onMoveDown()
+        return true
+    }
+}

--- a/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceDetailsView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceDetailsView.swift
@@ -75,7 +75,6 @@ final class SidebarAppKitWorkspaceDetailsView: NSStackView {
                 pointSize: max(7, descriptor.font.pointSize - 1),
                 weight: .medium
             )
-            maximumNumberOfLines = descriptor.maximumLines
             lineBreakMode = .byTruncatingTail
             cell?.wraps = descriptor.maximumLines > 1
             cell?.usesSingleLineMode = descriptor.maximumLines == 1

--- a/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceDetailsView.swift
+++ b/Sources/Sidebar/AppKit/SidebarAppKitWorkspaceDetailsView.swift
@@ -1,0 +1,518 @@
+import AppKit
+import CmuxFoundation
+import CmuxSidebar
+import Foundation
+
+/// Retained native detail rows for one realized workspace cell.
+///
+/// The view creates a small reusable control pool and reconfigures it from the
+/// immutable workspace projection. Metadata expansion is local to the realized
+/// row, while collapsed rows inspect only the same bounded prefixes as the
+/// legacy sidebar. Pull-request, port, and metadata URLs retain independent hit
+/// targets instead of being flattened into one ambiguous text label.
+@MainActor
+final class SidebarAppKitWorkspaceDetailsView: NSStackView {
+    struct Actions {
+        let onActivate: () -> Void
+        let onOpenMetadataURL: (URL) -> Void
+        let onOpenPullRequest: (URL) -> Void
+        let onOpenPort: (Int) -> Void
+
+        static let none = Self(
+            onActivate: {},
+            onOpenMetadataURL: { _ in },
+            onOpenPullRequest: { _ in },
+            onOpenPort: { _ in }
+        )
+    }
+
+    private struct Descriptor {
+        let title: String
+        let symbolName: String?
+        let color: NSColor
+        let font: NSFont
+        let maximumLines: Int
+        let toolTip: String?
+        let accessibilityIdentifier: String?
+        let underlinesTitle: Bool
+        let action: (() -> Void)?
+    }
+
+    private final class DetailRowButton: NSButton {
+        private var handler: (() -> Void)?
+
+        var isInteractive: Bool { handler != nil }
+
+        override init(frame frameRect: NSRect) {
+            super.init(frame: frameRect)
+            translatesAutoresizingMaskIntoConstraints = false
+            isBordered = false
+            bezelStyle = .regularSquare
+            focusRingType = .none
+            imagePosition = .imageLeading
+            imageHugsTitle = true
+            alignment = .left
+            setButtonType(.momentaryChange)
+            target = self
+            action = #selector(performAction)
+            setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+            setContentHuggingPriority(.defaultLow, for: .horizontal)
+        }
+
+        required init?(coder: NSCoder) {
+            nil
+        }
+
+        func configure(_ descriptor: Descriptor) {
+            handler = descriptor.action
+            title = descriptor.title
+            font = descriptor.font
+            contentTintColor = descriptor.color
+            image = descriptor.symbolName.flatMap {
+                NSImage(systemSymbolName: $0, accessibilityDescription: nil)
+            }
+            symbolConfiguration = NSImage.SymbolConfiguration(
+                pointSize: max(7, descriptor.font.pointSize - 1),
+                weight: .medium
+            )
+            maximumNumberOfLines = descriptor.maximumLines
+            lineBreakMode = .byTruncatingTail
+            cell?.wraps = descriptor.maximumLines > 1
+            cell?.usesSingleLineMode = descriptor.maximumLines == 1
+            toolTip = descriptor.toolTip
+            var attributes: [NSAttributedString.Key: Any] = [
+                .foregroundColor: descriptor.color,
+                .font: descriptor.font,
+            ]
+            if descriptor.underlinesTitle {
+                attributes[.underlineStyle] = NSUnderlineStyle.single.rawValue
+            }
+            attributedTitle = NSAttributedString(string: descriptor.title, attributes: attributes)
+            setAccessibilityRole(descriptor.action == nil ? .staticText : .button)
+            setAccessibilityLabel(descriptor.title)
+            setAccessibilityHelp(descriptor.toolTip)
+            setAccessibilityIdentifier(descriptor.accessibilityIdentifier)
+            isHidden = false
+        }
+
+        func resetForReuse() {
+            handler = nil
+            title = ""
+            attributedTitle = NSAttributedString(string: "")
+            image = nil
+            toolTip = nil
+            setAccessibilityLabel(nil)
+            setAccessibilityHelp(nil)
+            setAccessibilityIdentifier(nil)
+            isHidden = true
+        }
+
+        @objc private func performAction() {
+            handler?()
+        }
+    }
+
+    private static let collapsedMetadataLimit = 3
+    private static let collapsedMetadataBlockLimit = 1
+    private static let maximumMetadataBlockLines = 12
+    private static let maximumMetadataBlockCharacters = 4_096
+
+    private var rows: [DetailRowButton] = []
+    private var currentWorkspaceId: UUID?
+    private var isMetadataExpanded = false
+    private var areMetadataBlocksExpanded = false
+    private var snapshot: SidebarWorkspaceRowSnapshot?
+    private var fontScale: CGFloat = 1
+    private var primaryColor: NSColor = .labelColor
+    private var secondaryColor: NSColor = .secondaryLabelColor
+    private var actions = Actions.none
+
+    var onHeightChanged: (() -> Void)?
+
+    override init(frame frameRect: NSRect) {
+        super.init(frame: frameRect)
+        translatesAutoresizingMaskIntoConstraints = false
+        orientation = .vertical
+        alignment = .leading
+        distribution = .fill
+        spacing = 2
+        setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        setContentHuggingPriority(.defaultLow, for: .horizontal)
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func configure(
+        snapshot: SidebarWorkspaceRowSnapshot,
+        fontScale: CGFloat,
+        primaryColor: NSColor,
+        secondaryColor: NSColor,
+        actions: Actions
+    ) {
+        if currentWorkspaceId != snapshot.workspaceId {
+            currentWorkspaceId = snapshot.workspaceId
+            isMetadataExpanded = false
+            areMetadataBlocksExpanded = false
+        }
+        self.snapshot = snapshot
+        self.fontScale = fontScale
+        self.primaryColor = primaryColor
+        self.secondaryColor = secondaryColor
+        self.actions = actions
+        rebuildRows()
+    }
+
+    func resetForReuse() {
+        currentWorkspaceId = nil
+        snapshot = nil
+        isMetadataExpanded = false
+        areMetadataBlocksExpanded = false
+        actions = .none
+        for row in rows {
+            row.resetForReuse()
+        }
+        isHidden = true
+    }
+
+    func containsInteractiveDescendant(_ view: NSView) -> Bool {
+        var candidate: NSView? = view
+        while let current = candidate, current !== self {
+            if let row = current as? DetailRowButton {
+                return row.isInteractive
+            }
+            candidate = current.superview
+        }
+        return false
+    }
+
+    private func rebuildRows() {
+        guard let snapshot else {
+            resetForReuse()
+            return
+        }
+        let descriptors = makeDescriptors(snapshot: snapshot)
+        ensureRowCapacity(descriptors.count)
+        for (index, row) in rows.enumerated() {
+            if descriptors.indices.contains(index) {
+                row.configure(descriptors[index])
+            } else {
+                row.resetForReuse()
+            }
+        }
+        isHidden = descriptors.isEmpty
+        needsLayout = true
+    }
+
+    private func ensureRowCapacity(_ count: Int) {
+        while rows.count < count {
+            let row = DetailRowButton(frame: .zero)
+            rows.append(row)
+            addArrangedSubview(row)
+            row.widthAnchor.constraint(equalTo: widthAnchor).isActive = true
+        }
+    }
+
+    private func makeDescriptors(snapshot: SidebarWorkspaceRowSnapshot) -> [Descriptor] {
+        let workspace = snapshot.workspace
+        let visibility = snapshot.settings.visibleAuxiliaryDetails
+        let textFont = GlobalFontMagnification.monospacedSystemFont(
+            ofSize: 10 * fontScale,
+            weight: .regular
+        )
+        let emphasizedFont = GlobalFontMagnification.systemFont(
+            ofSize: 10 * fontScale,
+            weight: .semibold
+        )
+        var result: [Descriptor] = []
+
+        if visibility.showsMetadata {
+            let entries = isMetadataExpanded
+                ? workspace.metadataEntries
+                : Array(workspace.metadataEntries.prefix(Self.collapsedMetadataLimit))
+            for entry in entries {
+                let normalized = normalizedMetadataEntry(entry)
+                let color = snapshot.isActive
+                    ? primaryColor.withAlphaComponent(0.95)
+                    : (entry.color.flatMap(NSColor.init(hex:)) ?? secondaryColor)
+                let url = entry.url
+                result.append(Descriptor(
+                    title: normalized.title,
+                    symbolName: normalized.symbolName,
+                    color: color,
+                    font: textFont,
+                    maximumLines: 1,
+                    toolTip: url?.absoluteString ?? normalized.title,
+                    accessibilityIdentifier: "SidebarMetadataEntryRow",
+                    underlinesTitle: url != nil,
+                    action: url.map { url in
+                        { [actions] in
+                            actions.onOpenMetadataURL(url)
+                        }
+                    }
+                ))
+            }
+            if workspace.metadataEntries.count > Self.collapsedMetadataLimit {
+                result.append(Descriptor(
+                    title: isMetadataExpanded
+                        ? String(localized: "sidebar.metadata.showLess", defaultValue: "Show less")
+                        : String(localized: "sidebar.metadata.showMore", defaultValue: "Show more"),
+                    symbolName: isMetadataExpanded ? "chevron.up" : "chevron.down",
+                    color: secondaryColor,
+                    font: emphasizedFont,
+                    maximumLines: 1,
+                    toolTip: nil,
+                    accessibilityIdentifier: "SidebarMetadataExpansionButton",
+                    underlinesTitle: false,
+                    action: { [weak self] in
+                        guard let self else { return }
+                        actions.onActivate()
+                        isMetadataExpanded.toggle()
+                        rebuildRows()
+                        onHeightChanged?()
+                    }
+                ))
+            }
+
+            let blocks = areMetadataBlocksExpanded
+                ? workspace.metadataBlocks
+                : Array(workspace.metadataBlocks.prefix(Self.collapsedMetadataBlockLimit))
+            for block in blocks {
+                let display = Self.boundedMetadataBlock(block.markdown)
+                result.append(Descriptor(
+                    title: display,
+                    symbolName: nil,
+                    color: secondaryColor,
+                    font: GlobalFontMagnification.systemFont(ofSize: 10 * fontScale),
+                    maximumLines: Self.maximumMetadataBlockLines,
+                    toolTip: block.markdown,
+                    accessibilityIdentifier: "SidebarMetadataBlockRow",
+                    underlinesTitle: false,
+                    action: nil
+                ))
+            }
+            if workspace.metadataBlocks.count > Self.collapsedMetadataBlockLimit {
+                result.append(Descriptor(
+                    title: areMetadataBlocksExpanded
+                        ? String(
+                            localized: "sidebar.metadata.showLessDetails",
+                            defaultValue: "Show less details"
+                        )
+                        : String(
+                            localized: "sidebar.metadata.showMoreDetails",
+                            defaultValue: "Show more details"
+                        ),
+                    symbolName: areMetadataBlocksExpanded ? "chevron.up" : "chevron.down",
+                    color: secondaryColor,
+                    font: emphasizedFont,
+                    maximumLines: 1,
+                    toolTip: nil,
+                    accessibilityIdentifier: "SidebarMetadataBlockExpansionButton",
+                    underlinesTitle: false,
+                    action: { [weak self] in
+                        guard let self else { return }
+                        actions.onActivate()
+                        areMetadataBlocksExpanded.toggle()
+                        rebuildRows()
+                        onHeightChanged?()
+                    }
+                ))
+            }
+        }
+
+        if visibility.showsLog, let log = workspace.latestLog {
+            result.append(Descriptor(
+                title: log.message,
+                symbolName: Self.logSymbol(log.level),
+                color: snapshot.isActive ? secondaryColor : Self.logColor(log.level),
+                font: textFont,
+                maximumLines: 1,
+                toolTip: log.message,
+                accessibilityIdentifier: "SidebarLogRow",
+                underlinesTitle: false,
+                action: nil
+            ))
+        }
+
+        if visibility.showsBranchDirectory {
+            result.append(contentsOf: branchDescriptors(
+                snapshot: snapshot,
+                font: textFont
+            ))
+        }
+
+        if visibility.showsPullRequests {
+            for pullRequest in workspace.pullRequestRows {
+                let title = "\(pullRequest.label) #\(pullRequest.number)  ·  \(Self.pullRequestStatusLabel(pullRequest.status))"
+                let url = pullRequest.url
+                result.append(Descriptor(
+                    title: title,
+                    symbolName: Self.pullRequestSymbol(pullRequest.status),
+                    color: secondaryColor.withAlphaComponent(pullRequest.isStale ? 0.5 : 1),
+                    font: emphasizedFont,
+                    maximumLines: 1,
+                    toolTip: snapshot.settings.makesPullRequestsClickable
+                        ? String(
+                            localized: "sidebar.pullRequest.openTooltip",
+                            defaultValue: "Open \(pullRequest.label) #\(pullRequest.number)"
+                        )
+                        : title,
+                    accessibilityIdentifier: "SidebarPullRequestRow",
+                    underlinesTitle: snapshot.settings.makesPullRequestsClickable,
+                    action: snapshot.settings.makesPullRequestsClickable
+                        ? { [actions] in
+                            actions.onOpenPullRequest(url)
+                        }
+                        : nil
+                ))
+            }
+        }
+
+        if visibility.showsPorts {
+            for port in workspace.listeningPorts {
+                result.append(Descriptor(
+                    title: SidebarPortDisplayText.label(for: port),
+                    symbolName: "network",
+                    color: secondaryColor,
+                    font: textFont,
+                    maximumLines: 1,
+                    toolTip: SidebarPortDisplayText.openTooltip(for: port),
+                    accessibilityIdentifier: "SidebarPortRow",
+                    underlinesTitle: true,
+                    action: { [actions] in
+                        actions.onOpenPort(port)
+                    }
+                ))
+            }
+        }
+
+        return result
+    }
+
+    private func branchDescriptors(
+        snapshot: SidebarWorkspaceRowSnapshot,
+        font: NSFont
+    ) -> [Descriptor] {
+        let workspace = snapshot.workspace
+        let symbol = snapshot.settings.showsGitBranchIcon ? "arrow.triangle.branch" : nil
+        var lines: [String] = []
+        if snapshot.settings.usesVerticalBranchLayout {
+            for line in workspace.branchDirectoryLines {
+                if snapshot.settings.stacksBranchAndDirectory {
+                    if let branch = line.branch { lines.append(branch) }
+                    if let directory = line.directory { lines.append(directory) }
+                } else {
+                    let pieces = [line.branch, line.directory].compactMap { $0 }
+                    if !pieces.isEmpty { lines.append(pieces.joined(separator: "  ·  ")) }
+                }
+            }
+        } else if snapshot.settings.stacksBranchAndDirectory {
+            if let branch = workspace.compactGitBranchSummaryText { lines.append(branch) }
+            if let directory = workspace.compactDirectoryCandidates.first { lines.append(directory) }
+        } else if let combined = workspace.compactBranchDirectoryCandidates.first {
+            lines.append(combined)
+        }
+        return lines.enumerated().map { index, line in
+            Descriptor(
+                title: line,
+                symbolName: index == 0 ? symbol : nil,
+                color: secondaryColor,
+                font: font,
+                maximumLines: 1,
+                toolTip: line,
+                accessibilityIdentifier: "SidebarBranchDirectoryRow",
+                underlinesTitle: false,
+                action: nil
+            )
+        }
+    }
+
+    private func normalizedMetadataEntry(
+        _ entry: SidebarStatusEntry
+    ) -> (title: String, symbolName: String?) {
+        let trimmed = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        var title = trimmed.isEmpty ? entry.key : trimmed
+        guard let rawIcon = entry.icon?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !rawIcon.isEmpty else {
+            return (title, nil)
+        }
+        if rawIcon.hasPrefix("emoji:") {
+            let icon = String(rawIcon.dropFirst("emoji:".count))
+            if !icon.isEmpty { title = "\(icon)  \(title)" }
+            return (title, nil)
+        }
+        if rawIcon.hasPrefix("text:") {
+            let icon = String(rawIcon.dropFirst("text:".count))
+            if !icon.isEmpty { title = "\(icon)  \(title)" }
+            return (title, nil)
+        }
+        let symbolName = rawIcon.hasPrefix("sf:")
+            ? String(rawIcon.dropFirst("sf:".count))
+            : rawIcon
+        return (title, symbolName.isEmpty ? nil : symbolName)
+    }
+
+    private static func boundedMetadataBlock(_ markdown: String) -> String {
+        var result = ""
+        result.reserveCapacity(min(markdown.count, maximumMetadataBlockCharacters))
+        var lines = 1
+        var characters = 0
+        var truncated = false
+        for character in markdown {
+            if characters >= maximumMetadataBlockCharacters {
+                truncated = true
+                break
+            }
+            if character == "\n", lines >= maximumMetadataBlockLines {
+                truncated = true
+                break
+            }
+            if character == "\n" { lines += 1 }
+            result.append(character)
+            characters += 1
+        }
+        guard truncated else { return result }
+        let trimmed = result.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "..." : "\(trimmed)..."
+    }
+
+    private static func logSymbol(_ level: SidebarLogLevel) -> String {
+        switch level {
+        case .info: "circle.fill"
+        case .progress: "arrowtriangle.right.fill"
+        case .success: "checkmark.circle.fill"
+        case .warning: "exclamationmark.triangle.fill"
+        case .error: "xmark.circle.fill"
+        }
+    }
+
+    private static func logColor(_ level: SidebarLogLevel) -> NSColor {
+        switch level {
+        case .info: .secondaryLabelColor
+        case .progress: .systemBlue
+        case .success: .systemGreen
+        case .warning: .systemOrange
+        case .error: .systemRed
+        }
+    }
+
+    private static func pullRequestStatusLabel(_ status: SidebarPullRequestStatus) -> String {
+        switch status {
+        case .open:
+            String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
+        case .merged:
+            String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
+        case .closed:
+            String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+        }
+    }
+
+    private static func pullRequestSymbol(_ status: SidebarPullRequestStatus) -> String {
+        switch status {
+        case .open: "arrow.triangle.pull"
+        case .merged: "arrow.triangle.merge"
+        case .closed: "xmark.circle"
+        }
+    }
+}

--- a/Sources/Sidebar/AppKit/VerticalTabsSidebarAppKitRouter.swift
+++ b/Sources/Sidebar/AppKit/VerticalTabsSidebarAppKitRouter.swift
@@ -1,0 +1,112 @@
+import AppKit
+import CmuxSettings
+import CmuxSidebarRemoteRender
+import CmuxUpdater
+import SwiftUI
+
+/// Lightweight provider router for the sidebar.
+///
+/// The built-in provider uses the native AppKit bridge only while its staged
+/// feature flag is enabled. The existing SwiftUI sidebar remains the default
+/// and continues to host custom or installed providers.
+struct VerticalTabsSidebar: View {
+    var updateViewModel: UpdateStateModel
+    let fileExplorerState: FileExplorerState
+    let windowId: UUID
+    let onSendFeedback: () -> Void
+    let onToggleSidebar: () -> Void
+    let onNewTab: () -> Void
+    let observedWindow: NSWindow?
+    let tabManager: TabManager
+    let sidebarUnread: SidebarUnreadModel
+    let cmuxConfigStore: CmuxConfigStore
+    @Binding var selection: SidebarSelection
+    @Binding var selectedTabIds: Set<UUID>
+    @Binding var lastSidebarSelectionIndex: Int?
+    @Binding var sidebarRenderWorkerClient: RenderWorkerClient?
+    var appKitSidebarEnabledOverride: Bool? = nil
+    @AppStorage(CmuxExtensionSidebarSelection.defaultsKey)
+    private var selectedExtensionSidebarProviderId = CmuxExtensionSidebarSelection.defaultProviderId
+    @LiveSetting(\.betaFeatures.extensions) private var extensionsExperimentalEnabled
+    @LiveSetting(\.betaFeatures.customSidebars) private var customSidebarsExperimentalEnabled
+    @LiveSetting(\.sidebar.showAgentActivity) private var showAgentActivity
+    @LiveSetting(\.shortcuts.showModifierHoldHints) private var showModifierHoldHints
+#if DEBUG
+    @Environment(\.minimalModeInvalidationProbe) private var minimalModeInvalidationProbe
+    @Environment(\.sidebarLazyContractProbe) private var sidebarLazyContractProbe
+#endif
+
+    private var effectiveExtensionSidebarProviderId: String {
+        let selected = selectedExtensionSidebarProviderId
+        if selected.hasPrefix(CmuxExtensionSidebarSelection.customSidebarProviderPrefix) {
+            _ = customSidebarsExperimentalEnabled
+            return CmuxExtensionSidebarSelection.customSidebarsEnabled
+                ? selected
+                : CmuxExtensionSidebarSelection.defaultProviderId
+        }
+        return CmuxExtensionSidebarSelection.effectiveProviderId(
+            selected,
+            extensionsEnabled: extensionsExperimentalEnabled
+        )
+    }
+
+    private var workspaceRowInputProjection: (() -> Void)? {
+#if DEBUG
+        sidebarLazyContractProbe.workspaceRowInputProjection
+#else
+        nil
+#endif
+    }
+
+    private var isAppKitSidebarEnabled: Bool {
+        appKitSidebarEnabledOverride ?? CmuxFeatureFlags.shared.isAppKitSidebarEnabled
+    }
+
+    @ViewBuilder
+    var body: some View {
+#if DEBUG
+        let _ = { minimalModeInvalidationProbe.verticalTabsSidebarBody?() }()
+#endif
+        if isAppKitSidebarEnabled,
+           CmuxExtensionSidebarSelection.resolvesToDefaultSidebar(
+            effectiveProviderId: effectiveExtensionSidebarProviderId
+        ) {
+            SidebarAppKitRuntimeHostRepresentable(
+                updateViewModel: updateViewModel,
+                fileExplorerState: fileExplorerState,
+                windowId: windowId,
+                onSendFeedback: onSendFeedback,
+                onToggleSidebar: onToggleSidebar,
+                onNewTab: onNewTab,
+                observedWindow: observedWindow,
+                tabManager: tabManager,
+                sidebarUnread: sidebarUnread,
+                cmuxConfigStore: cmuxConfigStore,
+                selection: $selection,
+                selectedTabIds: $selectedTabIds,
+                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                showsAgentActivity: showAgentActivity
+                    && CmuxFeatureFlags.shared.isSidebarWorkspaceAgentSpinnerEnabled,
+                enablesModifierShortcutHints: showModifierHoldHints,
+                workspaceRowInputProjection: workspaceRowInputProjection
+            )
+            .accessibilityIdentifier("Sidebar")
+            .ignoresSafeArea()
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        } else {
+            LegacyVerticalTabsSidebar(
+                updateViewModel: updateViewModel,
+                fileExplorerState: fileExplorerState,
+                windowId: windowId,
+                onSendFeedback: onSendFeedback,
+                onToggleSidebar: onToggleSidebar,
+                onNewTab: onNewTab,
+                observedWindow: observedWindow,
+                selection: $selection,
+                selectedTabIds: $selectedTabIds,
+                lastSidebarSelectionIndex: $lastSidebarSelectionIndex,
+                sidebarRenderWorkerClient: $sidebarRenderWorkerClient
+            )
+        }
+    }
+}

--- a/Sources/Sidebar/AppKit/VerticalTabsSidebarAppKitRouter.swift
+++ b/Sources/Sidebar/AppKit/VerticalTabsSidebarAppKitRouter.swift
@@ -1,5 +1,7 @@
 import AppKit
 import CmuxSettings
+import CmuxSettingsUI
+import CmuxSidebarInterpreterClient
 import CmuxSidebarRemoteRender
 import CmuxUpdater
 import SwiftUI

--- a/Sources/SidebarWorkspaceSnapshotFactory.swift
+++ b/Sources/SidebarWorkspaceSnapshotFactory.swift
@@ -15,6 +15,21 @@ struct SidebarWorkspaceSnapshotFactory {
     let workspace: Workspace
     let settings: SidebarTabItemSettingsSnapshot
     let showsAgentActivity: Bool
+    /// The AppKit sidebar resolves checklist items lazily only after the user
+    /// opens the native checklist. Legacy SwiftUI rows still receive the array.
+    let includesChecklistItems: Bool
+
+    init(
+        workspace: Workspace,
+        settings: SidebarTabItemSettingsSnapshot,
+        showsAgentActivity: Bool,
+        includesChecklistItems: Bool = true
+    ) {
+        self.workspace = workspace
+        self.settings = settings
+        self.showsAgentActivity = showsAgentActivity
+        self.includesChecklistItems = includesChecklistItems
+    }
 
     func makeSnapshot() -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         let detailVisibility = settings.visibleAuxiliaryDetails
@@ -102,7 +117,7 @@ struct SidebarWorkspaceSnapshotFactory {
             finderDirectoryPath: WorkspaceFinderDirectoryResolver.path(for: workspace),
             mediaActivity: workspace.browserMediaActivity,
             taskStatus: taskStatusResolution?.effective,
-            checklistItems: workspace.todoState.checklist,
+            checklistItems: includesChecklistItems ? workspace.todoState.checklist : [],
             checklistCompletedCount: checklistProgress.completedCount,
             checklistTotalCount: checklistProgress.totalCount,
             checklistFirstUncheckedText: checklistProgress.firstUncheckedText

--- a/Sources/TerminalNotificationStore.swift
+++ b/Sources/TerminalNotificationStore.swift
@@ -1,5 +1,6 @@
 import CmuxFoundation
 import AppKit
+import Combine
 import Foundation
 import os
 import UserNotifications
@@ -2208,6 +2209,14 @@ struct SidebarWorkspaceUnreadSummary: Equatable {
     var latestNotificationText: String?
 }
 
+/// One keyed summary mutation emitted alongside the coalesced unread snapshot.
+/// The AppKit sidebar consumes these changes directly so it never has to diff
+/// the complete workspace-summary dictionary after every notification update.
+struct SidebarWorkspaceUnreadSummaryChange: Equatable {
+    let workspaceId: UUID
+    let summary: SidebarWorkspaceUnreadSummary?
+}
+
 /// Workspace + surface pair used to mirror the store's per-surface unread set.
 struct SidebarSurfaceUnreadKey: Hashable {
     var workspaceId: UUID
@@ -2231,6 +2240,19 @@ final class SidebarUnreadModel: ObservableObject {
     @Published private(set) var focusedReadIndicatorByWorkspaceId: [UUID: UUID] = [:]
     @Published private(set) var manualUnreadWorkspaceIds: Set<UUID> = []
 
+    /// Synchronously emitted on the main actor after `summaryByWorkspaceId` is
+    /// assigned. Existing `@Published` behavior is preserved for legacy users.
+    private let summaryChangesSubject = PassthroughSubject<
+        [SidebarWorkspaceUnreadSummaryChange],
+        Never
+    >()
+    var summaryChangesPublisher: AnyPublisher<
+        [SidebarWorkspaceUnreadSummaryChange],
+        Never
+    > {
+        summaryChangesSubject.eraseToAnyPublisher()
+    }
+
     func apply(
         totalUnreadCount: Int,
         summaries: [UUID: SidebarWorkspaceUnreadSummary],
@@ -2241,8 +2263,13 @@ final class SidebarUnreadModel: ObservableObject {
         if self.totalUnreadCount != totalUnreadCount {
             self.totalUnreadCount = totalUnreadCount
         }
-        if summaryByWorkspaceId != summaries {
+        let summaryChanges = Self.summaryChanges(
+            from: summaryByWorkspaceId,
+            to: summaries
+        )
+        if !summaryChanges.isEmpty {
             summaryByWorkspaceId = summaries
+            summaryChangesSubject.send(summaryChanges)
         }
         if self.unreadSurfaceKeys != unreadSurfaceKeys {
             self.unreadSurfaceKeys = unreadSurfaceKeys
@@ -2273,6 +2300,31 @@ final class SidebarUnreadModel: ObservableObject {
 
     func hasManualUnread(forWorkspaceId id: UUID) -> Bool {
         manualUnreadWorkspaceIds.contains(id)
+    }
+
+    private static func summaryChanges(
+        from previous: [UUID: SidebarWorkspaceUnreadSummary],
+        to next: [UUID: SidebarWorkspaceUnreadSummary]
+    ) -> [SidebarWorkspaceUnreadSummaryChange] {
+        var changes: [SidebarWorkspaceUnreadSummaryChange] = []
+        changes.reserveCapacity(abs(next.count - previous.count) + 1)
+
+        for (workspaceId, previousSummary) in previous {
+            let nextSummary = next[workspaceId]
+            if nextSummary != previousSummary {
+                changes.append(SidebarWorkspaceUnreadSummaryChange(
+                    workspaceId: workspaceId,
+                    summary: nextSummary
+                ))
+            }
+        }
+        for (workspaceId, nextSummary) in next where previous[workspaceId] == nil {
+            changes.append(SidebarWorkspaceUnreadSummaryChange(
+                workspaceId: workspaceId,
+                summary: nextSummary
+            ))
+        }
+        return changes
     }
 
     func hasUnreadNotification(forWorkspaceId id: UUID, surfaceId: UUID?) -> Bool {

--- a/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
+++ b/Sources/VerticalTabsSidebar+WorkspaceGroups.swift
@@ -4,7 +4,7 @@ import SwiftUI
 import CmuxSettings
 import CmuxWorkspaces
 
-extension VerticalTabsSidebar {
+extension LegacyVerticalTabsSidebar {
     func sidebarWorkspaceGroupRowSnapshot(
         group: WorkspaceGroup,
         memberWorkspaceIds: [UUID],

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1430,6 +1430,28 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A6AC71020000000000000001 /* SidebarAgentActivityIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC71030000000000000001 /* SidebarAgentActivityIndicator.swift */; };
 		A6AC71040000000000000001 /* SidebarAgentActivitySummary.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC71050000000000000001 /* SidebarAgentActivitySummary.swift */; };
 		211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */; };
+		5BA771000000000000000001 /* SidebarAppKitBadgeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000001 /* SidebarAppKitBadgeView.swift */; };
+		5BA771000000000000000002 /* SidebarAppKitCellSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000002 /* SidebarAppKitCellSupport.swift */; };
+		5BA771000000000000000014 /* SidebarAppKitChecklistController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000014 /* SidebarAppKitChecklistController.swift */; };
+		5BA771000000000000000003 /* SidebarAppKitConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000003 /* SidebarAppKitConfiguration.swift */; };
+		5BA771000000000000000004 /* SidebarAppKitContextMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000004 /* SidebarAppKitContextMenuController.swift */; };
+		5BA771000000000000000005 /* SidebarAppKitDragCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000005 /* SidebarAppKitDragCoordinator.swift */; };
+		5BA771000000000000000006 /* SidebarAppKitFooterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000006 /* SidebarAppKitFooterView.swift */; };
+		5BA771000000000000000007 /* SidebarAppKitGroupCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000007 /* SidebarAppKitGroupCellView.swift */; };
+		5BA771000000000000000008 /* SidebarAppKitHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000008 /* SidebarAppKitHeaderView.swift */; };
+		5BA771000000000000000009 /* SidebarAppKitHelpMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000009 /* SidebarAppKitHelpMenuController.swift */; };
+		5BA77100000000000000000A /* SidebarAppKitInteractionCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA77000000000000000000A /* SidebarAppKitInteractionCoordinator.swift */; };
+		5BA77100000000000000000B /* SidebarAppKitModifierMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA77000000000000000000B /* SidebarAppKitModifierMonitor.swift */; };
+		5BA77100000000000000000C /* SidebarAppKitProjectionSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA77000000000000000000C /* SidebarAppKitProjectionSource.swift */; };
+		5BA77100000000000000000D /* SidebarAppKitRuntimeHostRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA77000000000000000000D /* SidebarAppKitRuntimeHostRepresentable.swift */; };
+		5BA77100000000000000000E /* SidebarAppKitShortcutMenuController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA77000000000000000000E /* SidebarAppKitShortcutMenuController.swift */; };
+		5BA77100000000000000000F /* SidebarAppKitSnapshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA77000000000000000000F /* SidebarAppKitSnapshotStore.swift */; };
+		5BA773000000000000000001 /* SidebarAppKitSnapshotStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA772000000000000000001 /* SidebarAppKitSnapshotStoreTests.swift */; };
+		5BA771000000000000000010 /* SidebarAppKitTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000010 /* SidebarAppKitTableView.swift */; };
+		5BA771000000000000000011 /* SidebarAppKitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000011 /* SidebarAppKitViewController.swift */; };
+		5BA773000000000000000002 /* SidebarAppKitViewControllerScaleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA772000000000000000002 /* SidebarAppKitViewControllerScaleTests.swift */; };
+		5BA771000000000000000012 /* SidebarAppKitWorkspaceCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000012 /* SidebarAppKitWorkspaceCellView.swift */; };
+		5BA771000000000000000015 /* SidebarAppKitWorkspaceDetailsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000015 /* SidebarAppKitWorkspaceDetailsView.swift */; };
 		D7AB34310000000000000003 /* SidebarBonsplitTabDropDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34310000000000000004 /* SidebarBonsplitTabDropDelegate.swift */; };
 		D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */; };
 		D7AB34310000000000000001 /* SidebarBonsplitWorkspaceRowDropModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB34310000000000000002 /* SidebarBonsplitWorkspaceRowDropModifier.swift */; };
@@ -1823,6 +1845,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F76550060000000000000001 /* VaultObservedAgentProcess.swift in Sources */ = {isa = PBXBuildFile; fileRef = F76550060000000000000002 /* VaultObservedAgentProcess.swift */; };
 		F7216001000000000000001 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7216001000000000000002 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift */; };
 		C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */; };
+		5BA771000000000000000013 /* VerticalTabsSidebarAppKitRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5BA770000000000000000013 /* VerticalTabsSidebarAppKitRouter.swift */; };
 		A28B087F0000000000000005 /* ViewerNavigationKeyRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F0000000000000006 /* ViewerNavigationKeyRouter.swift */; };
 		A3340002A3340002A3340002 /* ViewerNavigationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A3340001A3340001A3340001 /* ViewerNavigationTests.swift */; };
 		ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */; };
@@ -3383,6 +3406,28 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A6AC71030000000000000001 /* SidebarAgentActivityIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarAgentActivityIndicator.swift; sourceTree = "<group>"; };
 		A6AC71050000000000000001 /* SidebarAgentActivitySummary.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarAgentActivitySummary.swift; sourceTree = "<group>"; };
 		243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarAppearanceSupport.swift; sourceTree = "<group>"; };
+		5BA770000000000000000001 /* SidebarAppKitBadgeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitBadgeView.swift; sourceTree = "<group>"; };
+		5BA770000000000000000002 /* SidebarAppKitCellSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitCellSupport.swift; sourceTree = "<group>"; };
+		5BA770000000000000000014 /* SidebarAppKitChecklistController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitChecklistController.swift; sourceTree = "<group>"; };
+		5BA770000000000000000003 /* SidebarAppKitConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitConfiguration.swift; sourceTree = "<group>"; };
+		5BA770000000000000000004 /* SidebarAppKitContextMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitContextMenuController.swift; sourceTree = "<group>"; };
+		5BA770000000000000000005 /* SidebarAppKitDragCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitDragCoordinator.swift; sourceTree = "<group>"; };
+		5BA770000000000000000006 /* SidebarAppKitFooterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitFooterView.swift; sourceTree = "<group>"; };
+		5BA770000000000000000007 /* SidebarAppKitGroupCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitGroupCellView.swift; sourceTree = "<group>"; };
+		5BA770000000000000000008 /* SidebarAppKitHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitHeaderView.swift; sourceTree = "<group>"; };
+		5BA770000000000000000009 /* SidebarAppKitHelpMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitHelpMenuController.swift; sourceTree = "<group>"; };
+		5BA77000000000000000000A /* SidebarAppKitInteractionCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitInteractionCoordinator.swift; sourceTree = "<group>"; };
+		5BA77000000000000000000B /* SidebarAppKitModifierMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitModifierMonitor.swift; sourceTree = "<group>"; };
+		5BA77000000000000000000C /* SidebarAppKitProjectionSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitProjectionSource.swift; sourceTree = "<group>"; };
+		5BA77000000000000000000D /* SidebarAppKitRuntimeHostRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitRuntimeHostRepresentable.swift; sourceTree = "<group>"; };
+		5BA77000000000000000000E /* SidebarAppKitShortcutMenuController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitShortcutMenuController.swift; sourceTree = "<group>"; };
+		5BA77000000000000000000F /* SidebarAppKitSnapshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitSnapshotStore.swift; sourceTree = "<group>"; };
+		5BA772000000000000000001 /* SidebarAppKitSnapshotStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarAppKitSnapshotStoreTests.swift; sourceTree = "<group>"; };
+		5BA770000000000000000010 /* SidebarAppKitTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitTableView.swift; sourceTree = "<group>"; };
+		5BA770000000000000000011 /* SidebarAppKitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitViewController.swift; sourceTree = "<group>"; };
+		5BA772000000000000000002 /* SidebarAppKitViewControllerScaleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarAppKitViewControllerScaleTests.swift; sourceTree = "<group>"; };
+		5BA770000000000000000012 /* SidebarAppKitWorkspaceCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitWorkspaceCellView.swift; sourceTree = "<group>"; };
+		5BA770000000000000000015 /* SidebarAppKitWorkspaceDetailsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/SidebarAppKitWorkspaceDetailsView.swift; sourceTree = "<group>"; };
 		D7AB34310000000000000004 /* SidebarBonsplitTabDropDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarBonsplitTabDropDelegate.swift; sourceTree = "<group>"; };
 		D7AB34300000000000000004 /* SidebarBonsplitTabWorkspaceDropOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarBonsplitTabWorkspaceDropOverlay.swift; sourceTree = "<group>"; };
 		D7AB34310000000000000002 /* SidebarBonsplitWorkspaceRowDropModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarBonsplitWorkspaceRowDropModifier.swift; sourceTree = "<group>"; };
@@ -3768,6 +3813,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F76550060000000000000002 /* VaultObservedAgentProcess.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VaultObservedAgentProcess.swift; sourceTree = "<group>"; };
 		F7216001000000000000002 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+EmptyAreasAndFooter.swift"; sourceTree = "<group>"; };
 		C9A5720AC9A5720AC9A5720A /* VerticalTabsSidebar+WorkspaceGroups.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "VerticalTabsSidebar+WorkspaceGroups.swift"; sourceTree = "<group>"; };
+		5BA770000000000000000013 /* VerticalTabsSidebarAppKitRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKit/VerticalTabsSidebarAppKitRouter.swift; sourceTree = "<group>"; };
 		A28B087F0000000000000006 /* ViewerNavigationKeyRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/ViewerNavigationKeyRouter.swift; sourceTree = "<group>"; };
 		A3340001A3340001A3340001 /* ViewerNavigationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewerNavigationTests.swift; sourceTree = "<group>"; };
 		9CEC6EF35B71AE59FA45BA69 /* VMClient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = VMClient.swift; sourceTree = "<group>"; };
@@ -4394,6 +4440,27 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D36A00070000000000000002 /* RendererRealizationReclaimTrigger.swift */,
 				7490D00F7490D00F7490D00F /* TaskVMInfoMemoryPressureFootprintSampler.swift */,
 				243632BA1DBBA36FD46E0610 /* SidebarAppearanceSupport.swift */,
+				5BA770000000000000000001 /* SidebarAppKitBadgeView.swift */,
+				5BA770000000000000000002 /* SidebarAppKitCellSupport.swift */,
+				5BA770000000000000000003 /* SidebarAppKitConfiguration.swift */,
+				5BA770000000000000000004 /* SidebarAppKitContextMenuController.swift */,
+				5BA770000000000000000014 /* SidebarAppKitChecklistController.swift */,
+				5BA770000000000000000005 /* SidebarAppKitDragCoordinator.swift */,
+				5BA770000000000000000006 /* SidebarAppKitFooterView.swift */,
+				5BA770000000000000000007 /* SidebarAppKitGroupCellView.swift */,
+				5BA770000000000000000008 /* SidebarAppKitHeaderView.swift */,
+				5BA770000000000000000009 /* SidebarAppKitHelpMenuController.swift */,
+				5BA77000000000000000000A /* SidebarAppKitInteractionCoordinator.swift */,
+				5BA77000000000000000000B /* SidebarAppKitModifierMonitor.swift */,
+				5BA77000000000000000000C /* SidebarAppKitProjectionSource.swift */,
+				5BA77000000000000000000D /* SidebarAppKitRuntimeHostRepresentable.swift */,
+				5BA77000000000000000000E /* SidebarAppKitShortcutMenuController.swift */,
+				5BA77000000000000000000F /* SidebarAppKitSnapshotStore.swift */,
+				5BA770000000000000000010 /* SidebarAppKitTableView.swift */,
+				5BA770000000000000000011 /* SidebarAppKitViewController.swift */,
+				5BA770000000000000000012 /* SidebarAppKitWorkspaceCellView.swift */,
+				5BA770000000000000000015 /* SidebarAppKitWorkspaceDetailsView.swift */,
+				5BA770000000000000000013 /* VerticalTabsSidebarAppKitRouter.swift */,
 				D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */,
 				AABBCC00000000000000020B /* SidebarInlineRenameAction.swift */,
 				AABBCC00000000000000020D /* SidebarInlineRenameCommit.swift */,
@@ -5700,6 +5767,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C9A57514C9A57514C9A57514 /* SidebarScrollViewConfiguratorTests.swift */,
 				C9A57506C9A57506C9A57506 /* SidebarWorkspaceScrollLayoutTests.swift */,
 				D41A7C02D41A7C02D41A7C02 /* SidebarLazyLayoutScaleTests.swift */,
+				5BA772000000000000000001 /* SidebarAppKitSnapshotStoreTests.swift */,
+				5BA772000000000000000002 /* SidebarAppKitViewControllerScaleTests.swift */,
 				6707F0186707F0186707F018 /* SidebarWorkspaceContextMenuWindowTargetsTests.swift */,
 				6707F0246707F0246707F024 /* SidebarWorkspaceNotificationIndexTests.swift */,
 				A80070020000000000000001 /* SidebarPointerInteractionMonitorTests.swift */,
@@ -7257,6 +7326,26 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A6AC71020000000000000001 /* SidebarAgentActivityIndicator.swift in Sources */,
 				A6AC71040000000000000001 /* SidebarAgentActivitySummary.swift in Sources */,
 				211A75777F433ED8BA5AE208 /* SidebarAppearanceSupport.swift in Sources */,
+				5BA771000000000000000001 /* SidebarAppKitBadgeView.swift in Sources */,
+				5BA771000000000000000002 /* SidebarAppKitCellSupport.swift in Sources */,
+				5BA771000000000000000014 /* SidebarAppKitChecklistController.swift in Sources */,
+				5BA771000000000000000003 /* SidebarAppKitConfiguration.swift in Sources */,
+				5BA771000000000000000004 /* SidebarAppKitContextMenuController.swift in Sources */,
+				5BA771000000000000000005 /* SidebarAppKitDragCoordinator.swift in Sources */,
+				5BA771000000000000000006 /* SidebarAppKitFooterView.swift in Sources */,
+				5BA771000000000000000007 /* SidebarAppKitGroupCellView.swift in Sources */,
+				5BA771000000000000000008 /* SidebarAppKitHeaderView.swift in Sources */,
+				5BA771000000000000000009 /* SidebarAppKitHelpMenuController.swift in Sources */,
+				5BA77100000000000000000A /* SidebarAppKitInteractionCoordinator.swift in Sources */,
+				5BA77100000000000000000B /* SidebarAppKitModifierMonitor.swift in Sources */,
+				5BA77100000000000000000C /* SidebarAppKitProjectionSource.swift in Sources */,
+				5BA77100000000000000000D /* SidebarAppKitRuntimeHostRepresentable.swift in Sources */,
+				5BA77100000000000000000E /* SidebarAppKitShortcutMenuController.swift in Sources */,
+				5BA77100000000000000000F /* SidebarAppKitSnapshotStore.swift in Sources */,
+				5BA771000000000000000010 /* SidebarAppKitTableView.swift in Sources */,
+				5BA771000000000000000011 /* SidebarAppKitViewController.swift in Sources */,
+				5BA771000000000000000012 /* SidebarAppKitWorkspaceCellView.swift in Sources */,
+				5BA771000000000000000015 /* SidebarAppKitWorkspaceDetailsView.swift in Sources */,
 				D7AB34310000000000000003 /* SidebarBonsplitTabDropDelegate.swift in Sources */,
 				D7AB34300000000000000003 /* SidebarBonsplitTabWorkspaceDropOverlay.swift in Sources */,
 				D7AB34310000000000000001 /* SidebarBonsplitWorkspaceRowDropModifier.swift in Sources */,
@@ -7545,6 +7634,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F76550060000000000000001 /* VaultObservedAgentProcess.swift in Sources */,
 				F7216001000000000000001 /* VerticalTabsSidebar+EmptyAreasAndFooter.swift in Sources */,
 				C9A57209C9A57209C9A57209 /* VerticalTabsSidebar+WorkspaceGroups.swift in Sources */,
+				5BA771000000000000000013 /* VerticalTabsSidebarAppKitRouter.swift in Sources */,
 				A28B087F0000000000000005 /* ViewerNavigationKeyRouter.swift in Sources */,
 				ACE4FE1A8F1CC6C0B6A673AB /* VMClient.swift in Sources */,
 				ACE4FE2A8F1CC6C0B6A673AB /* VMClientSocketCommands.swift in Sources */,
@@ -8192,6 +8282,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6042A0016042A0016042A001 /* ShortcutHintModifierPolicyTests.swift in Sources */,
 				F6001000A1B2C3D4E5F60718 /* ShortcutUnbindingTests.swift in Sources */,
 				C3467AB10000000000000001 /* ShortcutWhenClauseTests.swift in Sources */,
+				5BA773000000000000000001 /* SidebarAppKitSnapshotStoreTests.swift in Sources */,
+				5BA773000000000000000002 /* SidebarAppKitViewControllerScaleTests.swift in Sources */,
 				51D800000000000000000001 /* SidebarIdentifierFormattingTests.swift in Sources */,
 				AABBCC000000000000000206 /* SidebarInlineRenameKeyResolverTests.swift in Sources */,
 				D41A7C01D41A7C01D41A7C01 /* SidebarLazyLayoutScaleTests.swift in Sources */,

--- a/cmuxTests/SidebarAppKitSnapshotStoreTests.swift
+++ b/cmuxTests/SidebarAppKitSnapshotStoreTests.swift
@@ -1,0 +1,172 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("AppKit sidebar snapshot store scale")
+struct SidebarAppKitSnapshotStoreTests {
+    private struct Input: Equatable {
+        let revision: Int
+    }
+
+    private struct Presentation: Equatable {
+        let revision: Int
+        let isHovered: Bool
+    }
+
+    private typealias Store = SidebarAppKitSnapshotStore<Int, Input, Presentation>
+    private typealias Item = SidebarAppKitSnapshotItem<Int, Input>
+    private typealias Snapshot = SidebarAppKitSnapshot<Int, Input>
+
+    @Test(arguments: [1, 10, 100, 1_000])
+    func keyedUpdateVisitsProjectsAndReloadsExactlyOneRow(itemCount: Int) {
+        let store = Self.makeStore(itemCount: itemCount)
+        let targetID = itemCount / 2
+        store.resetInstrumentation()
+
+        let diff = store.updatePresentation(
+            for: targetID,
+            input: Input(revision: 1)
+        )
+
+        #expect(diff.insertedItemIDs.isEmpty)
+        #expect(diff.removedItemIDs.isEmpty)
+        #expect(diff.movedItemIDs.isEmpty)
+        #expect(diff.reloadedItemIDs == Set([targetID]))
+        #expect(diff.reloadedItemIDs.count <= 1)
+        #expect(diff.reloadedRows == IndexSet(integer: targetID))
+        #expect(store.rowIndex(for: targetID) == targetID)
+        #expect(store.presentation(for: targetID) == Presentation(revision: 1, isHovered: false))
+        #expect(store.instrumentation.keyedPresentationUpdateCount == 1)
+        #expect(store.instrumentation.lastOperationItemVisitCount == 1)
+        #expect(store.instrumentation.lastOperationProjectionCount == 1)
+        #expect(store.instrumentation.lastOperationReloadCount == 1)
+        #expect(store.lastProjectedItemIDs == Set([targetID]))
+    }
+
+    @Test(arguments: [1, 10, 100, 1_000])
+    func structuralSingleInputChangeProjectsAndReloadsOnlyChangedRow(itemCount: Int) {
+        let store = Self.makeStore(itemCount: itemCount)
+        let targetID = itemCount / 2
+        store.resetInstrumentation()
+
+        let diff = store.apply(snapshot: Self.makeSnapshot(
+            itemCount: itemCount,
+            revisions: [targetID: 1]
+        ))
+
+        #expect(diff.insertedItemIDs.isEmpty)
+        #expect(diff.removedItemIDs.isEmpty)
+        #expect(diff.movedItemIDs.isEmpty)
+        #expect(diff.reloadedItemIDs == Set([targetID]))
+        #expect(diff.reloadedRows == IndexSet(integer: targetID))
+        #expect(store.instrumentation.structuralSnapshotApplyCount == 1)
+        #expect(store.instrumentation.lastOperationItemVisitCount == itemCount)
+        #expect(store.instrumentation.lastOperationProjectionCount == 1)
+        #expect(store.instrumentation.lastOperationReloadCount == 1)
+        #expect(store.lastProjectedItemIDs == Set([targetID]))
+    }
+
+    @Test(arguments: [1, 10, 100, 1_000])
+    func hoverTransitionTouchesOnlyOldAndNewRows(itemCount: Int) {
+        let store = Self.makeStore(itemCount: itemCount)
+        let oldHoveredID = 0
+        _ = store.setHoveredItemID(oldHoveredID)
+        store.resetInstrumentation()
+
+        let nextHoveredID: Int? = itemCount == 1 ? nil : itemCount - 1
+        let diff = store.setHoveredItemID(nextHoveredID)
+        let expectedIDs = nextHoveredID.map { Set([oldHoveredID, $0]) } ?? Set([oldHoveredID])
+        var expectedRows = IndexSet()
+        for itemID in expectedIDs {
+            expectedRows.insert(itemID)
+        }
+
+        #expect(diff.insertedItemIDs.isEmpty)
+        #expect(diff.removedItemIDs.isEmpty)
+        #expect(diff.movedItemIDs.isEmpty)
+        #expect(diff.reloadedItemIDs == expectedIDs)
+        #expect(diff.reloadedItemIDs.count <= 2)
+        #expect(diff.reloadedRows == expectedRows)
+        #expect(diff.reloadedRows.count <= 2)
+        #expect(store.instrumentation.hoverTransitionCount == 1)
+        #expect(store.instrumentation.lastOperationItemVisitCount == expectedIDs.count)
+        #expect(store.instrumentation.lastOperationProjectionCount == expectedIDs.count)
+        #expect(store.instrumentation.lastOperationReloadCount == expectedIDs.count)
+        #expect(store.lastProjectedItemIDs == expectedIDs)
+        #expect(store.presentation(for: oldHoveredID)?.isHovered == false)
+        if let nextHoveredID {
+            #expect(store.presentation(for: nextHoveredID)?.isHovered == true)
+        }
+    }
+
+    @Test func structuralDiffReportsInsertRemoveMoveAndReloadSets() {
+        let store = Store(
+            snapshot: Snapshot(items: [0, 1, 2, 3].map {
+                Item(id: $0, input: Input(revision: 0))
+            }),
+            projector: Self.project
+        )
+        store.resetInstrumentation()
+
+        let next = Snapshot(items: [
+            Item(id: 3, input: Input(revision: 0)),
+            Item(id: 1, input: Input(revision: 0)),
+            Item(id: 2, input: Input(revision: 1)),
+            Item(id: 4, input: Input(revision: 0)),
+        ])
+        let diff = store.apply(snapshot: next)
+
+        #expect(diff.insertedItemIDs == Set([4]))
+        #expect(diff.removedItemIDs == Set([0]))
+        #expect(diff.movedItemIDs == Set([3]))
+        #expect(diff.reloadedItemIDs == Set([2]))
+        #expect(diff.insertedRows == IndexSet(integer: 3))
+        #expect(diff.removedRows == IndexSet(integer: 0))
+        #expect(diff.moves == [SidebarAppKitSnapshotMove(itemID: 3, fromRow: 3, toRow: 0)])
+        #expect(diff.reloadedRows == IndexSet(integer: 2))
+        #expect(store.orderedItemIDs == [3, 1, 2, 4])
+        #expect(store.rowIndex(for: 3) == 0)
+        #expect(store.rowIndex(for: 4) == 3)
+        #expect(store.itemID(atRow: 2) == 2)
+        #expect(store.instrumentation.lastOperationItemVisitCount == 4)
+        #expect(store.instrumentation.lastOperationProjectionCount == 2)
+        #expect(store.lastProjectedItemIDs == Set([2, 4]))
+    }
+
+    private static func makeStore(itemCount: Int) -> Store {
+        Store(
+            snapshot: makeSnapshot(itemCount: itemCount),
+            projector: project
+        )
+    }
+
+    private static func makeSnapshot(
+        itemCount: Int,
+        revisions: [Int: Int] = [:]
+    ) -> Snapshot {
+        Snapshot(items: (0..<itemCount).map { itemID in
+            Item(
+                id: itemID,
+                input: Input(revision: revisions[itemID] ?? 0)
+            )
+        })
+    }
+
+    private static func project(
+        _ itemID: Int,
+        _ input: Input,
+        _ context: SidebarAppKitProjectionContext
+    ) -> Presentation {
+        _ = itemID
+        return Presentation(
+            revision: input.revision,
+            isHovered: context.isHovered
+        )
+    }
+}

--- a/cmuxTests/SidebarAppKitViewControllerScaleTests.swift
+++ b/cmuxTests/SidebarAppKitViewControllerScaleTests.swift
@@ -1,0 +1,351 @@
+import AppKit
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@MainActor
+@Suite("AppKit sidebar native controller scale", .serialized)
+struct SidebarAppKitViewControllerScaleTests {
+    private static let viewportRowCeiling = 32
+    private static let viewportResolverCallCeiling = 64
+
+    @Test(arguments: [1, 10, 100, 1_000])
+    func lazyResolversStayViewportBounded(workspaceCount: Int) throws {
+        let harness = try Harness(workspaceCount: workspaceCount)
+        defer { harness.tearDown() }
+
+        let realizedRows = harness.realizeVisibleRows()
+        let realizedWorkspaceIDs = Set(realizedRows.compactMap {
+            harness.workspaceID(atRow: $0)
+        })
+        let resolvedWorkspaceIDs = Set(harness.recorder.workspaceSnapshotIDs)
+
+        #expect(!realizedRows.isEmpty)
+        #expect(realizedRows.count <= Self.viewportRowCeiling)
+        #expect(!resolvedWorkspaceIDs.isEmpty)
+        #expect(resolvedWorkspaceIDs.isSubset(of: realizedWorkspaceIDs))
+        #expect(
+            harness.recorder.workspaceSnapshotIDs.count
+                <= Self.viewportResolverCallCeiling
+        )
+        #expect(
+            harness.recorder.workspaceActionIDs.count
+                <= Self.viewportResolverCallCeiling
+        )
+        #expect(
+            Set(harness.recorder.workspaceActionIDs)
+                .isSubset(of: realizedWorkspaceIDs)
+        )
+        if workspaceCount >= 100 {
+            #expect(harness.recorder.workspaceSnapshotIDs.count < workspaceCount)
+            #expect(harness.recorder.workspaceActionIDs.count < workspaceCount)
+        }
+
+        #if DEBUG
+        #expect(
+            harness.controller.resolverInvocationCounts.workspaceSnapshots
+                == harness.recorder.workspaceSnapshotIDs.count
+        )
+        #expect(
+            harness.controller.resolverInvocationCounts.workspaceActions
+                == harness.recorder.workspaceActionIDs.count
+        )
+        #expect(harness.controller.resolverInvocationCounts.groupSnapshots == 0)
+        #expect(harness.controller.resolverInvocationCounts.groupActions == 0)
+        #endif
+    }
+
+    @Test(arguments: [1, 10, 100, 1_000])
+    func keyedUpdateReloadsAtMostOneVisibleNativeRow(workspaceCount: Int) throws {
+        let harness = try Harness(workspaceCount: workspaceCount)
+        defer { harness.tearDown() }
+
+        let realizedRows = harness.realizeVisibleRows()
+        let targetRow = try #require(realizedRows.first)
+        let targetWorkspaceID = try #require(harness.workspaceID(atRow: targetRow))
+        let cellIdentitiesBeforeUpdate = harness.realizedCellIdentities()
+        harness.recorder.reset()
+        #if DEBUG
+        harness.controller.resetResolverInvocationCounts()
+        #endif
+
+        harness.controller.reconfigure(
+            itemIDs: Set([SidebarWorkspaceRenderItemID.workspace(targetWorkspaceID)])
+        )
+        harness.layout()
+        _ = harness.controller.tableView.view(
+            atColumn: 0,
+            row: targetRow,
+            makeIfNecessary: true
+        )
+
+        let resolvedWorkspaceIDs = Set(harness.recorder.workspaceSnapshotIDs)
+        let resolvedActionIDs = Set(harness.recorder.workspaceActionIDs)
+        #expect(resolvedWorkspaceIDs == Set([targetWorkspaceID]))
+        #expect(resolvedWorkspaceIDs.count <= 1)
+        #expect(resolvedActionIDs == Set([targetWorkspaceID]))
+        #expect(resolvedActionIDs.count <= 1)
+
+        let cellIdentitiesAfterUpdate = harness.realizedCellIdentities()
+        for (row, identity) in cellIdentitiesBeforeUpdate where row != targetRow {
+            #expect(cellIdentitiesAfterUpdate[row] == identity)
+        }
+
+        #if DEBUG
+        #expect(harness.controller.resolverInvocationCounts.workspaceSnapshots >= 1)
+        #expect(harness.controller.resolverInvocationCounts.workspaceActions >= 1)
+        #expect(harness.controller.resolverInvocationCounts.groupSnapshots == 0)
+        #expect(harness.controller.resolverInvocationCounts.groupActions == 0)
+        #endif
+    }
+
+    @Test(arguments: [1, 10, 100, 1_000])
+    func hoverTransitionDoesNotResolveNativeRows(workspaceCount: Int) throws {
+        let harness = try Harness(workspaceCount: workspaceCount)
+        defer { harness.tearDown() }
+
+        let realizedRows = harness.realizeVisibleRows()
+        let oldRow = try #require(realizedRows.first)
+        let nextRow = realizedRows.dropFirst().first
+        let nextWorkspaceID = nextRow.flatMap { harness.workspaceID(atRow: $0) }
+
+        harness.controller.tableView.onHoveredRowChanged?(nil, oldRow)
+        harness.recorder.reset()
+        harness.recorder.hoveredItemIDs.removeAll(keepingCapacity: true)
+        #if DEBUG
+        harness.controller.resetResolverInvocationCounts()
+        #endif
+
+        harness.controller.tableView.onHoveredRowChanged?(oldRow, nextRow)
+
+        #expect(harness.recorder.workspaceSnapshotIDs.isEmpty)
+        #expect(harness.recorder.workspaceActionIDs.isEmpty)
+        #expect(
+            harness.recorder.hoveredItemIDs
+                == [nextWorkspaceID.map { SidebarWorkspaceRenderItemID.workspace($0) }]
+        )
+
+        #if DEBUG
+        #expect(harness.controller.resolverInvocationCounts.workspaceSnapshots == 0)
+        #expect(harness.controller.resolverInvocationCounts.workspaceActions == 0)
+        #expect(harness.controller.resolverInvocationCounts.groupSnapshots == 0)
+        #expect(harness.controller.resolverInvocationCounts.groupActions == 0)
+        #endif
+    }
+
+    @MainActor
+    private final class ResolverRecorder {
+        var workspaceSnapshotIDs: [UUID] = []
+        var workspaceActionIDs: [UUID] = []
+        var hoveredItemIDs: [SidebarWorkspaceRenderItemID?] = []
+
+        func reset() {
+            workspaceSnapshotIDs.removeAll(keepingCapacity: true)
+            workspaceActionIDs.removeAll(keepingCapacity: true)
+        }
+    }
+
+    @MainActor
+    private final class Harness {
+        let workspaceIDs: [UUID]
+        let recorder: ResolverRecorder
+        let controller: SidebarAppKitViewController
+
+        private let defaults: UserDefaults
+        private let defaultsSuiteName: String
+        private let window: NSWindow
+
+        init(workspaceCount: Int) throws {
+            _ = NSApplication.shared
+
+            let workspaceIDs = (0..<workspaceCount).map { _ in UUID() }
+            let rowByWorkspaceID = Dictionary(
+                uniqueKeysWithValues: workspaceIDs.enumerated().map { ($0.element, $0.offset) }
+            )
+            let recorder = ResolverRecorder()
+            let defaultsSuiteName = "SidebarAppKitViewControllerScaleTests.\(UUID().uuidString)"
+            let defaults = try #require(UserDefaults(suiteName: defaultsSuiteName))
+            let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+            let contextMenu = Self.contextMenuSnapshot()
+            let controller = SidebarAppKitViewController()
+
+            controller.apply(SidebarAppKitConfiguration(
+                renderItems: workspaceIDs.map { .workspace(workspaceId: $0) },
+                selectedWorkspaceIDs: [],
+                activeWorkspaceID: nil,
+                workspaceSnapshot: { workspaceID in
+                    recorder.workspaceSnapshotIDs.append(workspaceID)
+                    guard let row = rowByWorkspaceID[workspaceID] else { return nil }
+                    return Self.rowSnapshot(
+                        workspaceID: workspaceID,
+                        row: row,
+                        workspaceCount: workspaceCount,
+                        settings: settings,
+                        contextMenu: contextMenu
+                    )
+                },
+                groupSnapshot: { _ in nil },
+                workspaceActions: { workspaceID in
+                    recorder.workspaceActionIDs.append(workspaceID)
+                    return .none
+                },
+                groupActions: { _ in .none },
+                interactions: .init(onHoveredItemChanged: { itemID in
+                    recorder.hoveredItemIDs.append(itemID)
+                })
+            ))
+
+            let viewportSize = NSSize(width: 280, height: 320)
+            let window = NSWindow(
+                contentRect: NSRect(origin: .zero, size: viewportSize),
+                styleMask: .borderless,
+                backing: .buffered,
+                defer: false
+            )
+            window.isReleasedWhenClosed = false
+            window.setFrameOrigin(NSPoint(x: -10_000, y: -10_000))
+            window.contentViewController = controller
+            window.setContentSize(viewportSize)
+
+            self.workspaceIDs = workspaceIDs
+            self.recorder = recorder
+            self.controller = controller
+            self.defaults = defaults
+            self.defaultsSuiteName = defaultsSuiteName
+            self.window = window
+
+            layout()
+        }
+
+        func tearDown() {
+            controller.prepareForRemoval()
+            window.contentViewController = nil
+            window.close()
+            defaults.removePersistentDomain(forName: defaultsSuiteName)
+        }
+
+        func layout() {
+            controller.view.layoutSubtreeIfNeeded()
+            controller.scrollView.layoutSubtreeIfNeeded()
+            controller.tableView.layoutSubtreeIfNeeded()
+        }
+
+        func realizeVisibleRows() -> IndexSet {
+            layout()
+            let tableView = controller.tableView
+            let visibleRange = tableView.rows(in: tableView.visibleRect)
+            if visibleRange.location != NSNotFound, visibleRange.length > 0 {
+                let upperBound = min(
+                    tableView.numberOfRows,
+                    visibleRange.location + visibleRange.length
+                )
+                if visibleRange.location < upperBound {
+                    for row in visibleRange.location..<upperBound {
+                        _ = tableView.view(
+                            atColumn: 0,
+                            row: row,
+                            makeIfNecessary: true
+                        )
+                    }
+                }
+            } else if tableView.numberOfRows > 0 {
+                _ = tableView.view(atColumn: 0, row: 0, makeIfNecessary: true)
+            }
+            layout()
+
+            var rows = IndexSet()
+            for row in 0..<tableView.numberOfRows where tableView.rowView(
+                atRow: row,
+                makeIfNecessary: false
+            ) != nil {
+                rows.insert(row)
+            }
+            return rows
+        }
+
+        func workspaceID(atRow row: Int) -> UUID? {
+            guard workspaceIDs.indices.contains(row) else { return nil }
+            return workspaceIDs[row]
+        }
+
+        func realizedCellIdentities() -> [Int: ObjectIdentifier] {
+            var identities: [Int: ObjectIdentifier] = [:]
+            for row in 0..<controller.tableView.numberOfRows {
+                guard let view = controller.tableView.view(
+                    atColumn: 0,
+                    row: row,
+                    makeIfNecessary: false
+                ) else { continue }
+                identities[row] = ObjectIdentifier(view)
+            }
+            return identities
+        }
+
+        private static func rowSnapshot(
+            workspaceID: UUID,
+            row: Int,
+            workspaceCount: Int,
+            settings: SidebarTabItemSettingsSnapshot,
+            contextMenu: SidebarWorkspaceContextMenuSnapshot
+        ) -> SidebarWorkspaceRowSnapshot {
+            SidebarWorkspaceRowSnapshot(
+                workspaceId: workspaceID,
+                groupId: nil,
+                index: row,
+                workspaceCount: workspaceCount,
+                workspace: SidebarWorkspaceSnapshotRefreshPolicyTests.snapshot(
+                    title: "Workspace \(row + 1)"
+                ),
+                isActive: row == 0,
+                isMultiSelected: false,
+                hasUserCustomTitle: false,
+                hasCustomTitle: false,
+                hasCustomDescription: false,
+                customTitle: nil,
+                workspaceShortcutDigit: nil,
+                workspaceShortcutModifierSymbol: "⌘",
+                canCloseWorkspace: workspaceCount > 1,
+                unreadCount: 0,
+                latestNotificationText: nil,
+                showsAgentActivity: false,
+                rowSpacing: 0,
+                showsModifierShortcutHints: false,
+                isPointerHovering: false,
+                isBeingDragged: false,
+                topDropIndicatorVisible: false,
+                bottomDropIndicatorVisible: false,
+                isBonsplitWorkspaceDropActive: false,
+                settings: settings,
+                isChecklistExpanded: false,
+                checklistAddFieldActivationToken: 0,
+                isChecklistPopoverPresented: false,
+                contextMenu: contextMenu
+            )
+        }
+
+        private static func contextMenuSnapshot() -> SidebarWorkspaceContextMenuSnapshot {
+            SidebarWorkspaceContextMenuSnapshot(
+                targetWorkspaceIds: [],
+                remoteTargetWorkspaceIds: [],
+                allRemoteTargetsConnecting: false,
+                allRemoteTargetsDisconnected: false,
+                pinState: nil,
+                groupMenuSnapshot: WorkspaceGroupMenuSnapshot(items: []),
+                canCreateEmptyGroup: true,
+                eligibleGroupTargetIds: [],
+                allEligibleTargetsGroupId: nil,
+                hasGroupedEligibleTarget: false,
+                todoStatusLanes: [],
+                canMarkRead: false,
+                canMarkUnread: false,
+                hasLatestNotification: false,
+                notifications: []
+            )
+        }
+    }
+}

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -427,6 +427,53 @@ final class SidebarLazyLayoutScaleTests {
         )
     }
 
+    /// A value change owned by one workspace must not rebuild presentation
+    /// inputs for every workspace. Viewport virtualization alone is
+    /// insufficient: projecting all 300 inputs before the lazy boundary still
+    /// makes each notification update O(total workspaces) on the main actor.
+    @Test
+    @MainActor
+    func testSingleUnreadChangeProjectsOnlyTheChangedWorkspace() async throws {
+        let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
+        defer { harness.tearDown() }
+
+        await Self.drainMainRunLoop(for: harness.window)
+        harness.counter.reset()
+
+        let target = try #require(harness.tabManager.tabs.first?.id)
+        harness.unread.apply(
+            totalUnreadCount: 1,
+            summaries: [
+                target: SidebarWorkspaceUnreadSummary(
+                    unreadCount: 1,
+                    latestNotificationText: "one changed workspace"
+                )
+            ],
+            unreadSurfaceKeys: [],
+            focusedReadIndicatorByWorkspaceId: [:],
+            manualUnreadWorkspaceIds: []
+        )
+
+        let refreshDeadline = ProcessInfo.processInfo.systemUptime + 3
+        while harness.counter.workspaceRowInputProjections == 0,
+              ProcessInfo.processInfo.systemUptime < refreshDeadline {
+            Self.turnMainRunLoopOnce(layingOut: harness.window)
+            await Task.yield()
+        }
+        await Self.drainMainRunLoop(for: harness.window)
+
+        let projections = harness.counter.workspaceRowInputProjections
+        #expect(projections > 0, "The unread change never reached the sidebar projection owner.")
+        #expect(
+            projections <= 4,
+            """
+            One workspace unread change projected \(projections) workspace inputs at a scale of \
+            \(Self.workspaceCount). Non-structural changes must be keyed to the changed workspace; \
+            rebuilding the full list makes high-frequency sidebar updates O(total workspaces).
+            """
+        )
+    }
+
 
     /// Harness self-test: prove the drain loop + body counter actually detect
     /// a layout feedback loop. This fixture reproduces the historical

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -10,9 +10,9 @@ import SwiftUI
 @testable import cmux
 #endif
 
-/// Behavioral gate for the workspace sidebar's lazy-layout contract: layout
-/// and diff work must stay O(visible rows) no matter how many workspaces are
-/// open, and updates must converge (no self-sustaining invalidation).
+/// Behavioral gate for the feature-flagged AppKit sidebar's virtualization
+/// contract: resolver and keyed-update work must stay O(visible rows) no matter
+/// how many workspaces are open, and updates must converge.
 ///
 /// The contract has regressed five times through five different mechanisms —
 /// per-row anchorPreference aggregation (#5323), per-row String ids (#5764),
@@ -21,18 +21,17 @@ import SwiftUI
 /// shipped to stable before being detected, because nothing exercised the
 /// sidebar at the 100+ workspace scale where O(N) per pass becomes a
 /// main-thread livelock (issue #2586). These tests mount the real
-/// `VerticalTabsSidebar` at that scale and count actual row body evaluations
-/// through `SidebarLazyContractProbe`, so ANY future mechanism that realizes
-/// the whole list or loops the AttributeGraph fails here instead of on a
-/// user's machine. `scripts/check-sidebar-lazy-layout.py` bans the known
-/// source shapes; this is the mechanism-independent backstop.
+/// `VerticalTabsSidebar` at that scale, discover its native controller, and
+/// count resolver calls through `SidebarLazyContractProbe`. They also prove
+/// that the enabled AppKit path never executes retained SwiftUI workspace/group
+/// row bodies.
 @Suite(.serialized)
 final class SidebarLazyLayoutScaleTests {
-    static let workspaceCount = 300
-    /// Generous ceiling for "how many rows may be realized for one viewport".
-    /// A 640pt window shows ~20 rows; LazyVStack prefetch and a second layout
-    /// pass can multiply that, but a virtualization defeat realizes all 300.
-    private static let realizedRowCeiling = 150
+    static let workspaceCount = 1_000
+    /// Generous ceiling for native snapshot resolvers in one 640pt viewport.
+    /// The table shows roughly 20 rows; a virtualization defeat resolves all
+    /// 1,000 workspace/group rows.
+    private static let nativeResolverCeiling = 150
 
     final class InjectableMouseLocationWindow: NSWindow {
         var injectedMouseLocation = NSPoint.zero
@@ -43,8 +42,8 @@ final class SidebarLazyLayoutScaleTests {
     }
 
     // Plain class (not @MainActor) so the probe's nonisolated `() -> Void`
-    // closures can mutate it; bodies only run on the main thread. Same shape
-    // as MinimalModeBodyProbeCounts in WorkspaceContentViewVisibilityTests.
+    // closures can mutate it; all callbacks run on the main thread. The row
+    // body counters must remain zero for the enabled AppKit sidebar.
     final class RowBodyCounter {
         var workspaceRowBodies = 0
         var groupHeaderBodies = 0
@@ -76,16 +75,99 @@ final class SidebarLazyLayoutScaleTests {
         let window: InjectableMouseLocationWindow
         let defaultsSuiteName: String
 
+        func nativeSidebarController() -> SidebarAppKitViewController? {
+            guard let contentView = window.contentView else { return nil }
+            return Self.findSidebarController(in: contentView)
+        }
+
+        func sidebarController() throws -> SidebarAppKitViewController {
+            return try #require(
+                nativeSidebarController(),
+                "The enabled AppKit sidebar mounted without its native table controller."
+            )
+        }
+
+        func visibleNonAnchorWorkspace(
+            in controller: SidebarAppKitViewController
+        ) throws -> Workspace {
+            let visibleRows = Self.visibleRows(in: controller.tableView)
+            let anchorWorkspaceIds = Set(
+                tabManager.workspaceGroups.map(\.anchorWorkspaceId)
+            )
+            let workspace = tabManager.tabs.first { workspace in
+                guard !anchorWorkspaceIds.contains(workspace.id),
+                      let groupId = workspace.groupId,
+                      let workspaceRow = controller.rowIndex(
+                        for: .workspace(workspace.id)
+                      ),
+                      let groupRow = controller.rowIndex(for: .group(groupId)) else {
+                    return false
+                }
+                return visibleRows.contains(workspaceRow)
+                    && visibleRows.contains(groupRow)
+            }
+            return try #require(
+                workspace,
+                "No visible non-anchor workspace and group header were found."
+            )
+        }
+
+        func offscreenWorkspace(
+            in controller: SidebarAppKitViewController
+        ) throws -> Workspace {
+            let visibleRows = Self.visibleRows(in: controller.tableView)
+            let anchorWorkspaceIds = Set(
+                tabManager.workspaceGroups.map(\.anchorWorkspaceId)
+            )
+            let workspace = tabManager.tabs.reversed().first { workspace in
+                guard !anchorWorkspaceIds.contains(workspace.id),
+                      let row = controller.rowIndex(for: .workspace(workspace.id)) else {
+                    return false
+                }
+                return !visibleRows.contains(row)
+            }
+            return try #require(
+                workspace,
+                "No offscreen non-anchor workspace was found."
+            )
+        }
+
         func tearDown() {
             window.contentView = nil
             window.close()
             UserDefaults(suiteName: defaultsSuiteName)?
                 .removePersistentDomain(forName: defaultsSuiteName)
         }
+
+        private static func findSidebarController(
+            in view: NSView
+        ) -> SidebarAppKitViewController? {
+            if let tableView = view as? SidebarAppKitTableView,
+               let controller = tableView.delegate as? SidebarAppKitViewController {
+                return controller
+            }
+            for subview in view.subviews {
+                if let controller = findSidebarController(in: subview) {
+                    return controller
+                }
+            }
+            return nil
+        }
+
+        private static func visibleRows(in tableView: NSTableView) -> IndexSet {
+            let range = tableView.rows(in: tableView.visibleRect)
+            guard range.location != NSNotFound, range.length > 0 else { return [] }
+            let upperBound = min(tableView.numberOfRows, range.location + range.length)
+            guard range.location < upperBound else { return [] }
+            return IndexSet(integersIn: range.location..<upperBound)
+        }
     }
 
     @MainActor
-    static func mountSidebar(workspaceCount: Int) async throws -> Harness {
+    static func mountSidebar(
+        workspaceCount: Int,
+        appKitSidebarEnabled: Bool = true
+    ) async throws -> Harness {
         _ = NSApplication.shared
 
         // Hermetic defaults: VerticalTabsSidebar picks between the workspace
@@ -151,10 +233,14 @@ final class SidebarLazyLayoutScaleTests {
             onToggleSidebar: {},
             onNewTab: {},
             observedWindow: nil,
+            tabManager: tabManager,
+            sidebarUnread: unread,
+            cmuxConfigStore: CmuxConfigStore(),
             selection: .constant(.tabs),
             selectedTabIds: .constant([]),
             lastSidebarSelectionIndex: .constant(nil),
-            sidebarRenderWorkerClient: .constant(nil)
+            sidebarRenderWorkerClient: .constant(nil),
+            appKitSidebarEnabledOverride: appKitSidebarEnabled
         )
         .frame(width: 280)
         .environmentObject(tabManager)
@@ -234,146 +320,132 @@ final class SidebarLazyLayoutScaleTests {
         }
     }
 
-
-    /// Mounting the sidebar with 300 workspaces must realize only the rows a
-    /// single viewport needs. Realizing all of them is the #5323/#6210 defeat:
-    /// at scale, every subsequent update pays an O(N) layout pass and the main
-    /// thread livelocks.
     @Test
     @MainActor
-    func testMountRealizesOnlyViewportRowsAt300Workspaces() async throws {
-        let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
-        defer { harness.tearDown() }
+    func testAppKitSidebarFeatureFlagDefaultsOff() throws {
+        let suiteName = "cmux.feature.flags.appkit-sidebar.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defer { defaults.removePersistentDomain(forName: suiteName) }
 
-        await Self.drainMainRunLoop(for: harness.window)
-
-        let realized = harness.counter.workspaceRowBodies
-        #expect(realized > 0, "Sidebar mounted but no workspace row body ran; harness is broken.")
-        #expect(
-            realized < Self.realizedRowCeiling,
-            """
-            \(realized) workspace row bodies evaluated for a single ~20-row viewport with \
-            \(Self.workspaceCount) workspaces. The LazyVStack is being defeated (all rows \
-            realized per pass) — the #2586 sidebar livelock class. Look for per-row geometry \
-            feedback (GeometryReader/@State height, anchorPreference aggregation) or a \
-            force-measuring Layout; see scripts/check-sidebar-lazy-layout.py.
-            """
+        let flags = CmuxFeatureFlags(
+            defaults: defaults,
+            remoteFlagValueProvider: { _ in nil }
         )
 
-        let headerRealized = harness.counter.groupHeaderBodies
-        #expect(
-            headerRealized > 0,
-            """
-            Groups were created at the top of the list but no group-header body ran; the \
-            grouped-workspace coverage is broken.
-            """
-        )
-        #expect(
-            headerRealized < Self.realizedRowCeiling,
-            """
-            \(headerRealized) group-header bodies evaluated for 5 groups in one viewport. \
-            The group-header row wrapper (sidebarWorkspaceGroupRow) is defeating \
-            virtualization or re-evaluating without bound — the #4385 regression site.
-            """
-        )
+        #expect(!flags.isAppKitSidebarEnabled)
     }
 
-    /// TabItemView.body must never build a workspace snapshot. The parent owns
-    /// the full per-workspace projection (bonsplit tree walk, git summaries,
-    /// PR rows) and passes the resulting value across the LazyVStack boundary.
-    /// Building it while a row is being realized would read the live workspace
-    /// graph from inside SwiftUI layout and recreate the #6707 reentry path.
     @Test
     @MainActor
-    func testRowBodyEvaluationNeverBuildsWorkspaceSnapshot() async throws {
-        let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
+    func testDisabledAppKitSidebarFlagKeepsLegacyDefaultSidebar() async throws {
+        let harness = try await Self.mountSidebar(
+            workspaceCount: 20,
+            appKitSidebarEnabled: false
+        )
         defer { harness.tearDown() }
 
         await Self.drainMainRunLoop(for: harness.window)
 
-        #expect(
-            harness.counter.workspaceSnapshotBuilds > 0,
-            "Sidebar mounted but no workspace snapshot was built; the probe wiring is broken."
-        )
-        let worstBody = harness.counter.maxSnapshotBuildsInOneRowBody
-        #expect(
-            worstBody == 0,
-            """
-            A single TabItemView.body evaluation built the workspace snapshot \(worstBody) \
-            times. Workspace snapshots must be built by VerticalTabsSidebar before the \
-            LazyVStack realization closure and passed to rows as immutable values.
-            """
-        )
+        #expect(harness.nativeSidebarController() == nil)
+        #expect(harness.counter.workspaceRowBodies > 0)
     }
 
-    /// A simultaneous workspace-publisher burst must cross the parent snapshot
-    /// boundary once per batch. Re-projecting all 300 row inputs once per
-    /// emitting workspace is O(N²) main-actor work even though LazyVStack only
-    /// realizes the viewport rows.
+
+    /// Mounting the sidebar with 1,000 workspaces must resolve only the rows a
+    /// single native viewport needs. Resolving all rows makes every subsequent
+    /// update pay O(total workspaces) on the main actor.
     @Test
     @MainActor
-    func testWorkspacePublisherBatchProjectsParentListLinearly() async throws {
+    func testMountResolvesOnlyViewportRowsAt1000Workspaces() async throws {
+        let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
+        defer { harness.tearDown() }
+
+        await Self.drainMainRunLoop(for: harness.window)
+        let controller = try harness.sidebarController()
+        let counts = controller.resolverInvocationCounts
+        let nativeSnapshotResolutions = counts.workspaceSnapshots + counts.groupSnapshots
+
+        #expect(controller.tableView.numberOfRows == Self.workspaceCount)
+        #expect(
+            counts.workspaceSnapshots > 0,
+            "Sidebar mounted but no native workspace snapshot resolver ran."
+        )
+        #expect(
+            counts.groupSnapshots > 0,
+            "Grouped rows were visible but no native group snapshot resolver ran."
+        )
+        #expect(
+            nativeSnapshotResolutions < Self.nativeResolverCeiling,
+            """
+            \(nativeSnapshotResolutions) native row snapshots resolved for one viewport with \
+            \(Self.workspaceCount) workspaces. The AppKit table must resolve only visible rows.
+            """
+        )
+        #expect(
+            harness.counter.workspaceRowInputProjections == counts.workspaceSnapshots
+        )
+        #expect(counts.workspaceActions == counts.workspaceSnapshots)
+        #expect(counts.groupActions == counts.groupSnapshots)
+    }
+
+    /// The enabled AppKit provider must remain fully native below its representable.
+    /// Executing a retained SwiftUI workspace or group row would reintroduce
+    /// AttributeGraph invalidation into the hot list path.
+    @Test
+    @MainActor
+    func testEnabledAppKitSidebarExecutesNoSwiftUIWorkspaceOrGroupRowBodies() async throws {
         let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
         defer { harness.tearDown() }
 
         await Self.drainMainRunLoop(for: harness.window)
 
-        // The default sidebar intentionally accepts the initial value from
-        // both workspace publisher families. Wait for those known initial
-        // projections before isolating the operation count for this burst.
-        // Initial mount builds fallback + owner snapshots, then each of the
-        // two keyed publisher families delivers its accepted initial value.
-        let initialObservationBuildFloor = Self.workspaceCount * 4
-        let initialDeadline = ProcessInfo.processInfo.systemUptime + 3
-        while harness.counter.workspaceSnapshotBuilds < initialObservationBuildFloor,
-              ProcessInfo.processInfo.systemUptime < initialDeadline {
-            Self.turnMainRunLoopOnce(layingOut: harness.window)
-            await Task.yield()
-        }
+        _ = try harness.sidebarController()
+        #expect(harness.counter.workspaceRowBodies == 0)
+        #expect(harness.counter.groupHeaderBodies == 0)
+        #expect(harness.counter.workspaceSnapshotBuilds == 0)
+        #expect(harness.counter.maxSnapshotBuildsInOneRowBody == 0)
+    }
+
+    /// Offscreen workspaces have no native cell and no live row observation.
+    /// Their publishers must not project or reload any row.
+    @Test
+    @MainActor
+    func testOffscreenWorkspacePublisherChangeProjectsNoRows() async throws {
+        let harness = try await Self.mountSidebar(workspaceCount: Self.workspaceCount)
+        defer { harness.tearDown() }
+
+        await Self.drainMainRunLoop(for: harness.window)
+        let controller = try harness.sidebarController()
+        let target = try harness.offscreenWorkspace(in: controller)
+        let targetRow = try #require(controller.rowIndex(for: .workspace(target.id)))
         #expect(
-            harness.counter.workspaceSnapshotBuilds >= initialObservationBuildFloor,
-            "Initial keyed workspace publisher values did not reach the snapshot owner."
+            controller.tableView.rowView(
+                atRow: targetRow,
+                makeIfNecessary: false
+            ) == nil
         )
 
         harness.counter.reset()
-        let targets = Array(harness.tabManager.tabs.suffix(80))
-        for (index, workspace) in targets.enumerated() {
-            workspace.statusEntries["issue-6707.batch"] = SidebarStatusEntry(
-                key: "issue-6707.batch",
-                value: "batch update \(index)",
-                icon: "bolt.fill"
-            )
-        }
-
-        let refreshDeadline = ProcessInfo.processInfo.systemUptime + 3
-        while harness.counter.workspaceSnapshotBuilds < targets.count,
-              ProcessInfo.processInfo.systemUptime < refreshDeadline {
-            Self.turnMainRunLoopOnce(layingOut: harness.window)
-            await Task.yield()
-        }
-        #expect(
-            harness.counter.workspaceSnapshotBuilds >= targets.count,
-            "The \(targets.count)-workspace publisher batch did not reach the snapshot owner."
+        controller.resetResolverInvocationCounts()
+        target.statusEntries["issue-6707.offscreen"] = SidebarStatusEntry(
+            key: "issue-6707.offscreen",
+            value: "offscreen update",
+            icon: "bolt.fill"
         )
         await Self.drainMainRunLoop(for: harness.window)
 
-        let projections = harness.counter.workspaceRowInputProjections
-        #expect(projections > 0, "The parent row-input projection probe did not run.")
-        #expect(
-            projections <= Self.workspaceCount * 4,
-            """
-            \(projections) parent row-input projections ran for one \(targets.count)-workspace \
-            event batch at \(Self.workspaceCount) workspaces. The batch must cause O(N) parent \
-            projection work, not O(N²) work from one parent invalidation per emitter.
-            """
-        )
+        #expect(harness.counter.workspaceRowInputProjections == 0)
+        #expect(controller.resolverInvocationCounts.workspaceSnapshots == 0)
+        #expect(controller.resolverInvocationCounts.groupSnapshots == 0)
+        #expect(controller.resolverInvocationCounts.workspaceActions == 0)
+        #expect(controller.resolverInvocationCounts.groupActions == 0)
+        #expect(harness.counter.workspaceRowBodies == 0)
+        #expect(harness.counter.groupHeaderBodies == 0)
     }
 
-    /// A burst of unread-model updates (the agent-notification churn path,
-    /// the sidebar's highest-frequency whole-body invalidation) must cost
-    /// O(changed rows), and the sidebar must go quiet when the burst stops.
-    /// Unbounded or non-converging row re-evaluation here is the exact
-    /// signature of the #6556 GeometryReader → @State feedback livelock.
+    /// A burst of unread-model updates must stay keyed to one visible
+    /// non-anchor workspace and its group header. The native table must stop
+    /// resolving rows when the burst stops.
     @Test
     @MainActor
     func testUnreadStormStaysRowScopedAndConverges() async throws {
@@ -381,16 +453,17 @@ final class SidebarLazyLayoutScaleTests {
         defer { harness.tearDown() }
 
         await Self.drainMainRunLoop(for: harness.window)
+        let controller = try harness.sidebarController()
+        let target = try harness.visibleNonAnchorWorkspace(in: controller)
         harness.counter.reset()
+        controller.resetResolverInvocationCounts()
 
-        let stormTargets = Array(harness.tabManager.tabs.prefix(3).map(\.id))
         let storms = 40
         for i in 1...storms {
-            let target = stormTargets[i % stormTargets.count]
             harness.unread.apply(
                 totalUnreadCount: i,
                 summaries: [
-                    target: SidebarWorkspaceUnreadSummary(
+                    target.id: SidebarWorkspaceUnreadSummary(
                         unreadCount: i,
                         latestNotificationText: "agent update \(i)"
                     )
@@ -403,34 +476,41 @@ final class SidebarLazyLayoutScaleTests {
         }
         await Self.drainMainRunLoop(for: harness.window)
 
-        let stormEvals = harness.counter.workspaceRowBodies
+        let counts = controller.resolverInvocationCounts
+        let workspaceProjections = harness.counter.workspaceRowInputProjections
+        #expect(workspaceProjections > 0)
         #expect(
-            stormEvals < storms * 10,
+            workspaceProjections <= storms * 2,
             """
-            \(stormEvals) workspace row bodies evaluated for \(storms) single-workspace unread \
-            updates. Updates must invalidate only the changed rows (TabItemView.== + \
-            .equatable()), not re-evaluate the list. \(Self.workspaceCount) workspaces × \
-            \(storms) updates re-realizing per pass is the #2586 livelock at scale.
+            \(workspaceProjections) workspace snapshots resolved for \(storms) unread updates. \
+            Native updates must stay keyed to the changed visible workspace.
             """
         )
+        #expect(counts.workspaceSnapshots == workspaceProjections)
+        #expect(counts.groupSnapshots > 0)
+        #expect(counts.groupSnapshots <= storms * 2)
+        #expect(counts.workspaceActions == counts.workspaceSnapshots)
+        #expect(counts.groupActions == counts.groupSnapshots)
+        #expect(harness.counter.workspaceRowBodies == 0)
+        #expect(harness.counter.groupHeaderBodies == 0)
 
-        harness.counter.reset()
+        // Drain pending delivery first, then observe a fresh quiet interval.
         await Self.drainMainRunLoop(for: harness.window, iterations: 30)
-        let quietEvals = harness.counter.workspaceRowBodies + harness.counter.groupHeaderBodies
-        #expect(
-            quietEvals < 20,
-            """
-            \(quietEvals) row bodies (workspace + group header) evaluated with no state \
-            changes at all. The sidebar is re-invalidating itself — a layout/state feedback \
-            loop (the #6556 signature). This livelocks the main thread at scale.
-            """
-        )
+        harness.counter.reset()
+        controller.resetResolverInvocationCounts()
+        await Self.drainMainRunLoop(for: harness.window, iterations: 30)
+        #expect(harness.counter.workspaceRowInputProjections == 0)
+        #expect(controller.resolverInvocationCounts.workspaceSnapshots == 0)
+        #expect(controller.resolverInvocationCounts.groupSnapshots == 0)
+        #expect(controller.resolverInvocationCounts.workspaceActions == 0)
+        #expect(controller.resolverInvocationCounts.groupActions == 0)
+        #expect(harness.counter.workspaceRowBodies == 0)
+        #expect(harness.counter.groupHeaderBodies == 0)
     }
 
-    /// A value change owned by one workspace must not rebuild presentation
-    /// inputs for every workspace. Viewport virtualization alone is
-    /// insufficient: projecting all 300 inputs before the lazy boundary still
-    /// makes each notification update O(total workspaces) on the main actor.
+    /// Regression test for one unread change. A visible non-anchor workspace
+    /// must resolve only its native workspace row and group header, independent
+    /// of the total workspace count.
     @Test
     @MainActor
     func testSingleUnreadChangeProjectsOnlyTheChangedWorkspace() async throws {
@@ -438,13 +518,15 @@ final class SidebarLazyLayoutScaleTests {
         defer { harness.tearDown() }
 
         await Self.drainMainRunLoop(for: harness.window)
+        let controller = try harness.sidebarController()
+        let target = try harness.visibleNonAnchorWorkspace(in: controller)
         harness.counter.reset()
+        controller.resetResolverInvocationCounts()
 
-        let target = try #require(harness.tabManager.tabs.first?.id)
         harness.unread.apply(
             totalUnreadCount: 1,
             summaries: [
-                target: SidebarWorkspaceUnreadSummary(
+                target.id: SidebarWorkspaceUnreadSummary(
                     unreadCount: 1,
                     latestNotificationText: "one changed workspace"
                 )
@@ -463,15 +545,22 @@ final class SidebarLazyLayoutScaleTests {
         await Self.drainMainRunLoop(for: harness.window)
 
         let projections = harness.counter.workspaceRowInputProjections
+        let counts = controller.resolverInvocationCounts
         #expect(projections > 0, "The unread change never reached the sidebar projection owner.")
         #expect(
-            projections <= 4,
+            projections <= 2,
             """
-            One workspace unread change projected \(projections) workspace inputs at a scale of \
-            \(Self.workspaceCount). Non-structural changes must be keyed to the changed workspace; \
-            rebuilding the full list makes high-frequency sidebar updates O(total workspaces).
+            One visible non-anchor unread change resolved \(projections) workspace snapshots at \
+            a scale of \(Self.workspaceCount). The update must remain keyed to that workspace.
             """
         )
+        #expect(counts.workspaceSnapshots == projections)
+        #expect(counts.groupSnapshots > 0)
+        #expect(counts.groupSnapshots <= 2)
+        #expect(counts.workspaceActions == counts.workspaceSnapshots)
+        #expect(counts.groupActions == counts.groupSnapshots)
+        #expect(harness.counter.workspaceRowBodies == 0)
+        #expect(harness.counter.groupHeaderBodies == 0)
     }
 
 

--- a/cmuxTests/SidebarWorkspaceNotificationIndexTests.swift
+++ b/cmuxTests/SidebarWorkspaceNotificationIndexTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 import CmuxCore
 import CmuxWorkspaces
 import Testing
@@ -105,6 +106,76 @@ struct SidebarWorkspaceNotificationIndexTests {
             body: "",
             createdAt: Date(timeIntervalSince1970: timestamp),
             isRead: false
+        )
+    }
+}
+
+@MainActor
+@Suite
+struct SidebarUnreadModelKeyedChangeTests {
+    @Test
+    func lateSubscriberReceivesOnlyChangedSummaryKeys() throws {
+        let model = SidebarUnreadModel()
+        let workspaceIds = (0..<1_000).map { _ in UUID() }
+        let initial = Dictionary(uniqueKeysWithValues: workspaceIds.map {
+            ($0, SidebarWorkspaceUnreadSummary(unreadCount: 1, latestNotificationText: "initial"))
+        })
+        Self.apply(initial, to: model)
+
+        var changeBatches: [[SidebarWorkspaceUnreadSummaryChange]] = []
+        let changeCancellable = model.summaryChangesPublisher.sink {
+            changeBatches.append($0)
+        }
+        var publishedSnapshots: [[UUID: SidebarWorkspaceUnreadSummary]] = []
+        let publishedCancellable = model.$summaryByWorkspaceId.sink {
+            publishedSnapshots.append($0)
+        }
+
+        #expect(changeBatches.isEmpty)
+        #expect(publishedSnapshots == [initial])
+
+        let targetId = try #require(workspaceIds.last)
+        var updated = initial
+        let targetSummary = SidebarWorkspaceUnreadSummary(
+            unreadCount: 2,
+            latestNotificationText: "updated"
+        )
+        updated[targetId] = targetSummary
+        Self.apply(updated, to: model)
+
+        #expect(changeBatches == [[SidebarWorkspaceUnreadSummaryChange(
+            workspaceId: targetId,
+            summary: targetSummary
+        )]])
+        #expect(publishedSnapshots.count == 2)
+        #expect(publishedSnapshots.last == updated)
+
+        Self.apply(updated, to: model)
+        #expect(changeBatches.count == 1)
+        #expect(publishedSnapshots.count == 2)
+
+        updated.removeValue(forKey: targetId)
+        Self.apply(updated, to: model)
+        #expect(changeBatches.last == [SidebarWorkspaceUnreadSummaryChange(
+            workspaceId: targetId,
+            summary: nil
+        )])
+        #expect(publishedSnapshots.count == 3)
+        #expect(model.summaryByWorkspaceId == updated)
+
+        withExtendedLifetime((changeCancellable, publishedCancellable)) {}
+    }
+
+    private static func apply(
+        _ summaries: [UUID: SidebarWorkspaceUnreadSummary],
+        to model: SidebarUnreadModel
+    ) {
+        model.apply(
+            totalUnreadCount: summaries.values.reduce(0) { $0 + $1.unreadCount },
+            summaries: summaries,
+            unreadSurfaceKeys: [],
+            focusedReadIndicatorByWorkspaceId: [:],
+            manualUnreadWorkspaceIds: []
         )
     }
 }


### PR DESCRIPTION
Replaces the built-in workspace sidebar with a retained native AppKit table behind `appkit-sidebar-enabled-experiment`, default off. Custom and extension sidebar providers continue through the legacy SwiftUI host.

The native path keeps only visible workspace observers, applies keyed workspace and group row updates, snapshots drag state once per session, and implements native groups, menus, remote actions, checklists, footer/update state, global font scaling, and accessibility actions. The AppKit projection omits checklist arrays until the checklist is opened.

The first commit adds the keyed unread projection regression contract. The second commit adds the implementation and 1,000-workspace scale contracts.

Verification was intentionally source-only at the requester’s direction. Passed: Swift parser lint, `git diff --check`, feature-flag lint, localization coverage, project-file integrity, test-target wiring, and sidebar lazy-layout source contracts. No compile, build, reload, runtime test, or test execution was performed.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8275"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786819362&installation_id=133855650&pr_number=8275&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8275&signature=e1223339a6343aca63990c015872393f0dcfca7f77fa85646b2024eddc05d659"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rewrote the built-in workspace sidebar with a native AppKit implementation behind the `appkit-sidebar-enabled-experiment` flag (off by default). Also fixed startup wiring so the AppKit sidebar initializes correctly when enabled.

- New Features
  - AppKit sidebar behind `appkit-sidebar-enabled-experiment`; legacy SwiftUI remains default and hosts custom/extension providers.
  - Virtualized `NSTableView`: visible-row observation, keyed row updates, stable ids.
  - Native UX: groups, unread badges, context menus, drag/drop with per-session snapshot, details links, on-demand checklists, header/footer, shortcut/help menus, accessibility, global font scaling.
  - Keyed unread summary change publisher to avoid full-dictionary diffs.
  - Localized feature flag strings (EN/JA). Enable via Settings → Feature Flags → “AppKit sidebar” (key: `appkit-sidebar-enabled-experiment`).

- Bug Fixes
  - Fixed AppKit sidebar startup by routing through `VerticalTabsSidebar` and injecting `tabManager`, `sidebarUnread`, and `cmuxConfigStore`.
  - Renamed SwiftUI path to `LegacyVerticalTabsSidebar` to ensure provider hosting remains stable.

<sup>Written for commit a59b88f689ffa2832efdac8f6925f9d87fc3c7a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8275?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a native AppKit sidebar experience with workspace/group navigation, unread badges, checklists, context menus, drag-and-drop, details, help, keyboard shortcuts, and footer update controls.
  * Introduced a feature flag to enable the native sidebar, with English and Japanese UI text for the setting.
* **Performance**
  * Improved sidebar efficiency by reprojecting and reloading only affected/visible rows, including incremental unread-summary updates.
* **Tests**
  * Added and expanded AppKit sidebar snapshot/scale, hover/selection behavior, and keyed unread-summary change tests (including Combine-based coverage).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->