### PR TITLE
Fix explicit-self capture in the sidebar tint closure

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -98,7 +98,7 @@ final class SidebarRowPullRequestIconView: NSView {
                 // transparent backing draws nothing (no destination pixels).
                 let tinted = NSImage(size: image.size, flipped: false) { drawRect in
                     image.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1)
-                    color.set()
+                    self.color.set()
                     drawRect.fill(using: .sourceAtop)
                     return true
                 }


### PR DESCRIPTION
main does not compile on Xcode 26.2 toolchains since #8270: the NSImage drawing handler in SidebarWorkspaceRowSlotViews references the view's color property without self, which strict capture-semantics checking rejects as an error (SidebarWorkspaceRowSlotViews.swift:101). One token: self.color.set().

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8313"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786859839&installation_id=133855650&pr_number=8313&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8313&signature=f82d9a42815b22caf379e0a3b5de7d3335d702171bf428cfd12848b2e48bfb49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix build on Xcode 26.2 by making the tinting closure explicitly capture `self` in the sidebar PR icon view. Replaces `color.set()` with `self.color.set()` in the `NSImage` drawing handler in `SidebarWorkspaceRowSlotViews.swift`.

<sup>Written for commit 65e4db06ab94e0a16ca79cb2e426e76cc251751a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8313?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the tint color applied to pull request icons when displayed in their closed state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->