### PR TITLE
Fix stale terminal frames while scrolling

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -11309,6 +11309,9 @@ final class GhosttySurfaceScrollView: NSView {
         logDragGeometryChange(event: "surfaceOrigin", old: surfaceView.frame.origin, new: visibleRect.origin)
 #endif
         surfaceView.frame.origin = visibleRect.origin
+        // NSClipView minimizes scroll damage, so moving the viewport-sized Metal view
+        // must explicitly invalidate its new footprint instead of reusing copied pixels.
+        documentView.setNeedsDisplay(surfaceView.frame)
     }
 
     /// Match upstream Ghostty behavior: use content area width (excluding non-content

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8388,12 +8388,13 @@ final class GhosttySurfaceScrollView: NSView {
         )
     }
 
-    init(surfaceView: GhosttyNSView) {
+    init(surfaceView: GhosttyNSView, documentView: NSView = NSView(frame: .zero)) {
         #if DEBUG
         dispatchPrecondition(condition: .onQueue(.main))
         #endif
 
         self.surfaceView = surfaceView
+        self.documentView = documentView
         backgroundView = TerminalPaneBackgroundView(frame: .zero)
         scrollView = GhosttyScrollView()
         inactiveOverlayView = GhosttyFlashOverlayView(frame: .zero)
@@ -8423,7 +8424,6 @@ final class GhosttySurfaceScrollView: NSView {
         scrollView.contentView.backgroundColor = .clear
         scrollView.surfaceView = surfaceView
 
-        documentView = NSView(frame: .zero)
         scrollView.documentView = documentView
         documentView.addSubview(surfaceView)
 

--- a/cmuxTests/GhosttyScrollViewTests.swift
+++ b/cmuxTests/GhosttyScrollViewTests.swift
@@ -22,4 +22,47 @@ struct GhosttyScrollViewTests {
         #expect(scrollView.contentInsets.bottom == 0)
         #expect(scrollView.contentInsets.right == 0)
     }
+
+    @Test func scrollingInvalidatesTheRelocatedTerminalViewport() throws {
+        let documentView = ScrollDamageRecordingView(
+            frame: NSRect(x: 0, y: 0, width: 240, height: 800)
+        )
+        let surfaceView = GhosttyNSView(
+            frame: NSRect(x: 0, y: 0, width: 240, height: 120)
+        )
+        let hostedView = GhosttySurfaceScrollView(
+            surfaceView: surfaceView,
+            documentView: documentView
+        )
+        hostedView.frame = NSRect(x: 0, y: 0, width: 240, height: 120)
+        hostedView.layoutSubtreeIfNeeded()
+
+        let scrollView = try #require(
+            hostedView.subviews.compactMap { $0 as? GhosttyScrollView }.first
+        )
+        documentView.frame.size.height = 800
+        documentView.invalidatedRects.removeAll()
+
+        scrollView.contentView.scroll(to: NSPoint(x: 0, y: 200))
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification,
+            object: scrollView.contentView
+        )
+
+        #expect(surfaceView.frame.origin == scrollView.contentView.documentVisibleRect.origin)
+        #expect(
+            documentView.invalidatedRects.contains { $0.contains(surfaceView.frame) },
+            "moving the viewport-sized Metal surface must invalidate its complete new footprint"
+        )
+    }
+}
+
+@MainActor
+private final class ScrollDamageRecordingView: NSView {
+    var invalidatedRects: [NSRect] = []
+
+    override func setNeedsDisplay(_ invalidRect: NSRect) {
+        invalidatedRects.append(invalidRect)
+        super.setNeedsDisplay(invalidRect)
+    }
 }


### PR DESCRIPTION
## Summary
- make terminal viewport relocation and compositor damage invalidation one atomic AppKit operation
- invalidate the complete relocated Metal viewport so minimized scroll damage cannot preserve stale pixels
- add a behavior regression that exercises the real clip-view scroll path

## Root cause
`GhosttySurfaceScrollView` moves its viewport-sized CAMetalLayer after `NSClipView` changes bounds. AppKit minimizes document invalidation while scrolling, but the later surface relocation did not invalidate its new footprint. Under streamed output, an old compositor copy could therefore survive until a full redraw.

The reported “Jump to bottom (click)” text is emitted inside Claude Code terminal cells; it is not a separate cmux overlay. Its duplication and the stale prompt rows share the same terminal-surface compositing failure.

## Regression proof
- Red on the test-only commit: https://github.com/manaflow-ai/cmux/actions/runs/29541369793 — the existing inset test passed, the surface moved to the new visible origin, and the new test failed only because the complete relocated footprint was not invalidated.
- Green on the fix commit with the same focused selector: https://github.com/manaflow-ai/cmux/actions/runs/29541754175

The deterministic regression covers the AppKit damage contract that owns this fix. The SDK `NSClipView.h` documents that clip views minimize document invalidation while scrolling and directs callers to `setNeedsDisplayInRect:` to force invalidation. It intentionally does not pixel-assert the intermittent live CAMetalLayer compositor artifact, which would make a unit test nondeterministic.

## Test plan
- [x] red regression recorded on the test-only commit
- [x] focused unit test green on the fix commit in CI
- [x] full dispatched CI green: https://github.com/manaflow-ai/cmux/actions/runs/29541870669
- [ ] tagged app build (intentionally deferred per issue instructions)
- [ ] macOS 26 cloud visual verification (two provisioned leases timed out before becoming Tailscale-visible, so no video was captured)

No local `xcodebuild` test, reload, or app build was run, per the issue instructions.

## Issue
https://github.com/manaflow-ai/cmux/issues/8262

Closes #8262
