### PR TITLE
Enable window dragging from sidebar blank space

### DIFF
--- a/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
+++ b/Sources/VerticalTabsSidebar+EmptyAreasAndFooter.swift
@@ -92,6 +92,15 @@ struct SidebarEmptyArea: View {
                 )
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
+            .overlay {
+                // The rows layer is above this background and keeps ownership
+                // of workspace reordering; this handle only wins in the blank
+                // area that remains below the final row.
+                WindowDragHandleView(
+                    yieldsToSiblingHits: false,
+                    onDoubleClick: createWorkspace
+                )
+            }
             .overlay(alignment: .top) {
                 if topDropIndicatorVisible {
                     Rectangle()
@@ -106,28 +115,6 @@ struct SidebarEmptyArea: View {
     @ViewBuilder
     private var dropTarget: some View {
         let base = hitTarget
-            .onTapGesture(count: 2) {
-                // When the active workspace is a remote-tmux mirror, route through
-                // performNewWorkspaceAction so a new workspace becomes a new tmux
-                // session instead of a local (orphan) workspace. Gate on the
-                // SELECTED tab, not `tabs.contains`: a dedicated remote window can
-                // be polluted with a dragged-in local workspace (move targets don't
-                // exclude dedicated windows), and `contains` would then misroute a
-                // local empty-area double-tap into spawning an unwanted tmux session.
-                if tabManager.selectedTab?.isRemoteTmuxMirror == true {
-                    _ = AppDelegate.shared?.performNewWorkspaceAction(
-                        tabManager: tabManager,
-                        debugSource: "sidebar.emptyArea.remoteTmux"
-                    )
-                } else {
-                    tabManager.addWorkspace(placementOverride: .end)
-                }
-                if let selectedId = tabManager.selectedTabId {
-                    selectedTabIds = [selectedId]
-                    lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
-                }
-                selection = .tabs
-            }
         if let tabDropDelegate {
             base
                 .sidebarEmptyAreaWorkspaceGroupContextMenu(tabManager: tabManager)
@@ -136,6 +123,29 @@ struct SidebarEmptyArea: View {
             base
                 .sidebarEmptyAreaWorkspaceGroupContextMenu(tabManager: tabManager)
         }
+    }
+
+    private func createWorkspace() {
+        // When the active workspace is a remote-tmux mirror, route through
+        // performNewWorkspaceAction so a new workspace becomes a new tmux
+        // session instead of a local (orphan) workspace. Gate on the
+        // SELECTED tab, not `tabs.contains`: a dedicated remote window can
+        // be polluted with a dragged-in local workspace (move targets don't
+        // exclude dedicated windows), and `contains` would then misroute a
+        // local empty-area double-tap into spawning an unwanted tmux session.
+        if tabManager.selectedTab?.isRemoteTmuxMirror == true {
+            _ = AppDelegate.shared?.performNewWorkspaceAction(
+                tabManager: tabManager,
+                debugSource: "sidebar.emptyArea.remoteTmux"
+            )
+        } else {
+            tabManager.addWorkspace(placementOverride: .end)
+        }
+        if let selectedId = tabManager.selectedTabId {
+            selectedTabIds = [selectedId]
+            lastSidebarSelectionIndex = tabManager.tabs.firstIndex { $0.id == selectedId }
+        }
+        selection = .tabs
     }
 
     @ViewBuilder
@@ -187,7 +197,6 @@ struct ExtensionSidebarBrowserStackEmptyArea: View {
         Color.clear
             .contentShape(Rectangle())
             .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .onTapGesture(count: 2, perform: onNewTab)
             .onDrop(of: SidebarTabDragPayload.dropContentTypes, delegate: ExtensionSidebarBrowserStackEndDropDelegate(
                 orderedRows: orderedRows,
                 draggedTabId: $draggedTabId,
@@ -195,6 +204,14 @@ struct ExtensionSidebarBrowserStackEmptyArea: View {
                 dropIndicator: $dropIndicator,
                 onMove: onMove
             ))
+            .overlay {
+                // Browser-stack rows are laid out before this bounded filler,
+                // so their reorder gestures never compete with window movement.
+                WindowDragHandleView(
+                    yieldsToSiblingHits: false,
+                    onDoubleClick: onNewTab
+                )
+            }
             .overlay(alignment: .top) {
                 if shouldShowTopDropIndicator {
                     Rectangle()

--- a/Sources/WindowDragHandleView.swift
+++ b/Sources/WindowDragHandleView.swift
@@ -1095,14 +1095,15 @@ private func windowDragHandleSiblingHitResolutionScope(
     return ObjectIdentifier(superview)
 }
 
-/// Returns whether the titlebar drag handle should capture a hit at `point`.
-/// We only claim the hit when no sibling view already handles it, so interactive
-/// controls layered in the titlebar (e.g. proxy folder icon) keep their gestures.
+/// Returns whether an explicit window drag handle should capture a hit at `point`.
+/// Titlebar handles yield when a sibling already owns the point. A region whose
+/// bounds are already known to be non-interactive can opt out of that sibling walk.
 func windowDragHandleShouldCaptureHit(
     _ point: NSPoint,
     in dragHandleView: NSView,
     eventType: NSEvent.EventType? = NSApp.currentEvent?.type,
-    eventWindow: NSWindow? = NSApp.currentEvent?.window
+    eventWindow: NSWindow? = NSApp.currentEvent?.window,
+    yieldsToSiblingHits: Bool = true
 ) -> Bool {
     let dragHandleWindow = dragHandleView.window
 
@@ -1188,6 +1189,13 @@ func windowDragHandleShouldCaptureHit(
         }
     }
 
+    guard yieldsToSiblingHits else {
+        #if DEBUG
+        cmuxDebugLog("titlebar.dragHandle.hitTest capture=true reason=explicitRegion point=\(windowDragHandleFormatPoint(point))")
+        #endif
+        return true
+    }
+
     guard let superview = dragHandleView.superview else {
         #if DEBUG
         cmuxDebugLog("titlebar.dragHandle.hitTest capture=true reason=noSuperview point=\(windowDragHandleFormatPoint(point))")
@@ -1262,33 +1270,53 @@ func windowDragHandleShouldCaptureHit(
     return true
 }
 
-/// A transparent view that enables dragging the window when clicking in empty titlebar space.
+/// A transparent view that enables dragging the window from an explicitly bounded region.
 /// This lets us keep `window.isMovableByWindowBackground = false` so drags in the app content
 /// (e.g. sidebar tab reordering) don't move the whole window.
 struct WindowDragHandleView: NSViewRepresentable {
     static let viewIdentifier = NSUserInterfaceItemIdentifier("cmux.titlebarDragHandle")
 
     var doubleClickBehavior: TitlebarDoubleClickBehavior = .standardAction
+    var yieldsToSiblingHits = true
+    /// Overrides ``doubleClickBehavior`` when the bounded region owns an existing action.
+    var onDoubleClick: (() -> Void)?
 
     func makeNSView(context: Context) -> NSView {
-        DraggableView(doubleClickBehavior: doubleClickBehavior)
+        DraggableView(
+            doubleClickBehavior: doubleClickBehavior,
+            yieldsToSiblingHits: yieldsToSiblingHits,
+            onDoubleClick: onDoubleClick
+        )
     }
 
     func updateNSView(_ nsView: NSView, context: Context) {
-        (nsView as? DraggableView)?.doubleClickBehavior = doubleClickBehavior
+        guard let draggableView = nsView as? DraggableView else { return }
+        draggableView.doubleClickBehavior = doubleClickBehavior
+        draggableView.yieldsToSiblingHits = yieldsToSiblingHits
+        draggableView.onDoubleClick = onDoubleClick
     }
 
     private final class DraggableView: NSView {
         var doubleClickBehavior: TitlebarDoubleClickBehavior
+        var yieldsToSiblingHits: Bool
+        var onDoubleClick: (() -> Void)?
 
-        init(doubleClickBehavior: TitlebarDoubleClickBehavior) {
+        init(
+            doubleClickBehavior: TitlebarDoubleClickBehavior,
+            yieldsToSiblingHits: Bool,
+            onDoubleClick: (() -> Void)?
+        ) {
             self.doubleClickBehavior = doubleClickBehavior
+            self.yieldsToSiblingHits = yieldsToSiblingHits
+            self.onDoubleClick = onDoubleClick
             super.init(frame: .zero)
             identifier = WindowDragHandleView.viewIdentifier
         }
 
         required init?(coder: NSCoder) {
             self.doubleClickBehavior = .standardAction
+            self.yieldsToSiblingHits = true
+            self.onDoubleClick = nil
             super.init(coder: coder)
             identifier = WindowDragHandleView.viewIdentifier
         }
@@ -1308,7 +1336,8 @@ struct WindowDragHandleView: NSViewRepresentable {
                 point,
                 in: self,
                 eventType: currentEvent?.type,
-                eventWindow: currentEvent?.window
+                eventWindow: currentEvent?.window,
+                yieldsToSiblingHits: yieldsToSiblingHits
             )
             #if DEBUG
             cmuxDebugLog(
@@ -1328,6 +1357,10 @@ struct WindowDragHandleView: NSViewRepresentable {
             #endif
 
             if event.clickCount >= 2 {
+                if let onDoubleClick {
+                    onDoubleClick()
+                    return
+                }
                 let result = handleTitlebarDoubleClick(
                     window: window,
                     behavior: doubleClickBehavior

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -19,6 +19,20 @@ import struct CmuxSettings.AccountCatalogSection
 import struct CmuxSettings.AppCatalogSection
 import struct CmuxSettings.FileRouteSettingsStore
 
+private extension NSView {
+    func firstDescendantOrSelf(matching predicate: (NSView) -> Bool) -> NSView? {
+        if predicate(self) {
+            return self
+        }
+        for subview in subviews {
+            if let match = subview.firstDescendantOrSelf(matching: predicate) {
+                return match
+            }
+        }
+        return nil
+    }
+}
+
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
 #elseif canImport(cmux)
@@ -799,23 +813,6 @@ final class WindowDragHandleHitTests: XCTestCase {
             )
             return nil
         }
-    }
-
-    private static func firstSubview(
-        in view: NSView,
-        matching predicate: (NSView) -> Bool
-    ) -> NSView? {
-        if predicate(view) {
-            return view
-        }
-
-        for subview in view.subviews {
-            if let match = firstSubview(in: subview, matching: predicate) {
-                return match
-            }
-        }
-
-        return nil
     }
 
     private static func firstCapturableTitlebarPoint(
@@ -1906,8 +1903,7 @@ final class WindowDragHandleHitTests: XCTestCase {
         window.displayIfNeeded()
         hostingView.layoutSubtreeIfNeeded()
 
-        guard let dragHandle = Self.firstSubview(
-            in: hostingView,
+        guard let dragHandle = hostingView.firstDescendantOrSelf(
             matching: { $0.identifier == WindowDragHandleView.viewIdentifier }
         ) else {
             XCTFail("Expected right-sidebar mode bar to install a titlebar drag handle")
@@ -1942,6 +1938,85 @@ final class WindowDragHandleHitTests: XCTestCase {
 
         XCTAssertEqual(window.zoomCallCount, 1)
         XCTAssertEqual(window.miniaturizeCallCount, 0)
+    }
+}
+
+@MainActor
+@Suite("Explicit window drag regions")
+struct ExplicitWindowDragRegionTests {
+    @Test func explicitRegionOwnsLeftMouseDownOverItsInteractiveBackground() {
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 220, height: 80))
+        let dragHandle = NSView(frame: container.bounds)
+        container.addSubview(dragHandle)
+
+        let interactiveBackground = NSButton(frame: container.bounds)
+        container.addSubview(interactiveBackground)
+
+        let point = NSPoint(x: 110, y: 40)
+        #expect(
+            !windowDragHandleShouldCaptureHit(
+                point,
+                in: dragHandle,
+                eventType: .leftMouseDown
+            ),
+            "Titlebar drag handles should continue yielding to interactive sibling content."
+        )
+        #expect(
+            windowDragHandleShouldCaptureHit(
+                point,
+                in: dragHandle,
+                eventType: .leftMouseDown,
+                yieldsToSiblingHits: false
+            ),
+            "An explicit blank-area drag region should own left mouse-down even when its SwiftUI background is interactive."
+        )
+    }
+
+    @Test func explicitRegionCanPreserveItsExistingDoubleClickAction() throws {
+        _ = NSApplication.shared
+        var doubleClickCount = 0
+        let rootView = WindowDragHandleView(
+            yieldsToSiblingHits: false,
+            onDoubleClick: { doubleClickCount += 1 }
+        )
+        .frame(width: 220, height: 80)
+
+        let hostingView = NSHostingView(rootView: rootView)
+        hostingView.frame = NSRect(x: 0, y: 0, width: 220, height: 80)
+        let window = NSWindow(
+            contentRect: hostingView.bounds,
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        window.contentView = hostingView
+        window.makeKeyAndOrderFront(nil)
+        window.displayIfNeeded()
+        hostingView.layoutSubtreeIfNeeded()
+
+        let dragHandle = try #require(hostingView.firstDescendantOrSelf(
+            matching: { $0.identifier == WindowDragHandleView.viewIdentifier }
+        ))
+        let pointInWindow = dragHandle.convert(
+            NSPoint(x: dragHandle.bounds.midX, y: dragHandle.bounds.midY),
+            to: nil
+        )
+        let event = try #require(NSEvent.mouseEvent(
+            with: .leftMouseDown,
+            location: pointInWindow,
+            modifierFlags: [],
+            timestamp: ProcessInfo.processInfo.systemUptime,
+            windowNumber: window.windowNumber,
+            context: nil,
+            eventNumber: 1,
+            clickCount: 2,
+            pressure: 1
+        ))
+
+        NSApp.sendEvent(event)
+
+        #expect(doubleClickCount == 1)
     }
 }
 


### PR DESCRIPTION
## Summary

- make the blank area below workspace rows an explicit window drag region
- preserve workspace row drag-and-hold reordering by keeping rows above the drag background
- preserve blank-area double-click workspace creation, context menus, and drop handling
- apply the behavior to default and extension sidebar variants

## Testing

- Swift frontend parsing for the changed source and test files
- added focused Swift Testing coverage for explicit-region hit capture and double-click preservation

## Dogfood checklist

- [ ] dragging a workspace row still reorders it
- [ ] dragging the genuine blank area below the final workspace moves the window
- [ ] right-click and workspace drops still work in the blank area
- [ ] double-clicking the blank area still creates a workspace

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8280"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786820980&installation_id=133855650&pr_number=8280&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8280&signature=7bb287d66318d4b55af5c75a62925d47a0c7def07314a02b242880d3365a5a4d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable dragging the window by clicking and dragging the blank area below the workspace list in both default and extension sidebars. Keeps row reordering, context menus, drops, and double-click to create a workspace unchanged.

- New Features
  - Overlaid `WindowDragHandleView` on the blank sidebar area (default and extension) and routed double-click via onDoubleClick to create a workspace.
  - Extended the drag handle with yieldsToSiblingHits (set to false for this region) so the blank area captures clicks even over interactive backgrounds; added tests for sibling hit capture and double-click override.

<sup>Written for commit d5acdc98d16d66be04671d38f8551a15f92fa411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8280?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



