### PR TITLE
Add regression coverage for terminal grow resize flush

### DIFF
--- a/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
+++ b/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
@@ -180,6 +180,8 @@ extension TerminalWindowPortalLifecycleTests {
             expectedGeneration: surface.portalBindingGeneration()
         )
         TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+        drainMainQueue()
+        drainMainQueue()
         realizeWindowLayout(window)
         let initialPixelWidth = surface.debugCurrentPixelSize().width
         XCTAssertGreaterThan(initialPixelWidth, 0)

--- a/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
+++ b/cmuxTests/TerminalWindowPortalLifecycleHiddenRefreshTests.swift
@@ -157,4 +157,68 @@ extension TerminalWindowPortalLifecycleTests {
         )
         withExtendedLifetime((leftSurface, rightSurface)) {}
     }
+
+    /// Regression for #8285: an intermediate shrink can reach the PTY while
+    /// the divider is moving, so the interaction's final grow must be flushed
+    /// even when its anchor notification was coalesced away.
+    @MainActor
+    func testDividerShrinkThenGrowFlushesFinalWiderSurfaceSize() throws {
+        let window = makeTestWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 760, height: 420)
+        )
+        let contentView = try XCTUnwrap(window.contentView)
+        let surface = makeTrackedTerminalSurface()
+        let initialAnchorFrame = NSRect(x: 40, y: 60, width: 420, height: 220)
+        let anchor = NSView(frame: initialAnchorFrame)
+        contentView.addSubview(anchor)
+
+        TerminalWindowPortalRegistry.bind(
+            hostedView: surface.hostedView,
+            to: anchor,
+            visibleInUI: true,
+            expectedSurfaceId: surface.id,
+            expectedGeneration: surface.portalBindingGeneration()
+        )
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+        realizeWindowLayout(window)
+        let initialPixelWidth = surface.debugCurrentPixelSize().width
+        XCTAssertGreaterThan(initialPixelWidth, 0)
+
+        anchor.postsFrameChangedNotifications = false
+        let dragOwner = NSObject()
+        TerminalWindowPortalRegistry.beginInteractiveGeometryResize(owner: dragOwner, in: window)
+        var dragIsActive = true
+        defer {
+            if dragIsActive {
+                TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: dragOwner)
+            }
+        }
+
+        anchor.frame.size.width = 180
+        TerminalWindowPortalRegistry.synchronizeForAnchor(anchor)
+        drainMainQueue()
+        drainMainQueue()
+        let narrowPixelWidth = surface.debugCurrentPixelSize().width
+        XCTAssertLessThan(
+            narrowPixelWidth,
+            initialPixelWidth,
+            "The fixture must deliver the intermediate narrow PTY width"
+        )
+
+        // The final anchor change emits no notification, matching a grow
+        // generation swallowed by interactive geometry coalescing.
+        anchor.frame = initialAnchorFrame
+        XCTAssertEqual(surface.debugCurrentPixelSize().width, narrowPixelWidth)
+
+        TerminalWindowPortalRegistry.endInteractiveGeometryResize(owner: dragOwner)
+        dragIsActive = false
+        drainMainQueue()
+        drainMainQueue()
+
+        XCTAssertEqual(
+            surface.debugCurrentPixelSize().width,
+            initialPixelWidth,
+            "Divider drag end must flush the final wider width after an intermediate shrink"
+        )
+    }
 }


### PR DESCRIPTION
## Summary

- add a behavior-level regression for a split-divider drag that delivers an intermediate shrink but loses the final grow notification
- verify the interaction-end transaction flushes the terminal surface back to the authoritative final width
- keep the runtime change in the already-merged shared sizing fix from #8240; this PR is regression coverage only

## Root cause

The affected nightly could apply an intermediate narrow surface size during a divider drag, then lose/coalesce the final wider anchor notification. At that point `TerminalWindowPortalRegistry.endInteractiveGeometryResize` only ended the interaction; it did not schedule a final geometry reconciliation. Nothing called the final Ghostty surface/PTY resize, so the TUI remained at the narrow width.

The dropped layer was therefore **portal interaction end → final surface/PTY resize**, not Ghostty grid reflow or scrollback compression.

Merged PR #8240 fixed the shared boundary: the zero crossing of the window-scoped interactive geometry transaction schedules one settled portal synchronization, which applies the exact final renderer and PTY dimensions. That is the architectural invariant this test locks in; no repaint kick, polling, or sleep-based repair is involved.

## Regression evidence

The fixture reproduces the report deterministically:

1. Bind a tracked terminal surface at 420 px.
2. Begin an interactive divider resize.
3. Deliver an intermediate shrink to 180 px and drain synchronization.
4. Restore the anchor to 420 px with frame notifications disabled, modeling a coalesced/lost final grow event.
5. End the interaction and assert the terminal returns to its initial width.

Against affected nightly commit `1c22c5564`, the test fails:

```text
XCTAssertEqual failed: ("180") is not equal to ("420")
Divider drag end must flush the final wider width after an intermediate shrink
```

Because the runtime fix was already merged through #8240 before this issue branch was finalized, a two-commit red/fix sequence in this PR would be artificial. The red run above is from the exact historical runtime; this PR contains one regression-test commit.

Against current main `de74852e5c` on an AWS M4 Pro running macOS 15.7.4 / Xcode 26.3, the focused app-host test passes:

```text
Test Case '-[cmuxTests.TerminalWindowPortalLifecycleTests testDividerShrinkThenGrowFlushesFinalWiderSurfaceSize]' passed
Executed 2 tests, with 0 failures
```

The second selected test initializes the app-host routing fixture required by direct `xctest` execution.

## Link to #8229

This is the grow-direction manifestation of the same interactive sizing transaction fixed for #8229 by #8240. The #8229 investigation ruled out Ghostty scrollback compression; no Ghostty submodule change is needed here.

## Validation

- AWS macOS 15.7.4: `cmux-unit` `build-for-testing` succeeded
- AWS focused direct `xctest`: 2 tests, 0 failures
- `git diff --check`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`

Current main no longer contains `.github/swift-file-length-budget.tsv` or `scripts/swift_file_length_budget.py` (removed by #8125); this PR does not recreate or modify them. The touched test file remains 224 lines.

No user-facing strings changed, so localization catalogs are unaffected.

Closes #8285
