### PR TITLE
Fix Kimi hook config path and migrate legacy block

### DIFF
--- a/CLI/CMUXCLI+AgentHookCatalog.swift
+++ b/CLI/CMUXCLI+AgentHookCatalog.swift
@@ -229,20 +229,19 @@ extension CMUXCLI {
         ),
         AgentHookDef(
             name: "kimi", displayName: "Kimi Code", statusKey: "kimi",
-            configDir: ".kimi-code", configFile: "config.toml", configDirEnvOverride: "KIMI_CODE_HOME",
-            binaryName: "kimi",
+            configDir: ".kimi", configFile: "config.toml", configDirEnvOverride: "KIMI_SHARE_DIR",
+            createConfigDirIfMissing: true, binaryName: "kimi",
             sessionStoreSuffix: "kimi", disableEnvVar: "CMUX_KIMI_HOOKS_DISABLED",
             hookMarker: "cmux hooks kimi", format: .tomlArrayTable,
             events: [
                 .init(agentEvent: "SessionStart", cmuxSubcommand: "session-start"),
                 .init(agentEvent: "UserPromptSubmit", cmuxSubcommand: "prompt-submit"),
-                .init(agentEvent: "PermissionRequest", cmuxSubcommand: "notification"),
+                .init(agentEvent: "Notification", cmuxSubcommand: "notification"),
                 .init(agentEvent: "Stop", cmuxSubcommand: "stop"),
                 .init(agentEvent: "StopFailure", cmuxSubcommand: "notification"),
-                .init(agentEvent: "Interrupt", cmuxSubcommand: "stop"),
                 .init(agentEvent: "SessionEnd", cmuxSubcommand: "session-end"),
             ],
-            feedHookEvents: ["PreToolUse", "PostToolUse", "PermissionRequest"]
+            feedHookEvents: ["PreToolUse", "PostToolUse"]
         ),
     ]
 

--- a/CLI/CMUXCLI+AgentHookDefinitions.swift
+++ b/CLI/CMUXCLI+AgentHookDefinitions.swift
@@ -58,7 +58,7 @@ extension CMUXCLI {
             case antigravityJSON(timeoutSeconds: Int) // ~/.gemini/config/hooks.json named hook groups
             case rovoDevYAML
             case hermesAgentYAML
-            case tomlArrayTable // ~/.kimi-code/config.toml [[hooks]] array-of-tables
+            case tomlArrayTable // ~/.kimi/config.toml [[hooks]] array-of-tables
         }
 
         struct HookEvent {

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -96,7 +96,9 @@ extension CMUXCLI {
 
         let activeConfigURL = URL(fileURLWithPath: filePath, isDirectory: false)
         let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
-        guard activeConfigURL.standardizedFileURL != legacyConfigURL.standardizedFileURL else { return }
+        guard Self.canonicalKimiConfigURL(activeConfigURL) != Self.canonicalKimiConfigURL(legacyConfigURL) else {
+            return
+        }
         do {
             _ = try removeKimiHooks(at: legacyConfigURL, def: def, reportNoChange: false)
         } catch {
@@ -118,7 +120,8 @@ extension CMUXCLI {
             .appendingPathComponent(def.configFile, isDirectory: false)
         let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
         let configURLs = [activeConfigURL, legacyConfigURL].reduce(into: [URL]()) { urls, url in
-            guard !urls.contains(where: { $0.standardizedFileURL == url.standardizedFileURL }) else { return }
+            let canonicalURL = Self.canonicalKimiConfigURL(url)
+            guard !urls.contains(where: { Self.canonicalKimiConfigURL($0) == canonicalURL }) else { return }
             urls.append(url)
         }
 
@@ -182,5 +185,9 @@ extension CMUXCLI {
             ?? URL(fileURLWithPath: home, isDirectory: true)
                 .appendingPathComponent(legacyKimiConfigDirectory, isDirectory: true)
         return legacyDirectory.appendingPathComponent(fileName, isDirectory: false)
+    }
+
+    private static func canonicalKimiConfigURL(_ url: URL) -> URL {
+        url.resolvingSymlinksInPath().standardizedFileURL
     }
 }

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -153,16 +153,24 @@ extension CMUXCLI {
         let activeConfigURL = URL(fileURLWithPath: configDir, isDirectory: true)
             .appendingPathComponent(def.configFile, isDirectory: false)
         let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
-        let configURLs = [activeConfigURL, legacyConfigURL].reduce(into: [URL]()) { urls, url in
-            let canonicalURL = Self.canonicalKimiConfigURL(url)
-            guard !urls.contains(where: { Self.canonicalKimiConfigURL($0) == canonicalURL }) else { return }
-            urls.append(url)
+        let configURLs = [
+            (url: activeConfigURL, isLegacy: false),
+            (url: legacyConfigURL, isLegacy: true),
+        ].reduce(into: [(url: URL, isLegacy: Bool)]()) { configs, config in
+            let canonicalURL = Self.canonicalKimiConfigURL(config.url)
+            guard !configs.contains(where: { Self.canonicalKimiConfigURL($0.url) == canonicalURL }) else { return }
+            configs.append(config)
         }
 
         var foundConfig = false
-        for configURL in configURLs where FileManager.default.fileExists(atPath: configURL.path) {
+        for config in configURLs where FileManager.default.fileExists(atPath: config.url.path) {
             foundConfig = true
-            _ = try removeKimiHooks(at: configURL, def: def, reportNoChange: true)
+            do {
+                _ = try removeKimiHooks(at: config.url, def: def, reportNoChange: true)
+            } catch {
+                guard config.isLegacy else { throw error }
+                reportKimiLegacyUninstallWarning(legacyConfigURL: config.url)
+            }
         }
         guard !foundConfig else { return }
 
@@ -216,6 +224,17 @@ extension CMUXCLI {
                 defaultValue: "Warning: cmux hooks are active at %@, but cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks setup kimi` to finish cleanup."
             ),
             activeConfigURL.path,
+            legacyConfigURL.path
+        )
+        cliWriteStderr(warning + "\n")
+    }
+
+    private func reportKimiLegacyUninstallWarning(legacyConfigURL: URL) {
+        let warning = String.localizedStringWithFormat(
+            String(
+                localized: "cli.hooks.kimi.legacyUninstallWarning",
+                defaultValue: "Warning: cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks uninstall kimi` to finish cleanup."
+            ),
             legacyConfigURL.path
         )
         cliWriteStderr(warning + "\n")

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -97,7 +97,19 @@ extension CMUXCLI {
         let activeConfigURL = URL(fileURLWithPath: filePath, isDirectory: false)
         let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
         guard activeConfigURL.standardizedFileURL != legacyConfigURL.standardizedFileURL else { return }
-        _ = try removeKimiHooks(at: legacyConfigURL, def: def, reportNoChange: false)
+        do {
+            _ = try removeKimiHooks(at: legacyConfigURL, def: def, reportNoChange: false)
+        } catch {
+            let warning = String.localizedStringWithFormat(
+                String(
+                    localized: "cli.hooks.kimi.legacyCleanupWarning",
+                    defaultValue: "Warning: cmux hooks are active at %@, but cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks setup kimi` to finish cleanup."
+                ),
+                activeConfigURL.path,
+                legacyConfigURL.path
+            )
+            cliWriteStderr(warning + "\n")
+        }
     }
 
     func uninstallKimiHooks(_ def: AgentHookDef) throws {

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -2,12 +2,6 @@ import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
-    private struct KimiConfigEdit {
-        let url: URL
-        let oldContent: String
-        let newContent: String
-    }
-
     private static let kimiLifecycleHookTimeoutSeconds = 10
     private static let kimiFeedHookTimeoutSeconds = 120
     private static let legacyKimiConfigDirectory = ".kimi-code"
@@ -55,11 +49,9 @@ extension CMUXCLI {
 
         let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
         let newString = KimiCodeHookConfig.installing(events: kimiCodeHookEvents(def: def), in: oldString)
-        let activeEdit = oldString == newString ? nil : KimiConfigEdit(
-            url: activeConfigURL,
-            oldContent: oldString,
-            newContent: newString
-        )
+        let activeEdit: (url: URL, oldContent: String, newContent: String)? = oldString == newString
+            ? nil
+            : (url: activeConfigURL, oldContent: oldString, newContent: newString)
         if activeEdit == nil {
             print(String.localizedStringWithFormat(
                 String(
@@ -71,7 +63,7 @@ extension CMUXCLI {
             ))
         }
 
-        var legacyEdit: KimiConfigEdit?
+        var legacyEdit: (url: URL, oldContent: String, newContent: String)?
         var legacyCleanupFailed = false
         if Self.canonicalKimiConfigURL(activeConfigURL) != Self.canonicalKimiConfigURL(legacyConfigURL) {
             do {
@@ -81,7 +73,7 @@ extension CMUXCLI {
                 )
                 let legacyNewString = KimiCodeHookConfig.uninstalling(from: legacyOldString)
                 if legacyOldString != legacyNewString {
-                    legacyEdit = KimiConfigEdit(
+                    legacyEdit = (
                         url: legacyConfigURL,
                         oldContent: legacyOldString,
                         newContent: legacyNewString

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -4,6 +4,8 @@ import Foundation
 extension CMUXCLI {
     private static let kimiLifecycleHookTimeoutSeconds = 10
     private static let kimiFeedHookTimeoutSeconds = 120
+    private static let legacyKimiConfigDirectory = ".kimi-code"
+    private static let legacyKimiConfigDirectoryOverride = "KIMI_CODE_HOME"
 
     func kimiCodeHookEvents(def: AgentHookDef) -> [KimiCodeHookConfig.Event] {
         var events = def.events.map { event in
@@ -61,73 +63,112 @@ extension CMUXCLI {
                 def.displayName,
                 filePath
             ))
-            return
+        } else {
+            if !skipConfirm {
+                Self.printInstallPreview(
+                    path: filePath,
+                    oldContent: oldString,
+                    newContent: newString,
+                    fallbackContent: newString
+                )
+                print(String(
+                    localized: "cli.hooks.kimi.confirmProceed",
+                    defaultValue: "\nProceed? [y/N] "
+                ), terminator: "")
+                guard readLine()?.lowercased().hasPrefix("y") == true else {
+                    print(String(
+                        localized: "cli.hooks.kimi.aborted",
+                        defaultValue: "Aborted."
+                    ))
+                    return
+                }
+            }
+            try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
+            print(String.localizedStringWithFormat(
+                String(
+                    localized: "cli.hooks.kimi.installed",
+                    defaultValue: "%@ hooks installed at %@"
+                ),
+                def.displayName,
+                filePath
+            ))
         }
 
-        if !skipConfirm {
-            Self.printInstallPreview(
-                path: filePath,
-                oldContent: oldString,
-                newContent: newString,
-                fallbackContent: newString
-            )
-            print(String(
-                localized: "cli.hooks.kimi.confirmProceed",
-                defaultValue: "\nProceed? [y/N] "
-            ), terminator: "")
-            guard readLine()?.lowercased().hasPrefix("y") == true else {
-                print(String(
-                    localized: "cli.hooks.kimi.aborted",
-                    defaultValue: "Aborted."
-                ))
-                return
-            }
-        }
-        try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
-        print(String.localizedStringWithFormat(
-            String(
-                localized: "cli.hooks.kimi.installed",
-                defaultValue: "%@ hooks installed at %@"
-            ),
-            def.displayName,
-            filePath
-        ))
+        let activeConfigURL = URL(fileURLWithPath: filePath, isDirectory: false)
+        let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
+        guard activeConfigURL.standardizedFileURL != legacyConfigURL.standardizedFileURL else { return }
+        _ = try removeKimiHooks(at: legacyConfigURL, def: def, reportNoChange: false)
     }
 
     func uninstallKimiHooks(_ def: AgentHookDef) throws {
-        let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
-        let filePath = "\(configDir)/\(def.configFile)"
-        guard fm.fileExists(atPath: filePath) else {
-            print(String.localizedStringWithFormat(
-                String(
-                    localized: "cli.hooks.kimi.noneFound",
-                    defaultValue: "No %@ found at %@"
-                ),
-                def.configFile,
-                filePath
-            ))
-            return
+        let activeConfigURL = URL(fileURLWithPath: configDir, isDirectory: true)
+            .appendingPathComponent(def.configFile, isDirectory: false)
+        let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
+        let configURLs = [activeConfigURL, legacyConfigURL].reduce(into: [URL]()) { urls, url in
+            guard !urls.contains(where: { $0.standardizedFileURL == url.standardizedFileURL }) else { return }
+            urls.append(url)
         }
-        let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
+
+        var foundConfig = false
+        for configURL in configURLs where FileManager.default.fileExists(atPath: configURL.path) {
+            foundConfig = true
+            _ = try removeKimiHooks(at: configURL, def: def, reportNoChange: true)
+        }
+        guard !foundConfig else { return }
+
+        print(String.localizedStringWithFormat(
+            String(
+                localized: "cli.hooks.kimi.noneFound",
+                defaultValue: "No %@ found at %@"
+            ),
+            def.configFile,
+            activeConfigURL.path
+        ))
+    }
+
+    private func removeKimiHooks(
+        at configURL: URL,
+        def: AgentHookDef,
+        reportNoChange: Bool
+    ) throws -> Bool {
+        let oldString = try readAgentHookConfig(filePath: configURL.path, displayName: def.displayName)
         let newString = KimiCodeHookConfig.uninstalling(from: oldString)
         guard oldString != newString else {
-            print(String.localizedStringWithFormat(
-                String(
-                    localized: "cli.hooks.kimi.removedZero",
-                    defaultValue: "Removed 0 cmux hook(s) from %@"
-                ),
-                filePath
-            ))
-            return
+            if reportNoChange {
+                print(String.localizedStringWithFormat(
+                    String(
+                        localized: "cli.hooks.kimi.removedZero",
+                        defaultValue: "Removed 0 cmux hook(s) from %@"
+                    ),
+                    configURL.path
+                ))
+            }
+            return false
         }
-        try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
+        try newString.write(to: configURL, atomically: true, encoding: .utf8)
         print(String.localizedStringWithFormat(
             String(
                 localized: "cli.hooks.kimi.removed",
                 defaultValue: "Removed Kimi Code cmux hooks from %@"
             ),
-            filePath
+            configURL.path
         ))
+        return true
+    }
+
+    private static func legacyKimiConfigURL(fileName: String) -> URL {
+        let environment = ProcessInfo.processInfo.environment
+        let home = environment["HOME"].flatMap { value -> String? in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : trimmed
+        } ?? NSHomeDirectory()
+        let legacyDirectory = environment[legacyKimiConfigDirectoryOverride].flatMap { value -> String? in
+            let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed.isEmpty ? nil : NSString(string: trimmed).expandingTildeInPath
+        }.map { URL(fileURLWithPath: $0, isDirectory: true) }
+            ?? URL(fileURLWithPath: home, isDirectory: true)
+                .appendingPathComponent(legacyKimiConfigDirectory, isDirectory: true)
+        return legacyDirectory.appendingPathComponent(fileName, isDirectory: false)
     }
 }

--- a/CLI/CMUXCLI+KimiHooks.swift
+++ b/CLI/CMUXCLI+KimiHooks.swift
@@ -2,6 +2,12 @@ import CMUXAgentLaunch
 import Foundation
 
 extension CMUXCLI {
+    private struct KimiConfigEdit {
+        let url: URL
+        let oldContent: String
+        let newContent: String
+    }
+
     private static let kimiLifecycleHookTimeoutSeconds = 10
     private static let kimiFeedHookTimeoutSeconds = 120
     private static let legacyKimiConfigDirectory = ".kimi-code"
@@ -29,6 +35,8 @@ extension CMUXCLI {
         let fm = FileManager.default
         let configDir = def.resolvedConfigDir()
         let filePath = "\(configDir)/\(def.configFile)"
+        let activeConfigURL = URL(fileURLWithPath: filePath, isDirectory: false)
+        let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
         let skipConfirm = ProcessInfo.processInfo.arguments.contains("--yes")
             || ProcessInfo.processInfo.arguments.contains("-y")
 
@@ -44,17 +52,15 @@ extension CMUXCLI {
         if configPathExists, !isConfigDirectory.boolValue {
             throw CLIError(message: configDirectoryFileError)
         }
-        if !configPathExists {
-            do {
-                try fm.createDirectory(atPath: configDir, withIntermediateDirectories: true)
-            } catch {
-                throw CLIError(message: configDirectoryFileError)
-            }
-        }
 
         let oldString = try readAgentHookConfig(filePath: filePath, displayName: def.displayName)
         let newString = KimiCodeHookConfig.installing(events: kimiCodeHookEvents(def: def), in: oldString)
-        if oldString == newString {
+        let activeEdit = oldString == newString ? nil : KimiConfigEdit(
+            url: activeConfigURL,
+            oldContent: oldString,
+            newContent: newString
+        )
+        if activeEdit == nil {
             print(String.localizedStringWithFormat(
                 String(
                     localized: "cli.hooks.kimi.alreadyUpToDate",
@@ -63,27 +69,61 @@ extension CMUXCLI {
                 def.displayName,
                 filePath
             ))
-        } else {
-            if !skipConfirm {
-                Self.printInstallPreview(
-                    path: filePath,
-                    oldContent: oldString,
-                    newContent: newString,
-                    fallbackContent: newString
+        }
+
+        var legacyEdit: KimiConfigEdit?
+        var legacyCleanupFailed = false
+        if Self.canonicalKimiConfigURL(activeConfigURL) != Self.canonicalKimiConfigURL(legacyConfigURL) {
+            do {
+                let legacyOldString = try readAgentHookConfig(
+                    filePath: legacyConfigURL.path,
+                    displayName: def.displayName
                 )
+                let legacyNewString = KimiCodeHookConfig.uninstalling(from: legacyOldString)
+                if legacyOldString != legacyNewString {
+                    legacyEdit = KimiConfigEdit(
+                        url: legacyConfigURL,
+                        oldContent: legacyOldString,
+                        newContent: legacyNewString
+                    )
+                }
+            } catch {
+                legacyCleanupFailed = true
+            }
+        }
+
+        let edits = [activeEdit, legacyEdit].compactMap { $0 }
+        if !skipConfirm, !edits.isEmpty {
+            for edit in edits {
+                Self.printInstallPreview(
+                    path: edit.url.path,
+                    oldContent: edit.oldContent,
+                    newContent: edit.newContent,
+                    fallbackContent: edit.newContent
+                )
+            }
+            print(String(
+                localized: "cli.hooks.kimi.confirmProceed",
+                defaultValue: "\nProceed? [y/N] "
+            ), terminator: "")
+            guard readLine()?.lowercased().hasPrefix("y") == true else {
                 print(String(
-                    localized: "cli.hooks.kimi.confirmProceed",
-                    defaultValue: "\nProceed? [y/N] "
-                ), terminator: "")
-                guard readLine()?.lowercased().hasPrefix("y") == true else {
-                    print(String(
-                        localized: "cli.hooks.kimi.aborted",
-                        defaultValue: "Aborted."
-                    ))
-                    return
+                    localized: "cli.hooks.kimi.aborted",
+                    defaultValue: "Aborted."
+                ))
+                return
+            }
+        }
+
+        if let activeEdit {
+            if !configPathExists {
+                do {
+                    try fm.createDirectory(atPath: configDir, withIntermediateDirectories: true)
+                } catch {
+                    throw CLIError(message: configDirectoryFileError)
                 }
             }
-            try newString.write(toFile: filePath, atomically: true, encoding: .utf8)
+            try activeEdit.newContent.write(to: activeEdit.url, atomically: true, encoding: .utf8)
             print(String.localizedStringWithFormat(
                 String(
                     localized: "cli.hooks.kimi.installed",
@@ -94,23 +134,25 @@ extension CMUXCLI {
             ))
         }
 
-        let activeConfigURL = URL(fileURLWithPath: filePath, isDirectory: false)
-        let legacyConfigURL = Self.legacyKimiConfigURL(fileName: def.configFile)
-        guard Self.canonicalKimiConfigURL(activeConfigURL) != Self.canonicalKimiConfigURL(legacyConfigURL) else {
-            return
+        if let legacyEdit {
+            do {
+                try legacyEdit.newContent.write(to: legacyEdit.url, atomically: true, encoding: .utf8)
+                print(String.localizedStringWithFormat(
+                    String(
+                        localized: "cli.hooks.kimi.removed",
+                        defaultValue: "Removed Kimi Code cmux hooks from %@"
+                    ),
+                    legacyEdit.url.path
+                ))
+            } catch {
+                legacyCleanupFailed = true
+            }
         }
-        do {
-            _ = try removeKimiHooks(at: legacyConfigURL, def: def, reportNoChange: false)
-        } catch {
-            let warning = String.localizedStringWithFormat(
-                String(
-                    localized: "cli.hooks.kimi.legacyCleanupWarning",
-                    defaultValue: "Warning: cmux hooks are active at %@, but cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks setup kimi` to finish cleanup."
-                ),
-                activeConfigURL.path,
-                legacyConfigURL.path
+        if legacyCleanupFailed {
+            reportKimiLegacyCleanupWarning(
+                activeConfigURL: activeConfigURL,
+                legacyConfigURL: legacyConfigURL
             )
-            cliWriteStderr(warning + "\n")
         }
     }
 
@@ -170,6 +212,21 @@ extension CMUXCLI {
             configURL.path
         ))
         return true
+    }
+
+    private func reportKimiLegacyCleanupWarning(
+        activeConfigURL: URL,
+        legacyConfigURL: URL
+    ) {
+        let warning = String.localizedStringWithFormat(
+            String(
+                localized: "cli.hooks.kimi.legacyCleanupWarning",
+                defaultValue: "Warning: cmux hooks are active at %@, but cmux could not remove its legacy hook block from %@. Check that path and re-run `cmux hooks setup kimi` to finish cleanup."
+            ),
+            activeConfigURL.path,
+            legacyConfigURL.path
+        )
+        cliWriteStderr(warning + "\n")
     }
 
     private static func legacyKimiConfigURL(fileName: String) -> URL {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -8135,7 +8135,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				468160000000000000000001 /* KeyboardShortcutSettingsObserverTests.swift in Sources */,
 				A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */,
 				C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */,
-					827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */,
+				827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */,
 				87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */,
 				A7C0F0010000000000000002 /* MacPairedMacBackupPublisherScopeTests.swift in Sources */,
 				6512F0C06512F0C06512F002 /* MainWindowFocusRestoreTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -951,6 +951,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		468160000000000000000001 /* KeyboardShortcutSettingsObserverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 468160000000000000000002 /* KeyboardShortcutSettingsObserverTests.swift */; };
 		A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */; };
 		C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */; };
+		827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 827300000000000000000003 /* KimiHookConfigLocationTests.swift */; };
 		87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */; };
 		A11CE0060000000000000001 /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = A11CE0050000000000000001 /* LICENSE */; };
 		DA7A10CA710E000000000003 /* Localizable.xcstrings in Resources */ = {isa = PBXBuildFile; fileRef = DA7A10CA710E000000000001 /* Localizable.xcstrings */; };
@@ -2924,6 +2925,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		468160000000000000000002 /* KeyboardShortcutSettingsObserverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSettingsObserverTests.swift; sourceTree = "<group>"; };
 		A17110000000000000000002 /* KeyboardShortcutSpaceKeyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutSpaceKeyTests.swift; sourceTree = "<group>"; };
 		C34670040000000000000002 /* KeyboardShortcutTestSettingsIsolation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardShortcutTestSettingsIsolation.swift; sourceTree = "<group>"; };
+		827300000000000000000003 /* KimiHookConfigLocationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KimiHookConfigLocationTests.swift; sourceTree = "<group>"; };
 		F2EE0C080FF0FCCE8A8CA930 /* LastSurfaceClosePreferenceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LastSurfaceClosePreferenceTests.swift; sourceTree = "<group>"; };
 		A11CE0050000000000000001 /* LICENSE */ = {isa = PBXFileReference; lastKnownFileType = text; path = LICENSE; sourceTree = SOURCE_ROOT; };
 		DA7A10CA710E000000000001 /* Localizable.xcstrings */ = {isa = PBXFileReference; lastKnownFileType = text.json.xcstrings; path = Localizable.xcstrings; sourceTree = "<group>"; };
@@ -5777,6 +5779,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					C0DE6495000000000000000C /* CMUXCLISessionsListTranscriptPidTests.swift */,
 					C0DE64950000000000000004 /* CMUXCLITestAssertions.swift */,
 					C12985000000000000000003 /* CMUXCLISentryTelemetryRegressionTests.swift */,
+					827300000000000000000003 /* KimiHookConfigLocationTests.swift */,
 				C47110010000000000000002 /* ProcessPipeReadCrashRegressionTests.swift */,
 				F50030040000000000000002 /* TitlebarInteractiveControlTests.swift */,
 				E30760060000000000000001 /* TmuxWorkspacePaneOverlayModelTests.swift */,
@@ -8132,6 +8135,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				468160000000000000000001 /* KeyboardShortcutSettingsObserverTests.swift in Sources */,
 				A17110000000000000000001 /* KeyboardShortcutSpaceKeyTests.swift in Sources */,
 				C34670040000000000000001 /* KeyboardShortcutTestSettingsIsolation.swift in Sources */,
+					827300000000000000000004 /* KimiHookConfigLocationTests.swift in Sources */,
 				87C609D63F03597AC12C8B0A /* LastSurfaceClosePreferenceTests.swift in Sources */,
 				A7C0F0010000000000000002 /* MacPairedMacBackupPublisherScopeTests.swift in Sources */,
 				6512F0C06512F0C06512F002 /* MainWindowFocusRestoreTests.swift in Sources */,

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -1,4 +1,5 @@
 import CMUXAgentLaunch
+import Darwin
 import Foundation
 import Testing
 
@@ -9,6 +10,7 @@ struct KimiHookConfigLocationTests {
     private struct ProcessResult {
         let status: Int32
         let output: String
+        let timedOut: Bool
     }
 
     @Test("Setup writes the default Kimi config file")
@@ -31,6 +33,7 @@ struct KimiHookConfigLocationTests {
             fixture: fixture
         )
 
+        #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
         #expect(FileManager.default.fileExists(atPath: currentConfig.path), Comment(rawValue: result.output))
         #expect(!FileManager.default.fileExists(atPath: legacyConfig.path), Comment(rawValue: result.output))
@@ -68,6 +71,7 @@ struct KimiHookConfigLocationTests {
             ]
         )
 
+        #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
         let installed = try String(contentsOf: currentConfig, encoding: .utf8)
         let migratedLegacy = try String(contentsOf: legacyConfig, encoding: .utf8)
@@ -104,6 +108,7 @@ struct KimiHookConfigLocationTests {
             ]
         )
 
+        #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
         #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentUserContent)
         #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyUserContent)
@@ -158,12 +163,22 @@ struct KimiHookConfigLocationTests {
         process.standardInput = FileHandle.nullDevice
         process.standardOutput = output
         process.standardError = output
+        let exitSignal = DispatchSemaphore(value: 0)
+        process.terminationHandler = { _ in exitSignal.signal() }
         try process.run()
-        let data = output.fileHandleForReading.readDataToEndOfFile()
-        process.waitUntilExit()
+        let timedOut = exitSignal.wait(timeout: .now() + 10) == .timedOut
+        if timedOut {
+            process.terminate()
+            if exitSignal.wait(timeout: .now() + 1) == .timedOut {
+                kill(process.processIdentifier, SIGKILL)
+                _ = exitSignal.wait(timeout: .now() + 1)
+            }
+        }
+        let data = try output.fileHandleForReading.readToEnd() ?? Data()
         return ProcessResult(
-            status: process.terminationStatus,
-            output: String(data: data, encoding: .utf8) ?? ""
+            status: process.isRunning ? SIGKILL : process.terminationStatus,
+            output: String(data: data, encoding: .utf8) ?? "",
+            timedOut: timedOut
         )
     }
 

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -36,6 +36,9 @@ struct KimiHookConfigLocationTests {
         #expect(!FileManager.default.fileExists(atPath: legacyConfig.path), Comment(rawValue: result.output))
         let installed = try String(contentsOf: currentConfig, encoding: .utf8)
         #expect(installed.contains("cmux hooks kimi stop"))
+        #expect(installed.contains(#"event = "Notification""#))
+        #expect(!installed.contains(#"event = "PermissionRequest""#))
+        #expect(!installed.contains(#"event = "Interrupt""#))
     }
 
     @Test("Setup honors KIMI_SHARE_DIR and cleans the legacy cmux block")

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -1,0 +1,190 @@
+import CMUXAgentLaunch
+import Foundation
+import Testing
+
+private final class KimiHookConfigLocationBundleToken {}
+
+@Suite("Kimi hook config location", .serialized)
+struct KimiHookConfigLocationTests {
+    private struct ProcessResult {
+        let status: Int32
+        let output: String
+    }
+
+    @Test("Setup writes the default Kimi config file")
+    func setupWritesDefaultKimiConfigFile() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentConfig = fixture.home
+            .appendingPathComponent(".kimi", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+        let legacyConfig = fixture.home
+            .appendingPathComponent(".kimi-code", isDirectory: true)
+            .appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(
+            at: currentConfig.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(FileManager.default.fileExists(atPath: currentConfig.path), Comment(rawValue: result.output))
+        #expect(!FileManager.default.fileExists(atPath: legacyConfig.path), Comment(rawValue: result.output))
+        let installed = try String(contentsOf: currentConfig, encoding: .utf8)
+        #expect(installed.contains("cmux hooks kimi stop"))
+    }
+
+    @Test("Setup honors KIMI_SHARE_DIR and cleans the legacy cmux block")
+    func setupHonorsShareDirectoryAndCleansLegacyBlock() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
+        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+
+        let currentUserContent = Self.userHookContent(command: "vibe-island")
+        let legacyUserContent = Self.userHookContent(command: "orca")
+        let legacyWithCmuxBlock = Self.installingCmuxBlock(in: legacyUserContent)
+        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try currentUserContent.write(to: currentConfig, atomically: true, encoding: .utf8)
+        try legacyWithCmuxBlock.write(to: legacyConfig, atomically: true, encoding: .utf8)
+
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_SHARE_DIR": currentDirectory.path,
+                "KIMI_CODE_HOME": legacyDirectory.path,
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        let installed = try String(contentsOf: currentConfig, encoding: .utf8)
+        let migratedLegacy = try String(contentsOf: legacyConfig, encoding: .utf8)
+        #expect(installed.contains(#"command = "vibe-island""#))
+        #expect(installed.contains("cmux hooks kimi stop"))
+        #expect(migratedLegacy == legacyUserContent)
+    }
+
+    @Test("Uninstall removes cmux blocks from current and legacy Kimi configs")
+    func uninstallRemovesCurrentAndLegacyBlocks() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
+        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+
+        let currentUserContent = Self.userHookContent(command: "vibe-island")
+        let legacyUserContent = Self.userHookContent(command: "orca")
+        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try Self.installingCmuxBlock(in: currentUserContent)
+            .write(to: currentConfig, atomically: true, encoding: .utf8)
+        try Self.installingCmuxBlock(in: legacyUserContent)
+            .write(to: legacyConfig, atomically: true, encoding: .utf8)
+
+        let result = try runCLI(
+            arguments: ["hooks", "uninstall", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_SHARE_DIR": currentDirectory.path,
+                "KIMI_CODE_HOME": legacyDirectory.path,
+            ]
+        )
+
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentUserContent)
+        #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyUserContent)
+    }
+
+    private struct Fixture {
+        let root: URL
+        let home: URL
+        let bin: URL
+    }
+
+    private func makeFixture() throws -> Fixture {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-kimi-hooks-\(UUID().uuidString)", isDirectory: true)
+        let home = root.appendingPathComponent("home", isDirectory: true)
+        let bin = root.appendingPathComponent("bin", isDirectory: true)
+        try FileManager.default.createDirectory(at: home, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: bin, withIntermediateDirectories: true)
+
+        let kimi = bin.appendingPathComponent("kimi", isDirectory: false)
+        try "#!/bin/sh\nexit 0\n".write(to: kimi, atomically: true, encoding: .utf8)
+        try FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: kimi.path)
+        return Fixture(root: root, home: home, bin: bin)
+    }
+
+    private func runCLI(
+        arguments: [String],
+        fixture: Fixture,
+        environmentOverrides: [String: String] = [:]
+    ) throws -> ProcessResult {
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(
+            fileURLWithPath: try BundledCLITestSupport.bundledCLIPath(
+                for: KimiHookConfigLocationBundleToken.self
+            )
+        )
+        process.arguments = arguments
+
+        var environment = ProcessInfo.processInfo.environment
+        for key in Array(environment.keys) where key.hasPrefix("CMUX_") {
+            environment.removeValue(forKey: key)
+        }
+        environment.removeValue(forKey: "KIMI_SHARE_DIR")
+        environment.removeValue(forKey: "KIMI_CODE_HOME")
+        environment["HOME"] = fixture.home.path
+        environment["PATH"] = "\(fixture.bin.path):/usr/bin:/bin:/usr/sbin:/sbin"
+        environment["CMUX_CLI_SENTRY_DISABLED"] = "1"
+        environment.merge(environmentOverrides) { _, override in override }
+
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = output
+        process.standardError = output
+        try process.run()
+        let data = output.fileHandleForReading.readDataToEndOfFile()
+        process.waitUntilExit()
+        return ProcessResult(
+            status: process.terminationStatus,
+            output: String(data: data, encoding: .utf8) ?? ""
+        )
+    }
+
+    private static func userHookContent(command: String) -> String {
+        """
+        default_model = "user-model"
+
+        [[hooks]]
+        event = "Stop"
+        command = "\(command)"
+
+        """
+    }
+
+    private static func installingCmuxBlock(in content: String) -> String {
+        KimiCodeHookConfig.installing(
+            events: [
+                KimiCodeHookConfig.Event(
+                    name: "Stop",
+                    command: "cmux hooks kimi stop",
+                    timeout: 10
+                ),
+            ],
+            in: content
+        )
+    }
+}

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -138,6 +138,81 @@ struct KimiHookConfigLocationTests {
         #expect(installed.contains("hooks kimi stop"), Comment(rawValue: result.output))
     }
 
+    @Test("Declining setup previews and preserves both Kimi configs")
+    func decliningSetupPreviewsAndPreservesBothConfigs() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
+        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+
+        let currentContent = Self.userHookContent(command: "vibe-island")
+        let legacyContent = Self.installingCmuxBlock(in: Self.userHookContent(command: "orca"))
+        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try currentContent.write(to: currentConfig, atomically: true, encoding: .utf8)
+        try legacyContent.write(to: legacyConfig, atomically: true, encoding: .utf8)
+
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_SHARE_DIR": currentDirectory.path,
+                "KIMI_CODE_HOME": legacyDirectory.path,
+            ],
+            standardInput: "n\n"
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentContent)
+        #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyContent)
+        #expect(result.output.contains(currentConfig.path))
+        #expect(result.output.contains(legacyConfig.path))
+    }
+
+    @Test("Declining legacy cleanup preserves an up-to-date active Kimi config")
+    func decliningLegacyCleanupPreservesCurrentConfigs() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
+        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+
+        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let environment = [
+            "KIMI_SHARE_DIR": currentDirectory.path,
+            "KIMI_CODE_HOME": legacyDirectory.path,
+        ]
+        let seedResult = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: environment
+        )
+        #expect(seedResult.status == 0, Comment(rawValue: seedResult.output))
+        let currentContent = try String(contentsOf: currentConfig, encoding: .utf8)
+        let legacyContent = Self.installingCmuxBlock(in: Self.userHookContent(command: "orca"))
+        try legacyContent.write(to: legacyConfig, atomically: true, encoding: .utf8)
+
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi"],
+            fixture: fixture,
+            environmentOverrides: environment,
+            standardInput: "n\n"
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentContent)
+        #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyContent)
+        #expect(result.output.contains(legacyConfig.path))
+    }
+
     @Test("Uninstall removes cmux blocks from current and legacy Kimi configs")
     func uninstallRemovesCurrentAndLegacyBlocks() throws {
         let fixture = try makeFixture()
@@ -195,10 +270,12 @@ struct KimiHookConfigLocationTests {
     private func runCLI(
         arguments: [String],
         fixture: Fixture,
-        environmentOverrides: [String: String] = [:]
+        environmentOverrides: [String: String] = [:],
+        standardInput: String? = nil
     ) throws -> ProcessResult {
         let process = Process()
         let output = Pipe()
+        let input = standardInput == nil ? nil : Pipe()
         process.executableURL = URL(
             fileURLWithPath: try BundledCLITestSupport.bundledCLIPath(
                 for: KimiHookConfigLocationBundleToken.self
@@ -218,12 +295,20 @@ struct KimiHookConfigLocationTests {
         environment.merge(environmentOverrides) { _, override in override }
 
         process.environment = environment
-        process.standardInput = FileHandle.nullDevice
+        if let input {
+            process.standardInput = input
+        } else {
+            process.standardInput = FileHandle.nullDevice
+        }
         process.standardOutput = output
         process.standardError = output
         let exitSignal = DispatchSemaphore(value: 0)
         process.terminationHandler = { _ in exitSignal.signal() }
         try process.run()
+        if let standardInput, let input {
+            input.fileHandleForWriting.write(Data(standardInput.utf8))
+            try input.fileHandleForWriting.close()
+        }
         let timedOut = exitSignal.wait(timeout: .now() + 10) == .timedOut
         if timedOut {
             process.terminate()

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -38,7 +38,7 @@ struct KimiHookConfigLocationTests {
         #expect(FileManager.default.fileExists(atPath: currentConfig.path), Comment(rawValue: result.output))
         #expect(!FileManager.default.fileExists(atPath: legacyConfig.path), Comment(rawValue: result.output))
         let installed = try String(contentsOf: currentConfig, encoding: .utf8)
-        #expect(installed.contains("cmux hooks kimi stop"))
+        #expect(installed.contains("hooks kimi stop"))
         #expect(installed.contains(#"event = "Notification""#))
         #expect(!installed.contains(#"event = "PermissionRequest""#))
         #expect(!installed.contains(#"event = "Interrupt""#))
@@ -76,7 +76,7 @@ struct KimiHookConfigLocationTests {
         let installed = try String(contentsOf: currentConfig, encoding: .utf8)
         let migratedLegacy = try String(contentsOf: legacyConfig, encoding: .utf8)
         #expect(installed.contains(#"command = "vibe-island""#))
-        #expect(installed.contains("cmux hooks kimi stop"))
+        #expect(installed.contains("hooks kimi stop"))
         #expect(migratedLegacy == legacyUserContent)
     }
 
@@ -105,7 +105,7 @@ struct KimiHookConfigLocationTests {
 
         #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
-        #expect(try String(contentsOf: currentConfig, encoding: .utf8).contains("cmux hooks kimi stop"))
+        #expect(try String(contentsOf: currentConfig, encoding: .utf8).contains("hooks kimi stop"))
         #expect(result.output.contains(legacyConfig.path))
     }
 
@@ -135,7 +135,7 @@ struct KimiHookConfigLocationTests {
         #expect(!result.timedOut, Comment(rawValue: result.output))
         #expect(result.status == 0, Comment(rawValue: result.output))
         let installed = try String(contentsOf: currentConfig, encoding: .utf8)
-        #expect(installed.contains("cmux hooks kimi stop"), Comment(rawValue: result.output))
+        #expect(installed.contains("hooks kimi stop"), Comment(rawValue: result.output))
     }
 
     @Test("Uninstall removes cmux blocks from current and legacy Kimi configs")
@@ -247,8 +247,7 @@ struct KimiHookConfigLocationTests {
         [[hooks]]
         event = "Stop"
         command = "\(command)"
-
-        """
+        """ + "\n\n"
     }
 
     private static func installingCmuxBlock(in content: String) -> String {

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -247,6 +247,40 @@ struct KimiHookConfigLocationTests {
         #expect(try String(contentsOf: legacyConfig, encoding: .utf8) == legacyUserContent)
     }
 
+    @Test("Uninstall succeeds when the legacy Kimi config cannot be read")
+    func uninstallSucceedsWhenLegacyConfigCannotBeRead() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
+        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+
+        let currentUserContent = Self.userHookContent(command: "vibe-island")
+        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try Self.installingCmuxBlock(in: currentUserContent)
+            .write(to: currentConfig, atomically: true, encoding: .utf8)
+        try FileManager.default.createDirectory(at: legacyConfig, withIntermediateDirectories: true)
+
+        let result = try runCLI(
+            arguments: ["hooks", "uninstall", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_SHARE_DIR": currentDirectory.path,
+                "KIMI_CODE_HOME": legacyDirectory.path,
+            ]
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(try String(contentsOf: currentConfig, encoding: .utf8) == currentUserContent)
+        #expect(FileManager.default.fileExists(atPath: legacyConfig.path))
+        #expect(result.output.contains(legacyConfig.path))
+        #expect(result.output.contains("cmux hooks uninstall kimi"))
+    }
+
     private struct Fixture {
         let root: URL
         let home: URL

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -109,6 +109,35 @@ struct KimiHookConfigLocationTests {
         #expect(result.output.contains(legacyConfig.path))
     }
 
+    @Test("Setup does not clean the active Kimi config through a legacy symlink")
+    func setupDoesNotCleanActiveConfigThroughLegacySymlink() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
+        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createSymbolicLink(
+            at: legacyDirectory,
+            withDestinationURL: currentDirectory
+        )
+
+        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_SHARE_DIR": currentDirectory.path,
+                "KIMI_CODE_HOME": legacyDirectory.path,
+            ]
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        let installed = try String(contentsOf: currentConfig, encoding: .utf8)
+        #expect(installed.contains("cmux hooks kimi stop"), Comment(rawValue: result.output))
+    }
+
     @Test("Uninstall removes cmux blocks from current and legacy Kimi configs")
     func uninstallRemovesCurrentAndLegacyBlocks() throws {
         let fixture = try makeFixture()

--- a/cmuxTests/KimiHookConfigLocationTests.swift
+++ b/cmuxTests/KimiHookConfigLocationTests.swift
@@ -80,6 +80,35 @@ struct KimiHookConfigLocationTests {
         #expect(migratedLegacy == legacyUserContent)
     }
 
+    @Test("Setup succeeds when the legacy Kimi config cannot be read")
+    func setupSucceedsWhenLegacyConfigCannotBeRead() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let currentDirectory = fixture.root.appendingPathComponent("current-kimi", isDirectory: true)
+        let legacyDirectory = fixture.root.appendingPathComponent("legacy-kimi", isDirectory: true)
+        try FileManager.default.createDirectory(at: currentDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: legacyDirectory, withIntermediateDirectories: true)
+
+        let currentConfig = currentDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        let legacyConfig = legacyDirectory.appendingPathComponent("config.toml", isDirectory: false)
+        try FileManager.default.createDirectory(at: legacyConfig, withIntermediateDirectories: true)
+
+        let result = try runCLI(
+            arguments: ["hooks", "setup", "kimi", "--yes"],
+            fixture: fixture,
+            environmentOverrides: [
+                "KIMI_SHARE_DIR": currentDirectory.path,
+                "KIMI_CODE_HOME": legacyDirectory.path,
+            ]
+        )
+
+        #expect(!result.timedOut, Comment(rawValue: result.output))
+        #expect(result.status == 0, Comment(rawValue: result.output))
+        #expect(try String(contentsOf: currentConfig, encoding: .utf8).contains("cmux hooks kimi stop"))
+        #expect(result.output.contains(legacyConfig.path))
+    }
+
     @Test("Uninstall removes cmux blocks from current and legacy Kimi configs")
     func uninstallRemovesCurrentAndLegacyBlocks() throws {
         let fixture = try makeFixture()

--- a/docs/agent-hooks.md
+++ b/docs/agent-hooks.md
@@ -33,7 +33,7 @@ Supported agent names are `codex`, `grok`, `opencode`, `pi`, `omp`, `campfire`, 
 | CodeBuddy | `codebuddy` | `~/.codebuddy/settings.json` | `codebuddy --resume <id>` | PreToolUse |
 | Factory | `droid` | `~/.factory/settings.json` | `droid --resume <id>` | PreToolUse |
 | Qoder | `qodercli` | `~/.qoder/settings.json` | `qodercli --resume <id>` | PreToolUse |
-| Kimi Code | `kimi` | `~/.kimi-code/config.toml` | not yet | PreToolUse, PostToolUse, PermissionRequest |
+| Kimi Code | `kimi` | `~/.kimi/config.toml` | not yet | PreToolUse, PostToolUse |
 
 OpenCode also supports project-local Feed installation:
 
@@ -145,7 +145,7 @@ and browser state. Restored agent terminals stay idle until you resume them manu
 | Cursor CLI | none | `CMUX_CURSOR_HOOKS_DISABLED=1` |
 | Gemini | none | `CMUX_GEMINI_HOOKS_DISABLED=1` |
 | Kiro CLI | `KIRO_HOME` | `CMUX_KIRO_HOOKS_DISABLED=1` |
-| Kimi Code | `KIMI_CODE_HOME` | `CMUX_KIMI_HOOKS_DISABLED=1` |
+| Kimi Code | `KIMI_SHARE_DIR` | `CMUX_KIMI_HOOKS_DISABLED=1` |
 | Rovo Dev | none | `CMUX_ROVODEV_HOOKS_DISABLED=1` |
 | Copilot | `COPILOT_HOME` | `CMUX_COPILOT_HOOKS_DISABLED=1` |
 | CodeBuddy | `CODEBUDDY_CONFIG_DIR` | `CMUX_CODEBUDDY_HOOKS_DISABLED=1` |
@@ -161,6 +161,8 @@ Campfire ships this integration natively: current campfire versions include a bu
 Kiro stores hooks inside agent configuration files. The cmux installer creates or updates a `cmux` agent config with lifecycle, tool, and completion hooks; merge the generated `hooks` block into another Kiro agent config if you want the same cmux notifications on that agent.
 
 Kiro Feed verbosity follows **Settings > Automation > Kiro Notification Level** or `automation.kiroNotificationLevel` in `cmux.json`. `minimal` keeps actionable approval cards only, `standard` also keeps mutating tool events, and `verbose` keeps every Kiro tool event.
+
+Kimi Code reads its main config from `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`. During setup and uninstall, cmux also removes its marker-delimited block from the obsolete `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml` location while preserving all unrelated TOML and third-party hooks.
 
 ## Troubleshooting
 

--- a/docs/cli-contract.md
+++ b/docs/cli-contract.md
@@ -373,6 +373,8 @@ Hook subcommands:
 | `hooks feed --source <agent>` | Convert agent hook events into Feed context. |
 | `hooks <agent> <event>` | Generic hook surface for `grok`, `opencode`, `pi`, `amp`, `cursor`, `gemini`, `kimi`, `rovodev`, `copilot`, `codebuddy`, `factory`, and `qoder`. |
 
+Kimi hook setup targets `${KIMI_SHARE_DIR:-~/.kimi}/config.toml`. Setup and uninstall also remove only cmux's marker-delimited block from the legacy `${KIMI_CODE_HOME:-~/.kimi-code}/config.toml` path.
+
 Right sidebar commands:
 
 | Command | Contract |

--- a/docs/feed.md
+++ b/docs/feed.md
@@ -84,7 +84,7 @@ Installs supported agent hooks whose binaries are on `PATH`. See [Agent hook int
 | CodeBuddy    | `~/.codebuddy/settings.json`              | PreToolUse               |
 | Factory      | `~/.factory/settings.json`                | PreToolUse               |
 | Qoder        | `~/.qoder/settings.json`                  | PreToolUse               |
-| Kimi Code    | `~/.kimi-code/config.toml`                | PreToolUse / PostToolUse / PermissionRequest |
+| Kimi Code    | `~/.kimi/config.toml`                     | PreToolUse / PostToolUse |
 | Pi           | `~/.pi/agent/extensions/cmux-session.ts`  | tool_execution_start / tool_execution_end telemetry |
 | OMP          | `~/.omp/agent/extensions/cmux-omp-session.ts` or `$PI_CODING_AGENT_DIR/extensions/cmux-omp-session.ts` | lifecycle only           |
 | Campfire     | `~/.campfire/agent/extensions/cmux-campfire-session.ts` or `$CAMPFIRE_CODING_AGENT_DIR/extensions/cmux-campfire-session.ts` | lifecycle + collaborative notifications |


### PR DESCRIPTION
## Summary

- install cmux hooks in the active Kimi CLI config at `~/.kimi/config.toml`
- honor the current `KIMI_SHARE_DIR` override and retire the unsupported `KIMI_CODE_HOME` override
- remove only the cmux marker block from legacy `KIMI_CODE_HOME` / `~/.kimi-code` configs during setup and uninstall
- align generated hooks with the Kimi 1.49 event schema (`Notification` replaces unsupported `PermissionRequest`; unsupported `Interrupt` is removed)
- preserve unrelated user and third-party `[[hooks]]` entries in both files
- update the agent-hook, CLI-contract, and Feed documentation

## Architecture

`AgentHookDef` remains the single source of truth for the active vendor config contract. Kimi-specific legacy cleanup stays in the existing TOML-format installer/uninstaller, so the migration does not add generic catalog fields that no other agent needs. The marker-block transformer remains the only content mutation path.

## Regression coverage

The first commit contains executable bundled-CLI regression tests only and is intentionally red against the old destination. The second commit fixes setup, `KIMI_SHARE_DIR`, legacy cleanup, uninstall cleanup, and the Kimi 1.49 event set, preserving the red-to-green history.

## Verification

- `swift test` in `Packages/macOS/CMUXAgentLaunch`: 235 tests passed
- `./scripts/lint-pbxproj-test-wiring.sh`: 517 test files checked
- `./scripts/reload.sh --tag issue-8273-kimi`: succeeded without launch
- Swift warning check against the tagged build log: 0 cmux-owned warnings
- Kimi 1.49 config validation through `kimi_cli.config.load_config`: passed
- real `kimi --quiet --prompt "Say hi in exactly two words."`: returned `Hello there!`
- capture stub inherited through `CMUX_BUNDLED_CLI_PATH`: exactly one `hooks kimi stop` invocation, plus one session-start, prompt-submit, and session-end invocation
- real `~/.kimi/config.toml`: seven vibe-island references retained and one cmux marker block installed
- real legacy config: nine Orca references retained and byte-for-byte unchanged

The repository revision does not contain `scripts/swift_file_length_budget.py` or `.github/swift-file-length-budget.tsv`, so the requested checker could not run. Manual counts are 174 lines for `CMUXCLI+KimiHooks.swift` and 193 for the new test file; neither budget TSV was changed. The localization audit found no new runtime string keys, parsed `Localizable.xcstrings`, and updated all English Markdown surfaces that named the old path; these docs have no parallel localized Markdown catalogs.

Fixes #8273

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated **kimi** agent hook event mapping and feed events, shifting away from `PermissionRequest`/`Interrupt` toward `Notification`.
  * Updated **Kimi Code** setup to use `~/.kimi/config.toml`, with legacy marker-block cleanup supported during setup/uninstall.
* **Bug Fixes**
  * Improved uninstall to remove cmux blocks from both current and legacy locations without modifying unrelated TOML content.
* **Tests**
  * Added integration tests covering setup, migration, symlink/legacy edge cases, and uninstall across both locations.
* **Documentation**
  * Updated docs and CLI contract to reflect the new config paths and legacy cleanup behavior.
* **Chores**
  * Added a localized warning message when legacy cleanup needs follow-up setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->