### PR TITLE
Terminal: add macOS dictionary Look Up (three-finger tap / ⌃⌘D / force-click)

### DIFF
--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7201,9 +7201,10 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
 
     override func quickLook(with event: NSEvent) {
         // macOS dictionary "Look Up" (three-finger tap, force-click, or ⌃⌘D)
-        // for the word under the cursor. Mirrors upstream Ghostty's SurfaceView;
-        // cmux already links the libghostty quicklook APIs (used for cmd-click
-        // path resolution), so no ghostty-submodule change is needed.
+        // for the word under the cursor, following upstream Ghostty's SurfaceView
+        // (with cmux's length-bounded ghostty_text_s decoding). cmux already links
+        // the libghostty quicklook APIs (used for cmd-click path resolution), so no
+        // ghostty-submodule change is needed.
         guard let surface = self.surface else { return super.quickLook(with: event) }
 
         // Grab the word under the cursor from the terminal grid.
@@ -7219,16 +7220,18 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // Use the terminal's primary font for the definition popover when available.
         var attributes: [NSAttributedString.Key: Any] = [:]
         if let fontRaw = ghostty_surface_quicklook_font(surface) {
-            // ghostty_surface_quicklook_font returns a copied CTFont. Swift retains
-            // it when stored in the dictionary, so release the original copy here.
-            let font = Unmanaged<CTFont>.fromOpaque(fontRaw)
-            attributes[.font] = font.takeUnretainedValue()
-            font.release()
+            // ghostty_surface_quicklook_font returns a +1 (Create-rule) CTFont;
+            // takeRetainedValue() transfers that ownership to ARC.
+            attributes[.font] = Unmanaged<CTFont>.fromOpaque(fontRaw).takeRetainedValue()
         }
+
+        // Decode exactly text_len bytes, matching the other ghostty_text_s decode
+        // sites in this file; the buffer is length-counted, not NUL-terminated.
+        let word = String(decoding: Data(bytes: textPtr, count: Int(text.text_len)), as: UTF8.self)
 
         // Ghostty uses a top-left origin; convert to AppKit's bottom-left.
         let point = NSPoint(x: text.tl_px_x, y: frame.size.height - text.tl_px_y)
-        let string = NSAttributedString(string: String(cString: textPtr), attributes: attributes)
+        let string = NSAttributedString(string: word, attributes: attributes)
         showDefinition(for: string, at: point)
     }
 

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7199,6 +7199,39 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         _ = ghostty_surface_mouse_button(surface, GHOSTTY_MOUSE_RELEASE, GHOSTTY_MOUSE_MIDDLE, mouseModsFromEvent(event))
     }
 
+    override func quickLook(with event: NSEvent) {
+        // macOS dictionary "Look Up" (three-finger tap, force-click, or ⌃⌘D)
+        // for the word under the cursor. Mirrors upstream Ghostty's SurfaceView;
+        // cmux already links the libghostty quicklook APIs (used for cmd-click
+        // path resolution), so no ghostty-submodule change is needed.
+        guard let surface = self.surface else { return super.quickLook(with: event) }
+
+        // Grab the word under the cursor from the terminal grid.
+        var text = ghostty_text_s()
+        guard ghostty_surface_quicklook_word(surface, &text) else {
+            return super.quickLook(with: event)
+        }
+        defer { ghostty_surface_free_text(surface, &text) }
+        guard text.text_len > 0, let textPtr = text.text else {
+            return super.quickLook(with: event)
+        }
+
+        // Use the terminal's primary font for the definition popover when available.
+        var attributes: [NSAttributedString.Key: Any] = [:]
+        if let fontRaw = ghostty_surface_quicklook_font(surface) {
+            // ghostty_surface_quicklook_font returns a copied CTFont. Swift retains
+            // it when stored in the dictionary, so release the original copy here.
+            let font = Unmanaged<CTFont>.fromOpaque(fontRaw)
+            attributes[.font] = font.takeUnretainedValue()
+            font.release()
+        }
+
+        // Ghostty uses a top-left origin; convert to AppKit's bottom-left.
+        let point = NSPoint(x: text.tl_px_x, y: frame.size.height - text.tl_px_y)
+        let string = NSAttributedString(string: String(cString: textPtr), attributes: attributes)
+        showDefinition(for: string, at: point)
+    }
+
     override func menu(for event: NSEvent) -> NSMenu? {
         makeContextMenu(for: event, sendsTerminalPointerEvent: true)
     }

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -7229,8 +7229,9 @@ class GhosttyNSView: NSView, NSUserInterfaceValidations {
         // sites in this file; the buffer is length-counted, not NUL-terminated.
         let word = String(decoding: Data(bytes: textPtr, count: Int(text.text_len)), as: UTF8.self)
 
-        // Ghostty uses a top-left origin; convert to AppKit's bottom-left.
-        let point = NSPoint(x: text.tl_px_x, y: frame.size.height - text.tl_px_y)
+        // Ghostty uses a top-left origin; convert to AppKit's bottom-left. Use the
+        // view's own bounds (matching the other coordinate conversions in this file).
+        let point = NSPoint(x: text.tl_px_x, y: bounds.height - text.tl_px_y)
         let string = NSAttributedString(string: word, attributes: attributes)
         showDefinition(for: string, at: point)
     }


### PR DESCRIPTION
## Summary

Adds macOS dictionary **Look Up** for terminal text — three-finger tap, force-click, and `⌃⌘D` now show the system definition popover for the word under the cursor, matching upstream Ghostty and Terminal.app / iTerm2. Fixes #8237.

## What was missing

`GhosttyNSView` (the macOS terminal view) didn't override the `quickLook(with:)` NSResponder method, so the OS Look-Up gesture/shortcut had nothing to invoke over terminal text. The existing `ghostty_surface_quicklook_word` call in `resolveWordUnderCursorPath` is cmd-click *path* resolution; other `quickLook` references are the *file*-preview feature — neither is dictionary look-up.

## Change

Override `quickLook(with:)` on `GhosttyNSView`, mirroring upstream Ghostty's `SurfaceView`. It reuses libghostty quicklook APIs the project already links (`ghostty_surface_quicklook_word` / `ghostty_surface_quicklook_font` / `ghostty_surface_free_text`), so **no ghostty-submodule change** is needed. One file, +33 lines.

## Testing

⚠️ **Not built/tested locally** — I don't have the cmux build toolchain (Xcode + Zig) on this machine. The change:

- passes `swiftc -parse` (no syntax errors),
- mirrors upstream Ghostty's proven implementation almost verbatim, and
- only calls libghostty APIs already used elsewhere in this file.

Opening as a **draft** so CI and a maintainer can validate the build and confirm the popover appears. Happy to adjust.

### Manual verification

1. System Settings → Trackpad → Point & Click → "Look up & data detectors" = *Tap with three fingers*.
2. In a terminal, hover a word and three-finger tap (or press `⌃⌘D`, or force-click).
3. The macOS definition popover should appear for that word.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8311"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786852376&installation_id=133855650&pr_number=8311&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8311&signature=a70d87ddd3404ca1421307cf6264c756b1b948b127f4a44acc7bb17f5667f892"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable macOS Dictionary Look Up in the terminal: three‑finger tap, force‑click, and ⌃⌘D now show the system definition popover for the word under the cursor. Matches Ghostty upstream and Terminal.app/iTerm2. Fixes #8237.

- **New Features**
  - Override `quickLook(with:)` on `GhosttyNSView` to trigger Look Up at the cursor.
  - Reuse existing libghostty APIs: `ghostty_surface_quicklook_word`, `ghostty_surface_quicklook_font`, `ghostty_surface_free_text` (no submodule changes).
  - Convert to AppKit coordinates and apply the terminal’s primary font for the popover.

- **Bug Fixes**
  - Decode the word with `text_len` and use `Unmanaged.takeRetainedValue()` for the `CTFont` (Create rule).
  - Use `bounds.height` for the y‑flip during coordinate conversion to fix popover positioning.

<sup>Written for commit f7b80035331dd9a98398534d20ab73da6cf6ce21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8311?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added macOS Look Up/Quick Look support for words under the terminal cursor.
  * Definitions now leverage the detected word and terminal font for more accurate, styled results.
  * Falls back to standard macOS Quick Look when no word is identified or when a quicklook lookup fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->