### PR TITLE
Fix Swift 6 capture error breaking app builds from main

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -96,7 +96,7 @@ final class SidebarRowPullRequestIconView: NSView {
                 )
                 // Tint inside the image first: .sourceAtop against the view's
                 // transparent backing draws nothing (no destination pixels).
-                let tinted = NSImage(size: image.size, flipped: false) { drawRect in
+                let tinted = NSImage(size: image.size, flipped: false) { [color = self.color] drawRect in
                     image.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1)
                     color.set()
                     drawRect.fill(using: .sourceAtop)


### PR DESCRIPTION
Current main fails to build the macOS app: `SidebarWorkspaceRowSlotViews.swift:101` references the view's `color` property inside `NSImage`'s escaping drawing handler without explicit capture semantics, a hard compile error. https://github.com/manaflow-ai/cmux/pull/8270 merged while PR CI is off (advisory experiment), so the breakage reached main unbuilt. Capture the color by value in the closure's capture list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8326"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786866047&installation_id=133855650&pr_number=8326&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8326&signature=69dc675dac17d7f2bfebe398da5a6d4bd19fe83e07888e30b1dac4753ca8eb9b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Swift 6 compile error that broke macOS app builds by explicitly capturing the view’s color in `NSImage`’s escaping drawing closure. Adds `[color = self.color]` in `SidebarWorkspaceRowSlotViews.swift` to avoid implicit property capture.

<sup>Written for commit 3c924ea98bd77cfcd195b6e88393d49c4faa58f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8326?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

