### PR TITLE
Make terminal closes undoable by default

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/AppCatalogSection.swift
@@ -131,8 +131,14 @@ public struct AppCatalogSection: SettingCatalogSection {
 
     public let warnBeforeClosingTab = DefaultsKey<Bool>(
         id: "app.warnBeforeClosingTab",
-        defaultValue: true,
+        defaultValue: false,
         userDefaultsKey: "warnBeforeClosingTabShortcut"
+    )
+
+    public let terminalCloseGracePeriodSeconds = DefaultsKey<Double>(
+        id: "app.terminalCloseGracePeriodSeconds",
+        defaultValue: 5,
+        userDefaultsKey: "terminalCloseGracePeriodSeconds"
     )
 
     public let warnBeforeClosingTabXButton = DefaultsKey<Bool>(

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/DomainSettingsStoreTests.swift
@@ -15,15 +15,15 @@ struct DefaultsKeyDirectAccessTests {
     @Test func readsDefaultWhenUnsetAndRoundTrips() {
         let defaults = makeScratchDefaults()
         let key = AppCatalogSection().warnBeforeClosingTab
-        #expect(key.value(in: defaults) == true)
+        #expect(key.value(in: defaults) == false)
         #expect(!key.hasStoredValue(in: defaults))
 
-        key.set(false, in: defaults)
-        #expect(key.value(in: defaults) == false)
+        key.set(true, in: defaults)
+        #expect(key.value(in: defaults) == true)
         #expect(key.hasStoredValue(in: defaults))
 
         key.removeValue(in: defaults)
-        #expect(key.value(in: defaults) == true)
+        #expect(key.value(in: defaults) == false)
     }
 
     @Test func undecodableStoredValueReadsAsDefault() {
@@ -51,7 +51,7 @@ struct DefaultsKeyDirectAccessTests {
 struct CloseTabWarningStoreTests {
     @Test func defaultsMatchLegacyNamespace() {
         let store = CloseTabWarningStore(defaults: makeScratchDefaults())
-        #expect(store.warnsBeforeClosingTab == true)
+        #expect(store.warnsBeforeClosingTab == false)
         #expect(store.warnsBeforeClosingTabXButton == false)
         #expect(store.hidesTabCloseButton == false)
     }

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Navigation/CuratedSettingEntry+Default.swift
@@ -50,6 +50,7 @@ extension Array where Element == CuratedSettingEntry {
             .init(section: .app, id: "telemetry", title: "Send anonymous telemetry", synonyms: "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy"),
             .init(section: .app, id: "warn-before-quit", title: "Warn Before Quit", synonyms: "app.confirmQuit quit confirmation command-q cmd-q exit close app"),
             .init(section: .app, id: "warn-before-closing-tab", title: "Warn Before Closing Tab", synonyms: "app.warnBeforeClosingTab close tab confirmation command-w cmd-w terminal surface"),
+            .init(section: .app, id: "terminal-close-grace-period", title: "Terminal Close Grace Period", synonyms: "app.terminalCloseGracePeriodSeconds command-shift-t reopen restore terminal grace seconds"),
             .init(section: .app, id: "warn-before-closing-tab-x-button", title: "Warn Before Tab Close Button", synonyms: "app.warnBeforeClosingTabXButton x button close tab confirmation terminal surface"),
             .init(section: .app, id: "hide-tab-close-button", title: "Hide Tab Close Button", synonyms: "app.hideTabCloseButton hide x button close tab terminal surface"),
             .init(section: .app, id: "rename-selects-name", title: "Rename Selects Existing Name", synonyms: "app.renameSelectsExistingName rename select all existing title command palette workspace name"),

--- a/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
+++ b/Packages/macOS/CmuxSettingsUI/Sources/CmuxSettingsUI/Sections/AppSection.swift
@@ -58,6 +58,7 @@ public struct AppSection: View {
     @State private var telemetry: DefaultsValueModel<Bool>
     @State private var confirmQuit: DefaultsValueModel<ConfirmQuitMode>
     @State private var warnCloseTab: DefaultsValueModel<Bool>
+    @State private var terminalCloseGracePeriod: DefaultsValueModel<Double>
     @State private var warnCloseX: DefaultsValueModel<Bool>
     @State private var hideCloseButton: DefaultsValueModel<Bool>
     @State private var renameSelects: DefaultsValueModel<Bool>
@@ -110,6 +111,7 @@ public struct AppSection: View {
         _telemetry = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.sendAnonymousTelemetry))
         _confirmQuit = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.confirmQuitMode))
         _warnCloseTab = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.warnBeforeClosingTab))
+        _terminalCloseGracePeriod = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.terminalCloseGracePeriodSeconds))
         _warnCloseX = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.warnBeforeClosingTabXButton))
         _hideCloseButton = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.hideTabCloseButton))
         _renameSelects = State(initialValue: DefaultsValueModel(store: defaultsStore, key: catalog.app.renameSelectsExistingName))
@@ -136,7 +138,7 @@ public struct AppSection: View {
             mainCard
         }
         .task {
-            startSettingsObservation([language, appearance, appIcon, placement, inheritDir, minimalMode, keepWorkspaceOpen, firstClick, fileDrop, preferredEditor, openSupported, openMarkdown, globalFontMagnification, markdownFontSize, markdownFontFamily, markdownMaxWidth, canvasPaneGap, canvasSnapping, fileEditorWordWrap, iMessage, reorder, dockBadge, menuBarOnly, showInMenuBar, paneRing, paneFlash, agentPermissionPrompt, agentTurnComplete, agentIdleReminder, soundName, soundCommand, customSoundFile, telemetry, confirmQuit, warnCloseTab, warnCloseX, hideCloseButton, renameSelects, paletteAllSurfaces])
+            startSettingsObservation([language, appearance, appIcon, placement, inheritDir, minimalMode, keepWorkspaceOpen, firstClick, fileDrop, preferredEditor, openSupported, openMarkdown, globalFontMagnification, markdownFontSize, markdownFontFamily, markdownMaxWidth, canvasPaneGap, canvasSnapping, fileEditorWordWrap, iMessage, reorder, dockBadge, menuBarOnly, showInMenuBar, paneRing, paneFlash, agentPermissionPrompt, agentTurnComplete, agentIdleReminder, soundName, soundCommand, customSoundFile, telemetry, confirmQuit, warnCloseTab, terminalCloseGracePeriod, warnCloseX, hideCloseButton, renameSelects, paletteAllSurfaces])
             if languageAtAppear == nil { languageAtAppear = language.current }; if telemetryAtAppear == nil { telemetryAtAppear = telemetry.current }
         }
     }
@@ -712,11 +714,41 @@ public struct AppSection: View {
                 String(localized: "settings.app.warnBeforeClosingTab", defaultValue: "Warn Before Closing Tab"),
                 subtitle: warnCloseTab.current
                     ? String(localized: "settings.app.warnBeforeClosingTab.subtitleOn", defaultValue: "Show a confirmation before closing a tab.")
-                    : String(localized: "settings.app.warnBeforeClosingTab.subtitleOff", defaultValue: "Tabs close immediately without confirmation.")
+                    : String(localized: "settings.app.warnBeforeClosingTab.subtitleOff", defaultValue: "Terminals close without confirmation and remain available briefly for Command-Shift-T.")
             ) {
                 Toggle("", isOn: Binding(get: { warnCloseTab.current }, set: { warnCloseTab.set($0) }))
                     .labelsHidden()
                     .controlSize(.small)
+            }
+            SettingsCardDivider()
+
+            SettingsCardRow(
+                configurationReview: .json("app.terminalCloseGracePeriodSeconds"),
+                String(localized: "settings.app.terminalCloseGracePeriod", defaultValue: "Terminal Close Grace Period"),
+                subtitle: String(localized: "settings.app.terminalCloseGracePeriod.subtitle", defaultValue: "Keep closed terminals alive for Command-Shift-T. Set to 0 to close immediately."),
+                controlWidth: Self.columnWidth
+            ) {
+                HStack(spacing: 8) {
+                    Text(String(
+                        format: String(localized: "settings.app.terminalCloseGracePeriod.value", defaultValue: "%.0f s"),
+                        terminalCloseGracePeriod.current
+                    ))
+                    .cmuxFont(.body, design: .monospaced)
+                    .monospacedDigit()
+                    .frame(width: 56, alignment: .trailing)
+                    Stepper(
+                        "",
+                        value: Binding(
+                            get: { terminalCloseGracePeriod.current },
+                            set: { terminalCloseGracePeriod.set($0) }
+                        ),
+                        in: 0...60,
+                        step: 1
+                    )
+                    .labelsHidden()
+                }
+                .disabled(warnCloseTab.current)
+                .accessibilityIdentifier("SettingsTerminalCloseGracePeriodStepper")
             }
             SettingsCardDivider()
 

--- a/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
+++ b/Packages/macOS/CmuxSettingsUI/Tests/CmuxSettingsUITests/SettingsRowAnchorResolutionTests.swift
@@ -54,6 +54,7 @@ struct SettingsRowAnchorResolutionTests {
         "app.reorderOnNotification",
         "app.sendAnonymousTelemetry",
         "app.warnBeforeClosingTab",
+        "app.terminalCloseGracePeriodSeconds",
         "app.warnBeforeClosingTabXButton",
         "app.workspaceInheritWorkingDirectory",
         "automation.claudeBinaryPath",

--- a/Sources/AppDelegate+ClosedItemHistory.swift
+++ b/Sources/AppDelegate+ClosedItemHistory.swift
@@ -1,5 +1,63 @@
 import AppKit
 
+@MainActor
+final class UndoableTerminalCloseStore {
+    static let shared = UndoableTerminalCloseStore()
+
+    private struct PendingClose {
+        let id: UUID
+        let restore: @MainActor () -> Bool
+        let finalize: @MainActor () -> Void
+        var expirationTask: Task<Void, Never>?
+    }
+
+    private var pendingCloses: [PendingClose] = []
+
+    @discardableResult
+    func stage(
+        gracePeriod: TimeInterval,
+        restore: @escaping @MainActor () -> Bool,
+        finalize: @escaping @MainActor () -> Void
+    ) -> UUID? {
+        guard gracePeriod > 0 else {
+            finalize()
+            return nil
+        }
+
+        let id = UUID()
+        pendingCloses.append(PendingClose(id: id, restore: restore, finalize: finalize))
+        let task = Task { @MainActor [weak self] in
+            try? await Task.sleep(for: .seconds(gracePeriod))
+            guard !Task.isCancelled else { return }
+            self?.expire(id: id)
+        }
+        pendingCloses[pendingCloses.count - 1].expirationTask = task
+        return id
+    }
+
+    @discardableResult
+    func restoreMostRecent() -> Bool {
+        guard var pending = pendingCloses.popLast() else { return false }
+        pending.expirationTask?.cancel()
+        pending.expirationTask = nil
+        guard pending.restore() else {
+            pending.finalize()
+            return false
+        }
+        return true
+    }
+
+    func expire(id: UUID) {
+        guard let index = pendingCloses.firstIndex(where: { $0.id == id }) else { return }
+        var pending = pendingCloses.remove(at: index)
+        pending.expirationTask?.cancel()
+        pending.expirationTask = nil
+        pending.finalize()
+    }
+
+    var pendingCount: Int { pendingCloses.count }
+}
+
 extension AppDelegate {
     func clearRecentlyClosedHistory(preferredTabManager: TabManager? = nil) {
         ClosedItemHistoryStore.shared.removeAll()
@@ -26,6 +84,10 @@ extension AppDelegate {
         preferredTabManager: TabManager? = nil,
         shouldActivate: Bool = true
     ) -> Bool {
+        if UndoableTerminalCloseStore.shared.restoreMostRecent() {
+            return true
+        }
+
         var failedStoreRecordIds: Set<UUID> = []
         let restoreStoreItem: (Date?) -> Bool = { cutoff in
             ClosedItemHistoryStore.shared.restoreFirstRestorable(

--- a/Sources/CmuxSettingsJSONPathSupport.swift
+++ b/Sources/CmuxSettingsJSONPathSupport.swift
@@ -398,6 +398,7 @@ extension CmuxSettingsFileStore {
         "app.confirmQuit",
         "app.warnBeforeQuit",
         "app.warnBeforeClosingTab",
+        "app.terminalCloseGracePeriodSeconds",
         "app.warnBeforeClosingTabXButton",
         "app.hideTabCloseButton",
         "app.renameSelectsExistingName",

--- a/Sources/KeyboardShortcutSettingsFileStore+Template.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore+Template.swift
@@ -76,6 +76,7 @@ extension CmuxSettingsFileStore {
                     "sendAnonymousTelemetry": AppCatalogSection().sendAnonymousTelemetry.defaultValue,
                     "confirmQuit": AppCatalogSection().confirmQuitMode.defaultValue.rawValue,
                     "warnBeforeClosingTab": AppCatalogSection().warnBeforeClosingTab.defaultValue,
+                    "terminalCloseGracePeriodSeconds": AppCatalogSection().terminalCloseGracePeriodSeconds.defaultValue,
                     "warnBeforeClosingTabXButton": AppCatalogSection().warnBeforeClosingTabXButton.defaultValue,
                     "hideTabCloseButton": AppCatalogSection().hideTabCloseButton.defaultValue,
                     "renameSelectsExistingName": AppCatalogSection().renameSelectsExistingName.defaultValue,

--- a/Sources/KeyboardShortcutSettingsFileStore.swift
+++ b/Sources/KeyboardShortcutSettingsFileStore.swift
@@ -515,6 +515,15 @@ final class CmuxSettingsFileStore {
         }
         applyBooleanSettings(AppSettingsFileMapping.booleanSettings, from: section, sourcePath: sourcePath, snapshot: &snapshot)
         applyStringSettings(AppSettingsFileMapping.stringSettings, from: section, snapshot: &snapshot)
+        if let value = jsonDouble(section["terminalCloseGracePeriodSeconds"]) {
+            if (0...60).contains(value) {
+                snapshot.managedUserDefaults[AppCatalogSection().terminalCloseGracePeriodSeconds.userDefaultsKey] = .double(value)
+            } else {
+                logInvalid("app.terminalCloseGracePeriodSeconds", sourcePath: sourcePath)
+            }
+        } else if section.keys.contains("terminalCloseGracePeriodSeconds") {
+            logInvalid("app.terminalCloseGracePeriodSeconds", sourcePath: sourcePath)
+        }
         if let value = jsonBool(section["minimalMode"]) {
             let mode = value ? WorkspacePresentationModeSettings.Mode.minimal : .standard
             snapshot.managedUserDefaults[WorkspacePresentationModeSettings.modeKey] = .string(mode.rawValue)

--- a/Sources/SettingsNavigation.swift
+++ b/Sources/SettingsNavigation.swift
@@ -363,6 +363,7 @@ enum SettingsSearchIndex {
         setting(.app, "default-terminal", String(localized: "settings.app.defaultTerminal", defaultValue: "Default Terminal"), "ssh links command tool unix executable launch services handler registration system default"),
         setting(.app, "warn-before-quit", String(localized: "settings.app.warnBeforeQuit", defaultValue: "Warn Before Quit"), "cmd q confirmation confirmQuit"),
         setting(.app, "warn-before-closing-tab", String(localized: "settings.app.warnBeforeClosingTab", defaultValue: "Warn Before Closing Tab"), "cmd w close tab confirmation"),
+        setting(.app, "terminal-close-grace-period", String(localized: "settings.app.terminalCloseGracePeriod", defaultValue: "Terminal Close Grace Period"), "cmd shift t reopen restore terminal grace seconds"),
         setting(
             .app,
             "warn-before-closing-tab-x-button",
@@ -519,6 +520,7 @@ enum SettingsSearchIndex {
         "app.confirmQuit": settingID(for: .app, idSuffix: "warn-before-quit"),
         "app.warnBeforeQuit": settingID(for: .app, idSuffix: "warn-before-quit"),
         "app.warnBeforeClosingTab": settingID(for: .app, idSuffix: "warn-before-closing-tab"),
+        "app.terminalCloseGracePeriodSeconds": settingID(for: .app, idSuffix: "terminal-close-grace-period"),
         "app.warnBeforeClosingTabXButton": settingID(for: .app, idSuffix: "warn-before-closing-tab-x-button"),
         "app.hideTabCloseButton": settingID(for: .app, idSuffix: "hide-tab-close-button"),
         "app.renameSelectsExistingName": settingID(for: .app, idSuffix: "rename-selects-name"),

--- a/Sources/SettingsSearchAliases.swift
+++ b/Sources/SettingsSearchAliases.swift
@@ -84,6 +84,7 @@ enum SettingsSearchAliasIndex {
         "app:telemetry": localized("settings.search.alias.setting.app.telemetry", defaultValue: "app.sendAnonymousTelemetry analytics crash reports sentry posthog usage anonymous privacy"),
         "app:warn-before-quit": localized("settings.search.alias.setting.app.warn-before-quit", defaultValue: "app.warnBeforeQuit quit confirmation command-q cmd-q exit close app"),
         "app:warn-before-closing-tab": localized("settings.search.alias.setting.app.warn-before-closing-tab", defaultValue: "app.warnBeforeClosingTab close tab confirmation command-w cmd-w terminal surface"),
+        "app:terminal-close-grace-period": localized("settings.search.alias.setting.app.terminal-close-grace-period", defaultValue: "app.terminalCloseGracePeriodSeconds command-shift-t reopen restore terminal grace seconds"),
         "app:warn-before-closing-tab-x-button": localized(
             "settings.search.alias.setting.app.warn-before-closing-tab-x-button",
             defaultValue: "app.warnBeforeClosingTabXButton close tab x button confirmation terminal surface"

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -2709,6 +2709,41 @@ class TabManager: ObservableObject {
         )
 #endif
 
+        let closeWarningEnabled = CloseTabWarningStore(defaults: closeTabWarningDefaults).warnsBeforeClosingTab
+        let closeGracePeriod = max(
+            0,
+            min(60, settings.value(for: settingsCatalog.app.terminalCloseGracePeriodSeconds))
+        )
+        if !closeWarningEnabled,
+           closeGracePeriod > 0,
+           tab.panels[panelId] is TerminalPanel {
+            if closesWorkspaceOnLastSurfaceShortcut,
+               stageUndoableWorkspaceClose(tab, gracePeriod: closeGracePeriod) {
+                return
+            }
+            if let closed = tab.detachTerminalForUndo(panelId: panelId) {
+                UndoableTerminalCloseStore.shared.stage(
+                    gracePeriod: closeGracePeriod,
+                    restore: { [weak self, weak tab] in
+                        guard let self,
+                              let tab,
+                              self.tabs.contains(where: { $0 === tab }) else {
+                            return false
+                        }
+                        return tab.restoreUndoableTerminal(closed)
+                    },
+                    finalize: { [weak tab] in
+                        if let tab {
+                            tab.finalizeUndoableTerminal(closed)
+                        } else {
+                            closed.transfer.panel.close()
+                        }
+                    }
+                )
+                return
+            }
+        }
+
         if closesWorkspaceOnLastSurfaceShortcut,
            let surfaceId = tab.surfaceIdFromPanelId(panelId) {
             tab.markExplicitClose(surfaceId: surfaceId)
@@ -2722,6 +2757,39 @@ class TabManager: ObservableObject {
             "panelsAfterCall=\(tab.panels.count)"
         )
 #endif
+    }
+
+    @discardableResult
+    private func stageUndoableWorkspaceClose(_ workspace: Workspace, gracePeriod: TimeInterval) -> Bool {
+        guard let index = tabs.firstIndex(where: { $0 === workspace }) else { return false }
+        panelTitleUpdateCoalescer.flushNow()
+        let historyEntry = ClosedWorkspaceHistoryEntry(
+            workspaceId: workspace.id,
+            windowId: AppDelegate.shared?.windowId(for: self),
+            workspaceIndex: index,
+            snapshot: workspace.sessionSnapshot(
+                includeScrollback: true,
+                restorableAgentIndex: SharedLiveAgentIndex.shared.currentIndexSchedulingRefresh()
+                    ?? RestorableAgentSessionIndex.load()
+            )
+        )
+        guard let detachedWorkspace = detachWorkspace(tabId: workspace.id) else { return false }
+
+        UndoableTerminalCloseStore.shared.stage(
+            gracePeriod: gracePeriod,
+            restore: { [weak self] in
+                guard let self else { return false }
+                self.attachWorkspace(detachedWorkspace, at: index, select: true)
+                return true
+            },
+            finalize: {
+                ClosedItemHistoryStore.shared.push(.workspace(historyEntry))
+                AppDelegate.shared?.notificationStore?.clearNotifications(forTabId: detachedWorkspace.id)
+                detachedWorkspace.teardownAllPanels()
+                detachedWorkspace.teardownRemoteConnection()
+            }
+        )
+        return true
     }
 
     private func shortcutCloseTargetPanelId(in workspace: Workspace) -> UUID? {

--- a/Sources/Workspace+DetachedSurfaceTransfer.swift
+++ b/Sources/Workspace+DetachedSurfaceTransfer.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Bonsplit
 import CmuxCore
 import CmuxWorkspaces
 import Darwin
@@ -6,6 +7,13 @@ import CmuxNotifications
 import CmuxSidebar
 
 extension Workspace {
+    struct UndoableDetachedTerminal {
+        let transfer: DetachedSurfaceTransfer
+        let originalPaneId: PaneID
+        let originalTabIndex: Int
+        let historyEntry: ClosedPanelHistoryEntry
+    }
+
     struct DetachedAgentRuntimeState {
         let panelId: UUID
         let statusEntries: [String: SidebarStatusEntry]
@@ -81,5 +89,62 @@ extension Workspace {
                 remoteCleanupConfiguration: configuration
             )
         }
+    }
+
+    func detachTerminalForUndo(panelId: UUID) -> UndoableDetachedTerminal? {
+        guard panels[panelId] is TerminalPanel,
+              let tabId = surfaceIdFromPanelId(panelId),
+              let paneId = paneId(forPanelId: panelId),
+              let tabIndex = bonsplitController.tabs(inPane: paneId).firstIndex(where: { $0.id == tabId }),
+              let historyEntry = closedPanelHistoryEntry(panelId: panelId, tabId: tabId, pane: paneId),
+              let transfer = detachSurface(panelId: panelId) else {
+            return nil
+        }
+        return UndoableDetachedTerminal(
+            transfer: transfer,
+            originalPaneId: paneId,
+            originalTabIndex: tabIndex,
+            historyEntry: historyEntry
+        )
+    }
+
+    @discardableResult
+    func restoreUndoableTerminal(_ closed: UndoableDetachedTerminal) -> Bool {
+        let paneId = bonsplitController.allPaneIds.contains(closed.originalPaneId)
+            ? closed.originalPaneId
+            : (bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first)
+        guard let paneId else { return false }
+        return attachDetachedSurface(
+            closed.transfer,
+            inPane: paneId,
+            atIndex: closed.originalTabIndex,
+            focus: true
+        ) != nil
+    }
+
+    func finalizeUndoableTerminal(_ closed: UndoableDetachedTerminal) {
+        ClosedItemHistoryStore.shared.push(.panel(closed.historyEntry))
+        AppDelegate.shared?.notificationStore?.clearNotifications(
+            forTabId: closed.transfer.sourceWorkspaceId,
+            surfaceId: closed.transfer.panelId
+        )
+
+        let paneId = bonsplitController.allPaneIds.contains(closed.originalPaneId)
+            ? closed.originalPaneId
+            : (bonsplitController.focusedPaneId ?? bonsplitController.allPaneIds.first)
+        if let paneId,
+           attachDetachedSurface(
+               closed.transfer,
+               inPane: paneId,
+               atIndex: closed.originalTabIndex,
+               focus: false
+           ) != nil {
+            withClosedPanelHistorySuppressed {
+                _ = closePanel(closed.transfer.panelId, force: true)
+            }
+            return
+        }
+
+        closed.transfer.panel.close()
     }
 }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -707,7 +707,7 @@ extension Workspace {
             project: projectSnapshot, workspaceTodo: workspaceTodoSnapshot
         )
     }
-    private func closedPanelHistoryEntry(panelId: UUID, tabId: TabID, pane: PaneID) -> ClosedPanelHistoryEntry? {
+    func closedPanelHistoryEntry(panelId: UUID, tabId: TabID, pane: PaneID) -> ClosedPanelHistoryEntry? {
         guard !suppressClosedPanelHistory else { return nil }
         owningTabManager?.flushPendingPanelTitleUpdatesForWorkspaceSnapshot()
         guard let tabIndex = bonsplitController.tabs(inPane: pane).firstIndex(where: { $0.id == tabId }) else {

--- a/cmuxTests/TabManagerUnitTests.swift
+++ b/cmuxTests/TabManagerUnitTests.swift
@@ -1595,12 +1595,32 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
         )
     }
 
-    func testCloseCurrentPanelWarnBeforeClosingTabDefaultsToEnabledWhenUnset() throws {
+    func testCloseCurrentPanelWarnBeforeClosingTabDefaultsToDisabledWhenUnset() throws {
         try assertCloseCurrentPanelConfirmation(
             warnBeforeClosingTab: nil,
-            expectedPromptCount: 1,
-            expectedPanelClosed: false
+            expectedPromptCount: 0,
+            expectedPanelClosed: true
         )
+    }
+
+    func testCloseCurrentPanelRestoresSameLiveTerminalDuringGracePeriod() throws {
+        try withCloseTabConfig(warnBeforeClosingTab: false, terminalCloseGracePeriodSeconds: 60) {
+            let manager = TabManager()
+            guard let workspace = manager.selectedWorkspace,
+                  let paneId = workspace.bonsplitController.focusedPaneId,
+                  let panelId = workspace.focusedPanelId,
+                  let terminal = workspace.terminalPanel(for: panelId),
+                  workspace.newTerminalSurface(inPane: paneId, focus: false) != nil else {
+                XCTFail("Expected workspace with two terminal surfaces")
+                return
+            }
+            workspace.focusPanel(panelId)
+
+            manager.closeCurrentPanelWithConfirmation()
+            XCTAssertNil(workspace.panels[panelId])
+            XCTAssertTrue(UndoableTerminalCloseStore.shared.restoreMostRecent())
+            XCTAssertTrue(workspace.panels[panelId] === terminal)
+        }
     }
 
     func testTabCloseButtonWarningHonorsCmuxJSON() throws {
@@ -2216,6 +2236,7 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
         warnBeforeClosingTab: Bool? = nil,
         warnBeforeClosingTabXButton: Bool? = nil,
         hideTabCloseButton: Bool? = nil,
+        terminalCloseGracePeriodSeconds: Double = 0,
         run: () throws -> Void
     ) throws {
         let originalSettingsFileStore = KeyboardShortcutSettings.settingsFileStore
@@ -2223,16 +2244,19 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
         let originalWarnBeforeClosingTab = defaults.object(forKey: AppCatalogSection().warnBeforeClosingTab.userDefaultsKey)
         let originalWarnBeforeClosingTabXButton = defaults.object(forKey: AppCatalogSection().warnBeforeClosingTabXButton.userDefaultsKey)
         let originalHideTabCloseButton = defaults.object(forKey: AppCatalogSection().hideTabCloseButton.userDefaultsKey)
+        let originalGracePeriod = defaults.object(forKey: AppCatalogSection().terminalCloseGracePeriodSeconds.userDefaultsKey)
         let originalBackups = defaults.object(forKey: settingsFileBackupsDefaultsKey)
         defaults.removeObject(forKey: AppCatalogSection().warnBeforeClosingTab.userDefaultsKey)
         defaults.removeObject(forKey: AppCatalogSection().warnBeforeClosingTabXButton.userDefaultsKey)
         defaults.removeObject(forKey: AppCatalogSection().hideTabCloseButton.userDefaultsKey)
+        defaults.removeObject(forKey: AppCatalogSection().terminalCloseGracePeriodSeconds.userDefaultsKey)
         defaults.removeObject(forKey: settingsFileBackupsDefaultsKey)
         defer {
             KeyboardShortcutSettings.settingsFileStore = originalSettingsFileStore
             restore(originalWarnBeforeClosingTab, forKey: AppCatalogSection().warnBeforeClosingTab.userDefaultsKey, defaults: defaults)
             restore(originalWarnBeforeClosingTabXButton, forKey: AppCatalogSection().warnBeforeClosingTabXButton.userDefaultsKey, defaults: defaults)
             restore(originalHideTabCloseButton, forKey: AppCatalogSection().hideTabCloseButton.userDefaultsKey, defaults: defaults)
+            restore(originalGracePeriod, forKey: AppCatalogSection().terminalCloseGracePeriodSeconds.userDefaultsKey, defaults: defaults)
             if let originalBackups {
                 defaults.set(originalBackups, forKey: settingsFileBackupsDefaultsKey)
             } else {
@@ -2252,6 +2276,7 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
             warnBeforeClosingTab.map { #"    "warnBeforeClosingTab": \#($0)"# },
             warnBeforeClosingTabXButton.map { #"    "warnBeforeClosingTabXButton": \#($0)"# },
             hideTabCloseButton.map { #"    "hideTabCloseButton": \#($0)"# },
+            #"    "terminalCloseGracePeriodSeconds": \#(terminalCloseGracePeriodSeconds)"#,
         ].compactMap { $0 }
         let appBody = settingLines.isEmpty ? "" : "\n\(settingLines.joined(separator: ",\n"))\n  "
         try """
@@ -2267,6 +2292,52 @@ final class TabManagerCloseCurrentPanelTests: XCTestCase {
         )
 
         try run()
+    }
+}
+
+@MainActor
+final class UndoableTerminalCloseStoreTests: XCTestCase {
+    func testRestoresMostRecentCloseAndExpiresOlderClose() {
+        let store = UndoableTerminalCloseStore()
+        var events: [String] = []
+        let olderID = store.stage(
+            gracePeriod: 60,
+            restore: { events.append("restore older"); return true },
+            finalize: { events.append("finalize older") }
+        )
+        _ = store.stage(
+            gracePeriod: 60,
+            restore: { events.append("restore newer"); return true },
+            finalize: { events.append("finalize newer") }
+        )
+
+        XCTAssertEqual(store.pendingCount, 2)
+        XCTAssertTrue(store.restoreMostRecent())
+        XCTAssertEqual(events, ["restore newer"])
+        XCTAssertEqual(store.pendingCount, 1)
+
+        guard let olderID else {
+            XCTFail("Expected staged close identifier")
+            return
+        }
+        store.expire(id: olderID)
+        XCTAssertEqual(events, ["restore newer", "finalize older"])
+        XCTAssertEqual(store.pendingCount, 0)
+    }
+
+    func testZeroGracePeriodFinalizesImmediately() {
+        let store = UndoableTerminalCloseStore()
+        var finalized = false
+
+        let id = store.stage(
+            gracePeriod: 0,
+            restore: { XCTFail("Zero-grace close must not be restorable"); return false },
+            finalize: { finalized = true }
+        )
+
+        XCTAssertNil(id)
+        XCTAssertTrue(finalized)
+        XCTAssertEqual(store.pendingCount, 0)
     }
 }
 

--- a/skills/cmux-settings/references/all-keys.md
+++ b/skills/cmux-settings/references/all-keys.md
@@ -24,7 +24,8 @@ General app preferences from Settings > App.
 | `app.iMessageMode` | boolean | `false` | Move a workspace to the top and show the submitted message when sending an agent prompt. |
 | `app.sendAnonymousTelemetry` | boolean | `true` | Allow anonymous telemetry. |
 | `app.warnBeforeQuit` | boolean | `true` | Show a confirmation before quitting cmux. |
-| `app.warnBeforeClosingTab` | boolean | `true` | Show a confirmation before closing a tab. |
+| `app.warnBeforeClosingTab` | boolean | `false` | Show a confirmation before closing a tab. |
+| `app.terminalCloseGracePeriodSeconds` | number | `5` | Keep a terminal alive briefly so Command-Shift-T can restore it. Set to 0 to close immediately. |
 | `app.renameSelectsExistingName` | boolean | `true` | Select the current name when opening rename flows. |
 | `app.commandPaletteSearchesAllSurfaces` | boolean | `false` | Search every surface in the command palette switcher instead of only the active workspace. |
 

--- a/web/data/cmux.schema.json
+++ b/web/data/cmux.schema.json
@@ -505,8 +505,15 @@
         },
         "warnBeforeClosingTab": {
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Show a confirmation before closing a tab."
+        },
+        "terminalCloseGracePeriodSeconds": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 60,
+          "default": 5,
+          "description": "Keep a terminal alive for this many seconds after Command-W so Command-Shift-T can restore it. Set to 0 to close immediately."
         },
         "warnBeforeClosingTabXButton": {
           "type": "boolean",


### PR DESCRIPTION
## Summary
- disable Cmd+W close prompts by default while preserving the opt-in warning setting
- keep closed terminals and their foreground processes alive for a configurable five-second grace period
- restore the exact live terminal with Cmd+Shift+T before falling back to persisted recently-closed history
- expose `app.terminalCloseGracePeriodSeconds` in Settings and cmux.json

## Testing
- `swift test` in `Packages/macOS/CmuxSettings` (258 tests passed)
- `swift test` in `Packages/macOS/CmuxSettingsUI` (112 tests passed)
- tagged `ucgp` app built successfully on `lawrence-m5max` with Xcode 26.3
- debug-socket preflight: foreground process survived Cmd+W and returned on Cmd+Shift+T with the same surface UUID
- focused app XCTest selection was blocked before execution by the existing `PortScannerIdentityContinuityTests.swift` Xcode 26.3 compile error: `Cannot use mutating member on immutable value: $0 is immutable`

## Task
Plain-text feature request: make Cmd+W prompt-free by default and undoable for a configurable grace period.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8353"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786888225&installation_id=133855650&pr_number=8353&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8353&signature=f3410492a78d81b3ff661b5f39ff7b933a083f09ff2d7657d5342526b8f6ac77"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Cmd+W prompt-free by default and make terminal closes undoable for a short window. Adds a new setting to keep closed terminals alive for Cmd+Shift+T restore before falling back to recently-closed history.

- **New Features**
  - Turned off “Warn Before Closing Tab” by default; updated schema and Settings copy.
  - Added `app.terminalCloseGracePeriodSeconds` (0–60s, default 5s) in Settings and `cmux.json`, with search aliases and JSON-path support.
  - Cmd+Shift+T now restores the exact live terminal during the grace period; otherwise, it restores from persisted history.
  - Added an internal undo store to stage terminal/workspace closes and finalize them on expiry.

- **Migration**
  - If you prefer the old confirmation, re-enable “Warn Before Closing Tab” in Settings or via `cmux.json`.
  - Tune `app.terminalCloseGracePeriodSeconds`; set to 0 to close immediately without an undo window.

<sup>Written for commit 9a2f76dd1476ad426f424efa98f2442c01674ec6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8353?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Closed terminals can now be restored shortly after closing with Command-Shift-T.
  * Added a configurable Terminal Close Grace Period from 0–60 seconds, defaulting to 5 seconds.
  * Added settings search support and configuration-file support for the new option.

* **Changes**
  * “Warn Before Closing Tab” is now disabled by default.
  * Updated messaging and documentation to explain terminal restoration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->