### PR TITLE
Publish Nightly for every main merge

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,7 +1,10 @@
 name: Nightly macOS build
 
 on:
-  # Keep PR Release builds warm, then publish one signed Nightly each day.
+  # Publish every changed main revision, while keeping the scheduled cache warm.
+  push:
+    branches:
+      - main
   schedule:
     - cron: "17 */6 * * *"
     - cron: "47 8 * * *"
@@ -49,15 +52,10 @@ jobs:
               : 'main';
             const isMainRef = requestedRef === 'main';
 
-            let headSha = context.sha;
-            if (isMainRef) {
-              const branch = await github.rest.repos.getBranch({
-                owner,
-                repo,
-                branch: 'main',
-              });
-              headSha = branch.data.commit.sha;
-            }
+            // Pin every run to the revision that triggered it. In particular,
+            // queued main pushes must each build their own merge commit instead
+            // of all resolving to whichever commit is newest when `decide` runs.
+            const headSha = context.sha;
 
             let nightlySha = null;
             if (isMainRef) {

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -54,6 +54,27 @@ if ! grep -Fq 'cron: "47 8 * * *"' "$WORKFLOW_FILE"; then
 fi
 
 if ! awk '
+  /^  push:/ { in_push=1; next }
+  in_push && /^  [a-zA-Z0-9_-]+:/ { in_push=0 }
+  in_push && /^    branches:/ { saw_branches=1 }
+  in_push && /^      - main$/ { saw_main=1 }
+  END { exit !(saw_branches && saw_main) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: every push to main must trigger a Nightly publication attempt"
+  exit 1
+fi
+
+if ! grep -Fq 'const headSha = context.sha;' "$WORKFLOW_FILE"; then
+  echo "FAIL: each Nightly run must build the exact revision that triggered it"
+  exit 1
+fi
+
+if grep -Fq 'github.rest.repos.getBranch' "$WORKFLOW_FILE"; then
+  echo "FAIL: queued Nightly runs must not replace their triggering revision with a newer main HEAD"
+  exit 1
+fi
+
+if ! awk '
   /^  refresh-compilation-cache:/ { in_refresh=1; next }
   in_refresh && /^  [a-zA-Z0-9_-]+:/ { in_refresh=0 }
   in_refresh && /timeout-minutes: 45/ { saw_cold_build_timeout=1 }


### PR DESCRIPTION
Trigger the Nightly workflow on every push to `main`.

Pin each queued run to its triggering SHA so consecutive merges each publish their own revision.

Tests:
- `bash tests/test_nightly_universal_build.sh`
- `actionlint .github/workflows/nightly.yml`
- `bash -n tests/test_nightly_universal_build.sh`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8301"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786844106&installation_id=133855650&pr_number=8301&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8301&signature=4fcd90cfeea5c8ba48a039bae13559d0ce8d1ea9c17886b93a632be1cbcef1e2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Trigger Nightly on every push to `main` and pin each run to the exact commit that triggered it. This ensures consecutive merges each publish their own build, while scheduled jobs remain for cache warming.

- **Bug Fixes**
  - Build with `context.sha` instead of resolving to the latest `main` head to avoid queued-run drift.
  - Add tests to enforce the push-to-`main` trigger and SHA pinning.

<sup>Written for commit 6ef0fef7917e1c17f0d790543705e1702f596dc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8301?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Nightly builds now consistently publish the exact revision that triggered the workflow.
  * Queued nightly runs no longer switch to a newer revision from the main branch.

* **Tests**
  * Added regression coverage to verify nightly publishing triggers and revision consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->