### PR TITLE
Mirror pane freezes at its old size after split churn

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -105,7 +105,7 @@ extension TerminalSurface {
             area: current.area
         )
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
-        notifyPortalHostVacated(vacatedHostId: hostId)
+        notifyPortalHostVacated(vacatedHostId: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.rearm surface=\(id.uuidString.prefix(5)) " +
@@ -148,8 +148,10 @@ extension TerminalSurface {
     /// vacate mid divider-drag, where a default-mode block waits for mouse-up.
     /// Deferred a turn so no retry mutates the lease inside the dying host's
     /// dismantle.
-    private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier) {
-        portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
+    private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier, instanceSerial: UInt64) {
+        if portalHostVacancyRetries[vacatedHostId]?.instanceSerial == instanceSerial {
+            portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
+        }
         guard !portalHostVacancyRetries.isEmpty else { return }
         let retries = portalHostVacancyRetries.values
             .sorted { $0.instanceSerial > $1.instanceSerial }
@@ -320,7 +322,7 @@ extension TerminalSurface {
               current.instanceSerial == instanceSerial else { return }
         activePortalHostLease = nil
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
-        notifyPortalHostVacated(vacatedHostId: hostId)
+        notifyPortalHostVacated(vacatedHostId: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.release surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -157,18 +157,22 @@ extension TerminalSurface {
             clearPortalHostVacancyRetries()
             return
         }
-        guard !portalHostVacancyRetries.isEmpty else { return }
-        guard !portalHostVacancyWakeScheduled else { return }
-        portalHostVacancyWakeScheduled = true
         let scheduledGeneration = portalLifecycleGeneration
+        guard portalHostVacancyRetries.values.contains(where: { $0.generation == scheduledGeneration }) else { return }
+        guard portalHostVacancyWakeGeneration != scheduledGeneration else { return }
+        portalHostVacancyWakeGeneration = scheduledGeneration
         RunLoop.main.perform(inModes: [.common]) { [weak self] in
             guard let self else { return }
-            self.portalHostVacancyWakeScheduled = false
+            guard self.portalHostVacancyWakeGeneration == scheduledGeneration else { return }
+            self.portalHostVacancyWakeGeneration = nil
             guard self.canAcceptPortalBinding(expectedSurfaceId: self.id, expectedGeneration: scheduledGeneration) else {
-                self.clearPortalHostVacancyRetries()
+                self.portalHostVacancyRetries = self.portalHostVacancyRetries.filter {
+                    $0.value.generation != scheduledGeneration
+                }
                 return
             }
             let retries = self.portalHostVacancyRetries.values
+                .filter { $0.generation == scheduledGeneration }
                 .sorted { $0.instanceSerial > $1.instanceSerial }
                 .map(\.retry)
             for retry in retries { retry() }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -105,6 +105,7 @@ extension TerminalSurface {
             area: current.area
         )
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
+        notifyPortalHostVacated(vacatedHostId: hostId)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.rearm surface=\(id.uuidString.prefix(5)) " +
@@ -139,6 +140,23 @@ extension TerminalSurface {
             "generation=\(authority.ownershipGeneration) serial=\(authority.instanceSerial)"
         )
 #endif
+    }
+
+    /// Wakes every parked candidate now that the owner is gone. One deferred
+    /// block per vacancy, newest host first so a single claim wins and the
+    /// rest are rejected against it; common run-loop modes because owners
+    /// vacate mid divider-drag, where a default-mode block waits for mouse-up.
+    /// Deferred a turn so no retry mutates the lease inside the dying host's
+    /// dismantle.
+    private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier) {
+        portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
+        guard !portalHostVacancyRetries.isEmpty else { return }
+        let retries = portalHostVacancyRetries.values
+            .sorted { $0.instanceSerial > $1.instanceSerial }
+            .map(\.retry)
+        RunLoop.main.perform(inModes: [.common]) {
+            for retry in retries { retry() }
+        }
     }
 
     /// Claims (or re-claims) the portal host for a pane.
@@ -302,6 +320,7 @@ extension TerminalSurface {
               current.instanceSerial == instanceSerial else { return }
         activePortalHostLease = nil
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
+        notifyPortalHostVacated(vacatedHostId: hostId)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.release surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -20,7 +20,7 @@ extension TerminalSurface {
 
     /// Whether a portal may bind this surface for the expected id/generation.
     public func canAcceptPortalBinding(expectedSurfaceId: UUID?, expectedGeneration: UInt64?) -> Bool {
-        guard portalLifecycleState == .live else { return false }
+        guard portalLifecycleState == .live, !runtimeSurfaceSuspendedForAgentHibernation else { return false }
         if let expectedSurfaceId, expectedSurfaceId != id {
             return false
         }
@@ -142,21 +142,35 @@ extension TerminalSurface {
 #endif
     }
 
-    /// Wakes every parked candidate now that the owner is gone. One deferred
-    /// block per vacancy, newest host first so a single claim wins and the
-    /// rest are rejected against it; common run-loop modes because owners
-    /// vacate mid divider-drag, where a default-mode block waits for mouse-up.
-    /// Deferred a turn so no retry mutates the lease inside the dying host's
-    /// dismantle.
+    /// Wakes parked candidates after an owner vacancy. The surface owns the
+    /// wake phase: one scheduled drain observes the latest retry registry for
+    /// one lifecycle generation, newest host first so a single claim wins and
+    /// the rest are rejected against it. Common run-loop modes are used because
+    /// owners vacate mid divider-drag, where a default-mode block waits for
+    /// mouse-up. Deferred a turn so no retry mutates the lease inside the dying
+    /// host's dismantle.
     private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier, instanceSerial: UInt64) {
         if portalHostVacancyRetries[vacatedHostId]?.instanceSerial == instanceSerial {
             portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
         }
+        guard canAcceptPortalBinding(expectedSurfaceId: nil, expectedGeneration: nil) else {
+            clearPortalHostVacancyRetries()
+            return
+        }
         guard !portalHostVacancyRetries.isEmpty else { return }
-        let retries = portalHostVacancyRetries.values
-            .sorted { $0.instanceSerial > $1.instanceSerial }
-            .map(\.retry)
-        RunLoop.main.perform(inModes: [.common]) {
+        guard !portalHostVacancyWakeScheduled else { return }
+        portalHostVacancyWakeScheduled = true
+        let scheduledGeneration = portalLifecycleGeneration
+        RunLoop.main.perform(inModes: [.common]) { [weak self] in
+            guard let self else { return }
+            self.portalHostVacancyWakeScheduled = false
+            guard self.canAcceptPortalBinding(expectedSurfaceId: self.id, expectedGeneration: scheduledGeneration) else {
+                self.clearPortalHostVacancyRetries()
+                return
+            }
+            let retries = self.portalHostVacancyRetries.values
+                .sorted { $0.instanceSerial > $1.instanceSerial }
+                .map(\.retry)
             for retry in retries { retry() }
         }
     }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -162,7 +162,13 @@ extension TerminalSurface {
             area: Self.portalHostArea(for: bounds)
         )
 
-        let alreadyOwnsLease = activePortalHostLease?.hostId == hostId
+        // Owner identity is host AND creation serial: ObjectIdentifier values
+        // are reused after dealloc, and a new incarnation at a recycled address
+        // must not inherit the old owner's standing (or bypass
+        // allowsAuthorityAcquisition through it).
+        let alreadyOwnsLease = activePortalHostLease.map {
+            $0.hostId == hostId && $0.instanceSerial == instanceSerial
+        } ?? false
         guard alreadyOwnsLease || allowsAuthorityAcquisition else {
 #if DEBUG
             logDebugEvent(
@@ -190,7 +196,7 @@ extension TerminalSurface {
 #endif
 
         if let current = activePortalHostLease {
-            if current.hostId == hostId {
+            if current.hostId == hostId, current.instanceSerial == instanceSerial {
                 guard reservePortalHostAuthority(
                     hostId: hostId,
                     paneId: paneId,

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -81,8 +81,18 @@ extension TerminalSurface {
 
     /// Re-arms the lease when SwiftUI is about to rebuild the owning host.
     @discardableResult
-    public func preparePortalHostReplacementIfOwned(hostId: ObjectIdentifier, reason: String) -> Bool {
-        guard let current = activePortalHostLease, current.hostId == hostId else { return false }
+    public func preparePortalHostReplacementIfOwned(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        reason: String
+    ) -> Bool {
+        // The serial authenticates the vacating incarnation: ObjectIdentifier
+        // values are reused after dealloc, so a stale vacate from an earlier
+        // object at the same address must not re-arm the lease or clear a
+        // newer host's authority.
+        guard let current = activePortalHostLease,
+              current.hostId == hostId,
+              current.instanceSerial == instanceSerial else { return false }
         // SwiftUI can tear down and rebuild the host NSView during split churn. Keep the
         // existing portal binding alive, but make the old lease non-usable so the next
         // distinct host in the same pane can claim immediately instead of waiting for a
@@ -94,6 +104,7 @@ extension TerminalSurface {
             inWindow: false,
             area: current.area
         )
+        clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.rearm surface=\(id.uuidString.prefix(5)) " +
@@ -102,6 +113,32 @@ extension TerminalSurface {
         )
 #endif
         return true
+    }
+
+    /// Drops host-authority supremacy when the authority holder itself vacates.
+    ///
+    /// The authority record exists to stop a retired host from stealing the
+    /// surface back from the host that replaced it. Once the replacement host
+    /// is dismantled there is nobody left to protect, but its record would
+    /// still outrank every live host with an older creation serial at the same
+    /// ownership generation — claimPortalHost decides "replace" yet the
+    /// reservation refuses, and the surface stays pinned to a dead host's
+    /// final anchor until an unrelated model-generation bump.
+    ///
+    /// Matched on host AND creation serial: a stale vacate from an earlier
+    /// incarnation of the same host object must not erase a newer record.
+    private func clearPortalHostAuthorityIfHeld(by hostId: ObjectIdentifier, instanceSerial: UInt64) {
+        guard let authority = portalHostAuthority,
+              authority.hostId == hostId,
+              authority.instanceSerial == instanceSerial else { return }
+        portalHostAuthority = nil
+#if DEBUG
+        logDebugEvent(
+            "terminal.portal.host.authorityCleared surface=\(id.uuidString.prefix(5)) " +
+            "host=\(hostId) pane=\(authority.paneId.uuidString.prefix(5)) " +
+            "generation=\(authority.ownershipGeneration) serial=\(authority.instanceSerial)"
+        )
+#endif
     }
 
     /// Claims (or re-claims) the portal host for a pane.
@@ -137,6 +174,21 @@ extension TerminalSurface {
             return false
         }
 
+#if DEBUG
+        func logAuthorityRefusal() {
+            logDebugEvent(
+                "terminal.portal.host.skip surface=\(id.uuidString.prefix(5)) " +
+                "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+                "cause=authorityRefused authorityHost=\(portalHostAuthority.map { String(describing: $0.hostId) } ?? "nil") " +
+                "authorityGeneration=\(portalHostAuthority?.ownershipGeneration ?? 0) " +
+                "authoritySerial=\(portalHostAuthority?.instanceSerial ?? 0) " +
+                "claimGeneration=\(ownershipGeneration) claimSerial=\(instanceSerial)"
+            )
+        }
+#else
+        func logAuthorityRefusal() {}
+#endif
+
         if let current = activePortalHostLease {
             if current.hostId == hostId {
                 guard reservePortalHostAuthority(
@@ -144,7 +196,10 @@ extension TerminalSurface {
                     paneId: paneId,
                     instanceSerial: instanceSerial,
                     ownershipGeneration: ownershipGeneration
-                ) else { return false }
+                ) else {
+                    logAuthorityRefusal()
+                    return false
+                }
                 activePortalHostLease = next
                 return true
             }
@@ -176,7 +231,10 @@ extension TerminalSurface {
                     paneId: paneId,
                     instanceSerial: instanceSerial,
                     ownershipGeneration: ownershipGeneration
-                ) else { return false }
+                ) else {
+                    logAuthorityRefusal()
+                    return false
+                }
 #if DEBUG
                 logDebugEvent(
                     "terminal.portal.host.claim surface=\(id.uuidString.prefix(5)) " +
@@ -211,7 +269,10 @@ extension TerminalSurface {
             paneId: paneId,
             instanceSerial: instanceSerial,
             ownershipGeneration: ownershipGeneration
-        ) else { return false }
+        ) else {
+            logAuthorityRefusal()
+            return false
+        }
         activePortalHostLease = next
 #if DEBUG
         logDebugEvent(
@@ -225,9 +286,16 @@ extension TerminalSurface {
     }
 
     /// Releases the lease when the owning host disappears.
-    public func releasePortalHostIfOwned(hostId: ObjectIdentifier, reason: String) {
-        guard let current = activePortalHostLease, current.hostId == hostId else { return }
+    public func releasePortalHostIfOwned(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        reason: String
+    ) {
+        guard let current = activePortalHostLease,
+              current.hostId == hostId,
+              current.instanceSerial == instanceSerial else { return }
         activePortalHostLease = nil
+        clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.release surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -198,6 +198,9 @@ extension TerminalSurface {
         guard portalLifecycleState != .closing else { return }
         recordTeardownRequest(reason: reason)
         portalLifecycleState = .closing
+        // Parked wake-ups are for re-anchoring live content; a closing surface
+        // has none, and the park guard refuses new entries from here on.
+        portalHostVacancyRetries.removeAll()
         portalLifecycleGeneration &+= 1
 #if DEBUG
         logDebugEvent(
@@ -212,6 +215,7 @@ extension TerminalSurface {
         guard portalLifecycleState != .closed else { return }
         portalLifecycleState = .closed
         portalLifecycleGeneration &+= 1
+        portalHostVacancyRetries.removeAll()
 #if DEBUG
         logDebugEvent(
             "surface.lifecycle.close.sealed surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -200,7 +200,7 @@ extension TerminalSurface {
         portalLifecycleState = .closing
         // Parked wake-ups are for re-anchoring live content; a closing surface
         // has none, and the park guard refuses new entries from here on.
-        portalHostVacancyRetries.removeAll()
+        clearPortalHostVacancyRetries()
         portalLifecycleGeneration &+= 1
 #if DEBUG
         logDebugEvent(
@@ -215,7 +215,7 @@ extension TerminalSurface {
         guard portalLifecycleState != .closed else { return }
         portalLifecycleState = .closed
         portalLifecycleGeneration &+= 1
-        portalHostVacancyRetries.removeAll()
+        clearPortalHostVacancyRetries()
 #if DEBUG
         logDebugEvent(
             "surface.lifecycle.close.sealed surface=\(id.uuidString.prefix(5)) " +
@@ -319,6 +319,8 @@ extension TerminalSurface {
         surface = nil
         activePortalHostLease = nil
         portalHostAuthority = nil
+        clearPortalHostVacancyRetries()
+        portalLifecycleGeneration &+= 1
         pendingSocketInputQueue.removeAll(keepingCapacity: false)
         pendingSocketInputBytes = 0
         desiredFocusState = false

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -319,9 +319,16 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// no view state and no strong reference back to itself, so a dead
     /// coordinator turns its entry into a no-op and no retain cycle exists.
     /// Entries drop when their own host vacates the lease, when the host
-    /// dismantles, and when the portal lifecycle leaves `.live`; parking is
-    /// refused from `.closing` onward.
+    /// dismantles, when the runtime is hibernated, and when the portal
+    /// lifecycle leaves `.live`; parking is refused outside bindable runtime
+    /// states.
     var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, retry: () -> Void)] = [:]
+    var portalHostVacancyWakeScheduled = false
+
+    func clearPortalHostVacancyRetries() {
+        portalHostVacancyRetries.removeAll()
+        portalHostVacancyWakeScheduled = false
+    }
 
     /// Parks (or refreshes) a host's vacancy retry. See
     /// `portalHostVacancyRetries` for lifetime rules.
@@ -330,7 +337,7 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         instanceSerial: UInt64,
         _ retry: @escaping () -> Void
     ) {
-        guard portalLifecycleState == .live else { return }
+        guard canAcceptPortalBinding(expectedSurfaceId: nil, expectedGeneration: nil) else { return }
         portalHostVacancyRetries[hostId] = (instanceSerial, retry)
     }
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -309,6 +309,36 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     var portalLifecycleGeneration: UInt64 = 1
     var activePortalHostLease: PortalHostLease?
     var portalHostAuthority: TerminalPortalHostAuthority?
+    /// Wake-up retries for the owner-death edge, one per live candidate host.
+    ///
+    /// Every claim runs on a candidate's own edge (its SwiftUI update, window
+    /// entry, geometry change); the lease owner dying fires no edge on any
+    /// survivor, so a pane whose owner dismantled can wait a full settle
+    /// budget for an unrelated update before it re-anchors. The values are
+    /// weak trampolines into each candidate's coordinator — the surface holds
+    /// no view state and no strong reference back to itself, so a dead
+    /// coordinator turns its entry into a no-op and no retain cycle exists.
+    /// Entries drop when their own host vacates the lease, when the host
+    /// dismantles, and when the portal lifecycle leaves `.live`; parking is
+    /// refused from `.closing` onward.
+    var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, retry: () -> Void)] = [:]
+
+    /// Parks (or refreshes) a host's vacancy retry. See
+    /// `portalHostVacancyRetries` for lifetime rules.
+    public func parkPortalVacancyRetry(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        _ retry: @escaping () -> Void
+    ) {
+        guard portalLifecycleState == .live else { return }
+        portalHostVacancyRetries[hostId] = (instanceSerial, retry)
+    }
+
+    /// Drops a host's vacancy retry (dismantle, or the host stopped owning
+    /// its pane; the owner's own vacate paths drop theirs).
+    public func removePortalVacancyRetry(hostId: ObjectIdentifier) {
+        portalHostVacancyRetries.removeValue(forKey: hostId)
+    }
 
     /// The live find session, or nil when find is closed. Setting it arms the
     /// debounced needle pipeline; clearing it ends the runtime search.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -322,12 +322,15 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// dismantles, when the runtime is hibernated, and when the portal
     /// lifecycle leaves `.live`; parking is refused outside bindable runtime
     /// states.
-    var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, retry: () -> Void)] = [:]
-    var portalHostVacancyWakeScheduled = false
+    var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, generation: UInt64, retry: () -> Void)] = [:]
+    var portalHostVacancyWakeGeneration: UInt64?
+    var portalHostVacancyWakeScheduled: Bool {
+        portalHostVacancyWakeGeneration != nil
+    }
 
     func clearPortalHostVacancyRetries() {
         portalHostVacancyRetries.removeAll()
-        portalHostVacancyWakeScheduled = false
+        portalHostVacancyWakeGeneration = nil
     }
 
     /// Parks (or refreshes) a host's vacancy retry. See
@@ -338,7 +341,9 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         _ retry: @escaping () -> Void
     ) {
         guard canAcceptPortalBinding(expectedSurfaceId: nil, expectedGeneration: nil) else { return }
-        portalHostVacancyRetries[hostId] = (instanceSerial, retry)
+        let generation = portalLifecycleGeneration
+        portalHostVacancyRetries = portalHostVacancyRetries.filter { $0.value.generation == generation }
+        portalHostVacancyRetries[hostId] = (instanceSerial, generation, retry)
     }
 
     /// Drops a host's vacancy retry (dismantle, or the host stopped owning

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -335,8 +335,11 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     /// Drops a host's vacancy retry (dismantle, or the host stopped owning
-    /// its pane; the owner's own vacate paths drop theirs).
-    public func removePortalVacancyRetry(hostId: ObjectIdentifier) {
+    /// its pane; the owner's own vacate paths drop theirs). Serial-matched
+    /// like every other identity check here: a recycled object address must
+    /// not remove a newer incarnation's park.
+    public func removePortalVacancyRetry(hostId: ObjectIdentifier, instanceSerial: UInt64) {
+        guard portalHostVacancyRetries[hostId]?.instanceSerial == instanceSerial else { return }
         portalHostVacancyRetries.removeValue(forKey: hostId)
     }
 

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
@@ -8,6 +8,51 @@ import Testing
 
 @MainActor
 @Suite struct TerminalSurfacePortalHostVacancyTests {
+    @Test func vacatedNewerSameGenerationAuthorityDoesNotPinOlderCandidate() {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let ownershipGeneration = surface.currentPortalHostOwnershipGeneration()
+        let olderHost = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let newerHost = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(olderHost),
+            paneId: paneId,
+            instanceSerial: 1,
+            ownershipGeneration: ownershipGeneration,
+            inWindow: true,
+            bounds: olderHost.bounds,
+            reason: "test.olderInitialClaim"
+        ))
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(newerHost),
+            paneId: paneId,
+            instanceSerial: 2,
+            ownershipGeneration: ownershipGeneration,
+            inWindow: true,
+            bounds: newerHost.bounds,
+            reason: "test.newerSameGenerationClaim"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(newerHost),
+            instanceSerial: 2,
+            reason: "test.newerVacated"
+        )
+
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(olderHost),
+            paneId: paneId,
+            instanceSerial: 1,
+            ownershipGeneration: ownershipGeneration,
+            inWindow: true,
+            bounds: olderHost.bounds,
+            reason: "test.olderRetryAfterNewerVacated"
+        ))
+    }
+
     @Test func repeatedOwnerVacanciesCoalesceIntoOneLatestRetryDrain() async {
         let surface = makeSurface()
         defer { surface.releaseSurfaceForTesting() }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
@@ -114,6 +114,65 @@ import Testing
         #expect(retryCount == 0)
     }
 
+    @Test func staleGenerationDrainDoesNotEraseFreshVacancyRetry() async {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let oldOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let freshOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let oldCandidate = NSView()
+        let freshCandidate = NSView()
+        var retries: [Int] = []
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(oldCandidate),
+            instanceSerial: 2
+        ) {
+            retries.append(2)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(oldOwner),
+            paneId: paneId,
+            instanceSerial: 1,
+            inWindow: true,
+            bounds: oldOwner.bounds,
+            reason: "test.oldOwner"
+        ))
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(oldOwner),
+            instanceSerial: 1,
+            reason: "test.oldVacancy"
+        )
+        #expect(surface.portalHostVacancyWakeScheduled)
+
+        surface.updateWorkspaceId(UUID())
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(freshCandidate),
+            instanceSerial: 4
+        ) {
+            retries.append(4)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(freshOwner),
+            paneId: paneId,
+            instanceSerial: 3,
+            inWindow: true,
+            bounds: freshOwner.bounds,
+            reason: "test.freshOwner"
+        ))
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(freshOwner),
+            instanceSerial: 3,
+            reason: "test.freshVacancy"
+        )
+
+        drainMainRunLoop()
+
+        #expect(retries == [4])
+        #expect(!surface.portalHostVacancyWakeScheduled)
+    }
+
     private func drainMainRunLoop() {
         RunLoop.main.run(until: Date().addingTimeInterval(0.02))
     }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
@@ -1,0 +1,149 @@
+import AppKit
+import Bonsplit
+import CmuxTerminalCore
+import Foundation
+import GhosttyKit
+import Testing
+@testable import CmuxTerminal
+
+@MainActor
+@Suite struct TerminalSurfacePortalHostVacancyTests {
+    @Test func repeatedOwnerVacanciesCoalesceIntoOneLatestRetryDrain() async {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let firstOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let secondOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let olderCandidate = NSView()
+        let newerCandidate = NSView()
+        var retries: [Int] = []
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(olderCandidate),
+            instanceSerial: 2
+        ) {
+            retries.append(2)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(firstOwner),
+            paneId: paneId,
+            instanceSerial: 1,
+            inWindow: true,
+            bounds: firstOwner.bounds,
+            reason: "test.firstOwner"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(firstOwner),
+            instanceSerial: 1,
+            reason: "test.firstVacancy"
+        )
+        #expect(surface.portalHostVacancyWakeScheduled)
+        #expect(retries.isEmpty)
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(newerCandidate),
+            instanceSerial: 4
+        ) {
+            retries.append(4)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(secondOwner),
+            paneId: paneId,
+            instanceSerial: 3,
+            inWindow: true,
+            bounds: secondOwner.bounds,
+            reason: "test.secondOwner"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(secondOwner),
+            instanceSerial: 3,
+            reason: "test.secondVacancy"
+        )
+
+        drainMainRunLoop()
+
+        #expect(retries == [4, 2])
+        #expect(!surface.portalHostVacancyWakeScheduled)
+    }
+
+    @Test func hibernationInvalidatesQueuedVacancyRetriesBeforeRunLoopDrain() async {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let owner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let candidate = NSView()
+        let generationBeforeHibernation = surface.portalBindingGeneration()
+        var retryCount = 0
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(candidate),
+            instanceSerial: 2
+        ) {
+            retryCount += 1
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(owner),
+            paneId: paneId,
+            instanceSerial: 1,
+            inWindow: true,
+            bounds: owner.bounds,
+            reason: "test.owner"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(owner),
+            instanceSerial: 1,
+            reason: "test.vacancy"
+        )
+        #expect(surface.portalHostVacancyWakeScheduled)
+
+        surface.suspendRuntimeSurfaceForAgentHibernation(reason: "test.hibernate")
+        #expect(surface.portalHostVacancyRetries.isEmpty)
+        #expect(!surface.portalHostVacancyWakeScheduled)
+        #expect(!surface.canAcceptPortalBinding(
+            expectedSurfaceId: surface.id,
+            expectedGeneration: generationBeforeHibernation
+        ))
+
+        drainMainRunLoop()
+
+        #expect(retryCount == 0)
+    }
+
+    private func drainMainRunLoop() {
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+    }
+
+    private func makeSurface() -> TerminalSurface {
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
+        return TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            dependencies: TerminalSurfaceRuntimeDependencies(
+                registry: FakeSurfaceRegistry(),
+                engine: FakeTerminalEngine(),
+                viewProvider: FakeTerminalSurfaceViewProvider(surfaceView: nativeView, paneHost: paneHost),
+                spawnPolicy: FakeSpawnPolicyProvider(),
+                byteTee: FakeTerminalByteTee(),
+                rendererRealization: FakeRendererRealizationScheduler(),
+                hibernationRecorder: FakeHibernationRecorder(),
+                runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
+                restoreSpawnScheduler: TerminalSurfaceRestoreSpawnScheduler(interSpawnDelay: .zero),
+                runtimeFilesystem: TerminalSurfaceRuntimeFilesystem(
+                    claudeCommandShimTemporaryDirectory: URL(fileURLWithPath: "/tmp/cmux-terminal-tests", isDirectory: true),
+                    installClaudeCommandShim: { _, _, _ in nil },
+                    isExecutableFile: { _ in false }
+                ),
+                sessionPortBase: 40_000,
+                sessionPortRangeSize: 100,
+                scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"
+            )
+        )
+    }
+}

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -474,10 +474,21 @@ extension TerminalController {
                         if abs(plannedContent.width - actual.width) > 1.5
                             || abs(plannedContent.height - actual.height) > 1.5 {
                             nativeGeometryReady = false
+                            // The portal positions this view from whichever pane HOST
+                            // holds the surface's lease; a view at the wrong size with a
+                            // correct plan usually means the lease is held by the wrong
+                            // pane. Name both sides so the mismatch says which.
+                            let lease = mirror.panelsByPaneId[leaf]?.surface.debugPortalHostLease()
+                            let leasePane = lease?.paneId.map { String($0.uuidString.prefix(5)) } ?? "none"
+                            let expectedPane = mirror.paneIdByPaneId[leaf].map {
+                                String($0.id.uuidString.prefix(5))
+                            } ?? "none"
                             mismatches.append(
                                 "%\(leaf) native-geometry"
                                     + " plan=\(Int(plannedContent.width))x\(Int(plannedContent.height))"
                                     + " view=\(Int(actual.width))x\(Int(actual.height))"
+                                    + " lease_pane=\(leasePane) expected_pane=\(expectedPane)"
+                                    + " lease_inWin=\(lease?.inWindow == true ? 1 : 0)"
                             )
                         }
                     } else {

--- a/Sources/GhosttyTerminalImmediateHostedStateAction.swift
+++ b/Sources/GhosttyTerminalImmediateHostedStateAction.swift
@@ -1,0 +1,16 @@
+/// What a `GhosttyTerminalView` update may do to the hosted view's immediate
+/// visible/active state.
+enum GhosttyTerminalImmediateHostedStateAction: Equatable {
+    /// The owner with a live binding applies both flags.
+    case applyVisibleAndActive
+
+    /// A bound host that lost the lease may still un-show its own surface and
+    /// nothing more. Active/focus state stays ownership-gated. An owner's hide
+    /// is allowed whether or not it is currently bound: the lease is
+    /// authoritative for the surface's state, and that was the apply rule
+    /// before this enum existed.
+    case hideOnly
+
+    /// A non-owner that is not bound must not touch the hosted view.
+    case deferred
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12477,6 +12477,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 )
                 coordinator.lastBoundHostId = ObjectIdentifier(host)
                 coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+                hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
+                hostedView.setActive(coordinator.desiredIsActive)
                 // The dying owner's dismantle cleared the shared hosted view's
                 // handlers, and this survivor skipped its own configuration
                 // when it lost the earlier claim. Restore the owner-owned

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12197,21 +12197,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
         return !hostedViewHasSuperview
     }
 
-    /// What an update may do to the hosted view's immediate visible/active
-    /// state.
-    enum ImmediateHostedStateAction: Equatable {
-        /// The owner with a live binding applies both flags.
-        case applyVisibleAndActive
-        /// A bound host that lost the lease may still un-show its own
-        /// surface — and nothing more. Active/focus state stays
-        /// ownership-gated. (An OWNER's hide is allowed whether or not it is
-        /// currently bound — the lease is authoritative for the surface's
-        /// state, and that has been the apply rule since before this enum.)
-        case hideOnly
-        /// A non-owner that is not bound must not touch the hosted view.
-        case deferred
-    }
-
     /// The complete immediate visible/active apply decision.
     ///
     /// Hiding never needs lease ownership or a live binding generation.
@@ -12227,7 +12212,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         desiredVisibleInUI: Bool,
         hostedViewHasSuperview: Bool,
         isBoundToCurrentHost: Bool
-    ) -> ImmediateHostedStateAction {
+    ) -> GhosttyTerminalImmediateHostedStateAction {
         if portalBindingLive, hostOwnsPortal, shouldApplyImmediateHostedStateUpdate(
             desiredVisibleInUI: desiredVisibleInUI,
             hostedViewHasSuperview: hostedViewHasSuperview,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12642,6 +12642,10 @@ struct GhosttyTerminalView: NSViewRepresentable {
             hostedView.setVisibleInUI(isVisibleInUI)
             hostedView.setActive(isActive)
         case .hideOnly:
+            TerminalWindowPortalRegistry.updateEntryVisibility(
+                for: hostedView,
+                visibleInUI: false
+            )
             hostedView.setVisibleInUI(false)
         case .deferred:
             // Preserve portal entry visibility while a stale host is still receiving SwiftUI updates.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12430,13 +12430,16 @@ struct GhosttyTerminalView: NSViewRepresentable {
             // can re-anchor on-screen content but can never reveal a hidden
             // tab (bind is a show path — a hidden survivor waits for its own
             // update instead).
-            coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator] in
-                guard let host, let hostedView, let coordinator else { return }
+            coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator, weak terminalSurface] in
+                guard let host, let hostedView, let coordinator, let terminalSurface else { return }
                 guard coordinator.attachGeneration == generation else { return }
                 guard isCurrentPaneOwner() else { return }
                 guard coordinator.desiredIsVisibleInUI else { return }
                 guard host.window != nil else { return }
-                guard portalBindingStillLive() else { return }
+                guard terminalSurface.canAcceptPortalBinding(
+                    expectedSurfaceId: portalExpectedSurfaceId,
+                    expectedGeneration: portalExpectedGeneration
+                ) else { return }
                 guard terminalSurface.claimPortalHost(
                     hostId: ObjectIdentifier(host),
                     paneId: paneId,
@@ -12463,7 +12466,10 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 // when it lost the earlier claim. Restore the owner-owned
                 // non-visibility state; visible/active stay with updates.
                 hostedView.setSessionContentWidthPresentation(sessionContentWidthPresentation)
-                hostedView.setFocusHandler { onFocus?(terminalSurface.id) }
+                hostedView.setFocusHandler { [weak terminalSurface] in
+                    guard let terminalSurface else { return }
+                    onFocus?(terminalSurface.id)
+                }
                 hostedView.setTriggerFlashHandler(onTriggerFlash)
                 hostedView.setPaneDropContext(TerminalPaneDropContext(
                     workspaceId: terminalSurface.tabId,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12482,6 +12482,16 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
             if ownsCurrentPane, isVisibleInUI {
+                // If an earlier update parked this host on a different surface,
+                // unregister there first: the stale trampoline would fire THIS
+                // coordinator's current retry, so a vacancy on the old surface
+                // could drive a claim against the new one.
+                if let previous = coordinator.vacancyParkedSurface, previous !== terminalSurface {
+                    previous.removePortalVacancyRetry(
+                        hostId: ObjectIdentifier(host),
+                        instanceSerial: host.instanceSerial
+                    )
+                }
                 coordinator.vacancyParkedSurface = terminalSurface
                 terminalSurface.parkPortalVacancyRetry(
                     hostId: ObjectIdentifier(host),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12488,7 +12488,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 }
             } else {
                 coordinator.vacancyRetry = nil
-                coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+                coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host), instanceSerial: host.instanceSerial)
                 coordinator.vacancyParkedSurface = nil
             }
             host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
@@ -12667,7 +12667,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
             // never owned has no vacate path, so drop it here — through the
             // coordinator's reference, since hostedView can already be gone.
             coordinator.vacancyRetry = nil
-            coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+            coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host), instanceSerial: host.instanceSerial)
             coordinator.vacancyParkedSurface = nil
             hostedView?.prepareOwnedPortalHostForTransientReattach(
                 hostId: ObjectIdentifier(host),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12204,7 +12204,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
         case applyVisibleAndActive
         /// A bound host that lost the lease may still un-show its own
         /// surface — and nothing more. Active/focus state stays
-        /// ownership-gated.
+        /// ownership-gated. (An OWNER's hide is allowed whether or not it is
+        /// currently bound — the lease is authoritative for the surface's
+        /// state, and that has been the apply rule since before this enum.)
         case hideOnly
         /// A non-owner that is not bound must not touch the hosted view.
         case deferred
@@ -12476,6 +12478,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 hostedView.setNotificationRing(visible: showsUnreadNotificationRing)
                 hostedView.setSearchOverlay(searchState: searchState)
                 hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
+                hostedView.setDropZoneOverlay(zone: forwardedDropZone)
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
             if ownsCurrentPane, isVisibleInUI {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12430,10 +12430,26 @@ struct GhosttyTerminalView: NSViewRepresentable {
             // can re-anchor on-screen content but can never reveal a hidden
             // tab (bind is a show path — a hidden survivor waits for its own
             // update instead).
+            // Snapshot every representable member the stored retry needs.
+            // `parkPortalVacancyRetry` stores a closure on TerminalSurface, so
+            // the retry body must not implicitly retain `self`, which would
+            // retain the same TerminalSurface and form a teardown cycle.
+            let vacancyIsCurrentPaneOwner = isCurrentPaneOwner
+            let vacancyPaneId = paneId
+            let vacancyOwnershipGeneration = ownershipGeneration
+            let vacancySessionContentWidthPresentation = sessionContentWidthPresentation
+            let vacancyOnFocus = onFocus
+            let vacancyOnTriggerFlash = onTriggerFlash
+            let vacancyInactiveOverlayColor = inactiveOverlayColor
+            let vacancyInactiveOverlayOpacity = inactiveOverlayOpacity
+            let vacancyShowsInactiveOverlay = showsInactiveOverlay
+            let vacancyShowsUnreadNotificationRing = showsUnreadNotificationRing
+            let vacancySearchState = searchState
+            let vacancyDropZone = forwardedDropZone
             coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator, weak terminalSurface] in
                 guard let host, let hostedView, let coordinator, let terminalSurface else { return }
                 guard coordinator.attachGeneration == generation else { return }
-                guard isCurrentPaneOwner() else { return }
+                guard vacancyIsCurrentPaneOwner() else { return }
                 guard coordinator.desiredIsVisibleInUI else { return }
                 guard host.window != nil else { return }
                 guard terminalSurface.canAcceptPortalBinding(
@@ -12442,9 +12458,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 ) else { return }
                 guard terminalSurface.claimPortalHost(
                     hostId: ObjectIdentifier(host),
-                    paneId: paneId,
+                    paneId: vacancyPaneId,
                     instanceSerial: host.instanceSerial,
-                    ownershipGeneration: ownershipGeneration,
+                    ownershipGeneration: vacancyOwnershipGeneration,
                     inWindow: true,
                     bounds: host.bounds,
                     allowsAuthorityAcquisition: true,
@@ -12465,26 +12481,26 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 // handlers, and this survivor skipped its own configuration
                 // when it lost the earlier claim. Restore the owner-owned
                 // non-visibility state; visible/active stay with updates.
-                hostedView.setSessionContentWidthPresentation(sessionContentWidthPresentation)
+                hostedView.setSessionContentWidthPresentation(vacancySessionContentWidthPresentation)
                 hostedView.setFocusHandler { [weak terminalSurface] in
                     guard let terminalSurface else { return }
-                    onFocus?(terminalSurface.id)
+                    vacancyOnFocus?(terminalSurface.id)
                 }
-                hostedView.setTriggerFlashHandler(onTriggerFlash)
+                hostedView.setTriggerFlashHandler(vacancyOnTriggerFlash)
                 hostedView.setPaneDropContext(TerminalPaneDropContext(
                     workspaceId: terminalSurface.tabId,
                     panelId: terminalSurface.id,
-                    paneId: paneId
+                    paneId: vacancyPaneId
                 ))
                 hostedView.setInactiveOverlay(
-                    color: inactiveOverlayColor,
-                    opacity: CGFloat(inactiveOverlayOpacity),
-                    visible: showsInactiveOverlay
+                    color: vacancyInactiveOverlayColor,
+                    opacity: CGFloat(vacancyInactiveOverlayOpacity),
+                    visible: vacancyShowsInactiveOverlay
                 )
-                hostedView.setNotificationRing(visible: showsUnreadNotificationRing)
-                hostedView.setSearchOverlay(searchState: searchState)
+                hostedView.setNotificationRing(visible: vacancyShowsUnreadNotificationRing)
+                hostedView.setSearchOverlay(searchState: vacancySearchState)
                 hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
-                hostedView.setDropZoneOverlay(zone: forwardedDropZone)
+                hostedView.setDropZoneOverlay(zone: vacancyDropZone)
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
             if ownsCurrentPane, isVisibleInUI {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12175,6 +12175,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
         var lastPaneDropZone: DropZone?
         var lastSynchronizedHostGeometryRevision: UInt64 = 0
         weak var hostedView: GhosttySurfaceScrollView?
+        /// The owner-death wake-up. The surface's vacancy registry holds only
+        /// a weak trampoline into this coordinator, so the real retry (and
+        /// everything it captures) dies with the representable.
+        var vacancyRetry: (() -> Void)?
+        /// The surface this representable last parked a wake-up on; dismantle
+        /// removes the park through this because `hostedView` is weak and can
+        /// already be gone by then.
+        weak var vacancyParkedSurface: TerminalSurface?
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -12411,6 +12419,78 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
+            // The owner-death wake. Every claim above runs on this host's own
+            // edges; the lease owner dying fires none of them, and a pane whose
+            // owner dismantled can otherwise wait a full settle budget for an
+            // unrelated SwiftUI update before it re-anchors. Parked only while
+            // this host owns its pane AND its content is presented; the wake
+            // re-checks both live and never writes visible/active state, so it
+            // can re-anchor on-screen content but can never reveal a hidden
+            // tab (bind is a show path — a hidden survivor waits for its own
+            // update instead).
+            coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator] in
+                guard let host, let hostedView, let coordinator else { return }
+                guard coordinator.attachGeneration == generation else { return }
+                guard isCurrentPaneOwner() else { return }
+                guard hostedView.isVisibleInUI, coordinator.desiredIsVisibleInUI else { return }
+                guard host.window != nil else { return }
+                guard portalBindingStillLive() else { return }
+                guard terminalSurface.claimPortalHost(
+                    hostId: ObjectIdentifier(host),
+                    paneId: paneId,
+                    instanceSerial: host.instanceSerial,
+                    ownershipGeneration: ownershipGeneration,
+                    inWindow: true,
+                    bounds: host.bounds,
+                    allowsAuthorityAcquisition: true,
+                    reason: "hostVacated"
+                ) else { return }
+                TerminalWindowPortalRegistry.bind(
+                    hostedView: hostedView,
+                    to: host,
+                    visibleInUI: coordinator.desiredIsVisibleInUI,
+                    zPriority: coordinator.desiredPortalZPriority,
+                    expectedSurfaceId: portalExpectedSurfaceId,
+                    expectedGeneration: portalExpectedGeneration,
+                    deferLayoutSynchronization: true
+                )
+                coordinator.lastBoundHostId = ObjectIdentifier(host)
+                coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+                // The dying owner's dismantle cleared the shared hosted view's
+                // handlers, and this survivor skipped its own configuration
+                // when it lost the earlier claim. Restore the owner-owned
+                // non-visibility state; visible/active stay with updates.
+                hostedView.setSessionContentWidthPresentation(sessionContentWidthPresentation)
+                hostedView.setFocusHandler { onFocus?(terminalSurface.id) }
+                hostedView.setTriggerFlashHandler(onTriggerFlash)
+                hostedView.setPaneDropContext(TerminalPaneDropContext(
+                    workspaceId: terminalSurface.tabId,
+                    panelId: terminalSurface.id,
+                    paneId: paneId
+                ))
+                hostedView.setInactiveOverlay(
+                    color: inactiveOverlayColor,
+                    opacity: CGFloat(inactiveOverlayOpacity),
+                    visible: showsInactiveOverlay
+                )
+                hostedView.setNotificationRing(visible: showsUnreadNotificationRing)
+                hostedView.setSearchOverlay(searchState: searchState)
+                hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
+                terminalSurface.flushPendingManualSizeReportIfAttached()
+            }
+            if ownsCurrentPane, isVisibleInUI {
+                coordinator.vacancyParkedSurface = terminalSurface
+                terminalSurface.parkPortalVacancyRetry(
+                    hostId: ObjectIdentifier(host),
+                    instanceSerial: host.instanceSerial
+                ) { [weak coordinator] in
+                    coordinator?.vacancyRetry?()
+                }
+            } else {
+                coordinator.vacancyRetry = nil
+                coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+                coordinator.vacancyParkedSurface = nil
+            }
             host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
                 guard let host, let hostedView, let coordinator else { return }
                 guard coordinator.attachGeneration == generation else { return }
@@ -12583,6 +12663,12 @@ struct GhosttyTerminalView: NSViewRepresentable {
         if let host = nsView as? HostContainerView {
             host.onDidMoveToWindow = nil
             host.onGeometryChanged = nil
+            // The owner's vacate path drops its own wake-up; a candidate that
+            // never owned has no vacate path, so drop it here — through the
+            // coordinator's reference, since hostedView can already be gone.
+            coordinator.vacancyRetry = nil
+            coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+            coordinator.vacancyParkedSurface = nil
             hostedView?.prepareOwnedPortalHostForTransientReattach(
                 hostId: ObjectIdentifier(host),
                 instanceSerial: host.instanceSerial,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12434,7 +12434,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 guard let host, let hostedView, let coordinator else { return }
                 guard coordinator.attachGeneration == generation else { return }
                 guard isCurrentPaneOwner() else { return }
-                guard hostedView.isVisibleInUI, coordinator.desiredIsVisibleInUI else { return }
+                guard coordinator.desiredIsVisibleInUI else { return }
                 guard host.window != nil else { return }
                 guard portalBindingStillLive() else { return }
                 guard terminalSurface.claimPortalHost(
@@ -12493,11 +12493,18 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     )
                 }
                 coordinator.vacancyParkedSurface = terminalSurface
+                let parkedAttachGeneration = generation
+                let parkedRetry = coordinator.vacancyRetry
                 terminalSurface.parkPortalVacancyRetry(
                     hostId: ObjectIdentifier(host),
                     instanceSerial: host.instanceSerial
-                ) { [weak coordinator] in
-                    coordinator?.vacancyRetry?()
+                ) { [weak coordinator, weak terminalSurface] in
+                    guard let coordinator,
+                          let terminalSurface,
+                          coordinator.attachGeneration == parkedAttachGeneration,
+                          coordinator.vacancyParkedSurface === terminalSurface,
+                          let parkedRetry else { return }
+                    parkedRetry()
                 }
             } else {
                 coordinator.vacancyRetry = nil

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8374,16 +8374,22 @@ final class GhosttySurfaceScrollView: NSView {
         )
     }
 
-    func releaseOwnedPortalHost(hostId: ObjectIdentifier, reason: String) {
+    func releaseOwnedPortalHost(hostId: ObjectIdentifier, instanceSerial: UInt64, reason: String) {
         surfaceView.terminalSurface?.releasePortalHostIfOwned(
             hostId: hostId,
+            instanceSerial: instanceSerial,
             reason: reason
         )
     }
 
-    func prepareOwnedPortalHostForTransientReattach(hostId: ObjectIdentifier, reason: String) {
+    func prepareOwnedPortalHostForTransientReattach(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        reason: String
+    ) {
         surfaceView.terminalSurface?.preparePortalHostReplacementIfOwned(
             hostId: hostId,
+            instanceSerial: instanceSerial,
             reason: reason
         )
     }
@@ -12183,6 +12189,46 @@ struct GhosttyTerminalView: NSViewRepresentable {
         return !hostedViewHasSuperview
     }
 
+    /// What an update may do to the hosted view's immediate visible/active
+    /// state.
+    enum ImmediateHostedStateAction: Equatable {
+        /// The owner with a live binding applies both flags.
+        case applyVisibleAndActive
+        /// A bound host that lost the lease may still un-show its own
+        /// surface — and nothing more. Active/focus state stays
+        /// ownership-gated.
+        case hideOnly
+        /// A non-owner that is not bound must not touch the hosted view.
+        case deferred
+    }
+
+    /// The complete immediate visible/active apply decision.
+    ///
+    /// Hiding never needs lease ownership or a live binding generation.
+    /// Ownership gates SHOWING and re-anchoring; the host a hosted view is
+    /// currently bound to is the only one that can un-show it, owner or not.
+    /// Gating the hide on the claim leaves a deselected tab's surface on
+    /// screen whenever ownership flips without a rebind: the bound host's
+    /// visible=false updates defer forever and the hidden tab draws over the
+    /// selected one.
+    static func immediateHostedStateAction(
+        hostOwnsPortal: Bool,
+        portalBindingLive: Bool,
+        desiredVisibleInUI: Bool,
+        hostedViewHasSuperview: Bool,
+        isBoundToCurrentHost: Bool
+    ) -> ImmediateHostedStateAction {
+        if portalBindingLive, hostOwnsPortal, shouldApplyImmediateHostedStateUpdate(
+            desiredVisibleInUI: desiredVisibleInUI,
+            hostedViewHasSuperview: hostedViewHasSuperview,
+            isBoundToCurrentHost: isBoundToCurrentHost
+        ) {
+            return .applyVisibleAndActive
+        }
+        if !desiredVisibleInUI, isBoundToCurrentHost { return .hideOnly }
+        return .deferred
+    }
+
     enum HostCallbackPortalGeometrySynchronizationAction<Window> {
         case skip
         case synchronizeWithoutLayoutFlush(Window)
@@ -12477,16 +12523,21 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let isBoundToCurrentHost = hostContainer.map { host in
             TerminalWindowPortalRegistry.isHostedView(hostedView, boundTo: host)
         } ?? true
-        let shouldApplyImmediateHostedState = hostOwnsPortalNow && Self.shouldApplyImmediateHostedStateUpdate(
+        let immediateStateAction = Self.immediateHostedStateAction(
+            hostOwnsPortal: hostOwnsPortalNow,
+            portalBindingLive: portalBindingStillLive(),
             desiredVisibleInUI: isVisibleInUI,
             hostedViewHasSuperview: hostedView.superview != nil,
             isBoundToCurrentHost: isBoundToCurrentHost
         )
 
-        if portalBindingStillLive() && shouldApplyImmediateHostedState {
+        switch immediateStateAction {
+        case .applyVisibleAndActive:
             hostedView.setVisibleInUI(isVisibleInUI)
             hostedView.setActive(isActive)
-        } else {
+        case .hideOnly:
+            hostedView.setVisibleInUI(false)
+        case .deferred:
             // Preserve portal entry visibility while a stale host is still receiving SwiftUI updates.
             // The currently bound host remains authoritative for immediate visible/active state.
 #if DEBUG
@@ -12534,6 +12585,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
             host.onGeometryChanged = nil
             hostedView?.prepareOwnedPortalHostForTransientReattach(
                 hostId: ObjectIdentifier(host),
+                instanceSerial: host.instanceSerial,
                 reason: "dismantle"
             )
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -909,6 +909,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */; };
 		A5F100000000000000000009 /* GhosttySurfaceScrollView+NotificationScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */; };
 		A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */; };
+		C0DEF828300000000000001 /* GhosttyTerminalImmediateHostedStateAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */; };
 		A5001B00 /* GhosttyTerminalScrollBoost.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001B01 /* GhosttyTerminalScrollBoost.swift */; };
 		D5671201D5671201D5671201 /* GhosttyTerminalScrollSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5671202D5671202D5671202 /* GhosttyTerminalScrollSpeed.swift */; };
 		C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */; };
@@ -2946,6 +2947,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/GhosttySurfaceConfigurationRefresh.swift; sourceTree = "<group>"; };
 		A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttySurfaceScrollView+NotificationScroll.swift"; sourceTree = "<group>"; };
 		A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalAppearance.swift; sourceTree = "<group>"; };
+		C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalImmediateHostedStateAction.swift; sourceTree = "<group>"; };
 		A5001B01 /* GhosttyTerminalScrollBoost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalScrollBoost.swift; sourceTree = "<group>"; };
 		D5671202D5671202D5671202 /* GhosttyTerminalScrollSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalScrollSpeed.swift; sourceTree = "<group>"; };
 		C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalStartupEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -4804,6 +4806,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001014 /* GhosttyConfig.swift */,
 				C4041001000000000000001A /* CommandClickFileOpenRouter.swift */,
 				C40410010000000000000020 /* FileExplorerDoubleClickActionSettings.swift */,
+				C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
 				816400000000000000000002 /* GhosttyScrollView.swift */,
 				A11E5E1E0000000000000002 /* TerminalSelectionAccessibilityNotifier.swift */,
@@ -7177,6 +7180,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */,
 				A5F100000000000000000009 /* GhosttySurfaceScrollView+NotificationScroll.swift in Sources */,
 				A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */,
+				C0DEF828300000000000001 /* GhosttyTerminalImmediateHostedStateAction.swift in Sources */,
 				A5001B00 /* GhosttyTerminalScrollBoost.swift in Sources */,
 				D5671201D5671201D5671201 /* GhosttyTerminalScrollSpeed.swift in Sources */,
 				793800000000000000000008 /* GhosttyTerminalView+Sizing.swift in Sources */,

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -113,6 +113,7 @@ struct DockPortalReconcileTests {
         ))
         panel.surface.releasePortalHostIfOwned(
             hostId: ObjectIdentifier(dockHost),
+            instanceSerial: 20,
             reason: "test.dock.rollback"
         )
 

--- a/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
+++ b/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -6,9 +6,10 @@ import XCTest
 @testable import cmux
 #endif
 
-final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
-    func testImmediateStateUpdateAllowedWhenDesiredStateIsHidden() {
-        XCTAssertTrue(
+@MainActor
+struct GhosttyTerminalViewVisibilityPolicyTests {
+    @Test func immediateStateUpdateAllowedWhenDesiredStateIsHidden() {
+        #expect(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: false,
                 hostedViewHasSuperview: true,
@@ -17,8 +18,8 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testImmediateStateUpdateAllowedWhenBoundToCurrentHost() {
-        XCTAssertTrue(
+    @Test func immediateStateUpdateAllowedWhenBoundToCurrentHost() {
+        #expect(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: true,
                 hostedViewHasSuperview: true,
@@ -27,9 +28,9 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testImmediateStateUpdateSkippedForStaleHostBoundElsewhere() {
-        XCTAssertFalse(
-            GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
+    @Test func immediateStateUpdateSkippedForStaleHostBoundElsewhere() {
+        #expect(
+            !GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: true,
                 hostedViewHasSuperview: true,
                 isBoundToCurrentHost: false
@@ -37,8 +38,8 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testImmediateStateUpdateAllowedWhenUnboundAndNotAttachedAnywhere() {
-        XCTAssertTrue(
+    @Test func immediateStateUpdateAllowedWhenUnboundAndNotAttachedAnywhere() {
+        #expect(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: true,
                 hostedViewHasSuperview: false,
@@ -47,19 +48,109 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testSwiftUIHostGeometryCallbackUsesImmediateSyncWithoutLayoutFlush() {
+    // The full action: ownership and binding liveness gate SHOWING, but a
+    // host the hosted view is currently bound to may always HIDE it — and
+    // only hide it; active/focus state stays ownership-gated. The regression
+    // this pins: a deselected tab's bound-but-disowned host had its
+    // visible=false deferred forever, leaving the hidden tab's surface drawn
+    // over the selected tab's panes.
+    @Test func boundHostMayHideWithoutOwningTheLease() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: true,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .hideOnly
+        )
+    }
+
+    @Test func boundHostMayHideEvenWhenBindingGenerationMoved() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: false,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .hideOnly
+        )
+    }
+
+    @Test func unboundHostMayNotHideAnotherHostsContent() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: true,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: false
+            ) == .deferred
+        )
+    }
+
+    @Test func showingStillRequiresOwnership() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: true,
+                desiredVisibleInUI: true,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .deferred
+        )
+    }
+
+    @Test func showingStillRequiresLiveBinding() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: true,
+                portalBindingLive: false,
+                desiredVisibleInUI: true,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .deferred
+        )
+    }
+
+    @Test func owningHiderAppliesBothFlagsNotJustTheHide() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: true,
+                portalBindingLive: true,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .applyVisibleAndActive
+        )
+    }
+
+    @Test func ownerWithLiveBindingShowsBoundContent() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: true,
+                portalBindingLive: true,
+                desiredVisibleInUI: true,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .applyVisibleAndActive
+        )
+    }
+
+    @Test func hostGeometryCallbackUsesImmediateSyncWithoutLayoutFlush() {
         switch GhosttyTerminalView.hostCallbackPortalGeometrySynchronizationAction(window: 3873) {
         case .synchronizeWithoutLayoutFlush(let window):
-            XCTAssertEqual(window, 3873)
+            #expect(window == 3873)
         case .skip:
-            XCTFail("Window-attached host callbacks should immediately reconcile portal geometry without layout flushes")
+            Issue.record("Window-attached host callbacks should immediately reconcile portal geometry without layout flushes")
         }
     }
 
-    func testSwiftUIHostGeometryCallbackSkipsWithoutWindow() {
+    @Test func hostGeometryCallbackSkipsWithoutWindow() {
         switch GhosttyTerminalView.hostCallbackPortalGeometrySynchronizationAction(window: Optional<Int>.none) {
         case .synchronizeWithoutLayoutFlush:
-            XCTFail("Detached host callbacks must not synchronize terminal portal geometry")
+            Issue.record("Detached host callbacks must not synchronize terminal portal geometry")
         case .skip:
             break
         }

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -55,10 +55,12 @@ FUZZ_SERVER_OWNED=0
 cleanup() {
   local status=$?
   trap - EXIT
-  if [ "$DRY" != 1 ] && [ -n "$WORKSPACE_REF" ]; then
+  # FUZZ_KEEP_STATE=1 leaves the workspace and remote server up so a failed
+  # run's final state can be probed live (rpc pane_surfaces etc.) postmortem.
+  if [ "$DRY" != 1 ] && [ -n "$WORKSPACE_REF" ] && [ "${FUZZ_KEEP_STATE:-0}" != 1 ]; then
     "$CLI" workspace close "$WORKSPACE_REF" >/dev/null 2>&1
   fi
-  if [ "$FUZZ_SERVER_OWNED" = 1 ]; then
+  if [ "$FUZZ_SERVER_OWNED" = 1 ] && [ "${FUZZ_KEEP_STATE:-0}" != 1 ]; then
     t kill-server >/dev/null 2>&1 || true
   fi
   cmux_fuzz_lock_release
@@ -252,16 +254,61 @@ check_screen_oracle() {
   # census: every window with an on-screen pane is the VISIBLE window, so tmux's
   # full pane list for it must be on screen. A missing pane is the app failing to
   # render a pane of the visible window, which is a defect, not less coverage.
+  # One workspace presents one tmux window at a time, so surfaces from two
+  # windows on screen at once is a hidden tab drawing over the selected one.
+  # The per-window census below cannot see this: each window individually
+  # matches tmux while both are visible.
+  on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+    [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+  ' 2>/dev/null)
+  if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+    note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+  fi
   for window in $(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
     [.panes[]? | select(.on_screen == true) | .window_id] | unique[]
   ' 2>/dev/null); do
-    tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+    # A zoomed window presents only its active pane; tmux itself hides the
+    # rest, so the census for it is that one pane, not the full pane list.
+    zoom_flag=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
+    if [ -z "$zoom_flag" ]; then
+      # Without the zoom state the census cannot be judged; a display-message
+      # hiccup taking the unzoomed branch would report every hidden pane of a
+      # zoomed window as a defect. Skip this window this pass.
+      continue
+    fi
+    if [ "$zoom_flag" = 1 ]; then
+      tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
+    else
+      tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+    fi
     app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
       .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
     ' 2>/dev/null | sort)
     missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
     if [ -n "${missing// /}" ]; then
-      note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them)"
+      # The app census came from the earlier pane_surfaces snapshot; a zoom
+      # toggle anywhere between that snapshot and here manufactures a
+      # mismatch out of two individually consistent states. Confirm against
+      # fresh state on BOTH sides before recording a defect: a stable zoom
+      # flag alone cannot clear a toggle that completed before its first
+      # read. Only a mismatch that survives the re-read is one.
+      zoom_recheck=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
+      if [ "$zoom_recheck" != "$zoom_flag" ]; then
+        continue
+      fi
+      refresh_pane_surfaces || continue
+      if [ "$zoom_recheck" = 1 ]; then
+        tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
+      else
+        tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+      fi
+      app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
+        .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
+      ' 2>/dev/null | sort)
+      missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
+      if [ -n "${missing// /}" ]; then
+        note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them)"
+      fi
     fi
   done
   checked=0
@@ -446,7 +493,7 @@ check_iter() {
   done
   echo "  settle $((SECONDS - settle_start))s (iter $iter)"
   if [ "$settled" != 1 ]; then
-    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
+    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | jq -c '{counters, windows}' 2>/dev/null || printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
   elif settlement_has_render_mismatch "$settled_json"; then
     # Mismatch WHILE settled: re-read twice before failing, so a probe that
     # raced the last frame of a transition cannot manufacture a defect.

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -265,12 +265,15 @@ check_screen_oracle() {
     # Same re-read discipline as every other judge: a probe can land inside
     # the one-frame handoff of a tab switch, and only a state that persists
     # through a fresh census is a defect.
-    refresh_pane_surfaces || true
-    on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
-      [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
-    ' 2>/dev/null)
-    if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
-      note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+    # Judging the stale snapshot again would just repeat the first read, so
+    # a failed refresh defers the verdict to the next iteration entirely.
+    if refresh_pane_surfaces; then
+      on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+        [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+      ' 2>/dev/null)
+      if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+        note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+      fi
     fi
   fi
   for window in $on_screen_windows; do
@@ -500,7 +503,7 @@ check_iter() {
   done
   echo "  settle $((SECONDS - settle_start))s (iter $iter)"
   if [ "$settled" != 1 ]; then
-    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | jq -c '{counters, windows}' 2>/dev/null || printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
+    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | jq -ce '{counters, windows}' 2>/dev/null || printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
   elif settlement_has_render_mismatch "$settled_json"; then
     # Mismatch WHILE settled: re-read twice before failing, so a probe that
     # raced the last frame of a transition cannot manufacture a defect.

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -267,13 +267,16 @@ check_screen_oracle() {
     # through a fresh census is a defect.
     # Judging the stale snapshot again would just repeat the first read, so
     # a failed refresh defers the verdict to the next iteration entirely.
-    if refresh_pane_surfaces; then
-      on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
-        [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
-      ' 2>/dev/null)
-      if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
-        note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
-      fi
+    if ! refresh_pane_surfaces; then
+      return
+    fi
+    panes=$(on_screen_panes)
+    [ -n "$panes" ] || return
+    on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+      [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+    ' 2>/dev/null)
+    if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+      note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
     fi
   fi
   for window in $on_screen_windows; do
@@ -302,7 +305,11 @@ check_screen_oracle() {
       # fresh state on BOTH sides before recording a defect: a stable zoom
       # flag alone cannot clear a toggle that completed before its first
       # read. Only a mismatch that survives the re-read is one.
-      refresh_pane_surfaces || continue
+      if ! refresh_pane_surfaces; then
+        return
+      fi
+      panes=$(on_screen_panes)
+      [ -n "$panes" ] || return
       window_still_on_screen=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
         any(.panes[]?; .window_id == $w and .on_screen == true)
       ' 2>/dev/null)

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -262,11 +262,18 @@ check_screen_oracle() {
     [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
   ' 2>/dev/null)
   if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
-    note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+    # Same re-read discipline as every other judge: a probe can land inside
+    # the one-frame handoff of a tab switch, and only a state that persists
+    # through a fresh census is a defect.
+    refresh_pane_surfaces || true
+    on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+      [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+    ' 2>/dev/null)
+    if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+      note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+    fi
   fi
-  for window in $(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
-    [.panes[]? | select(.on_screen == true) | .window_id] | unique[]
-  ' 2>/dev/null); do
+  for window in $on_screen_windows; do
     # A zoomed window presents only its active pane; tmux itself hides the
     # rest, so the census for it is that one pane, not the full pane list.
     zoom_flag=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -302,11 +302,17 @@ check_screen_oracle() {
       # fresh state on BOTH sides before recording a defect: a stable zoom
       # flag alone cannot clear a toggle that completed before its first
       # read. Only a mismatch that survives the re-read is one.
-      zoom_recheck=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
-      if [ "$zoom_recheck" != "$zoom_flag" ]; then
+      refresh_pane_surfaces || continue
+      window_still_on_screen=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
+        any(.panes[]?; .window_id == $w and .on_screen == true)
+      ' 2>/dev/null)
+      if [ "$window_still_on_screen" != "true" ]; then
         continue
       fi
-      refresh_pane_surfaces || continue
+      zoom_recheck=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
+      if [ -z "$zoom_recheck" ]; then
+        continue
+      fi
       if [ "$zoom_recheck" = 1 ]; then
         tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
       else


### PR DESCRIPTION
Two user-visible rendering bugs in the remote-tmux mirror, both in the portal-lease bookkeeping that anchors a terminal's Metal surface to its pane: a pane can freeze at a stale size after split churn, and a deselected tab's terminal can stay painted over the selected tab. The runtime changes are narrowly scoped to clearing a vacated owner's authority, allowing a bound non-owner to hide, and waking eligible survivors when an owner dies; the remaining diff is focused unit coverage plus the fuzz judges that catch the freeze deterministically and the overlap whenever tab switching is exercised. All show paths remain gated by a successful lease claim and a live binding generation, so the change adds no new way to draw the wrong content.

## How each bug reproduces

**The freeze.** Run the live fuzz at seed 5: it builds a mirrored window with several panes, then does random split/kill churn. A kill removes a pane whose neighbor had just been re-hosted, and the surviving pane stops tracking the layout: tmux assigns it the freed space, the app's own layout math agrees, but the pane keeps rendering 456pt wide inside its new 714pt slot. It stays that way for 10+ consecutive settle checks — minutes of wall clock — until unrelated churn happens to rebuild that subtree. By hand: a mirrored tmux window, repeated splits and kills in quick succession; the freeze lands within a few rounds.

**The overlay.** Open two tabs, each mirroring a multi-pane tmux window. Churn the layout in tab B, switch to tab A. Tab B's terminal — deselected, supposedly hidden — stays painted on top of tab A's panes and does not go away. Deselected tabs keep their views alive by design, and the terminal surfaces float in a window-level layer, so SwiftUI opacity on the pane does nothing; the surface itself has to be told to hide. This showed up live while dogfooding, and the multi-window oracle reports the persistent overlap whenever the tab-switch path is exercised.

**The slow recovery.** With the freeze fixed, strict-judge seed 2 still failed deterministically at iteration 5: kill the pane whose host view owns the surface, and the surviving pane sits un-anchored past the full 8-second settle budget, because nothing tells it the owner died — it waits for its own next SwiftUI update, which quiet layouts don't send.

## What was actually wrong

The surface follows whichever pane host view holds its portal lease, and an authority record protects the current owner from being reclaimed by retired hosts. Three holes:

- **A dead holder kept its authority.** During churn a transient host claimed the lease while still zero-sized, recorded itself as authority, and was dismantled ~40ms later. The record outlived it, so the pane's real host was refused on every re-claim — silently, since the refusal paths had no logging. Now a vacating holder clears its own record, authenticated by host identity AND creation serial so a stale vacate from a recycled object address cannot erase a newer record, and refusals log.
- **A bound host could not hide its own surface.** Immediate visible/active state was applied only by the lease owner, so a host that lost the lease while still anchoring on-screen pixels could never apply visible=false. The update's action is now an explicit three-way: the owner with a live binding applies visible and active, a bound non-owner may only un-show its own surface, an unbound non-owner defers. Active/focus stays ownership-gated, so the hide exception cannot become a focus side channel. The action is a pure function with its truth table pinned in the visibility-policy suite.
- **Owner death fired no edge.** Each presented pane owner now registers a retry on its surface whose host, hosted view, coordinator, and surface captures are all weak, so a dead view turns its entry into a no-op. Vacancy schedules a generation-keyed, coalesced, newest-first drain, one run-loop turn later — the dying owner's teardown is still clearing handlers on the shared view when the vacancy is announced, and the deferral guarantees teardown has finished. A woken candidate re-checks pane ownership, desired visibility, window attachment, and binding generation before claiming; after rebinding it reapplies the coordinator's current visible and active state and restores the handlers teardown cleared. Hidden hosts never park retries and a queued retry exits once desired visibility becomes false, so the wake can re-anchor on-screen content but cannot reveal a hidden tab.

Later commits harden the same edges: every identity check on the claim, release, and retry paths matches host + creation serial, and the retry registry drops entries when a host moves to another surface or the surface's lifecycle closes.

The harness commit adds the judges that found all of this and now guard it: a zoom-aware coverage census that re-reads both sides before recording a mismatch, an oracle that fails any settle where surfaces from two windows are on screen at once, native-geometry failures that print the lease's pane and in-window state, and FUZZ_KEEP_STATE=1 to keep a failed run's final state alive for probing.

## Verification

Pre-fix, seed 5 produced 12 settle failures and strict seed 2 produced one 8-second timeout; on this head both pass 25 iterations with zero failures and settle times at the sub-second baseline, and the tab-switch overlay probes stay clean across repeated window flips. With the #8325 judges stacked on top, a full 5-seed x 25-iteration marathon on this revision passes with zero failures, zero hangs, and zero crashes, landing 12 mirror-tab switches with every seed exercising the path at least once.
