### PR TITLE
Speed up Nightly builds with the shared Xcode 26 cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1807,7 +1807,7 @@ jobs:
         run: |
           set -euo pipefail
           cache_path="build-universal/CompilationCache.noindex"
-          max_cache_kib=$((3 * 1024 * 1024))
+          max_cache_kib=$((5 * 1024 * 1024))
           if [ -d "$cache_path" ]; then
             cache_kib=$(du -sk "$cache_path" | awk '{print $1}')
           else
@@ -1815,7 +1815,7 @@ jobs:
           fi
           echo "Xcode compilation cache size: ${cache_kib} KiB (limit: ${max_cache_kib} KiB)"
           if [ "$cache_kib" -gt "$max_cache_kib" ]; then
-            echo "Xcode compilation cache exceeds 3 GiB; skipping cache save"
+            echo "Xcode compilation cache exceeds 5 GiB; skipping cache save"
             rm -rf "$cache_path"
           fi
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -308,18 +308,6 @@ jobs:
       - name: Sanitize Swift package cache
         run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
 
-      - name: Derive Sparkle public key from private key
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: |
-          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
-            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
-            exit 1
-          fi
-          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
-          echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
-          echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
-
       - name: Build universal nightly app (Release)
         run: |
           set -euo pipefail
@@ -446,6 +434,18 @@ jobs:
         with:
           go-version-file: daemon/remote/go.mod
           cache-dependency-path: daemon/remote/go.sum
+
+      - name: Derive Sparkle public key from private key
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
+            exit 1
+          fi
+          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
+          echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
+          echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
 
       - name: Inject universal Ghostty CLI helper
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -308,6 +308,18 @@ jobs:
       - name: Sanitize Swift package cache
         run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
 
+      - name: Derive Sparkle public key from private key
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
+            exit 1
+          fi
+          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
+          echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
+          echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
+
       - name: Build universal nightly app (Release)
         run: |
           set -euo pipefail
@@ -434,18 +446,6 @@ jobs:
         with:
           go-version-file: daemon/remote/go.mod
           cache-dependency-path: daemon/remote/go.sum
-
-      - name: Derive Sparkle public key from private key
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: |
-          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
-            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
-            exit 1
-          fi
-          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
-          echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
-          echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
 
       - name: Inject universal Ghostty CLI helper
         run: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -188,7 +188,7 @@ jobs:
         run: |
           set -euo pipefail
           cache_path="build-universal/CompilationCache.noindex"
-          max_cache_kib=$((3 * 1024 * 1024))
+          max_cache_kib=$((5 * 1024 * 1024))
           if [ -d "$cache_path" ]; then
             cache_kib=$(du -sk "$cache_path" | awk '{print $1}')
           else
@@ -196,23 +196,188 @@ jobs:
           fi
           echo "Xcode compilation cache size: ${cache_kib} KiB (limit: ${max_cache_kib} KiB)"
           if [ "$cache_kib" -gt "$max_cache_kib" ]; then
-            echo "Xcode compilation cache exceeds 3 GiB; skipping cache save"
+            echo "Xcode compilation cache exceeds 5 GiB; skipping cache save"
             rm -rf "$cache_path"
           fi
 
-  build-sign-notarize-nightly:
+  build-nightly-ghostty-cli-helper:
     needs: decide
     if: needs.decide.outputs.should_build == 'true' && (github.event_name != 'schedule' || github.event.schedule == '47 8 * * *')
-    # Run on the macOS 15 host that carries the signing/notarization secrets.
-    # Import the Apple Developer ID intermediate chain into the build keychain
-    # below so signing does not depend on mutable runner login-keychain state.
-    # The Swift app still selects an Xcode with the macOS 26 SDK so it adopts
-    # Liquid Glass on Tahoe. The Ghostty CLI helper is built separately and
-    # injected before signing, preferring a pre-26 SDK when the runner image has
-    # one but falling back to the selected app Xcode when the image only ships
-    # Xcode 26. The helper build remains required and lipo-verified below.
+    # Zig 0.15.2 cannot link the real helper on macOS 26. Match the stable
+    # release workflow by building and verifying it on macOS 15 instead.
     runs-on: ${{ vars.MACOS_RUNNER_15 || 'blacksmith-6vcpu-macos-15' }}
-    timeout-minutes: 60
+    timeout-minutes: 20
+    steps:
+      - name: Clear stale git locks (self-hosted reused workspace)
+        shell: bash
+        run: |
+          ws="${GITHUB_WORKSPACE:-$PWD}"
+          rm -f "$ws/.git/index.lock" 2>/dev/null || true
+          if [ -d "$ws/.git/modules" ]; then
+            find "$ws/.git/modules" -type f -name "*.lock" -delete 2>/dev/null || true
+          fi
+
+      - name: Checkout helper ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.decide.outputs.head_sha }}
+          submodules: recursive
+
+      - name: Install Zig
+        run: ./scripts/install-zig-ci.sh
+
+      - name: Cache Zig packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: ~/.cache/zig
+          key: zig-packages-${{ hashFiles('ghostty/build.zig.zon', 'ghostty/build.zig.zon.json') }}
+          restore-keys: zig-packages-
+
+      - name: Build universal Ghostty CLI helper
+        run: |
+          set -euo pipefail
+          mkdir -p nightly-helper
+          ./scripts/build-ghostty-cli-helper.sh --universal --output nightly-helper/ghostty
+          lipo nightly-helper/ghostty -verify_arch arm64 x86_64
+
+      - name: Upload universal Ghostty CLI helper
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-nightly-ghostty-cli-helper
+          path: nightly-helper/ghostty
+          if-no-files-found: error
+          retention-days: 1
+
+  build-nightly-app:
+    needs: decide
+    if: needs.decide.outputs.should_build == 'true' && (github.event_name != 'schedule' || github.event.schedule == '47 8 * * *')
+    # Match the cache warmer and stable release app build exactly. Keeping the
+    # runner and pinned Xcode identical makes their compilation caches reusable.
+    runs-on: ${{ vars.MACOS_RUNNER_26_RELEASE || 'blacksmith-6vcpu-macos-26' }}
+    timeout-minutes: 45
+    env:
+      CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_26 }}
+      CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
+    steps:
+      - name: Clear stale git locks (self-hosted reused workspace)
+        shell: bash
+        run: |
+          ws="${GITHUB_WORKSPACE:-$PWD}"
+          rm -f "$ws/.git/index.lock" 2>/dev/null || true
+          if [ -d "$ws/.git/modules" ]; then
+            find "$ws/.git/modules" -type f -name "*.lock" -delete 2>/dev/null || true
+          fi
+
+      - name: Checkout build ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          ref: ${{ needs.decide.outputs.head_sha }}
+          submodules: recursive
+
+      - name: Select Xcode
+        run: ./scripts/select-ci-xcode.sh
+
+      - name: Compute Xcode compilation cache key
+        id: compilation-cache-key
+        run: |
+          set -euo pipefail
+          echo "toolchain=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+
+      - name: Cache Xcode compilation results
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: build-universal/CompilationCache.noindex
+          key: xcode-compilation-release-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ needs.decide.outputs.head_sha }}
+          restore-keys: |
+            xcode-compilation-release-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
+
+      - name: Install compilation dependencies
+        run: |
+          ./scripts/install-rust-ci.sh
+          ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Cache Swift packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .spm-cache
+          key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: spm-
+
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
+      - name: Derive Sparkle public key from private key
+        env:
+          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
+        run: |
+          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
+            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
+            exit 1
+          fi
+          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
+          echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
+          echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
+
+      - name: Build universal nightly app (Release)
+        run: |
+          set -euo pipefail
+          CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
+            -destination 'generic/platform=macOS' \
+            -clonedSourcePackagesDirPath .spm-cache \
+            -showBuildTimingSummary \
+            ARCHS="arm64 x86_64" \
+            ONLY_ACTIVE_ARCH=NO \
+            COMPILATION_CACHE_ENABLE_CACHING=YES \
+            COMPILATION_CACHE_LIMIT_SIZE=3221225472 \
+            COMPILER_INDEX_STORE_ENABLE=NO \
+            CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
+
+      - name: Bound Xcode compilation cache size
+        run: |
+          set -euo pipefail
+          cache_path="build-universal/CompilationCache.noindex"
+          max_cache_kib=$((5 * 1024 * 1024))
+          if [ -d "$cache_path" ]; then
+            cache_kib=$(du -sk "$cache_path" | awk '{print $1}')
+          else
+            cache_kib=0
+          fi
+          echo "Xcode compilation cache size: ${cache_kib} KiB (limit: ${max_cache_kib} KiB)"
+          if [ "$cache_kib" -gt "$max_cache_kib" ]; then
+            echo "Xcode compilation cache exceeds 5 GiB; skipping cache save"
+            rm -rf "$cache_path"
+          fi
+
+      - name: Archive unsigned nightly app and debug symbols
+        run: |
+          set -euo pipefail
+          products="build-universal/Build/Products/Release"
+          if [ ! -d "$products/cmux.app" ]; then
+            echo "Built app not found at $products/cmux.app" >&2
+            exit 1
+          fi
+          payload=("cmux.app")
+          while IFS= read -r dsym; do
+            payload+=("$(basename "$dsym")")
+          done < <(find "$products" -maxdepth 1 -name '*.dSYM' -print | sort)
+          tar -C "$products" -czf "$RUNNER_TEMP/cmux-nightly-unsigned.tar.gz" "${payload[@]}"
+
+      - name: Upload unsigned nightly app
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: cmux-nightly-unsigned-app
+          path: ${{ runner.temp }}/cmux-nightly-unsigned.tar.gz
+          if-no-files-found: error
+          retention-days: 1
+
+  build-sign-notarize-nightly:
+    needs: [decide, build-nightly-ghostty-cli-helper, build-nightly-app]
+    if: needs.decide.outputs.should_build == 'true' && (github.event_name != 'schedule' || github.event.schedule == '47 8 * * *')
+    # Sign and notarize on the same macOS 26 lane proven by stable releases.
+    runs-on: ${{ vars.MACOS_RUNNER_26 || 'blacksmith-6vcpu-macos-26' }}
+    timeout-minutes: 40
     steps:
       - name: Clear stale git locks (self-hosted reused workspace)
         shell: bash
@@ -232,29 +397,24 @@ jobs:
           ref: ${{ needs.decide.outputs.head_sha }}
           submodules: recursive
 
-      - name: Select Xcode
-        run: |
-          set -euo pipefail
-          ./scripts/select-nightly-xcodes.sh
-
-      # Xcode 26 compilation caching reuses unchanged Swift/Clang compilation
-      # results even though each nightly uses a clean DerivedData directory.
-      # Key snapshots by source revision and restore the newest compatible
-      # predecessor. Scheduled refreshes and release builds advance the same
-      # rolling cache instead of leaving one weekly snapshot to become stale.
-      - name: Compute Xcode compilation cache key
-        id: compilation-cache-key
-        run: |
-          set -euo pipefail
-          echo "toolchain=$(xcodebuild -version | shasum -a 256 | awk '{print $1}')" >> "$GITHUB_OUTPUT"
-
-      - name: Cache Xcode compilation results
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - name: Download unsigned nightly app
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
-          path: build-universal/CompilationCache.noindex
-          key: xcode-compilation-release-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-${{ needs.decide.outputs.head_sha }}
-          restore-keys: |
-            xcode-compilation-release-${{ runner.os }}-${{ runner.arch }}-${{ steps.compilation-cache-key.outputs.toolchain }}-
+          name: cmux-nightly-unsigned-app
+          path: nightly-inputs/app
+
+      - name: Download universal Ghostty CLI helper
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: cmux-nightly-ghostty-cli-helper
+          path: nightly-inputs/ghostty
+
+      - name: Restore unsigned nightly products
+        run: |
+          set -euo pipefail
+          products="build-universal/Build/Products/Release"
+          mkdir -p "$products"
+          tar -C "$products" -xzf nightly-inputs/app/cmux-nightly-unsigned.tar.gz
 
       # Provide node/npm explicitly. The build/sign/notarize job can land on a
       # self-hosted macOS runner (the iOS-CI minis match the same label) that has
@@ -268,8 +428,6 @@ jobs:
 
       - name: Install build deps
         run: |
-          ./scripts/install-rust-ci.sh
-          ./scripts/install-zig-ci.sh
           CMUX_NODE_BIN="$(command -v node)"
           export npm_config_prefix="$RUNNER_TEMP/npm-global"
           mkdir -p "$npm_config_prefix"
@@ -283,96 +441,11 @@ jobs:
           chmod +x "$wrapper_dir/create-dmg"
           echo "$wrapper_dir" >> "$GITHUB_PATH"
 
-      - name: Download pre-built GhosttyKit.xcframework
-        run: |
-          ./scripts/download-prebuilt-ghosttykit.sh
-
-      - name: Cache Swift packages
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: .spm-cache
-          key: spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
-          restore-keys: spm-
-
-      - name: Sanitize Swift package cache
-        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
-
       - name: Setup Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6.4.0
         with:
           go-version-file: daemon/remote/go.mod
           cache-dependency-path: daemon/remote/go.sum
-
-      - name: Derive Sparkle public key from private key
-        env:
-          SPARKLE_PRIVATE_KEY: ${{ secrets.SPARKLE_PRIVATE_KEY }}
-        run: |
-          if [ -z "$SPARKLE_PRIVATE_KEY" ]; then
-            echo "Missing SPARKLE_PRIVATE_KEY secret" >&2
-            exit 1
-          fi
-          DERIVED_PUBLIC_KEY=$(swift scripts/derive_sparkle_public_key.swift "$SPARKLE_PRIVATE_KEY")
-          echo "Derived Sparkle public key: $DERIVED_PUBLIC_KEY"
-          echo "SPARKLE_PUBLIC_KEY=$DERIVED_PUBLIC_KEY" >> "$GITHUB_ENV"
-
-      - name: Build universal nightly app and Ghostty CLI helper (Release)
-        run: |
-          set -euo pipefail
-          HELPER_LOG="$RUNNER_TEMP/cmux-nightly-ghostty-helper.log"
-          (
-            set -euo pipefail
-            export DEVELOPER_DIR="$HELPER_DEVELOPER_DIR"
-            ./scripts/build-ghostty-cli-helper.sh --universal --output /tmp/cmux-ghostty-helper-universal
-            ARCHS_OUT="$(lipo -archs /tmp/cmux-ghostty-helper-universal)"
-            echo "Universal Ghostty CLI helper architectures: $ARCHS_OUT"
-            case " $ARCHS_OUT " in *" arm64 "*) ;; *) echo "helper missing arm64 slice" >&2; exit 1 ;; esac
-            case " $ARCHS_OUT " in *" x86_64 "*) ;; *) echo "helper missing x86_64 slice" >&2; exit 1 ;; esac
-          ) >"$HELPER_LOG" 2>&1 &
-          HELPER_PID=$!
-
-          APP_STATUS=0
-          set +e
-          # Skip only the in-Xcode helper build; the background helper process
-          # above must build the real universal Zig helper, not the CI stub.
-          CMUX_SKIP_ZIG_BUILD=1 xcodebuild -scheme cmux -configuration Release -derivedDataPath build-universal \
-            -destination 'generic/platform=macOS' \
-            -clonedSourcePackagesDirPath .spm-cache \
-            -showBuildTimingSummary \
-            ARCHS="arm64 x86_64" \
-            ONLY_ACTIVE_ARCH=NO \
-            COMPILATION_CACHE_ENABLE_CACHING=YES \
-            COMPILATION_CACHE_LIMIT_SIZE=3221225472 \
-            COMPILER_INDEX_STORE_ENABLE=NO \
-            CODE_SIGNING_ALLOWED=NO ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly build
-          APP_STATUS=$?
-          set -e
-          HELPER_STATUS=0
-          wait "$HELPER_PID" || HELPER_STATUS=$?
-          cat "$HELPER_LOG"
-          if [ "$APP_STATUS" -ne 0 ]; then
-            echo "Universal nightly app build failed" >&2
-            exit "$APP_STATUS"
-          fi
-          if [ "$HELPER_STATUS" -ne 0 ]; then
-            echo "Universal Ghostty CLI helper build failed" >&2
-            exit "$HELPER_STATUS"
-          fi
-
-      - name: Bound Xcode compilation cache size
-        run: |
-          set -euo pipefail
-          cache_path="build-universal/CompilationCache.noindex"
-          max_cache_kib=$((3 * 1024 * 1024))
-          if [ -d "$cache_path" ]; then
-            cache_kib=$(du -sk "$cache_path" | awk '{print $1}')
-          else
-            cache_kib=0
-          fi
-          echo "Xcode compilation cache size: ${cache_kib} KiB (limit: ${max_cache_kib} KiB)"
-          if [ "$cache_kib" -gt "$max_cache_kib" ]; then
-            echo "Xcode compilation cache exceeds 3 GiB; skipping cache save"
-            rm -rf "$cache_path"
-          fi
 
       - name: Inject universal Ghostty CLI helper
         run: |
@@ -384,7 +457,7 @@ jobs:
           fi
           DEST="$APP_DIR/Contents/Resources/bin/ghostty"
           mkdir -p "$(dirname "$DEST")"
-          install -m 755 /tmp/cmux-ghostty-helper-universal "$DEST"
+          install -m 755 nightly-inputs/ghostty/ghostty "$DEST"
           echo "Injected Ghostty CLI helper architectures: $(lipo -archs "$DEST")"
 
       - name: Run bundled Ghostty theme picker helper regression

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -382,6 +382,7 @@ jobs:
       - name: Checkout build ref
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          persist-credentials: false
           ref: ${{ needs.decide.outputs.head_sha }}
           submodules: recursive
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -366,6 +366,9 @@ jobs:
     # Sign and notarize on the same macOS 26 lane proven by stable releases.
     runs-on: ${{ vars.MACOS_RUNNER_26 || 'blacksmith-6vcpu-macos-26' }}
     timeout-minutes: 40
+    env:
+      CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_26 }}
+      CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
     steps:
       - name: Clear stale git locks (self-hosted reused workspace)
         shell: bash
@@ -385,6 +388,9 @@ jobs:
           persist-credentials: false
           ref: ${{ needs.decide.outputs.head_sha }}
           submodules: recursive
+
+      - name: Select Xcode
+        run: ./scripts/select-ci-xcode.sh
 
       - name: Download unsigned nightly app
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -338,7 +338,7 @@ jobs:
             rm -rf "$cache_path"
           fi
 
-      - name: Archive unsigned nightly app and debug symbols
+      - name: Archive unsigned nightly app
         run: |
           set -euo pipefail
           products="build-universal/Build/Products/Release"
@@ -346,11 +346,7 @@ jobs:
             echo "Built app not found at $products/cmux.app" >&2
             exit 1
           fi
-          payload=("cmux.app")
-          while IFS= read -r dsym; do
-            payload+=("$(basename "$dsym")")
-          done < <(find "$products" -maxdepth 1 -name '*.dSYM' -print | sort)
-          tar -C "$products" -czf "$RUNNER_TEMP/cmux-nightly-unsigned.tar.gz" "${payload[@]}"
+          tar -C "$products" -czf "$RUNNER_TEMP/cmux-nightly-unsigned.tar.gz" cmux.app
 
       - name: Upload unsigned nightly app
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -359,6 +355,20 @@ jobs:
           path: ${{ runner.temp }}/cmux-nightly-unsigned.tar.gz
           if-no-files-found: error
           retention-days: 1
+
+      - name: Upload dSYMs to Sentry
+        env:
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: manaflow
+          SENTRY_PROJECT: cmuxterm-macos
+        run: |
+          if [ -z "${SENTRY_AUTH_TOKEN:-}" ]; then
+            echo "SENTRY_AUTH_TOKEN not set, skipping dSYM upload"
+            exit 0
+          fi
+          SENTRY_CLI="$(./scripts/ensure-sentry-cli.sh)"
+          "$SENTRY_CLI" debug-files upload --include-sources \
+            build-universal/Build/Products/Release/
 
   build-sign-notarize-nightly:
     needs: [decide, build-nightly-ghostty-cli-helper, build-nightly-app]
@@ -763,20 +773,6 @@ jobs:
             "build-universal/Build/Products/Release/cmux NIGHTLY.app" \
             "cmux-nightly-macos.dmg" \
             "$NIGHTLY_DMG_IMMUTABLE"
-
-      - name: Upload dSYMs to Sentry
-        env:
-          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_ORG: manaflow
-          SENTRY_PROJECT: cmuxterm-macos
-        run: |
-          if [ -z "$SENTRY_AUTH_TOKEN" ]; then
-            echo "SENTRY_AUTH_TOKEN not set, skipping dSYM upload"
-            exit 0
-          fi
-          SENTRY_CLI="$(./scripts/ensure-sentry-cli.sh)"
-          "$SENTRY_CLI" debug-files upload --include-sources \
-            build-universal/Build/Products/Release/
 
       - name: Generate Sparkle appcasts (nightly)
         env:

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -186,6 +186,19 @@ if ! awk '
 fi
 
 if ! awk '
+  /^  build-nightly-app:/ { job="build"; next }
+  /^  build-sign-notarize-nightly:/ { job="publish"; next }
+  /^  [a-zA-Z0-9_-]+:/ { job="" }
+  job == "build" && /^      - name: Derive Sparkle public key from private key/ { derived_in_build=1 }
+  job == "publish" && /^      - name: Derive Sparkle public key from private key/ { derived_in_publish=1 }
+  job == "publish" && /echo "SPARKLE_PUBLIC_KEY=\$DERIVED_PUBLIC_KEY" >> "\$GITHUB_ENV"/ { exported_in_publish=1 }
+  END { exit !(!derived_in_build && derived_in_publish && exported_in_publish) }
+' "$WORKFLOW_FILE"; then
+  echo "FAIL: the publishing job must derive and export the Sparkle public key it consumes"
+  exit 1
+fi
+
+if ! awk '
   /^      - name: Verify nightly binary architectures/ { in_verify=1; next }
   in_verify && /^      - name:/ { in_verify=0 }
   in_verify && /lipo -archs "\$APP_BINARY"/ { saw_app=1 }

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -6,7 +6,7 @@ ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW_FILE="$ROOT_DIR/.github/workflows/nightly.yml"
 
 if ! awk '
-  /^      - name: Build universal nightly app and Ghostty CLI helper \(Release\)/ { in_universal=1; next }
+  /^      - name: Build universal nightly app \(Release\)/ { in_universal=1; next }
   in_universal && /^      - name:/ { in_universal=0 }
   in_universal && /-destination '\''generic\/platform=macOS'\''/ { saw_universal_destination=1 }
   in_universal && /ARCHS="arm64 x86_64"/ { saw_universal_archs=1 }
@@ -25,7 +25,7 @@ fi
 
 if ! awk '
   /^  refresh-compilation-cache:/ { job="refresh"; next }
-  /^  build-sign-notarize-nightly:/ { job="publish"; next }
+  /^  build-nightly-app:/ { job="build"; next }
   /^  [a-zA-Z0-9_-]+:/ { job="" }
   job && /^      - name: Cache Xcode compilation results/ { in_cache=1; next }
   in_cache && /^      - name:/ { in_cache=0 }
@@ -36,10 +36,10 @@ if ! awk '
   in_cache && /restore-keys:/ { saw_restore[job]=1 }
   END {
     exit !(saw_path["refresh"] && saw_key["refresh"] && saw_toolchain["refresh"] && saw_head_sha["refresh"] && saw_restore["refresh"] &&
-           saw_path["publish"] && saw_key["publish"] && saw_toolchain["publish"] && saw_head_sha["publish"] && saw_restore["publish"])
+           saw_path["build"] && saw_key["build"] && saw_toolchain["build"] && saw_head_sha["build"] && saw_restore["build"])
   }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: cache warming and publishing must both roll the shared Release compilation cache forward by source revision"
+  echo "FAIL: cache warming and nightly app builds must both roll the shared Release compilation cache forward by source revision"
   exit 1
 fi
 
@@ -125,15 +125,15 @@ fi
 
 if ! awk '
   /^  refresh-compilation-cache:/ { job="refresh"; next }
-  /^  build-sign-notarize-nightly:/ { job="publish"; next }
+  /^  build-nightly-app:/ { job="build"; next }
   /^  [a-zA-Z0-9_-]+:/ { job="" }
   job && /^      - name: Bound Xcode compilation cache size/ { in_bound=1; next }
   in_bound && /^      - name:/ { in_bound=0 }
-  in_bound && /max_cache_kib=\$\(\(3 \* 1024 \* 1024\)\)/ { saw_limit[job]=1 }
+  in_bound && /max_cache_kib=\$\(\(5 \* 1024 \* 1024\)\)/ { saw_limit[job]=1 }
   in_bound && /rm -rf "\$cache_path"/ { saw_skip_save[job]=1 }
-  END { exit !(saw_limit["refresh"] && saw_skip_save["refresh"] && saw_limit["publish"] && saw_skip_save["publish"]) }
+  END { exit !(saw_limit["refresh"] && saw_skip_save["refresh"] && saw_limit["build"] && saw_skip_save["build"]) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: cache warming and publishing must each skip saving Xcode compilation caches larger than 3 GiB"
+  echo "FAIL: cache warming and nightly app builds must retain caches through 5 GiB and skip larger saves"
   exit 1
 fi
 
@@ -147,7 +147,7 @@ if ! awk '
   in_release && /restore-keys:/ { saw_restore=1 }
   in_release && /COMPILATION_CACHE_ENABLE_CACHING=YES/ { saw_cache_flag=1 }
   in_release && /COMPILATION_CACHE_LIMIT_SIZE=3221225472/ { saw_runtime_limit=1 }
-  in_release && /max_cache_kib=\$\(\(3 \* 1024 \* 1024\)\)/ { saw_save_limit=1 }
+  in_release && /max_cache_kib=\$\(\(5 \* 1024 \* 1024\)\)/ { saw_save_limit=1 }
   in_release && /rm -rf "\$cache_path"/ { saw_skip_save=1 }
   END { exit !(saw_path && saw_parent_exclusion && saw_key && saw_restore && saw_cache_flag && saw_runtime_limit && saw_save_limit && saw_skip_save) }
 ' "$CI_WORKFLOW_FILE"; then
@@ -156,23 +156,29 @@ if ! awk '
 fi
 
 if ! awk '
-  /^      - name: Build universal nightly app and Ghostty CLI helper \(Release\)/ { in_helper=1; next }
-  in_helper && /^      - name:/ { in_helper=0 }
-  in_helper && /build-ghostty-cli-helper\.sh --universal/ { saw_build=1 }
-  in_helper && /helper missing arm64 slice/ { saw_arm64_assert=1 }
-  in_helper && /helper missing x86_64 slice/ { saw_x86_assert=1 }
-  in_helper && /wait "\$HELPER_PID"/ { saw_wait=1 }
-  in_helper && /cat "\$HELPER_LOG"/ { saw_log=1 }
-  END { exit !(saw_build && saw_arm64_assert && saw_x86_assert && saw_wait && saw_log) }
+  /^  build-nightly-ghostty-cli-helper:/ { job="helper"; next }
+  /^  build-nightly-app:/ { job="app"; next }
+  /^  build-sign-notarize-nightly:/ { job="publish"; next }
+  /^  [a-zA-Z0-9_-]+:/ { job="" }
+  job == "helper" && /runs-on: \$\{\{ vars\.MACOS_RUNNER_15/ { saw_helper_runner=1 }
+  job == "helper" && /build-ghostty-cli-helper\.sh --universal/ { saw_build=1 }
+  job == "helper" && /lipo .* -verify_arch arm64 x86_64/ { saw_arch_assert=1 }
+  job == "helper" && /name: cmux-nightly-ghostty-cli-helper/ { saw_helper_artifact=1 }
+  job == "app" && /runs-on: \$\{\{ vars\.MACOS_RUNNER_26_RELEASE/ { saw_app_runner=1 }
+  job == "app" && /CMUX_CI_XCODE_APP_MACOS_26/ { saw_app_xcode=1 }
+  job == "app" && /select-ci-xcode\.sh/ { saw_app_selection=1 }
+  job == "publish" && /build-nightly-ghostty-cli-helper/ { saw_publish_needs_helper=1 }
+  job == "publish" && /build-nightly-app/ { saw_publish_needs_app=1 }
+  END { exit !(saw_helper_runner && saw_build && saw_arch_assert && saw_helper_artifact && saw_app_runner && saw_app_xcode && saw_app_selection && saw_publish_needs_helper && saw_publish_needs_app) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly workflow must build and verify the real universal Ghostty helper alongside the app build"
+  echo "FAIL: nightly must build the Ghostty helper on macOS 15 and the Xcode 26.5 app on macOS 26 before publishing"
   exit 1
 fi
 
 if ! awk '
   /^      - name: Inject universal Ghostty CLI helper/ { in_inject=1; next }
   in_inject && /^      - name:/ { in_inject=0 }
-  in_inject && /install -m 755 \/tmp\/cmux-ghostty-helper-universal "\$DEST"/ { saw_install=1 }
+  in_inject && /install -m 755 nightly-inputs\/ghostty\/ghostty "\$DEST"/ { saw_install=1 }
   END { exit !saw_install }
 ' "$WORKFLOW_FILE"; then
   echo "FAIL: nightly workflow must inject the verified universal Ghostty helper into the app"

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -186,19 +186,6 @@ if ! awk '
 fi
 
 if ! awk '
-  /^  build-nightly-app:/ { job="build"; next }
-  /^  build-sign-notarize-nightly:/ { job="publish"; next }
-  /^  [a-zA-Z0-9_-]+:/ { job="" }
-  job == "build" && /^      - name: Derive Sparkle public key from private key/ { derived_in_build=1 }
-  job == "publish" && /^      - name: Derive Sparkle public key from private key/ { derived_in_publish=1 }
-  job == "publish" && /echo "SPARKLE_PUBLIC_KEY=\$DERIVED_PUBLIC_KEY" >> "\$GITHUB_ENV"/ { exported_in_publish=1 }
-  END { exit !(!derived_in_build && derived_in_publish && exported_in_publish) }
-' "$WORKFLOW_FILE"; then
-  echo "FAIL: the publishing job must derive and export the Sparkle public key it consumes"
-  exit 1
-fi
-
-if ! awk '
   /^      - name: Verify nightly binary architectures/ { in_verify=1; next }
   in_verify && /^      - name:/ { in_verify=0 }
   in_verify && /lipo -archs "\$APP_BINARY"/ { saw_app=1 }

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -167,11 +167,15 @@ if ! awk '
   job == "app" && /runs-on: \$\{\{ vars\.MACOS_RUNNER_26_RELEASE/ { saw_app_runner=1 }
   job == "app" && /CMUX_CI_XCODE_APP_MACOS_26/ { saw_app_xcode=1 }
   job == "app" && /select-ci-xcode\.sh/ { saw_app_selection=1 }
+  job == "app" && /name: cmux-nightly-unsigned-app/ { saw_app_artifact=1 }
   job == "publish" && /build-nightly-ghostty-cli-helper/ { saw_publish_needs_helper=1 }
   job == "publish" && /build-nightly-app/ { saw_publish_needs_app=1 }
-  END { exit !(saw_helper_runner && saw_build && saw_arch_assert && saw_helper_artifact && saw_app_runner && saw_app_xcode && saw_app_selection && saw_publish_needs_helper && saw_publish_needs_app) }
+  job == "publish" && /name: cmux-nightly-unsigned-app/ { saw_app_download=1 }
+  job == "publish" && /path: nightly-inputs\/app/ { saw_app_download_path=1 }
+  job == "publish" && /tar -C "\$products" -xzf nightly-inputs\/app\/cmux-nightly-unsigned\.tar\.gz/ { saw_app_restore=1 }
+  END { exit !(saw_helper_runner && saw_build && saw_arch_assert && saw_helper_artifact && saw_app_runner && saw_app_xcode && saw_app_selection && saw_app_artifact && saw_publish_needs_helper && saw_publish_needs_app && saw_app_download && saw_app_download_path && saw_app_restore) }
 ' "$WORKFLOW_FILE"; then
-  echo "FAIL: nightly must build the Ghostty helper on macOS 15 and the Xcode 26.5 app on macOS 26 before publishing"
+  echo "FAIL: nightly must build and hand off the macOS 15 helper and Xcode 26.5 app before publishing"
   exit 1
 fi
 

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -168,6 +168,8 @@ if ! awk '
   job == "app" && /CMUX_CI_XCODE_APP_MACOS_26/ { saw_app_xcode=1 }
   job == "app" && /select-ci-xcode\.sh/ { saw_app_selection=1 }
   job == "app" && /name: cmux-nightly-unsigned-app/ { saw_app_artifact=1 }
+  job == "app" && /tar -C "\$products" -czf "\$RUNNER_TEMP\/cmux-nightly-unsigned\.tar\.gz" cmux\.app/ { saw_app_only_archive=1 }
+  job == "app" && /^      - name: Upload dSYMs to Sentry/ { saw_app_dsym_upload=1 }
   job == "publish" && /build-nightly-ghostty-cli-helper/ { saw_publish_needs_helper=1 }
   job == "publish" && /build-nightly-app/ { saw_publish_needs_app=1 }
   job == "publish" && /CMUX_CI_XCODE_APP_MACOS_26/ { saw_publish_xcode=1 }
@@ -175,7 +177,8 @@ if ! awk '
   job == "publish" && /name: cmux-nightly-unsigned-app/ { saw_app_download=1 }
   job == "publish" && /path: nightly-inputs\/app/ { saw_app_download_path=1 }
   job == "publish" && /tar -C "\$products" -xzf nightly-inputs\/app\/cmux-nightly-unsigned\.tar\.gz/ { saw_app_restore=1 }
-  END { exit !(saw_helper_runner && saw_build && saw_arch_assert && saw_helper_artifact && saw_app_runner && saw_app_xcode && saw_app_selection && saw_app_artifact && saw_publish_needs_helper && saw_publish_needs_app && saw_publish_xcode && saw_publish_selection && saw_app_download && saw_app_download_path && saw_app_restore) }
+  job == "publish" && /^      - name: Upload dSYMs to Sentry/ { saw_publish_dsym_upload=1 }
+  END { exit !(saw_helper_runner && saw_build && saw_arch_assert && saw_helper_artifact && saw_app_runner && saw_app_xcode && saw_app_selection && saw_app_artifact && saw_app_only_archive && saw_app_dsym_upload && saw_publish_needs_helper && saw_publish_needs_app && saw_publish_xcode && saw_publish_selection && saw_app_download && saw_app_download_path && saw_app_restore && !saw_publish_dsym_upload) }
 ' "$WORKFLOW_FILE"; then
   echo "FAIL: nightly must build and hand off the macOS 15 helper and Xcode 26.5 app before publishing"
   exit 1

--- a/tests/test_nightly_universal_build.sh
+++ b/tests/test_nightly_universal_build.sh
@@ -170,10 +170,12 @@ if ! awk '
   job == "app" && /name: cmux-nightly-unsigned-app/ { saw_app_artifact=1 }
   job == "publish" && /build-nightly-ghostty-cli-helper/ { saw_publish_needs_helper=1 }
   job == "publish" && /build-nightly-app/ { saw_publish_needs_app=1 }
+  job == "publish" && /CMUX_CI_XCODE_APP_MACOS_26/ { saw_publish_xcode=1 }
+  job == "publish" && /select-ci-xcode\.sh/ { saw_publish_selection=1 }
   job == "publish" && /name: cmux-nightly-unsigned-app/ { saw_app_download=1 }
   job == "publish" && /path: nightly-inputs\/app/ { saw_app_download_path=1 }
   job == "publish" && /tar -C "\$products" -xzf nightly-inputs\/app\/cmux-nightly-unsigned\.tar\.gz/ { saw_app_restore=1 }
-  END { exit !(saw_helper_runner && saw_build && saw_arch_assert && saw_helper_artifact && saw_app_runner && saw_app_xcode && saw_app_selection && saw_app_artifact && saw_publish_needs_helper && saw_publish_needs_app && saw_app_download && saw_app_download_path && saw_app_restore) }
+  END { exit !(saw_helper_runner && saw_build && saw_arch_assert && saw_helper_artifact && saw_app_runner && saw_app_xcode && saw_app_selection && saw_app_artifact && saw_publish_needs_helper && saw_publish_needs_app && saw_publish_xcode && saw_publish_selection && saw_app_download && saw_app_download_path && saw_app_restore) }
 ' "$WORKFLOW_FILE"; then
   echo "FAIL: nightly must build and hand off the macOS 15 helper and Xcode 26.5 app before publishing"
   exit 1


### PR DESCRIPTION
## Summary
- build the Nightly app with Xcode 26.5 on the same macOS 26 lane as cache warming and stable releases
- build the macOS 15-only Ghostty helper concurrently and combine artifacts before signing
- retain compilation caches up to 5 GiB instead of deleting the observed 3.36 GiB cache

## Testing
- `bash tests/test_nightly_universal_build.sh`
- `bash tests/test_ci_nightly_tag_push_auth.sh`
- `bash tests/test_ci_r2_upload_python.sh`
- `bash tests/test_ci_create_dmg_pinned.sh`
- `bash tests/test_ci_attestation_retry.sh`
- `bash tests/test_ci_ghosttykit_checksum_verification.sh`
- `bash tests/test_ci_self_hosted_guard.sh`
- Ruby YAML parse for `.github/workflows/nightly.yml` and `.github/workflows/ci.yml`

## Context
- The previous Nightly restored an Xcode 26.2 cache, grew it to 3.36 GiB, then deleted it before save.
- The four-times-daily warmer used Xcode 26.5, so its cache key could never match the Xcode 26.2 Nightly job.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8348"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786883520&installation_id=133855650&pr_number=8348&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8348&signature=2f8679b9c95827c322cadcdef90236930de83ec4d54c31261d3d117cd6d76b8c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Speed up Nightly builds by matching cache-warmer/stable lanes: build the app on macOS 26 with pinned Xcode 26.5, build the Ghostty helper on macOS 15, and sign on macOS 26. Share the Xcode 26 cache (retain up to 5 GiB), keep checkout tokens off runners, and keep debug symbols out of artifacts.

- **Refactors**
  - Split `nightly.yml` into `build-nightly-ghostty-cli-helper` (macOS 15), `build-nightly-app` (macOS 26 with pinned Xcode via `select-ci-xcode.sh`), and `build-sign-notarize-nightly` (macOS 26 with pinned Xcode).
  - Build and lipo-verify a universal Ghostty CLI helper on macOS 15; upload as an artifact and inject during signing.
  - Build the app on macOS 26; archive the unsigned app only as an artifact; upload dSYMs to Sentry from the build job.
  - Derive the Sparkle public key in the publish job and export `SPARKLE_PUBLIC_KEY` for packaging.
  - Raise the Xcode compilation cache save limit from 3 GiB to 5 GiB in `nightly.yml` and `ci.yml`; align cache keys with warmer/stable to share the Xcode 26 cache.
  - Use `persist-credentials: false` for all nightly checkouts.
  - Add tests to guard the helper/app artifact handoff, shared cache behavior, and dSYM upload location.

<sup>Written for commit 38225f6e6cdead5a4b285ffdce147050d55b3753. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8348?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved nightly macOS build reliability by splitting the pipeline into separate cache refresh, helper build, app build, and signing/notarization steps.
  - Increased the Xcode compilation cache limit to 5 GiB; when exceeded, large caches are cleaned and not saved.
  - Strengthened nightly universal build verification across macOS versions/architectures, including helper and app artifact checks.
  - Improved nightly release packaging and signing preparation, with clearer handling of publishing keys during release publishing only.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->