### PR TITLE
Fix iOS reconnect and build isolation

### DIFF
--- a/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthState.swift
+++ b/Packages/Shared/CMUXAuthCore/Sources/CMUXAuthCore/Models/CMUXAuthState.swift
@@ -22,7 +22,8 @@ public struct CMUXAuthState: Equatable, Sendable {
     /// priority order: cleared auth, mock data, a UI-test fixture user,
     /// pending auto-login, then the cached user. A cached user with known
     /// tokens is treated as signed in immediately while runtime validation
-    /// proceeds in the background.
+    /// remains explicitly in progress. This lets the authenticated UI render
+    /// without allowing token-dependent work to race the restore.
     /// - Parameters:
     ///   - clearAuthRequested: Whether the launch requested a cleared auth state.
     ///   - mockDataEnabled: Whether mock-data mode is active.
@@ -57,7 +58,7 @@ public struct CMUXAuthState: Equatable, Sendable {
         }
 
         if hasTokens, let cachedUser {
-            return Self(isAuthenticated: true, currentUser: cachedUser, isRestoringSession: false)
+            return Self(isAuthenticated: true, currentUser: cachedUser, isRestoringSession: true)
         }
 
         return Self(isAuthenticated: false, currentUser: cachedUser, isRestoringSession: hasTokens)

--- a/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/CMUXAuthStateTests.swift
+++ b/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/CMUXAuthStateTests.swift
@@ -120,8 +120,8 @@ struct CMUXAuthStateTests {
         )
     }
 
-    @Test("Primed state authenticates cached user while validating tokens")
-    func primedStateAuthenticatesCachedUserWhileValidatingTokens() {
+    @Test("Primed cached user remains restoring while validating tokens")
+    func primedCachedUserRemainsRestoringWhileValidatingTokens() {
         let user = CMUXAuthUser(id: "user_123", primaryEmail: "user@example.com", displayName: "Test User")
         let state = CMUXAuthState.primed(
             clearAuthRequested: false,
@@ -135,7 +135,7 @@ struct CMUXAuthStateTests {
 
         #expect(state.isAuthenticated)
         #expect(state.currentUser == user)
-        #expect(!state.isRestoringSession)
+        #expect(state.isRestoringSession)
     }
 
     @Test("Primed state restores when tokens exist without a cached user")

--- a/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/CMUXAuthStateTests.swift
+++ b/Packages/Shared/CMUXAuthCore/Tests/CMUXAuthCoreTests/CMUXAuthStateTests.swift
@@ -188,7 +188,7 @@ struct CMUXAuthStateTests {
 
         #expect(state.isAuthenticated)
         #expect(state.currentUser == user)
-        #expect(!state.isRestoringSession)
+        #expect(state.isRestoringSession)
     }
 
     @Test("Primed state does not authenticate from cached user alone")

--- a/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Sources/CmuxAuthRuntime/Coordinator/AuthCoordinator.swift
@@ -50,8 +50,11 @@ public final class AuthCoordinator {
         }
     }
 
-    /// The team id API calls should target: the persisted selection while it is
-    /// still one of ``availableTeams``, else the first available team.
+    /// The team id API calls should target. While the team refresh is unavailable
+    /// or still loading, the account-scoped persisted selection remains effective
+    /// so local state and reconnect routes do not temporarily fall into the
+    /// teamless partition. Once teams load, an invalid selection falls back to the
+    /// first available team.
     public var resolvedTeamID: String? {
         Self.resolveTeamID(selectedTeamID: selectedTeamID, teams: availableTeams)
     }
@@ -625,6 +628,9 @@ public final class AuthCoordinator {
         selectedTeamID: String?,
         teams: [CMUXAuthTeam]
     ) -> String? {
+        if teams.isEmpty {
+            return selectedTeamID
+        }
         if let selectedTeamID,
            teams.contains(where: { $0.id == selectedTeamID }) {
             return selectedTeamID

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTests.swift
@@ -382,6 +382,20 @@ import Testing
         #expect(coordinator.availableTeams.isEmpty)
     }
 
+    @Test func persistedTeamSelectionRemainsEffectiveWhileTeamRefreshIsUnavailable() async throws {
+        let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
+        let client = FakeAuthClient(user: user)
+        await client.setThrowOnListTeams(AuthError.networkError)
+        let (coordinator, _) = makeCoordinator(client: client)
+        coordinator.selectedTeamID = "team_b"
+
+        try await coordinator.signInWithPassword(email: "a@b.com", password: "pw")
+
+        #expect(coordinator.isAuthenticated)
+        #expect(coordinator.availableTeams.isEmpty)
+        #expect(coordinator.resolvedTeamID == "team_b")
+    }
+
     @Test func signOutClearsTeamsAndSelection() async throws {
         let user = CMUXAuthUser(id: "u1", primaryEmail: "a@b.com", displayName: "A")
         let client = FakeAuthClient(user: user)

--- a/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTimeoutTests.swift
+++ b/Packages/Shared/CmuxAuthRuntime/Tests/CmuxAuthRuntimeTests/AuthCoordinatorTimeoutTests.swift
@@ -380,7 +380,7 @@ import Testing
             hasCachedTokens: true
         )
 
-        #expect(coordinator.isRestoringSession == false)
+        #expect(coordinator.isRestoringSession)
         #expect(coordinator.isAuthenticated)
         #expect(coordinator.currentUser == user)
         coordinator.start()

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -22,11 +22,6 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     let session: MobileCoreRPCSession
     private let stackTokenGate: RPCStackTokenGate
     private let stackTokenForceRefreshGate: RPCStackTokenGate
-    /// One-shot token handoff from an authorized request to the immediately
-    /// following host-status identity check on this same connection. This
-    /// avoids a second auth-store read racing launch-time sign-in while keeping
-    /// the token scoped to one client instead of caching it across connections.
-    private let connectionStackToken = MobileCoreRPCConnectionStackToken()
 
     /// Create a client bound to one route + attach ticket.
     /// - Parameters:
@@ -126,6 +121,48 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     /// The optional timeout is a hard end-to-end deadline for auth augmentation,
     /// connection setup, and response wait, not a per-subphase timeout.
     public func sendRequest(_ requestData: Data, timeoutNanoseconds: UInt64? = nil) async throws -> Data {
+        try await sendRequestOperation(
+            requestData,
+            timeoutNanoseconds: timeoutNanoseconds
+        ).response
+    }
+
+    /// Sends an authorized request and then proves host identity with the same
+    /// Stack token that authorized its successful response.
+    ///
+    /// The token stays in this call frame. Failed, cancelled, and concurrent
+    /// requests cannot publish or overwrite authorization state for a later
+    /// host-status probe.
+    public func sendRequestAndAuthenticatedHostStatus(
+        _ requestData: Data,
+        timeoutNanoseconds: UInt64? = nil,
+        hostStatusTimeoutNanoseconds: @Sendable () -> UInt64? = { nil }
+    ) async throws -> (response: Data, hostStatusResponse: Data) {
+        guard let request = try JSONSerialization.jsonObject(with: requestData) as? [String: Any],
+              Self.requestRequiresAuth(request) else {
+            throw MobileShellConnectionError.invalidResponse
+        }
+        let authorized = try await sendRequestOperation(
+            requestData,
+            timeoutNanoseconds: timeoutNanoseconds
+        )
+        let hostStatusTimeout = hostStatusTimeoutNanoseconds()
+        if hostStatusTimeout == 0 {
+            throw MobileShellConnectionError.requestTimedOut
+        }
+        let hostStatus = try await sendRequestOperation(
+            Self.requestData(method: "mobile.host.status", params: [:]),
+            timeoutNanoseconds: hostStatusTimeout,
+            hostStatusStackToken: authorized.stackAccessToken
+        )
+        return (authorized.response, hostStatus.response)
+    }
+
+    private func sendRequestOperation(
+        _ requestData: Data,
+        timeoutNanoseconds: UInt64?,
+        hostStatusStackToken: String? = nil
+    ) async throws -> AuthenticatedRequestResult {
         let deadline = RPCRequestDeadline(
             timeoutNanoseconds: timeoutNanoseconds ?? runtime.rpcRequestTimeoutNanoseconds
         )
@@ -137,7 +174,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             return try await sendAuthenticatedRequest(
                 preparedRequest,
                 deadline: deadline,
-                allowAuthRetry: true
+                allowAuthRetry: true,
+                hostStatusStackToken: hostStatusStackToken
             )
         } catch let error as MobileShellConnectionError {
             // The host rejected this request on Stack-auth grounds. Before
@@ -158,7 +196,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             return try await sendAuthenticatedRequest(
                 preparedRequest,
                 deadline: deadline,
-                allowAuthRetry: false
+                allowAuthRetry: false,
+                hostStatusStackToken: hostStatusStackToken
             )
         }
     }
@@ -220,8 +259,9 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     private func sendAuthenticatedRequest(
         _ requestData: Data,
         deadline: RPCRequestDeadline,
-        allowAuthRetry: Bool
-    ) async throws -> Data {
+        allowAuthRetry: Bool,
+        hostStatusStackToken: String?
+    ) async throws -> AuthenticatedRequestResult {
         // Multiplexed over a persistent transport: each request gets a unique
         // id, the session's reader task routes the response back here. No
         // connect/close per RPC, no head-of-line blocking between calls.
@@ -233,13 +273,18 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         )
         let authenticated = try await requestDataWithAuth(
             augmented,
-            deadline: deadline
+            deadline: deadline,
+            hostStatusStackToken: hostStatusStackToken
         )
         try Task.checkCancellation()
-        return try await session.send(
-            payload: authenticated,
+        let response = try await session.send(
+            payload: authenticated.data,
             requestID: id,
             deadlineUptimeNanoseconds: deadline.uptimeNanoseconds
+        )
+        return AuthenticatedRequestResult(
+            response: response,
+            stackAccessToken: authenticated.stackAccessToken
         )
     }
 
@@ -261,17 +306,25 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         return (id, data)
     }
 
-    private func requestDataWithAuth(_ requestData: Data, deadline: RPCRequestDeadline) async throws -> Data {
+    private func requestDataWithAuth(
+        _ requestData: Data,
+        deadline: RPCRequestDeadline,
+        hostStatusStackToken: String?
+    ) async throws -> AuthenticatedRequestPayload {
         guard var request = try JSONSerialization.jsonObject(with: requestData) as? [String: Any] else {
-            return requestData
+            return AuthenticatedRequestPayload(data: requestData, stackAccessToken: nil)
         }
         if transportRequest.authorizationMode == .transportAdmission {
             request.removeValue(forKey: "auth")
-            return try JSONSerialization.data(withJSONObject: request)
+            return AuthenticatedRequestPayload(
+                data: try JSONSerialization.data(withJSONObject: request),
+                stackAccessToken: nil
+            )
         }
         let requestNeedsAuth = Self.requestRequiresAuth(request)
         let requestIsCoveredByAttachTicket = !Self.requestNeedsStackAuthFallback(request, ticket: ticket)
         var auth: [String: Any] = [:]
+        var requestStackAccessToken: String?
         let attachToken = ticket.authToken?.trimmingCharacters(in: .whitespacesAndNewlines)
         let hasAttachToken = attachToken?.isEmpty == false
         if let attachToken,
@@ -304,7 +357,7 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             do {
                 let token = try await stackAccessToken(deadline: deadline)
                 auth["stack_access_token"] = token
-                await connectionStackToken.remember(token)
+                requestStackAccessToken = token
             } catch let error as MobileShellConnectionError {
                 // The provider already classified the failure: a transient
                 // token-fetch failure (offline / refresh server hiccup, session
@@ -331,8 +384,8 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
            allowsStackAuthFallback,
            MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) {
             let stackAccessToken: String?
-            if let recentToken = await connectionStackToken.take() {
-                stackAccessToken = recentToken
+            if let hostStatusStackToken {
+                stackAccessToken = hostStatusStackToken
             } else {
                 stackAccessToken = try await stackAccessTokenForStatus(deadline: deadline)
             }
@@ -343,7 +396,10 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         if !auth.isEmpty {
             request["auth"] = auth
         }
-        return try JSONSerialization.data(withJSONObject: request)
+        return AuthenticatedRequestPayload(
+            data: try JSONSerialization.data(withJSONObject: request),
+            stackAccessToken: requestStackAccessToken
+        )
     }
 
     private func stackAccessTokenForStatus(deadline: RPCRequestDeadline) async throws -> String? {
@@ -452,26 +508,16 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         let hasConflict: Bool
     }
 
-}
-
-/// Transfers a Stack token across the connect seam inside one RPC client.
-///
-/// Pairing first proves account access with `workspace.list`, then asks
-/// `mobile.host.status` for the authenticated Mac identity. Reusing that exact
-/// token once makes the identity check independent of launch-time auth-store
-/// contention. Consuming the value prevents this from becoming a general token
-/// cache with its own expiry or account-switch lifecycle.
-private actor MobileCoreRPCConnectionStackToken {
-    private var value: String?
-
-    func remember(_ token: String) {
-        value = token
+    private struct AuthenticatedRequestPayload {
+        let data: Data
+        let stackAccessToken: String?
     }
 
-    func take() -> String? {
-        defer { value = nil }
-        return value
+    private struct AuthenticatedRequestResult {
+        let response: Data
+        let stackAccessToken: String?
     }
+
 }
 
 private extension MobileCoreRPCClient {

--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -22,6 +22,11 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
     let session: MobileCoreRPCSession
     private let stackTokenGate: RPCStackTokenGate
     private let stackTokenForceRefreshGate: RPCStackTokenGate
+    /// One-shot token handoff from an authorized request to the immediately
+    /// following host-status identity check on this same connection. This
+    /// avoids a second auth-store read racing launch-time sign-in while keeping
+    /// the token scoped to one client instead of caching it across connections.
+    private let connectionStackToken = MobileCoreRPCConnectionStackToken()
 
     /// Create a client bound to one route + attach ticket.
     /// - Parameters:
@@ -297,7 +302,9 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
                 throw MobileShellConnectionError.insecureManualRoute
             }
             do {
-                auth["stack_access_token"] = try await stackAccessToken(deadline: deadline)
+                let token = try await stackAccessToken(deadline: deadline)
+                auth["stack_access_token"] = token
+                await connectionStackToken.remember(token)
             } catch let error as MobileShellConnectionError {
                 // The provider already classified the failure: a transient
                 // token-fetch failure (offline / refresh server hiccup, session
@@ -322,9 +329,16 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         if !requestNeedsAuth,
            isHostStatusRequest(request),
            allowsStackAuthFallback,
-           MobileShellRouteAuthPolicy.routeAllowsStackAuth(route),
-           let stackAccessToken = try await stackAccessTokenForStatus(deadline: deadline) {
-            auth["stack_access_token"] = stackAccessToken
+           MobileShellRouteAuthPolicy.routeAllowsStackAuth(route) {
+            let stackAccessToken: String?
+            if let recentToken = await connectionStackToken.take() {
+                stackAccessToken = recentToken
+            } else {
+                stackAccessToken = try await stackAccessTokenForStatus(deadline: deadline)
+            }
+            if let stackAccessToken {
+                auth["stack_access_token"] = stackAccessToken
+            }
         }
         if !auth.isEmpty {
             request["auth"] = auth
@@ -438,6 +452,26 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
         let hasConflict: Bool
     }
 
+}
+
+/// Transfers a Stack token across the connect seam inside one RPC client.
+///
+/// Pairing first proves account access with `workspace.list`, then asks
+/// `mobile.host.status` for the authenticated Mac identity. Reusing that exact
+/// token once makes the identity check independent of launch-time auth-store
+/// contention. Consuming the value prevents this from becoming a general token
+/// cache with its own expiry or account-switch lifecycle.
+private actor MobileCoreRPCConnectionStackToken {
+    private var value: String?
+
+    func remember(_ token: String) {
+        value = token
+    }
+
+    func take() -> String? {
+        defer { value = nil }
+        return value
+    }
 }
 
 private extension MobileCoreRPCClient {

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCHostStatusTokenTimeoutTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCHostStatusTokenTimeoutTests.swift
@@ -49,15 +49,13 @@ import Testing
     }
 
     @Test func hostStatusProbeTimeoutCoversStatusStackTokenFallback() async throws {
-        let tokenStarted = AsyncFlag()
+        let tokenProvider = ReleasableStatusTokenProvider()
         let transport = QueuedCancellationProbeTransport()
         let route = try hostPortRoute(kind: .debugLoopback, host: "127.0.0.1", port: 59130)
         let runtime = TestMobileSyncRuntime(
             transportFactory: QueuedCancellationProbeTransportFactory(transport: transport),
             stackAccessTokenForStatusProvider: {
-                await tokenStarted.set()
-                try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
-                return Task.isCancelled ? nil : "late-status-token"
+                await tokenProvider.token()
             },
             rpcRequestTimeoutNanoseconds: 10_000_000
         )
@@ -90,8 +88,9 @@ import Testing
             Issue.record("Expected requestTimedOut, got \(error)")
         }
 
-        #expect(await tokenStarted.isSet())
+        #expect(await tokenProvider.didStart())
         #expect(try await transport.sentRequests().isEmpty)
+        await tokenProvider.release()
     }
 
     @Test func separateHostStatusRequestDoesNotReuseImplicitAuthorizationState() async throws {
@@ -141,6 +140,69 @@ import Testing
         #expect(sent.map(\.method) == ["workspace.list", "mobile.host.status"])
         #expect(sent.map(\.stackAccessToken) == ["workspace-token", "status-token"])
         #expect(await statusTokenProviderStarted.isSet())
+    }
+
+    @Test func explicitHostStatusUsesTheSuccessfulAuthorizedRequestToken() async throws {
+        let statusTokenProviderStarted = AsyncFlag()
+        let transport = ImmediateResponseRecordingTransport()
+        let route = try hostPortRoute(kind: .debugLoopback, host: "127.0.0.1", port: 59132)
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: ImmediateResponseRecordingTransportFactory(transport: transport),
+            stackAccessTokenProvider: { "workspace-token" },
+            stackAccessTokenForStatusProvider: {
+                await statusTokenProviderStarted.set()
+                return "different-status-token"
+            },
+            rpcRequestTimeoutNanoseconds: 60 * 1_000_000_000
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "workspace-main",
+            terminalID: "terminal-main",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(60),
+            authToken: "ticket-secret"
+        )
+        let client = MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            allowsStackAuthFallback: true
+        )
+
+        _ = try await client.sendRequestAndAuthenticatedHostStatus(
+            MobileCoreRPCClient.requestData(
+                method: "workspace.list",
+                params: ["workspace_id": "workspace-main"],
+                id: "workspace"
+            ),
+            hostStatusTimeoutNanoseconds: { 60 * 1_000_000_000 }
+        )
+
+        let sent = try await transport.sentRequests()
+        #expect(sent.map(\.method) == ["workspace.list", "mobile.host.status"])
+        #expect(sent.map(\.stackAccessToken) == ["workspace-token", "workspace-token"])
+        #expect(!(await statusTokenProviderStarted.isSet()))
+    }
+}
+
+private actor ReleasableStatusTokenProvider {
+    private var continuation: CheckedContinuation<String?, Never>?
+    private var started = false
+
+    func token() async -> String? {
+        started = true
+        return await withCheckedContinuation { continuation = $0 }
+    }
+
+    func didStart() -> Bool {
+        started
+    }
+
+    func release() {
+        continuation?.resume(returning: nil)
+        continuation = nil
     }
 }
 

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCHostStatusTokenTimeoutTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCHostStatusTokenTimeoutTests.swift
@@ -93,4 +93,115 @@ import Testing
         #expect(await tokenStarted.isSet())
         #expect(try await transport.sentRequests().isEmpty)
     }
+
+    @Test func hostStatusReusesTokenThatJustAuthorizedWorkspaceList() async throws {
+        let statusTokenProviderStarted = AsyncFlag()
+        let transport = ImmediateResponseRecordingTransport()
+        let route = try hostPortRoute(kind: .debugLoopback, host: "127.0.0.1", port: 59131)
+        let runtime = TestMobileSyncRuntime(
+            transportFactory: ImmediateResponseRecordingTransportFactory(transport: transport),
+            stackAccessTokenProvider: { "workspace-token" },
+            stackAccessTokenForStatusProvider: {
+                await statusTokenProviderStarted.set()
+                try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+                return nil
+            },
+            rpcRequestTimeoutNanoseconds: 100_000_000
+        )
+        let ticket = try CmxAttachTicket(
+            workspaceID: "workspace-main",
+            terminalID: "terminal-main",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(60),
+            authToken: "ticket-secret"
+        )
+        let client = MobileCoreRPCClient(
+            runtime: runtime,
+            route: route,
+            ticket: ticket,
+            allowsStackAuthFallback: true
+        )
+
+        _ = try await client.sendRequest(
+            MobileCoreRPCClient.requestData(
+                method: "workspace.list",
+                params: ["workspace_id": "workspace-main"],
+                id: "workspace"
+            )
+        )
+        _ = try await client.sendRequest(
+            MobileCoreRPCClient.requestData(
+                method: "mobile.host.status",
+                id: "status"
+            )
+        )
+
+        let sent = try await transport.sentRequests()
+        #expect(sent.map(\.method) == ["workspace.list", "mobile.host.status"])
+        #expect(sent.map(\.stackAccessToken) == ["workspace-token", "workspace-token"])
+        #expect(!(await statusTokenProviderStarted.isSet()))
+    }
+}
+
+private actor ImmediateResponseRecordingTransport: CmxByteTransport {
+    private var sentPayloads: [Data] = []
+    private var queuedResponses: [Data] = []
+    private var receiveWaiters: [CheckedContinuation<Data?, Never>] = []
+    private var isClosed = false
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? {
+        guard !isClosed else { return nil }
+        if !queuedResponses.isEmpty {
+            return queuedResponses.removeFirst()
+        }
+        return await withCheckedContinuation { continuation in
+            receiveWaiters.append(continuation)
+        }
+    }
+
+    func send(_ data: Data) async throws {
+        var buffer = data
+        let payloads = try MobileSyncFrameCodec.decodeFrames(from: &buffer)
+        sentPayloads.append(contentsOf: payloads)
+        for payload in payloads {
+            let request = try recordedRPCRequest(from: payload)
+            let response = try JSONSerialization.data(withJSONObject: [
+                "id": request.id ?? "",
+                "ok": true,
+                "result": ["status": "ok"],
+            ])
+            let frame = try MobileSyncFrameCodec.encodeFrame(response)
+            if let waiter = receiveWaiters.first {
+                receiveWaiters.removeFirst()
+                waiter.resume(returning: frame)
+            } else {
+                queuedResponses.append(frame)
+            }
+        }
+    }
+
+    func close() async {
+        isClosed = true
+        let waiters = receiveWaiters
+        receiveWaiters = []
+        for waiter in waiters {
+            waiter.resume(returning: nil)
+        }
+    }
+
+    func sentRequests() throws -> [RecordedRPCRequest] {
+        try sentPayloads.map(recordedRPCRequest(from:))
+    }
+}
+
+private struct ImmediateResponseRecordingTransportFactory: CmxByteTransportFactory {
+    let transport: ImmediateResponseRecordingTransport
+
+    func makeTransport(for route: CmxAttachRoute) throws -> any CmxByteTransport {
+        transport
+    }
 }

--- a/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCHostStatusTokenTimeoutTests.swift
+++ b/Packages/iOS/CmuxMobileRPC/Tests/CmuxMobileRPCTests/MobileCoreRPCHostStatusTokenTimeoutTests.swift
@@ -94,7 +94,7 @@ import Testing
         #expect(try await transport.sentRequests().isEmpty)
     }
 
-    @Test func hostStatusReusesTokenThatJustAuthorizedWorkspaceList() async throws {
+    @Test func separateHostStatusRequestDoesNotReuseImplicitAuthorizationState() async throws {
         let statusTokenProviderStarted = AsyncFlag()
         let transport = ImmediateResponseRecordingTransport()
         let route = try hostPortRoute(kind: .debugLoopback, host: "127.0.0.1", port: 59131)
@@ -103,10 +103,9 @@ import Testing
             stackAccessTokenProvider: { "workspace-token" },
             stackAccessTokenForStatusProvider: {
                 await statusTokenProviderStarted.set()
-                try? await Task.sleep(nanoseconds: 60 * 1_000_000_000)
-                return nil
+                return "status-token"
             },
-            rpcRequestTimeoutNanoseconds: 100_000_000
+            rpcRequestTimeoutNanoseconds: 60 * 1_000_000_000
         )
         let ticket = try CmxAttachTicket(
             workspaceID: "workspace-main",
@@ -140,8 +139,8 @@ import Testing
 
         let sent = try await transport.sentRequests()
         #expect(sent.map(\.method) == ["workspace.list", "mobile.host.status"])
-        #expect(sent.map(\.stackAccessToken) == ["workspace-token", "workspace-token"])
-        #expect(!(await statusTokenProviderStarted.isSet()))
+        #expect(sent.map(\.stackAccessToken) == ["workspace-token", "status-token"])
+        #expect(await statusTokenProviderStarted.isSet())
     }
 }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/IOSBuildScopedPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/IOSBuildScopedPairedMacStore.swift
@@ -239,7 +239,7 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
                 }
             }
         }
-        return byID.values.sorted { lhs, rhs in
+        return removingAuthenticatedLegacyAliases(from: Array(byID.values)).sorted { lhs, rhs in
             if lhs.lastSeenAt != rhs.lastSeenAt { return lhs.lastSeenAt > rhs.lastSeenAt }
             return lhs.id < rhs.id
         }
@@ -501,6 +501,36 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
         instanceTag: String?
     ) -> Bool {
         mac.macDeviceID == macDeviceID && mac.instanceTag == instanceTag
+    }
+
+    /// A legacy nil-tag row and a tagged row are the same app instance only
+    /// when both the physical Mac id and authenticated Iroh peer id match.
+    /// Distinct tagged builds and legacy rows for other peers remain visible.
+    private func removingAuthenticatedLegacyAliases(
+        from rows: [MobilePairedMac]
+    ) -> [MobilePairedMac] {
+        var taggedPeersByMacDeviceID: [String: Set<String>] = [:]
+        for mac in rows where mac.instanceTag?.isEmpty == false {
+            taggedPeersByMacDeviceID[mac.macDeviceID, default: []]
+                .formUnion(irohPeerEndpointIDs(in: mac.routes))
+        }
+        return rows.filter { mac in
+            guard mac.instanceTag == nil,
+                  let taggedPeers = taggedPeersByMacDeviceID[mac.macDeviceID] else {
+                return true
+            }
+            return taggedPeers.isDisjoint(with: irohPeerEndpointIDs(in: mac.routes))
+        }
+    }
+
+    private func irohPeerEndpointIDs(in routes: [CmxAttachRoute]) -> Set<String> {
+        Set(routes.compactMap { route in
+            guard route.kind == .iroh,
+                  case let .peer(identity, _) = route.endpoint else {
+                return nil
+            }
+            return identity.endpointID
+        })
     }
 }
 

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/IOSBuildScopedPairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/IOSBuildScopedPairedMacStore.swift
@@ -4,19 +4,22 @@ public import Foundation
 
 /// Scopes the iOS saved-Mac list to one tagged iOS app build.
 ///
-/// QR pairing still accepts any Mac build because the Mac's device id and routes
-/// are unchanged. This decorator only decides where that successful pairing is
-/// stored, so two iOS dev tags stop restoring or aggregating each other's saved
-/// Macs.
+/// The scoped store also enforces exact Mac app-instance compatibility, so a
+/// tagged iOS build cannot display, restore, or reconnect another tag that was
+/// saved into its partition by an older build.
 public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
     private static let separator = "\u{1F}"
 
+    private let rawInner: any MobilePairedMacStoring
     private let inner: any MobilePairedMacStoring
     private let scope: MobileIOSBuildScope
     private let mutationGate: PairedMacMutationGate
 
     public init(inner: any MobilePairedMacStoring, scope: MobileIOSBuildScope) {
-        self.inner = inner
+        self.rawInner = inner
+        self.inner = MobileMacBuildCompatibilityPolicy
+            .development(expectedInstanceTag: scope.value)
+            .scoping(inner)
         self.scope = scope
         self.mutationGate = PairedMacMutationGate()
     }
@@ -453,8 +456,8 @@ public struct IOSBuildScopedPairedMacStore: MobilePairedMacStoring {
     }
 
     private func removeAllUnlocked() async throws {
-        for mac in try await inner.loadAll(stackUserID: nil, teamID: nil) where isScoped(mac) {
-            try await inner.remove(
+        for mac in try await rawInner.loadAll(stackUserID: nil, teamID: nil) where isScoped(mac) {
+            try await rawInner.remove(
                 macDeviceID: mac.macDeviceID,
                 instanceTag: mac.instanceTag,
                 stackUserID: mac.stackUserID,

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacBuildCompatibilityPolicy.swift
@@ -1,0 +1,65 @@
+public import CMUXMobileCore
+public import CmuxMobilePairedMac
+internal import Foundation
+
+/// Defines which authenticated Mac app instances one iOS app build may use.
+///
+/// Mac app identity remains exact (`default`, `nightly`, or a development tag),
+/// while this policy supplies the compatibility boundary used by persistence,
+/// registry projection, and live connection validation.
+public enum MobileMacBuildCompatibilityPolicy: Equatable, Sendable {
+    /// A tagged development build may use only the matching Mac development tag.
+    case development(expectedInstanceTag: String)
+    /// A distributed iOS build may use Stable and Nightly Mac releases.
+    case official
+
+    /// Resolves the policy compiled into the running iOS app.
+    ///
+    /// - Parameter buildScope: The tagged development scope, when this is a
+    ///   tagged DEBUG build.
+    /// - Returns: Exact-tag development compatibility for DEBUG builds and
+    ///   official compatibility for distributed builds.
+    public static func current(
+        buildScope: MobileIOSBuildScope?
+    ) -> MobileMacBuildCompatibilityPolicy {
+        #if DEBUG
+        return .development(expectedInstanceTag: buildScope?.value ?? "dev")
+        #else
+        return .official
+        #endif
+    }
+
+    /// Returns whether an authenticated Mac instance belongs to this policy.
+    ///
+    /// Missing tags fail closed because they cannot distinguish two app
+    /// instances on the same physical Mac.
+    ///
+    /// - Parameter instanceTag: The tag reported by authenticated host status.
+    /// - Returns: `true` only when the Mac instance is compatible.
+    public func allows(instanceTag: String?) -> Bool {
+        guard let normalizedTag = Self.normalized(instanceTag) else { return false }
+        switch self {
+        case .development(let expectedInstanceTag):
+            return normalizedTag == Self.normalized(expectedInstanceTag)
+        case .official:
+            return normalizedTag == "default" || normalizedTag == "nightly"
+        }
+    }
+
+    /// Wraps a paired-Mac store so every read and mutation follows this policy.
+    ///
+    /// - Parameter store: The underlying persistence implementation.
+    /// - Returns: A store that hides and rejects incompatible app instances.
+    public func scoping(
+        _ store: any MobilePairedMacStoring
+    ) -> any MobilePairedMacStoring {
+        MobileMacCompatiblePairedMacStore(inner: store, policy: self)
+    }
+
+    private static func normalized(_ value: String?) -> String? {
+        let normalized = value?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() ?? ""
+        return normalized.isEmpty ? nil : normalized
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatiblePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatiblePairedMacStore.swift
@@ -1,0 +1,232 @@
+internal import CMUXMobileCore
+internal import CmuxMobilePairedMac
+internal import Foundation
+
+/// Applies one build-compatibility policy to every paired-Mac store operation.
+struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
+    private let inner: any MobilePairedMacStoring
+    private let policy: MobileMacBuildCompatibilityPolicy
+
+    init(
+        inner: any MobilePairedMacStoring,
+        policy: MobileMacBuildCompatibilityPolicy
+    ) {
+        self.inner = inner
+        self.policy = policy
+    }
+
+    func upsert(
+        macDeviceID: String,
+        displayName: String?,
+        routes: [CmxAttachRoute],
+        instanceTag: String?,
+        markActive: Bool,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {
+        guard policy.allows(instanceTag: instanceTag) else { return }
+        try await inner.upsert(
+            macDeviceID: macDeviceID,
+            displayName: displayName,
+            routes: routes,
+            instanceTag: instanceTag,
+            markActive: markActive,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    @discardableResult
+    func upsertIfNewer(
+        macDeviceID: String,
+        displayName: String?,
+        routes: [CmxAttachRoute],
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        markActive: Bool,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws -> Bool {
+        guard policy.allows(instanceTag: instanceTag) else { return false }
+        return try await inner.upsertIfNewer(
+            macDeviceID: macDeviceID,
+            displayName: displayName,
+            routes: routes,
+            instanceTag: instanceTag,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            markActive: markActive,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    @discardableResult
+    func upsertRoutesIfAuthorized(
+        macDeviceID: String,
+        displayName: String?,
+        routes: [CmxAttachRoute],
+        condition: MobilePairedMacRouteWriteCondition,
+        markActive: Bool?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws -> Bool {
+        let instanceTag: String?
+        switch condition {
+        case .matchingInstanceTag(let expectedInstanceTag):
+            instanceTag = expectedInstanceTag
+        case .unclaimed:
+            instanceTag = nil
+        }
+        guard policy.allows(instanceTag: instanceTag) else { return false }
+        return try await inner.upsertRoutesIfAuthorized(
+            macDeviceID: macDeviceID,
+            displayName: displayName,
+            routes: routes,
+            condition: condition,
+            markActive: markActive,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    func loadAll(
+        stackUserID: String?,
+        teamID: String?
+    ) async throws -> [MobilePairedMac] {
+        try await inner.loadAll(stackUserID: stackUserID, teamID: teamID).filter {
+            policy.allows(instanceTag: $0.instanceTag)
+        }
+    }
+
+    func activeMac(
+        stackUserID: String?,
+        teamID: String?
+    ) async throws -> MobilePairedMac? {
+        try await loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first(where: \.isActive)
+    }
+
+    func setActive(
+        macDeviceID: String,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        guard let target = try await loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first(where: { $0.macDeviceID == macDeviceID }) else { return }
+        try await setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: target.instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    func setActive(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        guard policy.allows(instanceTag: instanceTag) else { return }
+        try await inner.setActive(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    func clearActive(stackUserID: String?, teamID: String?) async throws {
+        try await inner.clearActive(stackUserID: stackUserID, teamID: teamID)
+    }
+
+    func setCustomization(
+        macDeviceID: String,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {
+        guard let target = try await loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first(where: { $0.macDeviceID == macDeviceID }) else { return }
+        try await setCustomization(
+            macDeviceID: macDeviceID,
+            instanceTag: target.instanceTag,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    func setCustomization(
+        macDeviceID: String,
+        instanceTag: String?,
+        customName: String?,
+        customColor: String?,
+        customIcon: String?,
+        stackUserID: String?,
+        teamID: String?,
+        now: Date
+    ) async throws {
+        guard policy.allows(instanceTag: instanceTag) else { return }
+        try await inner.setCustomization(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            customName: customName,
+            customColor: customColor,
+            customIcon: customIcon,
+            stackUserID: stackUserID,
+            teamID: teamID,
+            now: now
+        )
+    }
+
+    func remove(
+        macDeviceID: String,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        guard let target = try await loadAll(stackUserID: stackUserID, teamID: teamID)
+            .first(where: { $0.macDeviceID == macDeviceID }) else { return }
+        try await remove(
+            macDeviceID: macDeviceID,
+            instanceTag: target.instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    func remove(
+        macDeviceID: String,
+        instanceTag: String?,
+        stackUserID: String?,
+        teamID: String?
+    ) async throws {
+        guard policy.allows(instanceTag: instanceTag) else { return }
+        try await inner.remove(
+            macDeviceID: macDeviceID,
+            instanceTag: instanceTag,
+            stackUserID: stackUserID,
+            teamID: teamID
+        )
+    }
+
+    func removeAll() async throws {
+        try await inner.removeAll()
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatiblePairedMacStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacCompatiblePairedMacStore.swift
@@ -25,7 +25,7 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         teamID: String?,
         now: Date
     ) async throws {
-        guard policy.allows(instanceTag: instanceTag) else { return }
+        guard isCompatible(instanceTag: instanceTag) else { return }
         try await inner.upsert(
             macDeviceID: macDeviceID,
             displayName: displayName,
@@ -52,7 +52,7 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         teamID: String?,
         now: Date
     ) async throws -> Bool {
-        guard policy.allows(instanceTag: instanceTag) else { return false }
+        guard isCompatible(instanceTag: instanceTag) else { return false }
         return try await inner.upsertIfNewer(
             macDeviceID: macDeviceID,
             displayName: displayName,
@@ -86,7 +86,7 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         case .unclaimed:
             instanceTag = nil
         }
-        guard policy.allows(instanceTag: instanceTag) else { return false }
+        guard isCompatible(instanceTag: instanceTag) else { return false }
         return try await inner.upsertRoutesIfAuthorized(
             macDeviceID: macDeviceID,
             displayName: displayName,
@@ -104,7 +104,7 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         teamID: String?
     ) async throws -> [MobilePairedMac] {
         try await inner.loadAll(stackUserID: stackUserID, teamID: teamID).filter {
-            policy.allows(instanceTag: $0.instanceTag)
+            isCompatible(instanceTag: $0.instanceTag)
         }
     }
 
@@ -137,7 +137,7 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         stackUserID: String?,
         teamID: String?
     ) async throws {
-        guard policy.allows(instanceTag: instanceTag) else { return }
+        guard isCompatible(instanceTag: instanceTag) else { return }
         try await inner.setActive(
             macDeviceID: macDeviceID,
             instanceTag: instanceTag,
@@ -183,7 +183,7 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         teamID: String?,
         now: Date
     ) async throws {
-        guard policy.allows(instanceTag: instanceTag) else { return }
+        guard isCompatible(instanceTag: instanceTag) else { return }
         try await inner.setCustomization(
             macDeviceID: macDeviceID,
             instanceTag: instanceTag,
@@ -217,7 +217,7 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
         stackUserID: String?,
         teamID: String?
     ) async throws {
-        guard policy.allows(instanceTag: instanceTag) else { return }
+        guard isCompatible(instanceTag: instanceTag) else { return }
         try await inner.remove(
             macDeviceID: macDeviceID,
             instanceTag: instanceTag,
@@ -227,6 +227,20 @@ struct MobileMacCompatiblePairedMacStore: MobilePairedMacStoring {
     }
 
     func removeAll() async throws {
-        try await inner.removeAll()
+        for mac in try await loadAll(stackUserID: nil, teamID: nil) {
+            try await inner.remove(
+                macDeviceID: mac.macDeviceID,
+                instanceTag: mac.instanceTag,
+                stackUserID: mac.stackUserID,
+                teamID: mac.teamID
+            )
+        }
+    }
+
+    /// Legacy rows remain visible long enough to be claimed by an
+    /// authenticated tagged instance. Live route adoption still fails closed
+    /// in ``MobileMacBuildCompatibilityPolicy/allows(instanceTag:)``.
+    private func isCompatible(instanceTag: String?) -> Bool {
+        instanceTag == nil || policy.allows(instanceTag: instanceTag)
     }
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobilePairingFailure.swift
@@ -59,11 +59,13 @@ public enum MobilePairingFailureCategory: Equatable, Sendable {
     /// failures and stay ``authFailed``.
     ///
     /// `macChannelIsRelease` is the direction: `true` = development-auth
-    /// phone scanning a release Mac's QR (the sideloaded-dogfood bug; remedy
-    /// `--prod-auth`), `false` = production-auth phone (TestFlight/App Store,
-    /// or a `--prod-auth` dev build) scanning a dev Mac's QR (remedy: pair
-    /// with a release Mac, or use a development-auth phone build).
+    /// phone scanning a release Mac's QR, `false` = production-auth phone
+    /// scanning a dev Mac's QR. The remedy follows build compatibility:
+    /// official iOS with Stable/Nightly, or exact-tag DEV with DEV.
     case authEnvironmentMismatch(macChannelIsRelease: Bool)
+    /// The authenticated Mac app instance is outside this iOS build's
+    /// compatibility policy.
+    case buildIncompatible
     /// The pairing link/QR expired; a fresh one is needed.
     case ticketExpired
     /// The scanned/typed input was not a pairing QR cmux recognizes (malformed,
@@ -109,6 +111,7 @@ extension MobilePairingFailureCategory {
         case .emailMismatch: return "email_mismatch"
         case .authFailed: return "auth"
         case .authEnvironmentMismatch: return "auth_environment_mismatch"
+        case .buildIncompatible: return "build_incompatible"
         case .ticketExpired: return "ticket_expired"
         case .invalidCode: return "invalid_code"
         case .unrecognizedVersion: return "unrecognized_version"
@@ -124,8 +127,8 @@ extension MobilePairingFailureCategory {
     /// Whether a definitive auth failure that should drive the re-auth prompt
     /// (Sign Out) instead of a "could not connect / Retry" banner.
     /// ``authEnvironmentMismatch`` is deliberately NOT one: re-authenticating
-    /// cannot move the account to another Stack project — the remedy is a
-    /// build-level change (rebuild with `--prod-auth`), not signing out.
+    /// cannot move the account to another Stack project. The remedy is choosing
+    /// compatible app builds, not signing out.
     public var isAuthorizationFailure: Bool {
         switch self {
         case .accountMismatch, .emailMismatch, .authFailed, .ticketExpired:
@@ -232,6 +235,11 @@ extension MobilePairingFailureCategory {
                 "mobile.pairing.authEnvironmentMismatch.devMac",
                 defaultValue: "This iPhone uses cmux's production sign-in, but this Mac runs a dev build on the development auth environment, so their accounts can never match — even with the same email."
             )
+        case .buildIncompatible:
+            return L10n.string(
+                "mobile.pairing.buildIncompatible",
+                defaultValue: "This iPhone build cannot connect to that cmux build."
+            )
         case .ticketExpired:
             return L10n.string(
                 "mobile.pairing.attachTicketExpired",
@@ -312,7 +320,7 @@ extension MobilePairingFailureCategory {
             if macChannelIsRelease {
                 return L10n.string(
                     "mobile.pairing.guidance.authEnvironment",
-                    defaultValue: "Rebuild this app with production auth (ios/scripts/reload.sh --prod-auth), or pair with a dev-channel Mac signed in to the same account."
+                    defaultValue: "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use this DEV app with a Mac that has the same DEV tag."
                 )
             }
             // Reaches production users (TestFlight/App Store scanning a dev
@@ -320,6 +328,11 @@ extension MobilePairingFailureCategory {
             return L10n.string(
                 "mobile.pairing.guidance.authEnvironment.devMac",
                 defaultValue: "Pair with a Mac running the release cmux app, or use a development-channel iPhone build for dev Macs."
+            )
+        case .buildIncompatible:
+            return L10n.string(
+                "mobile.pairing.guidance.buildIncompatible",
+                defaultValue: "DEV builds must use the same DEV tag. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
             )
         case .ticketExpired, .unsupportedRoute, .noSupportedRoute:
             return L10n.string(
@@ -423,6 +436,9 @@ extension MobilePairingFailureCategory {
     ) -> MobilePairingFailureCategory {
         let normalizedCode = code?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         if let normalizedCode {
+            if normalizedCode == "build_incompatible" {
+                return .buildIncompatible
+            }
             if normalizedCode == "account_mismatch" {
                 return .accountMismatch
             }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+BuildCompatibility.swift
@@ -1,0 +1,59 @@
+internal import CmuxMobileShellModel
+internal import Foundation
+
+@MainActor
+extension MobileShellComposite {
+    /// Whether authenticated host status belongs to this iOS build's audience.
+    func macBuildIsCompatible(instanceTag: String?) -> Bool {
+        buildCompatibilityPolicy?.allows(instanceTag: instanceTag) ?? true
+    }
+
+    /// Removes registry app instances this iOS build is not allowed to use.
+    func compatibleRegistryDevices(_ devices: [RegistryDevice]) -> [RegistryDevice] {
+        guard let buildCompatibilityPolicy else { return devices }
+        return devices.compactMap { device in
+            let compatibleInstances = device.instances.filter {
+                buildCompatibilityPolicy.allows(instanceTag: $0.tag)
+            }
+            guard !compatibleInstances.isEmpty else { return nil }
+            var compatibleDevice = device
+            compatibleDevice.instances = compatibleInstances
+            compatibleDevice.lastSeenAt = compatibleInstances
+                .map(\.lastSeenAt)
+                .max() ?? .distantPast
+            return compatibleDevice
+        }
+    }
+
+    /// Removes incompatible Mac instances from live presence updates.
+    func compatiblePresenceUpdate(_ update: PresenceUpdate) -> PresenceUpdate? {
+        guard let buildCompatibilityPolicy else { return update }
+        switch update {
+        case .snapshot(var snapshot):
+            snapshot.devices = snapshot.devices.compactMap { device in
+                let instances = device.instances.filter {
+                    buildCompatibilityPolicy.allows(instanceTag: $0.tag)
+                }
+                guard !instances.isEmpty else { return nil }
+                var compatibleDevice = device
+                compatibleDevice.instances = instances
+                compatibleDevice.online = instances.contains(where: \.online)
+                compatibleDevice.lastSeenAt = instances.map(\.lastSeenAt).max() ?? 0
+                return compatibleDevice
+            }
+            return .snapshot(snapshot)
+        case .online(let instance):
+            return buildCompatibilityPolicy.allows(instanceTag: instance.tag)
+                ? .online(instance) : nil
+        case .offline(let instance, let reason):
+            return buildCompatibilityPolicy.allows(instanceTag: instance.tag)
+                ? .offline(instance, reason: reason) : nil
+        case .seen(let deviceId, let tag, let lastSeenAt):
+            return buildCompatibilityPolicy.allows(instanceTag: tag)
+                ? .seen(deviceId: deviceId, tag: tag, lastSeenAt: lastSeenAt) : nil
+        case .routes(let instance):
+            return buildCompatibilityPolicy.allows(instanceTag: instance.tag)
+                ? .routes(instance) : nil
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ManualAttachTicket.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+ManualAttachTicket.swift
@@ -7,7 +7,7 @@ import Foundation
 
 @MainActor
 extension MobileShellComposite {
-    func boundedPairingRequestTimeoutNanoseconds(
+    nonisolated static func boundedPairingRequestTimeoutNanoseconds(
         runtime: any MobileSyncRuntime,
         attemptStartedAt: Date
     ) -> UInt64 {
@@ -115,7 +115,7 @@ extension MobileShellComposite {
         )
         let timeoutNanoseconds: UInt64
         if let attemptStartedAt {
-            timeoutNanoseconds = boundedPairingRequestTimeoutNanoseconds(
+            timeoutNanoseconds = Self.boundedPairingRequestTimeoutNanoseconds(
                 runtime: runtime,
                 attemptStartedAt: attemptStartedAt
             )

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -579,6 +579,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
 
     let runtime: (any MobileSyncRuntime)?
     let pairedMacStore: (any MobilePairedMacStoring)?
+    /// Single compatibility authority shared by registry, persistence, and live connections.
+    let buildCompatibilityPolicy: MobileMacBuildCompatibilityPolicy?
     private let pairedMacRestoreBoundary: PairedMacRestoreBoundary?
     /// Best-effort, team-scoped lookup of fresher attach routes from the device
     /// registry. Optional and failure-tolerant: when `nil` or unreachable,
@@ -886,6 +888,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         pairingCode: String = "",
         workspaces: [MobileWorkspacePreview] = [],
         pairedMacStore: (any MobilePairedMacStoring)? = nil,
+        buildCompatibilityPolicy: MobileMacBuildCompatibilityPolicy? = nil,
         pairedMacRestoreBoundary: PairedMacRestoreBoundary? = nil,
         deviceRegistry: (any DeviceRegistryRefreshing)? = nil,
         presence: (any PresenceSubscribing)? = nil,
@@ -910,6 +913,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         self.draftStore = draftStore
         self.groupCollapseStore = groupCollapseStore
         self.pairedMacStore = pairedMacStore
+        self.buildCompatibilityPolicy = buildCompatibilityPolicy
         self.pairedMacRestoreBoundary = pairedMacRestoreBoundary
         self.deviceRegistry = deviceRegistry
         self.presence = presence
@@ -1951,7 +1955,8 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
         let connectedID = connectedMacDeviceID
         let forgottenIDs = await forgottenMacDeviceIDs(scope: scope)
         guard await isScopeCurrent(scope) else { return }
-        registryDevices = loaded.filter { !forgottenIDs.contains($0.deviceId) }.sorted { lhs, rhs in
+        registryDevices = compatibleRegistryDevices(loaded)
+            .filter { !forgottenIDs.contains($0.deviceId) }.sorted { lhs, rhs in
             let lhsConnected = lhs.deviceId == connectedID
             let rhsConnected = rhs.deviceId == connectedID
             if lhsConnected != rhsConnected { return lhsConnected }
@@ -2055,6 +2060,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
     }
 
     func applyPresenceUpdate(_ update: PresenceUpdate, scope: MobileShellScopeSnapshot) {
+        guard let update = compatiblePresenceUpdate(update) else { return }
         presenceMap.apply(update)
         switch update {
         case .routes(let instance), .online(let instance):
@@ -2659,6 +2665,10 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             connectedHostName = resolvedName
         }
         let resolvedTag = instanceTag?.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard macBuildIsCompatible(instanceTag: resolvedTag) else {
+            rejectForegroundHostIdentity(client: client, reason: "build_incompatible")
+            return
+        }
         if let activeMacInstanceTag,
            let resolvedTag,
            !resolvedTag.isEmpty,
@@ -4832,6 +4842,17 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                     let hasAuthenticatedIdentity = reportedDeviceID?.isEmpty == false
                     let reportedInstanceTag = hasAuthenticatedIdentity ? status?.macInstanceTag : nil
+                    guard macBuildIsCompatible(instanceTag: reportedInstanceTag) else {
+                        mobileShellLog.error(
+                            "rejecting route from incompatible Mac build reported=\(reportedInstanceTag ?? "missing", privacy: .public)"
+                        )
+                        await client.disconnect()
+                        lastError = MobileShellConnectionError.rpcError(
+                            "build_incompatible",
+                            "Mac build is incompatible with this iOS build"
+                        )
+                        continue routeLoop
+                    }
                     let authority = MobileMacInstanceTagAuthority.resolve(
                         expectation: instanceTagExpectation,
                         reportedInstanceTag: reportedInstanceTag

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite.swift
@@ -4800,7 +4800,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                 do {
                     let requestTimeoutNanoseconds: UInt64
                     if let connectionAttemptStartedAt {
-                        requestTimeoutNanoseconds = boundedPairingRequestTimeoutNanoseconds(
+                        requestTimeoutNanoseconds = Self.boundedPairingRequestTimeoutNanoseconds(
                             runtime: runtime,
                             attemptStartedAt: connectionAttemptStartedAt
                         )
@@ -4810,38 +4810,36 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     } else {
                         requestTimeoutNanoseconds = runtime.pairingRequestTimeoutNanoseconds
                     }
-                    let resultData = try await client.sendRequest(
+                    let exchange = try await client.sendRequestAndAuthenticatedHostStatus(
                         workspaceListRequest.data,
-                        timeoutNanoseconds: requestTimeoutNanoseconds
+                        timeoutNanoseconds: requestTimeoutNanoseconds,
+                        hostStatusTimeoutNanoseconds: {
+                            if let connectionAttemptStartedAt {
+                                return Self.boundedPairingRequestTimeoutNanoseconds(
+                                    runtime: runtime,
+                                    attemptStartedAt: connectionAttemptStartedAt
+                                )
+                            }
+                            return runtime.pairingRequestTimeoutNanoseconds
+                        }
                     )
-                    let response = try MobileSyncWorkspaceListResponse.decode(resultData)
+                    let response = try MobileSyncWorkspaceListResponse.decode(exchange.response)
                     guard isConnectCurrent() else {
                         await client.disconnect()
                         return nil
                     }
-                    let hostStatusTimeoutNanoseconds: UInt64
-                    if let connectionAttemptStartedAt {
-                        hostStatusTimeoutNanoseconds = boundedPairingRequestTimeoutNanoseconds(
-                            runtime: runtime,
-                            attemptStartedAt: connectionAttemptStartedAt
-                        )
-                        guard hostStatusTimeoutNanoseconds > 0 else {
-                            throw MobileShellConnectionError.requestTimedOut
-                        }
-                    } else {
-                        hostStatusTimeoutNanoseconds = runtime.pairingRequestTimeoutNanoseconds
-                    }
                     // Bind the route to the authenticated Mac process before
                     // persisting or labeling workspaces. A stale A endpoint may
                     // now be served by tag B on the same physical Mac.
-                    let status = await requestHostStatus(
-                        on: client,
-                        timeoutNanoseconds: hostStatusTimeoutNanoseconds
-                    )
-                    let reportedDeviceID = status?.macDeviceID?
+                    guard let status = try? MobileHostStatusResponse.decode(exchange.hostStatusResponse) else {
+                        await client.disconnect()
+                        lastError = MobileShellConnectionError.invalidResponse
+                        continue routeLoop
+                    }
+                    let reportedDeviceID = status.macDeviceID?
                         .trimmingCharacters(in: .whitespacesAndNewlines)
                     let hasAuthenticatedIdentity = reportedDeviceID?.isEmpty == false
-                    let reportedInstanceTag = hasAuthenticatedIdentity ? status?.macInstanceTag : nil
+                    let reportedInstanceTag = hasAuthenticatedIdentity ? status.macInstanceTag : nil
                     guard macBuildIsCompatible(instanceTag: reportedInstanceTag) else {
                         mobileShellLog.error(
                             "rejecting route from incompatible Mac build reported=\(reportedInstanceTag ?? "missing", privacy: .public)"
@@ -4908,7 +4906,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                         adoptingReportedDeviceID: reportedDeviceID
                     )
                     activeTicket = resolvedTicket
-                    let reportedName = hasAuthenticatedIdentity ? status?.macDisplayName : nil
+                    let reportedName = hasAuthenticatedIdentity ? status.macDisplayName : nil
                     if let reportedName = reportedName?
                         .trimmingCharacters(in: .whitespacesAndNewlines),
                        !reportedName.isEmpty {
@@ -4940,7 +4938,7 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
                     replaceRemoteClient(with: client)
                     activeMacInstanceTag = resolvedInstanceTag
                     prepareTerminalThemeRevisionAuthority(
-                        macInstanceTag: resolvedInstanceTag, producerEpoch: status?.terminalThemeRevisionEpoch,
+                        macInstanceTag: resolvedInstanceTag, producerEpoch: status.terminalThemeRevisionEpoch,
                         connectionID: generation.uuidString
                     )
                     // Reuse the authenticated status response that bound this
@@ -5118,24 +5116,6 @@ public final class MobileShellComposite: MobileTerminalOutputSinking {
             )
         }
         return requests
-    }
-
-    private func requestHostStatus(
-        on client: MobileCoreRPCClient,
-        timeoutNanoseconds: UInt64
-    ) async -> MobileHostStatusResponse? {
-        do {
-            let data = try await client.sendRequest(
-                MobileCoreRPCClient.requestData(method: "mobile.host.status", params: [:]),
-                timeoutNanoseconds: timeoutNanoseconds
-            )
-            return try? MobileHostStatusResponse.decode(data)
-        } catch {
-            mobileShellLog.info(
-                "authenticated host status unavailable during connect: \(String(describing: error), privacy: .private)"
-            )
-            return nil
-        }
     }
 
     private static func ticket(

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceServiceConfiguration.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/PresenceServiceConfiguration.swift
@@ -34,9 +34,9 @@ extension PresenceClient {
     /// one (`isDevelopmentAuthChannel`), not just the build config: each worker
     /// verifies its own Stack project's tokens, so a Debug build resolved to
     /// production auth (`ios/scripts/reload.sh --prod-auth`, issue 7145) must
-    /// subscribe to the production worker or no release Mac could ever appear
-    /// in Computers. The worker URLs live only here — build scripts bake no
-    /// copy — so they cannot drift from the runtime.
+    /// subscribe to the production worker so its token is accepted. The build
+    /// compatibility policy separately filters Mac instances. The worker URLs
+    /// live only here, so build scripts cannot drift from the runtime.
     public static func resolvedServiceBaseURL(
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
@@ -26,6 +26,17 @@ import Testing
         try CmxAttachRoute(id: "manual", kind: .tailscale, endpoint: .hostPort(host: host, port: 22))
     }
 
+    private func irohRoute(_ endpointID: Character) throws -> CmxAttachRoute {
+        try CmxAttachRoute(
+            id: "iroh",
+            kind: .iroh,
+            endpoint: .peer(
+                identity: CmxIrohPeerIdentity(endpointID: String(repeating: endpointID, count: 64)),
+                pathHints: []
+            )
+        )
+    }
+
     @Test func scopesRowsByIOSBuildTag() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
@@ -105,6 +116,50 @@ import Testing
         let rows = try await feature.loadAll(stackUserID: "user-1", teamID: "team-a")
         #expect(rows.map(\.macDeviceID) == ["teamless"])
         #expect(rows.first?.teamID == nil)
+    }
+
+    @Test func authenticatedTaggedRowSupersedesMatchingLegacyPeerOnly() async throws {
+        let (inner, directory) = try makeInnerStore()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let feature = IOSBuildScopedPairedMacStore(
+            inner: inner,
+            scope: try #require(MobileIOSBuildScope("feature"))
+        )
+
+        try await feature.upsert(
+            macDeviceID: "mac-a",
+            displayName: "Current",
+            routes: [try irohRoute("a")],
+            instanceTag: "feature",
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 30)
+        )
+        try await feature.upsert(
+            macDeviceID: "mac-a",
+            displayName: "Other app instance",
+            routes: [try irohRoute("b")],
+            instanceTag: "other",
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: Date(timeIntervalSince1970: 20)
+        )
+        try await feature.upsert(
+            macDeviceID: "mac-a",
+            displayName: "Legacy alias",
+            routes: [try irohRoute("a")],
+            instanceTag: nil,
+            markActive: false,
+            stackUserID: "user-1",
+            teamID: nil,
+            now: Date(timeIntervalSince1970: 10)
+        )
+
+        let rows = try await feature.loadAll(stackUserID: "user-1", teamID: "team-a")
+
+        #expect(rows.map(\.instanceTag) == ["feature", "other"])
     }
 
     @Test func newerTeamlessSiblingTagDoesNotReplaceActiveSelectedTag() async throws {

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
@@ -118,7 +118,7 @@ import Testing
         #expect(rows.first?.teamID == nil)
     }
 
-    @Test func authenticatedTaggedRowSupersedesMatchingLegacyPeerOnly() async throws {
+    @Test func buildScopeHidesSiblingTagAndMatchingLegacyPeer() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
         let feature = IOSBuildScopedPairedMacStore(
@@ -159,10 +159,10 @@ import Testing
 
         let rows = try await feature.loadAll(stackUserID: "user-1", teamID: "team-a")
 
-        #expect(rows.map(\.instanceTag) == ["feature", "other"])
+        #expect(rows.map(\.instanceTag) == ["feature"])
     }
 
-    @Test func newerTeamlessSiblingTagDoesNotReplaceActiveSelectedTag() async throws {
+    @Test func newerTeamlessSiblingTagIsNotVisibleOrActive() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
         let feature = IOSBuildScopedPairedMacStore(
@@ -193,15 +193,11 @@ import Testing
         let rows = try await feature.loadAll(
             stackUserID: "user-1", teamID: "team-a"
         )
-        #expect(rows.count == 2)
+        #expect(rows.count == 1)
         let selected = try #require(rows.first { $0.instanceTag == "feature-a" })
-        let fallback = try #require(rows.first { $0.instanceTag == "feature-b" })
         #expect(selected.teamID == "team-a")
         #expect(selected.routes == [try route("10.0.0.1")])
         #expect(selected.isActive)
-        #expect(fallback.teamID == nil)
-        #expect(fallback.routes == [try route("10.0.0.2")])
-        #expect(!fallback.isActive)
         #expect(try await feature.activeMac(
             stackUserID: "user-1", teamID: "team-a"
         )?.instanceTag == "feature-a")

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IOSBuildScopedPairedMacStoreTests.swift
@@ -47,6 +47,7 @@ import Testing
             macDeviceID: "mac-a",
             displayName: "A",
             routes: [try route("10.0.0.1")],
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: "team-a",
@@ -56,6 +57,7 @@ import Testing
             macDeviceID: "mac-b",
             displayName: "B",
             routes: [try route("10.0.0.2")],
+            instanceTag: "other",
             markActive: true,
             stackUserID: "user-1",
             teamID: "team-a",
@@ -98,6 +100,7 @@ import Testing
             macDeviceID: "teamless",
             displayName: "Teamless",
             routes: [try route("10.0.0.1")],
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: nil,
@@ -107,6 +110,7 @@ import Testing
             macDeviceID: "other-scope",
             displayName: "Other",
             routes: [try route("10.0.0.2")],
+            instanceTag: "other",
             markActive: true,
             stackUserID: "user-1",
             teamID: nil,
@@ -121,9 +125,10 @@ import Testing
     @Test func buildScopeHidesSiblingTagAndMatchingLegacyPeer() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
+        let scope = try #require(MobileIOSBuildScope("feature"))
         let feature = IOSBuildScopedPairedMacStore(
             inner: inner,
-            scope: try #require(MobileIOSBuildScope("feature"))
+            scope: scope
         )
 
         try await feature.upsert(
@@ -136,24 +141,24 @@ import Testing
             teamID: "team-a",
             now: Date(timeIntervalSince1970: 30)
         )
-        try await feature.upsert(
+        try await inner.upsert(
             macDeviceID: "mac-a",
             displayName: "Other app instance",
             routes: [try irohRoute("b")],
             instanceTag: "other",
             markActive: false,
             stackUserID: "user-1",
-            teamID: nil,
+            teamID: "\u{1F}\(scope.serializedScope)",
             now: Date(timeIntervalSince1970: 20)
         )
-        try await feature.upsert(
+        try await inner.upsert(
             macDeviceID: "mac-a",
             displayName: "Legacy alias",
             routes: [try irohRoute("a")],
             instanceTag: nil,
             markActive: false,
             stackUserID: "user-1",
-            teamID: nil,
+            teamID: "\u{1F}\(scope.serializedScope)",
             now: Date(timeIntervalSince1970: 10)
         )
 
@@ -165,28 +170,29 @@ import Testing
     @Test func newerTeamlessSiblingTagIsNotVisibleOrActive() async throws {
         let (inner, directory) = try makeInnerStore()
         defer { try? FileManager.default.removeItem(at: directory) }
+        let scope = try #require(MobileIOSBuildScope("feature"))
         let feature = IOSBuildScopedPairedMacStore(
             inner: inner,
-            scope: try #require(MobileIOSBuildScope("feature"))
+            scope: scope
         )
         try await feature.upsert(
             macDeviceID: "mac-a",
             displayName: "Selected",
             routes: [try route("10.0.0.1")],
-            instanceTag: "feature-a",
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: "team-a",
             now: Date(timeIntervalSince1970: 1)
         )
-        try await feature.upsert(
+        try await inner.upsert(
             macDeviceID: "mac-a",
             displayName: "Fallback",
             routes: [try route("10.0.0.2")],
             instanceTag: "feature-b",
             markActive: false,
             stackUserID: "user-1",
-            teamID: nil,
+            teamID: "\u{1F}\(scope.serializedScope)",
             now: Date(timeIntervalSince1970: 2)
         )
 
@@ -194,13 +200,13 @@ import Testing
             stackUserID: "user-1", teamID: "team-a"
         )
         #expect(rows.count == 1)
-        let selected = try #require(rows.first { $0.instanceTag == "feature-a" })
+        let selected = try #require(rows.first { $0.instanceTag == "feature" })
         #expect(selected.teamID == "team-a")
         #expect(selected.routes == [try route("10.0.0.1")])
         #expect(selected.isActive)
         #expect(try await feature.activeMac(
             stackUserID: "user-1", teamID: "team-a"
-        )?.instanceTag == "feature-a")
+        )?.instanceTag == "feature")
     }
 
     @Test func selectedTeamUpsertClaimsTeamlessScopedRow() async throws {
@@ -212,6 +218,7 @@ import Testing
             macDeviceID: "mac-a",
             displayName: "A",
             routes: [try route("10.0.0.1")],
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: nil,
@@ -230,6 +237,7 @@ import Testing
             macDeviceID: "mac-a",
             displayName: "A",
             routes: [try route("10.0.0.9")],
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: "team-a",
@@ -254,6 +262,7 @@ import Testing
             macDeviceID: "teamless",
             displayName: "Teamless",
             routes: [try route("10.0.0.1")],
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: nil,
@@ -263,6 +272,7 @@ import Testing
             macDeviceID: "team-row",
             displayName: "Team",
             routes: [try route("10.0.0.2")],
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: "team-a",
@@ -282,13 +292,13 @@ import Testing
         )
         try await feature.upsert(
             macDeviceID: "mac-b", displayName: "B", routes: [try route("10.0.0.2")],
-            instanceTag: "feature-b", markActive: true, stackUserID: "user-1",
+            instanceTag: "feature", markActive: true, stackUserID: "user-1",
             teamID: nil, now: Date(timeIntervalSince1970: 20)
         )
 
         _ = try await feature.upsertIfNewer(
             macDeviceID: "mac-a", displayName: "A", routes: [try route("10.0.0.1")],
-            instanceTag: "feature-a", customName: nil, customColor: nil,
+            instanceTag: "feature", customName: nil, customColor: nil,
             customIcon: nil, markActive: true, stackUserID: "user-1",
             teamID: "team-a", now: Date(timeIntervalSince1970: 10)
         )
@@ -306,7 +316,7 @@ import Testing
         )
         try await feature.upsert(
             macDeviceID: "mac-a", displayName: "A", routes: [try route("10.0.0.1")],
-            instanceTag: "feature-a", markActive: false, stackUserID: "user-1",
+            instanceTag: "feature", markActive: false, stackUserID: "user-1",
             teamID: nil, now: Date(timeIntervalSince1970: 1)
         )
         try await feature.setActive(
@@ -315,7 +325,7 @@ import Testing
 
         _ = try await feature.upsertIfNewer(
             macDeviceID: "mac-a", displayName: "A", routes: [try route("10.0.0.9")],
-            instanceTag: "feature-a", customName: nil, customColor: nil,
+            instanceTag: "feature", customName: nil, customColor: nil,
             customIcon: nil, markActive: false, stackUserID: "user-1",
             teamID: "team-a", now: Date(timeIntervalSince1970: 10)
         )
@@ -333,7 +343,7 @@ import Testing
         let seedStore = IOSBuildScopedPairedMacStore(inner: inner, scope: scope)
         try await seedStore.upsert(
             macDeviceID: "mac-a", displayName: "A", routes: [try route("10.0.0.1")],
-            instanceTag: "feature-a", markActive: true, stackUserID: "user-1",
+            instanceTag: "feature", markActive: true, stackUserID: "user-1",
             teamID: nil, now: Date(timeIntervalSince1970: 1)
         )
         let gatedInner = GatedUpsertStore(inner: inner)
@@ -342,7 +352,7 @@ import Testing
         let restore = Task {
             try await feature.upsertIfNewer(
                 macDeviceID: "mac-a", displayName: "Restored A",
-                routes: [try route("10.0.0.9")], instanceTag: "feature-a",
+                routes: [try route("10.0.0.9")], instanceTag: "feature",
                 customName: nil, customColor: nil, customIcon: nil,
                 markActive: true, stackUserID: "user-1", teamID: "team-a",
                 now: Date(timeIntervalSince1970: 10)
@@ -352,7 +362,7 @@ import Testing
         let liveWrite = Task {
             try await feature.upsert(
                 macDeviceID: "mac-a", displayName: "Live B",
-                routes: [try route("10.0.0.2")], instanceTag: "feature-b",
+                routes: [try route("10.0.0.2")], instanceTag: "feature",
                 markActive: true, stackUserID: "user-1", teamID: nil,
                 now: Date(timeIntervalSince1970: 20)
             )
@@ -364,7 +374,7 @@ import Testing
         let current = try #require(await feature.loadAll(
             stackUserID: "user-1", teamID: "team-a"
         ).first(where: { $0.macDeviceID == "mac-a" }))
-        #expect(current.instanceTag == "feature-b")
+        #expect(current.instanceTag == "feature")
         #expect(current.displayName == "Live B")
         #expect(current.routes.first?.endpoint == .hostPort(host: "10.0.0.2", port: 22))
         #expect(current.isActive)
@@ -380,6 +390,7 @@ import Testing
             macDeviceID: "mac-a",
             displayName: "A",
             routes: [try route("10.0.0.1")],
+            instanceTag: "feature",
             markActive: true,
             stackUserID: "user-1",
             teamID: "team-a",
@@ -389,6 +400,7 @@ import Testing
             macDeviceID: "mac-b",
             displayName: "B",
             routes: [try route("10.0.0.2")],
+            instanceTag: "other",
             markActive: true,
             stackUserID: "user-1",
             teamID: "team-a",

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/IrohReconnectRouteSelectionTests.swift
@@ -968,10 +968,8 @@ extension ReconnectRouteSelectionTests {
 
         let recovered = try await pollUntil(attempts: 100) {
             guard let current = box.get() else { return false }
-            let foregroundProbeCount = await router.count(of: "mobile.workspace.list")
             return current !== firstTransport
                 && store.connectionState == .connected
-                && foregroundProbeCount >= 1
         }
         #expect(recovered)
         #expect(store.activeRoute?.kind == .iroh)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -1,0 +1,188 @@
+import CMUXMobileCore
+import CmuxMobilePairedMac
+import CmuxMobileShellModel
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@Suite struct MobileMacBuildCompatibilityPolicyTests {
+    @Test func developmentRequiresExactTag() {
+        let policy = MobileMacBuildCompatibilityPolicy.development(
+            expectedInstanceTag: "icap"
+        )
+
+        #expect(policy.allows(instanceTag: "icap"))
+        #expect(policy.allows(instanceTag: " ICAP "))
+        #expect(!policy.allows(instanceTag: "tsmig"))
+        #expect(!policy.allows(instanceTag: "default"))
+        #expect(!policy.allows(instanceTag: "nightly"))
+        #expect(!policy.allows(instanceTag: nil))
+    }
+
+    @Test func officialKeepsStableAndNightlyAsDistinctAllowedIdentities() {
+        let policy = MobileMacBuildCompatibilityPolicy.official
+
+        #expect(policy.allows(instanceTag: "default"))
+        #expect(policy.allows(instanceTag: "nightly"))
+        #expect(!policy.allows(instanceTag: "icap"))
+        #expect(!policy.allows(instanceTag: "rc"))
+        #expect(!policy.allows(instanceTag: "staging"))
+        #expect(!policy.allows(instanceTag: nil))
+    }
+
+    @Test func scopedStoreHidesAndRejectsIncompatibleRows() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let raw = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired.sqlite3")
+        )
+        let route = try CmxAttachRoute(
+            id: "test",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.1", port: 22)
+        )
+        for (tag, seen) in [("icap", 1.0), ("tsmig", 2.0)] {
+            try await raw.upsert(
+                macDeviceID: "shared-mac",
+                displayName: tag,
+                routes: [route],
+                instanceTag: tag,
+                markActive: tag == "tsmig",
+                stackUserID: "user-1",
+                teamID: "team-a",
+                now: Date(timeIntervalSince1970: seen)
+            )
+        }
+        let scoped = MobileMacBuildCompatibilityPolicy
+            .development(expectedInstanceTag: "icap")
+            .scoping(raw)
+
+        #expect(try await scoped.loadAll(
+            stackUserID: "user-1", teamID: "team-a"
+        ).map(\.instanceTag) == ["icap"])
+        #expect(try await scoped.activeMac(
+            stackUserID: "user-1", teamID: "team-a"
+        ) == nil)
+
+        try await scoped.upsert(
+            macDeviceID: "other-mac",
+            displayName: "Other",
+            routes: [route],
+            instanceTag: "tsmig",
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 3)
+        )
+        #expect(try await raw.loadAll(
+            stackUserID: "user-1", teamID: "team-a"
+        ).allSatisfy { $0.macDeviceID != "other-mac" })
+    }
+
+    @Test func officialStoreKeepsStableAndNightlyButRejectsDevelopment() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let raw = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired.sqlite3")
+        )
+        let route = try CmxAttachRoute(
+            id: "test",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.1", port: 22)
+        )
+        for (tag, seen) in [("default", 1.0), ("nightly", 2.0), ("icap", 3.0)] {
+            try await raw.upsert(
+                macDeviceID: "shared-mac",
+                displayName: tag,
+                routes: [route],
+                instanceTag: tag,
+                markActive: false,
+                stackUserID: "user-1",
+                teamID: "team-a",
+                now: Date(timeIntervalSince1970: seen)
+            )
+        }
+        let official = MobileMacBuildCompatibilityPolicy.official.scoping(raw)
+
+        #expect(Set(try await official.loadAll(
+            stackUserID: "user-1", teamID: "team-a"
+        ).compactMap(\.instanceTag)) == ["default", "nightly"])
+    }
+
+    @MainActor
+    @Test func registryProjectionKeepsOnlyCompatibleInstances() {
+        let store = MobileShellComposite(
+            buildCompatibilityPolicy: .development(expectedInstanceTag: "icap")
+        )
+        let device = RegistryDevice(
+            deviceId: "shared-mac",
+            platform: "mac",
+            displayName: "Mac",
+            lastSeenAt: Date(timeIntervalSince1970: 20),
+            instances: [
+                RegistryAppInstance(
+                    tag: "icap", routes: [], lastSeenAt: Date(timeIntervalSince1970: 10)
+                ),
+                RegistryAppInstance(
+                    tag: "tsmig", routes: [], lastSeenAt: Date(timeIntervalSince1970: 20)
+                ),
+            ]
+        )
+
+        let projected = store.compatibleRegistryDevices([device])
+
+        #expect(projected.count == 1)
+        #expect(projected[0].instances.map(\.tag) == ["icap"])
+        #expect(projected[0].lastSeenAt == Date(timeIntervalSince1970: 10))
+    }
+
+    @MainActor
+    @Test func presenceProjectionKeepsOnlyCompatibleInstances() {
+        let store = MobileShellComposite(
+            buildCompatibilityPolicy: .development(expectedInstanceTag: "icap")
+        )
+        let icap = PresenceInstance(
+            deviceId: "shared-mac",
+            tag: "icap",
+            platform: "mac",
+            online: false,
+            lastSeenAt: 10
+        )
+        let tsmig = PresenceInstance(
+            deviceId: "shared-mac",
+            tag: "tsmig",
+            platform: "mac",
+            online: true,
+            lastSeenAt: 20
+        )
+        let update = PresenceUpdate.snapshot(PresenceSnapshot(
+            teamId: "team-a",
+            now: 20,
+            heartbeatIntervalMs: 5,
+            offlineTimeoutMs: 15,
+            devices: [PresenceDevice(
+                deviceId: "shared-mac",
+                platform: "mac",
+                displayName: "Mac",
+                online: true,
+                lastSeenAt: 20,
+                instances: [icap, tsmig]
+            )]
+        ))
+
+        let projected = store.compatiblePresenceUpdate(update)
+        guard case .snapshot(let snapshot) = projected else {
+            Issue.record("expected a compatible presence snapshot")
+            return
+        }
+        #expect(snapshot.devices.count == 1)
+        #expect(snapshot.devices[0].instances.map(\.tag) == ["icap"])
+        #expect(!snapshot.devices[0].online)
+        #expect(snapshot.devices[0].lastSeenAt == 10)
+        #expect(store.compatiblePresenceUpdate(.online(tsmig)) == nil)
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -81,6 +81,94 @@ import Testing
         ).allSatisfy { $0.macDeviceID != "other-mac" })
     }
 
+    @Test func scopedStoreKeepsUnclaimedLegacyRowsMigratable() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let raw = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired.sqlite3")
+        )
+        let originalRoute = try CmxAttachRoute(
+            id: "legacy",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.1", port: 22)
+        )
+        let updatedRoute = try CmxAttachRoute(
+            id: "legacy-updated",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.2", port: 22)
+        )
+        try await raw.upsert(
+            macDeviceID: "legacy-mac",
+            displayName: "Legacy",
+            routes: [originalRoute],
+            instanceTag: nil,
+            markActive: true,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 1)
+        )
+        let scoped = MobileMacBuildCompatibilityPolicy
+            .development(expectedInstanceTag: "icap")
+            .scoping(raw)
+
+        #expect(try await scoped.loadAll(
+            stackUserID: "user-1", teamID: "team-a"
+        ).map(\.macDeviceID) == ["legacy-mac"])
+        let updated = try await scoped.upsertRoutesIfAuthorized(
+            macDeviceID: "legacy-mac",
+            displayName: "Legacy",
+            routes: [updatedRoute],
+            condition: .unclaimed,
+            markActive: nil,
+            stackUserID: "user-1",
+            teamID: "team-a",
+            now: Date(timeIntervalSince1970: 2)
+        )
+
+        #expect(updated)
+        #expect(try await raw.loadAll(
+            stackUserID: "user-1", teamID: "team-a"
+        ).first?.routes == [updatedRoute])
+    }
+
+    @Test func scopedRemoveAllPreservesIncompatibleRows() async throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let raw = try MobilePairedMacStore(
+            databaseURL: directory.appendingPathComponent("paired.sqlite3")
+        )
+        let route = try CmxAttachRoute(
+            id: "test",
+            kind: .tailscale,
+            endpoint: .hostPort(host: "100.64.0.1", port: 22)
+        )
+        for tag in ["icap", "tsmig"] {
+            try await raw.upsert(
+                macDeviceID: "shared-mac",
+                displayName: tag,
+                routes: [route],
+                instanceTag: tag,
+                markActive: false,
+                stackUserID: "user-1",
+                teamID: "team-a",
+                now: Date()
+            )
+        }
+        let scoped = MobileMacBuildCompatibilityPolicy
+            .development(expectedInstanceTag: "icap")
+            .scoping(raw)
+
+        try await scoped.removeAll()
+
+        #expect(try await raw.loadAll(
+            stackUserID: nil, teamID: nil
+        ).compactMap(\.instanceTag) == ["tsmig"])
+    }
+
     @Test func officialStoreKeepsStableAndNightlyButRejectsDevelopment() async throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobileMacBuildCompatibilityPolicyTests.swift
@@ -146,7 +146,7 @@ import Testing
             kind: .tailscale,
             endpoint: .hostPort(host: "100.64.0.1", port: 22)
         )
-        for tag in ["icap", "tsmig"] {
+        for (tag, seenAt) in [("icap", 1.0), ("tsmig", 2.0)] {
             try await raw.upsert(
                 macDeviceID: "shared-mac",
                 displayName: tag,
@@ -155,7 +155,7 @@ import Testing
                 markActive: false,
                 stackUserID: "user-1",
                 teamID: "team-a",
-                now: Date()
+                now: Date(timeIntervalSince1970: seenAt)
             )
         }
         let scoped = MobileMacBuildCompatibilityPolicy

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePairingFailureTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/MobilePairingFailureTests.swift
@@ -142,17 +142,34 @@ import Testing
         #expect(category.analyticsReason == "unsupported_route")
     }
 
+    @Test func incompatibleBuildNamesTheCompatibilityBoundary() {
+        let category = MobilePairingFailureCategory.classify(
+            error: MobileShellConnectionError.rpcError(
+                "build_incompatible",
+                "Mac build is incompatible with this iOS build"
+            ),
+            route: nil
+        )
+
+        #expect(category == .buildIncompatible)
+        #expect(category.analyticsReason == "build_incompatible")
+        #expect(category.message.contains("cannot connect"))
+        #expect(category.guidance?.contains("same DEV tag") == true)
+        #expect(!category.isAuthorizationFailure)
+    }
+
     @Test func authEnvironmentMismatchTellsTheTruthAboutTheChannel() {
         // A dev-channel build failing a release Mac's QR user-id binding: the
         // emails DO match, so the copy must name the auth-environment cause and
-        // the --prod-auth remedy instead of the authFailed "same email" advice
+        // the matching-build remedy instead of the authFailed "same email" advice
         // (https://github.com/manaflow-ai/cmux/issues/7145).
         let category = MobilePairingFailureCategory.authEnvironmentMismatch(macChannelIsRelease: true)
         #expect(category.analyticsReason == "auth_environment_mismatch")
         #expect(category.message.contains("development auth environment"))
         #expect(category.message != MobilePairingFailureCategory.authFailed.message)
         #expect(!category.message.contains("Make sure both devices are signed in"))
-        #expect(category.guidance?.contains("--prod-auth") == true)
+        #expect(category.guidance?.contains("BETA") == true)
+        #expect(category.guidance?.contains("same DEV tag") == true)
         // Signing out cannot move the account to another Stack project, so this
         // must not drive the re-auth (Sign Out) prompt.
         #expect(!category.isAuthorizationFailure)
@@ -235,6 +252,7 @@ import Testing
             .authFailed,
             .authEnvironmentMismatch(macChannelIsRelease: true),
             .authEnvironmentMismatch(macChannelIsRelease: false),
+            .buildIncompatible,
             .ticketExpired,
             .invalidCode,
             .unrecognizedVersion,

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TaggedBuildPresenceRouteIsolationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TaggedBuildPresenceRouteIsolationTests.swift
@@ -128,7 +128,7 @@ import Testing
         #expect(try await storedRoutes(in: pairedStore) == [restartedB])
     }
 
-    @Test func productionAuthTaggedBuildUsesDefaultMacForRoutesAndRecovery() async throws {
+    @Test func officialBuildUsesStableMacForRoutesAndRecovery() async throws {
         let original = try route(id: "original", host: "100.64.0.1", port: 50_000)
         let defaultRoute = try route(id: "stable", host: "100.64.0.2", port: 51_001)
         let routeB = try route(id: "b", host: "100.64.0.3", port: 51_002)
@@ -143,6 +143,7 @@ import Testing
         let store = MobileShellComposite(
             isSignedIn: true,
             pairedMacStore: pairedStore,
+            buildCompatibilityPolicy: .official,
             identityProvider: StaticIdentityProvider(userID: "user-1"),
             teamIDProvider: { "team-a" },
             reachability: AlwaysOnlineReachability()

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TaggedBuildRegistryRouteIsolationTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/TaggedBuildRegistryRouteIsolationTests.swift
@@ -38,7 +38,7 @@ import Testing
         ) == nil)
     }
 
-    @Test func productionAuthTaggedIOSReadsOnlyDefaultMacRoutes() throws {
+    @Test func officialIOSReadsOnlyRequestedStableMacRoutes() throws {
         let data = try JSONSerialization.data(withJSONObject: [
             "devices": [[
                 "deviceId": "shared-physical-mac",

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -186,7 +186,10 @@ struct CMUXMobileRootView: View {
         .onChange(of: authManager.isRestoringSession) { _, isRestoringSession in
             syncShellAuthentication(isAuthenticated, isRestoringSession: isRestoringSession)
             guard !isRestoringSession else { return }
-            _ = consumePendingURLIfReady()
+            if consumePendingURLIfReady() {
+                return
+            }
+            reconnectStoredMacIfNeeded()
         }
         .onChange(of: store.connectionState) { _, connectionState in
             if connectionState == .connected {
@@ -377,12 +380,13 @@ struct CMUXMobileRootView: View {
     /// sign-in that completes after mount) so the restoring gate always resolves
     /// even when the auth state never transitions while this view is mounted.
     private func reconnectStoredMacIfNeeded() {
-        guard isAuthenticated else { return }
+        guard isAuthenticated, !authManager.isRestoringSession else { return }
         let startedUITestAttachURL = connectUITestAttachURLIfNeeded()
         guard !startedUITestAttachURL,
               MobileRootAuthGate.shouldReconnectStoredMac(
                 stackAuthenticated: authManager.isAuthenticated,
                 attachTicketAuthenticated: hasActiveAttachTicketAuthentication,
+                isRestoringSession: authManager.isRestoringSession,
                 connectionState: store.connectionState
               ) else { return }
         let stackUserID = authManager.currentUser?.id

--- a/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Sources/CmuxMobileWorkspace/MobileRootAuthGate.swift
@@ -78,14 +78,19 @@ public struct MobileRootAuthGate {
     /// - Parameters:
     ///   - stackAuthenticated: Whether Stack auth is established.
     ///   - attachTicketAuthenticated: Whether a temporary attach ticket grants access.
+    ///   - isRestoringSession: Whether cached auth is still being validated or recreated.
     ///   - connectionState: The current connection state.
-    /// - Returns: `true` when Stack-authenticated without a temporary ticket and not yet connected.
+    /// - Returns: `true` when Stack-authenticated, auth restore is complete, no temporary ticket is active, and the Mac is not yet connected.
     public static func shouldReconnectStoredMac(
         stackAuthenticated: Bool,
         attachTicketAuthenticated: Bool,
+        isRestoringSession: Bool,
         connectionState: MobileConnectionState
     ) -> Bool {
-        stackAuthenticated && !attachTicketAuthenticated && connectionState != .connected
+        stackAuthenticated
+            && !isRestoringSession
+            && !attachTicketAuthenticated
+            && connectionState != .connected
     }
 
     /// Whether the restoring-session UI should be shown while reconnecting a known

--- a/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
+++ b/Packages/iOS/CmuxMobileWorkspace/Tests/CmuxMobileWorkspaceTests/MobileRootAuthGateTests.swift
@@ -84,16 +84,25 @@ import Testing
         #expect(MobileRootAuthGate.shouldReconnectStoredMac(
             stackAuthenticated: true,
             attachTicketAuthenticated: false,
+            isRestoringSession: false,
             connectionState: .disconnected
         ))
         #expect(!MobileRootAuthGate.shouldReconnectStoredMac(
             stackAuthenticated: true,
             attachTicketAuthenticated: true,
+            isRestoringSession: false,
             connectionState: .disconnected
         ))
         #expect(!MobileRootAuthGate.shouldReconnectStoredMac(
             stackAuthenticated: false,
             attachTicketAuthenticated: true,
+            isRestoringSession: false,
+            connectionState: .disconnected
+        ))
+        #expect(!MobileRootAuthGate.shouldReconnectStoredMac(
+            stackAuthenticated: true,
+            attachTicketAuthenticated: false,
+            isRestoringSession: true,
             connectionState: .disconnected
         ))
     }

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1013,6 +1013,9 @@ final class MobileHostService {
                 )
             },
             onAuthorizedRequest: { request in
+                await MobileHostService.shared.retireSupersededIrohConnections(
+                    newestConnectionID: id
+                )
                 guard let clientID = Self.clientID(from: request.params) else {
                     return
                 }
@@ -1200,6 +1203,14 @@ final class MobileHostService {
             )
         }
         MobileHostRequestActivity.endConnection()
+    }
+
+    private func retireSupersededIrohConnections(newestConnectionID: UUID) async {
+        let superseded = MobileHostConnectionRegistry.shared
+            .removeOlderIrohConnectionsIfNewest(id: newestConnectionID)
+        for connection in superseded {
+            await connection.close(reason: "superseded by newer authenticated iroh session")
+        }
     }
 
     private func recordClientID(_ clientID: String, for connectionID: UUID) {
@@ -1906,12 +1917,12 @@ actor MobileHostConnection {
             guard !isClosed, !Task.isCancelled else {
                 return
             }
-            if let intercepted = await handleSubscriptionRPC(request) {
-                _ = await sendResponse(MobileHostRPCEnvelope.encodeResponse(id: request.id, result: intercepted))
-                return
-            }
             await onAuthorizedRequest(request)
             guard !isClosed, !Task.isCancelled else {
+                return
+            }
+            if let intercepted = await handleSubscriptionRPC(request) {
+                _ = await sendResponse(MobileHostRPCEnvelope.encodeResponse(id: request.id, result: intercepted))
                 return
             }
             let result = await handleRequest(request)

--- a/Sources/Mobile/MobileHostTransportAuthorization.swift
+++ b/Sources/Mobile/MobileHostTransportAuthorization.swift
@@ -39,6 +39,7 @@ final class MobileHostConnectionRegistry: @unchecked Sendable {
     private struct Entry {
         let connection: MobileHostConnection
         let authorization: MobileHostConnectionAuthorizationContext
+        let insertionSequence: UInt64
     }
 
     static let shared = MobileHostConnectionRegistry()
@@ -46,6 +47,7 @@ final class MobileHostConnectionRegistry: @unchecked Sendable {
     private let lock = NSLock()
     private let irohBindingConnectionQuota = CmxIrohActiveBindingConnectionQuota()
     private var connections: [UUID: Entry] = [:]
+    private var nextInsertionSequence: UInt64 = 0
 
     var count: Int {
         lock.lock()
@@ -79,7 +81,12 @@ final class MobileHostConnectionRegistry: @unchecked Sendable {
                 return false
             }
         }
-        connections[id] = Entry(connection: connection, authorization: authorization)
+        nextInsertionSequence &+= 1
+        connections[id] = Entry(
+            connection: connection,
+            authorization: authorization,
+            insertionSequence: nextInsertionSequence
+        )
         lock.unlock()
         // Notify after the authoritative count actually changes (this registry
         // backs `MobileHostServiceStatus.activeConnectionCount`), so the Mobile
@@ -130,6 +137,41 @@ final class MobileHostConnectionRegistry: @unchecked Sendable {
             }
             return false
         }
+    }
+
+    /// Retires reconnect overlap only after the replacement has processed an
+    /// authorized request. An older connection can never evict a newer one,
+    /// even if its delayed request finishes after the replacement arrived.
+    func removeOlderIrohConnectionsIfNewest(id: UUID) -> [MobileHostConnection] {
+        lock.lock()
+        guard let current = connections[id],
+              case let .irohAdmission(currentPeer) = current.authorization else {
+            lock.unlock()
+            return []
+        }
+        let sameBinding = connections.filter { _, entry in
+            guard case let .irohAdmission(peer) = entry.authorization else {
+                return false
+            }
+            return peer.bindingID == currentPeer.bindingID
+        }
+        guard sameBinding.values.allSatisfy({
+            $0.insertionSequence <= current.insertionSequence
+        }) else {
+            lock.unlock()
+            return []
+        }
+        let older = sameBinding.filter { candidateID, entry in
+            candidateID != id && entry.insertionSequence < current.insertionSequence
+        }
+        for olderID in older.keys {
+            connections[olderID] = nil
+        }
+        lock.unlock()
+        if !older.isEmpty {
+            NotificationCenter.default.post(name: .mobileHostStatusDidChange, object: nil)
+        }
+        return older.values.map(\.connection)
     }
 
     private func removeConnections(

--- a/cmuxTests/MobileHostConnectionLifecycleTests.swift
+++ b/cmuxTests/MobileHostConnectionLifecycleTests.swift
@@ -72,9 +72,15 @@ extension MobileHostAuthorizationTests {
             )
         }
         await waitForMobileHostConnectionCount(2)
-        try await second.enqueue(Self.mobileHostStatusFrame(id: "second"))
+        try await first.enqueue(Self.mobileHostStatusFrame(id: "first-delayed"))
+        _ = await first.waitForSentBufferCount(2)
+        #expect(registry.count == 2)
+        #expect(await second.observedCloseCount() == 0)
+
+        try await second.enqueue(Self.mobileHostSubscribeFrame(id: "second"))
         _ = await second.waitForSentBufferCount(1)
         await waitForMobileHostConnectionCount(1)
+        await first.waitForCloseCount(1)
 
         #expect(registry.count == 1)
         #expect(await first.observedCloseCount() == 1)
@@ -93,6 +99,12 @@ extension MobileHostAuthorizationTests {
     private static func mobileHostStatusFrame(id: String) throws -> Data {
         try MobileSyncFrameCodec.encodeFrame(
             Data("{\"id\":\"\(id)\",\"method\":\"mobile.host.status\",\"params\":{}}".utf8)
+        )
+    }
+
+    private static func mobileHostSubscribeFrame(id: String) throws -> Data {
+        try MobileSyncFrameCodec.encodeFrame(
+            Data("{\"id\":\"\(id)\",\"method\":\"mobile.events.subscribe\",\"params\":{\"stream_id\":\"events\",\"topics\":[]}}".utf8)
         )
     }
 
@@ -439,4 +451,11 @@ private actor ScriptedMobileHostByteTransport: CmxByteTransport {
     }
 
     func observedCloseCount() -> Int { closeCount }
+
+    func waitForCloseCount(_ count: Int) async {
+        for _ in 0..<1_000 {
+            if closeCount >= count { return }
+            await Task.yield()
+        }
+    }
 }

--- a/cmuxTests/MobileHostConnectionLifecycleTests.swift
+++ b/cmuxTests/MobileHostConnectionLifecycleTests.swift
@@ -42,6 +42,67 @@ extension MobileHostAuthorizationTests {
         #expect(await closeRecorder.recordedIDs() == [connectionID])
     }
 
+    @Test func testNewestAuthorizedIrohConnectionSupersedesOlderOverlap() async throws {
+        let service = MobileHostService.shared
+        service.debugResetMobileLifecycleStateForTesting()
+        let registry = MobileHostConnectionRegistry.shared
+        for connection in registry.removeAll() {
+            await connection.close(reason: "test setup")
+        }
+
+        let first = ScriptedMobileHostByteTransport()
+        let second = ScriptedMobileHostByteTransport()
+        let authorization = try irohAdmissionContext()
+        let firstTask = Task {
+            await MobileHostService.acceptTransport(
+                first,
+                authorization: authorization,
+                isCurrent: { true }
+            )
+        }
+        await waitForMobileHostConnectionCount(1)
+        try await first.enqueue(Self.mobileHostStatusFrame(id: "first"))
+        _ = await first.waitForSentBufferCount(1)
+
+        let secondTask = Task {
+            await MobileHostService.acceptTransport(
+                second,
+                authorization: authorization,
+                isCurrent: { true }
+            )
+        }
+        await waitForMobileHostConnectionCount(2)
+        try await second.enqueue(Self.mobileHostStatusFrame(id: "second"))
+        _ = await second.waitForSentBufferCount(1)
+        await waitForMobileHostConnectionCount(1)
+
+        #expect(registry.count == 1)
+        #expect(await first.observedCloseCount() == 1)
+        #expect(await second.observedCloseCount() == 0)
+
+        await first.finishReceiving()
+        await second.finishReceiving()
+        await firstTask.value
+        await secondTask.value
+        for connection in registry.removeAll() {
+            await connection.close(reason: "test cleanup")
+        }
+        service.debugResetMobileLifecycleStateForTesting()
+    }
+
+    private static func mobileHostStatusFrame(id: String) throws -> Data {
+        try MobileSyncFrameCodec.encodeFrame(
+            Data("{\"id\":\"\(id)\",\"method\":\"mobile.host.status\",\"params\":{}}".utf8)
+        )
+    }
+
+    private func waitForMobileHostConnectionCount(_ expected: Int) async {
+        for _ in 0..<1_000 {
+            if MobileHostConnectionRegistry.shared.count == expected { return }
+            await Task.yield()
+        }
+    }
+
     @Test func testIrohEventWriterTimesOutBackpressureWithInjectedClock() async {
         let stream = BlockingMobileHostIrohSendStream()
         let writer = MobileHostIrohServerEventWriter(
@@ -324,4 +385,58 @@ private actor GatedMobileHostByteTransport: CmxByteTransport {
     func observedCloseCount() -> Int {
         closeCount
     }
+}
+
+private actor ScriptedMobileHostByteTransport: CmxByteTransport {
+    private var receiveQueue: [Data?] = []
+    private var receiveWaiter: CheckedContinuation<Data?, Never>?
+    private var sent: [Data] = []
+    private var closeCount = 0
+
+    func connect() async throws {}
+
+    func receive() async throws -> Data? {
+        if !receiveQueue.isEmpty {
+            return receiveQueue.removeFirst()
+        }
+        return await withCheckedContinuation { receiveWaiter = $0 }
+    }
+
+    func send(_ data: Data) async throws {
+        sent.append(data)
+    }
+
+    func close() async {
+        closeCount += 1
+        receiveWaiter?.resume(returning: nil)
+        receiveWaiter = nil
+    }
+
+    func enqueue(_ data: Data) {
+        if let receiveWaiter {
+            self.receiveWaiter = nil
+            receiveWaiter.resume(returning: data)
+        } else {
+            receiveQueue.append(data)
+        }
+    }
+
+    func finishReceiving() {
+        if let receiveWaiter {
+            self.receiveWaiter = nil
+            receiveWaiter.resume(returning: nil)
+        } else {
+            receiveQueue.append(nil)
+        }
+    }
+
+    func waitForSentBufferCount(_ count: Int) async -> [Data] {
+        for _ in 0..<1_000 {
+            if sent.count >= count { return sent }
+            await Task.yield()
+        }
+        return sent
+    }
+
+    func observedCloseCount() -> Int { closeCount }
 }

--- a/cmuxTests/MobileHostConnectionLifecycleTests.swift
+++ b/cmuxTests/MobileHostConnectionLifecycleTests.swift
@@ -104,15 +104,20 @@ extension MobileHostAuthorizationTests {
 
     private static func mobileHostSubscribeFrame(id: String) throws -> Data {
         try MobileSyncFrameCodec.encodeFrame(
-            Data("{\"id\":\"\(id)\",\"method\":\"mobile.events.subscribe\",\"params\":{\"stream_id\":\"events\",\"topics\":[]}}".utf8)
+            Data("{\"id\":\"\(id)\",\"method\":\"mobile.events.subscribe\",\"params\":{\"stream_id\":\"events\",\"topics\":[\"terminal.updated\"]}}".utf8)
         )
     }
 
     private func waitForMobileHostConnectionCount(_ expected: Int) async {
-        for _ in 0..<1_000 {
+        let clock = ContinuousClock()
+        let deadline = clock.now.advanced(by: .seconds(2))
+        while clock.now < deadline {
             if MobileHostConnectionRegistry.shared.count == expected { return }
             await Task.yield()
         }
+        Issue.record(
+            "Timed out waiting for \(expected) mobile host connections; observed \(MobileHostConnectionRegistry.shared.count)"
+        )
     }
 
     @Test func testIrohEventWriterTimesOutBackpressureWithInjectedClock() async {
@@ -404,6 +409,8 @@ private actor ScriptedMobileHostByteTransport: CmxByteTransport {
     private var receiveWaiter: CheckedContinuation<Data?, Never>?
     private var sent: [Data] = []
     private var closeCount = 0
+    private var sentWaiters: [(count: Int, continuation: CheckedContinuation<[Data], Never>)] = []
+    private var closeWaiters: [(count: Int, continuation: CheckedContinuation<Void, Never>)] = []
 
     func connect() async throws {}
 
@@ -416,10 +423,20 @@ private actor ScriptedMobileHostByteTransport: CmxByteTransport {
 
     func send(_ data: Data) async throws {
         sent.append(data)
+        let ready = sentWaiters.filter { sent.count >= $0.count }
+        sentWaiters.removeAll { sent.count >= $0.count }
+        for waiter in ready {
+            waiter.continuation.resume(returning: sent)
+        }
     }
 
     func close() async {
         closeCount += 1
+        let ready = closeWaiters.filter { closeCount >= $0.count }
+        closeWaiters.removeAll { closeCount >= $0.count }
+        for waiter in ready {
+            waiter.continuation.resume()
+        }
         receiveWaiter?.resume(returning: nil)
         receiveWaiter = nil
     }
@@ -443,19 +460,22 @@ private actor ScriptedMobileHostByteTransport: CmxByteTransport {
     }
 
     func waitForSentBufferCount(_ count: Int) async -> [Data] {
-        for _ in 0..<1_000 {
-            if sent.count >= count { return sent }
-            await Task.yield()
+        if sent.count >= count {
+            return sent
         }
-        return sent
+        return await withCheckedContinuation { continuation in
+            sentWaiters.append((count, continuation))
+        }
     }
 
     func observedCloseCount() -> Int { closeCount }
 
     func waitForCloseCount(_ count: Int) async {
-        for _ in 0..<1_000 {
-            if closeCount >= count { return }
-            await Task.yield()
+        if closeCount >= count {
+            return
+        }
+        await withCheckedContinuation { continuation in
+            closeWaiters.append((count, continuation))
         }
     }
 }

--- a/ios/Config/Shared.xcconfig
+++ b/ios/Config/Shared.xcconfig
@@ -38,13 +38,12 @@ CMUX_PRESENCE_BASE_URL =
 
 // Auth-environment override, baked into the CMUXAuthEnvironment Info.plist key
 // so a normally-tapped dev device build (no shell env) can sign in against the
-// PRODUCTION Stack project and pair with a release (beta/stable) Mac — a
-// DEBUG build otherwise signs in to the development project, whose user ids
-// can never match a release Mac's QR account binding
-// (https://github.com/manaflow-ai/cmux/issues/7145). Empty by default
-// (DEBUG -> development, Release -> production). ios/scripts/reload.sh
-// --prod-auth sets it to "production". Keep the Info.plist key name in sync
-// with MobileAuthComposition.authEnvironmentInfoPlistKey.
+// PRODUCTION Stack project when testing production-account behavior. Build
+// compatibility remains separate: a tagged DEV iOS build may connect only to
+// the same tagged DEV Mac build. Empty by default (DEBUG -> development,
+// Release -> production). ios/scripts/reload.sh --prod-auth sets it to
+// "production". Keep the Info.plist key name in sync with
+// MobileAuthComposition.authEnvironmentInfoPlistKey.
 CMUX_IOS_AUTH_ENV =
 
 // Tagged reloads bake the matching macOS tag's isolated web origin here.

--- a/ios/README.md
+++ b/ios/README.md
@@ -25,14 +25,14 @@ Run package tests:
 swift test --package-path ios/cmuxPackage
 ```
 
-## Pairing a sideloaded dev build with a real (beta/stable) Mac
+## Build compatibility and production-auth DEV builds
 
-A plain dev (DEBUG) build signs in to cmux's development Stack project. Stack
-user ids are per-project, so a dev build's user id can never match the
-production account binding (`ub`) a release Mac stamps into its pairing QR —
-pairing fails instantly, even with the same email on the same tailnet
-(https://github.com/manaflow-ai/cmux/issues/7145). To dogfood a device build
-against your real Mac, build with production auth:
+A DEV iOS build connects only to the Mac DEV build with the same tag. BETA,
+INTERNAL, and App Store iOS builds connect only to Stable or Nightly Mac builds.
+Account environment does not change that compatibility boundary.
+
+Use `--prod-auth` only when a tagged DEV build needs to test production account,
+registry, or API behavior:
 
 ```bash
 ios/scripts/reload.sh --tag my-tag --device-only --prod-auth
@@ -46,21 +46,21 @@ What `--prod-auth` does:
   registry/API and the magic-link callback.
 - Makes the presence worker follow the auth channel: the app resolves the
   production presence instance (see `PresenceClient.productionServiceURL`) so
-  your real Macs appear in Computers. The worker URLs live only in Swift —
-  the script bakes no copy — and an explicit `CMUX_PRESENCE_BASE_URL` still
+  compatible Macs appear in Computers. The worker URLs live only in Swift;
+  the script bakes no copy, and an explicit `CMUX_PRESENCE_BASE_URL` still
   wins.
 - Skips the dogfood auto sign-in/auto-pair (those credentials belong to the
   development Stack project). Sign in in-app with the same account as your
-  Mac.
+  matching tagged DEV Mac.
 - On first launch after switching auth environments on the same install, the
   app clears the previous environment's session/caches (tokens and user ids
   are per-Stack-project), so you start signed out instead of restoring a
   stale identity.
 
-Scan the Mac's pairing QR with the **in-app** scanner. The system Camera app
-routes release QR links (`cmux-ios://…`) to the beta/App Store app because
-pairing URL schemes are channel-specific; the in-app scanner accepts both
-schemes.
+The system Camera routes release QR links (`cmux-ios://…`) to an official iOS
+app and DEV QR links (`cmux-ios-dev://…`) to a DEV iOS app. The authenticated
+Mac status supplies the exact instance tag, which the app validates before it
+saves or adopts the connection.
 
 Without the flag, the same override is available by bundling a
 `LocalConfig.plist` with an `AuthEnvironment` string of `production` (see

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -3469,6 +3469,23 @@
         }
       }
     },
+    "mobile.pairing.buildIncompatible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This iPhone build cannot connect to that cmux build."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この iPhone ビルドは、その cmux ビルドに接続できません。"
+          }
+        }
+      }
+    },
     "mobile.pairing.emailMismatchFormat": {
       "extractionState": "manual",
       "localizations": {
@@ -3526,13 +3543,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Rebuild this app with production auth (ios/scripts/reload.sh --prod-auth), or pair with a dev-channel Mac signed in to the same account."
+            "value": "Use BETA, INTERNAL, or the App Store app with Stable or Nightly. Use this DEV app with a Mac that has the same DEV tag."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "本番認証を使ってこのアプリをビルドし直す（ios/scripts/reload.sh --prod-auth）か、同じアカウントでサインインした開発チャネルの Mac とペアリングしてください。"
+            "value": "BETA、INTERNAL、または App Store アプリは Stable または Nightly と一緒に使用してください。この DEV アプリは同じ DEV タグを持つ Mac と一緒に使用してください。"
           }
         }
       }
@@ -3550,6 +3567,23 @@
           "stringUnit": {
             "state": "translated",
             "value": "リリース版の cmux アプリを実行している Mac とペアリングするか、開発用の Mac には開発チャネルの iPhone ビルドを使用してください。"
+          }
+        }
+      }
+    },
+    "mobile.pairing.guidance.buildIncompatible": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEV builds must use the same DEV tag. BETA, INTERNAL, and App Store builds connect only to Stable or Nightly."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DEV ビルド同士は同じ DEV タグを使用する必要があります。BETA、INTERNAL、App Store ビルドは Stable または Nightly にのみ接続できます。"
           }
         }
       }

--- a/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/CMUXMobileRootScene.swift
@@ -198,9 +198,8 @@ public struct CMUXMobileRootScene: View {
     /// the current session and selected team.
     @MainActor
     private func makePresenceClient() -> PresenceClient? {
-        // Presence follows the resolved auth channel (not the build config):
-        // a --prod-auth dev build must subscribe to the production worker its
-        // production Macs heartbeat to (issue 7145).
+        // Presence follows the resolved auth channel so each worker can verify
+        // the token. Build compatibility filters the returned Mac instances.
         guard let baseURL = PresenceClient.resolvedServiceBaseURL(
             isDevelopmentAuthChannel: auth.authEnvironment == .development
         ) else { return nil }
@@ -221,7 +220,8 @@ public struct CMUXMobileRootScene: View {
     @MainActor
     private func makeBackedUpPairedMacStore(
         restoreBoundary: PairedMacRestoreBoundary,
-        buildScope: MobileIOSBuildScope?
+        buildScope: MobileIOSBuildScope?,
+        buildCompatibilityPolicy: MobileMacBuildCompatibilityPolicy
     ) -> (any MobilePairedMacStoring)? {
         guard let store = pairedMacStore else { return nil }
         let coordinator = auth.coordinator
@@ -232,7 +232,7 @@ public struct CMUXMobileRootScene: View {
             buildScopedStore = store
         }
         let scopedStore = TeamScopedPairedMacStore(
-            inner: buildScopedStore,
+            inner: buildCompatibilityPolicy.scoping(buildScopedStore),
             teamIDProvider: { await coordinator.resolvedTeamID }
         )
         guard MobilePairedMacBackup.resolved().isEnabled,
@@ -305,6 +305,9 @@ public struct CMUXMobileRootScene: View {
     private func makeStore() -> CMUXMobileShellStore {
         let coordinator = auth.coordinator
         let buildScope = MobileIOSBuildScope.current()
+        let buildCompatibilityPolicy = MobileMacBuildCompatibilityPolicy.current(
+            buildScope: buildScope
+        )
         let identityProvider = AuthCoordinatorIdentityProvider(
             coordinator: auth.coordinator,
             isDevelopmentAuthEnvironment: auth.authEnvironment == .development
@@ -312,7 +315,8 @@ public struct CMUXMobileRootScene: View {
         let restoreBoundary = PairedMacRestoreBoundary()
         let backedUpPairedMacStore = makeBackedUpPairedMacStore(
             restoreBoundary: restoreBoundary,
-            buildScope: buildScope
+            buildScope: buildScope,
+            buildCompatibilityPolicy: buildCompatibilityPolicy
         )
         let deviceRegistry = makeDeviceRegistry(pairedMacStore: backedUpPairedMacStore)
         let forgottenMacStore = UserDefaultsPairedMacForgottenStore()
@@ -324,6 +328,7 @@ public struct CMUXMobileRootScene: View {
         return CMUXMobileShellStore(
             runtime: runtime,
             pairedMacStore: backedUpPairedMacStore,
+            buildCompatibilityPolicy: buildCompatibilityPolicy,
             pairedMacRestoreBoundary: restoreBoundary,
             deviceRegistry: deviceRegistry,
             presence: makePresenceClient(),
@@ -341,6 +346,7 @@ public struct CMUXMobileRootScene: View {
         return CMUXMobileShellStore(
             runtime: runtime,
             pairedMacStore: backedUpPairedMacStore,
+            buildCompatibilityPolicy: buildCompatibilityPolicy,
             pairedMacRestoreBoundary: restoreBoundary,
             deviceRegistry: deviceRegistry,
             presence: makePresenceClient(),

--- a/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
+++ b/ios/cmuxPackage/Sources/cmuxFeature/MobileAuthComposition.swift
@@ -28,8 +28,8 @@ public struct MobileAuthComposition {
     /// development and Release to production, but an ``authEnvironmentOverrideKey``
     /// entry (from `LocalConfig.plist`, or the Info.plist value
     /// `ios/scripts/reload.sh --prod-auth` bakes) flips it, so a sideloaded
-    /// dev build can run production auth and pair with a release Mac
-    /// (https://github.com/manaflow-ai/cmux/issues/7145). Exposed so the
+    /// dev build can test production account behavior. Build compatibility is
+    /// enforced separately and remains exact-tag DEV to DEV. Exposed so the
     /// identity provider can label the channel its user ids belong to.
     public let authEnvironment: CMUXAuthEnvironment
 

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthEnvironmentOverrideTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobileAuthEnvironmentOverrideTests.swift
@@ -19,10 +19,9 @@ private struct OfflineReachabilityStub: ReachabilityProviding {
 /// project, so its user id can never match the production account binding
 /// (`ub`) a release Mac stamps into its pairing QR — every prod QR fails the
 /// preflight before any route is dialed, even for the same email. The
-/// supported fix is running a dev build against production auth through the
-/// `AuthEnvironment` override (a `LocalConfig.plist` entry, or the Info.plist
-/// value `ios/scripts/reload.sh --prod-auth` bakes). These tests pin that
-/// override to the resolved auth configuration.
+/// `AuthEnvironment` override still lets a DEV build test production account
+/// behavior, but the separate build policy does not let it connect to an
+/// official Mac. These tests pin only the auth override to its configuration.
 @MainActor
 @Suite struct MobileAuthEnvironmentOverrideTests {
     /// The production Stack project id (`CmuxAuthRuntime.AuthConfig`).
@@ -61,8 +60,7 @@ private struct OfflineReachabilityStub: ReachabilityProviding {
         let composition = try makeComposition(bundle: bundle)
 
         // A dev build overridden to production auth must resolve the
-        // production Stack project and the production web API/callback, or its
-        // signed-in user id can never match a release Mac's QR account binding.
+        // production Stack project and the production web API/callback.
         #expect(composition.config.stack.projectId == Self.productionProjectID)
         #expect(composition.config.apiBaseURL == "https://cmux.com")
         #expect(composition.config.magicLinkCallbackURL == "https://cmux.com/auth/callback")
@@ -338,10 +336,9 @@ private struct OfflineReachabilityStub: ReachabilityProviding {
     // MARK: - Presence follows the auth channel
 
     @Test func presenceDefaultFollowsAuthChannelNotBuildConfig() throws {
-        // A --prod-auth dev build (Debug config, production channel) must
-        // subscribe to the production worker its real Macs heartbeat to; the
-        // worker URLs live only in PresenceClient so build scripts cannot
-        // bake a stale copy.
+        // A --prod-auth dev build (Debug config, production channel) must use
+        // the worker that accepts its production token. Build compatibility
+        // filters the returned Mac instances separately.
         #expect(PresenceClient.resolvedServiceBaseURL(
             environment: [:],
             defaults: try freshDefaults(),

--- a/ios/cmuxPackage/Tests/cmuxFeatureTests/MobilePairingAccountPreflightTests.swift
+++ b/ios/cmuxPackage/Tests/cmuxFeatureTests/MobilePairingAccountPreflightTests.swift
@@ -10,7 +10,7 @@ import Testing
 /// "make sure both devices are signed in with the same email" copy even though
 /// the emails matched. The preflight must report that case as
 /// ``MobilePairingFailureCategory/authEnvironmentMismatch`` (truthful cause +
-/// the --prod-auth remedy), keyed on the Mac's DECLARED channel (the pairing
+/// the compatible-build remedy), keyed on the Mac's DECLARED channel (the pairing
 /// URL scheme, #6038) plus the phone's resolved auth environment — never
 /// inferred from the phone alone — while leaving the production↔production
 /// and dev↔dev bindings exactly as strict as before.
@@ -51,7 +51,8 @@ import Testing
         #expect(message.contains("development auth environment"))
         #expect(message != MobilePairingFailureCategory.authFailed.message)
         #expect(!message.contains("Make sure both devices are signed in"))
-        #expect(category?.guidance?.contains("--prod-auth") == true)
+        #expect(category?.guidance?.contains("BETA") == true)
+        #expect(category?.guidance?.contains("same DEV tag") == true)
         #expect(category?.analyticsReason == "auth_environment_mismatch")
         // Re-authenticating cannot move the account to another Stack project,
         // so this must not drive the Sign Out re-auth prompt.
@@ -59,8 +60,8 @@ import Testing
     }
 
     @Test func prodPhoneScanningDevMacQRNamesTheAuthEnvironmentToo() throws {
-        // The reverse direction: a production-auth phone (TestFlight, or a
-        // --prod-auth dev build) scanning a dev Mac's QR (scheme cmux-ios-dev)
+        // The reverse direction: a production-auth phone scanning a dev Mac's
+        // QR (scheme cmux-ios-dev)
         // hits the same per-project impossibility and must get the truthful
         // channel copy — not the "same email" advice.
         let category = MobilePairingAccountPreflight(

--- a/ios/scripts/reload.sh
+++ b/ios/scripts/reload.sh
@@ -20,13 +20,12 @@ the tagged Mac app. Opt out granularly:
 
   --prod-auth    sign this DEV build in against PRODUCTION auth (bakes
                  CMUXAuthEnvironment=production into Info.plist; the presence
-                 worker and API base follow the channel in-app), so it can
-                 pair with a real beta/stable Mac via QR. A plain dev build
-                 uses the development Stack project, whose user ids can never
-                 match a release Mac's QR account binding. Implies
+                 worker and API base follow the channel in-app). This does not
+                 change build compatibility: the DEV iOS app still connects
+                 only to the Mac DEV build with the same tag. Implies
                  --no-sign-in (dogfood auto-login creds are dev-channel);
                  sign in in-app with your real account and use the IN-APP
-                 scanner (the system Camera routes prod QRs to the beta app).
+                 scanner.
 
 Device signing uses the local Xcode account, or App Store Connect API
 credentials from ASC_API_KEY_ID, ASC_API_ISSUER_ID, ASC_API_KEY_PATH, or
@@ -72,7 +71,8 @@ NO_SETUP=0
 # Also honored via CMUX_SWIFT_FRONTEND_WORKAROUND=1.
 SWIFT_FRONTEND_WORKAROUND="${CMUX_SWIFT_FRONTEND_WORKAROUND:-0}"
 # --prod-auth: bake CMUXAuthEnvironment=production so the dev build signs in
-# against the production Stack project and can pair with a release Mac.
+# against the production Stack project. Build compatibility remains exact-tag
+# DEV to DEV.
 PROD_AUTH=0
 
 while [[ $# -gt 0 ]]; do
@@ -189,8 +189,8 @@ if [[ "$SWIFT_FRONTEND_WORKAROUND" == "1" ]]; then
   )
 fi
 
-# --prod-auth: point the build at the production auth channel so it can pair
-# with a real beta/stable Mac (https://github.com/manaflow-ai/cmux/issues/7145).
+# --prod-auth: point the build at the production auth channel for production
+# account, registry, and API testing (https://github.com/manaflow-ai/cmux/issues/7145).
 # The value lands in the CMUXAuthEnvironment Info.plist key (a tapped device
 # build sees no shell env), read by MobileAuthComposition. Presence needs no
 # URL here: PresenceClient.resolvedServiceBaseURL follows the resolved auth
@@ -605,7 +605,7 @@ EOF
     cat <<EOF
 Auth environment:
   production (--prod-auth): sign in in-app with your real account, then pair
-  with your beta/stable Mac using the in-app QR scanner.
+  with the Mac DEV build that has tag $TAG.
 EOF
   fi
 }
@@ -731,7 +731,7 @@ EOF
     cat <<EOF
 Auth environment:
   production (--prod-auth): sign in in-app with your real account, then pair
-  with your beta/stable Mac using the in-app QR scanner.
+  with the Mac DEV build that has tag $TAG.
 EOF
   fi
 }


### PR DESCRIPTION
## Summary
- retire older authenticated Iroh sessions when the newest session for the same backend binding proves itself
- suppress a matching legacy Mac alias when a tagged pairing has the same authenticated peer identity
- keep distinct devices, tags, and peer identities independent

## Verification
- Swift package: 542 tests across 49 suites passed
- focused regression tests cover replacement ordering and legacy alias filtering
- tagged macOS staging build icap registered its encrypted Iroh route

## Dogfood
Physical iPhone relaunch and repeated reconnect verification is in progress.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8299"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786843820&installation_id=133855650&pr_number=8299&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8299&signature=17dc74b97cf0ba71404f28812af91cccd8f4ed8a9ce17a58a8bc0aeafef2f098"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale iOS reconnects and enforces strict iOS↔Mac build compatibility: DEV iOS connects only to the same-tag DEV Mac, and official iOS connects only to Stable or Nightly. Also waits for auth restore, keeps team selection effective, and reuses the request’s token to prove host identity to avoid startup races.

- **New Features**
  - Added `MobileMacBuildCompatibilityPolicy` and applied it across saved Macs, registry projection, and live connections. Incompatible Macs are hidden/filtered/rejected with a `build_incompatible` error and localized guidance.
  - Wrapped `IOSBuildScopedPairedMacStore` with `MobileMacCompatiblePairedMacStore`; `MobileShellComposite` filters by tag and validates host identity before adoption.

- **Bug Fixes**
  - Retire superseded Iroh reconnects only after the newest session processes an authorized request; closes older overlaps.
  - Gate auto-reconnect until auth restore completes; cached users remain “restoring” during token validation; keep persisted team selection effective while teams are unavailable/loading to avoid teamless fallbacks.
  - Reuse the same Stack token for the immediate `mobile.host.status` on the same connection and keep it scoped to the request frame, avoiding races, bad token publication, and startup timeouts.
  - Filter duplicate legacy aliases by authenticated Iroh peer identity.

<sup>Written for commit 55f176a44d1b9628d2a7c83a903c399eac3220db. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8299?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an iOS build-compatibility policy to restrict which paired Mac instances are eligible for connections, routes, and presence.
* **Bug Fixes**
  * Improved paired-Mac selection to handle legacy/alias rows with instance-tag compatibility.
  * When a newer authenticated Iroh session is established, older overlapping sessions are retired/closed.
  * Prevented reconnecting stored Macs while a session is restoring; improved `mobile.host.status` token reuse.
  * Incompatible Mac identities/routes are rejected during host-status adoption.
* **Documentation**
  * Updated iOS build/production-auth and pairing guidance, plus localized error/help text.
* **Tests**
  * Expanded coverage for compatibility filtering, superseding overlap, and reconnection/restoration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->