### PR TITLE
Add deterministic sidebar ownership and scale gates

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -13779,7 +13779,7 @@ struct TabItemView: View, Equatable {
 
     var body: some View {
 #if DEBUG
-        let _ = { sidebarLazyContractProbe.workspaceRowBody?() }()
+        let _ = { sidebarLazyContractProbe.workspaceRowBody?(workspaceId) }()
 #endif
         let signpost = SidebarProfilingSignposts.begin("sidebar-tab-item-body", "index=\(index) workspace=\(sidebarShortTabId(workspaceId)) active=\(isActive) unread=\(unreadCount)")
         let workspaceSnapshot = self.workspaceSnapshot

--- a/Sources/Debug/SidebarLazyContractProbe.swift
+++ b/Sources/Debug/SidebarLazyContractProbe.swift
@@ -12,7 +12,7 @@ import SwiftUI
 ///
 /// Same pattern as `MinimalModeInvalidationProbe`; compiled out of Release.
 struct SidebarLazyContractProbe {
-    var workspaceRowBody: (() -> Void)?
+    var workspaceRowBody: ((UUID) -> Void)?
     var workspaceRowBodyEnd: (() -> Void)?
     var groupHeaderRowBody: (() -> Void)?
     var workspaceSnapshotBuild: (() -> Void)?

--- a/cmuxTests/SidebarLazyLayoutScaleTests.swift
+++ b/cmuxTests/SidebarLazyLayoutScaleTests.swift
@@ -50,6 +50,9 @@ final class SidebarLazyLayoutScaleTests {
         var groupHeaderBodies = 0
         var workspaceSnapshotBuilds = 0
         var workspaceRowInputProjections = 0
+        var verticalSidebarBodiesDuringViewportResize = 0
+        var isViewportResizeActive = false
+        var realizedWorkspaceIds: Set<UUID> = []
         // Snapshot builds bracketed by workspaceRowBody/workspaceRowBodyEnd,
         // i.e. synchronous work inside a single TabItemView.body evaluation.
         // Builds outside the bracket (onAppear refresh, observation publishers)
@@ -62,6 +65,9 @@ final class SidebarLazyLayoutScaleTests {
             groupHeaderBodies = 0
             workspaceSnapshotBuilds = 0
             workspaceRowInputProjections = 0
+            verticalSidebarBodiesDuringViewportResize = 0
+            isViewportResizeActive = false
+            realizedWorkspaceIds.removeAll(keepingCapacity: true)
             insideWorkspaceRowBody = false
             snapshotBuildsInCurrentRowBody = 0
             maxSnapshotBuildsInOneRowBody = 0
@@ -166,8 +172,9 @@ final class SidebarLazyLayoutScaleTests {
         .environment(
             \.sidebarLazyContractProbe,
             SidebarLazyContractProbe(
-                workspaceRowBody: {
+                workspaceRowBody: { workspaceId in
                     counter.workspaceRowBodies += 1
+                    counter.realizedWorkspaceIds.insert(workspaceId)
                     counter.insideWorkspaceRowBody = true
                     counter.snapshotBuildsInCurrentRowBody = 0
                 },
@@ -186,6 +193,15 @@ final class SidebarLazyLayoutScaleTests {
                 },
                 workspaceRowInputProjection: {
                     counter.workspaceRowInputProjections += 1
+                }
+            )
+        )
+        .environment(
+            \.minimalModeInvalidationProbe,
+            MinimalModeInvalidationProbe(
+                verticalTabsSidebarBody: {
+                    guard counter.isViewportResizeActive else { return }
+                    counter.verticalSidebarBodiesDuringViewportResize += 1
                 }
             )
         )
@@ -430,7 +446,7 @@ final class SidebarLazyLayoutScaleTests {
 
     /// Harness self-test: prove the drain loop + body counter actually detect
     /// a layout feedback loop. This fixture reproduces the historical
-    /// GeometryReader → @State row-height shape (#6556) in divergent form; if
+    /// GeometryReader → @State row-height shape (#6556) in bounded form; if
     /// the harness cannot flag THIS, the two tests above are vacuous.
     @Test
     @MainActor
@@ -438,13 +454,17 @@ final class SidebarLazyLayoutScaleTests {
         _ = NSApplication.shared
 
         let counter = RowBodyCounter()
-        let rows = 8
-        let root = VStack(spacing: 2) {
-            ForEach(0..<rows, id: \.self) { _ in
-                DivergentGeometryFeedbackRowFixture(onBody: { counter.workspaceRowBodies += 1 })
+        let rows = 80
+        let root = ScrollView(.vertical) {
+            LazyVStack(spacing: 2) {
+                ForEach(0..<rows, id: \.self) { _ in
+                    BoundedGeometryFeedbackRowFixture(
+                        onBody: { counter.workspaceRowBodies += 1 }
+                    )
+                }
             }
         }
-        .frame(width: 200)
+        .frame(width: 200, height: 200)
 
         let window = NSWindow(
             contentRect: NSRect(x: 0, y: 0, width: 200, height: 400),
@@ -462,9 +482,9 @@ final class SidebarLazyLayoutScaleTests {
         await Self.drainMainRunLoop(for: window, iterations: 40)
 
         #expect(
-            counter.workspaceRowBodies > rows * 3,
+            counter.workspaceRowBodies > 30,
             """
-            The divergent GeometryReader → @State fixture only produced \
+            The bounded GeometryReader → @State fixture only produced \
             \(counter.workspaceRowBodies) body evaluations for \(rows) rows; the harness \
             can no longer observe layout feedback loops, so the lazy-contract tests above \
             are not protecting anything. Fix the harness before trusting them.
@@ -473,14 +493,16 @@ final class SidebarLazyLayoutScaleTests {
     }
 }
 
-/// Reproduces the #6556 anti-pattern in deliberately divergent form: a
+/// Reproduces the #6556 anti-pattern in bounded form: a
 /// GeometryReader writes measured height back into `@State` that feeds the
-/// row's own frame, so every layout pass invalidates the next. Test fixture
-/// only — this shape is banned in real sidebar rows by
+/// row's own frame, so each layout pass invalidates the next. The cap keeps
+/// this canary from trapping the test host in a permanent layout loop. Test
+/// fixture only — this shape is banned in real sidebar rows by
 /// `scripts/check-sidebar-lazy-layout.py`.
-private struct DivergentGeometryFeedbackRowFixture: View {
+private struct BoundedGeometryFeedbackRowFixture: View {
     let onBody: () -> Void
     @State private var rowHeight: CGFloat = 20
+    @State private var feedbackCount = 0
 
     var body: some View {
         let _ = { onBody() }()
@@ -489,11 +511,17 @@ private struct DivergentGeometryFeedbackRowFixture: View {
             .background {
                 GeometryReader { proxy in
                     Color.clear
-                        .onAppear { rowHeight = proxy.size.height + 1 }
+                        .onAppear { publishMeasuredHeight(proxy.size.height) }
                         .onChange(of: proxy.size.height) { _, newHeight in
-                            rowHeight = newHeight + 1
+                            publishMeasuredHeight(newHeight)
                         }
                 }
             }
+    }
+
+    private func publishMeasuredHeight(_ measuredHeight: CGFloat) {
+        guard feedbackCount < 5 else { return }
+        feedbackCount += 1
+        rowHeight = measuredHeight + 1
     }
 }

--- a/cmuxTests/SidebarPointerInteractionScaleTests.swift
+++ b/cmuxTests/SidebarPointerInteractionScaleTests.swift
@@ -2,6 +2,7 @@ import AppKit
 import CmuxSidebar
 import CoreGraphics
 import OSLog
+import SwiftUI
 import Testing
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -278,6 +279,439 @@ final class SidebarOverflowingScrollStatusChurnTests {
             \(quietEvals) row bodies evaluated after scrolling and status churn ended. The sidebar \
             did not converge and is still feeding lazy layout back into view state.
             """
+        )
+    }
+}
+
+/// Guards the two ownership boundaries that keep AppKit-hosted SwiftUI layout
+/// from publishing state while `LazyVStack` is placing `ForEach` children.
+/// These are deterministic causal checks, not another attempt to win the
+/// timing race that made the reporter-shaped #6707 stress test pass pre-fix.
+@Suite(.serialized)
+final class SidebarHierarchyOwnershipTests {
+    private struct ObservationTopology: Equatable {
+        let agentObserverIDsByWorkspace: [UUID: Set<UUID>]
+        let processTitleObserverIDsByWorkspace: [UUID: Set<UUID>]
+    }
+
+    @MainActor
+    private static func observationTopology(
+        for harness: SidebarLazyLayoutScaleTests.Harness
+    ) -> ObservationTopology {
+        ObservationTopology(
+            agentObserverIDsByWorkspace: Dictionary(
+                uniqueKeysWithValues: harness.tabManager.tabs.map {
+                    ($0.id, Set($0.sidebarAgentRuntimeObservation.changeObservers.keys))
+                }
+            ),
+            processTitleObserverIDsByWorkspace: Dictionary(
+                uniqueKeysWithValues: harness.tabManager.tabs.map {
+                    ($0.id, Set($0.sidebarProcessTitleObservation.changeObservers.keys))
+                }
+            )
+        )
+    }
+
+    @MainActor
+    private static func waitForInitialParentObservations(
+        in harness: SidebarLazyLayoutScaleTests.Harness
+    ) async {
+        let deadline = ProcessInfo.processInfo.systemUptime + 5
+        while ProcessInfo.processInfo.systemUptime < deadline {
+            let topology = observationTopology(for: harness)
+            let agentReady = topology.agentObserverIDsByWorkspace.values.allSatisfy { $0.count == 1 }
+            let processTitleReady = topology.processTitleObserverIDsByWorkspace.values.allSatisfy { $0.count == 1 }
+            if agentReady, processTitleReady {
+                break
+            }
+            SidebarLazyLayoutScaleTests.turnMainRunLoopOnce(layingOut: harness.window)
+            await Task.yield()
+        }
+
+        let settledTopology = observationTopology(for: harness)
+        #expect(
+            settledTopology.agentObserverIDsByWorkspace.values.allSatisfy { $0.count == 1 },
+            "Every workspace must settle with one parent-owned agent observer."
+        )
+        #expect(
+            settledTopology.processTitleObserverIDsByWorkspace.values.allSatisfy { $0.count == 1 },
+            "Every workspace must settle with one parent-owned process-title observer."
+        )
+    }
+
+    /// Viewport size is a downward-only input to the hosted scroll hierarchy.
+    /// The pre-fix `.onGeometryChange` wrote it into owner `@State`, causing a
+    /// second `VerticalTabsSidebar.body` pass from inside the same graph that
+    /// was laying out `LazyVStack`. Direct GeometryReader input must not do so.
+    @Test
+    @MainActor
+    func testViewportResizeDoesNotPublishBackIntoSidebarOwner() async throws {
+        let harness = try await SidebarLazyLayoutScaleTests.mountSidebar(workspaceCount: 120)
+        defer { harness.tearDown() }
+
+        await Self.waitForInitialParentObservations(in: harness)
+        harness.counter.reset()
+
+        for height in [560, 680, 520, 640, 580, 700, 540, 660] {
+            harness.counter.isViewportResizeActive = true
+            harness.window.setContentSize(NSSize(width: 280, height: height))
+            SidebarLazyLayoutScaleTests.turnMainRunLoopOnce(layingOut: harness.window)
+            await Task.yield()
+            SidebarLazyLayoutScaleTests.turnMainRunLoopOnce(layingOut: harness.window)
+            harness.counter.isViewportResizeActive = false
+        }
+        await SidebarLazyLayoutScaleTests.drainMainRunLoop(
+            for: harness.window,
+            iterations: 20
+        )
+
+        #expect(
+            harness.counter.verticalSidebarBodiesDuringViewportResize == 0,
+            """
+            Viewport-only resizing re-evaluated VerticalTabsSidebar.body \
+            \(harness.counter.verticalSidebarBodiesDuringViewportResize) times inside the \
+            resize transaction. Geometry must flow directly \
+            down into scroll content; publishing it through owner state re-enters the \
+            NSHostingView → LazyVStack placement graph.
+            """
+        )
+    }
+
+    /// Crossing lazy-realization boundaries must be presentation-only. Before
+    /// #8211, each newly mounted TabItemView started model observers and called
+    /// `refreshWorkspaceSnapshot(force: true)`, publishing row `@State` while
+    /// SwiftUI was placing that row. Parent-owned observers and immutable
+    /// snapshots must remain unchanged throughout pure scrolling.
+    @Test
+    @MainActor
+    func testPureScrollDoesNotPublishFromLazyRowLifecycle() async throws {
+        let harness = try await SidebarLazyLayoutScaleTests.mountSidebar(
+            workspaceCount: SidebarLazyLayoutScaleTests.workspaceCount
+        )
+        defer { harness.tearDown() }
+
+        await Self.waitForInitialParentObservations(in: harness)
+        let topologyBeforeScroll = Self.observationTopology(for: harness)
+        let initiallyRealizedWorkspaceIds = harness.counter.realizedWorkspaceIds
+        #expect(
+            topologyBeforeScroll.agentObserverIDsByWorkspace.values.allSatisfy { $0.count == 1 },
+            "Every workspace must have one parent-owned agent observer before scrolling."
+        )
+        #expect(
+            topologyBeforeScroll.processTitleObserverIDsByWorkspace.values.allSatisfy { $0.count == 1 },
+            "Every workspace must have one parent-owned process-title observer before scrolling."
+        )
+
+        let rootView = try #require(harness.window.contentView)
+        let scrollView = try #require(SidebarLazyLayoutScaleTests.firstScrollView(in: rootView))
+        let documentHeight = try #require(scrollView.documentView?.bounds.height)
+        let viewportHeight = scrollView.contentView.bounds.height
+        let maximumOffset = max(0, documentHeight - viewportHeight)
+        try #require(
+            maximumOffset > viewportHeight,
+            "The production sidebar fixture must overflow by more than one viewport."
+        )
+
+        harness.counter.reset()
+        for offset in [maximumOffset, 0, maximumOffset / 2, maximumOffset, 0] {
+            scrollView.contentView.scroll(to: NSPoint(x: 0, y: offset))
+            scrollView.reflectScrolledClipView(scrollView.contentView)
+            await SidebarLazyLayoutScaleTests.drainMainRunLoop(
+                for: harness.window,
+                iterations: 6
+            )
+            #expect(
+                Self.observationTopology(for: harness) == topologyBeforeScroll,
+                """
+                Pure scrolling changed workspace observer identities. Model observation must \
+                be owned above the lazy renderer, independent of row appearance and disappearance.
+                """
+            )
+        }
+
+        let newlyRealizedWorkspaceIds = harness.counter.realizedWorkspaceIds
+            .subtracting(initiallyRealizedWorkspaceIds)
+        #expect(
+            !newlyRealizedWorkspaceIds.isEmpty,
+            """
+            Scrolling did not realize any workspace outside the initial viewport; the \
+            lazy-row lifecycle assertion is vacuous.
+            """
+        )
+    }
+}
+
+/// Renderer-neutral scale fixture for the production immutable row boundary.
+/// It reaches the same NSHostingView/LazyVStack/ForEach/TabItemView chain as
+/// the live sidebar without constructing 1,000 Workspace terminal graphs.
+/// An AppKit renderer can reuse these exact row values and operation bounds.
+@Suite(.serialized)
+final class SidebarImmutableRowScaleTests {
+    private static let realizedRowCeiling = 150
+
+    @MainActor
+    private struct Harness {
+        let window: NSWindow
+        let counter: SidebarLazyLayoutScaleTests.RowBodyCounter
+        let defaults: UserDefaults
+        let defaultsSuiteName: String
+
+        func tearDown() {
+            window.contentView = nil
+            window.close()
+            defaults.removePersistentDomain(forName: defaultsSuiteName)
+        }
+    }
+
+    @Test
+    @MainActor
+    func testProductionRowsStayViewportBoundedFromOneToOneThousand() async throws {
+        for workspaceCount in [1, 10, 100, 1_000] {
+            let harness = try Self.mountRows(workspaceCount: workspaceCount)
+            defer { harness.tearDown() }
+
+            await SidebarLazyLayoutScaleTests.drainMainRunLoop(for: harness.window)
+            let initialRowBodies = harness.counter.workspaceRowBodies
+            #expect(
+                initialRowBodies > 0,
+                "The production row hierarchy did not render at scale \(workspaceCount)."
+            )
+            #expect(
+                initialRowBodies < Self.realizedRowCeiling,
+                """
+                Initial layout evaluated \(initialRowBodies) row bodies for \
+                \(workspaceCount) immutable rows. Work must remain bounded by the \
+                viewport, not grow with the total row count.
+                """
+            )
+
+            let rootView = try #require(harness.window.contentView)
+            let scrollView = try #require(SidebarLazyLayoutScaleTests.firstScrollView(in: rootView))
+            let documentHeight = try #require(scrollView.documentView?.bounds.height)
+            let maximumOffset = max(0, documentHeight - scrollView.contentView.bounds.height)
+            var maximumJumpRowBodies = 0
+            if maximumOffset > 0 {
+                for offset in [maximumOffset, 0, maximumOffset / 2, maximumOffset, 0] {
+                    harness.counter.reset()
+                    scrollView.contentView.scroll(to: NSPoint(x: 0, y: offset))
+                    scrollView.reflectScrolledClipView(scrollView.contentView)
+                    await SidebarLazyLayoutScaleTests.drainMainRunLoop(
+                        for: harness.window,
+                        iterations: 6
+                    )
+                    maximumJumpRowBodies = max(
+                        maximumJumpRowBodies,
+                        harness.counter.workspaceRowBodies
+                    )
+                    #expect(
+                        harness.counter.workspaceRowBodies < Self.realizedRowCeiling,
+                        """
+                        One scroll jump evaluated \(harness.counter.workspaceRowBodies) \
+                        row bodies at scale \(workspaceCount). Lazy realization must remain \
+                        viewport-bounded at every position.
+                        """
+                    )
+                    #expect(
+                        harness.counter.workspaceSnapshotBuilds == 0,
+                        "Immutable row realization must never rebuild workspace snapshots."
+                    )
+                }
+            }
+
+            harness.counter.reset()
+            await SidebarLazyLayoutScaleTests.drainMainRunLoop(
+                for: harness.window,
+                iterations: 30
+            )
+            let quietRowBodies = harness.counter.workspaceRowBodies
+            #expect(
+                quietRowBodies < 20,
+                """
+                The immutable row hierarchy evaluated \(quietRowBodies) bodies after \
+                inputs stopped at scale \(workspaceCount); layout did not converge.
+                """
+            )
+            print(
+                "SIDEBAR_SCALE_BASELINE " +
+                "{\"workspaceCount\":\(workspaceCount)," +
+                "\"initialRowBodies\":\(initialRowBodies)," +
+                "\"maximumJumpRowBodies\":\(maximumJumpRowBodies)," +
+                "\"quietRowBodies\":\(quietRowBodies)}"
+            )
+        }
+    }
+
+    @MainActor
+    private static func mountRows(workspaceCount: Int) throws -> Harness {
+        _ = NSApplication.shared
+        let defaultsSuiteName = "SidebarImmutableRowScaleTests.\(workspaceCount).\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: defaultsSuiteName))
+        defaults.removePersistentDomain(forName: defaultsSuiteName)
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
+        let workspace = SidebarWorkspaceSnapshotRefreshPolicyTests.snapshot(
+            title: "Scale workspace"
+        )
+        let contextMenu = SidebarWorkspaceContextMenuSnapshot(
+            targetWorkspaceIds: [],
+            remoteTargetWorkspaceIds: [],
+            allRemoteTargetsConnecting: false,
+            allRemoteTargetsDisconnected: false,
+            pinState: nil,
+            groupMenuSnapshot: WorkspaceGroupMenuSnapshot(items: []),
+            canCreateEmptyGroup: true,
+            eligibleGroupTargetIds: [],
+            allEligibleTargetsGroupId: nil,
+            hasGroupedEligibleTarget: false,
+            todoStatusLanes: [],
+            canMarkRead: false,
+            canMarkUnread: false,
+            hasLatestNotification: false,
+            notifications: []
+        )
+        let snapshots = (0..<workspaceCount).map { index in
+            SidebarWorkspaceRowSnapshot(
+                workspaceId: deterministicWorkspaceID(index: index),
+                groupId: nil,
+                index: index,
+                workspaceCount: workspaceCount,
+                workspace: workspace,
+                isActive: index == 0,
+                isMultiSelected: false,
+                hasUserCustomTitle: false,
+                hasCustomTitle: false,
+                hasCustomDescription: false,
+                customTitle: nil,
+                workspaceShortcutDigit: index < 9 ? index + 1 : nil,
+                workspaceShortcutModifierSymbol: "⌘",
+                canCloseWorkspace: workspaceCount > 1,
+                unreadCount: 0,
+                latestNotificationText: nil,
+                showsAgentActivity: false,
+                rowSpacing: 0,
+                showsModifierShortcutHints: false,
+                isPointerHovering: false,
+                isBeingDragged: false,
+                topDropIndicatorVisible: false,
+                bottomDropIndicatorVisible: false,
+                isBonsplitWorkspaceDropActive: false,
+                settings: settings,
+                isChecklistExpanded: false,
+                checklistAddFieldActivationToken: 0,
+                isChecklistPopoverPresented: false,
+                contextMenu: contextMenu
+            )
+        }
+        #expect(Set(snapshots.map(\.workspaceId)).count == workspaceCount)
+
+        let counter = SidebarLazyLayoutScaleTests.RowBodyCounter()
+        let actions = Self.noOpActions()
+        let root = ScrollView(.vertical) {
+            LazyVStack(spacing: 0) {
+                ForEach(snapshots, id: \.workspaceId) { snapshot in
+                    SidebarWorkspaceRowView(
+                        snapshot: snapshot,
+                        actions: actions,
+                        shouldCollectWorkspaceDropTargets: false
+                    )
+                }
+            }
+        }
+        .frame(width: 280)
+        .environment(
+            \.sidebarLazyContractProbe,
+            SidebarLazyContractProbe(
+                workspaceRowBody: { workspaceId in
+                    counter.workspaceRowBodies += 1
+                    counter.realizedWorkspaceIds.insert(workspaceId)
+                    counter.insideWorkspaceRowBody = true
+                },
+                workspaceRowBodyEnd: {
+                    counter.insideWorkspaceRowBody = false
+                },
+                workspaceSnapshotBuild: {
+                    counter.workspaceSnapshotBuilds += 1
+                }
+            )
+        )
+        .defaultAppStorage(defaults)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 280, height: 640),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.isReleasedWhenClosed = false
+        window.contentView = NSHostingView(rootView: root)
+        return Harness(
+            window: window,
+            counter: counter,
+            defaults: defaults,
+            defaultsSuiteName: defaultsSuiteName
+        )
+    }
+
+    private static func deterministicWorkspaceID(index: Int) -> UUID {
+        let suffix = String(format: "%012X", index + 1)
+        return UUID(uuidString: "00000000-0000-0000-0000-\(suffix)")!
+    }
+
+    @MainActor
+    private static func noOpActions() -> SidebarWorkspaceRowActions {
+        SidebarWorkspaceRowActions(
+            select: { _ in },
+            setCustomTitle: { _ in },
+            clearCustomTitle: {},
+            clearCustomDescription: {},
+            editDescription: {},
+            closeWorkspace: {},
+            moveBy: { _ in },
+            moveTargetsToTop: { _ in },
+            currentWindowMoveTargets: { [] },
+            moveTargetsToWindow: { _, _ in },
+            moveTargetsToNewWindow: { _ in },
+            closeTargets: { _, _ in },
+            closeOtherTargets: { _ in },
+            closeTargetsBelow: {},
+            closeTargetsAbove: {},
+            performPin: {},
+            createEmptyGroup: {},
+            createGroup: { _ in },
+            addTargetsToGroup: { _, _ in },
+            removeTargetsFromGroup: { _ in },
+            reconnectTargets: { _ in },
+            disconnectTargets: { _ in },
+            applyColor: { _, _ in },
+            applyTodoStatus: { _, _ in },
+            hideTodoStatus: { _ in },
+            requestChecklistAdd: {},
+            markRead: { _ in },
+            markUnread: { _ in },
+            clearLatestNotifications: { _ in },
+            openNotification: { _ in },
+            copyWorkspaceLinks: { _ in },
+            openPullRequest: { _ in },
+            openPort: { _ in },
+            checklist: SidebarWorkspaceChecklistActions(
+                setItemState: { _, _ in },
+                removeItem: { _ in },
+                addItem: { _ in },
+                editItem: { _, _ in },
+                moveItem: { _, _ in },
+                openPane: {}
+            ),
+            onDragStart: { NSItemProvider() },
+            bonsplitSourceWorkspaceId: { _ in nil },
+            moveBonsplitTabToWorkspace: { _, _ in false },
+            syncAfterBonsplitDrop: {},
+            selectAfterBonsplitDrop: {},
+            onToggleChecklistExpansion: {},
+            onConsumeChecklistAddFieldActivation: {},
+            onChecklistPopoverPresentedChange: { _ in },
+            onContextMenuAppear: {},
+            onContextMenuDisappear: {},
+            onPointerFrameChange: { _ in },
+            onPointerFrameDisappear: {}
         )
     }
 }

--- a/cmuxTests/WorkspaceSidebarObservationTests.swift
+++ b/cmuxTests/WorkspaceSidebarObservationTests.swift
@@ -196,6 +196,114 @@ struct WorkspaceSidebarObservationTests {
         #expect(received == [1, 2, 5, 6])
     }
 
+    @Test func coalesceLatestRetainsScheduledTrailingValueUntilDemandReturns() {
+        let scheduler = VirtualCoalesceScheduler()
+        let subject = CurrentValueSubject<Int, Never>(1)
+        let subscriber = ManualDemandSubscriber<Int>()
+
+        subject
+            .coalesceLatest(for: .milliseconds(50), scheduler: scheduler)
+            .subscribe(subscriber)
+
+        #expect(
+            subscriber.received.isEmpty,
+            "A publisher cannot emit its replay before downstream requests demand."
+        )
+
+        subscriber.request(.max(1))
+        #expect(subscriber.received == [1])
+
+        subject.send(2)
+        subject.send(3)
+        scheduler.advance(by: 0.06)
+        scheduler.runScheduledActions()
+
+        #expect(
+            subscriber.received == [1],
+            "A burst cannot emit while downstream demand is exhausted."
+        )
+
+        subscriber.request(.max(1))
+        #expect(
+            subscriber.received == [1, 3],
+            "The next demand must receive the latest coalesced value."
+        )
+    }
+
+    @Test func coalesceLatestSerializesReentrantValuesAndCompletion() {
+        let scheduler = VirtualCoalesceScheduler()
+        let subject = PassthroughSubject<Int, Never>()
+        let subscriber = ReentrantDemandSubscriber {
+            subject.send(2)
+            subject.send(completion: .finished)
+        }
+
+        subject
+            .coalesceLatest(for: .milliseconds(50), scheduler: scheduler)
+            .subscribe(subscriber)
+
+        subscriber.request(.max(1))
+        subject.send(1)
+
+        #expect(
+            subscriber.events == [
+                "value 1 begin",
+                "value 1 end",
+                "value 2 begin",
+                "value 2 end",
+                "completion",
+            ]
+        )
+        #expect(
+            subscriber.maximumCallbackDepth == 1,
+            "Downstream value and completion callbacks must never nest."
+        )
+    }
+
+    @Test func coalesceLatestUsesDemandReturnedByDownstream() {
+        let scheduler = VirtualCoalesceScheduler()
+        let subject = PassthroughSubject<Int, Never>()
+        let subscriber = ManualDemandSubscriber<Int>(returning: .max(1))
+
+        subject
+            .coalesceLatest(for: .milliseconds(50), scheduler: scheduler)
+            .subscribe(subscriber)
+
+        subscriber.request(.max(1))
+        subject.send(1)
+        subject.send(2)
+        subject.send(3)
+        scheduler.advance(by: 0.06)
+        scheduler.runScheduledActions()
+
+        #expect(
+            subscriber.received == [1, 2, 3],
+            "Returned demand must carry replay, leading, and trailing values without another request."
+        )
+    }
+
+    @Test func coalesceLatestSupportsAsyncPublisherDemandBetweenIteratorCalls() async {
+        let scheduler = VirtualCoalesceScheduler()
+        let subject = CurrentValueSubject<Int, Never>(1)
+        let publisher = subject.coalesceLatest(
+            for: .milliseconds(50),
+            scheduler: scheduler
+        )
+        var iterator = publisher.values.makeAsyncIterator()
+
+        let replay = await iterator.next()
+        #expect(replay == 1)
+
+        subject.send(2)
+        subject.send(3)
+        subject.send(completion: .finished)
+
+        let latest = await iterator.next()
+        let end = await iterator.next()
+        #expect(latest == 3)
+        #expect(end == nil)
+    }
+
     @Test func coalesceLatestDropsStalePendingValueWhenLeadingSupersedesOverdueTrailing() {
         let scheduler = VirtualCoalesceScheduler()
         let subject = PassthroughSubject<Int, Never>()
@@ -460,6 +568,85 @@ private final class DemandControlledSubscriber<Input>: Subscriber {
     func cancel() {
         subscription?.cancel()
         subscription = nil
+    }
+}
+
+private final class ManualDemandSubscriber<Input>: Subscriber {
+    typealias Failure = Never
+
+    private let returnedDemand: Subscribers.Demand
+    private var subscription: Subscription?
+    private(set) var received: [Input] = []
+
+    init(returning returnedDemand: Subscribers.Demand = .none) {
+        self.returnedDemand = returnedDemand
+    }
+
+    func receive(subscription: Subscription) {
+        self.subscription = subscription
+    }
+
+    func receive(_ input: Input) -> Subscribers.Demand {
+        received.append(input)
+        return returnedDemand
+    }
+
+    func receive(completion: Subscribers.Completion<Never>) {
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        subscription?.request(demand)
+    }
+}
+
+private final class ReentrantDemandSubscriber: Subscriber {
+    typealias Input = Int
+    typealias Failure = Never
+
+    private let whileReceivingFirstValue: () -> Void
+    private var subscription: Subscription?
+    private var callbackDepth = 0
+    private var handledFirstValue = false
+    private(set) var maximumCallbackDepth = 0
+    private(set) var events: [String] = []
+
+    init(whileReceivingFirstValue: @escaping () -> Void) {
+        self.whileReceivingFirstValue = whileReceivingFirstValue
+    }
+
+    func receive(subscription: Subscription) {
+        self.subscription = subscription
+    }
+
+    func receive(_ input: Int) -> Subscribers.Demand {
+        beginCallback()
+        events.append("value \(input) begin")
+        if !handledFirstValue {
+            handledFirstValue = true
+            whileReceivingFirstValue()
+        }
+        events.append("value \(input) end")
+        endCallback()
+        return input == 1 ? .max(1) : .none
+    }
+
+    func receive(completion: Subscribers.Completion<Never>) {
+        beginCallback()
+        events.append("completion")
+        endCallback()
+    }
+
+    func request(_ demand: Subscribers.Demand) {
+        subscription?.request(demand)
+    }
+
+    private func beginCallback() {
+        callbackDepth += 1
+        maximumCallbackDepth = max(maximumCallbackDepth, callbackDepth)
+    }
+
+    private func endCallback() {
+        callbackDepth -= 1
     }
 }
 // Deterministic Combine scheduler for coalesceLatest tests: `now` only moves


### PR DESCRIPTION
## Summary

- assert viewport resize does not re-enter the sidebar owner during the active layout transaction
- assert lazy row realization preserves the exact parent-owned observation-token topology
- render production immutable row snapshots at 1, 10, 100, and 1,000 workspaces and bound work to the viewport
- cover sidebar snapshot publisher behavior when demand pauses, callbacks re-enter, and `AsyncPublisher.values` consumes values

This changes no release behavior. The only source change is DEBUG probe plumbing that records which workspace rows SwiftUI realizes.

## Verification

- 25 selected sidebar ownership and scale tests passed
- hierarchy tests passed 5 repeated in-process runs, 10 test executions total
- publisher tests passed, 22 of 22
- strict determinism check passed with 0 findings
- sidebar lazy-layout guard, its Python tests, project test wiring, and diff checks passed
- tagged `sblife` app exercised with 55 workspaces, top-to-bottom scrolling, and selection at both ends; no reentrant-layout, fatal, assertion, crash, or exception log entries

## Historical red replay

The two ownership tests were replayed against pre-#8211 sidebar commit `856a18629d8fb5d245aacccdfee37ed4e6d1f514`. No publisher fixes were applied.

- 2 tests executed, 2 failed
- active viewport resize reevaluated `VerticalTabsSidebar.body` 8 times, expected 0
- pure scrolling changed observer identities at all 5 offsets
- the non-vacuity check passed, proving scrolling realized rows beyond the initial viewport

The historical sidebar implementation remained unchanged. Compatibility adjustments only mapped the probe to the old `tab.id` name and exposed an existing test helper.
