### PR TITLE
Remove session content width ceiling

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/SessionContentWidthSettings.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Policies/SessionContentWidthSettings.swift
@@ -26,9 +26,6 @@ public struct SessionContentWidthSettings: Sendable {
     /// The smallest supported content width, in points.
     public static let minimumWidth = 320.0
 
-    /// The largest supported content width, in points.
-    public static let maximumWidth = 2400.0
-
     /// The width restored when enabling the cap without a remembered value.
     public static let defaultConfiguredMaximumWidth = 980.0
 
@@ -38,20 +35,21 @@ public struct SessionContentWidthSettings: Sendable {
     /// Returns the effective maximum width for a stored value.
     ///
     /// - Parameter storedValue: The persisted width value.
-    /// - Returns: A clamped width when the cap is enabled, or `nil`.
+    /// - Returns: A normalized width when the cap is enabled, or `nil`.
     public func configuredMaximumWidth(from storedValue: Double) -> Double? {
         guard storedValue.isFinite, storedValue > 0 else { return nil }
         return clampedMaximumWidth(storedValue)
     }
 
-    /// Clamps a requested maximum width to the supported range.
+    /// Normalizes a requested maximum width to the supported minimum and step.
     ///
     /// - Parameter value: The requested width in points.
-    /// - Returns: A finite, stepped width within the supported bounds.
+    /// - Returns: A finite width at or above the supported minimum.
     public func clampedMaximumWidth(_ value: Double) -> Double {
         guard value.isFinite else { return Self.defaultConfiguredMaximumWidth }
         let roundedToStep = (value / Self.widthStep).rounded() * Self.widthStep
-        return min(Self.maximumWidth, max(Self.minimumWidth, roundedToStep))
+        guard roundedToStep.isFinite else { return max(Self.minimumWidth, value) }
+        return max(Self.minimumWidth, roundedToStep)
     }
 
     /// Returns the width displayed by the settings editor.

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SessionContentWidthSettingsTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SessionContentWidthSettingsTests.swift
@@ -16,10 +16,10 @@ struct SessionContentWidthSettingsTests {
         #expect(settings.configuredMaximumWidth(from: SessionContentWidthSettings.noMaximumWidth) == nil)
     }
 
-    @Test func configuredWidthClampsAndRoundsToEditorStep() {
+    @Test func configuredWidthEnforcesMinimumAndRoundsWithoutUpperBound() {
         #expect(settings.configuredMaximumWidth(from: 1111) == 1120)
         #expect(settings.configuredMaximumWidth(from: 10) == SessionContentWidthSettings.minimumWidth)
-        #expect(settings.configuredMaximumWidth(from: 9999) == SessionContentWidthSettings.maximumWidth)
+        #expect(settings.configuredMaximumWidth(from: 10_000) == 10_000)
     }
 
     @Test func editorUsesRememberedWidthWhileDisabled() {

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SessionContentWidthSettingsTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/SessionContentWidthSettingsTests.swift
@@ -20,6 +20,7 @@ struct SessionContentWidthSettingsTests {
         #expect(settings.configuredMaximumWidth(from: 1111) == 1120)
         #expect(settings.configuredMaximumWidth(from: 10) == SessionContentWidthSettings.minimumWidth)
         #expect(settings.configuredMaximumWidth(from: 10_000) == 10_000)
+        #expect(settings.configuredMaximumWidth(from: .greatestFiniteMagnitude)?.isFinite == true)
     }
 
     @Test func editorUsesRememberedWidthWhileDisabled() {

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -575,8 +575,7 @@ final class CmuxSettingsFileStore {
         applyBooleanSettings(TerminalSettingsFileMapping.booleanSettings, from: section, sourcePath: sourcePath, snapshot: &snapshot)
         applyTerminalScrollSpeedSetting(from: section, assign: { snapshot.managedUserDefaults[$0] = .double($1) }, logInvalid: { logInvalid($0, sourcePath: sourcePath) })
         if let value = jsonDouble(section["sessionContentMaxWidth"]) {
-            if value >= SessionContentWidthSettings.minimumWidth,
-               value <= SessionContentWidthSettings.maximumWidth {
+            if value.isFinite, value >= SessionContentWidthSettings.minimumWidth {
                 snapshot.managedUserDefaults[SessionContentWidthSettings.maxWidthKey] = .double(
                     SessionContentWidthSettings().clampedMaximumWidth(value)
                 )

--- a/cmuxTests/SessionContentWidthSettingsFileStoreTests.swift
+++ b/cmuxTests/SessionContentWidthSettingsFileStoreTests.swift
@@ -36,6 +36,15 @@ struct SessionContentWidthSettingsFileStoreTests {
         }
     }
 
+    @Test
+    func settingsFileStoreAcceptsWidthAboveLegacyLimit() throws {
+        try loadSettings(maxWidthJSON: "10000", alignmentJSON: "\"center\"") { defaults in
+            #expect(
+                defaults.double(forKey: SessionContentWidthSettings.maxWidthKey) == 10_000
+            )
+        }
+    }
+
     private func loadSettings(
         maxWidthJSON: String,
         alignmentJSON: String,

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -560,7 +560,6 @@
             {
               "type": "number",
               "minimum": 320,
-              "maximum": 2400,
               "multipleOf": 20
             }
           ],


### PR DESCRIPTION
Removes the arbitrary 2400-point ceiling from session content width settings.

- accepts any finite width of at least 320 points
- keeps `false` as the default unlimited state
- updates Swift normalization, `cmux.json` import validation, and the published schema
- adds red/green regression coverage for values above the legacy limit

Verification:
- `swift test` in `Packages/macOS/CmuxSettings` (258 tests)
- tagged cloud build `unbnd`, run 29573644872
- canonical autoreview clean at 0.96 confidence

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8338"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786876774&installation_id=133855650&pr_number=8338&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8338&signature=a9f702181e1ed44f89fd3cf8af7f01643b5c1b1fffdf6926101e3bc0a9bb5c36"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes the 2400‑pt cap on session content width so users can set any finite width ≥320. Keeps the unlimited state by default and still rounds to the 20‑pt step.

- **New Features**
  - Normalize widths to the minimum and 20‑pt step with no upper bound in `SessionContentWidthSettings`.
  - Update settings import to accept finite widths above the legacy cap and apply normalization.
  - Remove the `maximum` constraint from the JSON schema and add tests for wide and extreme values.

<sup>Written for commit 8e3d25476a1eadb877338d3b9ca52235862d90ab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Increased flexibility for terminal session content widths by removing the previous upper limit.
  * Width values continue to require valid numbers, meet the minimum width, and follow the configured step size.
  * Configuration files and schema now accept widths above the former limit while preserving alignment settings.

* **Tests**
  * Added coverage confirming large width values are accepted and remain finite after normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->