### PR TITLE
fix(quicklook): unwrap the closing panel before objc_setAssociatedObject

### DIFF
--- a/Sources/WorkspaceChecklistAttachmentQuickLookController.swift
+++ b/Sources/WorkspaceChecklistAttachmentQuickLookController.swift
@@ -58,6 +58,7 @@ final class WorkspaceChecklistAttachmentQuickLookController: NSObject, QLPreview
     }
 
     nonisolated func previewPanelWillClose(_ panel: QLPreviewPanel!) {
+        guard let panel else { return }
         objc_setAssociatedObject(
             panel,
             &workspaceChecklistAttachmentQuickLookControllerAssociationKey,


### PR DESCRIPTION
Passing the implicitly-unwrapped `QLPreviewPanel!` straight into the `Any` parameter of `objc_setAssociatedObject` emits *coercion of implicitly unwrappable value to Any does not unwrap optional*, tripping the zero-budget Swift warning gate (`tests-build-and-lag`). The warning arrived with #8117, which has no budget entry for the file — CI on #8034's branch caught it after merging main.

One-line fix: guard-unwrap the panel (also removes a latent nil path) instead of refreshing the budget to accept debt.

Cherry-pick of `880412cfd3` from the already-merged #8034 branch, which went green on CI run 29562838948.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8332"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786871230&installation_id=133855650&pr_number=8332&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8332&signature=2ff8135953202285e82352b4ea062fe2572d8b47aba90ff2a08f4bf5bb6047a7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard-unwrap the `QLPreviewPanel` in `previewPanelWillClose` before passing it to `objc_setAssociatedObject`. This removes the Swift warning "coercion of implicitly unwrappable value to Any does not unwrap optional" and avoids a nil path, keeping the zero-warning gate green.

<sup>Written for commit e5475cffb4804fa483ed98b24bc81b57983388ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8332?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when closing a preview panel whose reference is unavailable.
  * Prevented unnecessary cleanup processing in this edge case.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->