### PR TITLE
Make the sizing fuzz judges say who is wrong and why

### DIFF
--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -105,7 +105,7 @@ extension TerminalSurface {
             area: current.area
         )
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
-        notifyPortalHostVacated(vacatedHostId: hostId)
+        notifyPortalHostVacated(vacatedHostId: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.rearm surface=\(id.uuidString.prefix(5)) " +
@@ -148,8 +148,10 @@ extension TerminalSurface {
     /// vacate mid divider-drag, where a default-mode block waits for mouse-up.
     /// Deferred a turn so no retry mutates the lease inside the dying host's
     /// dismantle.
-    private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier) {
-        portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
+    private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier, instanceSerial: UInt64) {
+        if portalHostVacancyRetries[vacatedHostId]?.instanceSerial == instanceSerial {
+            portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
+        }
         guard !portalHostVacancyRetries.isEmpty else { return }
         let retries = portalHostVacancyRetries.values
             .sorted { $0.instanceSerial > $1.instanceSerial }
@@ -320,7 +322,7 @@ extension TerminalSurface {
               current.instanceSerial == instanceSerial else { return }
         activePortalHostLease = nil
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
-        notifyPortalHostVacated(vacatedHostId: hostId)
+        notifyPortalHostVacated(vacatedHostId: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.release surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -157,18 +157,22 @@ extension TerminalSurface {
             clearPortalHostVacancyRetries()
             return
         }
-        guard !portalHostVacancyRetries.isEmpty else { return }
-        guard !portalHostVacancyWakeScheduled else { return }
-        portalHostVacancyWakeScheduled = true
         let scheduledGeneration = portalLifecycleGeneration
+        guard portalHostVacancyRetries.values.contains(where: { $0.generation == scheduledGeneration }) else { return }
+        guard portalHostVacancyWakeGeneration != scheduledGeneration else { return }
+        portalHostVacancyWakeGeneration = scheduledGeneration
         RunLoop.main.perform(inModes: [.common]) { [weak self] in
             guard let self else { return }
-            self.portalHostVacancyWakeScheduled = false
+            guard self.portalHostVacancyWakeGeneration == scheduledGeneration else { return }
+            self.portalHostVacancyWakeGeneration = nil
             guard self.canAcceptPortalBinding(expectedSurfaceId: self.id, expectedGeneration: scheduledGeneration) else {
-                self.clearPortalHostVacancyRetries()
+                self.portalHostVacancyRetries = self.portalHostVacancyRetries.filter {
+                    $0.value.generation != scheduledGeneration
+                }
                 return
             }
             let retries = self.portalHostVacancyRetries.values
+                .filter { $0.generation == scheduledGeneration }
                 .sorted { $0.instanceSerial > $1.instanceSerial }
                 .map(\.retry)
             for retry in retries { retry() }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -105,6 +105,7 @@ extension TerminalSurface {
             area: current.area
         )
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
+        notifyPortalHostVacated(vacatedHostId: hostId)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.rearm surface=\(id.uuidString.prefix(5)) " +
@@ -139,6 +140,23 @@ extension TerminalSurface {
             "generation=\(authority.ownershipGeneration) serial=\(authority.instanceSerial)"
         )
 #endif
+    }
+
+    /// Wakes every parked candidate now that the owner is gone. One deferred
+    /// block per vacancy, newest host first so a single claim wins and the
+    /// rest are rejected against it; common run-loop modes because owners
+    /// vacate mid divider-drag, where a default-mode block waits for mouse-up.
+    /// Deferred a turn so no retry mutates the lease inside the dying host's
+    /// dismantle.
+    private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier) {
+        portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
+        guard !portalHostVacancyRetries.isEmpty else { return }
+        let retries = portalHostVacancyRetries.values
+            .sorted { $0.instanceSerial > $1.instanceSerial }
+            .map(\.retry)
+        RunLoop.main.perform(inModes: [.common]) {
+            for retry in retries { retry() }
+        }
     }
 
     /// Claims (or re-claims) the portal host for a pane.
@@ -302,6 +320,7 @@ extension TerminalSurface {
               current.instanceSerial == instanceSerial else { return }
         activePortalHostLease = nil
         clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
+        notifyPortalHostVacated(vacatedHostId: hostId)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.release surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -20,7 +20,7 @@ extension TerminalSurface {
 
     /// Whether a portal may bind this surface for the expected id/generation.
     public func canAcceptPortalBinding(expectedSurfaceId: UUID?, expectedGeneration: UInt64?) -> Bool {
-        guard portalLifecycleState == .live else { return false }
+        guard portalLifecycleState == .live, !runtimeSurfaceSuspendedForAgentHibernation else { return false }
         if let expectedSurfaceId, expectedSurfaceId != id {
             return false
         }
@@ -142,21 +142,35 @@ extension TerminalSurface {
 #endif
     }
 
-    /// Wakes every parked candidate now that the owner is gone. One deferred
-    /// block per vacancy, newest host first so a single claim wins and the
-    /// rest are rejected against it; common run-loop modes because owners
-    /// vacate mid divider-drag, where a default-mode block waits for mouse-up.
-    /// Deferred a turn so no retry mutates the lease inside the dying host's
-    /// dismantle.
+    /// Wakes parked candidates after an owner vacancy. The surface owns the
+    /// wake phase: one scheduled drain observes the latest retry registry for
+    /// one lifecycle generation, newest host first so a single claim wins and
+    /// the rest are rejected against it. Common run-loop modes are used because
+    /// owners vacate mid divider-drag, where a default-mode block waits for
+    /// mouse-up. Deferred a turn so no retry mutates the lease inside the dying
+    /// host's dismantle.
     private func notifyPortalHostVacated(vacatedHostId: ObjectIdentifier, instanceSerial: UInt64) {
         if portalHostVacancyRetries[vacatedHostId]?.instanceSerial == instanceSerial {
             portalHostVacancyRetries.removeValue(forKey: vacatedHostId)
         }
+        guard canAcceptPortalBinding(expectedSurfaceId: nil, expectedGeneration: nil) else {
+            clearPortalHostVacancyRetries()
+            return
+        }
         guard !portalHostVacancyRetries.isEmpty else { return }
-        let retries = portalHostVacancyRetries.values
-            .sorted { $0.instanceSerial > $1.instanceSerial }
-            .map(\.retry)
-        RunLoop.main.perform(inModes: [.common]) {
+        guard !portalHostVacancyWakeScheduled else { return }
+        portalHostVacancyWakeScheduled = true
+        let scheduledGeneration = portalLifecycleGeneration
+        RunLoop.main.perform(inModes: [.common]) { [weak self] in
+            guard let self else { return }
+            self.portalHostVacancyWakeScheduled = false
+            guard self.canAcceptPortalBinding(expectedSurfaceId: self.id, expectedGeneration: scheduledGeneration) else {
+                self.clearPortalHostVacancyRetries()
+                return
+            }
+            let retries = self.portalHostVacancyRetries.values
+                .sorted { $0.instanceSerial > $1.instanceSerial }
+                .map(\.retry)
             for retry in retries { retry() }
         }
     }

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -162,7 +162,13 @@ extension TerminalSurface {
             area: Self.portalHostArea(for: bounds)
         )
 
-        let alreadyOwnsLease = activePortalHostLease?.hostId == hostId
+        // Owner identity is host AND creation serial: ObjectIdentifier values
+        // are reused after dealloc, and a new incarnation at a recycled address
+        // must not inherit the old owner's standing (or bypass
+        // allowsAuthorityAcquisition through it).
+        let alreadyOwnsLease = activePortalHostLease.map {
+            $0.hostId == hostId && $0.instanceSerial == instanceSerial
+        } ?? false
         guard alreadyOwnsLease || allowsAuthorityAcquisition else {
 #if DEBUG
             logDebugEvent(
@@ -190,7 +196,7 @@ extension TerminalSurface {
 #endif
 
         if let current = activePortalHostLease {
-            if current.hostId == hostId {
+            if current.hostId == hostId, current.instanceSerial == instanceSerial {
                 guard reservePortalHostAuthority(
                     hostId: hostId,
                     paneId: paneId,

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+PortalLease.swift
@@ -81,8 +81,18 @@ extension TerminalSurface {
 
     /// Re-arms the lease when SwiftUI is about to rebuild the owning host.
     @discardableResult
-    public func preparePortalHostReplacementIfOwned(hostId: ObjectIdentifier, reason: String) -> Bool {
-        guard let current = activePortalHostLease, current.hostId == hostId else { return false }
+    public func preparePortalHostReplacementIfOwned(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        reason: String
+    ) -> Bool {
+        // The serial authenticates the vacating incarnation: ObjectIdentifier
+        // values are reused after dealloc, so a stale vacate from an earlier
+        // object at the same address must not re-arm the lease or clear a
+        // newer host's authority.
+        guard let current = activePortalHostLease,
+              current.hostId == hostId,
+              current.instanceSerial == instanceSerial else { return false }
         // SwiftUI can tear down and rebuild the host NSView during split churn. Keep the
         // existing portal binding alive, but make the old lease non-usable so the next
         // distinct host in the same pane can claim immediately instead of waiting for a
@@ -94,6 +104,7 @@ extension TerminalSurface {
             inWindow: false,
             area: current.area
         )
+        clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.rearm surface=\(id.uuidString.prefix(5)) " +
@@ -102,6 +113,32 @@ extension TerminalSurface {
         )
 #endif
         return true
+    }
+
+    /// Drops host-authority supremacy when the authority holder itself vacates.
+    ///
+    /// The authority record exists to stop a retired host from stealing the
+    /// surface back from the host that replaced it. Once the replacement host
+    /// is dismantled there is nobody left to protect, but its record would
+    /// still outrank every live host with an older creation serial at the same
+    /// ownership generation — claimPortalHost decides "replace" yet the
+    /// reservation refuses, and the surface stays pinned to a dead host's
+    /// final anchor until an unrelated model-generation bump.
+    ///
+    /// Matched on host AND creation serial: a stale vacate from an earlier
+    /// incarnation of the same host object must not erase a newer record.
+    private func clearPortalHostAuthorityIfHeld(by hostId: ObjectIdentifier, instanceSerial: UInt64) {
+        guard let authority = portalHostAuthority,
+              authority.hostId == hostId,
+              authority.instanceSerial == instanceSerial else { return }
+        portalHostAuthority = nil
+#if DEBUG
+        logDebugEvent(
+            "terminal.portal.host.authorityCleared surface=\(id.uuidString.prefix(5)) " +
+            "host=\(hostId) pane=\(authority.paneId.uuidString.prefix(5)) " +
+            "generation=\(authority.ownershipGeneration) serial=\(authority.instanceSerial)"
+        )
+#endif
     }
 
     /// Claims (or re-claims) the portal host for a pane.
@@ -137,6 +174,21 @@ extension TerminalSurface {
             return false
         }
 
+#if DEBUG
+        func logAuthorityRefusal() {
+            logDebugEvent(
+                "terminal.portal.host.skip surface=\(id.uuidString.prefix(5)) " +
+                "reason=\(reason) host=\(hostId) pane=\(paneId.id.uuidString.prefix(5)) " +
+                "cause=authorityRefused authorityHost=\(portalHostAuthority.map { String(describing: $0.hostId) } ?? "nil") " +
+                "authorityGeneration=\(portalHostAuthority?.ownershipGeneration ?? 0) " +
+                "authoritySerial=\(portalHostAuthority?.instanceSerial ?? 0) " +
+                "claimGeneration=\(ownershipGeneration) claimSerial=\(instanceSerial)"
+            )
+        }
+#else
+        func logAuthorityRefusal() {}
+#endif
+
         if let current = activePortalHostLease {
             if current.hostId == hostId {
                 guard reservePortalHostAuthority(
@@ -144,7 +196,10 @@ extension TerminalSurface {
                     paneId: paneId,
                     instanceSerial: instanceSerial,
                     ownershipGeneration: ownershipGeneration
-                ) else { return false }
+                ) else {
+                    logAuthorityRefusal()
+                    return false
+                }
                 activePortalHostLease = next
                 return true
             }
@@ -176,7 +231,10 @@ extension TerminalSurface {
                     paneId: paneId,
                     instanceSerial: instanceSerial,
                     ownershipGeneration: ownershipGeneration
-                ) else { return false }
+                ) else {
+                    logAuthorityRefusal()
+                    return false
+                }
 #if DEBUG
                 logDebugEvent(
                     "terminal.portal.host.claim surface=\(id.uuidString.prefix(5)) " +
@@ -211,7 +269,10 @@ extension TerminalSurface {
             paneId: paneId,
             instanceSerial: instanceSerial,
             ownershipGeneration: ownershipGeneration
-        ) else { return false }
+        ) else {
+            logAuthorityRefusal()
+            return false
+        }
         activePortalHostLease = next
 #if DEBUG
         logDebugEvent(
@@ -225,9 +286,16 @@ extension TerminalSurface {
     }
 
     /// Releases the lease when the owning host disappears.
-    public func releasePortalHostIfOwned(hostId: ObjectIdentifier, reason: String) {
-        guard let current = activePortalHostLease, current.hostId == hostId else { return }
+    public func releasePortalHostIfOwned(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        reason: String
+    ) {
+        guard let current = activePortalHostLease,
+              current.hostId == hostId,
+              current.instanceSerial == instanceSerial else { return }
         activePortalHostLease = nil
+        clearPortalHostAuthorityIfHeld(by: hostId, instanceSerial: current.instanceSerial)
 #if DEBUG
         logDebugEvent(
             "terminal.portal.host.release surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -198,6 +198,9 @@ extension TerminalSurface {
         guard portalLifecycleState != .closing else { return }
         recordTeardownRequest(reason: reason)
         portalLifecycleState = .closing
+        // Parked wake-ups are for re-anchoring live content; a closing surface
+        // has none, and the park guard refuses new entries from here on.
+        portalHostVacancyRetries.removeAll()
         portalLifecycleGeneration &+= 1
 #if DEBUG
         logDebugEvent(
@@ -212,6 +215,7 @@ extension TerminalSurface {
         guard portalLifecycleState != .closed else { return }
         portalLifecycleState = .closed
         portalLifecycleGeneration &+= 1
+        portalHostVacancyRetries.removeAll()
 #if DEBUG
         logDebugEvent(
             "surface.lifecycle.close.sealed surface=\(id.uuidString.prefix(5)) " +

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface+RuntimeLifecycle.swift
@@ -200,7 +200,7 @@ extension TerminalSurface {
         portalLifecycleState = .closing
         // Parked wake-ups are for re-anchoring live content; a closing surface
         // has none, and the park guard refuses new entries from here on.
-        portalHostVacancyRetries.removeAll()
+        clearPortalHostVacancyRetries()
         portalLifecycleGeneration &+= 1
 #if DEBUG
         logDebugEvent(
@@ -215,7 +215,7 @@ extension TerminalSurface {
         guard portalLifecycleState != .closed else { return }
         portalLifecycleState = .closed
         portalLifecycleGeneration &+= 1
-        portalHostVacancyRetries.removeAll()
+        clearPortalHostVacancyRetries()
 #if DEBUG
         logDebugEvent(
             "surface.lifecycle.close.sealed surface=\(id.uuidString.prefix(5)) " +
@@ -319,6 +319,8 @@ extension TerminalSurface {
         surface = nil
         activePortalHostLease = nil
         portalHostAuthority = nil
+        clearPortalHostVacancyRetries()
+        portalLifecycleGeneration &+= 1
         pendingSocketInputQueue.removeAll(keepingCapacity: false)
         pendingSocketInputBytes = 0
         desiredFocusState = false

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -319,9 +319,16 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// no view state and no strong reference back to itself, so a dead
     /// coordinator turns its entry into a no-op and no retain cycle exists.
     /// Entries drop when their own host vacates the lease, when the host
-    /// dismantles, and when the portal lifecycle leaves `.live`; parking is
-    /// refused from `.closing` onward.
+    /// dismantles, when the runtime is hibernated, and when the portal
+    /// lifecycle leaves `.live`; parking is refused outside bindable runtime
+    /// states.
     var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, retry: () -> Void)] = [:]
+    var portalHostVacancyWakeScheduled = false
+
+    func clearPortalHostVacancyRetries() {
+        portalHostVacancyRetries.removeAll()
+        portalHostVacancyWakeScheduled = false
+    }
 
     /// Parks (or refreshes) a host's vacancy retry. See
     /// `portalHostVacancyRetries` for lifetime rules.
@@ -330,7 +337,7 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         instanceSerial: UInt64,
         _ retry: @escaping () -> Void
     ) {
-        guard portalLifecycleState == .live else { return }
+        guard canAcceptPortalBinding(expectedSurfaceId: nil, expectedGeneration: nil) else { return }
         portalHostVacancyRetries[hostId] = (instanceSerial, retry)
     }
 

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -309,6 +309,36 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     var portalLifecycleGeneration: UInt64 = 1
     var activePortalHostLease: PortalHostLease?
     var portalHostAuthority: TerminalPortalHostAuthority?
+    /// Wake-up retries for the owner-death edge, one per live candidate host.
+    ///
+    /// Every claim runs on a candidate's own edge (its SwiftUI update, window
+    /// entry, geometry change); the lease owner dying fires no edge on any
+    /// survivor, so a pane whose owner dismantled can wait a full settle
+    /// budget for an unrelated update before it re-anchors. The values are
+    /// weak trampolines into each candidate's coordinator — the surface holds
+    /// no view state and no strong reference back to itself, so a dead
+    /// coordinator turns its entry into a no-op and no retain cycle exists.
+    /// Entries drop when their own host vacates the lease, when the host
+    /// dismantles, and when the portal lifecycle leaves `.live`; parking is
+    /// refused from `.closing` onward.
+    var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, retry: () -> Void)] = [:]
+
+    /// Parks (or refreshes) a host's vacancy retry. See
+    /// `portalHostVacancyRetries` for lifetime rules.
+    public func parkPortalVacancyRetry(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        _ retry: @escaping () -> Void
+    ) {
+        guard portalLifecycleState == .live else { return }
+        portalHostVacancyRetries[hostId] = (instanceSerial, retry)
+    }
+
+    /// Drops a host's vacancy retry (dismantle, or the host stopped owning
+    /// its pane; the owner's own vacate paths drop theirs).
+    public func removePortalVacancyRetry(hostId: ObjectIdentifier) {
+        portalHostVacancyRetries.removeValue(forKey: hostId)
+    }
 
     /// The live find session, or nil when find is closed. Setting it arms the
     /// debounced needle pipeline; clearing it ends the runtime search.

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -322,12 +322,15 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     /// dismantles, when the runtime is hibernated, and when the portal
     /// lifecycle leaves `.live`; parking is refused outside bindable runtime
     /// states.
-    var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, retry: () -> Void)] = [:]
-    var portalHostVacancyWakeScheduled = false
+    var portalHostVacancyRetries: [ObjectIdentifier: (instanceSerial: UInt64, generation: UInt64, retry: () -> Void)] = [:]
+    var portalHostVacancyWakeGeneration: UInt64?
+    var portalHostVacancyWakeScheduled: Bool {
+        portalHostVacancyWakeGeneration != nil
+    }
 
     func clearPortalHostVacancyRetries() {
         portalHostVacancyRetries.removeAll()
-        portalHostVacancyWakeScheduled = false
+        portalHostVacancyWakeGeneration = nil
     }
 
     /// Parks (or refreshes) a host's vacancy retry. See
@@ -338,7 +341,9 @@ public final class TerminalSurface: Identifiable, ObservableObject {
         _ retry: @escaping () -> Void
     ) {
         guard canAcceptPortalBinding(expectedSurfaceId: nil, expectedGeneration: nil) else { return }
-        portalHostVacancyRetries[hostId] = (instanceSerial, retry)
+        let generation = portalLifecycleGeneration
+        portalHostVacancyRetries = portalHostVacancyRetries.filter { $0.value.generation == generation }
+        portalHostVacancyRetries[hostId] = (instanceSerial, generation, retry)
     }
 
     /// Drops a host's vacancy retry (dismantle, or the host stopped owning

--- a/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
+++ b/Packages/macOS/CmuxTerminal/Sources/CmuxTerminal/Surface/TerminalSurface.swift
@@ -335,8 +335,11 @@ public final class TerminalSurface: Identifiable, ObservableObject {
     }
 
     /// Drops a host's vacancy retry (dismantle, or the host stopped owning
-    /// its pane; the owner's own vacate paths drop theirs).
-    public func removePortalVacancyRetry(hostId: ObjectIdentifier) {
+    /// its pane; the owner's own vacate paths drop theirs). Serial-matched
+    /// like every other identity check here: a recycled object address must
+    /// not remove a newer incarnation's park.
+    public func removePortalVacancyRetry(hostId: ObjectIdentifier, instanceSerial: UInt64) {
+        guard portalHostVacancyRetries[hostId]?.instanceSerial == instanceSerial else { return }
         portalHostVacancyRetries.removeValue(forKey: hostId)
     }
 

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
@@ -8,6 +8,51 @@ import Testing
 
 @MainActor
 @Suite struct TerminalSurfacePortalHostVacancyTests {
+    @Test func vacatedNewerSameGenerationAuthorityDoesNotPinOlderCandidate() {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let ownershipGeneration = surface.currentPortalHostOwnershipGeneration()
+        let olderHost = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let newerHost = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(olderHost),
+            paneId: paneId,
+            instanceSerial: 1,
+            ownershipGeneration: ownershipGeneration,
+            inWindow: true,
+            bounds: olderHost.bounds,
+            reason: "test.olderInitialClaim"
+        ))
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(newerHost),
+            paneId: paneId,
+            instanceSerial: 2,
+            ownershipGeneration: ownershipGeneration,
+            inWindow: true,
+            bounds: newerHost.bounds,
+            reason: "test.newerSameGenerationClaim"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(newerHost),
+            instanceSerial: 2,
+            reason: "test.newerVacated"
+        )
+
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(olderHost),
+            paneId: paneId,
+            instanceSerial: 1,
+            ownershipGeneration: ownershipGeneration,
+            inWindow: true,
+            bounds: olderHost.bounds,
+            reason: "test.olderRetryAfterNewerVacated"
+        ))
+    }
+
     @Test func repeatedOwnerVacanciesCoalesceIntoOneLatestRetryDrain() async {
         let surface = makeSurface()
         defer { surface.releaseSurfaceForTesting() }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
@@ -114,6 +114,65 @@ import Testing
         #expect(retryCount == 0)
     }
 
+    @Test func staleGenerationDrainDoesNotEraseFreshVacancyRetry() async {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let oldOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let freshOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let oldCandidate = NSView()
+        let freshCandidate = NSView()
+        var retries: [Int] = []
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(oldCandidate),
+            instanceSerial: 2
+        ) {
+            retries.append(2)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(oldOwner),
+            paneId: paneId,
+            instanceSerial: 1,
+            inWindow: true,
+            bounds: oldOwner.bounds,
+            reason: "test.oldOwner"
+        ))
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(oldOwner),
+            instanceSerial: 1,
+            reason: "test.oldVacancy"
+        )
+        #expect(surface.portalHostVacancyWakeScheduled)
+
+        surface.updateWorkspaceId(UUID())
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(freshCandidate),
+            instanceSerial: 4
+        ) {
+            retries.append(4)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(freshOwner),
+            paneId: paneId,
+            instanceSerial: 3,
+            inWindow: true,
+            bounds: freshOwner.bounds,
+            reason: "test.freshOwner"
+        ))
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(freshOwner),
+            instanceSerial: 3,
+            reason: "test.freshVacancy"
+        )
+
+        drainMainRunLoop()
+
+        #expect(retries == [4])
+        #expect(!surface.portalHostVacancyWakeScheduled)
+    }
+
     private func drainMainRunLoop() {
         RunLoop.main.run(until: Date().addingTimeInterval(0.02))
     }

--- a/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
+++ b/Packages/macOS/CmuxTerminal/Tests/CmuxTerminalTests/TerminalSurfacePortalHostVacancyTests.swift
@@ -1,0 +1,149 @@
+import AppKit
+import Bonsplit
+import CmuxTerminalCore
+import Foundation
+import GhosttyKit
+import Testing
+@testable import CmuxTerminal
+
+@MainActor
+@Suite struct TerminalSurfacePortalHostVacancyTests {
+    @Test func repeatedOwnerVacanciesCoalesceIntoOneLatestRetryDrain() async {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let firstOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let secondOwner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let olderCandidate = NSView()
+        let newerCandidate = NSView()
+        var retries: [Int] = []
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(olderCandidate),
+            instanceSerial: 2
+        ) {
+            retries.append(2)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(firstOwner),
+            paneId: paneId,
+            instanceSerial: 1,
+            inWindow: true,
+            bounds: firstOwner.bounds,
+            reason: "test.firstOwner"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(firstOwner),
+            instanceSerial: 1,
+            reason: "test.firstVacancy"
+        )
+        #expect(surface.portalHostVacancyWakeScheduled)
+        #expect(retries.isEmpty)
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(newerCandidate),
+            instanceSerial: 4
+        ) {
+            retries.append(4)
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(secondOwner),
+            paneId: paneId,
+            instanceSerial: 3,
+            inWindow: true,
+            bounds: secondOwner.bounds,
+            reason: "test.secondOwner"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(secondOwner),
+            instanceSerial: 3,
+            reason: "test.secondVacancy"
+        )
+
+        drainMainRunLoop()
+
+        #expect(retries == [4, 2])
+        #expect(!surface.portalHostVacancyWakeScheduled)
+    }
+
+    @Test func hibernationInvalidatesQueuedVacancyRetriesBeforeRunLoopDrain() async {
+        let surface = makeSurface()
+        defer { surface.releaseSurfaceForTesting() }
+
+        let paneId = PaneID()
+        let owner = NSView(frame: NSRect(x: 0, y: 0, width: 80, height: 24))
+        let candidate = NSView()
+        let generationBeforeHibernation = surface.portalBindingGeneration()
+        var retryCount = 0
+
+        surface.parkPortalVacancyRetry(
+            hostId: ObjectIdentifier(candidate),
+            instanceSerial: 2
+        ) {
+            retryCount += 1
+        }
+        #expect(surface.claimPortalHost(
+            hostId: ObjectIdentifier(owner),
+            paneId: paneId,
+            instanceSerial: 1,
+            inWindow: true,
+            bounds: owner.bounds,
+            reason: "test.owner"
+        ))
+
+        surface.releasePortalHostIfOwned(
+            hostId: ObjectIdentifier(owner),
+            instanceSerial: 1,
+            reason: "test.vacancy"
+        )
+        #expect(surface.portalHostVacancyWakeScheduled)
+
+        surface.suspendRuntimeSurfaceForAgentHibernation(reason: "test.hibernate")
+        #expect(surface.portalHostVacancyRetries.isEmpty)
+        #expect(!surface.portalHostVacancyWakeScheduled)
+        #expect(!surface.canAcceptPortalBinding(
+            expectedSurfaceId: surface.id,
+            expectedGeneration: generationBeforeHibernation
+        ))
+
+        drainMainRunLoop()
+
+        #expect(retryCount == 0)
+    }
+
+    private func drainMainRunLoop() {
+        RunLoop.main.run(until: Date().addingTimeInterval(0.02))
+    }
+
+    private func makeSurface() -> TerminalSurface {
+        let nativeView = FakeTerminalSurfaceNativeView(frame: NSRect(x: 0, y: 0, width: 800, height: 600))
+        let paneHost = FakeTerminalSurfacePaneHost(surfaceView: nativeView)
+        return TerminalSurface(
+            tabId: UUID(),
+            context: GHOSTTY_SURFACE_CONTEXT_SPLIT,
+            configTemplate: nil,
+            dependencies: TerminalSurfaceRuntimeDependencies(
+                registry: FakeSurfaceRegistry(),
+                engine: FakeTerminalEngine(),
+                viewProvider: FakeTerminalSurfaceViewProvider(surfaceView: nativeView, paneHost: paneHost),
+                spawnPolicy: FakeSpawnPolicyProvider(),
+                byteTee: FakeTerminalByteTee(),
+                rendererRealization: FakeRendererRealizationScheduler(),
+                hibernationRecorder: FakeHibernationRecorder(),
+                runtimeTeardown: TerminalSurfaceRuntimeTeardownCoordinator(),
+                restoreSpawnScheduler: TerminalSurfaceRestoreSpawnScheduler(interSpawnDelay: .zero),
+                runtimeFilesystem: TerminalSurfaceRuntimeFilesystem(
+                    claudeCommandShimTemporaryDirectory: URL(fileURLWithPath: "/tmp/cmux-terminal-tests", isDirectory: true),
+                    installClaudeCommandShim: { _, _, _ in nil },
+                    isExecutableFile: { _ in false }
+                ),
+                sessionPortBase: 40_000,
+                sessionPortRangeSize: 100,
+                scrollbackReplayEnvironmentKey: "CMUX_TEST_SCROLLBACK_REPLAY"
+            )
+        )
+    }
+}

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -578,6 +578,7 @@ extension TerminalController {
                                     + " view=\(Int(actual.width))x\(Int(actual.height))"
                                     + " lease_pane=\(leasePane) expected_pane=\(expectedPane)"
                                     + " lease_inWin=\(lease?.inWindow == true ? 1 : 0)"
+                                    + " in \(Self.ancestryDescription(of: hostedView))"
                             )
                         }
                     } else {
@@ -773,6 +774,32 @@ extension TerminalController {
                 "full_hierarchy_sync": RemoteTmuxSizingDiagnostics.fullHierarchySyncCount,
             ],
         ]
+    }
+
+    /// The hosted view's enclosing containers, innermost first, each with its own
+    /// size and — for a split — how many panes it still arranges.
+    ///
+    /// A pane that misses its planned size says nothing about WHERE the size was
+    /// lost. If the enclosing split already holds the planned width, the pane
+    /// alone failed to fill it; if the split itself is short, the miss came from
+    /// above; and an arranged count that disagrees with the tree's child count
+    /// means the split never collapsed after a sibling closed, which no divider
+    /// imposition can correct because there is no longer a divider to move.
+    nonisolated static func ancestryDescription(of view: NSView, levels: Int = 3) -> String {
+        var parts: [String] = []
+        var next = view.superview
+        while let current = next, parts.count < levels {
+            let name = String(describing: type(of: current))
+                .replacingOccurrences(of: "Bonsplit.", with: "")
+            var term = "\(name)(\(Int(current.frame.width))x\(Int(current.frame.height))"
+            if let split = current as? NSSplitView {
+                term += ",arranged=\(split.arrangedSubviews.count)"
+                term += ",vertical=\(split.isVertical ? 1 : 0)"
+            }
+            parts.append(term + ")")
+            next = current.superview
+        }
+        return parts.isEmpty ? "no-superview" : parts.joined(separator: " < ")
     }
 }
 #endif

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -474,10 +474,21 @@ extension TerminalController {
                         if abs(plannedContent.width - actual.width) > 1.5
                             || abs(plannedContent.height - actual.height) > 1.5 {
                             nativeGeometryReady = false
+                            // The portal positions this view from whichever pane HOST
+                            // holds the surface's lease; a view at the wrong size with a
+                            // correct plan usually means the lease is held by the wrong
+                            // pane. Name both sides so the mismatch says which.
+                            let lease = mirror.panelsByPaneId[leaf]?.surface.debugPortalHostLease()
+                            let leasePane = lease?.paneId.map { String($0.uuidString.prefix(5)) } ?? "none"
+                            let expectedPane = mirror.paneIdByPaneId[leaf].map {
+                                String($0.id.uuidString.prefix(5))
+                            } ?? "none"
                             mismatches.append(
                                 "%\(leaf) native-geometry"
                                     + " plan=\(Int(plannedContent.width))x\(Int(plannedContent.height))"
                                     + " view=\(Int(actual.width))x\(Int(actual.height))"
+                                    + " lease_pane=\(leasePane) expected_pane=\(expectedPane)"
+                                    + " lease_inWin=\(lease?.inWindow == true ? 1 : 0)"
                             )
                         }
                     } else {

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -495,7 +495,7 @@ extension TerminalController {
                 if onScreen, !mirror.isVisibleForSizing {
                     mismatches.append(
                         "on screen but not visible-for-sizing"
-                            + " container=\(mirror.containerSizePt.map { "\(Int($0.width))x\(Int($0.height))" } ?? "nil")"
+                            + " container=\(Self.sizeDescription(mirror.containerSizePt))"
                             + " claimed=\(claimed.map { "\($0.0)x\($0.1)" } ?? "none")"
                     )
                 }
@@ -672,30 +672,34 @@ extension TerminalController {
                     && nativeGeometryReady
                     && portalGeometryReady
                     && gridParityReady
-                // Derivation parity, visible mirror only (hidden mirrors
-                // hold their attach-time claim by design). Delivery parity —
-                // claim == tmux layout — cannot see a claim that tmux
-                // honored but that no longer matches what the CURRENT
-                // container derives: the class where a stale claim settles
-                // green while the region cannot render the columns it
-                // promised. A settled visible window must be able to
-                // re-derive its own claim.
+                // Derivation parity. Delivery parity — claim == tmux layout —
+                // cannot see a claim that tmux honored but that no longer matches
+                // what the CURRENT container derives: the class where a stale
+                // claim settles green while the region cannot render the columns
+                // it promised. A window on screen must be able to re-derive its
+                // own claim.
+                //
+                // Keyed off `onScreen`, an independent read of view state, and not
+                // off `isVisibleForSizing`: that flag is the thing under test, and
+                // a judge that consults it hands the defect a way to excuse itself.
+                // A mirror that is off screen holds its attach-time claim by
+                // design and has nothing to re-derive.
                 let derivable: (columns: Int, rows: Int)? = {
-                    guard mirror.isVisibleForSizing,
-                          let container = mirror.containerSizePt else { return nil }
+                    guard let container = mirror.containerSizePt else { return nil }
                     return mirror.clientGrid(contentSize: container)
                 }()
-                let derivationSettled = derivable.flatMap { grid in
-                    claimed.map { $0.0 == grid.columns && $0.1 == grid.rows }
-                } ?? true
-                let renderFrameDescription: String = {
-                    guard let size = mirror.renderFrameSize else { return "none" }
-                    return "\(Int(size.width))x\(Int(size.height))"
+                // Absence of evidence is not settledness. An on-screen mirror with
+                // no container, or one whose grid will not derive, cannot have
+                // re-derived anything — and every other term can sit true on a
+                // cached plan, so defaulting this one to true let exactly that
+                // window settle green. Off screen, there is nothing to prove.
+                let derivationSettled: Bool = {
+                    guard onScreen else { return true }
+                    guard let grid = derivable, let claimed else { return false }
+                    return claimed.0 == grid.columns && claimed.1 == grid.rows
                 }()
-                let containerDescription: String = {
-                    guard let size = mirror.containerSizePt else { return "none" }
-                    return "\(Int(size.width))x\(Int(size.height))"
-                }()
+                let renderFrameDescription = Self.sizeDescription(mirror.renderFrameSize)
+                let containerDescription = Self.sizeDescription(mirror.containerSizePt)
                 windows.append([
                     "window": windowId,
                     "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
@@ -786,30 +790,16 @@ extension TerminalController {
         ]
     }
 
-    /// The hosted view's enclosing containers, innermost first, each with its own
-    /// size and — for a split — how many panes it still arranges.
+    /// `WxH` in whole points, or `none`.
     ///
-    /// A pane that misses its planned size says nothing about WHERE the size was
-    /// lost. If the enclosing split already holds the planned width, the pane
-    /// alone failed to fill it; if the split itself is short, the miss came from
-    /// above; and an arranged count that disagrees with the tree's child count
-    /// means the split never collapsed after a sibling closed, which no divider
-    /// imposition can correct because there is no longer a divider to move.
-    nonisolated static func ancestryDescription(of view: NSView, levels: Int = 3) -> String {
-        var parts: [String] = []
-        var next = view.superview
-        while let current = next, parts.count < levels {
-            let name = String(describing: type(of: current))
-                .replacingOccurrences(of: "Bonsplit.", with: "")
-            var term = "\(name)(\(Int(current.frame.width))x\(Int(current.frame.height))"
-            if let split = current as? NSSplitView {
-                term += ",arranged=\(split.arrangedSubviews.count)"
-                term += ",vertical=\(split.isVertical ? 1 : 0)"
-            }
-            parts.append(term + ")")
-            next = current.superview
-        }
-        return parts.isEmpty ? "no-superview" : parts.joined(separator: " < ")
+    /// Shared so the same size never reads `none` in one field and `nil` in
+    /// another for the same absent value. Named rather than inlined because the
+    /// payload literal below is already at the type-checker's limit: a handful of
+    /// inline `map { … } ?? "none"` closures in it push the whole expression past
+    /// the budget, and one concrete call each type-checks instantly.
+    nonisolated static func sizeDescription(_ size: CGSize?) -> String {
+        guard let size else { return "none" }
+        return "\(Int(size.width))x\(Int(size.height))"
     }
 }
 #endif

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -419,16 +419,105 @@ extension TerminalController {
             let connected = session.connection.connectionState == .connected
             connectionsConnected = connectionsConnected && connected
             let liveWindowIds = Set(session.connection.windowOrder)
+            // At most ONE mirror per session may own sizing — a workspace shows one
+            // tab at a time. This is checked at the SESSION level because it cannot
+            // be seen per-window: a mirror with a stale `visible == true` has
+            // on_screen == false, so the per-window checks below skip it by design
+            // (its panes are parked offscreen and judging their grids reports
+            // phantoms). That blind spot is exactly half the defect this judge exists
+            // for — the hide edge — so it is asserted here, where two owners are
+            // countable, rather than left to a check that structurally cannot fail.
+            // KNOWN GAP, stated rather than implied: a SOLE stale owner is not
+            // caught. If a mirror keeps visible_for_sizing while hidden and the tab
+            // now selected is a single-pane window (which has no mirror), the owner
+            // count is 1, no mirror is on screen, and nothing here fires. Closing it
+            // needs the workspace's selected tab as the authority — flag == (this
+            // mirror's panel is selected) — which this judge does not reach today.
+            // Two owners, and a shown mirror that owns nothing, ARE caught.
+            let owners = session.windowMirrorByWindowId
+                .filter { liveWindowIds.contains($0.key) && !$0.value.isTornDown }
+                .filter { $0.value.isVisibleForSizing }
+                .keys
+                .sorted()
+            if owners.count > 1 {
+                windows.append([
+                    "window": owners.first ?? -1,
+                    "claimed": "none",
+                    "settled": false,
+                    "mismatches": [
+                        "multiple mirrors own sizing: "
+                            + owners.map { "@\($0)" }.joined(separator: ",")
+                            + " — a switched-away mirror never released it",
+                    ],
+                ])
+            }
             for (windowId, mirror) in session.windowMirrorByWindowId {
                 // A window tmux no longer lists cannot settle and
                 // must not be judged; its mirror is mid-teardown.
                 guard liveWindowIds.contains(windowId) else { continue }
-                // Hidden mirrors stop tracking by design (they claim
-                // once and their surfaces report collapsed sizes);
-                // only the visible mirror's state is judgeable.
-                guard mirror.isEffectivelyVisibleForSizing else { continue }
+                guard !mirror.isTornDown else { continue }
+                // Never GATE on isVisibleForSizing. This judge used to open with
+                // `guard mirror.isEffectivelyVisibleForSizing else { continue }`,
+                // which ANDs the flag with the view state — and being an AND it
+                // could only SHRINK the judged set. A mirror whose flag lied was
+                // therefore dropped from the report instead of failing it: the
+                // defect blinded the judge rather than reddening it. Measured
+                // live: the one window actually on screen reported visible=0 and
+                // vanished from this list while a 125-iteration fuzz marathon
+                // read green.
+                //
+                // The two terms are still both needed — judging a mirror whose
+                // panes sit in the offscreen parking window reports phantom
+                // mismatches — so compare them and report the disagreement.
+                // Read view state HERE rather than through a mirror helper: the
+                // point is that this judge must not depend on the mirror's own
+                // notion of visibility, which is exactly the thing under test.
+                let onScreen = mirror.panelsByPaneId.values.contains { panel in
+                    let hostedView = panel.hostedView
+                    return hostedView.isVisibleInUI
+                        && !hostedView.isHidden
+                        && hostedView.superview != nil
+                        && hostedView.window?.isVisible == true
+                }
                 let claimed = mirror.connection?.lastWindowSizes[windowId]
                 var mismatches: [String] = []
+                // Directional on purpose. A window whose panes are ON SCREEN must
+                // own its sizing: if it does not, nothing derives its claim and it
+                // renders at whatever tmux last gave it — the defect this judge
+                // exists to catch.
+                //
+                // The converse is NOT a defect and must not be asserted:
+                // isVisibleForSizing tracks the tab being SELECTED within its
+                // window to be ordered in. A selected tab in a cmux window that
+                // sits behind another window is legitimately flag=1, on_screen=0.
+                // Asserting equality here reported that ordinary state as a
+                // contradiction on every iteration.
+                if onScreen, !mirror.isVisibleForSizing {
+                    mismatches.append(
+                        "on screen but not visible-for-sizing"
+                            + " container=\(mirror.containerSizePt.map { "\(Int($0.width))x\(Int($0.height))" } ?? "nil")"
+                            + " claimed=\(claimed.map { "\($0.0)x\($0.1)" } ?? "none")"
+                    )
+                }
+                // A window on screen with no claim can never render the grid
+                // tmux assigns it — report it rather than skipping it.
+                if onScreen, claimed == nil {
+                    mismatches.append("on screen but never claimed a size")
+                }
+                guard onScreen else {
+                    // Hidden mirrors stop tracking by design (their surfaces
+                    // report collapsed sizes), so their grids are not judgeable —
+                    // but a contradiction found above still reports.
+                    if !mismatches.isEmpty {
+                        windows.append([
+                            "window": windowId,
+                            "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
+                            "settled": false,
+                            "mismatches": mismatches,
+                        ])
+                    }
+                    continue
+                }
                 // While zoomed, the visible tree is what panes render.
                 let tree = mirror.visibleLayout ?? mirror.layout
                 let leavesByPaneID = tree.leavesByPaneID
@@ -603,6 +692,23 @@ extension TerminalController {
                     "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
                     "layout": "\(mirror.layout.width)x\(mirror.layout.height)",
                     "derivable": derivable.map { "\($0.columns)x\($0.rows)" } ?? "none",
+                    // The terms `settled` is made of. Without them an unsettled
+                    // window whose claim, derivable and layout all agreed with zero
+                    // mismatches gave no clue which one was false.
+                    "why": [
+                        "connected": connected,
+                        "publication_ready": publicationReady,
+                        "sizing_ready": sizingReady,
+                        "pass_scheduled": mirror.sizingPassScheduled,
+                        "completed_inputs": mirror.lastCompletedSizingInputs != nil,
+                        "native_geometry_ready": nativeGeometryReady,
+                        "portal_geometry_ready": portalGeometryReady,
+                        "grid_parity_ready": gridParityReady,
+                        "derivation_settled": derivationSettled,
+                        "window_grid": windowGrid.map { "\($0.width)x\($0.height)" } ?? "none",
+                        "visible_for_sizing": mirror.isVisibleForSizing,
+                        "on_screen": onScreen,
+                    ],
                     // The claim is a CLIENT size; `windowGrid` is the WINDOW tmux
                     // laid out. Columns agree exactly (tmux fits the window to the
                     // client width; dividers come out of panes, not the total), so
@@ -615,8 +721,18 @@ extension TerminalController {
                     // client==window; we settle on the panes rendering their
                     // assigned grids (gridParity, inside sizingReady) and the claim
                     // re-deriving from the current container (derivationSettled).
+                    // A mismatch must DECIDE this, not merely accompany it.
+                    // `settled` used to ignore `mismatches` entirely, so the
+                    // "on screen but not visible-for-sizing" report below was loud
+                    // in the payload and silent in the verdict: an on-screen mirror
+                    // whose flag read false — the exact defect this judge exists to
+                    // catch — settled GREEN, because `derivable` guards on that same
+                    // flag, returns nil, and `?? true` then forces
+                    // derivationSettled. The report has to be able to fail
+                    // something or it is decoration.
                     "settled": claimed.map { claim in
                         guard let windowGrid else { return false }
+                        guard mismatches.isEmpty else { return false }
                         return connected && publicationReady && sizingReady
                             && derivationSettled
                             && claim.0 == windowGrid.width

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -601,14 +601,13 @@ extension TerminalController {
                             let expectedPane = mirror.paneIdByPaneId[leaf].map {
                                 String($0.id.uuidString.prefix(5))
                             } ?? "none"
-                            mismatches.append(
-                                "%\(leaf) native-geometry"
-                                    + " plan=\(Int(plannedContent.width))x\(Int(plannedContent.height))"
-                                    + " view=\(Int(actual.width))x\(Int(actual.height))"
-                                    + " lease_pane=\(leasePane) expected_pane=\(expectedPane)"
-                                    + " lease_inWin=\(lease?.inWindow == true ? 1 : 0)"
-                                    + " in \(Self.ancestryDescription(of: hostedView))"
-                            )
+                            let planText = "\(Int(plannedContent.width))x\(Int(plannedContent.height))"
+                            let viewText = "\(Int(actual.width))x\(Int(actual.height))"
+                            let leaseInWin = lease?.inWindow == true ? 1 : 0
+                            var line = "%\(leaf) native-geometry plan=\(planText) view=\(viewText)"
+                            line += " lease_pane=\(leasePane) expected_pane=\(expectedPane)"
+                            line += " lease_inWin=\(leaseInWin)"
+                            mismatches.append(line)
                         }
                     } else {
                         nativeGeometryReady = false

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -427,13 +427,6 @@ extension TerminalController {
             // phantoms). That blind spot is exactly half the defect this judge exists
             // for — the hide edge — so it is asserted here, where two owners are
             // countable, rather than left to a check that structurally cannot fail.
-            // KNOWN GAP, stated rather than implied: a SOLE stale owner is not
-            // caught. If a mirror keeps visible_for_sizing while hidden and the tab
-            // now selected is a single-pane window (which has no mirror), the owner
-            // count is 1, no mirror is on screen, and nothing here fires. Closing it
-            // needs the workspace's selected tab as the authority — flag == (this
-            // mirror's panel is selected) — which this judge does not reach today.
-            // Two owners, and a shown mirror that owns nothing, ARE caught.
             let owners = session.windowMirrorByWindowId
                 .filter { liveWindowIds.contains($0.key) && !$0.value.isTornDown }
                 .filter { $0.value.isVisibleForSizing }
@@ -448,6 +441,42 @@ extension TerminalController {
                         "multiple mirrors own sizing: "
                             + owners.map { "@\($0)" }.joined(separator: ",")
                             + " — a switched-away mirror never released it",
+                    ],
+                ])
+            }
+            // A SOLE stale owner used to escape: one mirror keeps the flag while
+            // hidden, the tab now selected is a single-pane window (which has no
+            // mirror), so the count is 1, nothing is on screen, and no per-window
+            // check fires. Check each owner against the product's own rule instead
+            // of counting.
+            //
+            // The rule is `panelVisibleInUI`: isWorkspaceVisible && (isSelectedInPane
+            // || isFocused). Its first two inputs are view-level — `isWorkspaceVisible`
+            // and `isWorkspaceInputActive` are properties fed into the SwiftUI view, not
+            // model state — so the full equality is not recomputable here. The
+            // implication is: holding the flag REQUIRES the panel be selected in its
+            // pane or focused, and both of those are model state. An owner that is
+            // neither is stale, with no judgement needed about whether the workspace is
+            // showing. Necessary-condition only, so it cannot fire on a legitimately
+            // hidden-but-selected mirror — the case that makes the on-screen assertion
+            // directional.
+            let selectedPanelIds: Set<UUID> = Set(
+                workspace.bonsplitController.allPaneIds
+                    .compactMap { workspace.bonsplitController.selectedTab(inPane: $0)?.id }
+                    .compactMap { workspace.panelIdFromSurfaceId($0) }
+            )
+            for windowId in owners {
+                guard let mirror = session.windowMirrorByWindowId[windowId] else { continue }
+                let isSelectedInPane = selectedPanelIds.contains(mirror.panelId)
+                let isFocused = workspace.focusedPanelId == mirror.panelId
+                guard !isSelectedInPane, !isFocused else { continue }
+                windows.append([
+                    "window": windowId,
+                    "claimed": "none",
+                    "settled": false,
+                    "mismatches": [
+                        "@\(windowId) owns sizing but its panel is neither selected in its"
+                            + " pane nor focused — the flag outlived the hide edge",
                     ],
                 ])
             }

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -727,6 +727,16 @@ extension TerminalController {
                         // already at the type-checker's limit.
                         "render_frame": renderFrameDescription,
                         "container": containerDescription,
+                        // Does bonsplit's own LOGICAL tree agree with the tmux
+                        // layout this plan was built from? Panes are portal-hosted
+                        // at the window level, so a pane's frame tracks an anchor
+                        // inside the split tree rather than the split tree itself:
+                        // when the logical tree agrees and the geometry is still
+                        // wrong, the stale thing is downstream of the tree, and the
+                        // reconcile that consults this same predicate had no reason
+                        // to rebuild. Without it, "the trees disagree" stays a
+                        // guess, and it is the guess this judge kept inviting.
+                        "tree_matches_layout": mirror.bonsplitTreeMatches(layout: tree),
                     ],
                     // The claim is a CLIENT size; `windowGrid` is the WINDOW tmux
                     // laid out. Columns agree exactly (tmux fits the window to the

--- a/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
+++ b/Sources/Debug/RemoteTmux/TerminalController+RemoteTmuxTestSupport.swift
@@ -687,6 +687,14 @@ extension TerminalController {
                 let derivationSettled = derivable.flatMap { grid in
                     claimed.map { $0.0 == grid.columns && $0.1 == grid.rows }
                 } ?? true
+                let renderFrameDescription: String = {
+                    guard let size = mirror.renderFrameSize else { return "none" }
+                    return "\(Int(size.width))x\(Int(size.height))"
+                }()
+                let containerDescription: String = {
+                    guard let size = mirror.containerSizePt else { return "none" }
+                    return "\(Int(size.width))x\(Int(size.height))"
+                }()
                 windows.append([
                     "window": windowId,
                     "claimed": claimed.map { "\($0.0)x\($0.1)" } ?? "none",
@@ -708,6 +716,16 @@ extension TerminalController {
                         "window_grid": windowGrid.map { "\($0.width)x\($0.height)" } ?? "none",
                         "visible_for_sizing": mirror.isVisibleForSizing,
                         "on_screen": onScreen,
+                        // The parent this judge plans from, beside the live one. A
+                        // native-geometry mismatch says the panes disagree with a
+                        // plan, and the plan is only as good as its parent: if the
+                        // banked render frame has drifted from the container the
+                        // views were laid out against, the disagreement is the
+                        // judge's rather than the app's. Only reporting both tells
+                        // those apart. Built above, not inline: this literal is
+                        // already at the type-checker's limit.
+                        "render_frame": renderFrameDescription,
+                        "container": containerDescription,
                     ],
                     // The claim is a CLIENT size; `windowGrid` is the WINDOW tmux
                     // laid out. Columns agree exactly (tmux fits the window to the

--- a/Sources/GhosttyTerminalImmediateHostedStateAction.swift
+++ b/Sources/GhosttyTerminalImmediateHostedStateAction.swift
@@ -1,0 +1,16 @@
+/// What a `GhosttyTerminalView` update may do to the hosted view's immediate
+/// visible/active state.
+enum GhosttyTerminalImmediateHostedStateAction: Equatable {
+    /// The owner with a live binding applies both flags.
+    case applyVisibleAndActive
+
+    /// A bound host that lost the lease may still un-show its own surface and
+    /// nothing more. Active/focus state stays ownership-gated. An owner's hide
+    /// is allowed whether or not it is currently bound: the lease is
+    /// authoritative for the surface's state, and that was the apply rule
+    /// before this enum existed.
+    case hideOnly
+
+    /// A non-owner that is not bound must not touch the hosted view.
+    case deferred
+}

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12477,6 +12477,8 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 )
                 coordinator.lastBoundHostId = ObjectIdentifier(host)
                 coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+                hostedView.setVisibleInUI(coordinator.desiredIsVisibleInUI)
+                hostedView.setActive(coordinator.desiredIsActive)
                 // The dying owner's dismantle cleared the shared hosted view's
                 // handlers, and this survivor skipped its own configuration
                 // when it lost the earlier claim. Restore the owner-owned

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12197,21 +12197,6 @@ struct GhosttyTerminalView: NSViewRepresentable {
         return !hostedViewHasSuperview
     }
 
-    /// What an update may do to the hosted view's immediate visible/active
-    /// state.
-    enum ImmediateHostedStateAction: Equatable {
-        /// The owner with a live binding applies both flags.
-        case applyVisibleAndActive
-        /// A bound host that lost the lease may still un-show its own
-        /// surface — and nothing more. Active/focus state stays
-        /// ownership-gated. (An OWNER's hide is allowed whether or not it is
-        /// currently bound — the lease is authoritative for the surface's
-        /// state, and that has been the apply rule since before this enum.)
-        case hideOnly
-        /// A non-owner that is not bound must not touch the hosted view.
-        case deferred
-    }
-
     /// The complete immediate visible/active apply decision.
     ///
     /// Hiding never needs lease ownership or a live binding generation.
@@ -12227,7 +12212,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
         desiredVisibleInUI: Bool,
         hostedViewHasSuperview: Bool,
         isBoundToCurrentHost: Bool
-    ) -> ImmediateHostedStateAction {
+    ) -> GhosttyTerminalImmediateHostedStateAction {
         if portalBindingLive, hostOwnsPortal, shouldApplyImmediateHostedStateUpdate(
             desiredVisibleInUI: desiredVisibleInUI,
             hostedViewHasSuperview: hostedViewHasSuperview,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12642,6 +12642,10 @@ struct GhosttyTerminalView: NSViewRepresentable {
             hostedView.setVisibleInUI(isVisibleInUI)
             hostedView.setActive(isActive)
         case .hideOnly:
+            TerminalWindowPortalRegistry.updateEntryVisibility(
+                for: hostedView,
+                visibleInUI: false
+            )
             hostedView.setVisibleInUI(false)
         case .deferred:
             // Preserve portal entry visibility while a stale host is still receiving SwiftUI updates.

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12430,13 +12430,16 @@ struct GhosttyTerminalView: NSViewRepresentable {
             // can re-anchor on-screen content but can never reveal a hidden
             // tab (bind is a show path — a hidden survivor waits for its own
             // update instead).
-            coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator] in
-                guard let host, let hostedView, let coordinator else { return }
+            coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator, weak terminalSurface] in
+                guard let host, let hostedView, let coordinator, let terminalSurface else { return }
                 guard coordinator.attachGeneration == generation else { return }
                 guard isCurrentPaneOwner() else { return }
                 guard coordinator.desiredIsVisibleInUI else { return }
                 guard host.window != nil else { return }
-                guard portalBindingStillLive() else { return }
+                guard terminalSurface.canAcceptPortalBinding(
+                    expectedSurfaceId: portalExpectedSurfaceId,
+                    expectedGeneration: portalExpectedGeneration
+                ) else { return }
                 guard terminalSurface.claimPortalHost(
                     hostId: ObjectIdentifier(host),
                     paneId: paneId,
@@ -12463,7 +12466,10 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 // when it lost the earlier claim. Restore the owner-owned
                 // non-visibility state; visible/active stay with updates.
                 hostedView.setSessionContentWidthPresentation(sessionContentWidthPresentation)
-                hostedView.setFocusHandler { onFocus?(terminalSurface.id) }
+                hostedView.setFocusHandler { [weak terminalSurface] in
+                    guard let terminalSurface else { return }
+                    onFocus?(terminalSurface.id)
+                }
                 hostedView.setTriggerFlashHandler(onTriggerFlash)
                 hostedView.setPaneDropContext(TerminalPaneDropContext(
                     workspaceId: terminalSurface.tabId,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12482,6 +12482,16 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
             if ownsCurrentPane, isVisibleInUI {
+                // If an earlier update parked this host on a different surface,
+                // unregister there first: the stale trampoline would fire THIS
+                // coordinator's current retry, so a vacancy on the old surface
+                // could drive a claim against the new one.
+                if let previous = coordinator.vacancyParkedSurface, previous !== terminalSurface {
+                    previous.removePortalVacancyRetry(
+                        hostId: ObjectIdentifier(host),
+                        instanceSerial: host.instanceSerial
+                    )
+                }
                 coordinator.vacancyParkedSurface = terminalSurface
                 terminalSurface.parkPortalVacancyRetry(
                     hostId: ObjectIdentifier(host),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12488,7 +12488,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 }
             } else {
                 coordinator.vacancyRetry = nil
-                coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+                coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host), instanceSerial: host.instanceSerial)
                 coordinator.vacancyParkedSurface = nil
             }
             host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
@@ -12667,7 +12667,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
             // never owned has no vacate path, so drop it here — through the
             // coordinator's reference, since hostedView can already be gone.
             coordinator.vacancyRetry = nil
-            coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+            coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host), instanceSerial: host.instanceSerial)
             coordinator.vacancyParkedSurface = nil
             hostedView?.prepareOwnedPortalHostForTransientReattach(
                 hostId: ObjectIdentifier(host),

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12204,7 +12204,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
         case applyVisibleAndActive
         /// A bound host that lost the lease may still un-show its own
         /// surface — and nothing more. Active/focus state stays
-        /// ownership-gated.
+        /// ownership-gated. (An OWNER's hide is allowed whether or not it is
+        /// currently bound — the lease is authoritative for the surface's
+        /// state, and that has been the apply rule since before this enum.)
         case hideOnly
         /// A non-owner that is not bound must not touch the hosted view.
         case deferred
@@ -12476,6 +12478,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 hostedView.setNotificationRing(visible: showsUnreadNotificationRing)
                 hostedView.setSearchOverlay(searchState: searchState)
                 hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
+                hostedView.setDropZoneOverlay(zone: forwardedDropZone)
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
             if ownsCurrentPane, isVisibleInUI {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12430,10 +12430,26 @@ struct GhosttyTerminalView: NSViewRepresentable {
             // can re-anchor on-screen content but can never reveal a hidden
             // tab (bind is a show path — a hidden survivor waits for its own
             // update instead).
+            // Snapshot every representable member the stored retry needs.
+            // `parkPortalVacancyRetry` stores a closure on TerminalSurface, so
+            // the retry body must not implicitly retain `self`, which would
+            // retain the same TerminalSurface and form a teardown cycle.
+            let vacancyIsCurrentPaneOwner = isCurrentPaneOwner
+            let vacancyPaneId = paneId
+            let vacancyOwnershipGeneration = ownershipGeneration
+            let vacancySessionContentWidthPresentation = sessionContentWidthPresentation
+            let vacancyOnFocus = onFocus
+            let vacancyOnTriggerFlash = onTriggerFlash
+            let vacancyInactiveOverlayColor = inactiveOverlayColor
+            let vacancyInactiveOverlayOpacity = inactiveOverlayOpacity
+            let vacancyShowsInactiveOverlay = showsInactiveOverlay
+            let vacancyShowsUnreadNotificationRing = showsUnreadNotificationRing
+            let vacancySearchState = searchState
+            let vacancyDropZone = forwardedDropZone
             coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator, weak terminalSurface] in
                 guard let host, let hostedView, let coordinator, let terminalSurface else { return }
                 guard coordinator.attachGeneration == generation else { return }
-                guard isCurrentPaneOwner() else { return }
+                guard vacancyIsCurrentPaneOwner() else { return }
                 guard coordinator.desiredIsVisibleInUI else { return }
                 guard host.window != nil else { return }
                 guard terminalSurface.canAcceptPortalBinding(
@@ -12442,9 +12458,9 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 ) else { return }
                 guard terminalSurface.claimPortalHost(
                     hostId: ObjectIdentifier(host),
-                    paneId: paneId,
+                    paneId: vacancyPaneId,
                     instanceSerial: host.instanceSerial,
-                    ownershipGeneration: ownershipGeneration,
+                    ownershipGeneration: vacancyOwnershipGeneration,
                     inWindow: true,
                     bounds: host.bounds,
                     allowsAuthorityAcquisition: true,
@@ -12465,26 +12481,26 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 // handlers, and this survivor skipped its own configuration
                 // when it lost the earlier claim. Restore the owner-owned
                 // non-visibility state; visible/active stay with updates.
-                hostedView.setSessionContentWidthPresentation(sessionContentWidthPresentation)
+                hostedView.setSessionContentWidthPresentation(vacancySessionContentWidthPresentation)
                 hostedView.setFocusHandler { [weak terminalSurface] in
                     guard let terminalSurface else { return }
-                    onFocus?(terminalSurface.id)
+                    vacancyOnFocus?(terminalSurface.id)
                 }
-                hostedView.setTriggerFlashHandler(onTriggerFlash)
+                hostedView.setTriggerFlashHandler(vacancyOnTriggerFlash)
                 hostedView.setPaneDropContext(TerminalPaneDropContext(
                     workspaceId: terminalSurface.tabId,
                     panelId: terminalSurface.id,
-                    paneId: paneId
+                    paneId: vacancyPaneId
                 ))
                 hostedView.setInactiveOverlay(
-                    color: inactiveOverlayColor,
-                    opacity: CGFloat(inactiveOverlayOpacity),
-                    visible: showsInactiveOverlay
+                    color: vacancyInactiveOverlayColor,
+                    opacity: CGFloat(vacancyInactiveOverlayOpacity),
+                    visible: vacancyShowsInactiveOverlay
                 )
-                hostedView.setNotificationRing(visible: showsUnreadNotificationRing)
-                hostedView.setSearchOverlay(searchState: searchState)
+                hostedView.setNotificationRing(visible: vacancyShowsUnreadNotificationRing)
+                hostedView.setSearchOverlay(searchState: vacancySearchState)
                 hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
-                hostedView.setDropZoneOverlay(zone: forwardedDropZone)
+                hostedView.setDropZoneOverlay(zone: vacancyDropZone)
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
             if ownsCurrentPane, isVisibleInUI {

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12175,6 +12175,14 @@ struct GhosttyTerminalView: NSViewRepresentable {
         var lastPaneDropZone: DropZone?
         var lastSynchronizedHostGeometryRevision: UInt64 = 0
         weak var hostedView: GhosttySurfaceScrollView?
+        /// The owner-death wake-up. The surface's vacancy registry holds only
+        /// a weak trampoline into this coordinator, so the real retry (and
+        /// everything it captures) dies with the representable.
+        var vacancyRetry: (() -> Void)?
+        /// The surface this representable last parked a wake-up on; dismantle
+        /// removes the park through this because `hostedView` is weak and can
+        /// already be gone by then.
+        weak var vacancyParkedSurface: TerminalSurface?
     }
 
     func makeCoordinator() -> Coordinator { Coordinator() }
@@ -12411,6 +12419,78 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 hostedView.setNotificationRing(visible: coordinator.desiredShowsUnreadNotificationRing)
                 terminalSurface.flushPendingManualSizeReportIfAttached()
             }
+            // The owner-death wake. Every claim above runs on this host's own
+            // edges; the lease owner dying fires none of them, and a pane whose
+            // owner dismantled can otherwise wait a full settle budget for an
+            // unrelated SwiftUI update before it re-anchors. Parked only while
+            // this host owns its pane AND its content is presented; the wake
+            // re-checks both live and never writes visible/active state, so it
+            // can re-anchor on-screen content but can never reveal a hidden
+            // tab (bind is a show path — a hidden survivor waits for its own
+            // update instead).
+            coordinator.vacancyRetry = { [weak host, weak hostedView, weak coordinator] in
+                guard let host, let hostedView, let coordinator else { return }
+                guard coordinator.attachGeneration == generation else { return }
+                guard isCurrentPaneOwner() else { return }
+                guard hostedView.isVisibleInUI, coordinator.desiredIsVisibleInUI else { return }
+                guard host.window != nil else { return }
+                guard portalBindingStillLive() else { return }
+                guard terminalSurface.claimPortalHost(
+                    hostId: ObjectIdentifier(host),
+                    paneId: paneId,
+                    instanceSerial: host.instanceSerial,
+                    ownershipGeneration: ownershipGeneration,
+                    inWindow: true,
+                    bounds: host.bounds,
+                    allowsAuthorityAcquisition: true,
+                    reason: "hostVacated"
+                ) else { return }
+                TerminalWindowPortalRegistry.bind(
+                    hostedView: hostedView,
+                    to: host,
+                    visibleInUI: coordinator.desiredIsVisibleInUI,
+                    zPriority: coordinator.desiredPortalZPriority,
+                    expectedSurfaceId: portalExpectedSurfaceId,
+                    expectedGeneration: portalExpectedGeneration,
+                    deferLayoutSynchronization: true
+                )
+                coordinator.lastBoundHostId = ObjectIdentifier(host)
+                coordinator.lastSynchronizedHostGeometryRevision = host.geometryRevision
+                // The dying owner's dismantle cleared the shared hosted view's
+                // handlers, and this survivor skipped its own configuration
+                // when it lost the earlier claim. Restore the owner-owned
+                // non-visibility state; visible/active stay with updates.
+                hostedView.setSessionContentWidthPresentation(sessionContentWidthPresentation)
+                hostedView.setFocusHandler { onFocus?(terminalSurface.id) }
+                hostedView.setTriggerFlashHandler(onTriggerFlash)
+                hostedView.setPaneDropContext(TerminalPaneDropContext(
+                    workspaceId: terminalSurface.tabId,
+                    panelId: terminalSurface.id,
+                    paneId: paneId
+                ))
+                hostedView.setInactiveOverlay(
+                    color: inactiveOverlayColor,
+                    opacity: CGFloat(inactiveOverlayOpacity),
+                    visible: showsInactiveOverlay
+                )
+                hostedView.setNotificationRing(visible: showsUnreadNotificationRing)
+                hostedView.setSearchOverlay(searchState: searchState)
+                hostedView.syncKeyStateIndicator(text: terminalSurface.currentKeyStateIndicatorText)
+                terminalSurface.flushPendingManualSizeReportIfAttached()
+            }
+            if ownsCurrentPane, isVisibleInUI {
+                coordinator.vacancyParkedSurface = terminalSurface
+                terminalSurface.parkPortalVacancyRetry(
+                    hostId: ObjectIdentifier(host),
+                    instanceSerial: host.instanceSerial
+                ) { [weak coordinator] in
+                    coordinator?.vacancyRetry?()
+                }
+            } else {
+                coordinator.vacancyRetry = nil
+                coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+                coordinator.vacancyParkedSurface = nil
+            }
             host.onGeometryChanged = { [weak host, weak hostedView, weak coordinator] in
                 guard let host, let hostedView, let coordinator else { return }
                 guard coordinator.attachGeneration == generation else { return }
@@ -12583,6 +12663,12 @@ struct GhosttyTerminalView: NSViewRepresentable {
         if let host = nsView as? HostContainerView {
             host.onDidMoveToWindow = nil
             host.onGeometryChanged = nil
+            // The owner's vacate path drops its own wake-up; a candidate that
+            // never owned has no vacate path, so drop it here — through the
+            // coordinator's reference, since hostedView can already be gone.
+            coordinator.vacancyRetry = nil
+            coordinator.vacancyParkedSurface?.removePortalVacancyRetry(hostId: ObjectIdentifier(host))
+            coordinator.vacancyParkedSurface = nil
             hostedView?.prepareOwnedPortalHostForTransientReattach(
                 hostId: ObjectIdentifier(host),
                 instanceSerial: host.instanceSerial,

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -12434,7 +12434,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
                 guard let host, let hostedView, let coordinator else { return }
                 guard coordinator.attachGeneration == generation else { return }
                 guard isCurrentPaneOwner() else { return }
-                guard hostedView.isVisibleInUI, coordinator.desiredIsVisibleInUI else { return }
+                guard coordinator.desiredIsVisibleInUI else { return }
                 guard host.window != nil else { return }
                 guard portalBindingStillLive() else { return }
                 guard terminalSurface.claimPortalHost(
@@ -12493,11 +12493,18 @@ struct GhosttyTerminalView: NSViewRepresentable {
                     )
                 }
                 coordinator.vacancyParkedSurface = terminalSurface
+                let parkedAttachGeneration = generation
+                let parkedRetry = coordinator.vacancyRetry
                 terminalSurface.parkPortalVacancyRetry(
                     hostId: ObjectIdentifier(host),
                     instanceSerial: host.instanceSerial
-                ) { [weak coordinator] in
-                    coordinator?.vacancyRetry?()
+                ) { [weak coordinator, weak terminalSurface] in
+                    guard let coordinator,
+                          let terminalSurface,
+                          coordinator.attachGeneration == parkedAttachGeneration,
+                          coordinator.vacancyParkedSurface === terminalSurface,
+                          let parkedRetry else { return }
+                    parkedRetry()
                 }
             } else {
                 coordinator.vacancyRetry = nil

--- a/Sources/GhosttyTerminalView.swift
+++ b/Sources/GhosttyTerminalView.swift
@@ -8374,16 +8374,22 @@ final class GhosttySurfaceScrollView: NSView {
         )
     }
 
-    func releaseOwnedPortalHost(hostId: ObjectIdentifier, reason: String) {
+    func releaseOwnedPortalHost(hostId: ObjectIdentifier, instanceSerial: UInt64, reason: String) {
         surfaceView.terminalSurface?.releasePortalHostIfOwned(
             hostId: hostId,
+            instanceSerial: instanceSerial,
             reason: reason
         )
     }
 
-    func prepareOwnedPortalHostForTransientReattach(hostId: ObjectIdentifier, reason: String) {
+    func prepareOwnedPortalHostForTransientReattach(
+        hostId: ObjectIdentifier,
+        instanceSerial: UInt64,
+        reason: String
+    ) {
         surfaceView.terminalSurface?.preparePortalHostReplacementIfOwned(
             hostId: hostId,
+            instanceSerial: instanceSerial,
             reason: reason
         )
     }
@@ -12183,6 +12189,46 @@ struct GhosttyTerminalView: NSViewRepresentable {
         return !hostedViewHasSuperview
     }
 
+    /// What an update may do to the hosted view's immediate visible/active
+    /// state.
+    enum ImmediateHostedStateAction: Equatable {
+        /// The owner with a live binding applies both flags.
+        case applyVisibleAndActive
+        /// A bound host that lost the lease may still un-show its own
+        /// surface — and nothing more. Active/focus state stays
+        /// ownership-gated.
+        case hideOnly
+        /// A non-owner that is not bound must not touch the hosted view.
+        case deferred
+    }
+
+    /// The complete immediate visible/active apply decision.
+    ///
+    /// Hiding never needs lease ownership or a live binding generation.
+    /// Ownership gates SHOWING and re-anchoring; the host a hosted view is
+    /// currently bound to is the only one that can un-show it, owner or not.
+    /// Gating the hide on the claim leaves a deselected tab's surface on
+    /// screen whenever ownership flips without a rebind: the bound host's
+    /// visible=false updates defer forever and the hidden tab draws over the
+    /// selected one.
+    static func immediateHostedStateAction(
+        hostOwnsPortal: Bool,
+        portalBindingLive: Bool,
+        desiredVisibleInUI: Bool,
+        hostedViewHasSuperview: Bool,
+        isBoundToCurrentHost: Bool
+    ) -> ImmediateHostedStateAction {
+        if portalBindingLive, hostOwnsPortal, shouldApplyImmediateHostedStateUpdate(
+            desiredVisibleInUI: desiredVisibleInUI,
+            hostedViewHasSuperview: hostedViewHasSuperview,
+            isBoundToCurrentHost: isBoundToCurrentHost
+        ) {
+            return .applyVisibleAndActive
+        }
+        if !desiredVisibleInUI, isBoundToCurrentHost { return .hideOnly }
+        return .deferred
+    }
+
     enum HostCallbackPortalGeometrySynchronizationAction<Window> {
         case skip
         case synchronizeWithoutLayoutFlush(Window)
@@ -12477,16 +12523,21 @@ struct GhosttyTerminalView: NSViewRepresentable {
         let isBoundToCurrentHost = hostContainer.map { host in
             TerminalWindowPortalRegistry.isHostedView(hostedView, boundTo: host)
         } ?? true
-        let shouldApplyImmediateHostedState = hostOwnsPortalNow && Self.shouldApplyImmediateHostedStateUpdate(
+        let immediateStateAction = Self.immediateHostedStateAction(
+            hostOwnsPortal: hostOwnsPortalNow,
+            portalBindingLive: portalBindingStillLive(),
             desiredVisibleInUI: isVisibleInUI,
             hostedViewHasSuperview: hostedView.superview != nil,
             isBoundToCurrentHost: isBoundToCurrentHost
         )
 
-        if portalBindingStillLive() && shouldApplyImmediateHostedState {
+        switch immediateStateAction {
+        case .applyVisibleAndActive:
             hostedView.setVisibleInUI(isVisibleInUI)
             hostedView.setActive(isActive)
-        } else {
+        case .hideOnly:
+            hostedView.setVisibleInUI(false)
+        case .deferred:
             // Preserve portal entry visibility while a stale host is still receiving SwiftUI updates.
             // The currently bound host remains authoritative for immediate visible/active state.
 #if DEBUG
@@ -12534,6 +12585,7 @@ struct GhosttyTerminalView: NSViewRepresentable {
             host.onGeometryChanged = nil
             hostedView?.prepareOwnedPortalHostForTransientReattach(
                 hostId: ObjectIdentifier(host),
+                instanceSerial: host.instanceSerial,
                 reason: "dismantle"
             )
         }

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -909,6 +909,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */; };
 		A5F100000000000000000009 /* GhosttySurfaceScrollView+NotificationScroll.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */; };
 		A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */; };
+		C0DEF828300000000000001 /* GhosttyTerminalImmediateHostedStateAction.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */; };
 		A5001B00 /* GhosttyTerminalScrollBoost.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001B01 /* GhosttyTerminalScrollBoost.swift */; };
 		D5671201D5671201D5671201 /* GhosttyTerminalScrollSpeed.swift in Sources */ = {isa = PBXBuildFile; fileRef = D5671202D5671202D5671202 /* GhosttyTerminalScrollSpeed.swift */; };
 		C13519000000000000000003 /* GhosttyTerminalStartupEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */; };
@@ -2946,6 +2947,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		9DAB808A8EC74C40B95F7672 /* GhosttySurfaceConfigurationRefresh.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/GhosttySurfaceConfigurationRefresh.swift; sourceTree = "<group>"; };
 		A5F10000000000000000000A /* GhosttySurfaceScrollView+NotificationScroll.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "GhosttySurfaceScrollView+NotificationScroll.swift"; sourceTree = "<group>"; };
 		A11EAC000000000000000001 /* GhosttyTerminalAppearance.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalAppearance.swift; sourceTree = "<group>"; };
+		C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalImmediateHostedStateAction.swift; sourceTree = "<group>"; };
 		A5001B01 /* GhosttyTerminalScrollBoost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalScrollBoost.swift; sourceTree = "<group>"; };
 		D5671202D5671202D5671202 /* GhosttyTerminalScrollSpeed.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalScrollSpeed.swift; sourceTree = "<group>"; };
 		C13519000000000000000004 /* GhosttyTerminalStartupEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GhosttyTerminalStartupEnvironmentTests.swift; sourceTree = "<group>"; };
@@ -4804,6 +4806,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001014 /* GhosttyConfig.swift */,
 				C4041001000000000000001A /* CommandClickFileOpenRouter.swift */,
 				C40410010000000000000020 /* FileExplorerDoubleClickActionSettings.swift */,
+				C0DEF828300000000000002 /* GhosttyTerminalImmediateHostedStateAction.swift */,
 				A5001015 /* GhosttyTerminalView.swift */,
 				816400000000000000000002 /* GhosttyScrollView.swift */,
 				A11E5E1E0000000000000002 /* TerminalSelectionAccessibilityNotifier.swift */,
@@ -7177,6 +7180,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B84BD7AD94EE485B8DDAB6FF /* GhosttySurfaceConfigurationRefresh.swift in Sources */,
 				A5F100000000000000000009 /* GhosttySurfaceScrollView+NotificationScroll.swift in Sources */,
 				A11EAC000000000000000000 /* GhosttyTerminalAppearance.swift in Sources */,
+				C0DEF828300000000000001 /* GhosttyTerminalImmediateHostedStateAction.swift in Sources */,
 				A5001B00 /* GhosttyTerminalScrollBoost.swift in Sources */,
 				D5671201D5671201D5671201 /* GhosttyTerminalScrollSpeed.swift in Sources */,
 				793800000000000000000008 /* GhosttyTerminalView+Sizing.swift in Sources */,

--- a/cmuxTests/DockPortalReconcileTests.swift
+++ b/cmuxTests/DockPortalReconcileTests.swift
@@ -113,6 +113,7 @@ struct DockPortalReconcileTests {
         ))
         panel.surface.releasePortalHostIfOwned(
             hostId: ObjectIdentifier(dockHost),
+            instanceSerial: 20,
             reason: "test.dock.rollback"
         )
 

--- a/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
+++ b/cmuxTests/GhosttyTerminalViewVisibilityPolicyTests.swift
@@ -1,4 +1,4 @@
-import XCTest
+import Testing
 
 #if canImport(cmux_DEV)
 @testable import cmux_DEV
@@ -6,9 +6,10 @@ import XCTest
 @testable import cmux
 #endif
 
-final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
-    func testImmediateStateUpdateAllowedWhenDesiredStateIsHidden() {
-        XCTAssertTrue(
+@MainActor
+struct GhosttyTerminalViewVisibilityPolicyTests {
+    @Test func immediateStateUpdateAllowedWhenDesiredStateIsHidden() {
+        #expect(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: false,
                 hostedViewHasSuperview: true,
@@ -17,8 +18,8 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testImmediateStateUpdateAllowedWhenBoundToCurrentHost() {
-        XCTAssertTrue(
+    @Test func immediateStateUpdateAllowedWhenBoundToCurrentHost() {
+        #expect(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: true,
                 hostedViewHasSuperview: true,
@@ -27,9 +28,9 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testImmediateStateUpdateSkippedForStaleHostBoundElsewhere() {
-        XCTAssertFalse(
-            GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
+    @Test func immediateStateUpdateSkippedForStaleHostBoundElsewhere() {
+        #expect(
+            !GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: true,
                 hostedViewHasSuperview: true,
                 isBoundToCurrentHost: false
@@ -37,8 +38,8 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testImmediateStateUpdateAllowedWhenUnboundAndNotAttachedAnywhere() {
-        XCTAssertTrue(
+    @Test func immediateStateUpdateAllowedWhenUnboundAndNotAttachedAnywhere() {
+        #expect(
             GhosttyTerminalView.shouldApplyImmediateHostedStateUpdate(
                 desiredVisibleInUI: true,
                 hostedViewHasSuperview: false,
@@ -47,19 +48,109 @@ final class GhosttyTerminalViewVisibilityPolicyTests: XCTestCase {
         )
     }
 
-    func testSwiftUIHostGeometryCallbackUsesImmediateSyncWithoutLayoutFlush() {
+    // The full action: ownership and binding liveness gate SHOWING, but a
+    // host the hosted view is currently bound to may always HIDE it — and
+    // only hide it; active/focus state stays ownership-gated. The regression
+    // this pins: a deselected tab's bound-but-disowned host had its
+    // visible=false deferred forever, leaving the hidden tab's surface drawn
+    // over the selected tab's panes.
+    @Test func boundHostMayHideWithoutOwningTheLease() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: true,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .hideOnly
+        )
+    }
+
+    @Test func boundHostMayHideEvenWhenBindingGenerationMoved() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: false,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .hideOnly
+        )
+    }
+
+    @Test func unboundHostMayNotHideAnotherHostsContent() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: true,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: false
+            ) == .deferred
+        )
+    }
+
+    @Test func showingStillRequiresOwnership() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: false,
+                portalBindingLive: true,
+                desiredVisibleInUI: true,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .deferred
+        )
+    }
+
+    @Test func showingStillRequiresLiveBinding() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: true,
+                portalBindingLive: false,
+                desiredVisibleInUI: true,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .deferred
+        )
+    }
+
+    @Test func owningHiderAppliesBothFlagsNotJustTheHide() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: true,
+                portalBindingLive: true,
+                desiredVisibleInUI: false,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .applyVisibleAndActive
+        )
+    }
+
+    @Test func ownerWithLiveBindingShowsBoundContent() {
+        #expect(
+            GhosttyTerminalView.immediateHostedStateAction(
+                hostOwnsPortal: true,
+                portalBindingLive: true,
+                desiredVisibleInUI: true,
+                hostedViewHasSuperview: true,
+                isBoundToCurrentHost: true
+            ) == .applyVisibleAndActive
+        )
+    }
+
+    @Test func hostGeometryCallbackUsesImmediateSyncWithoutLayoutFlush() {
         switch GhosttyTerminalView.hostCallbackPortalGeometrySynchronizationAction(window: 3873) {
         case .synchronizeWithoutLayoutFlush(let window):
-            XCTAssertEqual(window, 3873)
+            #expect(window == 3873)
         case .skip:
-            XCTFail("Window-attached host callbacks should immediately reconcile portal geometry without layout flushes")
+            Issue.record("Window-attached host callbacks should immediately reconcile portal geometry without layout flushes")
         }
     }
 
-    func testSwiftUIHostGeometryCallbackSkipsWithoutWindow() {
+    @Test func hostGeometryCallbackSkipsWithoutWindow() {
         switch GhosttyTerminalView.hostCallbackPortalGeometrySynchronizationAction(window: Optional<Int>.none) {
         case .synchronizeWithoutLayoutFlush:
-            XCTFail("Detached host callbacks must not synchronize terminal portal geometry")
+            Issue.record("Detached host callbacks must not synchronize terminal portal geometry")
         case .skip:
             break
         }

--- a/scripts/remote-tmux-fuzz-marathon.sh
+++ b/scripts/remote-tmux-fuzz-marathon.sh
@@ -232,12 +232,30 @@ for seed in $(seq 1 "$SEEDS"); do
   fi
 done
 
-echo "MARATHON DONE seeds=$SEEDS hangs=$hangs crashes=$crashes fail-seeds=$fails dir=$DIR"
+# Coverage is a property of the whole run, not of one seed: whether a given seed
+# draws the mirror->mirror switch is the RNG's business, so a single seed missing
+# it is not a defect. A whole marathon missing it is — the run would report green
+# for a path it never entered, which is how the class this op exists for survived
+# 125 "clean" iterations. Assert the floor here, where the draw has room to even
+# out, and say what the coverage was either way rather than leaving it implied.
+switches=$(grep -h 'FUZZ COVERAGE' "$DIR"/seed-*.log 2>/dev/null \
+  | sed -E 's/.*op10_switches=([0-9]+).*/\1/' | awk '{ total += $1 } END { print total + 0 }')
+uncovered=$(grep -hc 'FUZZ UNCOVERED' "$DIR"/seed-*.log 2>/dev/null | awk '{ n += $1 } END { print n + 0 }')
+echo "MARATHON COVERAGE mirror-tab-switches=$switches seeds-without-any=$uncovered/$SEEDS"
+coverage_gap=0
+if [ "$switches" -eq 0 ]; then
+  echo "MARATHON UNCOVERED: no mirror->mirror tab switch landed in ANY of $SEEDS seeds —" \
+    "the reveal path was not exercised, so this run's green means nothing for it"
+  coverage_gap=1
+fi
+
+echo "MARATHON DONE seeds=$SEEDS hangs=$hangs crashes=$crashes fail-seeds=$fails switches=$switches dir=$DIR"
 {
   echo "seeds=$SEEDS iters=$ITERS hangs=$hangs crashes=$crashes fail-seeds=$fails"
+  echo "mirror-tab-switches=$switches seeds-without-any=$uncovered/$SEEDS"
   grep -l "FUZZ FAIL\|FUZZ HANG" "$DIR"/seed-*.log 2>/dev/null
 } > "$DIR/summary.txt"
 # Boolean exit — the counts live in the MARATHON DONE line and summary.txt;
 # a raw sum could wrap past 255 and read as success.
-[ $((hangs + crashes + fails)) -gt 0 ] && exit 1
+[ $((hangs + crashes + fails + coverage_gap)) -gt 0 ] && exit 1
 exit 0

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -55,10 +55,12 @@ FUZZ_SERVER_OWNED=0
 cleanup() {
   local status=$?
   trap - EXIT
-  if [ "$DRY" != 1 ] && [ -n "$WORKSPACE_REF" ]; then
+  # FUZZ_KEEP_STATE=1 leaves the workspace and remote server up so a failed
+  # run's final state can be probed live (rpc pane_surfaces etc.) postmortem.
+  if [ "$DRY" != 1 ] && [ -n "$WORKSPACE_REF" ] && [ "${FUZZ_KEEP_STATE:-0}" != 1 ]; then
     "$CLI" workspace close "$WORKSPACE_REF" >/dev/null 2>&1
   fi
-  if [ "$FUZZ_SERVER_OWNED" = 1 ]; then
+  if [ "$FUZZ_SERVER_OWNED" = 1 ] && [ "${FUZZ_KEEP_STATE:-0}" != 1 ]; then
     t kill-server >/dev/null 2>&1 || true
   fi
   cmux_fuzz_lock_release
@@ -252,16 +254,61 @@ check_screen_oracle() {
   # census: every window with an on-screen pane is the VISIBLE window, so tmux's
   # full pane list for it must be on screen. A missing pane is the app failing to
   # render a pane of the visible window, which is a defect, not less coverage.
+  # One workspace presents one tmux window at a time, so surfaces from two
+  # windows on screen at once is a hidden tab drawing over the selected one.
+  # The per-window census below cannot see this: each window individually
+  # matches tmux while both are visible.
+  on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+    [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+  ' 2>/dev/null)
+  if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+    note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+  fi
   for window in $(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
     [.panes[]? | select(.on_screen == true) | .window_id] | unique[]
   ' 2>/dev/null); do
-    tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+    # A zoomed window presents only its active pane; tmux itself hides the
+    # rest, so the census for it is that one pane, not the full pane list.
+    zoom_flag=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
+    if [ -z "$zoom_flag" ]; then
+      # Without the zoom state the census cannot be judged; a display-message
+      # hiccup taking the unzoomed branch would report every hidden pane of a
+      # zoomed window as a defect. Skip this window this pass.
+      continue
+    fi
+    if [ "$zoom_flag" = 1 ]; then
+      tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
+    else
+      tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+    fi
     app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
       .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
     ' 2>/dev/null | sort)
     missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
     if [ -n "${missing// /}" ]; then
-      note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them)"
+      # The app census came from the earlier pane_surfaces snapshot; a zoom
+      # toggle anywhere between that snapshot and here manufactures a
+      # mismatch out of two individually consistent states. Confirm against
+      # fresh state on BOTH sides before recording a defect: a stable zoom
+      # flag alone cannot clear a toggle that completed before its first
+      # read. Only a mismatch that survives the re-read is one.
+      zoom_recheck=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
+      if [ "$zoom_recheck" != "$zoom_flag" ]; then
+        continue
+      fi
+      refresh_pane_surfaces || continue
+      if [ "$zoom_recheck" = 1 ]; then
+        tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
+      else
+        tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+      fi
+      app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
+        .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
+      ' 2>/dev/null | sort)
+      missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
+      if [ -n "${missing// /}" ]; then
+        note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them)"
+      fi
     fi
   done
   checked=0
@@ -446,7 +493,7 @@ check_iter() {
   done
   echo "  settle $((SECONDS - settle_start))s (iter $iter)"
   if [ "$settled" != 1 ]; then
-    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
+    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | jq -c '{counters, windows}' 2>/dev/null || printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
   elif settlement_has_render_mismatch "$settled_json"; then
     # Mismatch WHILE settled: re-read twice before failing, so a probe that
     # raced the last frame of a transition cannot manufacture a defect.

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -690,12 +690,17 @@ switch_mirror_tab() {
     "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" 2>/dev/null) || return 0
   mirrored=$(printf '%s' "$grids" | jq -r '[.windows[]?.window_id] | join(" ")' 2>/dev/null)
   [ -n "$mirrored" ] || return 0
+  # Demand exactly one on-screen window, not panes[0]'s window: during an
+  # overlapping tab handoff two windows are briefly on screen at once and [0]
+  # could name either of them.
   shown=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
-    [.panes[] | select(.on_screen == true)][0].window_id // empty' 2>/dev/null)
-  # A vacuous landing check is worse than none: with no window shown, any window
-  # appearing later "differs" and the op would claim it proved a switch.
+    [.panes[] | select(.on_screen == true) | .window_id] | unique
+    | if length == 1 then .[0] else empty end' 2>/dev/null)
+  # A vacuous landing check is worse than none: without a single shown window,
+  # any window appearing later "differs" and the op would claim it proved a
+  # switch it cannot attribute.
   if [ -z "$shown" ]; then
-    echo "  (op10 skipped: no mirror on screen to switch away from)"
+    echo "  (op10 skipped: zero or several windows on screen; no clean start state)"
     return 0
   fi
   case " $mirrored " in *" $shown "*) : ;; *)
@@ -737,7 +742,12 @@ switch_mirror_tab() {
   for _ in 1 2 3 4 5 6; do
     if "$TIMEOUT_BIN" 3 "$CLI" rpc remote.tmux.pane_surfaces \
       "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" > "$RUN_DIR/op10.json" 2>/dev/null; then
-      after=$(jq -r '[.panes[] | select(.on_screen == true)][0].window_id // empty' \
+      # Same singleton rule as the start state: the landing only counts once
+      # the target is the ONLY on-screen window. Mid-handoff, target-plus-old
+      # is still on screen and must keep polling, not bank the switch early.
+      after=$(jq -r '
+        [.panes[] | select(.on_screen == true) | .window_id] | unique
+        | if length == 1 then .[0] else "\(length) windows: \(join(","))" end' \
         "$RUN_DIR/op10.json" 2>/dev/null)
       if [ -n "$after" ] && [ "$after" = "$target_window" ]; then
         OP10_SWITCHES=$((OP10_SWITCHES + 1))
@@ -748,7 +758,7 @@ switch_mirror_tab() {
     sleep 0.5
   done
   rm -f "$RUN_DIR/op10.json"
-  note_fail "$iter" "op10: focused $target but the shown window is @${after:-none}, not the target @$target_window (was @$shown) — the mirror tab never switched to it"
+  note_fail "$iter" "op10: focused $target but the shown window is ${after:-none}, not solely the target @$target_window (was @$shown) — the mirror tab never switched to it"
 }
 
 do_op() {

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -355,12 +355,18 @@ check_screen_oracle() {
     app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
       .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
     ' 2>/dev/null | sort)
+    # BOTH directions. Panes tmux draws that the app lacks drop coverage; panes the
+    # app shows that tmux does not draw are overdraw — and the zoom gate narrows the
+    # expected set precisely in that direction, so checking only the first half turns
+    # "the app kept painting a zoomed pane's siblings" into a silent pass. Same fault
+    # the one-sided census had, just pointed the other way.
     missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
-    if [ -n "${missing// /}" ]; then
+    unexpected=$(comm -13 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
+    if [ -n "${missing// /}${unexpected// /}" ]; then
       # The app census came from the earlier pane_surfaces snapshot; a zoom
       # toggle between that snapshot and the reads above manufactures a
-      # mismatch out of two individually consistent states. Confirm against
-      # fresh state on BOTH sides before recording a defect; only a mismatch
+      # difference out of two individually consistent states. Confirm against
+      # fresh state on BOTH sides before recording a defect; only a difference
       # that survives the re-read is one.
       if ! refresh_pane_surfaces; then
         return
@@ -375,7 +381,9 @@ check_screen_oracle() {
       fi
       window_panes=$(t list-panes -t "$window" \
         -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null) || continue
+      zoom_state=off
       if printf '%s\n' "$window_panes" | grep -q '^1 '; then
+        zoom_state=on
         tmux_panes=$(printf '%s\n' "$window_panes" | awk '$2 == 1 { print $3 }' | sort)
       else
         tmux_panes=$(printf '%s\n' "$window_panes" | awk '{ print $3 }' | sort)
@@ -384,15 +392,13 @@ check_screen_oracle() {
         .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
       ' 2>/dev/null | sort)
       missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
-      if [ -n "${missing// /}" ]; then
-        # Report both sides and the zoom flag, not just the difference. Whether a
-        # pane is EXPECTED on screen turns entirely on zoom — a sibling of a zoomed
-        # pane is absent by design — so naming the missing pane alone accuses the
-        # app in a sentence that reads identically when the harness is the one that
-        # is wrong.
-        zoom_state=off
-        printf '%s\n' "$window_panes" | grep -q '^1 ' && zoom_state=on
-        note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them) zoom=$zoom_state expected=[$(printf '%s' "$tmux_panes" | tr '\n' ' ')] app_on_screen=[$(printf '%s' "$app_panes" | tr '\n' ' ')]"
+      unexpected=$(comm -13 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
+      if [ -n "${missing// /}${unexpected// /}" ]; then
+        # Both sides and the zoom flag, not just the difference: whether a pane is
+        # expected on screen turns entirely on zoom, so naming the odd pane alone
+        # accuses the app in a sentence that reads identically when the harness is the
+        # one that is wrong.
+        note_fail "$iter" "visible $window: pane census differs missing=[$missing] unexpected=[$unexpected] zoom=$zoom_state expected=[$(printf '%s' "$tmux_panes" | tr '\n' ' ')] app_on_screen=[$(printf '%s' "$app_panes" | tr '\n' ' ')]"
       fi
     fi
   done

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -265,12 +265,15 @@ check_screen_oracle() {
     # Same re-read discipline as every other judge: a probe can land inside
     # the one-frame handoff of a tab switch, and only a state that persists
     # through a fresh census is a defect.
-    refresh_pane_surfaces || true
-    on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
-      [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
-    ' 2>/dev/null)
-    if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
-      note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+    # Judging the stale snapshot again would just repeat the first read, so
+    # a failed refresh defers the verdict to the next iteration entirely.
+    if refresh_pane_surfaces; then
+      on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+        [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+      ' 2>/dev/null)
+      if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+        note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+      fi
     fi
   fi
   for window in $on_screen_windows; do
@@ -500,7 +503,7 @@ check_iter() {
   done
   echo "  settle $((SECONDS - settle_start))s (iter $iter)"
   if [ "$settled" != 1 ]; then
-    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | jq -c '{counters, windows}' 2>/dev/null || printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
+    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | jq -ce '{counters, windows}' 2>/dev/null || printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
   elif settlement_has_render_mismatch "$settled_json"; then
     # Mismatch WHILE settled: re-read twice before failing, so a probe that
     # raced the last frame of a transition cannot manufacture a defect.

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -29,6 +29,16 @@ case "$FUZZ_HOST_NAME" in
 esac
 DEFAULT_TMUX_TMPDIR="$HOME/Library/Caches/cmux/remote-tmux-fuzz/${FUZZ_HOST_NAME}-tmux"
 TMPDIR_REMOTE="${CMUX_FUZZ_TMUX_TMPDIR:-$DEFAULT_TMUX_TMPDIR}"
+# tmux ignores a TMUX_TMPDIR that does not exist and falls back to /tmp/tmux-$UID
+# — the user's own default server, which this harness kills and resizes freely.
+# The isolation is only real while the directory is there, so refuse to run
+# rather than take the fallback silently.
+[ -d "$TMPDIR_REMOTE" ] || {
+  echo "ERROR: tmux socket dir does not exist: $TMPDIR_REMOTE" >&2
+  echo "  tmux would silently fall back to the DEFAULT server (/tmp/tmux-$(id -u))." >&2
+  echo "  Run scripts/remote-tmux-fuzz-host.sh first, or set CMUX_FUZZ_TMUX_TMPDIR." >&2
+  exit 2
+}
 DEBUG_LOG="${CMUX_FUZZ_DEBUG_LOG:-/tmp/cmux-debug-${CMUX_TAG}.log}"
 HERE="$(cd "$(dirname "$0")" && pwd)"
 CLI="$HERE/cmux-debug-cli.sh"
@@ -89,6 +99,10 @@ fi
 
 t() { TMUX_TMPDIR="$TMPDIR_REMOTE" tmux "$@"; }
 fail=0
+# Successful mirror->mirror switches. A seed that never managed one has not
+# exercised the reveal path, and a green run would be reporting coverage it never
+# delivered — the exact way this class stayed invisible.
+OP10_SWITCHES=0
 EVIDENCE_DIR="${CMUX_FUZZ_EVIDENCE_DIR:-}"
 
 # The end-of-seed debug-log capture cannot cover a mid-seed failure: later
@@ -144,7 +158,8 @@ settlement_clean() {
 
 settlement_has_render_mismatch() {
   printf '%s' "$1" | jq -e '
-    any(.windows[]?; ((.mismatches // []) | any(.[]; test("rendered=|misplaced"))))
+    any(.windows[]?; ((.mismatches // []) | any(.[];
+      test("rendered=|misplaced"))))
   ' >/dev/null 2>&1
 }
 
@@ -156,7 +171,8 @@ settlement_is_unsettled() {
 
 settlement_mismatch_lines() {
   printf '%s' "$1" | jq -r '
-    [.windows[]?.mismatches[]? | select(test("rendered=|misplaced"))][0:4][]
+    [.windows[]?.mismatches[]?
+      | select(test("rendered=|misplaced"))][0:4][]
   '
 }
 
@@ -251,9 +267,6 @@ check_screen_oracle() {
   # The app chooses which panes it is presenting, so it also chooses this
   # oracle's coverage — a pane the app quietly omitted would drop out of the
   # comparison and the run would still read green. Hold the app to tmux's own
-  # census: every window with an on-screen pane is the VISIBLE window, so tmux's
-  # full pane list for it must be on screen. A missing pane is the app failing to
-  # render a pane of the visible window, which is a defect, not less coverage.
   # One workspace presents one tmux window at a time, so surfaces from two
   # windows on screen at once is a hidden tab drawing over the selected one.
   # The per-window census below cannot see this: each window individually
@@ -279,20 +292,27 @@ check_screen_oracle() {
       note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
     fi
   fi
+  # census: a window with an on-screen pane is the one the app is showing, so
+  # every pane tmux DRAWS for it must be on screen too. A missing pane is the app
+  # failing to render a pane of the visible window, which is a defect, not less
+  # coverage.
+  #
+  # "Draws" is the load-bearing word, and `list-panes` cannot answer it. Zoom
+  # hides panes without closing them, so list-panes reports the whole base tree
+  # for a zoomed window just as it does for an unzoomed one. tmux draws only the
+  # zoomed pane, and the app matches that by design (renderedLayout is
+  # visibleLayout ?? layout, so only the zoomed leaf reaches the bonsplit tree
+  # while its siblings stay alive and unrendered). Taking list-panes as the
+  # expected set therefore reports every sibling of a zoomed pane as dropped
+  # coverage — all panes but one, on every iteration a zoomed window is visible.
+  # Gate on window_zoomed_flag and expect the zoomed pane by itself.
   for window in $on_screen_windows; do
-    # A zoomed window presents only its active pane; tmux itself hides the
-    # rest, so the census for it is that one pane, not the full pane list.
-    zoom_flag=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
-    if [ -z "$zoom_flag" ]; then
-      # Without the zoom state the census cannot be judged; a display-message
-      # hiccup taking the unzoomed branch would report every hidden pane of a
-      # zoomed window as a defect. Skip this window this pass.
-      continue
-    fi
-    if [ "$zoom_flag" = 1 ]; then
-      tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
+    window_panes=$(t list-panes -t "$window" \
+      -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null) || continue
+    if printf '%s\n' "$window_panes" | grep -q '^1 '; then
+      tmux_panes=$(printf '%s\n' "$window_panes" | awk '$2 == 1 { print $3 }' | sort)
     else
-      tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+      tmux_panes=$(printf '%s\n' "$window_panes" | awk '{ print $3 }' | sort)
     fi
     app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
       .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
@@ -597,10 +617,77 @@ app_resize() {
     "{\"window_id\":\"$WINDOW_ID\",\"width\":$width,\"height\":$height}" >/dev/null 2>&1
 }
 
+# Switch the cmux TAB to a different mirrored window.
+#
+# Op 1's `select-window` cannot reach this: cmux never follows tmux's current
+# window, so a tmux-side switch changes nothing about which tab is on screen.
+# Until this op existed the fuzz had never once switched a mirror tab — which is
+# exactly where the workspace reuses the mounted view and swaps the mirror
+# underneath it, so every change-gated visibility edge is dead and the newly
+# selected window must re-derive its own container. That whole class was
+# unreachable from here while the marathon read green.
+#
+# `surface.focus` is the same route a user's click takes
+# (ControlCommandCoordinator -> Workspace.focusPanel -> bonsplitController.selectTab);
+# a back-door that reconstructed the view would fire the very edge under test.
+switch_mirror_tab() {
+  local iter=$1
+  refresh_pane_surfaces || return 0
+  # MIRRORED windows only. pane_surfaces lists single-pane windows too, and those
+  # have no mirror — focusing one exercises mirror->ordinary-panel, not the
+  # mirror->mirror reveal this op exists for, and would report success for it.
+  # pane_grids lists exactly the mirrored windows.
+  local grids mirrored shown target
+  grids=$("$TIMEOUT_BIN" 8 "$CLI" rpc remote.tmux.pane_grids \
+    "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" 2>/dev/null) || return 0
+  mirrored=$(printf '%s' "$grids" | jq -r '[.windows[]?.window_id] | join(" ")' 2>/dev/null)
+  [ -n "$mirrored" ] || return 0
+  shown=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+    [.panes[] | select(.on_screen == true)][0].window_id // empty' 2>/dev/null)
+  # A vacuous landing check is worse than none: with no window shown, any window
+  # appearing later "differs" and the op would claim it proved a switch.
+  if [ -z "$shown" ]; then
+    echo "  (op10 skipped: no mirror on screen to switch away from)"
+    return 0
+  fi
+  case " $mirrored " in *" $shown "*) : ;; *)
+    echo "  (op10 skipped: shown window @$shown is not mirrored)"; return 0 ;;
+  esac
+  target=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg shown "$shown" --arg m "$mirrored" '
+    ($m | split(" ")) as $mir
+    | [.panes[]
+       | select(.on_screen == false)
+       | select((.window_id | tostring) != $shown)
+       | select(([.window_id | tostring] | inside($mir)))][0].surface_id // empty' 2>/dev/null)
+  if [ -z "$target" ]; then
+    echo "  (op10 skipped: no second MIRRORED window to switch to)"
+    return 0
+  fi
+  "$TIMEOUT_BIN" 8 "$CLI" rpc surface.focus "{\"surface_id\":\"$target\"}" >/dev/null 2>&1 || {
+    note_fail "$iter" "op10: surface.focus rejected $target (mirror->mirror switch never attempted)"
+    return 0
+  }
+  # Prove a DIFFERENT MIRRORED window is now shown. Bounded tightly: a wedged
+  # socket must reach the hang detector, not idle here for a minute.
+  local after
+  for _ in 1 2 3 4 5 6; do
+    sleep 0.5
+    "$TIMEOUT_BIN" 3 "$CLI" rpc remote.tmux.pane_surfaces \
+      "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" > /tmp/.op10.$$ 2>/dev/null || continue
+    after=$(jq -r '[.panes[] | select(.on_screen == true)][0].window_id // empty' /tmp/.op10.$$ 2>/dev/null)
+    rm -f /tmp/.op10.$$
+    if [ -n "$after" ] && [ "$after" != "$shown" ]; then
+      case " $mirrored " in *" $after "*) OP10_SWITCHES=$((OP10_SWITCHES + 1)); return 0 ;; esac
+    fi
+  done
+  note_fail "$iter" "op10: focused $target but @$shown is still the shown window — the mirror tab never switched"
+}
+
 do_op() {
+  local iter=${1:-0}
   local w
   random_window; w="$RW"
-  rand 10
+  rand 11
   # Reconnect-during-churn (op 9) exercises the control-mode reconnect
   # concurrency, a separate subsystem from sizing. CMUX_FUZZ_NO_RECONNECT
   # remaps it to a benign op so a run can isolate steady-state sizing
@@ -639,13 +726,39 @@ do_op() {
         1) t set-option -t $SESSION pane-border-status bottom 2>/dev/null ;;
         *) t set-option -t $SESSION pane-border-status off 2>/dev/null ;;
       esac ;;
-    6) # window churn: create a window or kill one (keep at least one)
-      local wins; wins=$(t list-windows -t $SESSION | wc -l | tr -d ' ')
+    6) # window churn: create a window or kill one.
+       #
+       # Biases toward keeping TWO MULTI-pane windows alive, because only
+       # multi-pane windows get a mirror: with fewer than two of them op 10 has no
+       # mirror->mirror switch to make and silently tests nothing, which is how the
+       # reveal path stayed unexercised while this harness reported green. A fresh
+       # window is split immediately for the same reason — an unsplit one is not
+       # mirrored.
+       #
+       # This is a BIAS, not a guarantee, and the difference matters: op 2 kills
+       # panes and can collapse both mirrors to single panes on its own, so a run
+       # can still reach multi<2 between op-6 draws. op 10 says so out loud when it
+       # skips rather than reporting silent coverage — that log line is the real
+       # safeguard here, not this arithmetic.
+      local multi; multi=$(t list-windows -t $SESSION -F '#{window_panes}' 2>/dev/null \
+        | awk '$1 > 1' | wc -l | tr -d ' ')
       rand 2
-      if [ "$wins" -gt 2 ] || { [ "$wins" -gt 1 ] && [ "$R" = 0 ]; }; then
+      if [ "${multi:-0}" -gt 2 ] && [ "$R" = 0 ]; then
         random_window; t kill-window -t "$RW" 2>/dev/null
       else
+        # Re-split an existing single-pane window when we are short of mirrors,
+        # rather than only ever adding new windows: op 2 flattens the ones we have.
+        if [ "${multi:-0}" -lt 2 ]; then
+          local flat
+          flat=$(t list-windows -t $SESSION -F '#{window_panes} #{window_id}' 2>/dev/null \
+            | awk '$1 == 1 { print $2; exit }')
+          if [ -n "$flat" ]; then
+            t split-window -h -t "$flat" "$RULER_COMMAND" 2>/dev/null
+            return 0
+          fi
+        fi
         t new-window -t $SESSION "$RULER_COMMAND" 2>/dev/null
+        t split-window -h -t $SESSION "$RULER_COMMAND" 2>/dev/null
       fi ;;
     7) # container and assignment changing in the same instant
       local pane; random_pane "$w"; pane="$RP"
@@ -661,6 +774,8 @@ do_op() {
       rand 50; t resize-pane -t "$pane" -x $(( 10 + R )) 2>/dev/null ;;
     9) # drop and re-establish the control connection (reseed + re-impose)
       "$CLI" workspace reconnect --workspace "$WORKSPACE_REF" >/dev/null 2>&1 ;;
+    10) # switch the cmux TAB (mirror->mirror), which op 1 cannot do
+      switch_mirror_tab "$iter" ;;
   esac
 }
 
@@ -708,7 +823,7 @@ for i in $(seq 1 "$ITERS"); do
   ops=1
   rand 3
   if [ "$R" = 0 ]; then rand 2; ops=$(( 2 + R )); fi
-  for _ in $(seq 1 "$ops"); do do_op; done
+  for _ in $(seq 1 "$ops"); do do_op "$i"; done
   echo "iter=$i/$ITERS ops=$ops panes=$(t list-panes -s -t $SESSION 2>/dev/null | wc -l | tr -d ' ') windows=$(t list-windows -t $SESSION 2>/dev/null | wc -l | tr -d ' ') fails=$fail"
   if [ "$DRY" = 1 ]; then
     t list-windows -t $SESSION -F "iter=$i win=#{window_name} #{window_width}x#{window_height} panes=#{window_panes} zoom=#{window_zoomed_flag} layout=#{window_layout}" 2>/dev/null
@@ -731,7 +846,16 @@ for i in $(seq 1 "$ITERS"); do
   last_size=$size
 done
 
-echo "FUZZ DONE seed=$SEED iters=$ITERS failures=$fail"
+# A seed that never switched a mirror tab did not exercise the reveal path, so its
+# green says nothing about the class this op exists for. Report it rather than
+# letting silent zero coverage read as a pass — that is precisely how a real mirror
+# bug survived 125 "clean" iterations.
+if [ "${OP10_SWITCHES:-0}" -eq 0 ]; then
+  echo "FUZZ FAIL seed=$SEED: no mirror->mirror tab switch landed in $ITERS iterations" \
+    "(op10 never got two mirrored windows, or never ran) — the reveal path was not tested"
+  fail=$((fail + 1))
+fi
+echo "FUZZ DONE seed=$SEED iters=$ITERS failures=$fail op10_switches=${OP10_SWITCHES:-0}"
 # Boolean exit: a raw count could wrap past 255 or collide with the
 # reserved sentinel codes (97 inert, 98 setup, 99 hang). The count itself
 # is in the FUZZ DONE line.

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -267,13 +267,16 @@ check_screen_oracle() {
     # through a fresh census is a defect.
     # Judging the stale snapshot again would just repeat the first read, so
     # a failed refresh defers the verdict to the next iteration entirely.
-    if refresh_pane_surfaces; then
-      on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
-        [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
-      ' 2>/dev/null)
-      if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
-        note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
-      fi
+    if ! refresh_pane_surfaces; then
+      return
+    fi
+    panes=$(on_screen_panes)
+    [ -n "$panes" ] || return
+    on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+      [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+    ' 2>/dev/null)
+    if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+      note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
     fi
   fi
   for window in $on_screen_windows; do
@@ -302,7 +305,11 @@ check_screen_oracle() {
       # fresh state on BOTH sides before recording a defect: a stable zoom
       # flag alone cannot clear a toggle that completed before its first
       # read. Only a mismatch that survives the re-read is one.
-      refresh_pane_surfaces || continue
+      if ! refresh_pane_surfaces; then
+        return
+      fi
+      panes=$(on_screen_panes)
+      [ -n "$panes" ] || return
       window_still_on_screen=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
         any(.panes[]?; .window_id == $w and .on_screen == true)
       ' 2>/dev/null)

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -262,11 +262,18 @@ check_screen_oracle() {
     [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
   ' 2>/dev/null)
   if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
-    note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+    # Same re-read discipline as every other judge: a probe can land inside
+    # the one-frame handoff of a tab switch, and only a state that persists
+    # through a fresh census is a defect.
+    refresh_pane_surfaces || true
+    on_screen_windows=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
+      [.panes[]? | select(.on_screen == true) | .window_id] | unique | join(" ")
+    ' 2>/dev/null)
+    if [ "$(printf '%s\n' $on_screen_windows | grep -c .)" -gt 1 ]; then
+      note_fail "$iter" "overlay: surfaces from multiple windows on screen at once [$on_screen_windows]"
+    fi
   fi
-  for window in $(printf '%s' "$PANE_SURFACES_JSON" | jq -r '
-    [.panes[]? | select(.on_screen == true) | .window_id] | unique[]
-  ' 2>/dev/null); do
+  for window in $on_screen_windows; do
     # A zoomed window presents only its active pane; tmux itself hides the
     # rest, so the census for it is that one pane, not the full pane list.
     zoom_flag=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -131,6 +131,27 @@ settlement_has_schema() {
   ' >/dev/null 2>&1
 }
 
+# The reason a window is unsettled lives in its `why` terms, and the payload
+# arrives pretty-printed: keeping its first few hundred characters spends the
+# whole budget on indentation and stops inside the first window, which is how a
+# settle failure came to be reported with no usable cause. Compact it and keep
+# every window whole.
+settlement_digest() {
+  local digest
+  digest=$(printf '%s' "$1" | jq -c '{counters, windows}' 2>/dev/null)
+  if [ -z "$digest" ]; then
+    printf 'unparsable payload: %s' "$(printf '%s' "$1" | tr -d '\n' | cut -c1-300)"
+    return
+  fi
+  # A cap so one pathological window cannot dump megabytes into the log, and it
+  # says what it dropped rather than trailing off mid-token.
+  if [ "${#digest}" -gt 4000 ]; then
+    printf '%s [digest cut at 4000 of %d chars]' "$(printf '%s' "$digest" | cut -c1-4000)" "${#digest}"
+  else
+    printf '%s' "$digest"
+  fi
+}
+
 settlement_has_reported_windows() {
   printf '%s' "$1" | jq -e '.windows | length > 0' >/dev/null 2>&1
 }
@@ -320,11 +341,10 @@ check_screen_oracle() {
     missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
     if [ -n "${missing// /}" ]; then
       # The app census came from the earlier pane_surfaces snapshot; a zoom
-      # toggle anywhere between that snapshot and here manufactures a
+      # toggle between that snapshot and the reads above manufactures a
       # mismatch out of two individually consistent states. Confirm against
-      # fresh state on BOTH sides before recording a defect: a stable zoom
-      # flag alone cannot clear a toggle that completed before its first
-      # read. Only a mismatch that survives the re-read is one.
+      # fresh state on BOTH sides before recording a defect; only a mismatch
+      # that survives the re-read is one.
       if ! refresh_pane_surfaces; then
         return
       fi
@@ -336,21 +356,26 @@ check_screen_oracle() {
       if [ "$window_still_on_screen" != "true" ]; then
         continue
       fi
-      zoom_recheck=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
-      if [ -z "$zoom_recheck" ]; then
-        continue
-      fi
-      if [ "$zoom_recheck" = 1 ]; then
-        tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
+      window_panes=$(t list-panes -t "$window" \
+        -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null) || continue
+      if printf '%s\n' "$window_panes" | grep -q '^1 '; then
+        tmux_panes=$(printf '%s\n' "$window_panes" | awk '$2 == 1 { print $3 }' | sort)
       else
-        tmux_panes=$(t list-panes -t "$window" -F '#{pane_id}' 2>/dev/null | sort) || continue
+        tmux_panes=$(printf '%s\n' "$window_panes" | awk '{ print $3 }' | sort)
       fi
       app_panes=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
         .panes[]? | select(.window_id == $w and .on_screen == true) | .pane_id
       ' 2>/dev/null | sort)
       missing=$(comm -23 <(printf '%s\n' "$tmux_panes") <(printf '%s\n' "$app_panes") | tr '\n' ' ')
       if [ -n "${missing// /}" ]; then
-        note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them)"
+        # Report both sides and the zoom flag, not just the difference. Whether a
+        # pane is EXPECTED on screen turns entirely on zoom — a sibling of a zoomed
+        # pane is absent by design — so naming the missing pane alone accuses the
+        # app in a sentence that reads identically when the harness is the one that
+        # is wrong.
+        zoom_state=off
+        printf '%s\n' "$window_panes" | grep -q '^1 ' && zoom_state=on
+        note_fail "$iter" "visible $window: tmux panes [$missing] are not on screen in the app (coverage would silently drop them) zoom=$zoom_state expected=[$(printf '%s' "$tmux_panes" | tr '\n' ' ')] app_on_screen=[$(printf '%s' "$app_panes" | tr '\n' ' ')]"
       fi
     fi
   done
@@ -536,7 +561,7 @@ check_iter() {
   done
   echo "  settle $((SECONDS - settle_start))s (iter $iter)"
   if [ "$settled" != 1 ]; then
-    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(printf '%s' "$settled_json" | jq -ce '{counters, windows}' 2>/dev/null || printf '%s' "$settled_json" | tr -d '\n' | cut -c1-300)"
+    note_fail "$iter" "settle exceeded ${budget}s budget (healthy baseline ~0.4s): $(settlement_digest "$settled_json")"
   elif settlement_has_render_mismatch "$settled_json"; then
     # Mismatch WHILE settled: re-read twice before failing, so a probe that
     # raced the last frame of a transition cannot manufacture a defect.
@@ -693,6 +718,11 @@ do_op() {
   # remaps it to a benign op so a run can isolate steady-state sizing
   # correctness from reconnect-race robustness. Default keeps op 9.
   if [ "${CMUX_FUZZ_NO_RECONNECT:-0}" = 1 ] && [ "$R" = 9 ]; then R=1; fi
+  # Record the op behind each iteration. Without it a failure names an iteration
+  # and nothing else, and the first question about any fuzz failure — which
+  # operation produced this state — can only be answered by re-running the seed
+  # and counting by hand.
+  OPS_THIS_ITER="${OPS_THIS_ITER:+$OPS_THIS_ITER,}op$R"
   case $R in
     0) # pane resize, including starvation sizes down to 1 cell
       local pane; random_pane "$w"; pane="$RP"
@@ -823,8 +853,9 @@ for i in $(seq 1 "$ITERS"); do
   ops=1
   rand 3
   if [ "$R" = 0 ]; then rand 2; ops=$(( 2 + R )); fi
+  OPS_THIS_ITER=""
   for _ in $(seq 1 "$ops"); do do_op "$i"; done
-  echo "iter=$i/$ITERS ops=$ops panes=$(t list-panes -s -t $SESSION 2>/dev/null | wc -l | tr -d ' ') windows=$(t list-windows -t $SESSION 2>/dev/null | wc -l | tr -d ' ') fails=$fail"
+  echo "iter=$i/$ITERS ops=$ops [$OPS_THIS_ITER] panes=$(t list-panes -s -t $SESSION 2>/dev/null | wc -l | tr -d ' ') windows=$(t list-windows -t $SESSION 2>/dev/null | wc -l | tr -d ' ') fails=$fail"
   if [ "$DRY" = 1 ]; then
     t list-windows -t $SESSION -F "iter=$i win=#{window_name} #{window_width}x#{window_height} panes=#{window_panes} zoom=#{window_zoomed_flag} layout=#{window_layout}" 2>/dev/null
     continue

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -302,11 +302,17 @@ check_screen_oracle() {
       # fresh state on BOTH sides before recording a defect: a stable zoom
       # flag alone cannot clear a toggle that completed before its first
       # read. Only a mismatch that survives the re-read is one.
-      zoom_recheck=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
-      if [ "$zoom_recheck" != "$zoom_flag" ]; then
+      refresh_pane_surfaces || continue
+      window_still_on_screen=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg w "$window" '
+        any(.panes[]?; .window_id == $w and .on_screen == true)
+      ' 2>/dev/null)
+      if [ "$window_still_on_screen" != "true" ]; then
         continue
       fi
-      refresh_pane_surfaces || continue
+      zoom_recheck=$(t display-message -p -t "$window" '#{window_zoomed_flag}' 2>/dev/null)
+      if [ -z "$zoom_recheck" ]; then
+        continue
+      fi
       if [ "$zoom_recheck" = 1 ]; then
         tmux_panes=$(t list-panes -t "$window" -F '#{?pane_active,#{pane_id},}' 2>/dev/null | sed '/^$/d' | sort) || continue
       else

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -138,18 +138,24 @@ settlement_has_schema() {
 # every window whole.
 settlement_digest() {
   local digest
-  digest=$(printf '%s' "$1" | jq -c '{counters, windows}' 2>/dev/null)
-  if [ -z "$digest" ]; then
-    printf 'unparsable payload: %s' "$(printf '%s' "$1" | tr -d '\n' | cut -c1-300)"
+  # Keep the UNSETTLED windows, whole. The failure is "nothing settled in 8s", so
+  # those windows are the entire cause, and bounding by window instead of by
+  # character is what keeps the output parsable — a character cap cuts mid-token,
+  # can drop the failing window's `why` outright depending on dictionary order,
+  # and leaves behind something that is no longer JSON.
+  # jq's status is honored: a payload of one valid value followed by garbage makes
+  # jq print and then exit non-zero, which a discarded status would report as a
+  # clean digest.
+  if digest=$(printf '%s' "$1" | jq -c '
+        {counters, windows: [.windows[]? | select(.settled != true)]}
+      ' 2>/dev/null) && [ -n "$digest" ]; then
+    printf '%s' "$digest"
     return
   fi
-  # A cap so one pathological window cannot dump megabytes into the log, and it
-  # says what it dropped rather than trailing off mid-token.
-  if [ "${#digest}" -gt 4000 ]; then
-    printf '%s [digest cut at 4000 of %d chars]' "$(printf '%s' "$digest" | cut -c1-4000)" "${#digest}"
-  else
-    printf '%s' "$digest"
-  fi
+  # Reachable and worth distinguishing: an RPC that times out at second 8 arrives
+  # here empty, and jq prints nothing for empty input. "The app stopped answering"
+  # is a different failure from "the app answered, unsettled".
+  printf 'unparsable or empty payload: %s' "$(printf '%s' "$1" | tr -d '\n' | cut -c1-300)"
 }
 
 settlement_has_reported_windows() {
@@ -329,8 +335,19 @@ check_screen_oracle() {
   # Gate on window_zoomed_flag and expect the zoomed pane by itself.
   for window in $on_screen_windows; do
     window_panes=$(t list-panes -t "$window" \
-      -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null) || continue
+      -F '#{window_zoomed_flag} #{pane_active} #{pane_id}' 2>/dev/null)
+    if [ -z "$window_panes" ]; then
+      # The app says it is SHOWING this window and tmux does not have it. Skipping
+      # here was the quiet path: another visible window's successful comparison
+      # keeps `checked` non-zero, so the iteration passes while the window whose
+      # panes are stale on screen is compared against nothing at all. If the app
+      # shows a window tmux has closed, that is the finding.
+      note_fail "$iter" "visible $window: the app shows it but tmux has no panes for it (window gone, mirror still on screen)"
+      continue
+    fi
+    zoom_state=off
     if printf '%s\n' "$window_panes" | grep -q '^1 '; then
+      zoom_state=on
       tmux_panes=$(printf '%s\n' "$window_panes" | awk '$2 == 1 { print $3 }' | sort)
     else
       tmux_panes=$(printf '%s\n' "$window_panes" | awk '{ print $3 }' | sort)
@@ -678,13 +695,28 @@ switch_mirror_tab() {
   case " $mirrored " in *" $shown "*) : ;; *)
     echo "  (op10 skipped: shown window @$shown is not mirrored)"; return 0 ;;
   esac
-  target=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r --arg shown "$shown" --arg m "$mirrored" '
-    ($m | split(" ")) as $mir
-    | [.panes[]
+  # Take the target's WINDOW beside its surface. "Some other mirrored window is
+  # shown now" is not proof this op switched to the one it asked for: with a third
+  # mirrored window in play, or any concurrent selection, the shown window can
+  # differ from where it started without the target ever being selected, and the
+  # counter would bank a switch that never landed — a coverage number reporting
+  # more than it delivered, which is the fault this op exists to remove.
+  # Exact membership, not `inside`: jq's `inside` compares strings by containment,
+  # so ["@3"] | inside(["@30","@1"]) is true — once tmux hands out @10 and up
+  # (routine across a marathon) @1 would pass as mirrored on the strength of @10,
+  # and the op would "switch" to a window it never verified was a mirror.
+  local target_window mirrored_json
+  mirrored_json=$(printf '%s' "$grids" | jq -c '[.windows[]?.window_id]' 2>/dev/null) || return 0
+  target=$(printf '%s' "$PANE_SURFACES_JSON" | jq -r \
+    --arg shown "$shown" --argjson mir "$mirrored_json" '
+    [.panes[]
        | select(.on_screen == false)
        | select((.window_id | tostring) != $shown)
-       | select(([.window_id | tostring] | inside($mir)))][0].surface_id // empty' 2>/dev/null)
-  if [ -z "$target" ]; then
+       | select(.window_id | IN($mir[]))][0]
+    | "\(.surface_id // "") \(.window_id // "")"' 2>/dev/null)
+  target_window=${target#* }
+  target=${target%% *}
+  if [ -z "$target" ] || [ -z "$target_window" ] || [ "$target" = "null" ]; then
     echo "  (op10 skipped: no second MIRRORED window to switch to)"
     return 0
   fi
@@ -692,20 +724,25 @@ switch_mirror_tab() {
     note_fail "$iter" "op10: surface.focus rejected $target (mirror->mirror switch never attempted)"
     return 0
   }
-  # Prove a DIFFERENT MIRRORED window is now shown. Bounded tightly: a wedged
-  # socket must reach the hang detector, not idle here for a minute.
+  # Prove the TARGET window is the one now shown. Bounded tightly: a wedged
+  # socket must reach the hang detector, not idle here for a minute. Probe before
+  # sleeping so an immediate switch costs nothing.
   local after
   for _ in 1 2 3 4 5 6; do
-    sleep 0.5
-    "$TIMEOUT_BIN" 3 "$CLI" rpc remote.tmux.pane_surfaces \
-      "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" > /tmp/.op10.$$ 2>/dev/null || continue
-    after=$(jq -r '[.panes[] | select(.on_screen == true)][0].window_id // empty' /tmp/.op10.$$ 2>/dev/null)
-    rm -f /tmp/.op10.$$
-    if [ -n "$after" ] && [ "$after" != "$shown" ]; then
-      case " $mirrored " in *" $after "*) OP10_SWITCHES=$((OP10_SWITCHES + 1)); return 0 ;; esac
+    if "$TIMEOUT_BIN" 3 "$CLI" rpc remote.tmux.pane_surfaces \
+      "{\"host\":\"$HOST\",\"session\":\"$SESSION\"}" > "$RUN_DIR/op10.json" 2>/dev/null; then
+      after=$(jq -r '[.panes[] | select(.on_screen == true)][0].window_id // empty' \
+        "$RUN_DIR/op10.json" 2>/dev/null)
+      if [ -n "$after" ] && [ "$after" = "$target_window" ]; then
+        OP10_SWITCHES=$((OP10_SWITCHES + 1))
+        rm -f "$RUN_DIR/op10.json"
+        return 0
+      fi
     fi
+    sleep 0.5
   done
-  note_fail "$iter" "op10: focused $target but @$shown is still the shown window — the mirror tab never switched"
+  rm -f "$RUN_DIR/op10.json"
+  note_fail "$iter" "op10: focused $target but the shown window is @${after:-none}, not the target @$target_window (was @$shown) — the mirror tab never switched to it"
 }
 
 do_op() {
@@ -878,13 +915,20 @@ for i in $(seq 1 "$ITERS"); do
 done
 
 # A seed that never switched a mirror tab did not exercise the reveal path, so its
-# green says nothing about the class this op exists for. Report it rather than
-# letting silent zero coverage read as a pass — that is precisely how a real mirror
-# bug survived 125 "clean" iterations.
+# green says nothing about the class this op exists for — and silent zero coverage
+# reading as a pass is exactly how a real mirror bug survived 125 "clean"
+# iterations. But whether a seed DRAWS op 10 is a property of the RNG, not of the
+# code under test: with one op in eleven and about 37 draws in a 25-iteration seed,
+# roughly one seed in thirty never draws it at all, and a shorter run far more
+# often. Counting that as a defect would file "the dice went another way" next to
+# real failures, and a gate that cries wolf gets ignored.
+#
+# So it is not a `fail`. It reports on its own line, and the marathon asserts the
+# floor across seeds, where the draw actually has room to even out.
+echo "FUZZ COVERAGE seed=$SEED op10_switches=${OP10_SWITCHES:-0}"
 if [ "${OP10_SWITCHES:-0}" -eq 0 ]; then
-  echo "FUZZ FAIL seed=$SEED: no mirror->mirror tab switch landed in $ITERS iterations" \
-    "(op10 never got two mirrored windows, or never ran) — the reveal path was not tested"
-  fail=$((fail + 1))
+  echo "FUZZ UNCOVERED seed=$SEED: no mirror->mirror tab switch landed in $ITERS iterations" \
+    "(op10 never drew, or never had two mirrored windows) — this seed says nothing about the reveal path"
 fi
 echo "FUZZ DONE seed=$SEED iters=$ITERS failures=$fail op10_switches=${OP10_SWITCHES:-0}"
 # Boolean exit: a raw count could wrap past 255 or collide with the

--- a/scripts/remote-tmux-live-fuzz.sh
+++ b/scripts/remote-tmux-live-fuzz.sh
@@ -146,8 +146,8 @@ settlement_digest() {
   # jq's status is honored: a payload of one valid value followed by garbage makes
   # jq print and then exit non-zero, which a discarded status would report as a
   # clean digest.
-  if digest=$(printf '%s' "$1" | jq -c '
-        {counters, windows: [.windows[]? | select(.settled != true)]}
+  if digest=$(printf '%s' "$1" | jq -ce '
+        {connected, counters, windows: [.windows[]? | select(.settled != true)]}
       ' 2>/dev/null) && [ -n "$digest" ]; then
     printf '%s' "$digest"
     return


### PR DESCRIPTION
Stacked on #8283: this branch currently includes its commits and re-targets to a clean diff after it lands. Above #8283, this PR changes only the live fuzz scripts and the DEBUG settlement diagnostics — no product code. The live sizing fuzz ran green for weeks while two real rendering bugs (the frozen pane and the hidden-tab overlay fixed in #8283) sat inside its blind spots; these judges close the blind spots and make every failure say what happened. Calibration is the merge argument: they fail deterministically on the unfixed build at the exact bug sites, and they run clean on the fixed one.

## The misses these judges close, specifically

- Seed 5's frozen pane failed 10+ consecutive settles while the old harness printed green. The settlement probe trusted the effective-visibility predicate it needed to judge, so broken visibility could omit the affected mirror, and reported mismatches did not fail settlement. It now reads hosted-view state directly, requires claim and derivation evidence for anything on screen, and makes mismatches decide the verdict.
- The old census was also one-directional, so overdraw always passed. It now rejects panes the app shows that tmux is not drawing, and fails a window the app still shows after tmux removed it.
- Nothing exercised the tab-reveal path. The tmux-side select-window operation changes tmux's active window, but cmux deliberately does not select another mirror tab for it — so the reveal path never ran. A new operation focuses another mirror's surface directly and counts the landing only when its target is the sole on-screen window, so a half-finished handoff cannot be banked as coverage. Each seed reports its switch count, and a marathon that never landed one fails instead of implying it did.
- Failures named the seed, iteration, and immediate reason, but not the operations preceding the settle, and settlement payloads did not expose their individual gate terms. Each iteration now records every operation run before its settle check, timeout output prints the settlement terms and related diagnostics — connection, publication, native geometry, portal geometry, grid parity, derivation state, and whether bonsplit's tree matches tmux's layout — and the existing native-geometry lines retain the lease's pane and in-window state, the discriminator that separated a dead-owner wedge from a wrong-pane lease during the original investigation.

Strictness needs guards against false alarms, because tmux state can legitimately change between two harness reads: this PR takes zoom state, active pane, and pane IDs from one atomic list-panes call, and retains #8283's fresh app/tmux recheck and its rule that a window which left the screen between reads is discarded rather than judged against stale expectations.

## Verification

A full 5-seed x 25-iteration marathon on this exact branch passes with zero failures, zero hangs, and zero crashes, landing 12 mirror-tab switches with every seed exercising the path at least once (seeds-without-any = 0/5). During development these judges went red twice against earlier revisions of the fixes, and each red pointed at the exact missing mechanism.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8325"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786866013&installation_id=133855650&pr_number=8325&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8325&signature=9976be46d9c3643ef2a970ecbfb8b7ebecc29c2e47a438ef1b145408d8de35b5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stricter, zoom‑aware fuzz judges now enforce a single sizing owner, compare on‑screen state vs flags, and explain failures; a new mirror→mirror tab switch proves the reveal path. Portal‑host leases authenticate by host+serial, clear dead authority, and wake survivors so panes reattach; a bound non‑owner can hide its surface; runs refuse missing `TMUX_TMPDIR` and can keep state.

- **Bug Fixes**
  - Portal lease/runtime: authenticate owner by `hostId`+`instanceSerial` on claim/prepare/release; clear authority when its holder vacates; log authority refusals; park and wake surviving candidates on owner death (newest‑first, generation‑keyed, coalesced); authenticate vacancy‑retry removal by serial; drop/unregister retries when lifecycle closes or a host moves; block binding while hibernated; restore non‑visibility handlers (incl. drop‑zone overlay) in the wake. Tests cover authority clear, wake coalescing, hibernation invalidation, and stale‑generation drains.
  - Visibility policy: a bound non‑owner may hide its hosted view even without the lease; action is now three‑way (apply both, hide‑only, defer) with the table pinned in Swift Testing.

- **New Features**
  - Judges: zoom‑aware pane census with bidirectional diffs and re‑reads; session‑level single sizing owner with stale‑owner check; judge on on‑screen view state (not the flag) and report disagreements; mismatches now gate `settled`; derivation keyed off on‑screen; “why” includes readiness terms, render‑frame vs container, tree‑vs‑layout, connection; native‑geometry lines name the lease’s pane and in‑window state.
  - New op 10: switch mirror→mirror via `surface.focus`, and count a landing only when the target is the sole on‑screen window; op 6 biases toward two multi‑pane windows (and re‑splits flats) so mirrors exist; per‑iteration op logging; coverage counted per seed; marathon sums switches and fails if none.
  - Reporting/safety: compact unsettled‑window digests that keep gate terms and `connected`; overlay oracle re‑reads before failing and only re‑judges windows still shown; refuse to run if `TMUX_TMPDIR` is missing; support `FUZZ_KEEP_STATE=1` to keep server/workspace for postmortem.

<sup>Written for commit ec7da901994a8c4598e0de4eb130a49c0c86d4c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8325?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened portal-host lease ownership and replacement by matching both host identity and instance serial; improved release/vacate handling and retry wakeups.
  * Enhanced “owner-death” recovery for portal bindings, with safer vacancy-retry parking and correct cleanup during closing/dismantling.
  * Refined immediate hosted-state behavior to consistently apply, hide-only, or defer based on ownership and binding liveness.
* **Diagnostics & Testing**
  * Expanded remote tmux sizing/portal mismatch diagnostics and made verdicts stricter.
  * Improved fuzz harness coverage reporting (including mirror-tab-switch coverage) and settlement mismatch evidence.
  * Updated visibility policy tests (including migration to Swift Testing) and adjusted related reconcile tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
