### PR TITLE
Fix escaping-closure capture in sidebar slot view tint

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -96,7 +96,7 @@ final class SidebarRowPullRequestIconView: NSView {
                 )
                 // Tint inside the image first: .sourceAtop against the view's
                 // transparent backing draws nothing (no destination pixels).
-                let tinted = NSImage(size: image.size, flipped: false) { drawRect in
+                let tinted = NSImage(size: image.size, flipped: false) { [color] drawRect in
                     image.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1)
                     color.set()
                     drawRect.fill(using: .sourceAtop)


### PR DESCRIPTION
Clean Debug builds of main currently fail: the NSImage drawing handler added in https://github.com/manaflow-ai/cmux/pull/8270 is escaping and references the enclosing view's color without an explicit capture, which is a hard Swift error. Capture the color by value. Found while merging main into feat-ios-panes-ux; required CI being off this week is why it landed unnoticed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8329"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786867048&installation_id=133855650&pr_number=8329&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8329&signature=fcc945a5138d23ac32be810f4f3e2503077db980899a6b5863801838812c8652"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a Debug build error by explicitly capturing the tint `color` in the `NSImage` drawing handler for sidebar slot views. Keeps the tinting behavior the same while removing the escaping-closure capture issue.

- **Bug Fixes**
  - Added `[color]` capture list to the `NSImage` drawing handler in `SidebarRowPullRequestIconView`.
  - Resolves Swift error from implicit capture of `self` and restores clean Debug builds.

<sup>Written for commit 0160d99b8463f9ec2585c5ddb7edfa5a74ea8bd1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8329?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when rendering icons for closed pull requests in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->