### PR TITLE
Hide Mobile Connect button by default in release builds

### DIFF
--- a/Sources/FeatureFlags.swift
+++ b/Sources/FeatureFlags.swift
@@ -37,7 +37,11 @@ final class CmuxFeatureFlags {
     private static let proUpgradeUIDefault = false
     #endif
 
+    #if DEBUG
     private static let mobileConnectButtonDefault = true
+    #else
+    private static let mobileConnectButtonDefault = false
+    #endif
 
     #if DEBUG
     private static let cloudVMUIDefault = true
@@ -72,10 +76,10 @@ final class CmuxFeatureFlags {
             ),
 
             // FLAG(key: mobile-connect-button-enabled-release, owner: lawrencecchen,
-            //      reviewBy: 2026-10-01, defaultWhenUnavailable: true)
+            //      reviewBy: 2026-10-01, defaultWhenUnavailable: false)
             // Shows the top-right iPhone button that opens the Mobile Connect
-            // (phone pairing) window. Default keeps it visible when flags are
-            // unavailable; the window it opens ships in every build.
+            // (phone pairing) window. Release builds hide it until the PostHog
+            // flag is enabled; DEBUG keeps it visible for dogfood.
             CmuxFeatureFlagDefinition(
                 key: "mobile-connect-button-enabled-release",
                 title: String(localized: "featureFlags.mobileConnect.title", defaultValue: "Mobile Connect button"),


### PR DESCRIPTION
## Summary

The `mobile-connect-button-enabled-release` flag defaulted to `true` when the PostHog remote value was unavailable, so the top-right iPhone button (the Mobile Connect titlebar accessory) showed in release builds even with the flag off. This flips it to the same DEBUG-true / release-false pattern the other `-enabled-release` flags use.

Why the old default caused the reported bug: macOS flag fetching (`CmuxFeatureFlags.start()`) runs once at launch via `PostHogSDK.reloadFeatureFlags()`, and that only happens if the PostHog SDK started, which is gated behind telemetry consent (`PostHogAnalytics.startIfNeeded()`). With telemetry off, or any time the flags request fails, no remote value ever arrives and the effective value falls back to the compiled default. Because that default was `true`, the button showed permanently and disabling the dashboard flag + relaunching had no effect. It was also impossible to tell "flag on" from "flags never loaded."

After this change, release builds hide the button until the PostHog flag is explicitly enabled; DEBUG keeps it visible for dogfood. The pairing window it opens still ships in every build (command palette `Connect iPhone/iPad` is unchanged), and the local override in Help → Feature Flags… still works for immediate control on any build.

## Test plan

- [ ] Release build: iPhone titlebar button is hidden by default; enabling `mobile-connect-button-enabled-release` in PostHog (or a local override) shows it.
- [ ] DEBUG build: button still visible by default (dogfood).
- [ ] `Connect iPhone/iPad` command palette entry still opens the pairing window.

Note: `scripts/lint-feature-flags.py` currently fails on `main` for an unrelated flag (`sidebar-appkit-list-experiment` evaluated in two files); not touched here.

Made with [Cursor](https://cursor.com)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8342"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786880310&installation_id=133855650&pr_number=8342&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8342&signature=3453913870163303ae516fac0e230e8bb2ac07fe0a77bf16c549910932d2a1f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Flip the default for `mobile-connect-button-enabled-release`: DEBUG=true, release=false. This hides the Mobile Connect titlebar button by default in release and fixes it showing when flags don’t load or telemetry is off.

- **Bug Fixes**
  - Release: button stays hidden until the PostHog flag (or a local override) enables it.
  - DEBUG: button remains visible for dogfooding.
  - The “Connect iPhone/iPad” command palette action still opens the pairing window.

<sup>Written for commit 183f7ef381edb0076add7f7131301fb5ce5d9403. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8342?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Mobile Connect is now hidden by default in release builds unless enabled remotely.
  * Debug builds continue to display the Mobile Connect button by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->