### PR TITLE
Fix explicit-self capture breaking clean macOS builds of main

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -96,7 +96,7 @@ final class SidebarRowPullRequestIconView: NSView {
                 )
                 // Tint inside the image first: .sourceAtop against the view's
                 // transparent backing draws nothing (no destination pixels).
-                let tinted = NSImage(size: image.size, flipped: false) { drawRect in
+                let tinted = NSImage(size: image.size, flipped: false) { [color] drawRect in
                     image.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1)
                     color.set()
                     drawRect.fill(using: .sourceAtop)

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -98,7 +98,7 @@ final class SidebarRowPullRequestIconView: NSView {
                 // transparent backing draws nothing (no destination pixels).
                 let tinted = NSImage(size: image.size, flipped: false) { [color] drawRect in
                     image.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1)
-                    color.set()
+                    self.color.set()
                     drawRect.fill(using: .sourceAtop)
                     return true
                 }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -98,7 +98,7 @@ final class SidebarRowPullRequestIconView: NSView {
                 // transparent backing draws nothing (no destination pixels).
                 let tinted = NSImage(size: image.size, flipped: false) { [color] drawRect in
                     image.draw(in: drawRect, from: .zero, operation: .sourceOver, fraction: 1)
-                    self.color.set()
+                    color.set()
                     drawRect.fill(using: .sourceAtop)
                     return true
                 }


### PR DESCRIPTION
`Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift:101` references `color` inside the `NSImage(size:flipped:)` drawing closure without explicit `self`, which Swift rejects (escaping closure capture semantics). Clean checkouts of main fail to build the macOS app with `reference to property 'color' in closure requires explicit use of 'self'`; unnoticed because PR CI is off during the advisory experiment (second clean-build breakage this week after the unpushed bonsplit pointer, https://github.com/manaflow-ai/bonsplit/pull/188).

One line: `self.color.set()`. Verified by compiling the tagged dev app from a checkout that previously failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8331"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786869457&installation_id=133855650&pr_number=8331&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8331&signature=6ddcda627843d7f9ea4bbdd92b0449051660e7e6b995de641b57ef9e9c114c69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the macOS build by capturing the tint `[color]` in the escaping `NSImage(size:flipped:)` drawing closure in `SidebarWorkspaceRowSlotViews`. This meets Swift capture rules, restores clean builds of main, and ensures pull request icons render with the correct tint.

<sup>Written for commit d2910055c11f8f2547c5bd4809b0aeba7c38f061. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8331?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pull request icons in the sidebar so their closed-state rendering consistently uses the correct tint and stroke color.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->