### PR TITLE
Prevent detached replacements from displacing rearmed Dock portal hosts

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -151,6 +151,22 @@ extension TerminalSurface {
 
             let currentUsable = Self.portalHostIsUsable(current)
             let nextUsable = Self.portalHostIsUsable(next)
+            // A distinct representable can appear before SwiftUI attaches or sizes it.
+            // Keep the rearmed owner authoritative until the replacement is usable;
+            // otherwise the detached host can be dismantled after stealing the lease,
+            // leaving the terminal alive but with no portal mounted in the Dock.
+            guard nextUsable else {
+#if DEBUG
+                logDebugEvent(
+                    "terminal.portal.host.skip surface=\(id.uuidString.prefix(5)) " +
+                    "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+                    "inWin=\(inWindow ? 1 : 0) " +
+                    "size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+                    "cause=detachedOrTiny"
+                )
+#endif
+                return false
+            }
             // During split churn SwiftUI can briefly keep the old host alive while the new
             // host for the same pane is already in the window. Prefer the newer live host
             // immediately so the surface moves with the pane instead of waiting for a later

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -30,16 +30,6 @@ extension TerminalSurface {
         return true
     }
 
-    static let portalHostAreaThreshold: CGFloat = 4
-
-    static func portalHostArea(for bounds: CGRect) -> CGFloat {
-        max(0, bounds.width) * max(0, bounds.height)
-    }
-
-    static func portalHostIsUsable(_ lease: PortalHostLease) -> Bool {
-        lease.inWindow && lease.area > portalHostAreaThreshold
-    }
-
     /// The model ownership epoch used before representable creation order breaks ties.
     public func currentPortalHostOwnershipGeneration() -> UInt64 {
         portalLifecycleGeneration
@@ -117,12 +107,13 @@ extension TerminalSurface {
         allowsAuthorityAcquisition: Bool = true,
         reason: String
     ) -> Bool {
+        let leasePolicy = PortalHostLeasePolicy()
         let next = PortalHostLease(
             hostId: hostId,
             paneId: paneId.id,
             instanceSerial: instanceSerial,
             inWindow: inWindow,
-            area: Self.portalHostArea(for: bounds)
+            area: leasePolicy.area(for: bounds)
         )
 
         let alreadyOwnsLease = activePortalHostLease?.hostId == hostId
@@ -149,42 +140,20 @@ extension TerminalSurface {
                 return true
             }
 
-            let currentUsable = Self.portalHostIsUsable(current)
-            let nextUsable = Self.portalHostIsUsable(next)
-            // A distinct representable can appear before SwiftUI attaches or sizes it.
-            // Keep the rearmed owner authoritative until the replacement is usable;
-            // otherwise the detached host can be dismantled after stealing the lease,
-            // leaving the terminal alive but with no portal mounted in the Dock.
-            guard nextUsable else {
-#if DEBUG
-                logDebugEvent(
-                    "terminal.portal.host.skip surface=\(id.uuidString.prefix(5)) " +
-                    "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
-                    "inWin=\(inWindow ? 1 : 0) " +
-                    "size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
-                    "cause=detachedOrTiny"
-                )
-#endif
-                return false
-            }
             // During split churn SwiftUI can briefly keep the old host alive while the new
             // host for the same pane is already in the window. Prefer the newer live host
             // immediately so the surface moves with the pane instead of waiting for a later
             // update from unrelated focus/layout work.
             let newerSamePaneHostReady =
                 current.paneId == paneId.id &&
-                nextUsable &&
                 next.instanceSerial > current.instanceSerial
             let newerModelOwnerReady =
-                nextUsable &&
                 ownershipGeneration > (portalHostAuthority?.ownershipGeneration ?? 0)
-            // A dragged terminal must hand off immediately when it moves to a different pane.
-            // Waiting for the old host to become "worse" leaves the moved pane blank/stale.
-            let shouldReplace =
-                current.paneId != paneId.id ||
-                !currentUsable ||
-                newerSamePaneHostReady ||
-                newerModelOwnerReady
+            let shouldReplace = leasePolicy.shouldReplace(
+                current: current,
+                with: next,
+                allowsSamePaneReplacement: newerSamePaneHostReady || newerModelOwnerReady
+            )
 
             if shouldReplace {
                 guard reservePortalHostAuthority(
@@ -216,7 +185,8 @@ extension TerminalSurface {
                 "size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
                 "ownerHost=\(current.hostId) ownerPane=\(current.paneId.uuidString.prefix(5)) " +
                 "ownerInWin=\(current.inWindow ? 1 : 0) " +
-                "ownerArea=\(String(format: "%.1f", current.area))"
+                "ownerArea=\(String(format: "%.1f", current.area)) " +
+                "cause=\(leasePolicy.isUsable(next) ? "ownerPreferred" : "detachedOrTiny")"
             )
 #endif
             return false

--- a/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/SurfaceValues/PortalHostLeasePolicy.swift
+++ b/Packages/macOS/CmuxTerminalCore/Sources/CmuxTerminalCore/SurfaceValues/PortalHostLeasePolicy.swift
@@ -1,0 +1,60 @@
+public import Foundation
+
+/// Applies the shared usability and replacement rules for portal hosts.
+///
+/// Terminal and browser portals use this policy so a detached or effectively
+/// zero-sized representable cannot displace a host that is still presenting the
+/// surface.
+public struct PortalHostLeasePolicy: Sendable {
+    private let minimumArea: CGFloat
+
+    /// Creates a portal host lease policy.
+    ///
+    /// - Parameter minimumArea: The area a window-attached host must exceed to
+    ///   participate in ownership replacement. Negative values are clamped to zero.
+    public init(minimumArea: CGFloat = 4) {
+        self.minimumArea = max(0, minimumArea)
+    }
+
+    /// Returns the nonnegative area represented by a host's bounds.
+    ///
+    /// - Parameter bounds: The host bounds reported by its representable.
+    /// - Returns: The product of the nonnegative width and height.
+    public func area(for bounds: CGRect) -> CGFloat {
+        max(0, bounds.width) * max(0, bounds.height)
+    }
+
+    /// Returns whether a lease represents an attached host with meaningful area.
+    ///
+    /// - Parameter lease: The portal host lease to evaluate.
+    /// - Returns: `true` when the host is window-attached and exceeds the configured area.
+    public func isUsable(_ lease: PortalHostLease) -> Bool {
+        lease.inWindow && lease.area > minimumArea
+    }
+
+    /// Returns whether a candidate may replace the current portal host.
+    ///
+    /// The current host may always refresh its own lease. A distinct host must be
+    /// usable before it can replace ownership, including during a cross-pane move.
+    ///
+    /// - Parameters:
+    ///   - current: The lease that currently owns the portal.
+    ///   - candidate: The lease requesting ownership.
+    ///   - allowsSamePaneReplacement: Whether renderer-specific rules authorize a
+    ///     distinct candidate in the same pane to supersede the current host.
+    /// - Returns: `true` when the candidate may become the active lease.
+    public func shouldReplace(
+        current: PortalHostLease,
+        with candidate: PortalHostLease,
+        allowsSamePaneReplacement: Bool
+    ) -> Bool {
+        if current.hostId == candidate.hostId {
+            return true
+        }
+
+        guard isUsable(candidate) else { return false }
+        return current.paneId != candidate.paneId
+            || !isUsable(current)
+            || allowsSamePaneReplacement
+    }
+}

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3428,8 +3428,7 @@ final class BrowserPanel: Panel, ObservableObject {
 
             let currentUsable = leasePolicy.isUsable(current)
             let isSamePaneReplacement = current.paneId == paneId.id
-            let shouldForceDistinctReplacement =
-                isSamePaneReplacement &&
+            let consumesPendingDistinctReplacement =
                 pendingDistinctPortalHostReplacementPaneId == paneId.id
 
             let lockBlocksSamePaneReplacement =
@@ -3438,7 +3437,7 @@ final class BrowserPanel: Panel, ObservableObject {
                 lockedPortalHost?.hostId == current.hostId &&
                 lockedPortalHost?.paneId == current.paneId
             let allowsSamePaneReplacement =
-                shouldForceDistinctReplacement ||
+                (isSamePaneReplacement && consumesPendingDistinctReplacement) ||
                 (
                     !lockBlocksSamePaneReplacement &&
                     next.area > (current.area * Self.portalHostReplacementAreaGainRatio)
@@ -3450,7 +3449,7 @@ final class BrowserPanel: Panel, ObservableObject {
             )
 
             if shouldReplace {
-                if shouldForceDistinctReplacement {
+                if consumesPendingDistinctReplacement {
                     pendingDistinctPortalHostReplacementPaneId = nil
                     lockedPortalHost = PortalHostLock(hostId: hostId, paneId: paneId.id)
                 } else if lockedPortalHost?.hostId == current.hostId &&
@@ -3464,7 +3463,7 @@ final class BrowserPanel: Panel, ObservableObject {
                     "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
                     "replacingHost=\(current.hostId) replacingPane=\(current.paneId.uuidString.prefix(5)) " +
                     "replacingInWin=\(current.inWindow ? 1 : 0) replacingArea=\(String(format: "%.1f", current.area)) " +
-                    "forced=\(shouldForceDistinctReplacement ? 1 : 0)"
+                    "forced=\(consumesPendingDistinctReplacement ? 1 : 0)"
                 )
 #endif
                 activePortalHostLease = next
@@ -3485,13 +3484,30 @@ final class BrowserPanel: Panel, ObservableObject {
             return false
         }
 
+        let consumesPendingDistinctReplacement =
+            pendingDistinctPortalHostReplacementPaneId == paneId.id
+        guard !consumesPendingDistinctReplacement || leasePolicy.isUsable(next) else {
+#if DEBUG
+            cmuxDebugLog(
+                "browser.portal.host.skip panel=\(id.uuidString.prefix(5)) " +
+                "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+                "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
+                "ownerHost=nil cause=detachedOrTiny"
+            )
+#endif
+            return false
+        }
+        if consumesPendingDistinctReplacement {
+            pendingDistinctPortalHostReplacementPaneId = nil
+            lockedPortalHost = PortalHostLock(hostId: hostId, paneId: paneId.id)
+        }
         activePortalHostLease = next
 #if DEBUG
         cmuxDebugLog(
             "browser.portal.host.claim panel=\(id.uuidString.prefix(5)) " +
             "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
             "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
-            "replacingHost=nil"
+            "replacingHost=nil forced=\(consumesPendingDistinctReplacement ? 1 : 0)"
         )
 #endif
         return true

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -3422,6 +3422,11 @@ final class BrowserPanel: Panel, ObservableObject {
             }
 
             if current.hostId == hostId {
+                if pendingDistinctPortalHostReplacementPaneId == paneId.id,
+                   leasePolicy.isUsable(next) {
+                    pendingDistinctPortalHostReplacementPaneId = nil
+                    lockedPortalHost = PortalHostLock(hostId: hostId, paneId: paneId.id)
+                }
                 activePortalHostLease = next
                 return true
             }

--- a/Sources/Panels/BrowserPanel.swift
+++ b/Sources/Panels/BrowserPanel.swift
@@ -2992,12 +2992,6 @@ final class BrowserPanel: Panel, ObservableObject {
         evaluator: BrowserFindWebViewEvaluator(panel: self)
     )
     let portalAnchorView = BrowserPortalAnchorView(frame: .zero)
-    private struct PortalHostLease {
-        let hostId: ObjectIdentifier
-        let paneId: UUID
-        let inWindow: Bool
-        let area: CGFloat
-    }
     private struct PortalHostLock {
         let hostId: ObjectIdentifier
         let paneId: UUID
@@ -3387,16 +3381,7 @@ final class BrowserPanel: Panel, ObservableObject {
         )
     }
 
-    private static let portalHostAreaThreshold: CGFloat = 4
     private static let portalHostReplacementAreaGainRatio: CGFloat = 1.2
-
-    private static func portalHostArea(for bounds: CGRect) -> CGFloat {
-        max(0, bounds.width) * max(0, bounds.height)
-    }
-
-    private static func portalHostIsUsable(_ lease: PortalHostLease) -> Bool {
-        lease.inWindow && lease.area > portalHostAreaThreshold
-    }
 
     func preparePortalHostReplacementForNextDistinctClaim(
         inPane paneId: PaneID,
@@ -3421,11 +3406,13 @@ final class BrowserPanel: Panel, ObservableObject {
         bounds: CGRect,
         reason: String
     ) -> Bool {
+        let leasePolicy = PortalHostLeasePolicy()
         let next = PortalHostLease(
             hostId: hostId,
             paneId: paneId.id,
+            instanceSerial: 0,
             inWindow: inWindow,
-            area: Self.portalHostArea(for: bounds)
+            area: leasePolicy.area(for: bounds)
         )
 
         if let current = activePortalHostLease {
@@ -3439,46 +3426,34 @@ final class BrowserPanel: Panel, ObservableObject {
                 return true
             }
 
-            let currentUsable = Self.portalHostIsUsable(current)
-            let nextUsable = Self.portalHostIsUsable(next)
+            let currentUsable = leasePolicy.isUsable(current)
             let isSamePaneReplacement = current.paneId == paneId.id
             let shouldForceDistinctReplacement =
                 isSamePaneReplacement &&
-                pendingDistinctPortalHostReplacementPaneId == paneId.id &&
-                inWindow
-            if shouldForceDistinctReplacement {
-#if DEBUG
-                cmuxDebugLog(
-                    "browser.portal.host.claim panel=\(id.uuidString.prefix(5)) " +
-                    "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
-                    "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
-                    "replacingHost=\(current.hostId) replacingPane=\(current.paneId.uuidString.prefix(5)) " +
-                    "replacingInWin=\(current.inWindow ? 1 : 0) replacingArea=\(String(format: "%.1f", current.area)) " +
-                    "forced=1"
-                )
-#endif
-                activePortalHostLease = next
-                pendingDistinctPortalHostReplacementPaneId = nil
-                lockedPortalHost = PortalHostLock(hostId: hostId, paneId: paneId.id)
-                return true
-            }
+                pendingDistinctPortalHostReplacementPaneId == paneId.id
 
             let lockBlocksSamePaneReplacement =
                 isSamePaneReplacement &&
                 currentUsable &&
                 lockedPortalHost?.hostId == current.hostId &&
                 lockedPortalHost?.paneId == current.paneId
-            let shouldReplace =
-                current.paneId != paneId.id ||
-                !currentUsable ||
+            let allowsSamePaneReplacement =
+                shouldForceDistinctReplacement ||
                 (
                     !lockBlocksSamePaneReplacement &&
-                    nextUsable &&
                     next.area > (current.area * Self.portalHostReplacementAreaGainRatio)
                 )
+            let shouldReplace = leasePolicy.shouldReplace(
+                current: current,
+                with: next,
+                allowsSamePaneReplacement: allowsSamePaneReplacement
+            )
 
             if shouldReplace {
-                if lockedPortalHost?.hostId == current.hostId &&
+                if shouldForceDistinctReplacement {
+                    pendingDistinctPortalHostReplacementPaneId = nil
+                    lockedPortalHost = PortalHostLock(hostId: hostId, paneId: paneId.id)
+                } else if lockedPortalHost?.hostId == current.hostId &&
                     lockedPortalHost?.paneId == current.paneId {
                     lockedPortalHost = nil
                 }
@@ -3488,7 +3463,8 @@ final class BrowserPanel: Panel, ObservableObject {
                     "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
                     "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
                     "replacingHost=\(current.hostId) replacingPane=\(current.paneId.uuidString.prefix(5)) " +
-                    "replacingInWin=\(current.inWindow ? 1 : 0) replacingArea=\(String(format: "%.1f", current.area))"
+                    "replacingInWin=\(current.inWindow ? 1 : 0) replacingArea=\(String(format: "%.1f", current.area)) " +
+                    "forced=\(shouldForceDistinctReplacement ? 1 : 0)"
                 )
 #endif
                 activePortalHostLease = next
@@ -3502,7 +3478,8 @@ final class BrowserPanel: Panel, ObservableObject {
                 "inWin=\(inWindow ? 1 : 0) size=\(String(format: "%.1fx%.1f", bounds.width, bounds.height)) " +
                 "ownerHost=\(current.hostId) ownerPane=\(current.paneId.uuidString.prefix(5)) " +
                 "ownerInWin=\(current.inWindow ? 1 : 0) ownerArea=\(String(format: "%.1f", current.area)) " +
-                "locked=\(lockBlocksSamePaneReplacement ? 1 : 0)"
+                "locked=\(lockBlocksSamePaneReplacement ? 1 : 0) " +
+                "cause=\(leasePolicy.isUsable(next) ? "ownerPreferred" : "detachedOrTiny")"
             )
 #endif
             return false

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -155,6 +155,38 @@ struct DockPortalReconcileTests {
             bounds: bounds,
             reason: "test.dock.browser.laterSamePaneHost"
         ))
+
+        let survivingPanel = BrowserPanel(workspaceId: UUID(), renderInitialNavigation: false)
+        defer { survivingPanel.close() }
+        let survivingHost = NSView()
+        let survivingPane = PaneID()
+        let laterSurvivingPaneHost = NSView()
+
+        #expect(survivingPanel.claimPortalHost(
+            hostId: ObjectIdentifier(survivingHost),
+            paneId: sourcePane,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.browser.survivingSource"
+        ))
+        survivingPanel.preparePortalHostReplacementForNextDistinctClaim(
+            inPane: survivingPane,
+            reason: "test.dock.browser.survivingMoveRearm"
+        )
+        #expect(survivingPanel.claimPortalHost(
+            hostId: ObjectIdentifier(survivingHost),
+            paneId: survivingPane,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.browser.survivingDestination"
+        ))
+        #expect(!survivingPanel.claimPortalHost(
+            hostId: ObjectIdentifier(laterSurvivingPaneHost),
+            paneId: survivingPane,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.browser.laterSurvivingPaneHost"
+        ))
     }
 
     @Test("Newer stale workspace host is rejected by live Dock ownership")

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -98,6 +98,46 @@ struct DockPortalReconcileTests {
         ))
     }
 
+    @Test("Detached browser destination cannot displace its live source host")
+    @MainActor
+    func detachedBrowserDestinationCannotDisplaceLiveSourceHost() {
+        let panel = BrowserPanel(workspaceId: UUID(), renderInitialNavigation: false)
+        defer { panel.close() }
+        let liveSourceHost = NSView()
+        let detachedDestinationHost = NSView()
+        let sourcePane = PaneID()
+        let destinationPane = PaneID()
+        let bounds = CGRect(x: 0, y: 0, width: 210, height: 510)
+
+        #expect(panel.claimPortalHost(
+            hostId: ObjectIdentifier(liveSourceHost),
+            paneId: sourcePane,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.browser.liveSource"
+        ))
+
+        #expect(!panel.claimPortalHost(
+            hostId: ObjectIdentifier(detachedDestinationHost),
+            paneId: destinationPane,
+            inWindow: false,
+            bounds: .zero,
+            reason: "test.dock.browser.detachedDestination"
+        ))
+        #expect(panel.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(liveSourceHost),
+            reason: "test.dock.browser.sourceDismantled"
+        ))
+
+        #expect(panel.claimPortalHost(
+            hostId: ObjectIdentifier(detachedDestinationHost),
+            paneId: destinationPane,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.browser.attachedDestination"
+        ))
+    }
+
     @Test("Newer stale workspace host is rejected by live Dock ownership")
     @MainActor
     func newerStaleWorkspaceHostIsRejectedByLiveDockOwnership() {

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -133,6 +133,13 @@ struct DockPortalReconcileTests {
             hostId: ObjectIdentifier(liveSourceHost),
             reason: "test.dock.browser.sourceDismantled"
         ))
+        #expect(!panel.claimPortalHost(
+            hostId: ObjectIdentifier(detachedDestinationHost),
+            paneId: destinationPane,
+            inWindow: false,
+            bounds: .zero,
+            reason: "test.dock.browser.detachedDestinationAfterSourceRelease"
+        ))
 
         #expect(panel.claimPortalHost(
             hostId: ObjectIdentifier(detachedDestinationHost),

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -49,6 +49,55 @@ struct DockPortalReconcileTests {
         #expect(panel.surface.debugPortalHostLease().paneId == dockPane.id)
     }
 
+    @Test("Detached replacement cannot displace a rearmed Dock portal host")
+    @MainActor
+    func detachedReplacementCannotDisplaceRearmedDockPortalHost() {
+        let panel = TerminalPanel(workspaceId: UUID())
+        defer { panel.surface.teardownSurface() }
+        let liveHost = NSView()
+        let detachedReplacement = NSView()
+        let pane = PaneID()
+        let bounds = CGRect(x: 0, y: 0, width: 400, height: 300)
+
+        #expect(panel.surface.claimPortalHost(
+            hostId: ObjectIdentifier(liveHost),
+            paneId: pane,
+            instanceSerial: 1,
+            ownershipGeneration: 1,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.liveHost"
+        ))
+        #expect(panel.surface.preparePortalHostReplacementIfOwned(
+            hostId: ObjectIdentifier(liveHost),
+            reason: "test.dock.liveHostDismantled"
+        ))
+
+        #expect(!panel.surface.claimPortalHost(
+            hostId: ObjectIdentifier(detachedReplacement),
+            paneId: pane,
+            instanceSerial: 2,
+            ownershipGeneration: 2,
+            inWindow: false,
+            bounds: .zero,
+            reason: "test.dock.detachedReplacement"
+        ))
+        #expect(
+            panel.surface.debugPortalHostLease().hostId ==
+                String(describing: ObjectIdentifier(liveHost))
+        )
+
+        #expect(panel.surface.claimPortalHost(
+            hostId: ObjectIdentifier(detachedReplacement),
+            paneId: pane,
+            instanceSerial: 2,
+            ownershipGeneration: 2,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.attachedReplacement"
+        ))
+    }
+
     @Test("Newer stale workspace host is rejected by live Dock ownership")
     @MainActor
     func newerStaleWorkspaceHostIsRejectedByLiveDockOwnership() {

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -105,6 +105,7 @@ struct DockPortalReconcileTests {
         defer { panel.close() }
         let liveSourceHost = NSView()
         let detachedDestinationHost = NSView()
+        let laterSamePaneHost = NSView()
         let sourcePane = PaneID()
         let destinationPane = PaneID()
         let bounds = CGRect(x: 0, y: 0, width: 210, height: 510)
@@ -116,6 +117,10 @@ struct DockPortalReconcileTests {
             bounds: bounds,
             reason: "test.dock.browser.liveSource"
         ))
+        panel.preparePortalHostReplacementForNextDistinctClaim(
+            inPane: destinationPane,
+            reason: "test.dock.browser.moveRearm"
+        )
 
         #expect(!panel.claimPortalHost(
             hostId: ObjectIdentifier(detachedDestinationHost),
@@ -135,6 +140,13 @@ struct DockPortalReconcileTests {
             inWindow: true,
             bounds: bounds,
             reason: "test.dock.browser.attachedDestination"
+        ))
+        #expect(!panel.claimPortalHost(
+            hostId: ObjectIdentifier(laterSamePaneHost),
+            paneId: destinationPane,
+            inWindow: true,
+            bounds: bounds,
+            reason: "test.dock.browser.laterSamePaneHost"
         ))
     }
 


### PR DESCRIPTION
## Summary

- Reproduces the Dock portal lifecycle race where SwiftUI dismantles a visible terminal host, rearms its lease, and briefly creates a detached zero-sized replacement.
- Preserves the live host as portal authority until a distinct replacement is attached to a window and has usable bounds.
- Allows that same replacement to claim normally as soon as it becomes usable.

## Why this is a draft

An earlier tagged dogfood flow also exposed stale browser placement and duplicate hover targets during pane dragging. Those are not claimed as fixed by this terminal lease change. The PR stays draft until fresh terminal/browser drag dogfood confirms this patch is isolated and does not reproduce those behaviors.

## Regression sequence

1. `04936dbad9` — adds the failing behavioral regression test only.
2. `f7e08c0353` — rejects ownership acquisition by a distinct detached/tiny host until it becomes usable.

The test-only commit was pushed first and the manual CI workflow was dispatched. Current `origin/main` blocks macOS tests earlier in `workflow-guard-tests` because `WorkspaceTodoNotificationRegressionTests.swift` is not wired into the `cmuxTests` target, so CI could not record the intended regression failure. Run: https://github.com/manaflow-ai/cmux/actions/runs/29552840750

## Verification

- Regression-only local Dock portal suite: 13 tests executed; only the new detached-replacement case failed, on both unauthorized ownership and displaced-host assertions.
- Fixed HEAD rebased onto current `origin/main`: 13 tests in `DockPortalReconcileTests` passed.
- `./scripts/reload.sh --tag detached-replacement-portal` succeeded on `f7e08c0353`.
- `git diff --check` passed.
- No user-facing strings changed; localization catalogs are unaffected.

## Dogfood checklist before ready for review

- Repeated terminal pane moves into, within, and out of the Dock.
- Repeated browser pane moves over the same targets.
- Confirm exactly one drop-target overlay is visible during drag.
- Confirm browser portals move with their pane and terminal portals never go blank.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved portal-host claiming and replacement to prevent detached or undersized hosts from taking over an active portal.
  * Enhanced ownership reconciliation during detach/rearm and browser detach/attach, including correct same-pane refresh behavior.
* **Tests**
  * Added new Dock and browser reconciliation tests covering detached vs attached claiming and lease selection outcomes.
* **Refactor**
  * Centralized portal-host lease usability and replacement decisioning into a shared policy, applied across terminal surfaces and the browser panel.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->