### PR TITLE
Make Codex subagent pane titles atomic

### DIFF
--- a/CLI/CodexTeamsApprovalBridge.swift
+++ b/CLI/CodexTeamsApprovalBridge.swift
@@ -3,6 +3,37 @@ import Foundation
 enum CodexTeamsApprovalBridge {
     private typealias CodexPermissionCapabilities = (supportsOnce: Bool, supportsAlways: Bool, supportsAll: Bool)
 
+    static func subagentPaneTitle(label: String, depth: Int) -> String {
+        "sub: d\(depth) \(label)"
+    }
+
+    static func subagentSplitParams(
+        workspaceID: String,
+        targetSurfaceID: String,
+        direction: String,
+        title: String,
+        initialCommand: String,
+        tmuxStartCommand: String,
+        startupEnvironment: [String: String],
+        workingDirectory: String?
+    ) -> [String: Any] {
+        var params: [String: Any] = [
+            "workspace_id": workspaceID,
+            "surface_id": targetSurfaceID,
+            "direction": direction,
+            "focus": false,
+            "title": title,
+            "initial_command": initialCommand,
+            "tmux_start_command": tmuxStartCommand,
+            "startup_environment": startupEnvironment,
+        ]
+        if let workingDirectory = workingDirectory?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !workingDirectory.isEmpty {
+            params["working_directory"] = workingDirectory
+        }
+        return params
+    }
+
     static func feedEvent(
         method: String,
         requestId: Any,

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -21023,6 +21023,7 @@ struct CMUXCLI {
                 "surface_id": targetSurfaceId,
                 "direction": direction,
                 "focus": false,
+                "title": CMUXCLI.codexTeamsTitle(thread: thread, spawn: spawn, depth: depth),
                 "initial_command": startupScript,
                 "tmux_start_command": commandText,
                 "startup_environment": [
@@ -21049,16 +21050,6 @@ struct CMUXCLI {
             }
             lastAgentSurfaceId = surfaceId
 
-            do {
-                _ = try socketClient.sendV2(method: "tab.action", params: [
-                    "workspace_id": workspaceId,
-                    "surface_id": surfaceId,
-                    "action": "rename",
-                    "title": CMUXCLI.codexTeamsTitle(thread: thread, spawn: spawn, depth: depth)
-                ])
-            } catch {
-                // The subagent pane already exists, so a rename failure should not stop watching.
-            }
             do {
                 _ = try socketClient.sendV2(method: "workspace.equalize_splits", params: [
                     "workspace_id": workspaceId,
@@ -21264,7 +21255,11 @@ struct CMUXCLI {
             .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
             .first { !$0.isEmpty }
             ?? String(thread.id.prefix(8))
-        return "Codex d\(depth): \(label)"
+        return codexTeamsPaneTitle(label: label, depth: depth)
+    }
+
+    static func codexTeamsPaneTitle(label: String, depth: Int) -> String {
+        "sub: d\(depth) \(label)"
     }
 
     private func runCodexTeams(

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -21018,25 +21018,21 @@ struct CMUXCLI {
 
             let targetSurfaceId = lastAgentSurfaceId ?? rootSurfaceId
             let direction = lastAgentSurfaceId == nil ? "right" : "down"
-            var splitParams: [String: Any] = [
-                "workspace_id": workspaceId,
-                "surface_id": targetSurfaceId,
-                "direction": direction,
-                "focus": false,
-                "title": CMUXCLI.codexTeamsTitle(thread: thread, spawn: spawn, depth: depth),
-                "initial_command": startupScript,
-                "tmux_start_command": commandText,
-                "startup_environment": [
+            let splitParams = CodexTeamsApprovalBridge.subagentSplitParams(
+                workspaceID: workspaceId,
+                targetSurfaceID: targetSurfaceId,
+                direction: direction,
+                title: CMUXCLI.codexTeamsTitle(thread: thread, spawn: spawn, depth: depth),
+                initialCommand: startupScript,
+                tmuxStartCommand: commandText,
+                startupEnvironment: [
                     managedSubagentEnvironmentKey: "1",
                     codexTeamsThreadEnvironmentKey: thread.id,
                     codexTeamsParentThreadEnvironmentKey: spawn.parentThreadId,
                     codexTeamsDepthEnvironmentKey: String(max(1, depth))
-                ]
-            ]
-            if let cwd = thread.cwd?.trimmingCharacters(in: .whitespacesAndNewlines),
-               !cwd.isEmpty {
-                splitParams["working_directory"] = cwd
-            }
+                ],
+                workingDirectory: thread.cwd
+            )
 
             let created = try socketClient.sendV2(method: "surface.split", params: splitParams)
             if (created["accepted"] as? Bool) == true {
@@ -21255,11 +21251,7 @@ struct CMUXCLI {
             .compactMap { $0?.trimmingCharacters(in: .whitespacesAndNewlines) }
             .first { !$0.isEmpty }
             ?? String(thread.id.prefix(8))
-        return codexTeamsPaneTitle(label: label, depth: depth)
-    }
-
-    static func codexTeamsPaneTitle(label: String, depth: Int) -> String {
-        "sub: d\(depth) \(label)"
+        return CodexTeamsApprovalBridge.subagentPaneTitle(label: label, depth: depth)
     }
 
     private func runCodexTeams(

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -346,6 +346,7 @@ extension ControlCommandCoordinator {
             initialCommand: optionalTrimmedRawString(params, "initial_command"),
             tmuxStartCommand: optionalTrimmedRawString(params, "tmux_start_command"),
             remotePTYSessionID: optionalTrimmedRawString(params, "remote_pty_session_id"),
+            title: optionalTrimmedRawString(params, "title"),
             remoteContextRaw: optionalTrimmedRawString(params, "remote_context"),
             startupEnvironment: trimmedStringMap(params, keys: ["startup_environment", "initial_env"]),
             clientUnsupportedRemoteTmuxOptions: stringArray(params, "remote_tmux_unsupported_options") ?? [],

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceSplitInputs.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceSplitInputs.swift
@@ -25,6 +25,8 @@ public struct ControlSurfaceSplitInputs: Sendable, Equatable {
     public let tmuxStartCommand: String?
     /// The trimmed-non-empty `remote_pty_session_id`, or `nil`.
     public let remotePTYSessionID: String?
+    /// The trimmed-non-empty custom title to apply to the created surface, or `nil`.
+    public let title: String?
     /// The raw `remote_context` token (`inherit`/`local`/`cloud`), or `nil`.
     public let remoteContextRaw: String?
     /// The startup environment (`startup_environment`/`initial_env`), `[:]` if none.
@@ -46,6 +48,7 @@ public struct ControlSurfaceSplitInputs: Sendable, Equatable {
         initialCommand: String?,
         tmuxStartCommand: String?,
         remotePTYSessionID: String?,
+        title: String?,
         remoteContextRaw: String?,
         startupEnvironment: [String: String],
         clientUnsupportedRemoteTmuxOptions: [String],
@@ -60,6 +63,7 @@ public struct ControlSurfaceSplitInputs: Sendable, Equatable {
         self.initialCommand = initialCommand
         self.tmuxStartCommand = tmuxStartCommand
         self.remotePTYSessionID = remotePTYSessionID
+        self.title = title
         self.remoteContextRaw = remoteContextRaw
         self.startupEnvironment = startupEnvironment
         self.clientUnsupportedRemoteTmuxOptions = clientUnsupportedRemoteTmuxOptions

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -122,7 +122,8 @@ extension TerminalController {
                 tmuxStartCommand: inputs.tmuxStartCommand,
                 startupEnvironment: inputs.startupEnvironment,
                 initialDividerPosition: inputs.initialDividerPosition,
-                remotePTYSessionID: inputs.remotePTYSessionID
+                remotePTYSessionID: inputs.remotePTYSessionID,
+                title: inputs.title
             )
                 + inputs.clientUnsupportedRemoteTmuxOptions
             if !unsupported.isEmpty {
@@ -180,6 +181,11 @@ extension TerminalController {
 
         guard let newId else {
             return .createFailed
+        }
+        // Apply the title in the same MainActor turn as creation so the socket
+        // response cannot expose a surface that still has its default title.
+        if let title = inputs.title {
+            ws.setPanelCustomTitle(panelId: newId, title: title)
         }
         return .created(
             windowID: v2ResolveWindowId(tabManager: tabManager),

--- a/Sources/TerminalController+RemoteTmuxControlMutations.swift
+++ b/Sources/TerminalController+RemoteTmuxControlMutations.swift
@@ -14,7 +14,8 @@ extension TerminalController {
         tmuxStartCommand: String?,
         startupEnvironment: [String: String],
         initialDividerPosition: Double? = nil,
-        remotePTYSessionID: String? = nil
+        remotePTYSessionID: String? = nil,
+        title: String? = nil
     ) -> [String] {
         var unsupported: [String] = []
         if insertFirst { unsupported.append("direction=left/up") }
@@ -24,6 +25,7 @@ extension TerminalController {
         if !startupEnvironment.isEmpty { unsupported.append("startup_environment") }
         if initialDividerPosition != nil { unsupported.append("initial_divider_position") }
         if remotePTYSessionID != nil { unsupported.append("remote_pty_session_id") }
+        if title != nil { unsupported.append("title") }
         return unsupported
     }
 
@@ -125,7 +127,8 @@ extension TerminalController {
             tmuxStartCommand: inputs.tmuxStartCommand,
             startupEnvironment: inputs.startupEnvironment,
             initialDividerPosition: inputs.initialDividerPosition,
-            remotePTYSessionID: inputs.remotePTYSessionID
+            remotePTYSessionID: inputs.remotePTYSessionID,
+            title: inputs.title
         ) + inputs.clientUnsupportedRemoteTmuxOptions
         guard unsupported.isEmpty else { return .mirrorUnsupportedOptions(unsupported) }
         guard location.requestSplit(vertical: direction.orientation == .vertical) else {

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -16,10 +16,6 @@ import Testing
         let timedOut: Bool
     }
 
-    @Test func testCodexTeamsPaneTitleUsesSubagentPrefix() {
-        #expect(CMUXCLI.codexTeamsPaneTitle(label: "contract-tests", depth: 2) == "sub: d2 contract-tests")
-    }
-
     @Test func testCLIErrorPathDoesNotCrashWhenStderrIsClosed() throws {
         let cliPath = try bundledCLIPath()
         let result = runShell(

--- a/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
+++ b/cmuxTests/CMUXCLIErrorOutputRegressionTests.swift
@@ -16,6 +16,10 @@ import Testing
         let timedOut: Bool
     }
 
+    @Test func testCodexTeamsPaneTitleUsesSubagentPrefix() {
+        #expect(CMUXCLI.codexTeamsPaneTitle(label: "contract-tests", depth: 2) == "sub: d2 contract-tests")
+    }
+
     @Test func testCLIErrorPathDoesNotCrashWhenStderrIsClosed() throws {
         let cliPath = try bundledCLIPath()
         let result = runShell(

--- a/cmuxTests/FeedCoordinatorTests.swift
+++ b/cmuxTests/FeedCoordinatorTests.swift
@@ -10,6 +10,25 @@ import CMUXAgentLaunch
 
 @Suite("Feed coordinator", .serialized)
 struct FeedCoordinatorTests {
+    @Test func codexTeamsSubagentSplitCarriesAtomicTitle() {
+        let title = CodexTeamsApprovalBridge.subagentPaneTitle(label: "contract-tests", depth: 2)
+        let params = CodexTeamsApprovalBridge.subagentSplitParams(
+            workspaceID: "workspace-id",
+            targetSurfaceID: "surface-id",
+            direction: "right",
+            title: title,
+            initialCommand: "/tmp/startup.sh",
+            tmuxStartCommand: "codex resume thread-id",
+            startupEnvironment: ["CMUX_AGENT_MANAGED_SUBAGENT": "1"],
+            workingDirectory: "  /tmp/cmux-review  "
+        )
+
+        #expect(title == "sub: d2 contract-tests")
+        #expect(params["title"] as? String == title)
+        #expect(params["working_directory"] as? String == "/tmp/cmux-review")
+        #expect(params["focus"] as? Bool == false)
+    }
+
     @Test func codexTeamsResolvesExplicitWorkingDirectoryFlags() {
         let base = "/tmp/cmux-base"
 

--- a/cmuxTests/RemoteTmuxMirrorCLIFailClosedTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCLIFailClosedTests.swift
@@ -345,6 +345,19 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
         }
     }
 
+    @Test func titledSplitFailsClosedBeforeRemoteTmuxMutation() throws {
+        let harness = try Harness()
+        defer { harness.tearDown() }
+        let surfaceID = try activeSurfaceID(in: harness)
+
+        let result = TerminalController.shared.controlSurfaceSplit(
+            routing: harness.routing(),
+            inputs: splitInputs(surfaceID: surfaceID, title: "sub: runtime-semantics")
+        )
+
+        #expect(result == .mirrorUnsupportedOptions(["title"]))
+    }
+
     private func activeSurfaceID(in harness: Harness) throws -> UUID {
         let paneID = try #require(harness.mirror.activePaneId)
         return try #require(harness.mirror.panel(forPane: paneID)?.id)
@@ -362,7 +375,7 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
         )
     }
 
-    private func splitInputs(surfaceID: UUID) -> ControlSurfaceSplitInputs {
+    private func splitInputs(surfaceID: UUID, title: String? = nil) -> ControlSurfaceSplitInputs {
         ControlSurfaceSplitInputs(
             directionRaw: "right",
             typeRaw: nil,
@@ -372,6 +385,7 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
             initialCommand: nil,
             tmuxStartCommand: nil,
             remotePTYSessionID: nil,
+            title: title,
             remoteContextRaw: nil,
             startupEnvironment: [:],
             clientUnsupportedRemoteTmuxOptions: [],

--- a/cmuxTests/RemoteTmuxMirrorCLIObservabilityTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCLIObservabilityTests.swift
@@ -278,6 +278,7 @@ struct RemoteTmuxMirrorCLIObservabilityTests {
                 initialCommand: nil,
                 tmuxStartCommand: nil,
                 remotePTYSessionID: nil,
+                title: nil,
                 remoteContextRaw: nil,
                 startupEnvironment: [:],
                 clientUnsupportedRemoteTmuxOptions: [],

--- a/cmuxTests/TerminalControllerSocketSecurityTests.swift
+++ b/cmuxTests/TerminalControllerSocketSecurityTests.swift
@@ -1252,6 +1252,45 @@ final class TerminalControllerSocketSecurityTests {
         XCTAssertFalse(workspace.suppressesRawTerminalNotification(panelId: sourcePanelId))
     }
 
+    @Test func testSurfaceSplitAppliesProvidedTitleBeforeReturning() async throws {
+        let socketPath = makeSocketPath("surface-split-title")
+        let manager = TabManager()
+        let workspace = manager.addWorkspace(select: true)
+
+        defer {
+            if manager.tabs.contains(where: { $0.id == workspace.id }) {
+                manager.closeWorkspace(workspace)
+            }
+        }
+
+        let sourcePanelId = try XCTUnwrap(workspace.focusedPanelId)
+        TerminalController.shared.start(
+            tabManager: manager,
+            socketPath: socketPath,
+            accessMode: .allowAll
+        )
+        try waitForSocket(at: socketPath)
+
+        let expectedTitle = "sub: contract-tests"
+        let response = try await sendV2RequestAsync(
+            method: "surface.split",
+            params: [
+                "workspace_id": workspace.id.uuidString,
+                "surface_id": sourcePanelId.uuidString,
+                "direction": "right",
+                "title": expectedTitle,
+            ],
+            to: socketPath
+        )
+
+        XCTAssertEqual(response["ok"] as? Bool, true, "Unexpected JSON-RPC response: \(response)")
+        let result = try XCTUnwrap(response["result"] as? [String: Any], "Unexpected JSON-RPC response: \(response)")
+        let newSurfaceIDString = try XCTUnwrap(result["surface_id"] as? String)
+        let newSurfaceID = try XCTUnwrap(UUID(uuidString: newSurfaceIDString))
+
+        XCTAssertEqual(workspace.panelCustomTitles[newSurfaceID], expectedTitle)
+    }
+
     @Test func testSurfaceRelayRPCsReturnResolvedFocusedSurfaceWhenSurfaceIDOmitted() async throws {
         let socketPath = makeSocketPath("relay-fallback")
         let manager = TabManager()


### PR DESCRIPTION
## Summary

- add an optional `title` to the `surface.split` request and apply it inside the split transaction
- make `cmux codex-teams` create `sub:<name>` panes atomically instead of splitting and then issuing a fallible rename
- share and directly test the Codex Teams split-parameter builder, including trimmed cwd and `focus=false`
- cover local and remote-tmux split paths plus CLI request encoding

## Verification

- `swift test --package-path Packages/macOS/CmuxControlSocket` — 269 tests passed in 40 suites
- `xcrun swiftc -frontend -parse` on the changed Swift sources — passed
- `git diff --check` — passed
- Fable 5 adversarial review of `a5a70ff..2f6883e` — APPROVE; its Medium test-coverage suggestion is addressed by `d4bdc7b`
- final Fable 5 adversarial review of `a5a70ff..d4bdc7b` — APPROVE, zero Blocker/High/Medium findings; approval conditioned on hosted CI becoming green
- Snyk Code retry through the final Fable review — succeeded; zero findings in changed files

## CI status

GitHub Actions run 29541244402 and its failed-job retry both failed before repository code ran: representative web, Linux preflight, and test jobs failed at `Set up job`. This is the third consecutive runner-start failure pattern across the final pushes/retries. Jobs that did start (`changes`, `workflow-guard-tests`, and `remote-daemon-tests`) passed.

## Constraints

- Zig was not installed, per operator instruction.
- Full app-host build/tagged dogfood is therefore not claimed.
- The first Snyk attempt returned HTTP 403 (`urn:snyk:interaction:86a41768-15c8-4d3a-88f9-b74b6a2c2190`); the final retry succeeded.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8291"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->
