### PR TITLE
Add agent-executable hang diagnosis skill at cmux.com/hang-diagnosis.md

### DIFF
--- a/web/app/api/hang-report/route.ts
+++ b/web/app/api/hang-report/route.ts
@@ -1,0 +1,255 @@
+import { checkRateLimit } from "@vercel/firewall";
+import { NextResponse } from "next/server";
+import { Resend } from "resend";
+import { z } from "zod";
+
+import { env } from "@/app/env";
+import { recordSpanError, setSpanAttributes, withApiRouteSpan } from "../../../services/telemetry";
+
+export const runtime = "nodejs";
+export const dynamic = "force-dynamic";
+
+const hangReportRecipient = "founders@manaflow.ai";
+// Keep multipart requests below Vercel Functions' 4.5 MB request-body limit.
+const maxArchiveBytes = Math.floor(3.5 * 1024 * 1024);
+const gzipMagic = Buffer.from([0x1f, 0x8b]);
+
+const hangReportSchema = z.object({
+  summary: z.string().trim().min(1).max(8000),
+  email: z
+    .union([z.literal(""), z.string().trim().email().max(320)])
+    .optional()
+    .default(""),
+  gistUrl: z
+    .union([
+      z.literal(""),
+      z
+        .string()
+        .trim()
+        .max(500)
+        .url()
+        .refine(
+          (value) => value.startsWith("https://gist.github.com/"),
+          "gistUrl must be a gist.github.com URL",
+        ),
+    ])
+    .optional()
+    .default(""),
+  appVersion: z.string().trim().max(120).optional().default(""),
+  osVersion: z.string().trim().max(200).optional().default(""),
+});
+
+type PreparedArchive = {
+  content: Buffer;
+  filename: string;
+  size: number;
+};
+
+export async function POST(request: Request) {
+  return withApiRouteSpan(
+    request,
+    "/api/hang-report",
+    { "cmux.subsystem": "hang-report", "cmux.hang_report.operation": "send" },
+    async (span): Promise<Response> => {
+      const config = resolveHangReportConfig();
+      if (!config) {
+        return jsonError("Hang report endpoint is not configured", 503);
+      }
+
+      if (process.env.VERCEL === "1") {
+        const { error, rateLimited } = await checkRateLimit(
+          config.rateLimitId,
+          { request },
+        );
+
+        setSpanAttributes(span, { "cmux.rate_limited": rateLimited || error === "blocked" });
+        if (rateLimited || error === "blocked") {
+          return jsonError("Rate limit exceeded", 429);
+        }
+
+        if (error === "not-found") {
+          console.error("hang_report.route.rate_limit_not_found", config.rateLimitId);
+          return jsonError("service_unavailable", 503);
+        } else if (error) {
+          console.error("hang_report.route.rate_limit_error", error);
+          return jsonError("service_unavailable", 503);
+        }
+      }
+
+      let formData: FormData;
+      try {
+        formData = await request.formData();
+      } catch {
+        return jsonError("Invalid multipart payload", 400);
+      }
+
+      const parsed = hangReportSchema.safeParse({
+        summary: getString(formData, "summary"),
+        email: getString(formData, "email"),
+        gistUrl: getString(formData, "gistUrl"),
+        appVersion: getString(formData, "appVersion"),
+        osVersion: getString(formData, "osVersion"),
+      });
+
+      if (!parsed.success) {
+        return jsonError("Invalid hang report payload", 400);
+      }
+
+      const archiveResult = await prepareArchive(formData.get("archive"));
+      if ("errorResponse" in archiveResult) {
+        return archiveResult.errorResponse;
+      }
+      const archive = archiveResult.archive;
+
+      const { appVersion, email, gistUrl, osVersion, summary } = parsed.data;
+      if (!archive && !gistUrl) {
+        return jsonError("A hang report needs an archive or a gistUrl", 400);
+      }
+
+      setSpanAttributes(span, {
+        "cmux.hang_report.summary_length": summary.length,
+        "cmux.hang_report.archive_bytes": archive?.size ?? 0,
+        "cmux.hang_report.gist_url_set": gistUrl.length > 0,
+      });
+
+      const resend = new Resend(config.resendApiKey);
+      const { error } = await resend.emails.send({
+        from: `Manaflow <${config.fromEmail}>`,
+        to: [hangReportRecipient],
+        ...(email ? { replyTo: email } : {}),
+        subject: buildSubject(summary, appVersion),
+        text: buildTextBody({ appVersion, archive, email, gistUrl, osVersion, summary }),
+        ...(archive
+          ? {
+              attachments: [
+                {
+                  content: archive.content,
+                  contentType: "application/gzip",
+                  filename: archive.filename,
+                },
+              ],
+            }
+          : {}),
+      });
+
+      if (error) {
+        recordSpanError(span, error);
+        console.error("hang_report.route.resend_failed", error);
+        return jsonError("Failed to send hang report", 502);
+      }
+
+      return NextResponse.json(
+        { ok: true },
+        {
+          headers: {
+            "Cache-Control": "no-store",
+          },
+        },
+      );
+    },
+  );
+}
+
+function resolveHangReportConfig() {
+  const resendApiKey = env.RESEND_API_KEY;
+  const fromEmail = env.CMUX_FEEDBACK_FROM_EMAIL;
+  const rateLimitId = env.CMUX_HANG_REPORT_RATE_LIMIT_ID ?? env.CMUX_FEEDBACK_RATE_LIMIT_ID;
+
+  if (!resendApiKey || !fromEmail || !rateLimitId) {
+    return null;
+  }
+
+  return {
+    resendApiKey,
+    fromEmail,
+    rateLimitId,
+  };
+}
+
+function getString(formData: FormData, key: string) {
+  const value = formData.get(key);
+  return typeof value === "string" ? value.trim() : "";
+}
+
+type PrepareArchiveResult =
+  | { archive: PreparedArchive | null }
+  | { errorResponse: Response };
+
+async function prepareArchive(value: FormDataEntryValue | null): Promise<PrepareArchiveResult> {
+  if (!(value instanceof File) || value.name.length === 0) {
+    return { archive: null };
+  }
+
+  if (value.size > maxArchiveBytes) {
+    return { errorResponse: jsonError("Archive is too large (max 3.5 MB)", 413) };
+  }
+
+  const content = Buffer.from(await value.arrayBuffer());
+  // Validate the payload is actually gzip data rather than trusting the
+  // client-supplied content type.
+  if (content.length < 2 || !content.subarray(0, 2).equals(gzipMagic)) {
+    return { errorResponse: jsonError("Archive must be a .tar.gz file", 415) };
+  }
+
+  return {
+    archive: {
+      content,
+      filename: sanitizeFilename(value.name),
+      size: value.size,
+    },
+  };
+}
+
+function buildSubject(summary: string, appVersion: string) {
+  const firstNonEmptyLine =
+    summary
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean) ?? "Hang report";
+  const headline =
+    firstNonEmptyLine.length > 72
+      ? `${firstNonEmptyLine.slice(0, 69)}...`
+      : firstNonEmptyLine;
+  const stamp = appVersion ? ` [v${appVersion}]` : "";
+
+  return `cmux hang report${stamp}: ${headline}`;
+}
+
+function buildTextBody(input: {
+  appVersion: string;
+  archive: PreparedArchive | null;
+  email: string;
+  gistUrl: string;
+  osVersion: string;
+  summary: string;
+}) {
+  return [
+    `From: ${input.email || "not provided"}`,
+    `App version: ${input.appVersion || "unknown"}`,
+    `macOS: ${input.osVersion || "unknown"}`,
+    `Gist: ${input.gistUrl || "none"}`,
+    input.archive
+      ? `Archive: ${input.archive.filename} (${input.archive.size} bytes, attached)`
+      : "Archive: none",
+    "",
+    "Summary:",
+    input.summary,
+  ].join("\n");
+}
+
+function sanitizeFilename(fileName: string) {
+  const cleaned = fileName.replace(/[\r\n"]/g, "").trim();
+  return cleaned.length > 0 ? cleaned : "cmux-hang-report.tar.gz";
+}
+
+function jsonError(message: string, status: number) {
+  return NextResponse.json(
+    { error: message },
+    {
+      status,
+      headers: {
+        "Cache-Control": "no-store",
+      },
+    },
+  );
+}

--- a/web/app/env.ts
+++ b/web/app/env.ts
@@ -113,6 +113,9 @@ export const env = createEnv({
     RESEND_API_KEY: z.string().min(1),
     CMUX_FEEDBACK_FROM_EMAIL: z.string().email(),
     CMUX_FEEDBACK_RATE_LIMIT_ID: z.string().min(1),
+    // Hang-report uploads (/api/hang-report). Optional: falls back to the
+    // feedback rate limit rule until a dedicated firewall rule exists.
+    CMUX_HANG_REPORT_RATE_LIMIT_ID: z.string().min(1).optional(),
     CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: requireVercelNonPreviewValue("CMUX_CLIENT_CONFIG_RATE_LIMIT_ID"),
     CMUX_ANALYTICS_RATE_LIMIT_ID: requireVercelProductionValue("CMUX_ANALYTICS_RATE_LIMIT_ID"),
     STACK_SECRET_SERVER_KEY: z.string().min(1),
@@ -209,6 +212,7 @@ export const env = createEnv({
     RESEND_API_KEY: trimEnv(process.env.RESEND_API_KEY),
     CMUX_FEEDBACK_FROM_EMAIL: trimEnv(process.env.CMUX_FEEDBACK_FROM_EMAIL),
     CMUX_FEEDBACK_RATE_LIMIT_ID: trimEnv(process.env.CMUX_FEEDBACK_RATE_LIMIT_ID),
+    CMUX_HANG_REPORT_RATE_LIMIT_ID: trimEnv(process.env.CMUX_HANG_REPORT_RATE_LIMIT_ID),
     CMUX_CLIENT_CONFIG_RATE_LIMIT_ID: trimEnv(process.env.CMUX_CLIENT_CONFIG_RATE_LIMIT_ID),
     CMUX_ANALYTICS_RATE_LIMIT_ID: trimEnv(process.env.CMUX_ANALYTICS_RATE_LIMIT_ID),
     CMUX_APNS_KEY_P8: trimEnv(process.env.CMUX_APNS_KEY_P8),

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -127,7 +127,17 @@ const nextConfig: NextConfig = {
         },
       ]),
     );
-    return [...(isDocsZone ? [] : baseNightlyMoves), ...agentRedirects];
+    return [
+      ...(isDocsZone ? [] : baseNightlyMoves),
+      ...agentRedirects,
+      // Agent-executable hang diagnosis skill; the canonical document is the
+      // static markdown file in public/.
+      {
+        source: "/hang-diagnosis",
+        destination: "/hang-diagnosis.md",
+        permanent: false,
+      },
+    ];
   },
   async headers() {
     if (docsChannel !== "nightly") return securityHeaderRules;

--- a/web/public/hang-diagnosis.md
+++ b/web/public/hang-diagnosis.md
@@ -1,0 +1,148 @@
+# cmux hang diagnosis
+
+Instructions for an AI coding agent (Claude Code, Codex, or similar) running in a terminal on the user's Mac. The user's cmux terminal app is hung, frozen, beachballing, or burning CPU. Follow these steps top to bottom: capture diagnostic evidence, review it with the user, and send it to the cmux team only after the user explicitly approves.
+
+## Step 0: tell the user what will happen
+
+Before running anything, tell the user, in your own words:
+
+1. You will capture read-only diagnostics from the running cmux process: a process list, thread stack samples, a memory summary, and recent macOS crash/hang reports for cmux. This does not read terminal contents, shell history, or project files. Nothing is killed or restarted; cmux is left exactly as it is.
+2. Everything lands in a local folder under `/tmp` that they can inspect before anything leaves the machine.
+3. Nothing is uploaded without their explicit approval. The options will be: upload to `https://cmux.com/api/hang-report` (delivered by email to founders@manaflow.ai), create a secret GitHub gist on their own account, or email the archive to founders@manaflow.ai themselves.
+
+Then start immediately. A live hang is perishable evidence: if cmux recovers or gets force-quit, the evidence is gone. Ask the user not to force-quit cmux until the capture finishes.
+
+## Step 1: capture
+
+Write this script to `/tmp/cmux-hang-capture.sh` and run `bash /tmp/cmux-hang-capture.sh`. It is read-only and never kills or restarts anything. If several cmux processes are running and the auto-picked one looks wrong, re-run with `CMUX_HANG_PID=<pid>`.
+
+```bash
+#!/bin/bash
+# cmux hang capture: read-only evidence collection for a hung cmux.
+set -u
+SECS=10
+OUT="/tmp/cmux-hang-$(date +%Y%m%d-%H%M%S)"
+mkdir -p "$OUT"
+LOG="$OUT/capture.log"
+note() { echo "[$(date +%H:%M:%S)] $*" | tee -a "$LOG"; }
+
+# 1. Snapshot every cmux app process.
+ps -axo pid=,pcpu=,pmem=,rss=,etime=,state=,args= \
+  | grep '\.app/Contents/MacOS/cmux' | grep -v grep > "$OUT/cmux-processes.txt" || true
+note "cmux app processes:"; tee -a "$LOG" < "$OUT/cmux-processes.txt"
+
+# 2. Target: explicit CMUX_HANG_PID, else the highest-CPU cmux process.
+PID="${CMUX_HANG_PID:-$(sort -k2 -rn "$OUT/cmux-processes.txt" | awk '{print $1; exit}')}"
+if [ -z "$PID" ] || ! kill -0 "$PID" 2>/dev/null; then
+  note "ERROR: no running cmux app process found"; exit 1
+fi
+APP_PATH=$(ps -o args= -p "$PID" | sed 's|\(.*\.app\)/Contents/MacOS/.*|\1|')
+{
+  echo "pid: $PID"
+  echo "app: $APP_PATH"
+  echo "version: $(plutil -extract CFBundleShortVersionString raw "$APP_PATH/Contents/Info.plist" 2>/dev/null)"
+  echo "build: $(plutil -extract CFBundleVersion raw "$APP_PATH/Contents/Info.plist" 2>/dev/null)"
+  echo "macos: $(sw_vers -productVersion) ($(sw_vers -buildVersion))"
+  echo "hardware: $(sysctl -n machdep.cpu.brand_string 2>/dev/null)"
+  echo "captured: $(date)"
+  echo "threads: $(ps -M -p "$PID" 2>/dev/null | tail -n +2 | wc -l | tr -d ' ')"
+  ps -o pid,pcpu,pmem,rss,vsz,etime,state -p "$PID"
+} > "$OUT/meta.txt" 2>&1
+tee -a "$LOG" < "$OUT/meta.txt"
+
+# 3. CPU sample: the core hang evidence. Works on fully hung processes.
+note "sampling pid $PID for ${SECS}s..."
+sample "$PID" "$SECS" -file "$OUT/sample.txt" >>"$LOG" 2>&1 || true
+if [ ! -s "$OUT/sample.txt" ]; then
+  note "NEEDS-SUDO: unprivileged sampling was blocked (normal for the notarized app)."
+  note "  sudo sample $PID $SECS -file $OUT/sample.txt"
+  note "  sudo spindump $PID $SECS -file $OUT/spindump.txt"
+fi
+if sudo -n true 2>/dev/null; then
+  note "spindump (passwordless sudo available)..."
+  sudo -n spindump "$PID" "$SECS" -file "$OUT/spindump.txt" >>"$LOG" 2>&1 || note "WARN: spindump failed"
+fi
+
+# 4. Memory state.
+vmmap --summary "$PID" > "$OUT/vmmap-summary.txt" 2>&1 || note "WARN: vmmap failed (may need sudo)"
+footprint "$PID" > "$OUT/footprint.txt" 2>&1 || true
+vm_stat > "$OUT/vm_stat.txt" 2>&1
+
+# 5. UI liveness probe through the cmux automation socket (read-only).
+if command -v cmux >/dev/null 2>&1; then
+  ( cmux identify --json > "$OUT/socket-probe.json" 2>>"$LOG" ) & CP=$!
+  ( sleep 5; kill -TERM "$CP" 2>/dev/null ) & W=$!
+  if wait "$CP" 2>/dev/null; then
+    note "SOCKET RESPONSIVE (main thread is servicing requests)"
+  else
+    note "SOCKET UNRESPONSIVE (consistent with a blocked main thread)"
+  fi
+  kill -TERM "$W" 2>/dev/null; wait "$W" 2>/dev/null
+fi
+
+# 6. Recent macOS crash/hang reports for cmux.
+ls -t "$HOME/Library/Logs/DiagnosticReports" 2>/dev/null | grep -i cmux | head -5 \
+  > "$OUT/diagnostic-reports-recent.txt"
+while IFS= read -r f; do
+  [ -n "$f" ] && cp "$HOME/Library/Logs/DiagnosticReports/$f" "$OUT/" 2>/dev/null
+done < "$OUT/diagnostic-reports-recent.txt"
+
+# 7. Second CPU reading for a delta.
+ps -o pid,pcpu,rss,etime,state -p "$PID" > "$OUT/ps-after.txt" 2>&1
+
+note "=== capture complete: $OUT ==="
+echo "$OUT"
+```
+
+The last line of output is the evidence folder. If the log contains `NEEDS-SUDO`, `sample.txt` is empty because macOS blocks unprivileged sampling of the notarized app. Ask the user for permission to run the two printed `sudo` commands (sudo is needed only to read the app's thread stacks), then run them in the user's interactive terminal so they can enter their password.
+
+## Step 2: review with the user
+
+1. List the files and sizes: `ls -lh <evidence folder>`.
+2. Read `sample.txt` (or `spindump.txt`) yourself and triage. The first thread is the main thread. Parked in `mach_msg2_trap` under `CFRunLoopRun` means idle (the problem is elsewhere). Sitting in `__psynch_mutexwait`, `__psynch_cvwait`, `semaphore_wait_trap`, `__ulock_wait`, or a synchronous `dispatch` call means blocked, and the frames below it name the culprit. High CPU with a responsive socket points at a background thread; check the heaviest non-main stacks. Write a two or three sentence triage; you will include it in the report.
+3. Tell the user what the files contain: stack samples hold only function names from cmux and system frameworks, `meta.txt` holds app/macOS versions and hardware model, and macOS diagnostic reports (`.ips`) can additionally include the app path and OS details. Offer to let them inspect the folder before anything is sent.
+
+## Step 3: package
+
+```bash
+cd /tmp && tar --exclude='*.trace' -czf <evidence-folder>.tar.gz "$(basename <evidence-folder>)" && ls -lh <evidence-folder>.tar.gz
+```
+
+The upload endpoint accepts up to 3.5 MB. If the archive is larger, drop the biggest `.ips` files from the folder (keep `sample.txt`, `spindump.txt`, `meta.txt`, `capture.log`) and re-create it.
+
+## Step 4: ask for consent, then send
+
+Ask the user plainly, and do not upload anything until they pick one:
+
+- **a) Upload to the cmux team** (default): sends the archive to `https://cmux.com/api/hang-report`, which emails it to founders@manaflow.ai. Include their email only if they want a reply.
+- **b) Secret GitHub gist**: creates an unlisted gist of the text files on their own GitHub account (they keep control and can delete it), then sends just the gist link to the same endpoint.
+- **c) Manual**: they email the archive themselves to founders@manaflow.ai.
+
+Option a:
+
+```bash
+curl -sS -X POST https://cmux.com/api/hang-report \
+  -F "archive=@/tmp/<archive>.tar.gz;type=application/gzip" \
+  -F "summary=<your triage plus what the user was doing when it hung>" \
+  -F "email=<user email, omit if they decline>" \
+  -F "appVersion=<version from meta.txt>" \
+  -F "osVersion=<macos from meta.txt>"
+```
+
+Option b (requires an authenticated `gh` CLI; gists created this way are secret/unlisted):
+
+```bash
+gh gist create -d "cmux hang report $(date +%F)" <evidence-folder>/*.txt <evidence-folder>/capture.log
+curl -sS -X POST https://cmux.com/api/hang-report \
+  -F "summary=<your triage plus what the user was doing when it hung>" \
+  -F "gistUrl=<gist url from the previous command>" \
+  -F "email=<user email, omit if they decline>"
+```
+
+A successful upload returns `{"ok":true}`. If the endpoint is unreachable, fall back to option b or c.
+
+## Step 5: close out
+
+1. Confirm to the user that the report was sent (or where the gist/archive is).
+2. Tell them it is now safe to force-quit cmux (right-click the Dock icon while holding Option, then Force Quit) and relaunch it.
+3. Give them your short triage summary so they know what the evidence showed.

--- a/web/tests/hang-report-route.test.ts
+++ b/web/tests/hang-report-route.test.ts
@@ -1,0 +1,180 @@
+const priorSkipEnvValidation = process.env.SKIP_ENV_VALIDATION;
+const priorVercel = process.env.VERCEL;
+
+process.env.SKIP_ENV_VALIDATION = "1";
+
+import { afterAll, afterEach, describe, expect, mock, test } from "bun:test";
+import {
+  checkRateLimit,
+  installVercelFirewallMock,
+} from "./vercel-firewall-mock";
+
+type SentEmail = {
+  to: string[];
+  replyTo?: string;
+  subject: string;
+  text: string;
+  attachments?: { filename: string }[];
+};
+
+const sentEmails: SentEmail[] = [];
+const sendEmail = mock(async (message: unknown) => {
+  sentEmails.push(message as SentEmail);
+  return { data: { id: "email-1" }, error: null };
+});
+
+installVercelFirewallMock();
+
+mock.module("@/app/env", () => ({
+  env: {
+    RESEND_API_KEY: "resend-test-key",
+    CMUX_FEEDBACK_FROM_EMAIL: "feedback@example.test",
+    CMUX_FEEDBACK_RATE_LIMIT_ID: "feedback-rate-limit-test",
+  },
+}));
+
+mock.module("resend", () => ({
+  Resend: class {
+    readonly emails = { send: sendEmail };
+  },
+}));
+
+const { POST } = await import("../app/api/hang-report/route");
+
+afterEach(() => {
+  checkRateLimit.mockClear();
+  checkRateLimit.mockResolvedValue({ rateLimited: false, error: null });
+  sendEmail.mockClear();
+  sentEmails.length = 0;
+  if (priorVercel === undefined) {
+    delete process.env.VERCEL;
+  } else {
+    process.env.VERCEL = priorVercel;
+  }
+});
+
+afterAll(() => {
+  restoreEnv("SKIP_ENV_VALIDATION", priorSkipEnvValidation);
+  restoreEnv("VERCEL", priorVercel);
+});
+
+describe("hang report route", () => {
+  test("fails closed when the Vercel firewall rule is missing", async () => {
+    process.env.VERCEL = "1";
+    checkRateLimit.mockResolvedValue({ rateLimited: false, error: "not-found" });
+
+    const res = await POST(hangReportRequest({ archive: gzipFile() }));
+
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({ error: "service_unavailable" });
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  test("rejects a report with neither archive nor gist URL", async () => {
+    const res = await POST(hangReportRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  test("rejects an archive that is not gzip data", async () => {
+    const res = await POST(
+      hangReportRequest({
+        archive: new File([Buffer.from("plain text, not gzip")], "evidence.tar.gz", {
+          type: "application/gzip",
+        }),
+      }),
+    );
+
+    expect(res.status).toBe(415);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  test("rejects an oversized archive", async () => {
+    const oversized = Buffer.alloc(Math.floor(3.5 * 1024 * 1024) + 1);
+    oversized[0] = 0x1f;
+    oversized[1] = 0x8b;
+    const res = await POST(
+      hangReportRequest({
+        archive: new File([oversized], "evidence.tar.gz", { type: "application/gzip" }),
+      }),
+    );
+
+    expect(res.status).toBe(413);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  test("rejects a non-gist URL", async () => {
+    const res = await POST(
+      hangReportRequest({ gistUrl: "https://example.com/evil" }),
+    );
+
+    expect(res.status).toBe(400);
+    expect(sendEmail).not.toHaveBeenCalled();
+  });
+
+  test("sends an archive report to founders@manaflow.ai", async () => {
+    const res = await POST(
+      hangReportRequest({ archive: gzipFile(), email: "user@example.test" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ ok: true });
+    expect(sentEmails).toHaveLength(1);
+    const message = sentEmails[0];
+    expect(message.to).toEqual(["founders@manaflow.ai"]);
+    expect(message.replyTo).toBe("user@example.test");
+    expect(message.subject).toContain("cmux hang report");
+    expect(message.attachments?.[0]?.filename).toBe("cmux-hang-20260717.tar.gz");
+  });
+
+  test("sends a gist-only report without attachments", async () => {
+    const res = await POST(
+      hangReportRequest({ gistUrl: "https://gist.github.com/someone/abc123" }),
+    );
+
+    expect(res.status).toBe(200);
+    expect(sentEmails).toHaveLength(1);
+    const message = sentEmails[0];
+    expect(message.attachments).toBeUndefined();
+    expect(message.replyTo).toBeUndefined();
+    expect(message.text).toContain("https://gist.github.com/someone/abc123");
+  });
+});
+
+function gzipFile(): File {
+  const gzipBytes = Buffer.from([0x1f, 0x8b, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00]);
+  return new File([gzipBytes], "cmux-hang-20260717.tar.gz", {
+    type: "application/gzip",
+  });
+}
+
+function hangReportRequest(input: {
+  archive?: File;
+  email?: string;
+  gistUrl?: string;
+}): Request {
+  const form = new FormData();
+  form.set("summary", "Main thread blocked in __psynch_mutexwait under WorkspaceStore.");
+  if (input.archive) {
+    form.set("archive", input.archive);
+  }
+  if (input.email) {
+    form.set("email", input.email);
+  }
+  if (input.gistUrl) {
+    form.set("gistUrl", input.gistUrl);
+  }
+  return new Request("https://cmux.test/api/hang-report", {
+    method: "POST",
+    body: form,
+  });
+}
+
+function restoreEnv(key: string, value: string | undefined): void {
+  if (value === undefined) {
+    delete process.env[key];
+    return;
+  }
+  process.env[key] = value;
+}


### PR DESCRIPTION
## Summary

When an end user's cmux hangs indefinitely, we can now tell them: open another terminal and tell your agent to "execute https://cmux.com/hang-diagnosis.md".

- `web/public/hang-diagnosis.md` is a self-contained skill for any coding agent (Claude Code, Codex, etc.) on the user's Mac. It tells the user up front what will be collected (process list, thread stack samples, memory summary, recent cmux `.ips` reports; no terminal contents or project files), captures read-only evidence with an inline script derived from cmuxterm-hq's `cmux-hang-capture.sh`, has the agent triage the main-thread stack, and only uploads after the user explicitly picks a channel: POST to the new endpoint, secret gist on their own account, or manual email to founders@manaflow.ai.
- `POST /api/hang-report` accepts a gzip archive (magic-byte validated, 3.5 MB cap to stay under the Vercel body limit) and/or a `gist.github.com` URL plus a summary, and emails it to founders@manaflow.ai via Resend, modeled on `/api/feedback`. Rate limited through the Vercel firewall using `CMUX_HANG_REPORT_RATE_LIMIT_ID` with fallback to the existing `CMUX_FEEDBACK_RATE_LIMIT_ID` rule; fails closed like feedback.
- `/hang-diagnosis` 307-redirects to `/hang-diagnosis.md`.

## Test plan

- [x] `bun test tests/hang-report-route.test.ts` (7 tests: fail-closed firewall, archive/gist validation, size cap, gzip magic, happy paths)
- [x] `bun run typecheck`
- [x] Capture script extracted from the markdown and executed end to end against a live cmux process (read-only; evidence folder + 191K tar.gz produced)
- [x] Local `bun dev` smoke: `/hang-diagnosis.md` serves, `/hang-diagnosis` redirects 307, endpoint validates payloads (Resend send 401s locally with the dev placeholder key, as expected)
- [ ] Verify on Vercel preview: markdown URL, redirect, and a real POST delivering email to founders@manaflow.ai

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8334"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786874905&installation_id=133855650&pr_number=8334&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8334&signature=60dcb74e2ea4d41dc4367b8b9c4be6645b2c17a95de97c2dd0b43aa0f24b9ead"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a terminal-executable hang diagnosis skill at /hang-diagnosis.md and a backend endpoint to receive user-approved reports, so we can capture read-only evidence and triage hangs faster. Users can upload a small `.tar.gz` or share a secret gist; reports are emailed to founders@manaflow.ai.

- **New Features**
  - Self-contained skill at `/hang-diagnosis.md` with a read-only capture script, triage guidance, and consented send options (direct upload, secret gist, or manual email). `/hang-diagnosis` redirects to the markdown.
  - `POST /api/hang-report`: accepts a gzip archive (3.5 MB cap; validates gzip magic) and/or a `gist.github.com` URL plus a summary; emails to founders via `resend`. Rate limited by `@vercel/firewall` using `CMUX_HANG_REPORT_RATE_LIMIT_ID` (falls back to `CMUX_FEEDBACK_RATE_LIMIT_ID`); fails closed.

- **Migration**
  - Add a Vercel firewall rule and set `CMUX_HANG_REPORT_RATE_LIMIT_ID` (optional; falls back to the feedback rule). Ensure `RESEND_API_KEY` and `CMUX_FEEDBACK_FROM_EMAIL` are set. Verify `/hang-diagnosis.md`, the redirect, and a real upload on a preview.

<sup>Written for commit 139413e189d318feddd7047a9dd9c43f3474fe56. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8334?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a hang-diagnosis workflow for collecting and submitting diagnostic information.
  * Added an API endpoint for securely submitting hang reports with optional compressed attachments or gist links.
  * Added validation, upload-size limits, and rate limiting for report submissions.
  * Added a redirect from `/hang-diagnosis` to the executable diagnosis guide.

* **Documentation**
  * Added step-by-step instructions for diagnosing frozen or high-CPU macOS sessions and sharing results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->