### PR TITLE
Multiplayer workspace share: live cursors, chat, and a web viewer at cmux.com/share/<id>

### DIFF
--- a/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
+++ b/Packages/macOS/CmuxCommandPalette/Sources/CmuxCommandPalette/Context/CommandPaletteContextKeys.swift
@@ -37,6 +37,8 @@ public struct CommandPaletteContextKeys: Hashable, Sendable {
     public static let workspaceHasAbove = CommandPaletteContextKeys(rawValue: "workspace.hasAbove")
     /// Whether a workspace exists below the selection.
     public static let workspaceHasBelow = CommandPaletteContextKeys(rawValue: "workspace.hasBelow")
+    /// Whether a multiplayer workspace share session is active.
+    public static let workspaceShareActive = CommandPaletteContextKeys(rawValue: "workspace.shareActive")
     /// Whether mark-read is available for the workspace.
     public static let workspaceCanMarkRead = CommandPaletteContextKeys(rawValue: "workspace.canMarkRead")
     /// Whether mark-unread is available for the workspace.

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -6634,6 +6634,7 @@ struct ContentView: View {
         snapshot.setBool(CommandPaletteContextKeys.workspaceMinimalModeEnabled, currentIsMinimalMode)
         snapshot.setBool(CommandPaletteContextKeys.sidebarMatchTerminalBackground, sidebarMatchTerminalBackground)
         snapshot.setBool(CommandPaletteContextKeys.browserDisabled, BrowserAvailabilitySettings.isDisabled())
+        snapshot.setBool(CommandPaletteContextKeys.workspaceShareActive, WorkspaceShareService.shared.isSharing)
         if let auth = AppDelegate.shared?.auth {
             snapshot.setBool(CommandPaletteContextKeys.authSignedIn, auth.coordinator.isAuthenticated)
             snapshot.setBool(CommandPaletteContextKeys.proUpgradeEnabled, CmuxFeatureFlags.shared.isProUpgradeUIEnabled)
@@ -7181,6 +7182,24 @@ struct ContentView: View {
         )
         contributions.append(contentsOf: Self.commandPaletteSettingsToggleCommandContributions())
 
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.shareWorkspace",
+                title: constant(String(localized: "command.shareWorkspace.title", defaultValue: "Share Workspace…")),
+                subtitle: workspaceSubtitle,
+                keywords: ["share", "workspace", "multiplayer", "collaborate", "invite", "live"],
+                when: { $0.bool(CommandPaletteContextKeys.hasWorkspace) }
+            )
+        )
+        contributions.append(
+            CommandPaletteCommandContribution(
+                commandId: "palette.stopSharingWorkspace",
+                title: constant(String(localized: "command.stopSharingWorkspace.title", defaultValue: "Stop Sharing Workspace")),
+                subtitle: workspaceSubtitle,
+                keywords: ["share", "stop", "workspace", "multiplayer", "end"],
+                when: { $0.bool(CommandPaletteContextKeys.workspaceShareActive) }
+            )
+        )
         contributions.append(
             CommandPaletteCommandContribution(
                 commandId: "palette.renameWorkspace",
@@ -8270,6 +8289,43 @@ struct ContentView: View {
         }
         registerSettingsToggleCommandHandlers(&registry)
 
+        registry.register(commandId: "palette.shareWorkspace") {
+            guard let workspace = tabManager.selectedWorkspace else {
+                NSSound.beep()
+                return
+            }
+            Task { @MainActor in
+                do {
+                    let url = try await WorkspaceShareService.shared.startSharing(workspace: workspace)
+                    let alert = NSAlert()
+                    alert.messageText = String(
+                        localized: "share.started.title",
+                        defaultValue: "Workspace share started"
+                    )
+                    alert.informativeText = String(
+                        format: String(
+                            localized: "share.started.message",
+                            defaultValue: "Share link copied to the clipboard:\n%@"
+                        ),
+                        url.absoluteString
+                    )
+                    alert.addButton(withTitle: String(localized: "share.started.ok", defaultValue: "OK"))
+                    _ = alert.runCmuxModal()
+                } catch {
+                    let alert = NSAlert()
+                    alert.messageText = String(
+                        localized: "share.failed.title",
+                        defaultValue: "Could not start workspace share"
+                    )
+                    alert.informativeText = WorkspaceShareService.startErrorDescription(error)
+                    alert.addButton(withTitle: String(localized: "share.failed.ok", defaultValue: "OK"))
+                    _ = alert.runCmuxModal()
+                }
+            }
+        }
+        registry.register(commandId: "palette.stopSharingWorkspace") {
+            WorkspaceShareService.shared.stopSharing()
+        }
         registry.register(commandId: "palette.renameWorkspace") {
             beginRenameWorkspaceFlow()
         }

--- a/Sources/Share/WorkspaceShareLayout.swift
+++ b/Sources/Share/WorkspaceShareLayout.swift
@@ -1,0 +1,103 @@
+import AppKit
+import Bonsplit
+import CmuxTerminal
+import Foundation
+import GhosttyKit
+
+/// Pure geometry helpers for the share protocol's normalized [0,1] workspace
+/// coordinates. Kept free of app types so unit tests can exercise the math
+/// without launching the app.
+enum WorkspaceShareLayoutMath {
+    /// Normalizes a pane's pixel frame against the workspace container frame.
+    /// Both rects share the same top-left-origin coordinate space (bonsplit's
+    /// `LayoutSnapshot` pixel space). Output components are clamped to [0,1].
+    static func normalizedRect(paneFrame: CGRect, container: CGRect) -> ShareRect {
+        guard container.width > 0, container.height > 0 else {
+            return ShareRect(x: 0, y: 0, w: 0, h: 0)
+        }
+        func clamp01(_ value: Double) -> Double { min(max(value, 0), 1) }
+        let x = clamp01(Double((paneFrame.minX - container.minX) / container.width))
+        let y = clamp01(Double((paneFrame.minY - container.minY) / container.height))
+        let w = clamp01(Double(paneFrame.width / container.width))
+        let h = clamp01(Double(paneFrame.height / container.height))
+        return ShareRect(x: x, y: y, w: min(w, 1 - x), h: min(h, 1 - y))
+    }
+
+    /// Normalizes a point (same pixel space as the container) to [0,1], or nil
+    /// when the point lies outside the container.
+    static func normalizedPoint(_ point: CGPoint, container: CGRect) -> (x: Double, y: Double)? {
+        guard container.width > 0, container.height > 0, container.contains(point) else { return nil }
+        return (
+            x: Double((point.x - container.minX) / container.width),
+            y: Double((point.y - container.minY) / container.height)
+        )
+    }
+}
+
+/// Builds the wire `ShareWorkspace` from a live workspace's bonsplit tree.
+@MainActor
+enum WorkspaceShareLayoutBuilder {
+    /// One pane per bonsplit pane, described by its selected tab's panel.
+    /// `includeReplay` adds the capped terminal replay tail (snapshot frames
+    /// only; live `layout` frames stay small).
+    static func makeWorkspace(workspace: Workspace, includeReplay: Bool) -> ShareWorkspace {
+        let snapshot = workspace.bonsplitController.layoutSnapshot()
+        let container = CGRect(
+            x: snapshot.containerFrame.x,
+            y: snapshot.containerFrame.y,
+            width: snapshot.containerFrame.width,
+            height: snapshot.containerFrame.height
+        )
+        var panes: [ShareWorkspacePane] = []
+        for geometry in snapshot.panes {
+            guard let selectedTabIdString = geometry.selectedTabId,
+                  let selectedTabUUID = UUID(uuidString: selectedTabIdString),
+                  let panelId = workspace.panelIdFromSurfaceId(TabID(uuid: selectedTabUUID)),
+                  let panel = workspace.panels[panelId] else {
+                continue
+            }
+            let paneFrame = CGRect(
+                x: geometry.frame.x,
+                y: geometry.frame.y,
+                width: geometry.frame.width,
+                height: geometry.frame.height
+            )
+            var pane = ShareWorkspacePane(
+                id: geometry.paneId,
+                kind: shareKind(for: panel),
+                title: workspace.panelTitle(panelId: panelId) ?? "",
+                rect: WorkspaceShareLayoutMath.normalizedRect(paneFrame: paneFrame, container: container)
+            )
+            if let terminal = panel as? TerminalPanel {
+                pane.surfaceId = terminal.id.uuidString
+                if terminal.surface.hasLiveSurface, let ghosttySurface = terminal.surface.surface {
+                    let size = ghostty_surface_size(ghosttySurface)
+                    if size.columns > 0, size.rows > 0 {
+                        pane.cols = Int(size.columns)
+                        pane.rows = Int(size.rows)
+                    }
+                }
+                if includeReplay,
+                   let replay = MobileTerminalByteTee.shared.replayState(surfaceID: terminal.id) {
+                    let capped = WorkspaceShareReplayCap.cappedReplayTail(replay.data)
+                    pane.replaySeq = replay.seq - UInt64(capped.count)
+                    pane.replay_b64 = capped.base64EncodedString()
+                }
+            }
+            panes.append(pane)
+        }
+        return ShareWorkspace(
+            title: workspace.title,
+            size: ShareWorkspaceSize(width: Double(container.width), height: Double(container.height)),
+            panes: panes
+        )
+    }
+
+    private static func shareKind(for panel: any Panel) -> String {
+        switch panel.panelType {
+        case .terminal: return "terminal"
+        case .browser: return "browser"
+        default: return "other"
+        }
+    }
+}

--- a/Sources/Share/WorkspaceShareModels.swift
+++ b/Sources/Share/WorkspaceShareModels.swift
@@ -1,0 +1,208 @@
+import Foundation
+
+// Wire types for the multiplayer workspace share protocol
+// (plans/feat-multiplayer-share/DESIGN.md). One JSON object per WebSocket
+// frame; key names match the design doc exactly (mixed camelCase and
+// snake_case like `data_b64` are intentional).
+
+// MARK: - Workspace shape
+
+struct ShareWorkspaceSize: Codable, Equatable, Sendable {
+    let width: Double
+    let height: Double
+}
+
+/// Normalized [0,1] rectangle within the shared workspace container.
+struct ShareRect: Codable, Equatable, Sendable {
+    let x: Double
+    let y: Double
+    let w: Double
+    let h: Double
+}
+
+struct ShareWorkspacePane: Codable, Equatable, Sendable {
+    let id: String
+    let kind: String
+    let title: String
+    let rect: ShareRect
+    var surfaceId: String?
+    var cols: Int?
+    var rows: Int?
+    /// Byte-stream sequence of the first byte in `replay_b64` (snapshot only).
+    var replaySeq: UInt64?
+    var replay_b64: String?
+}
+
+struct ShareWorkspace: Codable, Equatable, Sendable {
+    let title: String
+    let size: ShareWorkspaceSize
+    var panes: [ShareWorkspacePane]
+}
+
+// MARK: - Participants
+
+struct ShareParticipant: Codable, Equatable, Sendable {
+    let id: String
+    let email: String
+    let name: String
+    let color: Int
+    let role: String
+
+    var isHost: Bool { role == "host" }
+}
+
+// MARK: - Host -> DO frames
+
+enum ShareOutboundFrame: Equatable, Sendable {
+    case joinResponse(requestId: String, allow: Bool)
+    case snapshot(to: String, workspace: ShareWorkspace)
+    case layout(workspace: ShareWorkspace)
+    case term(surfaceId: String, seq: UInt64, dataB64: String)
+    case termResize(surfaceId: String, cols: Int, rows: Int)
+    case textbox(paneId: String, text: String, selStart: Int, selEnd: Int, active: Bool)
+    case cursor(x: Double, y: Double)
+    case chat(text: String, x: Double, y: Double)
+    case end
+}
+
+extension ShareOutboundFrame: Encodable {
+    private enum CodingKeys: String, CodingKey {
+        case type, requestId, allow, to, workspace, surfaceId, seq
+        case dataB64 = "data_b64"
+        case cols, rows, paneId, text, selStart, selEnd, active, x, y
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        switch self {
+        case .joinResponse(let requestId, let allow):
+            try container.encode("join_response", forKey: .type)
+            try container.encode(requestId, forKey: .requestId)
+            try container.encode(allow, forKey: .allow)
+        case .snapshot(let to, let workspace):
+            try container.encode("snapshot", forKey: .type)
+            try container.encode(to, forKey: .to)
+            try container.encode(workspace, forKey: .workspace)
+        case .layout(let workspace):
+            try container.encode("layout", forKey: .type)
+            try container.encode(workspace, forKey: .workspace)
+        case .term(let surfaceId, let seq, let dataB64):
+            try container.encode("term", forKey: .type)
+            try container.encode(surfaceId, forKey: .surfaceId)
+            try container.encode(seq, forKey: .seq)
+            try container.encode(dataB64, forKey: .dataB64)
+        case .termResize(let surfaceId, let cols, let rows):
+            try container.encode("term_resize", forKey: .type)
+            try container.encode(surfaceId, forKey: .surfaceId)
+            try container.encode(cols, forKey: .cols)
+            try container.encode(rows, forKey: .rows)
+        case .textbox(let paneId, let text, let selStart, let selEnd, let active):
+            try container.encode("textbox", forKey: .type)
+            try container.encode(paneId, forKey: .paneId)
+            try container.encode(text, forKey: .text)
+            try container.encode(selStart, forKey: .selStart)
+            try container.encode(selEnd, forKey: .selEnd)
+            try container.encode(active, forKey: .active)
+        case .cursor(let x, let y):
+            try container.encode("cursor", forKey: .type)
+            try container.encode(x, forKey: .x)
+            try container.encode(y, forKey: .y)
+        case .chat(let text, let x, let y):
+            try container.encode("chat", forKey: .type)
+            try container.encode(text, forKey: .text)
+            try container.encode(x, forKey: .x)
+            try container.encode(y, forKey: .y)
+        case .end:
+            try container.encode("end", forKey: .type)
+        }
+    }
+
+    func encodedJSONData() throws -> Data {
+        try JSONEncoder().encode(self)
+    }
+}
+
+// MARK: - DO -> host frames
+
+enum ShareInboundFrame: Equatable, Sendable {
+    case joinRequest(requestId: String, email: String, name: String)
+    case syncRequest(participantId: String)
+    case cursor(participantId: String, x: Double, y: Double)
+    case chat(participantId: String, ts: Double, text: String, x: Double, y: Double)
+    case presence(participants: [ShareParticipant])
+    case ended
+    /// Forward-compatibility: unrecognized frame types are surfaced (and
+    /// ignored by the service) instead of failing the decode loop.
+    case unknown(type: String)
+}
+
+extension ShareInboundFrame: Decodable {
+    private enum CodingKeys: String, CodingKey {
+        case type, requestId, email, name, participantId, x, y, ts, text, participants
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        switch type {
+        case "join_request":
+            self = .joinRequest(
+                requestId: try container.decode(String.self, forKey: .requestId),
+                email: try container.decodeIfPresent(String.self, forKey: .email) ?? "",
+                name: try container.decodeIfPresent(String.self, forKey: .name) ?? ""
+            )
+        case "sync_request":
+            self = .syncRequest(participantId: try container.decode(String.self, forKey: .participantId))
+        case "cursor":
+            self = .cursor(
+                participantId: try container.decodeIfPresent(String.self, forKey: .participantId) ?? "",
+                x: try container.decode(Double.self, forKey: .x),
+                y: try container.decode(Double.self, forKey: .y)
+            )
+        case "chat":
+            self = .chat(
+                participantId: try container.decodeIfPresent(String.self, forKey: .participantId) ?? "",
+                ts: try container.decodeIfPresent(Double.self, forKey: .ts) ?? 0,
+                text: try container.decode(String.self, forKey: .text),
+                x: try container.decodeIfPresent(Double.self, forKey: .x) ?? 0.5,
+                y: try container.decodeIfPresent(Double.self, forKey: .y) ?? 0.5
+            )
+        case "presence":
+            self = .presence(participants: try container.decode([ShareParticipant].self, forKey: .participants))
+        case "ended":
+            self = .ended
+        default:
+            self = .unknown(type: type)
+        }
+    }
+
+    static func decode(fromJSONData data: Data) throws -> ShareInboundFrame {
+        try JSONDecoder().decode(ShareInboundFrame.self, from: data)
+    }
+}
+
+// MARK: - Create-session HTTP response
+
+struct ShareCreateResponse: Decodable, Sendable {
+    let shareId: String
+    let hostToken: String
+    let url: String?
+}
+
+// MARK: - Replay capping
+
+enum WorkspaceShareReplayCap {
+    /// DESIGN.md caps `replay_b64` at 256 KB per pane. Base64 expands raw
+    /// bytes 4/3, so cap the raw tail at 3/4 of the budget and keep the most
+    /// recent bytes (the tail is what reconstructs the current screen).
+    static let maximumBase64ByteCount = 256 * 1024
+
+    static func cappedReplayTail(
+        _ data: Data,
+        maximumBase64ByteCount: Int = WorkspaceShareReplayCap.maximumBase64ByteCount
+    ) -> Data {
+        let maximumRawByteCount = (maximumBase64ByteCount / 4) * 3
+        guard data.count > maximumRawByteCount else { return data }
+        return Data(data.suffix(maximumRawByteCount))
+    }
+}

--- a/Sources/Share/WorkspaceShareOverlayController.swift
+++ b/Sources/Share/WorkspaceShareOverlayController.swift
@@ -1,0 +1,255 @@
+import AppKit
+import Foundation
+
+/// Fixed participant palette shared with the web viewer (index = participant
+/// `color`; host is 0).
+enum WorkspaceShareParticipantPalette {
+    static let colors: [NSColor] = [
+        NSColor(srgbRed: 0.35, green: 0.62, blue: 1.00, alpha: 1),  // sky (host)
+        NSColor(srgbRed: 1.00, green: 0.45, blue: 0.42, alpha: 1),
+        NSColor(srgbRed: 0.45, green: 0.85, blue: 0.55, alpha: 1),
+        NSColor(srgbRed: 1.00, green: 0.75, blue: 0.30, alpha: 1),
+        NSColor(srgbRed: 0.80, green: 0.55, blue: 1.00, alpha: 1),
+        NSColor(srgbRed: 0.35, green: 0.85, blue: 0.90, alpha: 1),
+        NSColor(srgbRed: 1.00, green: 0.55, blue: 0.80, alpha: 1),
+        NSColor(srgbRed: 0.75, green: 0.85, blue: 0.35, alpha: 1),
+    ]
+
+    static func color(forIndex index: Int) -> NSColor {
+        colors[((index % colors.count) + colors.count) % colors.count]
+    }
+}
+
+/// Non-activating, mouse-transparent child window layered over the shared
+/// workspace's window. Renders remote participants' kite cursors, name chips,
+/// and cursor-chat bubbles (same overlay approach as the computer-use cursor
+/// overlay). Positions use the share protocol's normalized [0,1] workspace
+/// coordinates mapped through the live bonsplit container frame.
+@MainActor
+final class WorkspaceShareOverlayController {
+    private var overlayWindow: NSWindow?
+    private weak var hostWindow: NSWindow?
+    private weak var workspace: Workspace?
+    private var cursorViews: [String: ShareCursorView] = [:]
+    private var participantsById: [String: ShareParticipant] = [:]
+    private var chatDismissTasks: [String: Task<Void, Never>] = [:]
+
+    func attach(to window: NSWindow?, workspace: Workspace) {
+        detach()
+        guard let window else { return }
+        self.workspace = workspace
+        hostWindow = window
+
+        let overlay = NSWindow(
+            contentRect: window.frame,
+            styleMask: .borderless,
+            backing: .buffered,
+            defer: false
+        )
+        overlay.isOpaque = false
+        overlay.backgroundColor = .clear
+        overlay.ignoresMouseEvents = true
+        overlay.hasShadow = false
+        overlay.level = window.level
+        overlay.collectionBehavior = [.fullScreenAuxiliary, .transient]
+        overlay.contentView = NSView(frame: NSRect(origin: .zero, size: window.frame.size))
+        window.addChildWindow(overlay, ordered: .above)
+        overlayWindow = overlay
+    }
+
+    func detach() {
+        for task in chatDismissTasks.values { task.cancel() }
+        chatDismissTasks.removeAll()
+        cursorViews.removeAll()
+        participantsById.removeAll()
+        if let overlayWindow {
+            overlayWindow.parent?.removeChildWindow(overlayWindow)
+            overlayWindow.orderOut(nil)
+        }
+        overlayWindow = nil
+        hostWindow = nil
+        workspace = nil
+    }
+
+    func updateParticipants(_ participants: [ShareParticipant]) {
+        participantsById = Dictionary(uniqueKeysWithValues: participants.map { ($0.id, $0) })
+        // Remove cursors for departed participants.
+        for (id, view) in cursorViews where participantsById[id] == nil {
+            view.removeFromSuperview()
+            cursorViews[id] = nil
+            chatDismissTasks[id]?.cancel()
+            chatDismissTasks[id] = nil
+        }
+        for (id, view) in cursorViews {
+            if let participant = participantsById[id] {
+                view.apply(participant: participant)
+            }
+        }
+    }
+
+    func updateRemoteCursor(participantId: String, x: Double, y: Double) {
+        guard !participantId.isEmpty,
+              let point = windowPoint(normalizedX: x, normalizedY: y),
+              let contentView = overlayWindow?.contentView else { return }
+        let view = cursorView(for: participantId, in: contentView)
+        view.setFrameOrigin(NSPoint(x: point.x, y: point.y - view.frame.height))
+        view.isHidden = false
+    }
+
+    func showChat(participantId: String, text: String, x: Double, y: Double) {
+        guard !text.isEmpty else { return }
+        updateRemoteCursor(participantId: participantId, x: x, y: y)
+        guard let view = cursorViews[participantId] else { return }
+        view.showBubble(text: text)
+        chatDismissTasks[participantId]?.cancel()
+        chatDismissTasks[participantId] = Task { [weak view, weak self] in
+            // Intentional bounded auto-dismiss delay; cancelled by newer
+            // messages and by detach().
+            try? await ContinuousClock().sleep(for: .seconds(6))
+            guard !Task.isCancelled else { return }
+            view?.hideBubble()
+            self?.chatDismissTasks[participantId] = nil
+        }
+    }
+
+    // MARK: - Geometry
+
+    /// Maps normalized share coordinates (top-left origin) to overlay-window
+    /// view coordinates (bottom-left origin), using the live container frame.
+    private func windowPoint(normalizedX: Double, normalizedY: Double) -> CGPoint? {
+        guard let workspace, let hostWindow, let contentView = hostWindow.contentView else { return nil }
+        let snapshot = workspace.bonsplitController.layoutSnapshot()
+        let container = snapshot.containerFrame
+        guard container.width > 0, container.height > 0 else { return nil }
+        let topLeftX = container.x + normalizedX * container.width
+        let topLeftY = container.y + normalizedY * container.height
+        // Overlay window tracks the host window frame, so content-view local
+        // coordinates line up 1:1 after the y-axis flip.
+        return CGPoint(x: topLeftX, y: Double(contentView.bounds.height) - topLeftY)
+    }
+
+    private func cursorView(for participantId: String, in contentView: NSView) -> ShareCursorView {
+        if let existing = cursorViews[participantId] { return existing }
+        let view = ShareCursorView()
+        if let participant = participantsById[participantId] {
+            view.apply(participant: participant)
+        }
+        contentView.addSubview(view)
+        cursorViews[participantId] = view
+        return view
+    }
+
+    /// Host-window frame changes (move/resize) must retarget the overlay.
+    func hostWindowFrameDidChange() {
+        guard let overlayWindow, let hostWindow else { return }
+        overlayWindow.setFrame(hostWindow.frame, display: false)
+        overlayWindow.contentView?.frame = NSRect(origin: .zero, size: hostWindow.frame.size)
+    }
+}
+
+/// One remote participant's kite cursor + name chip + optional chat bubble.
+@MainActor
+final class ShareCursorView: NSView {
+    private let kiteLayer = CAShapeLayer()
+    private let nameField = NSTextField(labelWithString: "")
+    private let bubbleField = NSTextField(wrappingLabelWithString: "")
+    private let bubbleBackground = NSView()
+    private var tint: NSColor = WorkspaceShareParticipantPalette.color(forIndex: 1)
+
+    private static let kiteSize: CGFloat = 18
+    private static let maxBubbleWidth: CGFloat = 240
+
+    init() {
+        super.init(frame: NSRect(x: 0, y: 0, width: 260, height: 120))
+        wantsLayer = true
+
+        // Kite pointer: a simple four-point kite path (stand-in matching the
+        // web viewer's inline SVG shape), tip at the view's top-left.
+        let path = CGMutablePath()
+        let s = Self.kiteSize
+        path.move(to: CGPoint(x: 0, y: 0))
+        path.addLine(to: CGPoint(x: s * 0.85, y: -s * 0.35))
+        path.addLine(to: CGPoint(x: s * 0.45, y: -s * 0.45))
+        path.addLine(to: CGPoint(x: s * 0.35, y: -s))
+        path.closeSubpath()
+        kiteLayer.path = path
+        kiteLayer.strokeColor = NSColor.white.withAlphaComponent(0.9).cgColor
+        kiteLayer.lineWidth = 1
+        kiteLayer.position = CGPoint(x: 0, y: frame.height)
+        layer?.addSublayer(kiteLayer)
+
+        nameField.font = NSFont.systemFont(ofSize: 10, weight: .semibold)
+        nameField.textColor = .white
+        nameField.wantsLayer = true
+        nameField.drawsBackground = false
+        addSubview(nameField)
+
+        bubbleBackground.wantsLayer = true
+        bubbleBackground.layer?.cornerRadius = 8
+        bubbleBackground.isHidden = true
+        addSubview(bubbleBackground)
+        bubbleField.font = NSFont.systemFont(ofSize: 11)
+        bubbleField.textColor = .white
+        bubbleField.maximumNumberOfLines = 4
+        bubbleField.isHidden = true
+        addSubview(bubbleField)
+
+        applyTint()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    override var isFlipped: Bool { true }
+
+    func apply(participant: ShareParticipant) {
+        tint = WorkspaceShareParticipantPalette.color(forIndex: participant.color)
+        let label = participant.name.isEmpty ? participant.email : participant.name
+        nameField.stringValue = label
+        applyTint()
+        layoutChrome()
+    }
+
+    func showBubble(text: String) {
+        bubbleField.stringValue = text
+        bubbleField.isHidden = false
+        bubbleBackground.isHidden = false
+        layoutChrome()
+    }
+
+    func hideBubble() {
+        bubbleField.isHidden = true
+        bubbleBackground.isHidden = true
+    }
+
+    private func applyTint() {
+        kiteLayer.fillColor = tint.cgColor
+        nameField.layer?.backgroundColor = tint.withAlphaComponent(0.9).cgColor
+        nameField.layer?.cornerRadius = 4
+        bubbleBackground.layer?.backgroundColor = tint.withAlphaComponent(0.85).cgColor
+    }
+
+    private func layoutChrome() {
+        nameField.sizeToFit()
+        var nameFrame = nameField.frame
+        nameFrame.origin = CGPoint(x: Self.kiteSize + 4, y: 2)
+        nameFrame.size.width += 8
+        nameFrame.size.height += 2
+        nameField.frame = nameFrame
+        nameField.alignment = .center
+
+        if !bubbleField.isHidden {
+            let fit = bubbleField.sizeThatFits(
+                NSSize(width: Self.maxBubbleWidth, height: .greatestFiniteMagnitude)
+            )
+            let bubbleFrame = NSRect(
+                x: Self.kiteSize + 4,
+                y: nameFrame.maxY + 4,
+                width: min(fit.width, Self.maxBubbleWidth) + 16,
+                height: fit.height + 12
+            )
+            bubbleBackground.frame = bubbleFrame
+            bubbleField.frame = bubbleFrame.insetBy(dx: 8, dy: 6)
+        }
+    }
+}

--- a/Sources/Share/WorkspaceShareService.swift
+++ b/Sources/Share/WorkspaceShareService.swift
@@ -1,0 +1,405 @@
+import AppKit
+import Bonsplit
+import Combine
+import Foundation
+import OSLog
+
+private let workspaceShareLog = Logger(subsystem: "dev.cmux", category: "workspace-share")
+
+/// Hosts one read-only multiplayer share of a workspace
+/// (plans/feat-multiplayer-share/DESIGN.md). Owns the session lifecycle:
+/// create over HTTPS, host WebSocket to the ShareSession Durable Object,
+/// per-surface PTY streaming, layout/textbox mirroring, join approvals, and
+/// the remote-cursor overlay.
+@MainActor
+final class WorkspaceShareService: ObservableObject {
+    static let shared = WorkspaceShareService()
+
+    enum State: Equatable {
+        case idle
+        case starting
+        case active(shareId: String, url: URL)
+    }
+
+    @Published private(set) var state: State = .idle
+    private(set) weak var sharedWorkspace: Workspace?
+
+    private var socket: WorkspaceShareSocket?
+    private var receiveTask: Task<Void, Never>?
+    private var termTasks: [UUID: Task<Void, Never>] = [:]
+    private var textBoxObservations: [UUID: AnyCancellable] = [:]
+    private var layoutObserver: NSObjectProtocol?
+    private var cursorMonitor: Any?
+    private var lastCursorSend: ContinuousClock.Instant?
+    private var lastSentWorkspace: ShareWorkspace?
+    private let overlay = WorkspaceShareOverlayController()
+
+    var isSharing: Bool {
+        if case .active = state { return true }
+        return false
+    }
+
+    func isSharing(workspace: Workspace) -> Bool {
+        isSharing && sharedWorkspace === workspace
+    }
+
+    // MARK: - Start / stop
+
+    /// Creates a session, connects the host lane, and starts streaming.
+    /// Returns the share URL (already copied to the pasteboard).
+    func startSharing(workspace: Workspace) async throws -> URL {
+        guard case .idle = state else {
+            if case .active(_, let url) = state { return url }
+            throw ShareStartError.alreadyStarting
+        }
+        state = .starting
+        do {
+            let created = try await createSession(title: workspace.title)
+            let base = WorkspaceShareEndpoints.serviceBaseURL()
+            guard let socketURL = WorkspaceShareEndpoints.hostSocketURL(
+                base: base, shareId: created.shareId, hostToken: created.hostToken
+            ) else {
+                throw ShareStartError.badServiceURL
+            }
+            let url = created.url.flatMap(URL.init(string:))
+                ?? WorkspaceShareEndpoints.sharePageURL(shareId: created.shareId)
+
+            let socket = WorkspaceShareSocket(url: socketURL)
+            socket.start()
+            self.socket = socket
+            sharedWorkspace = workspace
+            state = .active(shareId: created.shareId, url: url)
+
+            startReceiveLoop(socket: socket)
+            startLayoutMirror(workspace: workspace)
+            startCursorMonitor(workspace: workspace)
+            overlay.attach(to: workspaceWindow(for: workspace), workspace: workspace)
+            syncStreams(workspace: workspace)
+            sendLayout(workspace: workspace, force: true)
+
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(url.absoluteString, forType: .string)
+            workspaceShareLog.info("share started id=\(created.shareId, privacy: .public)")
+            return url
+        } catch {
+            state = .idle
+            sharedWorkspace = nil
+            socket?.close(sendEnd: false)
+            socket = nil
+            throw error
+        }
+    }
+
+    func stopSharing() {
+        guard state != .idle else { return }
+        socket?.close(sendEnd: true)
+        socket = nil
+        receiveTask?.cancel()
+        receiveTask = nil
+        for task in termTasks.values { task.cancel() }
+        termTasks.removeAll()
+        textBoxObservations.removeAll()
+        if let layoutObserver {
+            NotificationCenter.default.removeObserver(layoutObserver)
+            self.layoutObserver = nil
+        }
+        if let cursorMonitor {
+            NSEvent.removeMonitor(cursorMonitor)
+            self.cursorMonitor = nil
+        }
+        overlay.detach()
+        lastSentWorkspace = nil
+        sharedWorkspace = nil
+        state = .idle
+        workspaceShareLog.info("share stopped")
+    }
+
+    enum ShareStartError: Error, Equatable {
+        case alreadyStarting
+        case badServiceURL
+        case notSignedIn
+        case createFailed(status: Int)
+    }
+
+    static func startErrorDescription(_ error: Error) -> String {
+        switch error {
+        case ShareStartError.notSignedIn:
+            return String(
+                localized: "share.error.notSignedIn",
+                defaultValue: "Sign in to cmux to share a workspace."
+            )
+        case ShareStartError.alreadyStarting:
+            return String(
+                localized: "share.error.alreadyStarting",
+                defaultValue: "A share session is already starting."
+            )
+        case ShareStartError.badServiceURL:
+            return String(
+                localized: "share.error.badServiceURL",
+                defaultValue: "The share service URL is invalid."
+            )
+        case ShareStartError.createFailed(let status):
+            return String(
+                format: String(
+                    localized: "share.error.createFailed",
+                    defaultValue: "The share service rejected the request (status %d)."
+                ),
+                status
+            )
+        default:
+            return error.localizedDescription
+        }
+    }
+
+    // MARK: - Create
+
+    private func createSession(title: String) async throws -> ShareCreateResponse {
+        guard let coordinator = AppDelegate.shared?.auth?.coordinator else {
+            throw ShareStartError.notSignedIn
+        }
+        let token: String
+        do {
+            token = try await coordinator.accessToken()
+        } catch {
+            throw ShareStartError.notSignedIn
+        }
+        var request = URLRequest(url: WorkspaceShareEndpoints.createURL(
+            base: WorkspaceShareEndpoints.serviceBaseURL()
+        ))
+        request.httpMethod = "POST"
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try JSONEncoder().encode(["title": title])
+        let (data, response) = try await URLSession.shared.data(for: request)
+        guard let http = response as? HTTPURLResponse, http.statusCode == 200 else {
+            throw ShareStartError.createFailed(
+                status: (response as? HTTPURLResponse)?.statusCode ?? -1
+            )
+        }
+        return try JSONDecoder().decode(ShareCreateResponse.self, from: data)
+    }
+
+    // MARK: - Inbound
+
+    private func startReceiveLoop(socket: WorkspaceShareSocket) {
+        receiveTask = Task { [weak self] in
+            while !Task.isCancelled {
+                let frame: ShareInboundFrame
+                do {
+                    frame = try await socket.receive()
+                } catch {
+                    guard let self, self.socket === socket else { return }
+                    workspaceShareLog.warning("host socket closed: \(error, privacy: .public)")
+                    self.stopSharing()
+                    return
+                }
+                guard let self, self.socket === socket else { return }
+                self.handleInbound(frame)
+            }
+        }
+    }
+
+    private func handleInbound(_ frame: ShareInboundFrame) {
+        switch frame {
+        case .joinRequest(let requestId, let email, let name):
+            presentJoinRequest(requestId: requestId, email: email, name: name)
+        case .syncRequest(let participantId):
+            guard let workspace = sharedWorkspace else { return }
+            let snapshot = WorkspaceShareLayoutBuilder.makeWorkspace(
+                workspace: workspace, includeReplay: true
+            )
+            socket?.send(.snapshot(to: participantId, workspace: snapshot))
+        case .cursor(let participantId, let x, let y):
+            overlay.updateRemoteCursor(participantId: participantId, x: x, y: y)
+        case .chat(let participantId, _, let text, let x, let y):
+            overlay.showChat(participantId: participantId, text: text, x: x, y: y)
+        case .presence(let participants):
+            overlay.updateParticipants(participants)
+        case .ended:
+            stopSharing()
+        case .unknown(let type):
+            workspaceShareLog.debug("ignoring unknown frame type=\(type, privacy: .public)")
+        }
+    }
+
+    private func presentJoinRequest(requestId: String, email: String, name: String) {
+        let alert = NSAlert()
+        alert.messageText = String(
+            localized: "share.joinRequest.title",
+            defaultValue: "Workspace share join request"
+        )
+        let who = name.isEmpty ? email : "\(name) (\(email))"
+        alert.informativeText = String(
+            format: String(
+                localized: "share.joinRequest.message",
+                defaultValue: "%@ wants to view this workspace."
+            ),
+            who
+        )
+        alert.addButton(withTitle: String(localized: "share.joinRequest.allow", defaultValue: "Allow"))
+        alert.addButton(withTitle: String(localized: "share.joinRequest.deny", defaultValue: "Deny"))
+        let allow = alert.runCmuxModal() == .alertFirstButtonReturn
+        socket?.send(.joinResponse(requestId: requestId, allow: allow))
+    }
+
+    // MARK: - Layout mirror
+
+    private func startLayoutMirror(workspace: Workspace) {
+        layoutObserver = NotificationCenter.default.addObserver(
+            forName: .workspacePaneGeometryDidChange,
+            object: workspace,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                guard let self, let workspace = self.sharedWorkspace else { return }
+                self.syncStreams(workspace: workspace)
+                self.sendLayout(workspace: workspace, force: false)
+            }
+        }
+    }
+
+    private func sendLayout(workspace: Workspace, force: Bool) {
+        let shape = WorkspaceShareLayoutBuilder.makeWorkspace(workspace: workspace, includeReplay: false)
+        guard force || shape != lastSentWorkspace else { return }
+        lastSentWorkspace = shape
+        socket?.send(.layout(workspace: shape))
+        for pane in shape.panes {
+            if let surfaceIdString = pane.surfaceId, let cols = pane.cols, let rows = pane.rows,
+               UUID(uuidString: surfaceIdString) != nil {
+                socket?.send(.termResize(surfaceId: surfaceIdString, cols: cols, rows: rows))
+            }
+        }
+    }
+
+    // MARK: - Terminal streaming
+
+    /// Reconciles per-surface PTY streaming tasks and textbox mirrors with the
+    /// panels currently in the shared workspace.
+    private func syncStreams(workspace: Workspace) {
+        let terminalPanels = workspace.panels.values.compactMap { $0 as? TerminalPanel }
+        let liveIds = Set(terminalPanels.map(\.id))
+
+        for (id, task) in termTasks where !liveIds.contains(id) {
+            task.cancel()
+            termTasks[id] = nil
+            textBoxObservations[id] = nil
+        }
+        for panel in terminalPanels {
+            if termTasks[panel.id] == nil {
+                termTasks[panel.id] = makeTermStreamTask(surfaceId: panel.id)
+            }
+            if textBoxObservations[panel.id] == nil {
+                textBoxObservations[panel.id] = makeTextBoxObservation(panel: panel, workspace: workspace)
+            }
+        }
+    }
+
+    private func makeTermStreamTask(surfaceId: UUID) -> Task<Void, Never> {
+        Task { [weak self] in
+            // `outputUpdates` ends the stream on slow-consumer drop; loop to
+            // re-subscribe. Viewers detect the seq gap and re-request a
+            // snapshot through the DO's `sync_request` path.
+            while !Task.isCancelled {
+                guard let self, let socket = self.socket else { return }
+                let updates = MobileTerminalByteTee.shared.outputUpdates(surfaceID: surfaceId)
+                for await chunk in updates {
+                    guard !Task.isCancelled else { return }
+                    socket.send(.term(
+                        surfaceId: surfaceId.uuidString,
+                        seq: chunk.sequence,
+                        dataB64: chunk.data.base64EncodedString()
+                    ))
+                }
+                guard !Task.isCancelled else { return }
+                // Stream ended (drop or surface teardown). Yield before
+                // re-subscribing so a torn-down surface doesn't spin.
+                await Task.yield()
+                if MobileTerminalByteTee.shared.currentSequence(surfaceID: surfaceId) == nil {
+                    return
+                }
+            }
+        }
+    }
+
+    private func makeTextBoxObservation(panel: TerminalPanel, workspace: Workspace) -> AnyCancellable {
+        // First pass mirrors text content only; selection tracking is a
+        // follow-up (selStart/selEnd pinned to end of text).
+        panel.$textBoxContent
+            .removeDuplicates()
+            .sink { [weak self, weak panel, weak workspace] text in
+                guard let self, let panel, let workspace,
+                      let paneId = Self.paneId(forPanelId: panel.id, workspace: workspace) else { return }
+                self.socket?.send(.textbox(
+                    paneId: paneId,
+                    text: text,
+                    selStart: text.count,
+                    selEnd: text.count,
+                    active: !text.isEmpty
+                ))
+            }
+    }
+
+    private static func paneId(forPanelId panelId: UUID, workspace: Workspace) -> String? {
+        let snapshot = workspace.bonsplitController.layoutSnapshot()
+        for geometry in snapshot.panes {
+            guard let selected = geometry.selectedTabId,
+                  let selectedUUID = UUID(uuidString: selected),
+                  workspace.panelIdFromSurfaceId(TabID(uuid: selectedUUID)) == panelId else { continue }
+            return geometry.paneId
+        }
+        return nil
+    }
+
+    // MARK: - Host cursor
+
+    private func startCursorMonitor(workspace: Workspace) {
+        cursorMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.mouseMoved, .leftMouseDragged]
+        ) { [weak self] event in
+            MainActor.assumeIsolated {
+                self?.handleMouseEvent(event)
+            }
+            return event
+        }
+        workspaceWindow(for: workspace)?.acceptsMouseMovedEvents = true
+    }
+
+    private func handleMouseEvent(_ event: NSEvent) {
+        guard let workspace = sharedWorkspace,
+              let window = event.window,
+              window === workspaceWindow(for: workspace) else { return }
+        // Throttle to ~30/s (the DO also rate limits per sender).
+        let now = ContinuousClock.now
+        if let last = lastCursorSend, now - last < .milliseconds(33) { return }
+
+        let snapshot = workspace.bonsplitController.layoutSnapshot()
+        let container = CGRect(
+            x: snapshot.containerFrame.x,
+            y: snapshot.containerFrame.y,
+            width: snapshot.containerFrame.width,
+            height: snapshot.containerFrame.height
+        )
+        guard let contentView = window.contentView else { return }
+        // bonsplit's container frame is SwiftUI `.global` (top-left origin in
+        // the window's content); NSEvent locations are bottom-left origin.
+        let location = event.locationInWindow
+        let topLeftPoint = CGPoint(x: location.x, y: contentView.bounds.height - location.y)
+        guard let normalized = WorkspaceShareLayoutMath.normalizedPoint(topLeftPoint, container: container) else {
+            return
+        }
+        lastCursorSend = now
+        socket?.send(.cursor(x: normalized.x, y: normalized.y))
+    }
+
+    private func workspaceWindow(for workspace: Workspace) -> NSWindow? {
+        // The shared workspace renders in a cmux main window; use the window
+        // hosting a live terminal view when available, else the key/main window.
+        for panel in workspace.panels.values {
+            if let terminal = panel as? TerminalPanel,
+               let window = terminal.textBoxInputView?.window {
+                return window
+            }
+        }
+        return NSApp.cmuxMainWindowForModalPresentation()
+    }
+}

--- a/Sources/Share/WorkspaceShareSocket.swift
+++ b/Sources/Share/WorkspaceShareSocket.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Endpoint resolution for the share service. The base URL can be pointed at
+/// a local `wrangler dev` instance with
+/// `defaults write <bundle> cmux.share.serviceURL http://127.0.0.1:8787`.
+enum WorkspaceShareEndpoints {
+    static let serviceURLDefaultsKey = "cmux.share.serviceURL"
+    static let defaultServiceURL = URL(string: "https://share.cmux.dev")!
+    /// The user-facing share page origin (the worker URL is transport-only).
+    static let sharePageBase = URL(string: "https://cmux.com/share/")!
+
+    static func serviceBaseURL(defaults: UserDefaults = .standard) -> URL {
+        if let raw = defaults.string(forKey: serviceURLDefaultsKey),
+           let url = URL(string: raw), url.scheme != nil {
+            return url
+        }
+        return defaultServiceURL
+    }
+
+    static func createURL(base: URL) -> URL {
+        base.appendingPathComponent("v1/share/create")
+    }
+
+    static func hostSocketURL(base: URL, shareId: String, hostToken: String) -> URL? {
+        guard var components = URLComponents(
+            url: base.appendingPathComponent("v1/share/\(shareId)/host"),
+            resolvingAgainstBaseURL: false
+        ) else { return nil }
+        components.scheme = (components.scheme == "http") ? "ws" : "wss"
+        components.queryItems = [URLQueryItem(name: "token", value: hostToken)]
+        return components.url
+    }
+
+    static func sharePageURL(shareId: String) -> URL {
+        sharePageBase.appendingPathComponent(shareId)
+    }
+}
+
+/// One WebSocket connection attempt to the ShareSession Durable Object host
+/// lane. Owns a `URLSessionWebSocketTask`; outbound frames are serialized
+/// through a single sender task so per-surface `term` ordering is preserved.
+/// Reconnect policy lives in `WorkspaceShareService`; this type is one
+/// connection, dead once it fails.
+@MainActor
+final class WorkspaceShareSocket {
+    enum SocketError: Error {
+        case sendFailed
+        case receiveFailed
+    }
+
+    private let task: URLSessionWebSocketTask
+    private var outboundContinuation: AsyncStream<Data>.Continuation?
+    private var senderTask: Task<Void, Never>?
+    private(set) var isClosed = false
+
+    init(url: URL, session: URLSession = .shared) {
+        task = session.webSocketTask(with: url)
+    }
+
+    /// Connects and starts the sender loop. Frames yielded before the socket
+    /// finishes its handshake are buffered by URLSession.
+    func start() {
+        let (stream, continuation) = AsyncStream<Data>.makeStream(bufferingPolicy: .unbounded)
+        outboundContinuation = continuation
+        task.resume()
+        let webSocketTask = task
+        senderTask = Task { [weak self] in
+            for await data in stream {
+                guard let text = String(data: data, encoding: .utf8) else { continue }
+                do {
+                    try await webSocketTask.send(.string(text))
+                } catch {
+                    await self?.markClosed()
+                    break
+                }
+            }
+        }
+    }
+
+    func send(_ frame: ShareOutboundFrame) {
+        guard !isClosed, let data = try? frame.encodedJSONData() else { return }
+        outboundContinuation?.yield(data)
+    }
+
+    /// Receives one inbound frame; throws when the socket is dead.
+    func receive() async throws -> ShareInboundFrame {
+        let message = try await task.receive()
+        let data: Data
+        switch message {
+        case .string(let text):
+            data = Data(text.utf8)
+        case .data(let raw):
+            data = raw
+        @unknown default:
+            return .unknown(type: "")
+        }
+        return try ShareInboundFrame.decode(fromJSONData: data)
+    }
+
+    func close(sendEnd: Bool) {
+        guard !isClosed else { return }
+        if sendEnd, let data = try? ShareOutboundFrame.end.encodedJSONData() {
+            outboundContinuation?.yield(data)
+        }
+        isClosed = true
+        outboundContinuation?.finish()
+        outboundContinuation = nil
+        // Give the sender loop a chance to flush the `end` frame; the task
+        // cancel below tears down the connection either way.
+        senderTask = nil
+        task.cancel(with: .normalClosure, reason: nil)
+    }
+
+    private func markClosed() {
+        isClosed = true
+        outboundContinuation?.finish()
+        outboundContinuation = nil
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -2005,6 +2005,12 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		EE30D6000000000000000002 /* WorkspaceRemoteSessionHostAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE30D6000000000000000001 /* WorkspaceRemoteSessionHostAdapter.swift */; };
 		44FF9EFEEF762BE6CF158E42 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92CA6F2F239631988B2FB0C8 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift */; };
 		619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */; };
+		5A4E000000000000000000B2 /* WorkspaceShareLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E000000000000000000A2 /* WorkspaceShareLayout.swift */; };
+		5A4E000000000000000000B1 /* WorkspaceShareModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E000000000000000000A1 /* WorkspaceShareModels.swift */; };
+		5A4E000000000000000000B5 /* WorkspaceShareOverlayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E000000000000000000A5 /* WorkspaceShareOverlayController.swift */; };
+		5A4E000000000000000000B6 /* WorkspaceShareProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E000000000000000000A6 /* WorkspaceShareProtocolTests.swift */; };
+		5A4E000000000000000000B4 /* WorkspaceShareService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E000000000000000000A4 /* WorkspaceShareService.swift */; };
+		5A4E000000000000000000B3 /* WorkspaceShareSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A4E000000000000000000A3 /* WorkspaceShareSocket.swift */; };
 		6799A0016799A0016799A001 /* WorkspaceSidebarAgentRuntimeObservationModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6799A0026799A0026799A002 /* WorkspaceSidebarAgentRuntimeObservationModel.swift */; };
 		5659B0015659B0015659B001 /* WorkspaceSidebarLogEntryLimitProvider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659B0025659B0025659B002 /* WorkspaceSidebarLogEntryLimitProvider.swift */; };
 		5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */; };
@@ -4023,6 +4029,12 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		EE30D6000000000000000001 /* WorkspaceRemoteSessionHostAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteSessionHostAdapter.swift; sourceTree = "<group>"; };
 		92CA6F2F239631988B2FB0C8 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift; sourceTree = "<group>"; };
 		9960CC3992F3C44489E7627C /* WorkspaceRuntimeSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/WorkspaceRuntimeSettings.swift; sourceTree = "<group>"; };
+		5A4E000000000000000000A2 /* WorkspaceShareLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceShareLayout.swift; sourceTree = "<group>"; };
+		5A4E000000000000000000A1 /* WorkspaceShareModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceShareModels.swift; sourceTree = "<group>"; };
+		5A4E000000000000000000A5 /* WorkspaceShareOverlayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceShareOverlayController.swift; sourceTree = "<group>"; };
+		5A4E000000000000000000A6 /* WorkspaceShareProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceShareProtocolTests.swift; sourceTree = "<group>"; };
+		5A4E000000000000000000A4 /* WorkspaceShareService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceShareService.swift; sourceTree = "<group>"; };
+		5A4E000000000000000000A3 /* WorkspaceShareSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceShareSocket.swift; sourceTree = "<group>"; };
 		6799A0026799A0026799A002 /* WorkspaceSidebarAgentRuntimeObservationModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarAgentRuntimeObservationModel.swift; sourceTree = "<group>"; };
 		5659B0025659B0025659B002 /* WorkspaceSidebarLogEntryLimitProvider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarLogEntryLimitProvider.swift; sourceTree = "<group>"; };
 		5659A0025659A0025659A002 /* WorkspaceSidebarObservation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceSidebarObservation.swift; sourceTree = "<group>"; };
@@ -4277,6 +4289,19 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			);
 			name = AgentChat;
 			path = AgentChat;
+			sourceTree = "<group>";
+		};
+		5A4E000000000000000000C1 /* Share */ = {
+			isa = PBXGroup;
+			children = (
+				5A4E000000000000000000A1 /* WorkspaceShareModels.swift */,
+				5A4E000000000000000000A2 /* WorkspaceShareLayout.swift */,
+				5A4E000000000000000000A3 /* WorkspaceShareSocket.swift */,
+				5A4E000000000000000000A4 /* WorkspaceShareService.swift */,
+				5A4E000000000000000000A5 /* WorkspaceShareOverlayController.swift */,
+			);
+			name = Share;
+			path = Share;
 			sourceTree = "<group>";
 		};
 		59065015952E1B5BE5E23519 /* Mobile */ = {
@@ -5559,6 +5584,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				8054A0040000000000000004 /* TerminalController+BrowserAutomationRecovery.swift */,
 				C57B00050000000000000002 /* CmuxExtensionSidebarSelection+CustomSidebarName.swift */,
 				59065015952E1B5BE5E23519 /* Mobile */,
+				5A4E000000000000000000C1 /* Share */,
 				31B04B98376C9BA8B9E44DCB /* TerminalViewportUITestRecorder.swift */,
 			);
 			path = Sources;
@@ -6017,6 +6043,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C06552030000000000000002 /* TabManagerTitleUpdateStalenessTests.swift */,
 				C06552020000000000000002 /* TabManagerTitleUpdateTests.swift */,
 				42092CDB2109E250F7F2A76E /* TabManagerUnitTests.swift */,
+				5A4E000000000000000000A6 /* WorkspaceShareProtocolTests.swift */,
 				AB12CD340000000000000002 /* WorkspaceTodoNotificationRegressionTests.swift */,
 				DCE71A0F7E02A07A155241E4 /* SidebarWorkspaceRowStatusGlyphRemovalTests.swift */,
 				9C5C9824B98FFC44A2C44F47 /* WorkspaceTodoSnapshotTests.swift */,
@@ -7938,6 +7965,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				EE30D6000000000000000002 /* WorkspaceRemoteSessionHostAdapter.swift in Sources */,
 				44FF9EFEEF762BE6CF158E42 /* WorkspaceRemoteTmuxNonInteractiveCloseRoute.swift in Sources */,
 				619D509BC9B1EA946CBD6A8A /* WorkspaceRuntimeSettings.swift in Sources */,
+				5A4E000000000000000000B2 /* WorkspaceShareLayout.swift in Sources */,
+				5A4E000000000000000000B1 /* WorkspaceShareModels.swift in Sources */,
+				5A4E000000000000000000B5 /* WorkspaceShareOverlayController.swift in Sources */,
+				5A4E000000000000000000B4 /* WorkspaceShareService.swift in Sources */,
+				5A4E000000000000000000B3 /* WorkspaceShareSocket.swift in Sources */,
 				6799A0016799A0016799A001 /* WorkspaceSidebarAgentRuntimeObservationModel.swift in Sources */,
 				5659B0015659B0015659B001 /* WorkspaceSidebarLogEntryLimitProvider.swift in Sources */,
 				5659A0015659A0015659A001 /* WorkspaceSidebarObservation.swift in Sources */,
@@ -8632,6 +8664,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F6100000A1B2C3D4E5F60718 /* WorkspaceRemoteConnectionTests.swift in Sources */,
 				7277A0017277A0017277A001 /* WorkspaceRemoteDirectoryProvenanceTests.swift in Sources */,
 				F6357300A1B2C3D4E5F60718 /* WorkspaceRemoteReconnectPolicyTests.swift in Sources */,
+				5A4E000000000000000000B6 /* WorkspaceShareProtocolTests.swift in Sources */,
 				5659A0035659A0035659A003 /* WorkspaceSidebarObservationTests.swift in Sources */,
 				A1F4B4A6F4F043FCB3288A3D /* WorkspaceSidebarProcessTitleObservationTests.swift in Sources */,
 				6B524A0CB34FD46A771335AB /* WorkspaceSplitStartupCommandTests.swift in Sources */,

--- a/cmuxTests/WorkspaceShareProtocolTests.swift
+++ b/cmuxTests/WorkspaceShareProtocolTests.swift
@@ -1,0 +1,244 @@
+import Foundation
+import XCTest
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+/// Wire-format tests for the multiplayer workspace share protocol
+/// (plans/feat-multiplayer-share/DESIGN.md): outbound frame key names,
+/// inbound frame decoding including unknown-type tolerance, replay capping,
+/// and normalized-rect math.
+final class WorkspaceShareProtocolTests: XCTestCase {
+    private func json(_ frame: ShareOutboundFrame) throws -> [String: Any] {
+        let data = try frame.encodedJSONData()
+        let object = try JSONSerialization.jsonObject(with: data)
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    // MARK: - Outbound encoding
+
+    func testTermFrameUsesSnakeCaseDataKey() throws {
+        let object = try json(.term(surfaceId: "abc", seq: 42, dataB64: "aGk="))
+        XCTAssertEqual(object["type"] as? String, "term")
+        XCTAssertEqual(object["surfaceId"] as? String, "abc")
+        XCTAssertEqual(object["seq"] as? UInt64, 42)
+        XCTAssertEqual(object["data_b64"] as? String, "aGk=")
+        XCTAssertNil(object["dataB64"], "wire key must be data_b64 per DESIGN.md")
+    }
+
+    func testJoinResponseFrame() throws {
+        let object = try json(.joinResponse(requestId: "r1", allow: true))
+        XCTAssertEqual(object["type"] as? String, "join_response")
+        XCTAssertEqual(object["requestId"] as? String, "r1")
+        XCTAssertEqual(object["allow"] as? Bool, true)
+    }
+
+    func testTermResizeFrame() throws {
+        let object = try json(.termResize(surfaceId: "s", cols: 120, rows: 40))
+        XCTAssertEqual(object["type"] as? String, "term_resize")
+        XCTAssertEqual(object["cols"] as? Int, 120)
+        XCTAssertEqual(object["rows"] as? Int, 40)
+    }
+
+    func testSnapshotFrameTargetsOneViewerAndCarriesReplay() throws {
+        let workspace = ShareWorkspace(
+            title: "ws",
+            size: ShareWorkspaceSize(width: 1512, height: 916),
+            panes: [
+                ShareWorkspacePane(
+                    id: "p1",
+                    kind: "terminal",
+                    title: "zsh",
+                    rect: ShareRect(x: 0, y: 0, w: 0.5, h: 1),
+                    surfaceId: "u1",
+                    cols: 80,
+                    rows: 24,
+                    replaySeq: 100,
+                    replay_b64: "aGk="
+                )
+            ]
+        )
+        let object = try json(.snapshot(to: "viewer-1", workspace: workspace))
+        XCTAssertEqual(object["type"] as? String, "snapshot")
+        XCTAssertEqual(object["to"] as? String, "viewer-1")
+        let workspaceObject = try XCTUnwrap(object["workspace"] as? [String: Any])
+        let panes = try XCTUnwrap(workspaceObject["panes"] as? [[String: Any]])
+        XCTAssertEqual(panes.count, 1)
+        XCTAssertEqual(panes[0]["replay_b64"] as? String, "aGk=")
+        XCTAssertEqual(panes[0]["replaySeq"] as? UInt64, 100)
+    }
+
+    func testLayoutFrameOmitsReplayFields() throws {
+        let workspace = ShareWorkspace(
+            title: "ws",
+            size: ShareWorkspaceSize(width: 100, height: 100),
+            panes: [
+                ShareWorkspacePane(
+                    id: "p1",
+                    kind: "browser",
+                    title: "docs",
+                    rect: ShareRect(x: 0, y: 0, w: 1, h: 1)
+                )
+            ]
+        )
+        let object = try json(.layout(workspace: workspace))
+        let workspaceObject = try XCTUnwrap(object["workspace"] as? [String: Any])
+        let panes = try XCTUnwrap(workspaceObject["panes"] as? [[String: Any]])
+        XCTAssertNil(panes[0]["replay_b64"])
+        XCTAssertNil(panes[0]["replaySeq"])
+        XCTAssertNil(panes[0]["surfaceId"])
+    }
+
+    func testEndFrame() throws {
+        let object = try json(.end)
+        XCTAssertEqual(object["type"] as? String, "end")
+        XCTAssertEqual(object.count, 1)
+    }
+
+    // MARK: - Inbound decoding
+
+    private func decode(_ jsonString: String) throws -> ShareInboundFrame {
+        try ShareInboundFrame.decode(fromJSONData: Data(jsonString.utf8))
+    }
+
+    func testDecodeJoinRequest() throws {
+        let frame = try decode(
+            #"{"type":"join_request","requestId":"r9","email":"a@b.c","name":"Ada"}"#
+        )
+        XCTAssertEqual(frame, .joinRequest(requestId: "r9", email: "a@b.c", name: "Ada"))
+    }
+
+    func testDecodeSyncRequest() throws {
+        let frame = try decode(#"{"type":"sync_request","participantId":"v1"}"#)
+        XCTAssertEqual(frame, .syncRequest(participantId: "v1"))
+    }
+
+    func testDecodeCursorWithStampedParticipant() throws {
+        let frame = try decode(#"{"type":"cursor","participantId":"v2","x":0.25,"y":0.75}"#)
+        XCTAssertEqual(frame, .cursor(participantId: "v2", x: 0.25, y: 0.75))
+    }
+
+    func testDecodeChat() throws {
+        let frame = try decode(
+            #"{"type":"chat","participantId":"v3","ts":1700000000.5,"text":"hi","x":0.1,"y":0.2}"#
+        )
+        XCTAssertEqual(frame, .chat(participantId: "v3", ts: 1_700_000_000.5, text: "hi", x: 0.1, y: 0.2))
+    }
+
+    func testDecodePresence() throws {
+        let frame = try decode(
+            #"{"type":"presence","participants":[{"id":"h","email":"h@x.y","name":"Host","color":0,"role":"host"}]}"#
+        )
+        guard case .presence(let participants) = frame else {
+            return XCTFail("expected presence, got \(frame)")
+        }
+        XCTAssertEqual(participants.count, 1)
+        XCTAssertTrue(participants[0].isHost)
+        XCTAssertEqual(participants[0].color, 0)
+    }
+
+    func testDecodeEnded() throws {
+        XCTAssertEqual(try decode(#"{"type":"ended"}"#), .ended)
+    }
+
+    func testUnknownFrameTypeDoesNotThrow() throws {
+        let frame = try decode(#"{"type":"totally_new_thing","whatever":1}"#)
+        XCTAssertEqual(frame, .unknown(type: "totally_new_thing"))
+    }
+
+    // MARK: - Replay cap
+
+    func testReplayCapKeepsTailWithinBase64Budget() {
+        let data = Data((0..<300_000).map { UInt8($0 % 251) })
+        let capped = WorkspaceShareReplayCap.cappedReplayTail(data)
+        // 256 KB base64 budget => 192 KB raw.
+        XCTAssertEqual(capped.count, (256 * 1024 / 4) * 3)
+        XCTAssertEqual(capped, data.suffix(capped.count), "cap must keep the most recent bytes")
+        XCTAssertLessThanOrEqual(
+            capped.base64EncodedString().utf8.count,
+            WorkspaceShareReplayCap.maximumBase64ByteCount
+        )
+    }
+
+    func testReplayCapPassesSmallDataThrough() {
+        let data = Data(repeating: 7, count: 1024)
+        XCTAssertEqual(WorkspaceShareReplayCap.cappedReplayTail(data), data)
+    }
+
+    // MARK: - Layout math
+
+    func testNormalizedRectForRightHalfPane() {
+        let container = CGRect(x: 100, y: 50, width: 1000, height: 800)
+        let pane = CGRect(x: 600, y: 50, width: 500, height: 800)
+        let rect = WorkspaceShareLayoutMath.normalizedRect(paneFrame: pane, container: container)
+        XCTAssertEqual(rect.x, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(rect.y, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(rect.w, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(rect.h, 1.0, accuracy: 1e-9)
+    }
+
+    func testNormalizedRectClampsOverflow() {
+        let container = CGRect(x: 0, y: 0, width: 100, height: 100)
+        let pane = CGRect(x: 90, y: -10, width: 40, height: 200)
+        let rect = WorkspaceShareLayoutMath.normalizedRect(paneFrame: pane, container: container)
+        XCTAssertEqual(rect.x, 0.9, accuracy: 1e-9)
+        XCTAssertEqual(rect.y, 0.0, accuracy: 1e-9)
+        XCTAssertEqual(rect.x + rect.w, 1.0, accuracy: 1e-9)
+        XCTAssertEqual(rect.y + rect.h, 1.0, accuracy: 1e-9)
+    }
+
+    func testNormalizedRectZeroContainerIsSafe() {
+        let rect = WorkspaceShareLayoutMath.normalizedRect(
+            paneFrame: CGRect(x: 0, y: 0, width: 10, height: 10),
+            container: .zero
+        )
+        XCTAssertEqual(rect, ShareRect(x: 0, y: 0, w: 0, h: 0))
+    }
+
+    func testNormalizedPointInsideAndOutside() {
+        let container = CGRect(x: 100, y: 100, width: 200, height: 100)
+        let inside = WorkspaceShareLayoutMath.normalizedPoint(CGPoint(x: 200, y: 150), container: container)
+        XCTAssertEqual(inside?.x ?? -1, 0.5, accuracy: 1e-9)
+        XCTAssertEqual(inside?.y ?? -1, 0.5, accuracy: 1e-9)
+        XCTAssertNil(WorkspaceShareLayoutMath.normalizedPoint(CGPoint(x: 50, y: 50), container: container))
+    }
+
+    // MARK: - Endpoints
+
+    func testHostSocketURLUpgradesSchemeAndCarriesToken() throws {
+        let https = try XCTUnwrap(WorkspaceShareEndpoints.hostSocketURL(
+            base: URL(string: "https://share.cmux.dev")!,
+            shareId: "abc123",
+            hostToken: "tok"
+        ))
+        XCTAssertEqual(https.scheme, "wss")
+        XCTAssertEqual(https.path, "/v1/share/abc123/host")
+        XCTAssertEqual(https.query, "token=tok")
+
+        let http = try XCTUnwrap(WorkspaceShareEndpoints.hostSocketURL(
+            base: URL(string: "http://127.0.0.1:8787")!,
+            shareId: "abc123",
+            hostToken: "tok"
+        ))
+        XCTAssertEqual(http.scheme, "ws")
+        XCTAssertEqual(http.port, 8787)
+    }
+
+    func testServiceBaseURLDefaultsOverride() {
+        let defaults = UserDefaults(suiteName: "WorkspaceShareProtocolTests")!
+        defaults.removePersistentDomain(forName: "WorkspaceShareProtocolTests")
+        XCTAssertEqual(
+            WorkspaceShareEndpoints.serviceBaseURL(defaults: defaults),
+            WorkspaceShareEndpoints.defaultServiceURL
+        )
+        defaults.set("http://127.0.0.1:8787", forKey: WorkspaceShareEndpoints.serviceURLDefaultsKey)
+        XCTAssertEqual(
+            WorkspaceShareEndpoints.serviceBaseURL(defaults: defaults).absoluteString,
+            "http://127.0.0.1:8787"
+        )
+        defaults.removePersistentDomain(forName: "WorkspaceShareProtocolTests")
+    }
+}

--- a/plans/feat-multiplayer-share/DESIGN.md
+++ b/plans/feat-multiplayer-share/DESIGN.md
@@ -1,0 +1,131 @@
+# Multiplayer workspace share (cmux.com/share/&lt;id&gt;)
+
+A host Mac shares one workspace read-only to authenticated web viewers. Everyone
+sees everyone's cursor (colored kite pointers), can cursor-chat Figma-style, and
+messages also collect in a floating chat panel. Transport hub is a Cloudflare
+Durable Object (GPL-3.0-or-later, `workers/share/`).
+
+## Topology
+
+```
+cmux macOS host ── wss ──► ShareSession DO ◄── wss ── web viewer(s) at cmux.com/share/<id>
+```
+
+- One `ShareSession` Durable Object per share id (`idFromName(shareId)`).
+- Host authenticates with a per-session `hostToken` returned by create.
+- Viewers authenticate with a Stack access token; the worker verifies it
+  (same pattern as `workers/presence/src/auth.ts`) and passes verified
+  identity headers to the DO. The DO never sees unauthenticated input.
+- Viewer admission requires explicit host approval per user (allow/deny).
+
+## HTTP surface (worker)
+
+- `POST /v1/share/create` — Stack bearer auth. Body `{ title? }`. Returns
+  `{ shareId, hostToken, url }`. `shareId` is 22 chars base62.
+- `GET /v1/share/:id/host?token=<hostToken>` — WebSocket upgrade, host lane.
+- `GET /v1/share/:id/ws?access_token=<stack access token>` — WebSocket
+  upgrade, viewer lane (query param because browsers cannot set WS headers).
+- `GET /healthz` — liveness.
+
+## WebSocket messages (JSON, one object per frame)
+
+Participant = `{ id, email, name, color, role: "host"|"viewer" }`. The DO
+assigns `id` and `color` (index into a fixed palette; host is always color 0).
+
+Viewer lifecycle:
+- DO→viewer `{ type: "join_state", state: "pending"|"approved"|"denied" }`
+- DO→host `{ type: "join_request", requestId, email, name }`
+- host→DO `{ type: "join_response", requestId, allow: bool }`
+  Approval is remembered per user id for the life of the session.
+
+Sync (targeted; DO stores no terminal data):
+- DO→host `{ type: "sync_request", participantId }` when a viewer is approved
+- host→DO `{ type: "snapshot", to: participantId, workspace: Workspace }`
+  forwarded only to that viewer.
+
+Live stream, host→DO, broadcast to approved viewers:
+- `{ type: "layout", workspace: Workspace }` on any pane/layout change
+- `{ type: "term", surfaceId, seq, data_b64 }` raw PTY output chunk
+- `{ type: "term_resize", surfaceId, cols, rows }`
+- `{ type: "textbox", paneId, text, selStart, selEnd, active }` host textbox mirror
+
+Presence, any→DO, broadcast to everyone including host:
+- `{ type: "cursor", x, y }` — normalized [0,1] workspace coordinates; DO
+  stamps `participantId` and rebroadcasts (rate limited to 30/s per sender)
+- `{ type: "chat", text, x, y }` — cursor-chat bubble + floating panel entry;
+  DO stamps `participantId`, `ts`, keeps the last 200 in DO storage and
+  replays them to newly approved viewers
+- DO→all `{ type: "presence", participants: [Participant] }` on any change
+
+### Workspace shape
+
+```jsonc
+{
+  "title": "issue-118 korean ime",
+  "size": { "width": 1512, "height": 916 },       // host logical pixels
+  "panes": [
+    {
+      "id": "pane-uuid",
+      "kind": "terminal" | "browser" | "textbox" | "other",
+      "title": "zsh — worktrees/…",
+      "rect": { "x": 0, "y": 0, "w": 0.5, "h": 1.0 },  // normalized [0,1]
+      "surfaceId": "uuid",                              // terminal panes only
+      "cols": 120, "rows": 40,
+      "replaySeq": 123456,                              // snapshot only
+      "replay_b64": "…"                                 // snapshot only, ≤256KB
+    }
+  ]
+}
+```
+
+## Rendering (web)
+
+- Route `web/app/[locale]/share/[id]/page.tsx`. Requires Stack sign-in; the
+  signed-out state shows the Stack sign-in redirect.
+- Workspace is laid out at the host's logical size inside a wrapper that gets
+  `transform: scale(k)` to fit the viewport (mobile works for free; refined
+  scaling later).
+- Terminal panes render with `ghostty-web` (`Terminal.write` of decoded
+  chunks; `seq` gap ⇒ re-request snapshot). Read-only: no `onData` wiring.
+- Non-terminal panes render as titled placeholder tiles (browser panes show
+  title + URL if present).
+- Cursors: the Sky kite path from `AgentCursorPointerView` (cua PR
+  https://github.com/manaflow-ai/cmux/pull/7151) as inline SVG, gradient
+  recolored per participant; name label chip next to it.
+- Cursor chat: press `/` to type at your cursor; bubble floats next to the
+  cursor for 6s and every message appends to the floating chat panel pinned
+  bottom-right of the workspace.
+
+## macOS host
+
+- Command palette action `palette.shareWorkspace` ("Share Workspace…"):
+  creates the session, copies the URL, connects the host WebSocket
+  (`URLSessionWebSocketTask`), starts streaming.
+- Join requests present `NSAlert.runCmuxModal` — "<email> wants to view this
+  workspace" with Allow/Deny.
+- Terminal bytes come from `MobileTerminalByteTee` (`outputUpdates` streams +
+  `replayState` for snapshots).
+- Host cursor is a local `NSEvent` mouse-moved monitor over the workspace
+  window, normalized and throttled.
+- Remote cursors + chat bubbles render in a non-activating overlay window on
+  the workspace (same approach as `ComputerUseCursorOverlayController` from
+  PR 7151), tinted per participant.
+- Textbox mirror: host broadcasts textbox text + selection on change
+  (host→viewer only in this pass; viewer textbox carets are a follow-up).
+
+## Security
+
+- Share ids are unguessable but the page still requires Stack auth + explicit
+  host approval per user; denial is remembered for the session.
+- Host token is generated by the DO at create, stored hashed, single active
+  host connection at a time (new host connection supersedes the old).
+- Read-only: the DO drops any viewer message other than `cursor`/`chat`
+  (oversize frames close the socket). No input path to the Mac exists in the
+  protocol.
+- Session ends when the host disconnects for >60s or sends `{type:"end"}`;
+  the DO closes viewer sockets with an `ended` frame and deletes state.
+
+## Licensing
+
+`workers/share/` is GPL-3.0-or-later (LICENSE file + SPDX headers), matching
+the repo's open-source license lane.

--- a/web/app/[locale]/share/[id]/chat-panel.tsx
+++ b/web/app/[locale]/share/[id]/chat-panel.tsx
@@ -1,0 +1,106 @@
+"use client";
+
+import { useState } from "react";
+import { useTranslations } from "next-intl";
+import type { Participant } from "./protocol";
+import { displayName, participantColor } from "./palette";
+import { useNow } from "./use-now";
+
+export interface ChatEntry {
+  id: number;
+  participantId: string;
+  text: string;
+  ts: number;
+}
+
+function relativeTime(
+  ts: number,
+  now: number,
+  t: ReturnType<typeof useTranslations<"share">>,
+): string {
+  const seconds = Math.max(0, Math.round((now - ts) / 1000));
+  if (seconds < 60) return t("chat.justNow");
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return t("chat.minutesAgo", { minutes });
+  const hours = Math.round(minutes / 60);
+  return t("chat.hoursAgo", { hours });
+}
+
+export function ChatPanel({
+  entries,
+  participants,
+  onSend,
+}: {
+  entries: ChatEntry[];
+  participants: Map<string, Participant>;
+  onSend: (text: string) => void;
+}) {
+  const t = useTranslations("share");
+  const [collapsed, setCollapsed] = useState(false);
+  const [draft, setDraft] = useState("");
+  const now = useNow();
+
+  const submit = () => {
+    const text = draft.trim();
+    if (!text) return;
+    onSend(text);
+    setDraft("");
+  };
+
+  return (
+    <div className="pointer-events-auto fixed bottom-4 right-4 z-30 w-[300px] overflow-hidden rounded-lg border border-neutral-800 bg-neutral-950/95 shadow-xl backdrop-blur">
+      <button
+        type="button"
+        className="flex w-full items-center justify-between px-3 py-2 text-left text-[12px] font-medium text-neutral-300 hover:bg-neutral-900"
+        onClick={() => setCollapsed((c) => !c)}
+      >
+        <span>{t("chat.title")}</span>
+        <span className="text-neutral-500">{collapsed ? "+" : "−"}</span>
+      </button>
+      {collapsed ? null : (
+        <>
+          <div className="flex max-h-[260px] flex-col-reverse gap-1 overflow-y-auto px-3 pb-2">
+            {entries.length === 0 ? (
+              <p className="py-2 text-[12px] text-neutral-600">
+                {t("chat.empty")}
+              </p>
+            ) : (
+              [...entries].reverse().map((entry) => {
+                const participant = participants.get(entry.participantId);
+                const color = participantColor(participant?.color ?? 0);
+                return (
+                  <div key={entry.id} className="text-[12px] leading-5">
+                    <span
+                      className="font-medium"
+                      style={{ color: color.base }}
+                    >
+                      {participant ? displayName(participant) : "…"}
+                    </span>{" "}
+                    <span className="text-neutral-200">{entry.text}</span>{" "}
+                    <span className="text-[10px] text-neutral-600">
+                      {relativeTime(entry.ts, now, t)}
+                    </span>
+                  </div>
+                );
+              })
+            )}
+          </div>
+          <form
+            className="border-t border-neutral-800 p-2"
+            onSubmit={(event) => {
+              event.preventDefault();
+              submit();
+            }}
+          >
+            <input
+              value={draft}
+              onChange={(event) => setDraft(event.target.value)}
+              placeholder={t("chat.inputPlaceholder")}
+              className="w-full rounded-md border border-neutral-800 bg-neutral-900 px-2 py-1.5 text-[12px] text-neutral-200 outline-none placeholder:text-neutral-600 focus:border-neutral-600"
+            />
+          </form>
+        </>
+      )}
+    </div>
+  );
+}

--- a/web/app/[locale]/share/[id]/cursor-chat-input.tsx
+++ b/web/app/[locale]/share/[id]/cursor-chat-input.tsx
@@ -1,0 +1,60 @@
+"use client";
+
+import { useCallback, useState } from "react";
+import { useTranslations } from "next-intl";
+
+/**
+ * Small floating input rendered at the local user's cursor position (in
+ * workspace coordinates). Enter sends, Escape closes.
+ */
+export function CursorChatInput({
+  x,
+  y,
+  workspaceWidth,
+  workspaceHeight,
+  onSend,
+  onClose,
+}: {
+  x: number;
+  y: number;
+  workspaceWidth: number;
+  workspaceHeight: number;
+  onSend: (text: string) => void;
+  onClose: () => void;
+}) {
+  const t = useTranslations("share");
+  const [text, setText] = useState("");
+
+  const focusRef = useCallback((node: HTMLInputElement | null) => {
+    node?.focus();
+  }, []);
+
+  return (
+    <div
+      className="absolute z-20"
+      style={{
+        left: x * workspaceWidth,
+        top: y * workspaceHeight + 22,
+      }}
+    >
+      <input
+        ref={focusRef}
+        value={text}
+        onChange={(event) => setText(event.target.value)}
+        onBlur={onClose}
+        onKeyDown={(event) => {
+          if (event.key === "Enter") {
+            const trimmed = text.trim();
+            if (trimmed) onSend(trimmed);
+            onClose();
+          } else if (event.key === "Escape") {
+            onClose();
+          }
+          event.stopPropagation();
+        }}
+        placeholder={t("cursorChat.placeholder")}
+        className="w-[220px] rounded-full border border-neutral-700 bg-neutral-950/95 px-3 py-1.5 text-[12px] text-neutral-100 shadow-lg outline-none placeholder:text-neutral-500 focus:border-neutral-500"
+      />
+    </div>
+  );
+}

--- a/web/app/[locale]/share/[id]/cursor-layer.tsx
+++ b/web/app/[locale]/share/[id]/cursor-layer.tsx
@@ -1,0 +1,78 @@
+"use client";
+
+import type { Participant } from "./protocol";
+import { displayName, participantColor } from "./palette";
+import { KiteCursor } from "./kite-cursor";
+
+export interface RemoteCursor {
+  participantId: string;
+  x: number;
+  y: number;
+}
+
+export interface CursorBubble {
+  id: number;
+  participantId: string;
+  text: string;
+}
+
+/**
+ * Renders remote participant cursors + their transient chat bubbles in
+ * workspace coordinates. Positions are normalized [0,1] and mapped to the
+ * unscaled workspace size; the parent applies the fit-to-viewport scale.
+ */
+export function CursorLayer({
+  cursors,
+  bubbles,
+  participants,
+  workspaceWidth,
+  workspaceHeight,
+  selfParticipantId,
+}: {
+  cursors: RemoteCursor[];
+  bubbles: CursorBubble[];
+  participants: Map<string, Participant>;
+  workspaceWidth: number;
+  workspaceHeight: number;
+  selfParticipantId: string | null;
+}) {
+  return (
+    <div className="pointer-events-none absolute inset-0 overflow-visible">
+      {cursors.map((cursor) => {
+        if (cursor.participantId === selfParticipantId) return null;
+        const participant = participants.get(cursor.participantId);
+        const colorIndex = participant?.color ?? 0;
+        const color = participantColor(colorIndex);
+        const bubble = bubbles.findLast(
+          (b) => b.participantId === cursor.participantId,
+        );
+        return (
+          <div
+            key={cursor.participantId}
+            className="absolute left-0 top-0"
+            style={{
+              transform: `translate(${cursor.x * workspaceWidth}px, ${cursor.y * workspaceHeight}px)`,
+              transition: "transform 80ms linear",
+            }}
+          >
+            <KiteCursor colorIndex={colorIndex} />
+            <div
+              className="absolute left-[18px] top-[18px] max-w-[220px] whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-medium text-white"
+              style={{ background: color.base }}
+            >
+              {participant ? displayName(participant) : "…"}
+            </div>
+            {bubble ? (
+              <div
+                className="absolute left-[18px] top-[42px] max-w-[280px] rounded-2xl rounded-tl-sm px-3 py-1.5 text-[12px] leading-4 text-white shadow-lg"
+                style={{ background: color.base }}
+              >
+                {bubble.text}
+              </div>
+            ) : null}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/app/[locale]/share/[id]/ghostty.ts
+++ b/web/app/[locale]/share/[id]/ghostty.ts
@@ -1,0 +1,18 @@
+"use client";
+
+// Lazy, browser-only loader for ghostty-web. The package embeds its
+// ghostty-vt.wasm as a base64 data: URL inside the JS bundle and
+// `init()` fetches that first, so no public/ copy or explicit wasm path
+// is needed under Next's bundler.
+
+type GhosttyModule = typeof import("ghostty-web");
+
+let modulePromise: Promise<GhosttyModule> | null = null;
+
+export function loadGhostty(): Promise<GhosttyModule> {
+  modulePromise ??= import("ghostty-web").then(async (mod) => {
+    await mod.init();
+    return mod;
+  });
+  return modulePromise;
+}

--- a/web/app/[locale]/share/[id]/kite-cursor.tsx
+++ b/web/app/[locale]/share/[id]/kite-cursor.tsx
@@ -1,0 +1,47 @@
+"use client";
+
+import { useId } from "react";
+import { participantColor } from "./palette";
+
+const KITE_PATH =
+  "M 0.68 1.83 L 3.63 9.78 Q 4.67 12.59 5.3 9.66 L 5.44 9.01 Q 6.08 6.08 9.01 5.44 L 9.66 5.3 Q 12.59 4.67 9.78 3.63 L 1.83 0.68 Q 0 0 0.68 1.83 Z";
+
+export function KiteCursor({
+  colorIndex,
+  size = 22,
+}: {
+  colorIndex: number;
+  size?: number;
+}) {
+  const gradientId = useId();
+  const { stops } = participantColor(colorIndex);
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="-1 -1 20.59 20.59"
+      aria-hidden="true"
+      style={{ display: "block", overflow: "visible" }}
+    >
+      <defs>
+        <linearGradient id={gradientId} x1="0" y1="0" x2="1" y2="1">
+          {stops.map((stop, i) => (
+            <stop
+              key={stop + i}
+              offset={stops.length === 1 ? 0 : i / (stops.length - 1)}
+              stopColor={stop}
+            />
+          ))}
+        </linearGradient>
+      </defs>
+      <path
+        d={KITE_PATH}
+        fill={`url(#${gradientId})`}
+        stroke="#ffffff"
+        strokeWidth={1.7}
+        strokeLinejoin="round"
+        style={{ paintOrder: "stroke" }}
+      />
+    </svg>
+  );
+}

--- a/web/app/[locale]/share/[id]/page.tsx
+++ b/web/app/[locale]/share/[id]/page.tsx
@@ -1,0 +1,67 @@
+import { StackProvider, StackTheme } from "@stackframe/stack";
+import { getTranslations, setRequestLocale } from "next-intl/server";
+import { redirect } from "next/navigation";
+import { getStackServerApp, isStackConfigured } from "@/app/lib/stack";
+import { ShareViewer } from "./share-viewer";
+
+export const dynamic = "force-dynamic";
+
+const DEFAULT_SHARE_WS_BASE = "https://share.cmux.dev";
+
+function shareSignInHref(returnPath: string): string {
+  const afterSignIn = new URL("/handler/after-sign-in", "https://cmux.com");
+  afterSignIn.searchParams.set("after_auth_return_to", returnPath);
+  const signIn = new URL("/handler/sign-in", "https://cmux.com");
+  signIn.searchParams.set(
+    "after_auth_return_to",
+    `${afterSignIn.pathname}${afterSignIn.search}`,
+  );
+  return `${signIn.pathname}${signIn.search}`;
+}
+
+export default async function SharePage({
+  params,
+}: {
+  params: Promise<{ locale: string; id: string }>;
+}) {
+  const { locale, id } = await params;
+  setRequestLocale(locale);
+  const t = await getTranslations({ locale, namespace: "share" });
+
+  if (!isStackConfigured()) {
+    return (
+      <main className="flex min-h-dvh items-center justify-center bg-neutral-950 px-4">
+        <div className="max-w-md text-center">
+          <h1 className="text-[15px] font-medium text-neutral-200">
+            {t("unavailable.title")}
+          </h1>
+          <p className="mt-2 text-[13px] text-neutral-500">
+            {t("unavailable.description")}
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  const app = getStackServerApp();
+  const user = await app.getUser({ or: "return-null" });
+  if (!user) {
+    redirect(shareSignInHref(`/${locale}/share/${id}`));
+  }
+
+  const wsBase =
+    process.env.NEXT_PUBLIC_CMUX_SHARE_WS_BASE?.trim() ||
+    DEFAULT_SHARE_WS_BASE;
+
+  return (
+    <StackProvider app={app}>
+      <StackTheme>
+        <ShareViewer
+          shareId={id}
+          wsBase={wsBase}
+          userEmail={user.primaryEmail ?? ""}
+        />
+      </StackTheme>
+    </StackProvider>
+  );
+}

--- a/web/app/[locale]/share/[id]/palette.ts
+++ b/web/app/[locale]/share/[id]/palette.ts
@@ -1,0 +1,54 @@
+// Participant cursor palette. Index 0 is the host and uses the cmux brand
+// gradient; 1..9 are distinct hues for viewers. The server assigns `color`
+// as an index into this palette.
+
+export interface ParticipantColor {
+  /** Solid color used for chips, text, and avatar circles. */
+  base: string;
+  /** Gradient stops for the kite cursor fill (light to dark). */
+  stops: string[];
+}
+
+function darken(hex: string, amount: number): string {
+  const n = parseInt(hex.slice(1), 16);
+  const r = Math.round(((n >> 16) & 0xff) * (1 - amount));
+  const g = Math.round(((n >> 8) & 0xff) * (1 - amount));
+  const b = Math.round((n & 0xff) * (1 - amount));
+  return `#${((r << 16) | (g << 8) | b).toString(16).padStart(6, "0")}`;
+}
+
+function hueColor(base: string): ParticipantColor {
+  return { base, stops: [base, darken(base, 0.35)] };
+}
+
+export const PARTICIPANT_PALETTE: ParticipantColor[] = [
+  // 0: host — cmux gradient.
+  { base: "#2d8cff", stops: ["#12c7f5", "#2d8cff", "#6c5cff"] },
+  hueColor("#ff5c7a"), // 1 rose
+  hueColor("#ffb020"), // 2 amber
+  hueColor("#34d399"), // 3 green
+  hueColor("#b163ff"), // 4 violet
+  hueColor("#ff7a33"), // 5 orange
+  hueColor("#14b8a6"), // 6 teal
+  hueColor("#e879f9"), // 7 magenta
+  hueColor("#a3e635"), // 8 lime
+  hueColor("#60a5fa"), // 9 blue
+];
+
+export function participantColor(index: number): ParticipantColor {
+  const palette = PARTICIPANT_PALETTE;
+  const i = Number.isInteger(index) && index >= 0 ? index % palette.length : 0;
+  return palette[i];
+}
+
+export function displayName(participant: {
+  name?: string;
+  email?: string;
+}): string {
+  if (participant.name && participant.name.trim().length > 0) {
+    return participant.name.trim();
+  }
+  const email = participant.email ?? "";
+  const at = email.indexOf("@");
+  return at > 0 ? email.slice(0, at) : email;
+}

--- a/web/app/[locale]/share/[id]/pane-tile.tsx
+++ b/web/app/[locale]/share/[id]/pane-tile.tsx
@@ -1,0 +1,80 @@
+"use client";
+
+import { useTranslations } from "next-intl";
+import type { Pane, TextboxState } from "./protocol";
+import { SurfaceStore } from "./surface-store";
+import { TerminalPane } from "./terminal-pane";
+
+function TextboxMirror({ state }: { state: TextboxState }) {
+  const selStart = Math.max(0, Math.min(state.selStart, state.text.length));
+  const before = state.text.slice(0, selStart);
+  const after = state.text.slice(selStart);
+  return (
+    <pre className="m-0 h-full w-full overflow-auto whitespace-pre-wrap break-words p-3 font-mono text-[13px] leading-5 text-neutral-200">
+      {before}
+      <span
+        className="inline-block h-[1.1em] w-[2px] translate-y-[0.15em] animate-pulse rounded-sm align-baseline"
+        style={{ background: "#2d8cff" }}
+      />
+      {after}
+    </pre>
+  );
+}
+
+export function PaneTile({
+  pane,
+  store,
+  fontSize,
+  textbox,
+}: {
+  pane: Pane;
+  store: SurfaceStore;
+  fontSize: number;
+  textbox: TextboxState | null;
+}) {
+  const t = useTranslations("share");
+
+  if (pane.kind === "terminal" && pane.surfaceId) {
+    return (
+      <TerminalPane
+        surfaceId={pane.surfaceId}
+        cols={pane.cols ?? 80}
+        rows={pane.rows ?? 24}
+        fontSize={fontSize}
+        store={store}
+      />
+    );
+  }
+
+  const label =
+    pane.kind === "browser"
+      ? t("pane.browser")
+      : pane.kind === "textbox"
+        ? t("pane.textbox")
+        : t("pane.other");
+
+  return (
+    <div className="flex h-full w-full flex-col bg-neutral-900">
+      <div className="flex items-center gap-2 border-b border-neutral-800 px-3 py-1.5">
+        <span className="text-[11px] uppercase tracking-wide text-neutral-500">
+          {label}
+        </span>
+        <span className="truncate text-[12px] text-neutral-300">
+          {pane.title ?? ""}
+        </span>
+        {pane.kind === "browser" && pane.url ? (
+          <span className="truncate text-[11px] text-neutral-500">
+            {pane.url}
+          </span>
+        ) : null}
+      </div>
+      {pane.kind === "textbox" && textbox ? (
+        <TextboxMirror state={textbox} />
+      ) : (
+        <div className="flex flex-1 items-center justify-center text-[12px] text-neutral-600">
+          {t("pane.placeholder")}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/app/[locale]/share/[id]/presence-strip.tsx
+++ b/web/app/[locale]/share/[id]/presence-strip.tsx
@@ -1,0 +1,29 @@
+"use client";
+
+import type { Participant } from "./protocol";
+import { displayName, participantColor } from "./palette";
+
+export function PresenceStrip({
+  participants,
+}: {
+  participants: Participant[];
+}) {
+  return (
+    <div className="pointer-events-auto fixed right-4 top-4 z-30 flex -space-x-1.5">
+      {participants.map((participant) => {
+        const color = participantColor(participant.color);
+        const name = displayName(participant);
+        return (
+          <div
+            key={participant.id}
+            title={name}
+            className="flex h-7 w-7 items-center justify-center rounded-full border-2 border-neutral-950 text-[12px] font-semibold text-white"
+            style={{ background: color.base }}
+          >
+            {name.charAt(0).toUpperCase() || "?"}
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/app/[locale]/share/[id]/protocol.ts
+++ b/web/app/[locale]/share/[id]/protocol.ts
@@ -1,0 +1,95 @@
+// Wire protocol types for the multiplayer share viewer.
+// Mirrors plans/feat-multiplayer-share/DESIGN.md ("WebSocket messages").
+
+export type ParticipantRole = "host" | "viewer";
+
+export interface Participant {
+  id: string;
+  email: string;
+  name: string;
+  color: number;
+  role: ParticipantRole;
+}
+
+export type PaneKind = "terminal" | "browser" | "textbox" | "other";
+
+export interface PaneRect {
+  x: number;
+  y: number;
+  w: number;
+  h: number;
+}
+
+export interface Pane {
+  id: string;
+  kind: PaneKind;
+  title?: string;
+  rect: PaneRect;
+  surfaceId?: string;
+  cols?: number;
+  rows?: number;
+  replaySeq?: number;
+  replay_b64?: string;
+  url?: string;
+}
+
+export interface Workspace {
+  title?: string;
+  size: { width: number; height: number };
+  panes: Pane[];
+}
+
+export type JoinState = "pending" | "approved" | "denied";
+
+export interface TextboxState {
+  text: string;
+  selStart: number;
+  selEnd: number;
+  active: boolean;
+}
+
+export type ServerMessage =
+  | { type: "join_state"; state: JoinState }
+  | { type: "snapshot"; workspace: Workspace }
+  | { type: "layout"; workspace: Workspace }
+  | { type: "term"; surfaceId: string; seq: number; data_b64: string }
+  | { type: "term_resize"; surfaceId: string; cols: number; rows: number }
+  | ({ type: "textbox"; paneId: string } & TextboxState)
+  | { type: "cursor"; participantId: string; x: number; y: number }
+  | {
+      type: "chat";
+      participantId: string;
+      text: string;
+      x: number;
+      y: number;
+      ts: number;
+    }
+  | { type: "presence"; participants: Participant[] }
+  | { type: "ended" };
+
+export function parseServerMessage(raw: unknown): ServerMessage | null {
+  if (typeof raw !== "string") return null;
+  let value: unknown;
+  try {
+    value = JSON.parse(raw);
+  } catch {
+    return null;
+  }
+  if (
+    typeof value !== "object" ||
+    value === null ||
+    typeof (value as { type?: unknown }).type !== "string"
+  ) {
+    return null;
+  }
+  return value as ServerMessage;
+}
+
+export function decodeBase64(b64: string): Uint8Array {
+  const bin = atob(b64);
+  const bytes = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) {
+    bytes[i] = bin.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/web/app/[locale]/share/[id]/share-viewer.tsx
+++ b/web/app/[locale]/share/[id]/share-viewer.tsx
@@ -1,0 +1,219 @@
+"use client";
+
+import { useMemo, useRef, useState } from "react";
+import { useTranslations } from "next-intl";
+import { ChatPanel } from "./chat-panel";
+import { CursorChatInput } from "./cursor-chat-input";
+import { CursorLayer } from "./cursor-layer";
+import { PaneTile } from "./pane-tile";
+import { PresenceStrip } from "./presence-strip";
+import { displayName } from "./palette";
+import { SurfaceStore } from "./surface-store";
+import { useAccessToken } from "./use-access-token";
+import { useElementSize } from "./use-element-size";
+import { useShareSocket } from "./use-share-socket";
+import { useWindowKeydown } from "./use-window-keydown";
+
+const BASE_FONT_SIZE = 13;
+
+function isTypingTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target instanceof HTMLInputElement ||
+    target instanceof HTMLTextAreaElement ||
+    target.isContentEditable
+  );
+}
+
+function StatusOverlay({
+  title,
+  detail,
+  spinner,
+}: {
+  title: string;
+  detail?: string;
+  spinner?: boolean;
+}) {
+  return (
+    <div className="absolute inset-0 z-40 flex flex-col items-center justify-center gap-3 bg-neutral-950/90">
+      {spinner ? (
+        <div
+          className="h-6 w-6 animate-spin rounded-full border-2 border-neutral-700 border-t-neutral-200"
+          aria-hidden="true"
+        />
+      ) : null}
+      <p className="text-[14px] font-medium text-neutral-200">{title}</p>
+      {detail ? <p className="text-[12px] text-neutral-500">{detail}</p> : null}
+    </div>
+  );
+}
+
+export function ShareViewer({
+  shareId,
+  wsBase,
+  userEmail,
+}: {
+  shareId: string;
+  wsBase: string;
+  userEmail: string;
+}) {
+  const t = useTranslations("share");
+  const accessToken = useAccessToken();
+  const store = useMemo(() => new SurfaceStore(), []);
+  const [viewportRef, viewportSize] = useElementSize();
+
+  const {
+    status,
+    workspace,
+    participants,
+    cursors,
+    bubbles,
+    chatEntries,
+    textboxes,
+    sendCursor,
+    sendChat,
+  } = useShareSocket({ shareId, wsBase, accessToken, store });
+
+  const [chatInputOpen, setChatInputOpen] = useState(false);
+  const myCursorRef = useRef({ x: 0.5, y: 0.5 });
+  const [chatInputPos, setChatInputPos] = useState({ x: 0.5, y: 0.5 });
+
+  const participantById = useMemo(
+    () => new Map(participants.map((p) => [p.id, p] as const)),
+    [participants],
+  );
+  const selfParticipantId = useMemo(
+    () => participants.find((p) => p.email === userEmail)?.id ?? null,
+    [participants, userEmail],
+  );
+
+  useWindowKeydown((event) => {
+    if (event.key === "/" && !chatInputOpen && !isTypingTarget(event.target)) {
+      event.preventDefault();
+      setChatInputPos({ ...myCursorRef.current });
+      setChatInputOpen(true);
+    }
+  });
+
+  const host = participants.find((p) => p.role === "host");
+  const hostName = host ? displayName(host) : t("hostFallback");
+
+  const workspaceWidth = workspace?.size.width ?? 0;
+  const workspaceHeight = workspace?.size.height ?? 0;
+  const scale =
+    workspace && viewportSize.width > 0 && viewportSize.height > 0
+      ? Math.min(
+          viewportSize.width / workspaceWidth,
+          viewportSize.height / workspaceHeight,
+          1,
+        )
+      : 1;
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!workspace || workspaceWidth === 0 || workspaceHeight === 0) return;
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = Math.min(
+      1,
+      Math.max(0, (event.clientX - rect.left) / rect.width),
+    );
+    const y = Math.min(
+      1,
+      Math.max(0, (event.clientY - rect.top) / rect.height),
+    );
+    myCursorRef.current = { x, y };
+    sendCursor(x, y);
+  };
+
+  const sendChatAtCursor = (text: string) => {
+    const { x, y } = myCursorRef.current;
+    sendChat(text, x, y);
+  };
+
+  return (
+    <div
+      ref={viewportRef}
+      className="relative flex h-dvh w-full items-center justify-center overflow-hidden bg-neutral-950"
+    >
+      {status === "connecting" ? (
+        <StatusOverlay title={t("status.connecting")} spinner />
+      ) : null}
+      {status === "pending" ? (
+        <StatusOverlay
+          title={t("status.pending", { host: hostName })}
+          detail={t("status.pendingDetail")}
+          spinner
+        />
+      ) : null}
+      {status === "denied" ? (
+        <StatusOverlay title={t("status.denied")} />
+      ) : null}
+      {status === "ended" ? (
+        <StatusOverlay title={t("status.ended")} />
+      ) : null}
+
+      {workspace ? (
+        <div
+          className="relative"
+          style={{
+            width: workspaceWidth,
+            height: workspaceHeight,
+            transform: `scale(${scale})`,
+            transformOrigin: "center center",
+          }}
+          onPointerMove={handlePointerMove}
+        >
+          {workspace.panes.map((pane) => (
+            <div
+              key={pane.id}
+              className="absolute overflow-hidden rounded-md border border-neutral-800"
+              style={{
+                left: pane.rect.x * workspaceWidth,
+                top: pane.rect.y * workspaceHeight,
+                width: pane.rect.w * workspaceWidth,
+                height: pane.rect.h * workspaceHeight,
+              }}
+            >
+              <PaneTile
+                pane={pane}
+                store={store}
+                fontSize={BASE_FONT_SIZE}
+                textbox={textboxes.get(pane.id) ?? null}
+              />
+            </div>
+          ))}
+
+          <CursorLayer
+            cursors={cursors}
+            bubbles={bubbles}
+            participants={participantById}
+            workspaceWidth={workspaceWidth}
+            workspaceHeight={workspaceHeight}
+            selfParticipantId={selfParticipantId}
+          />
+
+          {chatInputOpen ? (
+            <CursorChatInput
+              x={chatInputPos.x}
+              y={chatInputPos.y}
+              workspaceWidth={workspaceWidth}
+              workspaceHeight={workspaceHeight}
+              onSend={sendChatAtCursor}
+              onClose={() => setChatInputOpen(false)}
+            />
+          ) : null}
+        </div>
+      ) : null}
+
+      {status === "live" || workspace ? (
+        <>
+          <PresenceStrip participants={participants} />
+          <ChatPanel
+            entries={chatEntries}
+            participants={participantById}
+            onSend={sendChatAtCursor}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/web/app/[locale]/share/[id]/surface-store.ts
+++ b/web/app/[locale]/share/[id]/surface-store.ts
@@ -1,0 +1,95 @@
+// Routes host terminal output to the pane that renders it. Chunks that
+// arrive before a pane's terminal is ready are buffered; sequence gaps are
+// tolerated (we render on) per the share viewer spec.
+
+export interface SurfaceSink {
+  write(bytes: Uint8Array): void;
+  resize(cols: number, rows: number): void;
+}
+
+interface SurfaceFeed {
+  lastSeq: number | null;
+  pending: Uint8Array[];
+  pendingResize: { cols: number; rows: number } | null;
+  sink: SurfaceSink | null;
+}
+
+export class SurfaceStore {
+  private feeds = new Map<string, SurfaceFeed>();
+
+  private feed(surfaceId: string): SurfaceFeed {
+    let feed = this.feeds.get(surfaceId);
+    if (!feed) {
+      feed = { lastSeq: null, pending: [], pendingResize: null, sink: null };
+      this.feeds.set(surfaceId, feed);
+    }
+    return feed;
+  }
+
+  /** Called when a snapshot arrives: drops stale buffered output. */
+  setBaseline(surfaceId: string, replaySeq: number | undefined): void {
+    const feed = this.feed(surfaceId);
+    feed.pending = [];
+    feed.lastSeq = replaySeq ?? null;
+  }
+
+  /** Snapshot replay: resets the feed baseline, then writes replay bytes. */
+  applySnapshot(
+    surfaceId: string,
+    bytes: Uint8Array,
+    replaySeq: number | undefined,
+  ): void {
+    const feed = this.feed(surfaceId);
+    feed.pending = [];
+    feed.lastSeq = replaySeq ?? null;
+    if (feed.sink) {
+      feed.sink.write(bytes);
+    } else {
+      feed.pending.push(bytes);
+    }
+  }
+
+  pushChunk(surfaceId: string, seq: number, bytes: Uint8Array): void {
+    const feed = this.feed(surfaceId);
+    if (feed.lastSeq !== null && seq <= feed.lastSeq) return;
+    feed.lastSeq = seq;
+    if (feed.sink) {
+      feed.sink.write(bytes);
+    } else {
+      feed.pending.push(bytes);
+    }
+  }
+
+  pushResize(surfaceId: string, cols: number, rows: number): void {
+    const feed = this.feed(surfaceId);
+    if (feed.sink) {
+      feed.sink.resize(cols, rows);
+    } else {
+      feed.pendingResize = { cols, rows };
+    }
+  }
+
+  attach(surfaceId: string, sink: SurfaceSink): void {
+    const feed = this.feed(surfaceId);
+    feed.sink = sink;
+    if (feed.pendingResize) {
+      sink.resize(feed.pendingResize.cols, feed.pendingResize.rows);
+      feed.pendingResize = null;
+    }
+    for (const bytes of feed.pending) {
+      sink.write(bytes);
+    }
+    feed.pending = [];
+  }
+
+  detach(surfaceId: string, sink: SurfaceSink): void {
+    const feed = this.feeds.get(surfaceId);
+    if (feed && feed.sink === sink) {
+      feed.sink = null;
+    }
+  }
+
+  reset(): void {
+    this.feeds.clear();
+  }
+}

--- a/web/app/[locale]/share/[id]/terminal-pane.tsx
+++ b/web/app/[locale]/share/[id]/terminal-pane.tsx
@@ -1,0 +1,90 @@
+"use client";
+
+import { useCallback, useRef } from "react";
+import type { Terminal as GhosttyTerminal } from "ghostty-web";
+import { loadGhostty } from "./ghostty";
+import type { SurfaceSink, SurfaceStore } from "./surface-store";
+
+const TERMINAL_THEME = {
+  background: "#0d0e12",
+  foreground: "#d8dbe2",
+};
+
+/**
+ * A read-only ghostty-web terminal attached to one shared surface. The
+ * terminal mounts through a callback ref: on attach we lazily init the
+ * wasm module, create the Terminal, and register a sink with the
+ * SurfaceStore (which replays any buffered snapshot/live chunks). No
+ * onData wiring — viewers cannot type.
+ */
+export function TerminalPane({
+  surfaceId,
+  cols,
+  rows,
+  fontSize,
+  store,
+}: {
+  surfaceId: string;
+  cols: number;
+  rows: number;
+  fontSize: number;
+  store: SurfaceStore;
+}) {
+  const cleanupRef = useRef<(() => void) | null>(null);
+
+  const hostRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      cleanupRef.current?.();
+      cleanupRef.current = null;
+      if (!node) return;
+
+      let disposed = false;
+      let terminal: GhosttyTerminal | null = null;
+      let sink: SurfaceSink | null = null;
+
+      void loadGhostty()
+        .then((mod) => {
+          if (disposed) return;
+          terminal = new mod.Terminal({
+            cols,
+            rows,
+            fontSize,
+            disableStdin: true,
+            cursorBlink: false,
+            scrollback: 2000,
+            theme: TERMINAL_THEME,
+          });
+          terminal.open(node);
+          const term = terminal;
+          sink = {
+            write: (bytes) => term.write(bytes),
+            resize: (nextCols, nextRows) => term.resize(nextCols, nextRows),
+          };
+          store.attach(surfaceId, sink);
+        })
+        .catch((error) => {
+          console.error("[share] failed to init ghostty-web", error);
+        });
+
+      cleanupRef.current = () => {
+        disposed = true;
+        if (sink) store.detach(surfaceId, sink);
+        terminal?.dispose();
+        terminal = null;
+        sink = null;
+      };
+    },
+    // The pane identity (surfaceId) owns this terminal; geometry changes
+    // are handled through term_resize messages, not remounts.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [surfaceId, store],
+  );
+
+  return (
+    <div
+      ref={hostRef}
+      className="h-full w-full overflow-hidden"
+      style={{ background: TERMINAL_THEME.background }}
+    />
+  );
+}

--- a/web/app/[locale]/share/[id]/use-access-token.ts
+++ b/web/app/[locale]/share/[id]/use-access-token.ts
@@ -1,0 +1,35 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useUser } from "@stackframe/stack";
+
+/**
+ * Resolves the current Stack access token once per user session. Narrow
+ * effect contract: async token fetch tied to the user identity.
+ */
+export function useAccessToken(): string | null {
+  const user = useUser();
+  const [token, setToken] = useState<string | null>(null);
+  const userId = user?.id ?? null;
+
+  useEffect(() => {
+    if (!user) return;
+    let cancelled = false;
+    void user.currentSession
+      .getTokens()
+      .then(({ accessToken }) => {
+        if (!cancelled) setToken(accessToken);
+      })
+      .catch(() => {
+        if (!cancelled) setToken(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+    // `user` object identity churns per render in the Stack SDK; the
+    // session is keyed by user id.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [userId]);
+
+  return user ? token : null;
+}

--- a/web/app/[locale]/share/[id]/use-element-size.ts
+++ b/web/app/[locale]/share/[id]/use-element-size.ts
@@ -1,0 +1,42 @@
+"use client";
+
+import { useCallback, useRef, useState } from "react";
+
+export interface ElementSize {
+  width: number;
+  height: number;
+}
+
+/**
+ * Observes an element's content box via ResizeObserver behind a callback
+ * ref (no useEffect). Returns [ref, size].
+ */
+export function useElementSize(): [
+  (node: HTMLElement | null) => void,
+  ElementSize,
+] {
+  const [size, setSize] = useState<ElementSize>({ width: 0, height: 0 });
+  const observerRef = useRef<ResizeObserver | null>(null);
+
+  const ref = useCallback((node: HTMLElement | null) => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+    if (!node) return;
+    const observer = new ResizeObserver((entries) => {
+      const entry = entries[entries.length - 1];
+      if (!entry) return;
+      const box = entry.contentRect;
+      setSize((prev) =>
+        prev.width === box.width && prev.height === box.height
+          ? prev
+          : { width: box.width, height: box.height },
+      );
+    });
+    observer.observe(node);
+    observerRef.current = observer;
+    const rect = node.getBoundingClientRect();
+    setSize({ width: rect.width, height: rect.height });
+  }, []);
+
+  return [ref, size];
+}

--- a/web/app/[locale]/share/[id]/use-now.ts
+++ b/web/app/[locale]/share/[id]/use-now.ts
@@ -1,0 +1,41 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+
+const REFRESH_MS = 30_000;
+
+let cachedNow = 0;
+const listeners = new Set<() => void>();
+let timer: ReturnType<typeof setInterval> | null = null;
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  if (!timer) {
+    cachedNow = Date.now();
+    timer = setInterval(() => {
+      cachedNow = Date.now();
+      for (const l of listeners) l();
+    }, REFRESH_MS);
+  }
+  return () => {
+    listeners.delete(listener);
+    if (listeners.size === 0 && timer) {
+      clearInterval(timer);
+      timer = null;
+    }
+  };
+}
+
+function getSnapshot(): number {
+  if (cachedNow === 0) cachedNow = Date.now();
+  return cachedNow;
+}
+
+function getServerSnapshot(): number {
+  return 0;
+}
+
+/** Coarse clock (30s resolution) for relative timestamps. */
+export function useNow(): number {
+  return useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
+}

--- a/web/app/[locale]/share/[id]/use-share-socket.ts
+++ b/web/app/[locale]/share/[id]/use-share-socket.ts
@@ -1,0 +1,304 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+import type { ChatEntry } from "./chat-panel";
+import type { CursorBubble, RemoteCursor } from "./cursor-layer";
+import {
+  decodeBase64,
+  parseServerMessage,
+  type Participant,
+  type TextboxState,
+  type Workspace,
+} from "./protocol";
+import { SurfaceStore } from "./surface-store";
+
+export type ShareStatus =
+  | "connecting"
+  | "pending"
+  | "denied"
+  | "ended"
+  | "live";
+
+export interface ShareState {
+  status: ShareStatus;
+  workspace: Workspace | null;
+  participants: Participant[];
+  cursors: RemoteCursor[];
+  bubbles: CursorBubble[];
+  chatEntries: ChatEntry[];
+  textboxes: Map<string, TextboxState>;
+}
+
+export interface ShareActions {
+  sendCursor: (x: number, y: number) => void;
+  sendChat: (text: string, x: number, y: number) => void;
+}
+
+const BUBBLE_LIFETIME_MS = 6000;
+const RECONNECT_DELAY_MS = 2000;
+const MAX_RECONNECT_ATTEMPTS = 5;
+const CURSOR_SENDS_PER_SECOND = 30;
+
+let nextEntryId = 1;
+
+/**
+ * Throttles cursor broadcasts to ~30/s using requestAnimationFrame
+ * gating. Defined at module scope so its methods never run during
+ * render (react-hooks/purity).
+ */
+class CursorThrottle {
+  private lastSend = 0;
+  private frame: number | null = null;
+  private pending: { x: number; y: number } | null = null;
+
+  constructor(private readonly emit: (x: number, y: number) => void) {}
+
+  push(x: number, y: number): void {
+    this.pending = { x, y };
+    this.frame ??= requestAnimationFrame(this.flush);
+  }
+
+  private flush = (): void => {
+    this.frame = null;
+    if (!this.pending) return;
+    const now = performance.now();
+    if (now - this.lastSend < 1000 / CURSOR_SENDS_PER_SECOND) {
+      this.frame = requestAnimationFrame(this.flush);
+      return;
+    }
+    const { x, y } = this.pending;
+    this.pending = null;
+    this.lastSend = now;
+    this.emit(x, y);
+  };
+}
+
+export function buildShareWsUrl(
+  wsBase: string,
+  shareId: string,
+  accessToken: string,
+): string {
+  const base = wsBase.replace(/\/$/, "");
+  const wsScheme = base
+    .replace(/^https:/, "wss:")
+    .replace(/^http:/, "ws:");
+  const url = new URL(`${wsScheme}/v1/share/${shareId}/ws`);
+  url.searchParams.set("access_token", accessToken);
+  return url.toString();
+}
+
+/**
+ * Owns the share WebSocket for the component's lifetime. The single
+ * effect covers connect/reconnect/teardown; everything else flows
+ * through state updates and the returned actions.
+ */
+export function useShareSocket({
+  shareId,
+  wsBase,
+  accessToken,
+  store,
+}: {
+  shareId: string;
+  wsBase: string;
+  accessToken: string | null;
+  store: SurfaceStore;
+}): ShareState & ShareActions {
+  const [status, setStatus] = useState<ShareStatus>("connecting");
+  const [workspace, setWorkspace] = useState<Workspace | null>(null);
+  const [participants, setParticipants] = useState<Participant[]>([]);
+  const [cursors, setCursors] = useState<RemoteCursor[]>([]);
+  const [bubbles, setBubbles] = useState<CursorBubble[]>([]);
+  const [chatEntries, setChatEntries] = useState<ChatEntry[]>([]);
+  const [textboxes, setTextboxes] = useState<Map<string, TextboxState>>(
+    () => new Map(),
+  );
+
+  const socketRef = useRef<WebSocket | null>(null);
+  const cursorThrottleRef = useRef<CursorThrottle | null>(null);
+
+  useEffect(() => {
+    if (!accessToken) return;
+
+    let disposed = false;
+    let attempts = 0;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+    const bubbleTimers = new Set<ReturnType<typeof setTimeout>>();
+
+    const handleMessage = (event: MessageEvent) => {
+      const message = parseServerMessage(event.data);
+      if (!message) return;
+      switch (message.type) {
+        case "join_state":
+          if (message.state === "pending") setStatus("pending");
+          else if (message.state === "denied") setStatus("denied");
+          else setStatus("live");
+          break;
+        case "snapshot": {
+          store.reset();
+          for (const pane of message.workspace.panes) {
+            if (pane.kind === "terminal" && pane.surfaceId && pane.replay_b64) {
+              store.applySnapshot(
+                pane.surfaceId,
+                decodeBase64(pane.replay_b64),
+                pane.replaySeq,
+              );
+            }
+          }
+          setWorkspace(message.workspace);
+          setStatus("live");
+          break;
+        }
+        case "layout":
+          setWorkspace(message.workspace);
+          break;
+        case "term":
+          store.pushChunk(
+            message.surfaceId,
+            message.seq,
+            decodeBase64(message.data_b64),
+          );
+          break;
+        case "term_resize":
+          store.pushResize(message.surfaceId, message.cols, message.rows);
+          break;
+        case "textbox":
+          setTextboxes((prev) => {
+            const next = new Map(prev);
+            next.set(message.paneId, {
+              text: message.text,
+              selStart: message.selStart,
+              selEnd: message.selEnd,
+              active: message.active,
+            });
+            return next;
+          });
+          break;
+        case "cursor":
+          setCursors((prev) => {
+            const next = prev.filter(
+              (c) => c.participantId !== message.participantId,
+            );
+            next.push({
+              participantId: message.participantId,
+              x: message.x,
+              y: message.y,
+            });
+            return next;
+          });
+          break;
+        case "chat": {
+          const entryId = nextEntryId++;
+          setChatEntries((prev) =>
+            [
+              ...prev,
+              {
+                id: entryId,
+                participantId: message.participantId,
+                text: message.text,
+                ts: message.ts,
+              },
+            ].slice(-200),
+          );
+          setBubbles((prev) => [
+            ...prev,
+            {
+              id: entryId,
+              participantId: message.participantId,
+              text: message.text,
+            },
+          ]);
+          const timer = setTimeout(() => {
+            bubbleTimers.delete(timer);
+            setBubbles((prev) => prev.filter((b) => b.id !== entryId));
+          }, BUBBLE_LIFETIME_MS);
+          bubbleTimers.add(timer);
+          break;
+        }
+        case "presence":
+          setParticipants(message.participants);
+          setCursors((prev) =>
+            prev.filter((c) =>
+              message.participants.some((p) => p.id === c.participantId),
+            ),
+          );
+          break;
+        case "ended":
+          setStatus("ended");
+          break;
+      }
+    };
+
+    const connect = () => {
+      if (disposed) return;
+      setStatus((prev) =>
+        prev === "ended" || prev === "denied" ? prev : "connecting",
+      );
+      const socket = new WebSocket(
+        buildShareWsUrl(wsBase, shareId, accessToken),
+      );
+      socketRef.current = socket;
+      socket.onopen = () => {
+        attempts = 0;
+      };
+      socket.onmessage = handleMessage;
+      socket.onclose = () => {
+        if (disposed || socketRef.current !== socket) return;
+        socketRef.current = null;
+        setStatus((prev) => {
+          if (prev === "ended" || prev === "denied") return prev;
+          if (attempts < MAX_RECONNECT_ATTEMPTS) {
+            attempts += 1;
+            reconnectTimer = setTimeout(connect, RECONNECT_DELAY_MS);
+            return "connecting";
+          }
+          return "ended";
+        });
+      };
+    };
+
+    connect();
+
+    return () => {
+      disposed = true;
+      if (reconnectTimer) clearTimeout(reconnectTimer);
+      for (const timer of bubbleTimers) clearTimeout(timer);
+      const socket = socketRef.current;
+      socketRef.current = null;
+      socket?.close();
+      store.reset();
+    };
+  }, [shareId, wsBase, accessToken, store]);
+
+  const sendJson = (payload: object) => {
+    const socket = socketRef.current;
+    if (socket && socket.readyState === WebSocket.OPEN) {
+      socket.send(JSON.stringify(payload));
+    }
+  };
+
+  const sendCursor = (x: number, y: number) => {
+    cursorThrottleRef.current ??= new CursorThrottle((cx, cy) => {
+      const socket = socketRef.current;
+      if (socket && socket.readyState === WebSocket.OPEN) {
+        socket.send(JSON.stringify({ type: "cursor", x: cx, y: cy }));
+      }
+    });
+    cursorThrottleRef.current.push(x, y);
+  };
+
+  const sendChat = (text: string, x: number, y: number) => {
+    sendJson({ type: "chat", text, x, y });
+  };
+
+  return {
+    status,
+    workspace,
+    participants,
+    cursors,
+    bubbles,
+    chatEntries,
+    textboxes,
+    sendCursor,
+    sendChat,
+  };
+}

--- a/web/app/[locale]/share/[id]/use-window-keydown.ts
+++ b/web/app/[locale]/share/[id]/use-window-keydown.ts
@@ -1,0 +1,22 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+/**
+ * Narrow-contract hook: subscribes to window keydown for the component's
+ * lifetime and forwards events to the latest handler. This is the one
+ * place a raw effect is unavoidable (global listener with cleanup).
+ */
+export function useWindowKeydown(handler: (event: KeyboardEvent) => void) {
+  const handlerRef = useRef(handler);
+
+  useEffect(() => {
+    handlerRef.current = handler;
+  });
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => handlerRef.current(event);
+    window.addEventListener("keydown", listener);
+    return () => window.removeEventListener("keydown", listener);
+  }, []);
+}

--- a/web/bun.lock
+++ b/web/bun.lock
@@ -34,6 +34,7 @@
         "effect": "^3.21.2",
         "freestyle": "0.1.51",
         "fzstd": "^0.1.1",
+        "ghostty-web": "^0.4.0",
         "next": "16.2.6",
         "next-intl": "^4.11.2",
         "next-themes": "^0.4.6",
@@ -1476,6 +1477,8 @@
     "get-symbol-description": ["get-symbol-description@1.1.0", "", { "dependencies": { "call-bound": "^1.0.3", "es-errors": "^1.3.0", "get-intrinsic": "^1.2.6" } }, "sha512-w9UMqWwJxHNOvoNzSJ2oPF5wvYcvP7jUvYzhp67yEhTi17ZDBBC1z9pTdGuzjD+EFIqLSYRweZjqfiPzQ06Ebg=="],
 
     "get-tsconfig": ["get-tsconfig@4.14.0", "", { "dependencies": { "resolve-pkg-maps": "^1.0.0" } }, "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA=="],
+
+    "ghostty-web": ["ghostty-web@0.4.0", "", {}, "sha512-0puDBik2qapbD/QQBW9o5ZHfXnZBqZWx/ctBiVtKZ6ZLds4NYb+wZuw1cRLXZk9zYovIQ908z3rvFhexAvc5Hg=="],
 
     "glob": ["glob@11.1.0", "", { "dependencies": { "foreground-child": "^3.3.1", "jackspeak": "^4.1.1", "minimatch": "^10.1.1", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^2.0.0" }, "bin": { "glob": "dist/esm/bin.mjs" } }, "sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw=="],
 

--- a/web/messages/en.json
+++ b/web/messages/en.json
@@ -4723,5 +4723,36 @@
         "action": "Manage plan"
       }
     }
+  },
+  "share": {
+    "status": {
+      "connecting": "Connecting…",
+      "pending": "Waiting for {host} to let you in…",
+      "pendingDetail": "The host has to approve each viewer.",
+      "denied": "The host declined your request to view this share.",
+      "ended": "This share has ended."
+    },
+    "hostFallback": "the host",
+    "pane": {
+      "browser": "Browser",
+      "textbox": "Textbox",
+      "other": "Pane",
+      "placeholder": "This pane is not mirrored."
+    },
+    "chat": {
+      "title": "Chat",
+      "empty": "No messages yet. Press / to chat at your cursor.",
+      "inputPlaceholder": "Send a message…",
+      "justNow": "just now",
+      "minutesAgo": "{minutes}m ago",
+      "hoursAgo": "{hours}h ago"
+    },
+    "cursorChat": {
+      "placeholder": "Say something…"
+    },
+    "unavailable": {
+      "title": "Sharing unavailable",
+      "description": "Workspace sharing is not configured on this deployment."
+    }
   }
 }

--- a/web/messages/ja.json
+++ b/web/messages/ja.json
@@ -4633,5 +4633,36 @@
         "action": "プランを管理"
       }
     }
+  },
+  "share": {
+    "status": {
+      "connecting": "接続中…",
+      "pending": "{host}の承認を待っています…",
+      "pendingDetail": "ホストが各閲覧者を承認する必要があります。",
+      "denied": "ホストが閲覧リクエストを拒否しました。",
+      "ended": "この共有は終了しました。"
+    },
+    "hostFallback": "ホスト",
+    "pane": {
+      "browser": "ブラウザ",
+      "textbox": "テキストボックス",
+      "other": "ペイン",
+      "placeholder": "このペインはミラーリングされていません。"
+    },
+    "chat": {
+      "title": "チャット",
+      "empty": "まだメッセージはありません。/ キーでカーソル位置からチャットできます。",
+      "inputPlaceholder": "メッセージを送信…",
+      "justNow": "たった今",
+      "minutesAgo": "{minutes}分前",
+      "hoursAgo": "{hours}時間前"
+    },
+    "cursorChat": {
+      "placeholder": "メッセージを入力…"
+    },
+    "unavailable": {
+      "title": "共有は利用できません",
+      "description": "このデプロイでは、ワークスペース共有が設定されていません。"
+    }
   }
 }

--- a/web/package.json
+++ b/web/package.json
@@ -60,6 +60,7 @@
     "effect": "^3.21.2",
     "freestyle": "0.1.51",
     "fzstd": "^0.1.1",
+    "ghostty-web": "^0.4.0",
     "next": "16.2.6",
     "next-intl": "^4.11.2",
     "next-themes": "^0.4.6",

--- a/workers/share/.gitignore
+++ b/workers/share/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+dist/
+.wrangler/
+.dev.vars

--- a/workers/share/LICENSE
+++ b/workers/share/LICENSE
@@ -1,0 +1,674 @@
+                    GNU GENERAL PUBLIC LICENSE
+                       Version 3, 29 June 2007
+
+ Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
+ Everyone is permitted to copy and distribute verbatim copies
+ of this license document, but changing it is not allowed.
+
+                            Preamble
+
+  The GNU General Public License is a free, copyleft license for
+software and other kinds of works.
+
+  The licenses for most software and other practical works are designed
+to take away your freedom to share and change the works.  By contrast,
+the GNU General Public License is intended to guarantee your freedom to
+share and change all versions of a program--to make sure it remains free
+software for all its users.  We, the Free Software Foundation, use the
+GNU General Public License for most of our software; it applies also to
+any other work released this way by its authors.  You can apply it to
+your programs, too.
+
+  When we speak of free software, we are referring to freedom, not
+price.  Our General Public Licenses are designed to make sure that you
+have the freedom to distribute copies of free software (and charge for
+them if you wish), that you receive source code or can get it if you
+want it, that you can change the software or use pieces of it in new
+free programs, and that you know you can do these things.
+
+  To protect your rights, we need to prevent others from denying you
+these rights or asking you to surrender the rights.  Therefore, you have
+certain responsibilities if you distribute copies of the software, or if
+you modify it: responsibilities to respect the freedom of others.
+
+  For example, if you distribute copies of such a program, whether
+gratis or for a fee, you must pass on to the recipients the same
+freedoms that you received.  You must make sure that they, too, receive
+or can get the source code.  And you must show them these terms so they
+know their rights.
+
+  Developers that use the GNU GPL protect your rights with two steps:
+(1) assert copyright on the software, and (2) offer you this License
+giving you legal permission to copy, distribute and/or modify it.
+
+  For the developers' and authors' protection, the GPL clearly explains
+that there is no warranty for this free software.  For both users' and
+authors' sake, the GPL requires that modified versions be marked as
+changed, so that their problems will not be attributed erroneously to
+authors of previous versions.
+
+  Some devices are designed to deny users access to install or run
+modified versions of the software inside them, although the manufacturer
+can do so.  This is fundamentally incompatible with the aim of
+protecting users' freedom to change the software.  The systematic
+pattern of such abuse occurs in the area of products for individuals to
+use, which is precisely where it is most unacceptable.  Therefore, we
+have designed this version of the GPL to prohibit the practice for those
+products.  If such problems arise substantially in other domains, we
+stand ready to extend this provision to those domains in future versions
+of the GPL, as needed to protect the freedom of users.
+
+  Finally, every program is threatened constantly by software patents.
+States should not allow patents to restrict development and use of
+software on general-purpose computers, but in those that do, we wish to
+avoid the special danger that patents applied to a free program could
+make it effectively proprietary.  To prevent this, the GPL assures that
+patents cannot be used to render the program non-free.
+
+  The precise terms and conditions for copying, distribution and
+modification follow.
+
+                       TERMS AND CONDITIONS
+
+  0. Definitions.
+
+  "This License" refers to version 3 of the GNU General Public License.
+
+  "Copyright" also means copyright-like laws that apply to other kinds of
+works, such as semiconductor masks.
+
+  "The Program" refers to any copyrightable work licensed under this
+License.  Each licensee is addressed as "you".  "Licensees" and
+"recipients" may be individuals or organizations.
+
+  To "modify" a work means to copy from or adapt all or part of the work
+in a fashion requiring copyright permission, other than the making of an
+exact copy.  The resulting work is called a "modified version" of the
+earlier work or a work "based on" the earlier work.
+
+  A "covered work" means either the unmodified Program or a work based
+on the Program.
+
+  To "propagate" a work means to do anything with it that, without
+permission, would make you directly or secondarily liable for
+infringement under applicable copyright law, except executing it on a
+computer or modifying a private copy.  Propagation includes copying,
+distribution (with or without modification), making available to the
+public, and in some countries other activities as well.
+
+  To "convey" a work means any kind of propagation that enables other
+parties to make or receive copies.  Mere interaction with a user through
+a computer network, with no transfer of a copy, is not conveying.
+
+  An interactive user interface displays "Appropriate Legal Notices"
+to the extent that it includes a convenient and prominently visible
+feature that (1) displays an appropriate copyright notice, and (2)
+tells the user that there is no warranty for the work (except to the
+extent that warranties are provided), that licensees may convey the
+work under this License, and how to view a copy of this License.  If
+the interface presents a list of user commands or options, such as a
+menu, a prominent item in the list meets this criterion.
+
+  1. Source Code.
+
+  The "source code" for a work means the preferred form of the work
+for making modifications to it.  "Object code" means any non-source
+form of a work.
+
+  A "Standard Interface" means an interface that either is an official
+standard defined by a recognized standards body, or, in the case of
+interfaces specified for a particular programming language, one that
+is widely used among developers working in that language.
+
+  The "System Libraries" of an executable work include anything, other
+than the work as a whole, that (a) is included in the normal form of
+packaging a Major Component, but which is not part of that Major
+Component, and (b) serves only to enable use of the work with that
+Major Component, or to implement a Standard Interface for which an
+implementation is available to the public in source code form.  A
+"Major Component", in this context, means a major essential component
+(kernel, window system, and so on) of the specific operating system
+(if any) on which the executable work runs, or a compiler used to
+produce the work, or an object code interpreter used to run it.
+
+  The "Corresponding Source" for a work in object code form means all
+the source code needed to generate, install, and (for an executable
+work) run the object code and to modify the work, including scripts to
+control those activities.  However, it does not include the work's
+System Libraries, or general-purpose tools or generally available free
+programs which are used unmodified in performing those activities but
+which are not part of the work.  For example, Corresponding Source
+includes interface definition files associated with source files for
+the work, and the source code for shared libraries and dynamically
+linked subprograms that the work is specifically designed to require,
+such as by intimate data communication or control flow between those
+subprograms and other parts of the work.
+
+  The Corresponding Source need not include anything that users
+can regenerate automatically from other parts of the Corresponding
+Source.
+
+  The Corresponding Source for a work in source code form is that
+same work.
+
+  2. Basic Permissions.
+
+  All rights granted under this License are granted for the term of
+copyright on the Program, and are irrevocable provided the stated
+conditions are met.  This License explicitly affirms your unlimited
+permission to run the unmodified Program.  The output from running a
+covered work is covered by this License only if the output, given its
+content, constitutes a covered work.  This License acknowledges your
+rights of fair use or other equivalent, as provided by copyright law.
+
+  You may make, run and propagate covered works that you do not
+convey, without conditions so long as your license otherwise remains
+in force.  You may convey covered works to others for the sole purpose
+of having them make modifications exclusively for you, or provide you
+with facilities for running those works, provided that you comply with
+the terms of this License in conveying all material for which you do
+not control copyright.  Those thus making or running the covered works
+for you must do so exclusively on your behalf, under your direction
+and control, on terms that prohibit them from making any copies of
+your copyrighted material outside their relationship with you.
+
+  Conveying under any other circumstances is permitted solely under
+the conditions stated below.  Sublicensing is not allowed; section 10
+makes it unnecessary.
+
+  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
+
+  No covered work shall be deemed part of an effective technological
+measure under any applicable law fulfilling obligations under article
+11 of the WIPO copyright treaty adopted on 20 December 1996, or
+similar laws prohibiting or restricting circumvention of such
+measures.
+
+  When you convey a covered work, you waive any legal power to forbid
+circumvention of technological measures to the extent such circumvention
+is effected by exercising rights under this License with respect to
+the covered work, and you disclaim any intention to limit operation or
+modification of the work as a means of enforcing, against the work's
+users, your or third parties' legal rights to forbid circumvention of
+technological measures.
+
+  4. Conveying Verbatim Copies.
+
+  You may convey verbatim copies of the Program's source code as you
+receive it, in any medium, provided that you conspicuously and
+appropriately publish on each copy an appropriate copyright notice;
+keep intact all notices stating that this License and any
+non-permissive terms added in accord with section 7 apply to the code;
+keep intact all notices of the absence of any warranty; and give all
+recipients a copy of this License along with the Program.
+
+  You may charge any price or no price for each copy that you convey,
+and you may offer support or warranty protection for a fee.
+
+  5. Conveying Modified Source Versions.
+
+  You may convey a work based on the Program, or the modifications to
+produce it from the Program, in the form of source code under the
+terms of section 4, provided that you also meet all of these conditions:
+
+    a) The work must carry prominent notices stating that you modified
+    it, and giving a relevant date.
+
+    b) The work must carry prominent notices stating that it is
+    released under this License and any conditions added under section
+    7.  This requirement modifies the requirement in section 4 to
+    "keep intact all notices".
+
+    c) You must license the entire work, as a whole, under this
+    License to anyone who comes into possession of a copy.  This
+    License will therefore apply, along with any applicable section 7
+    additional terms, to the whole of the work, and all its parts,
+    regardless of how they are packaged.  This License gives no
+    permission to license the work in any other way, but it does not
+    invalidate such permission if you have separately received it.
+
+    d) If the work has interactive user interfaces, each must display
+    Appropriate Legal Notices; however, if the Program has interactive
+    interfaces that do not display Appropriate Legal Notices, your
+    work need not make them do so.
+
+  A compilation of a covered work with other separate and independent
+works, which are not by their nature extensions of the covered work,
+and which are not combined with it such as to form a larger program,
+in or on a volume of a storage or distribution medium, is called an
+"aggregate" if the compilation and its resulting copyright are not
+used to limit the access or legal rights of the compilation's users
+beyond what the individual works permit.  Inclusion of a covered work
+in an aggregate does not cause this License to apply to the other
+parts of the aggregate.
+
+  6. Conveying Non-Source Forms.
+
+  You may convey a covered work in object code form under the terms
+of sections 4 and 5, provided that you also convey the
+machine-readable Corresponding Source under the terms of this License,
+in one of these ways:
+
+    a) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by the
+    Corresponding Source fixed on a durable physical medium
+    customarily used for software interchange.
+
+    b) Convey the object code in, or embodied in, a physical product
+    (including a physical distribution medium), accompanied by a
+    written offer, valid for at least three years and valid for as
+    long as you offer spare parts or customer support for that product
+    model, to give anyone who possesses the object code either (1) a
+    copy of the Corresponding Source for all the software in the
+    product that is covered by this License, on a durable physical
+    medium customarily used for software interchange, for a price no
+    more than your reasonable cost of physically performing this
+    conveying of source, or (2) access to copy the
+    Corresponding Source from a network server at no charge.
+
+    c) Convey individual copies of the object code with a copy of the
+    written offer to provide the Corresponding Source.  This
+    alternative is allowed only occasionally and noncommercially, and
+    only if you received the object code with such an offer, in accord
+    with subsection 6b.
+
+    d) Convey the object code by offering access from a designated
+    place (gratis or for a charge), and offer equivalent access to the
+    Corresponding Source in the same way through the same place at no
+    further charge.  You need not require recipients to copy the
+    Corresponding Source along with the object code.  If the place to
+    copy the object code is a network server, the Corresponding Source
+    may be on a different server (operated by you or a third party)
+    that supports equivalent copying facilities, provided you maintain
+    clear directions next to the object code saying where to find the
+    Corresponding Source.  Regardless of what server hosts the
+    Corresponding Source, you remain obligated to ensure that it is
+    available for as long as needed to satisfy these requirements.
+
+    e) Convey the object code using peer-to-peer transmission, provided
+    you inform other peers where the object code and Corresponding
+    Source of the work are being offered to the general public at no
+    charge under subsection 6d.
+
+  A separable portion of the object code, whose source code is excluded
+from the Corresponding Source as a System Library, need not be
+included in conveying the object code work.
+
+  A "User Product" is either (1) a "consumer product", which means any
+tangible personal property which is normally used for personal, family,
+or household purposes, or (2) anything designed or sold for incorporation
+into a dwelling.  In determining whether a product is a consumer product,
+doubtful cases shall be resolved in favor of coverage.  For a particular
+product received by a particular user, "normally used" refers to a
+typical or common use of that class of product, regardless of the status
+of the particular user or of the way in which the particular user
+actually uses, or expects or is expected to use, the product.  A product
+is a consumer product regardless of whether the product has substantial
+commercial, industrial or non-consumer uses, unless such uses represent
+the only significant mode of use of the product.
+
+  "Installation Information" for a User Product means any methods,
+procedures, authorization keys, or other information required to install
+and execute modified versions of a covered work in that User Product from
+a modified version of its Corresponding Source.  The information must
+suffice to ensure that the continued functioning of the modified object
+code is in no case prevented or interfered with solely because
+modification has been made.
+
+  If you convey an object code work under this section in, or with, or
+specifically for use in, a User Product, and the conveying occurs as
+part of a transaction in which the right of possession and use of the
+User Product is transferred to the recipient in perpetuity or for a
+fixed term (regardless of how the transaction is characterized), the
+Corresponding Source conveyed under this section must be accompanied
+by the Installation Information.  But this requirement does not apply
+if neither you nor any third party retains the ability to install
+modified object code on the User Product (for example, the work has
+been installed in ROM).
+
+  The requirement to provide Installation Information does not include a
+requirement to continue to provide support service, warranty, or updates
+for a work that has been modified or installed by the recipient, or for
+the User Product in which it has been modified or installed.  Access to a
+network may be denied when the modification itself materially and
+adversely affects the operation of the network or violates the rules and
+protocols for communication across the network.
+
+  Corresponding Source conveyed, and Installation Information provided,
+in accord with this section must be in a format that is publicly
+documented (and with an implementation available to the public in
+source code form), and must require no special password or key for
+unpacking, reading or copying.
+
+  7. Additional Terms.
+
+  "Additional permissions" are terms that supplement the terms of this
+License by making exceptions from one or more of its conditions.
+Additional permissions that are applicable to the entire Program shall
+be treated as though they were included in this License, to the extent
+that they are valid under applicable law.  If additional permissions
+apply only to part of the Program, that part may be used separately
+under those permissions, but the entire Program remains governed by
+this License without regard to the additional permissions.
+
+  When you convey a copy of a covered work, you may at your option
+remove any additional permissions from that copy, or from any part of
+it.  (Additional permissions may be written to require their own
+removal in certain cases when you modify the work.)  You may place
+additional permissions on material, added by you to a covered work,
+for which you have or can give appropriate copyright permission.
+
+  Notwithstanding any other provision of this License, for material you
+add to a covered work, you may (if authorized by the copyright holders of
+that material) supplement the terms of this License with terms:
+
+    a) Disclaiming warranty or limiting liability differently from the
+    terms of sections 15 and 16 of this License; or
+
+    b) Requiring preservation of specified reasonable legal notices or
+    author attributions in that material or in the Appropriate Legal
+    Notices displayed by works containing it; or
+
+    c) Prohibiting misrepresentation of the origin of that material, or
+    requiring that modified versions of such material be marked in
+    reasonable ways as different from the original version; or
+
+    d) Limiting the use for publicity purposes of names of licensors or
+    authors of the material; or
+
+    e) Declining to grant rights under trademark law for use of some
+    trade names, trademarks, or service marks; or
+
+    f) Requiring indemnification of licensors and authors of that
+    material by anyone who conveys the material (or modified versions of
+    it) with contractual assumptions of liability to the recipient, for
+    any liability that these contractual assumptions directly impose on
+    those licensors and authors.
+
+  All other non-permissive additional terms are considered "further
+restrictions" within the meaning of section 10.  If the Program as you
+received it, or any part of it, contains a notice stating that it is
+governed by this License along with a term that is a further
+restriction, you may remove that term.  If a license document contains
+a further restriction but permits relicensing or conveying under this
+License, you may add to a covered work material governed by the terms
+of that license document, provided that the further restriction does
+not survive such relicensing or conveying.
+
+  If you add terms to a covered work in accord with this section, you
+must place, in the relevant source files, a statement of the
+additional terms that apply to those files, or a notice indicating
+where to find the applicable terms.
+
+  Additional terms, permissive or non-permissive, may be stated in the
+form of a separately written license, or stated as exceptions;
+the above requirements apply either way.
+
+  8. Termination.
+
+  You may not propagate or modify a covered work except as expressly
+provided under this License.  Any attempt otherwise to propagate or
+modify it is void, and will automatically terminate your rights under
+this License (including any patent licenses granted under the third
+paragraph of section 11).
+
+  However, if you cease all violation of this License, then your
+license from a particular copyright holder is reinstated (a)
+provisionally, unless and until the copyright holder explicitly and
+finally terminates your license, and (b) permanently, if the copyright
+holder fails to notify you of the violation by some reasonable means
+prior to 60 days after the cessation.
+
+  Moreover, your license from a particular copyright holder is
+reinstated permanently if the copyright holder notifies you of the
+violation by some reasonable means, this is the first time you have
+received notice of violation of this License (for any work) from that
+copyright holder, and you cure the violation prior to 30 days after
+your receipt of the notice.
+
+  Termination of your rights under this section does not terminate the
+licenses of parties who have received copies or rights from you under
+this License.  If your rights have been terminated and not permanently
+reinstated, you do not qualify to receive new licenses for the same
+material under section 10.
+
+  9. Acceptance Not Required for Having Copies.
+
+  You are not required to accept this License in order to receive or
+run a copy of the Program.  Ancillary propagation of a covered work
+occurring solely as a consequence of using peer-to-peer transmission
+to receive a copy likewise does not require acceptance.  However,
+nothing other than this License grants you permission to propagate or
+modify any covered work.  These actions infringe copyright if you do
+not accept this License.  Therefore, by modifying or propagating a
+covered work, you indicate your acceptance of this License to do so.
+
+  10. Automatic Licensing of Downstream Recipients.
+
+  Each time you convey a covered work, the recipient automatically
+receives a license from the original licensors, to run, modify and
+propagate that work, subject to this License.  You are not responsible
+for enforcing compliance by third parties with this License.
+
+  An "entity transaction" is a transaction transferring control of an
+organization, or substantially all assets of one, or subdividing an
+organization, or merging organizations.  If propagation of a covered
+work results from an entity transaction, each party to that
+transaction who receives a copy of the work also receives whatever
+licenses to the work the party's predecessor in interest had or could
+give under the previous paragraph, plus a right to possession of the
+Corresponding Source of the work from the predecessor in interest, if
+the predecessor has it or can get it with reasonable efforts.
+
+  You may not impose any further restrictions on the exercise of the
+rights granted or affirmed under this License.  For example, you may
+not impose a license fee, royalty, or other charge for exercise of
+rights granted under this License, and you may not initiate litigation
+(including a cross-claim or counterclaim in a lawsuit) alleging that
+any patent claim is infringed by making, using, selling, offering for
+sale, or importing the Program or any portion of it.
+
+  11. Patents.
+
+  A "contributor" is a copyright holder who authorizes use under this
+License of the Program or a work on which the Program is based.  The
+work thus licensed is called the contributor's "contributor version".
+
+  A contributor's "essential patent claims" are all patent claims
+owned or controlled by the contributor, whether already acquired or
+hereafter acquired, that would be infringed by some manner, permitted
+by this License, of making, using, or selling its contributor version,
+but do not include claims that would be infringed only as a
+consequence of further modification of the contributor version.  For
+purposes of this definition, "control" includes the right to grant
+patent sublicenses in a manner consistent with the requirements of
+this License.
+
+  Each contributor grants you a non-exclusive, worldwide, royalty-free
+patent license under the contributor's essential patent claims, to
+make, use, sell, offer for sale, import and otherwise run, modify and
+propagate the contents of its contributor version.
+
+  In the following three paragraphs, a "patent license" is any express
+agreement or commitment, however denominated, not to enforce a patent
+(such as an express permission to practice a patent or covenant not to
+sue for patent infringement).  To "grant" such a patent license to a
+party means to make such an agreement or commitment not to enforce a
+patent against the party.
+
+  If you convey a covered work, knowingly relying on a patent license,
+and the Corresponding Source of the work is not available for anyone
+to copy, free of charge and under the terms of this License, through a
+publicly available network server or other readily accessible means,
+then you must either (1) cause the Corresponding Source to be so
+available, or (2) arrange to deprive yourself of the benefit of the
+patent license for this particular work, or (3) arrange, in a manner
+consistent with the requirements of this License, to extend the patent
+license to downstream recipients.  "Knowingly relying" means you have
+actual knowledge that, but for the patent license, your conveying the
+covered work in a country, or your recipient's use of the covered work
+in a country, would infringe one or more identifiable patents in that
+country that you have reason to believe are valid.
+
+  If, pursuant to or in connection with a single transaction or
+arrangement, you convey, or propagate by procuring conveyance of, a
+covered work, and grant a patent license to some of the parties
+receiving the covered work authorizing them to use, propagate, modify
+or convey a specific copy of the covered work, then the patent license
+you grant is automatically extended to all recipients of the covered
+work and works based on it.
+
+  A patent license is "discriminatory" if it does not include within
+the scope of its coverage, prohibits the exercise of, or is
+conditioned on the non-exercise of one or more of the rights that are
+specifically granted under this License.  You may not convey a covered
+work if you are a party to an arrangement with a third party that is
+in the business of distributing software, under which you make payment
+to the third party based on the extent of your activity of conveying
+the work, and under which the third party grants, to any of the
+parties who would receive the covered work from you, a discriminatory
+patent license (a) in connection with copies of the covered work
+conveyed by you (or copies made from those copies), or (b) primarily
+for and in connection with specific products or compilations that
+contain the covered work, unless you entered into that arrangement,
+or that patent license was granted, prior to 28 March 2007.
+
+  Nothing in this License shall be construed as excluding or limiting
+any implied license or other defenses to infringement that may
+otherwise be available to you under applicable patent law.
+
+  12. No Surrender of Others' Freedom.
+
+  If conditions are imposed on you (whether by court order, agreement or
+otherwise) that contradict the conditions of this License, they do not
+excuse you from the conditions of this License.  If you cannot convey a
+covered work so as to satisfy simultaneously your obligations under this
+License and any other pertinent obligations, then as a consequence you may
+not convey it at all.  For example, if you agree to terms that obligate you
+to collect a royalty for further conveying from those to whom you convey
+the Program, the only way you could satisfy both those terms and this
+License would be to refrain entirely from conveying the Program.
+
+  13. Use with the GNU Affero General Public License.
+
+  Notwithstanding any other provision of this License, you have
+permission to link or combine any covered work with a work licensed
+under version 3 of the GNU Affero General Public License into a single
+combined work, and to convey the resulting work.  The terms of this
+License will continue to apply to the part which is the covered work,
+but the special requirements of the GNU Affero General Public License,
+section 13, concerning interaction through a network will apply to the
+combination as such.
+
+  14. Revised Versions of this License.
+
+  The Free Software Foundation may publish revised and/or new versions of
+the GNU General Public License from time to time.  Such new versions will
+be similar in spirit to the present version, but may differ in detail to
+address new problems or concerns.
+
+  Each version is given a distinguishing version number.  If the
+Program specifies that a certain numbered version of the GNU General
+Public License "or any later version" applies to it, you have the
+option of following the terms and conditions either of that numbered
+version or of any later version published by the Free Software
+Foundation.  If the Program does not specify a version number of the
+GNU General Public License, you may choose any version ever published
+by the Free Software Foundation.
+
+  If the Program specifies that a proxy can decide which future
+versions of the GNU General Public License can be used, that proxy's
+public statement of acceptance of a version permanently authorizes you
+to choose that version for the Program.
+
+  Later license versions may give you additional or different
+permissions.  However, no additional obligations are imposed on any
+author or copyright holder as a result of your choosing to follow a
+later version.
+
+  15. Disclaimer of Warranty.
+
+  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
+APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
+HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
+OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
+IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
+ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
+
+  16. Limitation of Liability.
+
+  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
+THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
+GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
+USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
+DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
+PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
+EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES.
+
+  17. Interpretation of Sections 15 and 16.
+
+  If the disclaimer of warranty and limitation of liability provided
+above cannot be given local legal effect according to their terms,
+reviewing courts shall apply local law that most closely approximates
+an absolute waiver of all civil liability in connection with the
+Program, unless a warranty or assumption of liability accompanies a
+copy of the Program in return for a fee.
+
+                     END OF TERMS AND CONDITIONS
+
+            How to Apply These Terms to Your New Programs
+
+  If you develop a new program, and you want it to be of the greatest
+possible use to the public, the best way to achieve this is to make it
+free software which everyone can redistribute and change under these terms.
+
+  To do so, attach the following notices to the program.  It is safest
+to attach them to the start of each source file to most effectively
+state the exclusion of warranty; and each file should have at least
+the "copyright" line and a pointer to where the full notice is found.
+
+    <one line to give the program's name and a brief idea of what it does.>
+    Copyright (C) <year>  <name of author>
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <https://www.gnu.org/licenses/>.
+
+Also add information on how to contact you by electronic and paper mail.
+
+  If the program does terminal interaction, make it output a short
+notice like this when it starts in an interactive mode:
+
+    <program>  Copyright (C) <year>  <name of author>
+    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
+    This is free software, and you are welcome to redistribute it
+    under certain conditions; type `show c' for details.
+
+The hypothetical commands `show w' and `show c' should show the appropriate
+parts of the General Public License.  Of course, your program's commands
+might be different; for a GUI interface, you would use an "about box".
+
+  You should also get your employer (if you work as a programmer) or school,
+if any, to sign a "copyright disclaimer" for the program, if necessary.
+For more information on this, and how to apply and follow the GNU GPL, see
+<https://www.gnu.org/licenses/>.
+
+  The GNU General Public License does not permit incorporating your program
+into proprietary programs.  If your program is a subroutine library, you
+may consider it more useful to permit linking proprietary applications with
+the library.  If this is what you want to do, use the GNU Lesser General
+Public License instead of this License.  But first, please read
+<https://www.gnu.org/licenses/why-not-lgpl.html>.

--- a/workers/share/README.md
+++ b/workers/share/README.md
@@ -1,0 +1,55 @@
+# cmux-share
+
+Multiplayer workspace share: a Cloudflare Worker with one `ShareSession`
+Durable Object per share id. A cmux macOS host streams one workspace
+read-only; authenticated web viewers at `cmux.com/share/<id>` connect after
+explicit per-user host approval. Design and wire protocol:
+`plans/feat-multiplayer-share/DESIGN.md`.
+
+## License
+
+This package is GPL-3.0-or-later (see `LICENSE`; every `src/*.ts` file
+carries an SPDX header). Viewers connect from the proprietary cmux web app
+over the wire protocol documented in the design doc; the protocol boundary is
+the WebSocket JSON frames, and the web app links nothing from this package.
+
+## API
+
+| Route | Method | Purpose |
+| --- | --- | --- |
+| `/healthz` | GET | liveness (no auth) |
+| `/v1/share/create` | POST | Stack bearer auth; body `{ title? }`; returns `{ shareId, hostToken, url }` |
+| `/v1/share/:id/host` | GET | WebSocket upgrade, host lane (`?token=<hostToken>`) |
+| `/v1/share/:id/ws` | GET | WebSocket upgrade, viewer lane (`?access_token=<Stack access token>`) |
+
+`shareId` is 22 chars base62 (unguessable). The host token is minted at
+create and only its SHA-256 hash is stored; a new host connection supersedes
+the old one. Viewers are pending until the host answers a `join_request`;
+verdicts are remembered per Stack user id for the life of the session. The DO
+relays `layout`/`term`/`term_resize`/`textbox` frames to approved viewers
+without storing terminal data, stamps and rebroadcasts `cursor` (30/s per
+sender) and `chat` (last 200 kept and replayed to newly approved viewers),
+and broadcasts the `presence` participant list on every change. The session
+ends when the host sends `{type:"end"}` or stays disconnected for 60s; the DO
+sends `{type:"ended"}`, closes all sockets, and deletes all storage.
+
+## Secrets
+
+Stack Auth config is provisioned once as Worker secrets (never `[vars]`,
+which would be overwritten on deploy):
+
+```bash
+wrangler secret put STACK_PROJECT_ID
+wrangler secret put STACK_PUBLISHABLE_CLIENT_KEY
+```
+
+Optional plain var `STACK_API_URL` defaults to `https://api.stack-auth.com`.
+
+## Development
+
+```bash
+bun install
+bun run typecheck   # tsgo, src + tests
+bun test            # pure-logic tests (no miniflare)
+bun run check       # typecheck + tests + wrangler deploy --dry-run
+```

--- a/workers/share/bun.lock
+++ b/workers/share/bun.lock
@@ -1,0 +1,223 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "cmux-share-worker",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20260525.0",
+        "@types/bun": "^1.3.14",
+        "@typescript/native-preview": "7.0.0-dev.20260616.1",
+        "typescript": "^5.8.0",
+        "wrangler": "^4.20.0",
+      },
+    },
+  },
+  "packages": {
+    "@cloudflare/kv-asset-handler": ["@cloudflare/kv-asset-handler@0.5.0", "", {}, "sha512-jxQYkj8dSIzc0cD6cMMNdOc1UVjqSqu8BZdor5s8cGjW2I8BjODt/kWPVdY+u9zj3ms75Q5qaZgnxUad83+eAg=="],
+
+    "@cloudflare/unenv-preset": ["@cloudflare/unenv-preset@2.16.1", "", { "peerDependencies": { "unenv": "2.0.0-rc.24", "workerd": ">1.20260305.0 <2.0.0-0" }, "optionalPeers": ["workerd"] }, "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw=="],
+
+    "@cloudflare/workerd-darwin-64": ["@cloudflare/workerd-darwin-64@1.20260708.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-HXFCvhS1wpg3uXO0CLUwmwC41i2loM5FSK69EUchOBpmYBAXxT1oHLm6EOA5lqhTk5Mu9kjRiQYxa1GwKPwfJg=="],
+
+    "@cloudflare/workerd-darwin-arm64": ["@cloudflare/workerd-darwin-arm64@1.20260708.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-JVlJaKDoRTVKSroHIlf8g3UCPjKj4iDbMZE2CNYht5qQ+2rL0FAUiVlV82G3BqKnnw9kHYnnsMzC08b9zVtdzA=="],
+
+    "@cloudflare/workerd-linux-64": ["@cloudflare/workerd-linux-64@1.20260708.1", "", { "os": "linux", "cpu": "x64" }, "sha512-3daE60YdD7YX0Jtuzc9DE/r/qMkmx8ZvHTkF8Mzmp3F5tbzlV0DAzmu5PFUPF2WuvtKbAhZKbvC2cHmWpQYxnA=="],
+
+    "@cloudflare/workerd-linux-arm64": ["@cloudflare/workerd-linux-arm64@1.20260708.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-VLdNYOx5Hj+9C6isy0ACWZsbMtSxex2DIJWEe7cZxUdlphZ58ZT8zxNXK8yunFiowd34hn3VwGMopdvdj8lvmA=="],
+
+    "@cloudflare/workerd-windows-64": ["@cloudflare/workerd-windows-64@1.20260708.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bC/aSAwLy16Vjo24i9XU3aWH+eRgz7NeR5xPKavGbembO18ZywYTQbXh14eXtY6fAqN3RzRG8psijTdhX4xydA=="],
+
+    "@cloudflare/workers-types": ["@cloudflare/workers-types@4.20260702.1", "", {}, "sha512-mOhf5TUEB1m2vPrxtqoIGfz0fUC9xyxRDx5gWHy5s+OCo6dcV+g7wI1R7gYCMFohhqF/2y2xeKVwMwCJjfn/WA=="],
+
+    "@cspotcode/source-map-support": ["@cspotcode/source-map-support@0.8.1", "", { "dependencies": { "@jridgewell/trace-mapping": "0.3.9" } }, "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw=="],
+
+    "@emnapi/runtime": ["@emnapi/runtime@1.11.2", "", { "dependencies": { "tslib": "^2.4.0" } }, "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.28.1", "", { "os": "aix", "cpu": "ppc64" }, "sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.28.1", "", { "os": "android", "cpu": "arm" }, "sha512-0k2F129Xdio1TdJfzJ8sy1Q47vUD2NnwdhiAf7drUN1EBTfPf4hsFCtmMgu/6m8JSzsBrlmVjudMBQqOfG8usQ=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.28.1", "", { "os": "android", "cpu": "arm64" }, "sha512-34EGEbCIAgosYz6goLcopX6Mo7NyGv9tfwEM2/7Ce2VcVRk568iSvniGWcUXIy7wEDR1wzolcxcriFVrWYcwBg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.28.1", "", { "os": "android", "cpu": "x64" }, "sha512-dbwY7ltSMDWsRatcRpCnES4F+im88OCUgGZjy52shC7GqHRE/cYlxNbB4Z4UpJswpcc4Qxd2oE/ufM0p61IKng=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.28.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-TZbWkQY7kvTAXbXUT7uVACR5cMHsDiSz9z7ZKAX/RTq/WJEk3QyRr0wZpNhBDX+/0CtdqUIJlOiodQcta6tY3Q=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.28.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-zfdzgK9ACBNZLI/CyHTOx81SyNbM6YXn7rxSgX97VjyiPl9W1i4Ka4fgKECEoFCKGpvBj5qArWIGgQjOwkgskQ=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.28.1", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-wG2EA8ENdEI0qhkSZMjfqrdY+ziCYCPMmtZjjIwOmXFjmyzEHn+UUxk5of+SYsjtfs3VpnlC7QLzSI5hY/rOAw=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.28.1", "", { "os": "freebsd", "cpu": "x64" }, "sha512-i7dZ9vQgnvSCzi/rYCXNgtF/U+eKZNJBzu3eTQbRgHnM7tNSizLOkRFAl3qzVc/Op/u5YkHHa4pf/3DOYHthLQ=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.28.1", "", { "os": "linux", "cpu": "arm" }, "sha512-qVXBOHQS+d5Y722GwJzJUtOLlX7km3CraOaGormF1pDtPd2C/l1SHRPgjLunLGe51Sh5YYWKMFDyV4SxgMQYTQ=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.28.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-yHs+0uc8+nvEAfAfxrWQKK5peSNzBc4PegcMO0EJ2hT71uA7vB8Ihg2e77R2P7SG5uYjPbHlLLmve4LLLRCf0g=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.28.1", "", { "os": "linux", "cpu": "ia32" }, "sha512-d1z4ZuP0ajrfz/FhGT4vv278rX8KnPPJx8i5+AtK7TYbx9Le9F1hyzurZpkEyjkGa9dUGhQow4C1NmeGvqxN2w=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-M5sRjUVZrkm1OAPR3dlOYzNmN+loZKGVi1VUQGrwuqLcbR6qeAz+famMhjASeH3YVKvZz+zT1jlh/keC3Rj/lg=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-mRObBZeHh2OxcBFPWE/FjylkRgZdYuiTR3vaTozquCGOH14iP9oN4x4Ge81CoIDYQrXmIxpFumJBu5MtZpnQJQ=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.28.1", "", { "os": "linux", "cpu": "ppc64" }, "sha512-slScBsMAb3GFDcdrCgLwZtPYRoH2H/youv10QiZyRjmsP48fznoveWytSgCI/R0ZcUgpc0ZhIUEx6LHts8yrfQ=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.28.1", "", { "os": "linux", "cpu": "none" }, "sha512-kw0owk1o0GFETUJyW0jc0G4Yzs0BHZn0JDZ8JRT088vjJYX777BAs1fDGxAC+q831qOs2DTC96mNsG2opdfyyQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.28.1", "", { "os": "linux", "cpu": "s390x" }, "sha512-/lAIjX8aYFRByhh6L5rYtPEDRqa9de/4V/juOXcta5frjvzXO4/sqEtyytse0g3zZFuWu5cDN0MkLz2qRDD2Ag=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.28.1", "", { "os": "linux", "cpu": "x64" }, "sha512-u/anNYF2mmVOEDwLtnQ1wOr3EZ9sTNGLWrsYGYwHWzGA3Si84IOkHXlbWTD1NB+9/1lcnweYKO54uhxZydNzfA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-oks0DYbLwWMmaakTsCb+zL4E+aHRVLom9IJZOAthMQEPiQmydXHkziYEsGYRx0uNV/IjEKGAV941JzH02pflqw=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.28.1", "", { "os": "none", "cpu": "x64" }, "sha512-aeL6lAnN89Hz43Mlh1G8ARasbuoYvSITDEx0tHh5b7jJnHcssqgjy9Yx430GDpmCa6OyrKoS0aNRjKundRizGg=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.28.1", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-MEFJe5C3R8pwXdZ5Y21oo6m7ePiS0d9pWucn99O/wvyJZChoIQKrQDxKrGeW8F5+T0okTHesAmDeiHDTIq0V/Q=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.28.1", "", { "os": "openbsd", "cpu": "x64" }, "sha512-i/ZLIOafE0Z8cI/XANJAixoJL/uRAoS2xOA3rb0xN+KK0K177cMAsQYkzHtBrtMXAKuAc7HGgcWiZ/sRC1Nxgw=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.28.1", "", { "os": "none", "cpu": "arm64" }, "sha512-ge+Z7EXFNt2BO1oAMsVpiQ8EwndV9i1xXerAeTIK7AtPs3bKFXQM7nlRxDSIUIMeueR1CNXxqztLzdNeReKBJg=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.28.1", "", { "os": "sunos", "cpu": "x64" }, "sha512-BEjgtECkL3vY+SaSQ6nzVfiALUeFxpawyp8Jmf5PtYhf1Ug40N1h/hxlhts+f1FvSvarEigdxS3BlSMI2PJLcQ=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.28.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-lCv9eK/H6ZJWbE7bh2nw54CZ9M2nupBxJcTsdk/QQnWkdSjKGuxmmH8/GWrlT1eMmZfn4dGcCjRte397WqfQXA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.28.1", "", { "os": "win32", "cpu": "ia32" }, "sha512-zvb/mB2bSCoJOpoCBgYKKpX6YM6mJBlBUVUtVj41DlZJVEB6/0CKlRYxP5wWl1C1ILiCoAU5wZZ4q1P3qeS6Eg=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.28.1", "", { "os": "win32", "cpu": "x64" }, "sha512-bm4Mowrv+GXMlpWX++EcXw/iLyd1o3+bJkC2DkWXYVvgZCqD/bSj9ctZeAMC3cIxgjRVR2Dufaiu4YPxr5gW1A=="],
+
+    "@img/colour": ["@img/colour@1.1.0", "", {}, "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ=="],
+
+    "@img/sharp-darwin-arm64": ["@img/sharp-darwin-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-arm64": "1.2.4" }, "os": "darwin", "cpu": "arm64" }, "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w=="],
+
+    "@img/sharp-darwin-x64": ["@img/sharp-darwin-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-darwin-x64": "1.2.4" }, "os": "darwin", "cpu": "x64" }, "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw=="],
+
+    "@img/sharp-libvips-darwin-arm64": ["@img/sharp-libvips-darwin-arm64@1.2.4", "", { "os": "darwin", "cpu": "arm64" }, "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g=="],
+
+    "@img/sharp-libvips-darwin-x64": ["@img/sharp-libvips-darwin-x64@1.2.4", "", { "os": "darwin", "cpu": "x64" }, "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg=="],
+
+    "@img/sharp-libvips-linux-arm": ["@img/sharp-libvips-linux-arm@1.2.4", "", { "os": "linux", "cpu": "arm" }, "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A=="],
+
+    "@img/sharp-libvips-linux-arm64": ["@img/sharp-libvips-linux-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw=="],
+
+    "@img/sharp-libvips-linux-ppc64": ["@img/sharp-libvips-linux-ppc64@1.2.4", "", { "os": "linux", "cpu": "ppc64" }, "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA=="],
+
+    "@img/sharp-libvips-linux-riscv64": ["@img/sharp-libvips-linux-riscv64@1.2.4", "", { "os": "linux", "cpu": "none" }, "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA=="],
+
+    "@img/sharp-libvips-linux-s390x": ["@img/sharp-libvips-linux-s390x@1.2.4", "", { "os": "linux", "cpu": "s390x" }, "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ=="],
+
+    "@img/sharp-libvips-linux-x64": ["@img/sharp-libvips-linux-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw=="],
+
+    "@img/sharp-libvips-linuxmusl-arm64": ["@img/sharp-libvips-linuxmusl-arm64@1.2.4", "", { "os": "linux", "cpu": "arm64" }, "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw=="],
+
+    "@img/sharp-libvips-linuxmusl-x64": ["@img/sharp-libvips-linuxmusl-x64@1.2.4", "", { "os": "linux", "cpu": "x64" }, "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg=="],
+
+    "@img/sharp-linux-arm": ["@img/sharp-linux-arm@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm": "1.2.4" }, "os": "linux", "cpu": "arm" }, "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw=="],
+
+    "@img/sharp-linux-arm64": ["@img/sharp-linux-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg=="],
+
+    "@img/sharp-linux-ppc64": ["@img/sharp-linux-ppc64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-ppc64": "1.2.4" }, "os": "linux", "cpu": "ppc64" }, "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA=="],
+
+    "@img/sharp-linux-riscv64": ["@img/sharp-linux-riscv64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-riscv64": "1.2.4" }, "os": "linux", "cpu": "none" }, "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw=="],
+
+    "@img/sharp-linux-s390x": ["@img/sharp-linux-s390x@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-s390x": "1.2.4" }, "os": "linux", "cpu": "s390x" }, "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg=="],
+
+    "@img/sharp-linux-x64": ["@img/sharp-linux-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linux-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ=="],
+
+    "@img/sharp-linuxmusl-arm64": ["@img/sharp-linuxmusl-arm64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-arm64": "1.2.4" }, "os": "linux", "cpu": "arm64" }, "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg=="],
+
+    "@img/sharp-linuxmusl-x64": ["@img/sharp-linuxmusl-x64@0.34.5", "", { "optionalDependencies": { "@img/sharp-libvips-linuxmusl-x64": "1.2.4" }, "os": "linux", "cpu": "x64" }, "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q=="],
+
+    "@img/sharp-wasm32": ["@img/sharp-wasm32@0.34.5", "", { "dependencies": { "@emnapi/runtime": "^1.7.0" }, "cpu": "none" }, "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw=="],
+
+    "@img/sharp-win32-arm64": ["@img/sharp-win32-arm64@0.34.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g=="],
+
+    "@img/sharp-win32-ia32": ["@img/sharp-win32-ia32@0.34.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg=="],
+
+    "@img/sharp-win32-x64": ["@img/sharp-win32-x64@0.34.5", "", { "os": "win32", "cpu": "x64" }, "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.9", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.0.3", "@jridgewell/sourcemap-codec": "^1.4.10" } }, "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ=="],
+
+    "@poppinss/colors": ["@poppinss/colors@4.1.6", "", { "dependencies": { "kleur": "^4.1.5" } }, "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg=="],
+
+    "@poppinss/dumper": ["@poppinss/dumper@0.6.5", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@sindresorhus/is": "^7.0.2", "supports-color": "^10.0.0" } }, "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw=="],
+
+    "@poppinss/exception": ["@poppinss/exception@1.2.3", "", {}, "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw=="],
+
+    "@sindresorhus/is": ["@sindresorhus/is@7.2.0", "", {}, "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw=="],
+
+    "@speed-highlight/core": ["@speed-highlight/core@1.2.17", "", {}, "sha512-Z92FwKpCtfaW1V0jTU/fh3QzYEZN8wDwrzRIBoADCJfn4mJCNcJN/XegifX7BDrQ8/h9Xh/JnbyMchL0FqXrkg=="],
+
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
+    "@types/node": ["@types/node@26.1.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw=="],
+
+    "@typescript/native-preview": ["@typescript/native-preview@7.0.0-dev.20260616.1", "", { "optionalDependencies": { "@typescript/native-preview-darwin-arm64": "7.0.0-dev.20260616.1", "@typescript/native-preview-darwin-x64": "7.0.0-dev.20260616.1", "@typescript/native-preview-linux-arm": "7.0.0-dev.20260616.1", "@typescript/native-preview-linux-arm64": "7.0.0-dev.20260616.1", "@typescript/native-preview-linux-x64": "7.0.0-dev.20260616.1", "@typescript/native-preview-win32-arm64": "7.0.0-dev.20260616.1", "@typescript/native-preview-win32-x64": "7.0.0-dev.20260616.1" }, "bin": { "tsgo": "bin/tsgo.js" } }, "sha512-+AuZUl7nkLPXL1rwsyZZF7iasu0HkrL5O6aWwUC0cObD5EvNgxz3hXbBhsSvuJ8tb2JRpVwFsE0BHPcYVe5GkA=="],
+
+    "@typescript/native-preview-darwin-arm64": ["@typescript/native-preview-darwin-arm64@7.0.0-dev.20260616.1", "", { "os": "darwin", "cpu": "arm64" }, "sha512-9SwegwwE7fYutnZJjTi2PeUXhKGFg82MGjSpCFD2cj5v9YQcs5oO5QsmeeMit4fMG8Z83Jy8knOF97d9NaQ7Bg=="],
+
+    "@typescript/native-preview-darwin-x64": ["@typescript/native-preview-darwin-x64@7.0.0-dev.20260616.1", "", { "os": "darwin", "cpu": "x64" }, "sha512-gl7R8OiwEBNxzs5wjbM9XOibTs5b6/gAgu0+En9pLpYuWR/EITs8Eh0mNQui4JYTp1SkoHvn09aRZKTQf21XTg=="],
+
+    "@typescript/native-preview-linux-arm": ["@typescript/native-preview-linux-arm@7.0.0-dev.20260616.1", "", { "os": "linux", "cpu": "arm" }, "sha512-QWXQS2CrhSpXbng7vBtCVDszFgwVBuJU8MCFhxZL0hH6s+XjQDSNNkGO1oHueBr+7HbSkkyqfNYVNXvgVMUJLQ=="],
+
+    "@typescript/native-preview-linux-arm64": ["@typescript/native-preview-linux-arm64@7.0.0-dev.20260616.1", "", { "os": "linux", "cpu": "arm64" }, "sha512-CJjplWoE+EeYtbyNeP4fyuh0QcPiQBZJSLqPS07E3ugo3d9M/IG8WnL+3GFQ0g1p4c6QC/+OC0oTTQnGcNdd2Q=="],
+
+    "@typescript/native-preview-linux-x64": ["@typescript/native-preview-linux-x64@7.0.0-dev.20260616.1", "", { "os": "linux", "cpu": "x64" }, "sha512-UVySBNnGTAnul2kO2/EhlVZl0CeTDcd6Lzi+WkvgyCgapTcU0BX1selQ4MEPtbVWKUbt9HBhxNku2dyaCcmKVw=="],
+
+    "@typescript/native-preview-win32-arm64": ["@typescript/native-preview-win32-arm64@7.0.0-dev.20260616.1", "", { "os": "win32", "cpu": "arm64" }, "sha512-kdX0QcDXiESH0o5DFdSWw15Hth0EtQobT9tX28ofqBUwGU1FFhwTKzA6qo7chaYUSW5MMd6XIME9rBwk+WizLw=="],
+
+    "@typescript/native-preview-win32-x64": ["@typescript/native-preview-win32-x64@7.0.0-dev.20260616.1", "", { "os": "win32", "cpu": "x64" }, "sha512-EB0Pj/0+nXifS3+wN0HdR1mKu7IieSpjMXoDjdXtJAdiPGlmKazBgHj97qn6CBvXisgLx0Eyb7tLCEQNDG53cA=="],
+
+    "blake3-wasm": ["blake3-wasm@2.1.5", "", {}, "sha512-F1+K8EbfOZE49dtoPtmxUQrpXaBIl3ICvasLh+nJta0xkz+9kF/7uet9fLnwKqhDrmj6g+6K3Tw9yQPUg2ka5g=="],
+
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
+
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "error-stack-parser-es": ["error-stack-parser-es@1.0.5", "", {}, "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA=="],
+
+    "esbuild": ["esbuild@0.28.1", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.28.1", "@esbuild/android-arm": "0.28.1", "@esbuild/android-arm64": "0.28.1", "@esbuild/android-x64": "0.28.1", "@esbuild/darwin-arm64": "0.28.1", "@esbuild/darwin-x64": "0.28.1", "@esbuild/freebsd-arm64": "0.28.1", "@esbuild/freebsd-x64": "0.28.1", "@esbuild/linux-arm": "0.28.1", "@esbuild/linux-arm64": "0.28.1", "@esbuild/linux-ia32": "0.28.1", "@esbuild/linux-loong64": "0.28.1", "@esbuild/linux-mips64el": "0.28.1", "@esbuild/linux-ppc64": "0.28.1", "@esbuild/linux-riscv64": "0.28.1", "@esbuild/linux-s390x": "0.28.1", "@esbuild/linux-x64": "0.28.1", "@esbuild/netbsd-arm64": "0.28.1", "@esbuild/netbsd-x64": "0.28.1", "@esbuild/openbsd-arm64": "0.28.1", "@esbuild/openbsd-x64": "0.28.1", "@esbuild/openharmony-arm64": "0.28.1", "@esbuild/sunos-x64": "0.28.1", "@esbuild/win32-arm64": "0.28.1", "@esbuild/win32-ia32": "0.28.1", "@esbuild/win32-x64": "0.28.1" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HrJrvZv5ayxBzPfwphOoNzkzOIIlifzk0KJrGK2c8R4+LKpMtpYLQeUdjnwjWv/LZlkH2laZk+4w78pi99D4Vw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "kleur": ["kleur@4.1.5", "", {}, "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ=="],
+
+    "miniflare": ["miniflare@4.20260708.1", "", { "dependencies": { "@cspotcode/source-map-support": "0.8.1", "sharp": "0.34.5", "undici": "7.28.0", "workerd": "1.20260708.1", "ws": "8.21.0", "youch": "4.1.0-beta.10" }, "bin": { "miniflare": "bootstrap.js" } }, "sha512-c94O9zRDISdqO18EHt6l0iF/fWgWt8p18PJvRsA/L/NJZ9Cfke3s/F5Blg1XXF7WDutVRzWVWy8Vy4LaT5ifsA=="],
+
+    "path-to-regexp": ["path-to-regexp@6.3.0", "", {}, "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ=="],
+
+    "pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "sharp": ["sharp@0.34.5", "", { "dependencies": { "@img/colour": "^1.0.0", "detect-libc": "^2.1.2", "semver": "^7.7.3" }, "optionalDependencies": { "@img/sharp-darwin-arm64": "0.34.5", "@img/sharp-darwin-x64": "0.34.5", "@img/sharp-libvips-darwin-arm64": "1.2.4", "@img/sharp-libvips-darwin-x64": "1.2.4", "@img/sharp-libvips-linux-arm": "1.2.4", "@img/sharp-libvips-linux-arm64": "1.2.4", "@img/sharp-libvips-linux-ppc64": "1.2.4", "@img/sharp-libvips-linux-riscv64": "1.2.4", "@img/sharp-libvips-linux-s390x": "1.2.4", "@img/sharp-libvips-linux-x64": "1.2.4", "@img/sharp-libvips-linuxmusl-arm64": "1.2.4", "@img/sharp-libvips-linuxmusl-x64": "1.2.4", "@img/sharp-linux-arm": "0.34.5", "@img/sharp-linux-arm64": "0.34.5", "@img/sharp-linux-ppc64": "0.34.5", "@img/sharp-linux-riscv64": "0.34.5", "@img/sharp-linux-s390x": "0.34.5", "@img/sharp-linux-x64": "0.34.5", "@img/sharp-linuxmusl-arm64": "0.34.5", "@img/sharp-linuxmusl-x64": "0.34.5", "@img/sharp-wasm32": "0.34.5", "@img/sharp-win32-arm64": "0.34.5", "@img/sharp-win32-ia32": "0.34.5", "@img/sharp-win32-x64": "0.34.5" } }, "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg=="],
+
+    "supports-color": ["supports-color@10.2.2", "", {}, "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g=="],
+
+    "tslib": ["tslib@2.8.1", "", {}, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici": ["undici@7.28.0", "", {}, "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
+
+    "unenv": ["unenv@2.0.0-rc.24", "", { "dependencies": { "pathe": "^2.0.3" } }, "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw=="],
+
+    "workerd": ["workerd@1.20260708.1", "", { "optionalDependencies": { "@cloudflare/workerd-darwin-64": "1.20260708.1", "@cloudflare/workerd-darwin-arm64": "1.20260708.1", "@cloudflare/workerd-linux-64": "1.20260708.1", "@cloudflare/workerd-linux-arm64": "1.20260708.1", "@cloudflare/workerd-windows-64": "1.20260708.1" }, "bin": { "workerd": "bin/workerd" } }, "sha512-WAK+Kt/VVCSldH2qSr8lx46XCJ4Q+bdlHNaFqUtOHthBEIB8C1N8HVW+VOLrxDoTCk0NGNv0zajnBeQK4JOB9w=="],
+
+    "wrangler": ["wrangler@4.110.0", "", { "dependencies": { "@cloudflare/kv-asset-handler": "0.5.0", "@cloudflare/unenv-preset": "2.16.1", "blake3-wasm": "2.1.5", "esbuild": "0.28.1", "miniflare": "4.20260708.1", "path-to-regexp": "6.3.0", "unenv": "2.0.0-rc.24", "workerd": "1.20260708.1" }, "optionalDependencies": { "fsevents": "2.3.3" }, "peerDependencies": { "@cloudflare/workers-types": "^5.20260708.1" }, "optionalPeers": ["@cloudflare/workers-types"], "bin": { "wrangler": "bin/wrangler.js", "wrangler2": "bin/wrangler.js", "cf-wrangler": "bin/cf-wrangler.js" } }, "sha512-xZeXKYi7hxQRF5anL+v77RkufJNpF9f3Eqeyqq2QBsETpLZgh0Agj0jJ6JPtkbgn6ukZdh8OK5egsGPWIditgg=="],
+
+    "ws": ["ws@8.21.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g=="],
+
+    "youch": ["youch@4.1.0-beta.10", "", { "dependencies": { "@poppinss/colors": "^4.1.5", "@poppinss/dumper": "^0.6.4", "@speed-highlight/core": "^1.2.7", "cookie": "^1.0.2", "youch-core": "^0.3.3" } }, "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ=="],
+
+    "youch-core": ["youch-core@0.3.3", "", { "dependencies": { "@poppinss/exception": "^1.2.2", "error-stack-parser-es": "^1.0.5" } }, "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA=="],
+  }
+}

--- a/workers/share/package.json
+++ b/workers/share/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "cmux-share-worker",
+  "private": true,
+  "type": "module",
+  "license": "GPL-3.0-or-later",
+  "scripts": {
+    "dev": "wrangler dev",
+    "deploy": "wrangler deploy",
+    "test": "bun test",
+    "typecheck": "tsgo --noEmit && tsgo --noEmit -p tsconfig.test.json",
+    "check": "bun run typecheck && bun test && wrangler deploy --dry-run --outdir dist"
+  },
+  "devDependencies": {
+    "@cloudflare/workers-types": "^4.20260525.0",
+    "@types/bun": "^1.3.14",
+    "@typescript/native-preview": "7.0.0-dev.20260616.1",
+    "typescript": "^5.8.0",
+    "wrangler": "^4.20.0"
+  }
+}

--- a/workers/share/src/auth.ts
+++ b/workers/share/src/auth.ts
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+//
+// Stack Auth verification for the share worker, trimmed from
+// workers/presence/src/auth.ts (no team resolution: shares are scoped by
+// unguessable share id + explicit host approval, not by team).
+//
+// Two call shapes share one verification path:
+//   - `POST /v1/share/create` sends `Authorization: Bearer <access token>`
+//   - the viewer WebSocket sends `?access_token=` (browsers cannot set WS
+//     headers), extracted by the route and passed to `verifyAccessToken`.
+//
+// The worker calls Stack's REST `/api/v1/users/me` with the client access
+// type, which both validates the access token server-side and yields the
+// user's identity. Unlike presence, the share protocol shows each viewer's
+// email and display name to the host (join requests) and to other
+// participants (presence frames), so those fields ride along. Results are
+// cached in isolate memory keyed by a SHA-256 of the token, bounded by the
+// token's own `exp` and a short TTL so revocation latency stays small.
+
+export interface AuthEnv {
+  /** Stack REST API origin. Defaults to the hosted https://api.stack-auth.com. */
+  STACK_API_URL?: string;
+  STACK_PROJECT_ID?: string;
+  STACK_PUBLISHABLE_CLIENT_KEY?: string;
+}
+
+export interface AuthedUser {
+  id: string;
+  primaryEmail: string;
+  displayName: string;
+}
+
+/** Max cache age. A revoked-but-unexpired token stays usable for at most this
+ * long, which is acceptable here: admission still requires explicit host
+ * approval, and the host can end the session at any time. */
+export const AUTH_CACHE_TTL_MS = 60_000;
+const AUTH_CACHE_MAX_ENTRIES = 1024;
+/** Negative cache window for a token Stack rejected. Bounds the amplification
+ * where an unauthenticated caller forces one Stack subrequest per request by
+ * sending an opaque (non-JWT, so no client-side expiry short-circuit) token. */
+export const AUTH_NEGATIVE_CACHE_TTL_MS = 10_000;
+
+interface CacheEntry {
+  /** null marks a verified-failure (negative) entry. */
+  user: AuthedUser | null;
+  expiresAt: number;
+}
+
+// Isolate-global; resets whenever the isolate is recycled, which only costs an
+// extra Stack round trip.
+const authCache = new Map<string, CacheEntry>();
+
+/** Cache deadline for a verified token: short TTL, never past the token's own
+ * expiry. Pure for tests. */
+export function cacheDeadline(
+  nowMs: number,
+  tokenExpMs: number | null,
+  ttlMs: number = AUTH_CACHE_TTL_MS,
+): number {
+  const ttlDeadline = nowMs + ttlMs;
+  if (tokenExpMs === null) return ttlDeadline;
+  return Math.min(ttlDeadline, tokenExpMs);
+}
+
+/** Best-effort `exp` (epoch ms) from a JWT payload without verifying the
+ * signature; verification is the Stack API call itself. Returns null for
+ * opaque or malformed tokens. Pure for tests. */
+export function tokenExpiryMs(token: string): number | null {
+  const parts = token.split(".");
+  if (parts.length !== 3 || !parts[1]) return null;
+  try {
+    const base64 = parts[1].replace(/-/g, "+").replace(/_/g, "/");
+    const payload = JSON.parse(atob(base64)) as { exp?: unknown };
+    return typeof payload.exp === "number" ? payload.exp * 1000 : null;
+  } catch {
+    return null;
+  }
+}
+
+function normalized(value: string | null): string | null {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : null;
+}
+
+/** The bearer access token from the Authorization header, or null. */
+export function bearerToken(request: Request): string | null {
+  const header = request.headers.get("authorization");
+  if (!header?.toLowerCase().startsWith("bearer ")) return null;
+  return normalized(header.slice("bearer ".length));
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+function stackHeaders(env: AuthEnv, accessToken: string): Record<string, string> {
+  return {
+    "x-stack-access-type": "client",
+    "x-stack-project-id": env.STACK_PROJECT_ID ?? "",
+    "x-stack-publishable-client-key": env.STACK_PUBLISHABLE_CLIENT_KEY ?? "",
+    "x-stack-access-token": accessToken,
+  };
+}
+
+async function fetchStackUser(env: AuthEnv, accessToken: string): Promise<AuthedUser | null> {
+  const apiUrl = (env.STACK_API_URL ?? "https://api.stack-auth.com").replace(/\/$/, "");
+  const meResponse = await fetch(`${apiUrl}/api/v1/users/me`, {
+    headers: stackHeaders(env, accessToken),
+  });
+  if (!meResponse.ok) return null;
+  const me = (await meResponse.json()) as {
+    id?: unknown;
+    primary_email?: unknown;
+    display_name?: unknown;
+  };
+  const userId = typeof me.id === "string" && me.id ? me.id : null;
+  if (!userId) return null;
+  const primaryEmail =
+    typeof me.primary_email === "string" && me.primary_email ? me.primary_email : "";
+  const displayName =
+    typeof me.display_name === "string" && me.display_name ? me.display_name : "";
+  return { id: userId, primaryEmail, displayName };
+}
+
+/** Verify an access token (from a bearer header or a `?access_token=` query
+ * param). Returns the resolved user or null when unauthenticated or when
+ * Stack auth is not configured (fail closed). */
+export async function verifyAccessToken(
+  token: string | null,
+  env: AuthEnv,
+): Promise<AuthedUser | null> {
+  if (!env.STACK_PROJECT_ID || !env.STACK_PUBLISHABLE_CLIENT_KEY) return null;
+  if (!token) return null;
+
+  const now = Date.now();
+  const expMs = tokenExpiryMs(token);
+  if (expMs !== null && expMs <= now) return null;
+
+  const cacheKey = await sha256Hex(token);
+  const cached = authCache.get(cacheKey);
+  // A live entry serves either a verified user or a verified failure (null),
+  // so a rejected token does not re-hit Stack on every request.
+  if (cached && cached.expiresAt > now) return cached.user;
+  authCache.delete(cacheKey);
+
+  const user = await fetchStackUser(env, token);
+
+  if (authCache.size >= AUTH_CACHE_MAX_ENTRIES) {
+    // Drop the oldest insertion; Map preserves insertion order.
+    const oldest = authCache.keys().next().value;
+    if (oldest !== undefined) authCache.delete(oldest);
+  }
+  if (!user) {
+    // Negative cache: never past the token's own expiry.
+    const negativeDeadline =
+      expMs === null
+        ? now + AUTH_NEGATIVE_CACHE_TTL_MS
+        : Math.min(now + AUTH_NEGATIVE_CACHE_TTL_MS, expMs);
+    authCache.set(cacheKey, { user: null, expiresAt: negativeDeadline });
+    return null;
+  }
+  authCache.set(cacheKey, { user, expiresAt: cacheDeadline(now, expMs) });
+  return user;
+}
+
+/** Verify the caller from the Authorization header. */
+export async function verifyRequest(request: Request, env: AuthEnv): Promise<AuthedUser | null> {
+  return verifyAccessToken(bearerToken(request), env);
+}

--- a/workers/share/src/core.ts
+++ b/workers/share/src/core.ts
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+//
+// Pure decision logic for the ShareSession Durable Object: identifier
+// generation, palette colors, join verdict memory, chat history capping,
+// cursor rate limiting, and inbound message validation. Everything here is
+// side-effect free (random sources are injected) so bun tests cover it
+// without miniflare.
+
+export const SHARE_ID_LENGTH = 22;
+export const BASE62_ALPHABET =
+  "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz";
+export const HOST_TOKEN_BYTES = 32;
+export const PALETTE_SIZE = 10;
+export const HOST_COLOR = 0;
+/** Frames from viewers larger than this close the socket (1009). */
+export const MAX_VIEWER_FRAME_BYTES = 32 * 1024;
+/** Host frames may carry snapshots (replay_b64 <= 256KB per pane). */
+export const MAX_HOST_FRAME_BYTES = 1024 * 1024;
+export const CHAT_HISTORY_CAP = 200;
+/** Bound stored chat text so 200 retained messages stay small in DO storage. */
+export const MAX_CHAT_TEXT_LENGTH = 4096;
+export const CURSOR_RATE_PER_SEC = 30;
+/** Host reconnect grace before the session is ended and storage deleted. */
+export const HOST_GRACE_MS = 60_000;
+
+export type Role = "host" | "viewer";
+export type Verdict = "approved" | "denied";
+export type JoinState = "pending" | "approved" | "denied";
+
+export interface Participant {
+  id: string;
+  email: string;
+  name: string;
+  color: number;
+  role: Role;
+}
+
+export interface StoredChatMessage {
+  type: "chat";
+  participantId: string;
+  ts: number;
+  text: string;
+  x: number;
+  y: number;
+}
+
+/** Fill shape of crypto.getRandomValues, injected so tests are deterministic. */
+export type RandomFill = (bytes: Uint8Array) => Uint8Array;
+
+/** Uniform base62 id via rejection sampling: a byte is accepted only when it
+ * falls inside the largest multiple of 62 below 256 (62 * 4 = 248), so
+ * `byte % 62` is unbiased. Rejected bytes are simply redrawn. */
+export function generateShareId(
+  randomFill: RandomFill,
+  length: number = SHARE_ID_LENGTH,
+): string {
+  const limit = 62 * 4; // 248: largest multiple of 62 that fits in a byte
+  let out = "";
+  const buf = new Uint8Array(length * 2); // over-provision to cut redraw loops
+  while (out.length < length) {
+    randomFill(buf);
+    for (const byte of buf) {
+      if (byte >= limit) continue; // rejection sampling: redraw biased bytes
+      out += BASE62_ALPHABET[byte % 62];
+      if (out.length === length) break;
+    }
+  }
+  return out;
+}
+
+export function base64UrlEncode(bytes: Uint8Array): string {
+  let binary = "";
+  for (const byte of bytes) binary += String.fromCharCode(byte);
+  return btoa(binary).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+/** Per-session host credential: 32 random bytes, base64url (43 chars). Only
+ * its SHA-256 hash is stored in the DO. */
+export function generateHostToken(randomFill: RandomFill): string {
+  return base64UrlEncode(randomFill(new Uint8Array(HOST_TOKEN_BYTES)));
+}
+
+export async function sha256Hex(value: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("");
+}
+
+/** Viewer palette color for the nth admitted viewer (0-based ordinal). The
+ * host permanently owns index 0, so viewers cycle the remaining 9 slots and
+ * can never collide with the host color. */
+export function viewerColor(ordinal: number): number {
+  return 1 + (((ordinal % (PALETTE_SIZE - 1)) + (PALETTE_SIZE - 1)) % (PALETTE_SIZE - 1));
+}
+
+/** Initial join state from the remembered per-user verdict: an earlier allow
+ * admits immediately, an earlier deny rejects immediately, no verdict waits
+ * for the host. */
+export function joinStateForVerdict(verdict: Verdict | undefined): JoinState {
+  return verdict ?? "pending";
+}
+
+/** Append one chat message, keeping only the newest `cap` entries. */
+export function appendChat(
+  history: readonly StoredChatMessage[],
+  entry: StoredChatMessage,
+  cap: number = CHAT_HISTORY_CAP,
+): StoredChatMessage[] {
+  const next = [...history, entry];
+  return next.length > cap ? next.slice(next.length - cap) : next;
+}
+
+// ---- Cursor rate limiting (token bucket, 30 msgs/sec per socket) ----
+
+export interface TokenBucket {
+  tokens: number;
+  lastRefillMs: number;
+}
+
+export function newTokenBucket(
+  nowMs: number,
+  burst: number = CURSOR_RATE_PER_SEC,
+): TokenBucket {
+  return { tokens: burst, lastRefillMs: nowMs };
+}
+
+/** Take one token if available, refilling at `ratePerSec` up to `burst`.
+ * Returns false when the caller should silently drop the message. */
+export function tryTakeToken(
+  bucket: TokenBucket,
+  nowMs: number,
+  ratePerSec: number = CURSOR_RATE_PER_SEC,
+  burst: number = CURSOR_RATE_PER_SEC,
+): boolean {
+  const elapsedMs = Math.max(0, nowMs - bucket.lastRefillMs);
+  bucket.tokens = Math.min(burst, bucket.tokens + (elapsedMs * ratePerSec) / 1000);
+  bucket.lastRefillMs = nowMs;
+  if (bucket.tokens < 1) return false;
+  bucket.tokens -= 1;
+  return true;
+}
+
+// ---- Frame size gates ----
+
+/** Whether a frame of `byteLength` is admissible for `role`. Oversize frames
+ * close the socket with 1009 (message too big). */
+export function frameWithinLimit(role: Role, byteLength: number): boolean {
+  return byteLength <= (role === "host" ? MAX_HOST_FRAME_BYTES : MAX_VIEWER_FRAME_BYTES);
+}
+
+// ---- Inbound message validation ----
+
+export type IncomingMessage =
+  | { type: "join_response"; requestId: string; allow: boolean }
+  | { type: "snapshot"; to: string; workspace: unknown }
+  | { type: "layout"; workspace: unknown }
+  | { type: "term"; surfaceId: string; seq: number; data_b64: string }
+  | { type: "term_resize"; surfaceId: string; cols: number; rows: number }
+  | { type: "textbox"; paneId: string; text: string; selStart: number; selEnd: number; active: boolean }
+  | { type: "cursor"; x: number; y: number }
+  | { type: "chat"; text: string; x: number; y: number }
+  | { type: "end" };
+
+const VIEWER_TYPES: ReadonlySet<string> = new Set(["cursor", "chat"]);
+
+function clamp01(value: number): number {
+  return Math.min(1, Math.max(0, value));
+}
+
+function finiteNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function nonEmptyString(value: unknown): string | null {
+  return typeof value === "string" && value.length > 0 ? value : null;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/** Validate one decoded frame for `role`. Returns null for anything that
+ * should be silently dropped: unknown types, missing/ill-typed fields, and
+ * every non-cursor/chat type from a viewer (viewers are read-only by
+ * protocol; no input path to the Mac exists). Cursor coordinates are clamped
+ * to [0,1]; chat text is trimmed and bounded. */
+export function parseIncoming(role: Role, value: unknown): IncomingMessage | null {
+  if (!isRecord(value) || typeof value.type !== "string") return null;
+  const type = value.type;
+  if (role === "viewer" && !VIEWER_TYPES.has(type)) return null;
+
+  switch (type) {
+    case "cursor": {
+      const x = finiteNumber(value.x);
+      const y = finiteNumber(value.y);
+      if (x === null || y === null) return null;
+      return { type, x: clamp01(x), y: clamp01(y) };
+    }
+    case "chat": {
+      const rawText = typeof value.text === "string" ? value.text.trim() : "";
+      if (!rawText) return null;
+      const x = finiteNumber(value.x);
+      const y = finiteNumber(value.y);
+      if (x === null || y === null) return null;
+      return {
+        type,
+        text: rawText.slice(0, MAX_CHAT_TEXT_LENGTH),
+        x: clamp01(x),
+        y: clamp01(y),
+      };
+    }
+    case "join_response": {
+      const requestId = nonEmptyString(value.requestId);
+      if (requestId === null || typeof value.allow !== "boolean") return null;
+      return { type, requestId, allow: value.allow };
+    }
+    case "snapshot": {
+      const to = nonEmptyString(value.to);
+      if (to === null || !isRecord(value.workspace)) return null;
+      return { type, to, workspace: value.workspace };
+    }
+    case "layout": {
+      if (!isRecord(value.workspace)) return null;
+      return { type, workspace: value.workspace };
+    }
+    case "term": {
+      const surfaceId = nonEmptyString(value.surfaceId);
+      const seq = finiteNumber(value.seq);
+      if (surfaceId === null || seq === null || typeof value.data_b64 !== "string") return null;
+      return { type, surfaceId, seq, data_b64: value.data_b64 };
+    }
+    case "term_resize": {
+      const surfaceId = nonEmptyString(value.surfaceId);
+      const cols = finiteNumber(value.cols);
+      const rows = finiteNumber(value.rows);
+      if (surfaceId === null || cols === null || rows === null) return null;
+      return { type, surfaceId, cols, rows };
+    }
+    case "textbox": {
+      const paneId = nonEmptyString(value.paneId);
+      const selStart = finiteNumber(value.selStart);
+      const selEnd = finiteNumber(value.selEnd);
+      if (
+        paneId === null ||
+        typeof value.text !== "string" ||
+        selStart === null ||
+        selEnd === null ||
+        typeof value.active !== "boolean"
+      ) {
+        return null;
+      }
+      return { type, paneId, text: value.text, selStart, selEnd, active: value.active };
+    }
+    case "end":
+      return { type };
+    default:
+      return null;
+  }
+}

--- a/workers/share/src/do.ts
+++ b/workers/share/src/do.ts
@@ -1,0 +1,462 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+//
+// ShareSession Durable Object — one instance per share id (idFromName(shareId)).
+//
+// Relay hub for one shared workspace: a single host lane streams layout,
+// terminal bytes, and textbox mirrors; approved viewer lanes receive them.
+// Terminal data is NEVER stored here (pure relay); the DO durably keeps only
+// the host token hash, per-user join verdicts, and the last 200 chat
+// messages, and deletes everything when the session ends.
+//
+// Authorization happens in the worker before anything reaches this object:
+// viewer identity headers are set from a VERIFIED Stack token, never passed
+// through from the client. The host lane authenticates here, against the
+// stored SHA-256 of the per-session host token minted at create.
+//
+// Uses the WebSocket hibernation API; participant metadata rides each
+// socket's serialized attachment so an evicted DO wakes up with full state.
+
+import { DurableObject } from "cloudflare:workers";
+import {
+  appendChat,
+  CHAT_HISTORY_CAP,
+  frameWithinLimit,
+  HOST_COLOR,
+  HOST_GRACE_MS,
+  joinStateForVerdict,
+  newTokenBucket,
+  parseIncoming,
+  sha256Hex,
+  tryTakeToken,
+  viewerColor,
+  type IncomingMessage,
+  type JoinState,
+  type Participant,
+  type StoredChatMessage,
+  type TokenBucket,
+  type Verdict,
+} from "./core";
+
+const HOST_TOKEN_HASH_KEY = "meta:hostTokenHash";
+const HOST_PARTICIPANT_KEY = "meta:hostParticipant";
+const TITLE_KEY = "meta:title";
+const VIEWER_ORDINAL_KEY = "meta:viewerOrdinal";
+const CHAT_KEY = "chat";
+const VERDICT_PREFIX = "verdict:";
+
+const HOST_TAG = "host";
+const VIEWER_TAG = "viewer";
+
+/** Cap concurrent sockets so one session cannot pin unbounded DO memory. */
+const MAX_SOCKETS = 64;
+
+type Attachment =
+  | { role: "host" }
+  | { role: "viewer"; userId: string; participant: Participant; state: JoinState };
+
+export interface CreatorIdentity {
+  id: string;
+  email: string;
+  name: string;
+}
+
+function attachment(ws: WebSocket): Attachment | null {
+  try {
+    return ws.deserializeAttachment() as Attachment | null;
+  } catch {
+    return null;
+  }
+}
+
+function safeSend(ws: WebSocket, frame: unknown): void {
+  try {
+    ws.send(JSON.stringify(frame));
+  } catch {
+    // Socket already gone; the hibernation API cleans it up.
+  }
+}
+
+function safeClose(ws: WebSocket, code: number, reason: string): void {
+  try {
+    ws.close(code, reason);
+  } catch {
+    // already closed
+  }
+}
+
+export class ShareSession extends DurableObject {
+  /** Cursor rate limiter buckets, keyed by live socket. In-memory only: after
+   * hibernation the map is empty and buckets are lazily recreated on the next
+   * cursor message, which only ever grants a sender a fresh burst. */
+  private cursorBuckets = new Map<WebSocket, TokenBucket>();
+
+  // ---- RPC surface (called by the worker) ----
+
+  /** One-time initialization at create: store the host token HASH (never the
+   * token) plus the creator's identity as the host participant (color 0). A
+   * second initialize on the same id is refused so an id collision (or a
+   * replayed create) can never take over a live session. */
+  async initialize(
+    hostTokenHash: string,
+    creator: CreatorIdentity,
+    title: string | undefined,
+  ): Promise<{ ok: true } | { ok: false; error: "already_exists" }> {
+    const existing = await this.ctx.storage.get<string>(HOST_TOKEN_HASH_KEY);
+    if (existing !== undefined) return { ok: false, error: "already_exists" };
+    const host: Participant = {
+      id: crypto.randomUUID(),
+      email: creator.email,
+      name: creator.name,
+      color: HOST_COLOR,
+      role: "host",
+    };
+    await this.ctx.storage.put({
+      [HOST_TOKEN_HASH_KEY]: hostTokenHash,
+      [HOST_PARTICIPANT_KEY]: host,
+      ...(title !== undefined ? { [TITLE_KEY]: title } : {}),
+    });
+    return { ok: true };
+  }
+
+  // ---- WebSocket upgrades (worker forwards the original Request) ----
+
+  override async fetch(request: Request): Promise<Response> {
+    if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+      return new Response("expected websocket", { status: 426 });
+    }
+    const storedHash = await this.ctx.storage.get<string>(HOST_TOKEN_HASH_KEY);
+    if (storedHash === undefined) {
+      // Never created, or already ended (end deletes all storage).
+      return new Response("not found", { status: 404 });
+    }
+    if (this.ctx.getWebSockets().length >= MAX_SOCKETS) {
+      return new Response("too many connections", { status: 429 });
+    }
+
+    const url = new URL(request.url);
+    if (url.pathname.endsWith("/host")) {
+      return this.acceptHost(url, storedHash);
+    }
+    return this.acceptViewer(request);
+  }
+
+  private async acceptHost(url: URL, storedHash: string): Promise<Response> {
+    const token = url.searchParams.get("token") ?? "";
+    if (!token || (await sha256Hex(token)) !== storedHash) {
+      return new Response("forbidden", { status: 403 });
+    }
+
+    // Single active host connection: a new one supersedes the old.
+    for (const prior of this.ctx.getWebSockets(HOST_TAG)) {
+      safeClose(prior, 1000, "superseded by a new host connection");
+    }
+
+    const pair = new WebSocketPair();
+    this.ctx.acceptWebSocket(pair[1], [HOST_TAG]);
+    pair[1].serializeAttachment({ role: "host" } satisfies Attachment);
+    // The host is back (or here for the first time): the session is live, so
+    // cancel any pending disconnect-grace end.
+    await this.ctx.storage.deleteAlarm();
+    await this.broadcastPresence();
+    return new Response(null, { status: 101, webSocket: pair[0] });
+  }
+
+  private async acceptViewer(request: Request): Promise<Response> {
+    // Identity headers are set by the worker from a VERIFIED Stack token.
+    const userId = request.headers.get("x-share-user-id") ?? "";
+    if (!userId) return new Response("unauthorized", { status: 401 });
+    const email = decodeURIComponent(request.headers.get("x-share-email") ?? "");
+    const name = decodeURIComponent(request.headers.get("x-share-name") ?? "");
+
+    const verdict = await this.ctx.storage.get<Verdict>(`${VERDICT_PREFIX}${userId}`);
+    const state = joinStateForVerdict(verdict);
+
+    const ordinal = (await this.ctx.storage.get<number>(VIEWER_ORDINAL_KEY)) ?? 0;
+    await this.ctx.storage.put(VIEWER_ORDINAL_KEY, ordinal + 1);
+    const participant: Participant = {
+      id: crypto.randomUUID(),
+      email,
+      name: name || email,
+      color: viewerColor(ordinal),
+      role: "viewer",
+    };
+
+    const pair = new WebSocketPair();
+    this.ctx.acceptWebSocket(pair[1], [VIEWER_TAG]);
+    pair[1].serializeAttachment(
+      { role: "viewer", userId, participant, state } satisfies Attachment,
+    );
+
+    safeSend(pair[1], { type: "join_state", state });
+    if (state === "denied") {
+      safeClose(pair[1], 1000, "join denied");
+    } else if (state === "approved") {
+      // Previously approved user reconnecting: admit immediately.
+      await this.admitViewer(pair[1], participant);
+    } else {
+      // Pending: ask the (possibly momentarily disconnected) host.
+      this.sendToHost({
+        type: "join_request",
+        requestId: participant.id,
+        email,
+        name: participant.name,
+      });
+    }
+    return new Response(null, { status: 101, webSocket: pair[0] });
+  }
+
+  /** Post-approval admission: ask the host for a targeted snapshot, replay
+   * stored chat history to this viewer, and broadcast presence. */
+  private async admitViewer(ws: WebSocket, participant: Participant): Promise<void> {
+    this.sendToHost({ type: "sync_request", participantId: participant.id });
+    const history =
+      (await this.ctx.storage.get<StoredChatMessage[]>(CHAT_KEY)) ?? [];
+    for (const message of history) safeSend(ws, message);
+    await this.broadcastPresence();
+  }
+
+  // ---- Inbound frames ----
+
+  override async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const meta = attachment(ws);
+    if (meta === null) return;
+
+    const byteLength = typeof message === "string" ? message.length : message.byteLength;
+    if (!frameWithinLimit(meta.role, byteLength)) {
+      safeClose(ws, 1009, "frame too large");
+      return;
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(typeof message === "string" ? message : new TextDecoder().decode(message));
+    } catch {
+      return; // not JSON; drop
+    }
+    const parsed = parseIncoming(meta.role, body);
+    if (parsed === null) return; // unknown/ill-typed/forbidden-for-role; drop
+
+    if (meta.role === "host") {
+      await this.handleHostMessage(ws, parsed);
+      return;
+    }
+    // Viewer lane: parseIncoming already restricted to cursor/chat.
+    if (meta.state !== "approved") {
+      // A pending or denied viewer has no voice yet; cursor from anyone means
+      // host or APPROVED viewer (DESIGN.md).
+      return;
+    }
+    if (parsed.type === "cursor") {
+      this.relayCursor(ws, meta.participant.id, parsed.x, parsed.y);
+    } else if (parsed.type === "chat") {
+      await this.relayChat(meta.participant.id, parsed.text, parsed.x, parsed.y);
+    }
+  }
+
+  private async handleHostMessage(ws: WebSocket, message: IncomingMessage): Promise<void> {
+    switch (message.type) {
+      case "join_response":
+        await this.handleJoinResponse(message.requestId, message.allow);
+        return;
+      case "snapshot": {
+        // Targeted: forwarded ONLY to the requested participant.
+        const target = this.findViewer(message.to);
+        if (target !== null) {
+          safeSend(target.ws, { type: "snapshot", workspace: message.workspace });
+        }
+        return;
+      }
+      case "layout":
+      case "term":
+      case "term_resize":
+      case "textbox":
+        this.broadcastToApprovedViewers(message);
+        return;
+      case "cursor": {
+        const host = await this.hostParticipant();
+        if (host !== null) this.relayCursor(ws, host.id, message.x, message.y);
+        return;
+      }
+      case "chat": {
+        const host = await this.hostParticipant();
+        if (host !== null) await this.relayChat(host.id, message.text, message.x, message.y);
+        return;
+      }
+      case "end":
+        await this.endSession();
+        return;
+      default:
+        return;
+    }
+  }
+
+  private async handleJoinResponse(requestId: string, allow: boolean): Promise<void> {
+    const target = this.findViewer(requestId);
+    if (target === null || target.meta.state !== "pending") return;
+    const verdict: Verdict = allow ? "approved" : "denied";
+    // Remember the verdict per Stack user id for the life of the session.
+    await this.ctx.storage.put(`${VERDICT_PREFIX}${target.meta.userId}`, verdict);
+    const nextState: JoinState = verdict;
+    target.ws.serializeAttachment({ ...target.meta, state: nextState } satisfies Attachment);
+    safeSend(target.ws, { type: "join_state", state: nextState });
+    if (allow) {
+      await this.admitViewer(target.ws, target.meta.participant);
+    } else {
+      safeClose(target.ws, 1000, "join denied");
+    }
+  }
+
+  /** Stamp `participantId` and rebroadcast to everyone else, 30/s per sender;
+   * excess is silently dropped. */
+  private relayCursor(sender: WebSocket, participantId: string, x: number, y: number): void {
+    const now = Date.now();
+    let bucket = this.cursorBuckets.get(sender);
+    if (bucket === undefined) {
+      bucket = newTokenBucket(now);
+      this.cursorBuckets.set(sender, bucket);
+    }
+    if (!tryTakeToken(bucket, now)) return;
+    const frame = { type: "cursor", participantId, x, y };
+    for (const ws of this.ctx.getWebSockets()) {
+      if (ws === sender) continue;
+      if (!this.canReceive(ws)) continue;
+      safeSend(ws, frame);
+    }
+  }
+
+  /** Stamp `participantId` + `ts`, persist (capped at 200), and broadcast to
+   * everyone including the sender. */
+  private async relayChat(participantId: string, text: string, x: number, y: number): Promise<void> {
+    const entry: StoredChatMessage = {
+      type: "chat",
+      participantId,
+      ts: Date.now(),
+      text,
+      x,
+      y,
+    };
+    const history = (await this.ctx.storage.get<StoredChatMessage[]>(CHAT_KEY)) ?? [];
+    await this.ctx.storage.put(CHAT_KEY, appendChat(history, entry, CHAT_HISTORY_CAP));
+    for (const ws of this.ctx.getWebSockets()) {
+      if (!this.canReceive(ws)) continue;
+      safeSend(ws, entry);
+    }
+  }
+
+  // ---- Disconnects, session end, alarm ----
+
+  override async webSocketClose(ws: WebSocket): Promise<void> {
+    this.cursorBuckets.delete(ws);
+    const meta = attachment(ws);
+    safeClose(ws, 1000, "closing");
+    if (meta?.role === "host") {
+      // The closing socket is still in getWebSockets() during this callback,
+      // so count the OTHER host sockets (a superseded socket closing must not
+      // arm the end alarm while the new host is live).
+      const otherHosts = this.ctx.getWebSockets(HOST_TAG).filter((socket) => socket !== ws);
+      if (otherHosts.length === 0) {
+        // Grace window for the host to return before the session ends.
+        await this.ctx.storage.setAlarm(Date.now() + HOST_GRACE_MS);
+      }
+      await this.broadcastPresence(ws);
+      return;
+    }
+    if (meta?.role === "viewer" && meta.state === "approved") {
+      await this.broadcastPresence(ws);
+    }
+  }
+
+  override async webSocketError(ws: WebSocket): Promise<void> {
+    await this.webSocketClose(ws);
+  }
+
+  override async alarm(): Promise<void> {
+    // Host never returned within the grace window: end the session. If the
+    // host DID return, acceptHost deleted the alarm, so firing means gone.
+    if (this.ctx.getWebSockets(HOST_TAG).length > 0) return;
+    await this.endSession();
+  }
+
+  /** Broadcast `ended`, close every socket, and delete all durable state. */
+  private async endSession(): Promise<void> {
+    const frame = { type: "ended" };
+    for (const ws of this.ctx.getWebSockets()) {
+      safeSend(ws, frame);
+      safeClose(ws, 1000, "session ended");
+    }
+    this.cursorBuckets.clear();
+    await this.ctx.storage.deleteAlarm();
+    await this.ctx.storage.deleteAll();
+  }
+
+  // ---- Internals ----
+
+  private async hostParticipant(): Promise<Participant | null> {
+    return (await this.ctx.storage.get<Participant>(HOST_PARTICIPANT_KEY)) ?? null;
+  }
+
+  /** Send one frame to the live host socket(s). Best-effort: a host in its
+   * disconnect-grace window simply misses it (the viewer's approval replays
+   * via sync_request when it reconnects only if re-triggered; a pending
+   * join_request is re-sent by the viewer reconnecting). */
+  private sendToHost(frame: unknown): void {
+    for (const ws of this.ctx.getWebSockets(HOST_TAG)) {
+      safeSend(ws, frame);
+    }
+  }
+
+  private findViewer(participantId: string): { ws: WebSocket; meta: Attachment & { role: "viewer" } } | null {
+    for (const ws of this.ctx.getWebSockets(VIEWER_TAG)) {
+      const meta = attachment(ws);
+      if (meta?.role === "viewer" && meta.participant.id === participantId) {
+        return { ws, meta };
+      }
+    }
+    return null;
+  }
+
+  /** Whether this socket may receive session traffic: the host always, a
+   * viewer only once approved (pending/denied viewers see nothing but their
+   * own join_state). */
+  private canReceive(ws: WebSocket): boolean {
+    const meta = attachment(ws);
+    if (meta === null) return false;
+    return meta.role === "host" || meta.state === "approved";
+  }
+
+  private broadcastToApprovedViewers(frame: unknown): void {
+    for (const ws of this.ctx.getWebSockets(VIEWER_TAG)) {
+      const meta = attachment(ws);
+      if (meta?.role !== "viewer" || meta.state !== "approved") continue;
+      safeSend(ws, frame);
+    }
+  }
+
+  /** Full participant list (host when connected + approved connected viewers)
+   * to the host and every approved viewer. `closing` excludes a socket that
+   * is mid-close (webSocketClose still lists it). */
+  private async broadcastPresence(closing?: WebSocket): Promise<void> {
+    const participants: Participant[] = [];
+    const hostLive = this.ctx
+      .getWebSockets(HOST_TAG)
+      .some((ws) => ws !== closing);
+    if (hostLive) {
+      const host = await this.hostParticipant();
+      if (host !== null) participants.push(host);
+    }
+    for (const ws of this.ctx.getWebSockets(VIEWER_TAG)) {
+      if (ws === closing) continue;
+      const meta = attachment(ws);
+      if (meta?.role === "viewer" && meta.state === "approved") {
+        participants.push(meta.participant);
+      }
+    }
+    const frame = { type: "presence", participants };
+    for (const ws of this.ctx.getWebSockets()) {
+      if (ws === closing) continue;
+      if (!this.canReceive(ws)) continue;
+      safeSend(ws, frame);
+    }
+  }
+}

--- a/workers/share/src/index.ts
+++ b/workers/share/src/index.ts
@@ -1,0 +1,154 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+//
+// cmux workspace share service — worker entry.
+//
+// Routes (see plans/feat-multiplayer-share/DESIGN.md):
+//   GET  /healthz                  liveness, no auth
+//   POST /v1/share/create          Stack bearer auth; body { title? };
+//                                  returns { shareId, hostToken, url }
+//   GET  /v1/share/:id/host        WebSocket upgrade, host lane
+//                                  (?token=<hostToken>, verified in the DO
+//                                  against the stored hash)
+//   GET  /v1/share/:id/ws          WebSocket upgrade, viewer lane
+//                                  (?access_token=<Stack access token>,
+//                                  verified HERE; identity forwarded to the
+//                                  DO via headers — the DO never sees
+//                                  unauthenticated input)
+//
+// The DO id derives from the share id (idFromName), so one session's object
+// can never be reached with another session's URL.
+
+import { verifyAccessToken, verifyRequest, type AuthEnv } from "./auth";
+import { generateHostToken, generateShareId, sha256Hex } from "./core";
+import { ShareSession } from "./do";
+import { parseCreateBody, parseSharePath, readBoundedJson } from "./validate";
+
+export { ShareSession };
+
+export interface Env extends AuthEnv {
+  SHARE_SESSION: DurableObjectNamespace<ShareSession>;
+}
+
+// Browsers call create from the web app, so the endpoint answers CORS for the
+// production origin plus localhost dev servers. WebSocket upgrades are not
+// CORS-gated (the browser WS API sends no preflight); viewer auth is the
+// verified access token, not the Origin header.
+const ALLOWED_ORIGINS: ReadonlySet<string> = new Set([
+  "https://cmux.com",
+  "https://www.cmux.com",
+]);
+
+function corsOrigin(request: Request): string | null {
+  const origin = request.headers.get("origin");
+  if (!origin) return null;
+  if (ALLOWED_ORIGINS.has(origin)) return origin;
+  try {
+    const url = new URL(origin);
+    const isLocalHost = url.hostname === "localhost" || url.hostname === "127.0.0.1";
+    if (isLocalHost && (url.protocol === "http:" || url.protocol === "https:")) return origin;
+  } catch {
+    // fall through
+  }
+  return null;
+}
+
+function corsHeaders(request: Request): Record<string, string> {
+  const origin = corsOrigin(request);
+  if (!origin) return {};
+  return {
+    "access-control-allow-origin": origin,
+    "access-control-allow-methods": "POST, OPTIONS",
+    "access-control-allow-headers": "authorization, content-type",
+    "access-control-max-age": "86400",
+    vary: "origin",
+  };
+}
+
+function json(body: unknown, status = 200, extraHeaders: Record<string, string> = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...extraHeaders },
+  });
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const url = new URL(request.url);
+
+    if (url.pathname === "/healthz") {
+      return json({ ok: true, service: "cmux-share" });
+    }
+
+    if (url.pathname === "/v1/share/create") {
+      const cors = corsHeaders(request);
+      if (request.method === "OPTIONS") {
+        return new Response(null, { status: 204, headers: cors });
+      }
+      if (request.method !== "POST") {
+        return json({ error: "method_not_allowed" }, 405, cors);
+      }
+      const user = await verifyRequest(request, env);
+      if (!user) return json({ error: "unauthorized" }, 401, cors);
+      const body = await readBoundedJson(request);
+      if (!body.ok) return json({ error: "invalid_request" }, body.status, cors);
+      const parsed = parseCreateBody(body.value);
+      if (!parsed.ok) return json({ error: parsed.error }, 400, cors);
+
+      const randomFill = (bytes: Uint8Array) => crypto.getRandomValues(bytes);
+      const shareId = generateShareId(randomFill);
+      const hostToken = generateHostToken(randomFill);
+      const stub = env.SHARE_SESSION.get(env.SHARE_SESSION.idFromName(shareId));
+      // Only the hash crosses into (and is stored by) the DO.
+      const initialized = await stub.initialize(
+        await sha256Hex(hostToken),
+        {
+          id: user.id,
+          email: user.primaryEmail,
+          name: user.displayName || user.primaryEmail,
+        },
+        parsed.title,
+      );
+      if (!initialized.ok) {
+        // A 22-char base62 collision is effectively impossible; treat it as a
+        // transient server error rather than looping.
+        return json({ error: "share_id_collision" }, 500, cors);
+      }
+      return json(
+        { shareId, hostToken, url: `https://cmux.com/share/${shareId}` },
+        200,
+        cors,
+      );
+    }
+
+    const share = parseSharePath(url.pathname);
+    if (share !== null) {
+      if (request.method !== "GET") return json({ error: "method_not_allowed" }, 405);
+      if (request.headers.get("upgrade")?.toLowerCase() !== "websocket") {
+        return json({ error: "expected_websocket" }, 426);
+      }
+      const stub = env.SHARE_SESSION.get(env.SHARE_SESSION.idFromName(share.shareId));
+
+      if (share.lane === "host") {
+        // The host token is verified inside the DO against the stored hash;
+        // the worker just routes (it holds no per-session secrets).
+        return stub.fetch(request);
+      }
+
+      // Viewer lane: verify the Stack access token HERE (query param because
+      // browsers cannot set WS headers), then forward VERIFIED identity to
+      // the DO via headers. Client-supplied x-share-* headers are overwritten
+      // unconditionally, never passed through.
+      const user = await verifyAccessToken(url.searchParams.get("access_token"), env);
+      if (!user) return json({ error: "unauthorized" }, 401);
+      const headers = new Headers(request.headers);
+      headers.set("x-share-user-id", user.id);
+      // Header values must be ISO-8859-1-safe; identity fields are free text.
+      headers.set("x-share-email", encodeURIComponent(user.primaryEmail));
+      headers.set("x-share-name", encodeURIComponent(user.displayName));
+      return stub.fetch(new Request(request.url, { method: "GET", headers }));
+    }
+
+    return json({ error: "not_found" }, 404);
+  },
+} satisfies ExportedHandler<Env>;

--- a/workers/share/src/validate.ts
+++ b/workers/share/src/validate.ts
@@ -1,0 +1,90 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+//
+// Bounded HTTP body parsing for the share worker, copied from the presence
+// worker's validate.ts pattern: read the stream incrementally and abort the
+// moment it crosses the cap, so a chunked or lying-Content-Length body can
+// never make the worker buffer more than the limit.
+
+import { SHARE_ID_LENGTH } from "./core";
+
+export const MAX_REQUEST_BYTES = 16 * 1024;
+export const MAX_TITLE_LENGTH = 256;
+
+const SHARE_ID_RE = new RegExp(`^[0-9A-Za-z]{${SHARE_ID_LENGTH}}$`);
+
+/** `/v1/share/<id>/<lane>` -> { shareId, lane } or null. Pure for tests. */
+export function parseSharePath(
+  pathname: string,
+): { shareId: string; lane: "host" | "ws" } | null {
+  const match = /^\/v1\/share\/([^/]+)\/(host|ws)$/.exec(pathname);
+  if (!match || !match[1] || !match[2]) return null;
+  const shareId = match[1];
+  if (!SHARE_ID_RE.test(shareId)) return null;
+  return { shareId, lane: match[2] as "host" | "ws" };
+}
+
+export type CreateParse =
+  | { ok: true; title: string | undefined }
+  | { ok: false; error: string };
+
+/** Parse the `POST /v1/share/create` body (already JSON-decoded): an optional
+ * bounded `title`. Pure for tests. */
+export function parseCreateBody(body: Record<string, unknown>): CreateParse {
+  if (body.title === undefined) return { ok: true, title: undefined };
+  if (typeof body.title !== "string") return { ok: false, error: "invalid_title" };
+  const title = body.title.trim();
+  if (title.length > MAX_TITLE_LENGTH) return { ok: false, error: "invalid_title" };
+  return { ok: true, title: title || undefined };
+}
+
+/** Bounded JSON body reader. An empty body is allowed and yields `{}` so the
+ * create endpoint accepts a bare POST. */
+export async function readBoundedJson(
+  request: Request,
+  maxBytes: number = MAX_REQUEST_BYTES,
+): Promise<{ ok: true; value: Record<string, unknown> } | { ok: false; status: number }> {
+  const lengthHeader = request.headers.get("content-length");
+  if (lengthHeader && Number(lengthHeader) > maxBytes) {
+    return { ok: false, status: 413 };
+  }
+  if (!request.body) return { ok: true, value: {} };
+
+  const reader = request.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let received = 0;
+  try {
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      received += value.byteLength;
+      if (received > maxBytes) {
+        await reader.cancel();
+        return { ok: false, status: 413 };
+      }
+      chunks.push(value);
+    }
+  } catch {
+    return { ok: false, status: 400 };
+  }
+
+  if (received === 0) return { ok: true, value: {} };
+
+  const bytes = new Uint8Array(received);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    return { ok: false, status: 400 };
+  }
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    return { ok: false, status: 400 };
+  }
+  return { ok: true, value: parsed as Record<string, unknown> };
+}

--- a/workers/share/test/auth.test.ts
+++ b/workers/share/test/auth.test.ts
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+
+import { describe, expect, it } from "bun:test";
+import { AUTH_CACHE_TTL_MS, bearerToken, cacheDeadline, tokenExpiryMs } from "../src/auth";
+
+function jwtWithPayload(payload: Record<string, unknown>): string {
+  const b64 = btoa(JSON.stringify(payload)).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+  return `header.${b64}.signature`;
+}
+
+describe("tokenExpiryMs", () => {
+  it("extracts exp (seconds) as epoch ms", () => {
+    expect(tokenExpiryMs(jwtWithPayload({ exp: 1_750_000_000 }))).toBe(1_750_000_000_000);
+  });
+
+  it("returns null for opaque, malformed, or exp-less tokens", () => {
+    expect(tokenExpiryMs("opaque-token")).toBeNull();
+    expect(tokenExpiryMs("a.b")).toBeNull();
+    expect(tokenExpiryMs("a.!!!not-base64!!!.c")).toBeNull();
+    expect(tokenExpiryMs(jwtWithPayload({}))).toBeNull();
+    expect(tokenExpiryMs(jwtWithPayload({ exp: "soon" }))).toBeNull();
+  });
+});
+
+describe("cacheDeadline", () => {
+  const now = 1_000_000;
+
+  it("uses the TTL when the token has no expiry", () => {
+    expect(cacheDeadline(now, null)).toBe(now + AUTH_CACHE_TTL_MS);
+  });
+
+  it("never extends past the token's own expiry", () => {
+    expect(cacheDeadline(now, now + 5_000)).toBe(now + 5_000);
+    expect(cacheDeadline(now, now + AUTH_CACHE_TTL_MS * 10)).toBe(now + AUTH_CACHE_TTL_MS);
+  });
+});
+
+describe("bearerToken", () => {
+  function request(headers: Record<string, string>): Request {
+    return new Request("https://share.example/v1/share/create", { headers });
+  }
+
+  it("extracts the token case-insensitively and trimmed", () => {
+    expect(bearerToken(request({ authorization: "Bearer tok" }))).toBe("tok");
+    expect(bearerToken(request({ authorization: "bearer  tok " }))).toBe("tok");
+  });
+
+  it("returns null for missing, non-bearer, or empty credentials", () => {
+    expect(bearerToken(request({}))).toBeNull();
+    expect(bearerToken(request({ authorization: "Basic abc" }))).toBeNull();
+    expect(bearerToken(request({ authorization: "Bearer " }))).toBeNull();
+  });
+});

--- a/workers/share/test/core.test.ts
+++ b/workers/share/test/core.test.ts
@@ -1,0 +1,287 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+
+import { describe, expect, it } from "bun:test";
+import {
+  appendChat,
+  BASE62_ALPHABET,
+  base64UrlEncode,
+  CHAT_HISTORY_CAP,
+  frameWithinLimit,
+  generateHostToken,
+  generateShareId,
+  HOST_COLOR,
+  joinStateForVerdict,
+  MAX_CHAT_TEXT_LENGTH,
+  MAX_HOST_FRAME_BYTES,
+  MAX_VIEWER_FRAME_BYTES,
+  newTokenBucket,
+  parseIncoming,
+  PALETTE_SIZE,
+  sha256Hex,
+  SHARE_ID_LENGTH,
+  tryTakeToken,
+  viewerColor,
+  type RandomFill,
+  type StoredChatMessage,
+} from "../src/core";
+
+const cryptoFill: RandomFill = (bytes) => crypto.getRandomValues(bytes);
+
+/** Deterministic fill cycling through the given byte values. */
+function sequenceFill(values: number[]): RandomFill {
+  let i = 0;
+  return (bytes) => {
+    for (let j = 0; j < bytes.length; j++) {
+      bytes[j] = values[i % values.length]!;
+      i++;
+    }
+    return bytes;
+  };
+}
+
+describe("generateShareId", () => {
+  it("produces base62 ids of the configured length", () => {
+    const id = generateShareId(cryptoFill);
+    expect(id).toHaveLength(SHARE_ID_LENGTH);
+    expect(id).toMatch(/^[0-9A-Za-z]+$/);
+  });
+
+  it("rejection-samples bytes >= 248 instead of biasing", () => {
+    // 255 must be skipped (248..255 are rejected); 0 maps to alphabet[0].
+    const id = generateShareId(sequenceFill([255, 0]), 4);
+    expect(id).toBe(BASE62_ALPHABET[0]!.repeat(4));
+  });
+
+  it("maps accepted bytes with byte % 62", () => {
+    const id = generateShareId(sequenceFill([61, 62, 123]), 3);
+    // 61 -> 'z' (index 61), 62 -> index 0, 123 -> index 123-62=61 -> 'z'
+    expect(id).toBe(`${BASE62_ALPHABET[61]}${BASE62_ALPHABET[0]}${BASE62_ALPHABET[61]}`);
+  });
+
+  it("produces distinct ids", () => {
+    expect(generateShareId(cryptoFill)).not.toBe(generateShareId(cryptoFill));
+  });
+});
+
+describe("generateHostToken / base64UrlEncode", () => {
+  it("is url-safe base64 without padding, 43 chars for 32 bytes", () => {
+    const token = generateHostToken(cryptoFill);
+    expect(token).toHaveLength(43);
+    expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+  });
+
+  it("base64UrlEncode substitutes +/ and strips padding", () => {
+    // 0xfb 0xff -> base64 "+/8=" -> url-safe "-_8"
+    expect(base64UrlEncode(new Uint8Array([0xfb, 0xff]))).toBe("-_8");
+  });
+});
+
+describe("sha256Hex", () => {
+  it("matches a known digest", async () => {
+    expect(await sha256Hex("abc")).toBe(
+      "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad",
+    );
+  });
+});
+
+describe("viewerColor", () => {
+  it("never collides with the host color", () => {
+    for (let ordinal = 0; ordinal < 30; ordinal++) {
+      expect(viewerColor(ordinal)).not.toBe(HOST_COLOR);
+    }
+  });
+
+  it("cycles through the 9 non-host palette slots", () => {
+    const first = Array.from({ length: PALETTE_SIZE - 1 }, (_, i) => viewerColor(i));
+    expect(new Set(first).size).toBe(PALETTE_SIZE - 1);
+    expect(viewerColor(PALETTE_SIZE - 1)).toBe(viewerColor(0));
+  });
+});
+
+describe("joinStateForVerdict", () => {
+  it("maps verdicts to states", () => {
+    expect(joinStateForVerdict(undefined)).toBe("pending");
+    expect(joinStateForVerdict("approved")).toBe("approved");
+    expect(joinStateForVerdict("denied")).toBe("denied");
+  });
+});
+
+describe("appendChat", () => {
+  function msg(n: number): StoredChatMessage {
+    return { type: "chat", participantId: "p", ts: n, text: `m${n}`, x: 0, y: 0 };
+  }
+
+  it("appends below the cap", () => {
+    expect(appendChat([msg(1)], msg(2), 3)).toEqual([msg(1), msg(2)]);
+  });
+
+  it("drops the oldest entries above the cap", () => {
+    const history = [msg(1), msg(2), msg(3)];
+    expect(appendChat(history, msg(4), 3)).toEqual([msg(2), msg(3), msg(4)]);
+  });
+
+  it("does not mutate the input history", () => {
+    const history = [msg(1)];
+    appendChat(history, msg(2), 1);
+    expect(history).toEqual([msg(1)]);
+  });
+
+  it("defaults the cap to CHAT_HISTORY_CAP", () => {
+    const history = Array.from({ length: CHAT_HISTORY_CAP }, (_, i) => msg(i));
+    const next = appendChat(history, msg(999));
+    expect(next).toHaveLength(CHAT_HISTORY_CAP);
+    expect(next[next.length - 1]).toEqual(msg(999));
+    expect(next[0]).toEqual(msg(1));
+  });
+});
+
+describe("token bucket", () => {
+  it("allows a burst then drops until refill", () => {
+    const t0 = 1_000_000;
+    const bucket = newTokenBucket(t0, 3);
+    expect(tryTakeToken(bucket, t0, 3, 3)).toBe(true);
+    expect(tryTakeToken(bucket, t0, 3, 3)).toBe(true);
+    expect(tryTakeToken(bucket, t0, 3, 3)).toBe(true);
+    expect(tryTakeToken(bucket, t0, 3, 3)).toBe(false);
+    // One token refills after 1/3 s at 3/s.
+    expect(tryTakeToken(bucket, t0 + 334, 3, 3)).toBe(true);
+    expect(tryTakeToken(bucket, t0 + 334, 3, 3)).toBe(false);
+  });
+
+  it("caps refill at burst", () => {
+    const t0 = 0;
+    const bucket = newTokenBucket(t0, 2);
+    expect(tryTakeToken(bucket, t0 + 60_000, 2, 2)).toBe(true);
+    expect(tryTakeToken(bucket, t0 + 60_000, 2, 2)).toBe(true);
+    expect(tryTakeToken(bucket, t0 + 60_000, 2, 2)).toBe(false);
+  });
+
+  it("tolerates a clock going backwards", () => {
+    const bucket = newTokenBucket(10_000, 1);
+    expect(tryTakeToken(bucket, 10_000, 1, 1)).toBe(true);
+    expect(tryTakeToken(bucket, 5_000, 1, 1)).toBe(false);
+  });
+});
+
+describe("frameWithinLimit", () => {
+  it("enforces the smaller viewer cap and larger host cap", () => {
+    expect(frameWithinLimit("viewer", MAX_VIEWER_FRAME_BYTES)).toBe(true);
+    expect(frameWithinLimit("viewer", MAX_VIEWER_FRAME_BYTES + 1)).toBe(false);
+    expect(frameWithinLimit("host", MAX_VIEWER_FRAME_BYTES + 1)).toBe(true);
+    expect(frameWithinLimit("host", MAX_HOST_FRAME_BYTES)).toBe(true);
+    expect(frameWithinLimit("host", MAX_HOST_FRAME_BYTES + 1)).toBe(false);
+  });
+});
+
+describe("parseIncoming", () => {
+  it("drops non-objects and unknown types", () => {
+    expect(parseIncoming("host", null)).toBeNull();
+    expect(parseIncoming("host", "cursor")).toBeNull();
+    expect(parseIncoming("host", [])).toBeNull();
+    expect(parseIncoming("host", { type: "nope" })).toBeNull();
+    expect(parseIncoming("host", { type: 42 })).toBeNull();
+  });
+
+  it("restricts viewers to cursor and chat (read-only protocol)", () => {
+    for (const type of ["layout", "term", "term_resize", "textbox", "snapshot", "join_response", "end"]) {
+      expect(parseIncoming("viewer", { type })).toBeNull();
+    }
+    expect(parseIncoming("viewer", { type: "cursor", x: 0.5, y: 0.5 })).toEqual({
+      type: "cursor",
+      x: 0.5,
+      y: 0.5,
+    });
+    expect(parseIncoming("viewer", { type: "chat", text: "hi", x: 0, y: 1 })).toEqual({
+      type: "chat",
+      text: "hi",
+      x: 0,
+      y: 1,
+    });
+  });
+
+  it("clamps cursor coordinates to [0,1] and rejects non-finite", () => {
+    expect(parseIncoming("viewer", { type: "cursor", x: -3, y: 7 })).toEqual({
+      type: "cursor",
+      x: 0,
+      y: 1,
+    });
+    expect(parseIncoming("viewer", { type: "cursor", x: Number.NaN, y: 0 })).toBeNull();
+    expect(parseIncoming("viewer", { type: "cursor", x: Infinity, y: 0 })).toBeNull();
+    expect(parseIncoming("viewer", { type: "cursor", x: "0.5", y: 0 })).toBeNull();
+  });
+
+  it("trims, bounds, and rejects empty chat text", () => {
+    expect(parseIncoming("viewer", { type: "chat", text: "  hi  ", x: 0, y: 0 })).toEqual({
+      type: "chat",
+      text: "hi",
+      x: 0,
+      y: 0,
+    });
+    expect(parseIncoming("viewer", { type: "chat", text: "   ", x: 0, y: 0 })).toBeNull();
+    const long = parseIncoming("viewer", {
+      type: "chat",
+      text: "a".repeat(MAX_CHAT_TEXT_LENGTH + 100),
+      x: 0,
+      y: 0,
+    });
+    expect(long?.type).toBe("chat");
+    if (long?.type === "chat") expect(long.text).toHaveLength(MAX_CHAT_TEXT_LENGTH);
+  });
+
+  it("validates host join_response", () => {
+    expect(parseIncoming("host", { type: "join_response", requestId: "r1", allow: true })).toEqual({
+      type: "join_response",
+      requestId: "r1",
+      allow: true,
+    });
+    expect(parseIncoming("host", { type: "join_response", requestId: "", allow: true })).toBeNull();
+    expect(parseIncoming("host", { type: "join_response", requestId: "r1", allow: "yes" })).toBeNull();
+  });
+
+  it("validates host snapshot/layout envelopes", () => {
+    expect(parseIncoming("host", { type: "snapshot", to: "p1", workspace: { panes: [] } })).toEqual({
+      type: "snapshot",
+      to: "p1",
+      workspace: { panes: [] },
+    });
+    expect(parseIncoming("host", { type: "snapshot", to: "", workspace: {} })).toBeNull();
+    expect(parseIncoming("host", { type: "snapshot", to: "p1", workspace: [] })).toBeNull();
+    expect(parseIncoming("host", { type: "layout", workspace: {} })).toEqual({
+      type: "layout",
+      workspace: {},
+    });
+    expect(parseIncoming("host", { type: "layout", workspace: null })).toBeNull();
+  });
+
+  it("validates host term / term_resize / textbox", () => {
+    expect(
+      parseIncoming("host", { type: "term", surfaceId: "s1", seq: 1, data_b64: "AA==" }),
+    ).toEqual({ type: "term", surfaceId: "s1", seq: 1, data_b64: "AA==" });
+    expect(parseIncoming("host", { type: "term", surfaceId: "s1", seq: "1", data_b64: "" })).toBeNull();
+    expect(parseIncoming("host", { type: "term", surfaceId: "", seq: 1, data_b64: "" })).toBeNull();
+
+    expect(
+      parseIncoming("host", { type: "term_resize", surfaceId: "s1", cols: 80, rows: 24 }),
+    ).toEqual({ type: "term_resize", surfaceId: "s1", cols: 80, rows: 24 });
+    expect(parseIncoming("host", { type: "term_resize", surfaceId: "s1", cols: 80 })).toBeNull();
+
+    expect(
+      parseIncoming("host", {
+        type: "textbox",
+        paneId: "p1",
+        text: "draft",
+        selStart: 0,
+        selEnd: 5,
+        active: true,
+      }),
+    ).toEqual({ type: "textbox", paneId: "p1", text: "draft", selStart: 0, selEnd: 5, active: true });
+    expect(
+      parseIncoming("host", { type: "textbox", paneId: "p1", text: "x", selStart: 0, selEnd: 1 }),
+    ).toBeNull();
+  });
+
+  it("accepts host end", () => {
+    expect(parseIncoming("host", { type: "end" })).toEqual({ type: "end" });
+  });
+});

--- a/workers/share/test/validate.test.ts
+++ b/workers/share/test/validate.test.ts
@@ -1,0 +1,124 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// Copyright (C) 2026 Manaflow, Inc.
+
+import { describe, expect, it } from "bun:test";
+import { SHARE_ID_LENGTH } from "../src/core";
+import {
+  MAX_REQUEST_BYTES,
+  MAX_TITLE_LENGTH,
+  parseCreateBody,
+  parseSharePath,
+  readBoundedJson,
+} from "../src/validate";
+
+const SHARE_ID = "A".repeat(SHARE_ID_LENGTH);
+
+describe("parseSharePath", () => {
+  it("parses host and viewer lanes", () => {
+    expect(parseSharePath(`/v1/share/${SHARE_ID}/host`)).toEqual({
+      shareId: SHARE_ID,
+      lane: "host",
+    });
+    expect(parseSharePath(`/v1/share/${SHARE_ID}/ws`)).toEqual({
+      shareId: SHARE_ID,
+      lane: "ws",
+    });
+  });
+
+  it("rejects malformed ids and lanes", () => {
+    expect(parseSharePath(`/v1/share/${SHARE_ID}/other`)).toBeNull();
+    expect(parseSharePath(`/v1/share/short/ws`)).toBeNull();
+    expect(parseSharePath(`/v1/share/${"A".repeat(SHARE_ID_LENGTH + 1)}/ws`)).toBeNull();
+    expect(parseSharePath(`/v1/share/${"!".repeat(SHARE_ID_LENGTH)}/ws`)).toBeNull();
+    expect(parseSharePath(`/v1/share/${SHARE_ID}`)).toBeNull();
+    expect(parseSharePath(`/v1/share//ws`)).toBeNull();
+    expect(parseSharePath(`/v2/share/${SHARE_ID}/ws`)).toBeNull();
+  });
+});
+
+describe("parseCreateBody", () => {
+  it("accepts a missing title", () => {
+    expect(parseCreateBody({})).toEqual({ ok: true, title: undefined });
+  });
+
+  it("trims the title and treats whitespace-only as absent", () => {
+    expect(parseCreateBody({ title: "  demo  " })).toEqual({ ok: true, title: "demo" });
+    expect(parseCreateBody({ title: "   " })).toEqual({ ok: true, title: undefined });
+  });
+
+  it("rejects non-string and oversized titles", () => {
+    expect(parseCreateBody({ title: 42 })).toEqual({ ok: false, error: "invalid_title" });
+    expect(parseCreateBody({ title: "a".repeat(MAX_TITLE_LENGTH + 1) })).toEqual({
+      ok: false,
+      error: "invalid_title",
+    });
+    expect(parseCreateBody({ title: "a".repeat(MAX_TITLE_LENGTH) })).toEqual({
+      ok: true,
+      title: "a".repeat(MAX_TITLE_LENGTH),
+    });
+  });
+});
+
+function postRequest(
+  body: string | ReadableStream<Uint8Array> | null,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("https://share.example/v1/share/create", {
+    method: "POST",
+    body,
+    headers,
+  });
+}
+
+/** A chunked body with no usable Content-Length, as an attacker would send. */
+function chunkedRequest(chunks: readonly Uint8Array[]): Request {
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) controller.enqueue(chunk);
+      controller.close();
+    },
+  });
+  return postRequest(stream);
+}
+
+describe("readBoundedJson", () => {
+  it("parses a small JSON object", async () => {
+    const result = await readBoundedJson(postRequest(JSON.stringify({ title: "x" })));
+    expect(result).toEqual({ ok: true, value: { title: "x" } });
+  });
+
+  it("treats an absent or empty body as an empty object", async () => {
+    expect(await readBoundedJson(postRequest(null))).toEqual({ ok: true, value: {} });
+    expect(await readBoundedJson(postRequest(""))).toEqual({ ok: true, value: {} });
+  });
+
+  it("rejects an oversized Content-Length up front with 413", async () => {
+    const result = await readBoundedJson(
+      postRequest("{}", { "content-length": String(MAX_REQUEST_BYTES + 1) }),
+    );
+    expect(result).toEqual({ ok: false, status: 413 });
+  });
+
+  it("aborts a chunked body the moment it crosses the cap", async () => {
+    const chunk = new Uint8Array(1024).fill(0x61);
+    const chunks = Array.from({ length: MAX_REQUEST_BYTES / 1024 + 1 }, () => chunk);
+    const result = await readBoundedJson(chunkedRequest(chunks));
+    expect(result).toEqual({ ok: false, status: 413 });
+  });
+
+  it("rejects invalid JSON and non-object payloads with 400", async () => {
+    expect(await readBoundedJson(postRequest("not json"))).toEqual({ ok: false, status: 400 });
+    expect(await readBoundedJson(postRequest("[1,2]"))).toEqual({ ok: false, status: 400 });
+    expect(await readBoundedJson(postRequest("null"))).toEqual({ ok: false, status: 400 });
+    expect(await readBoundedJson(postRequest('"str"'))).toEqual({ ok: false, status: 400 });
+  });
+
+  it("reassembles a multi-chunk body under the cap", async () => {
+    const text = JSON.stringify({ title: "chunked" });
+    const bytes = new TextEncoder().encode(text);
+    const result = await readBoundedJson(
+      chunkedRequest([bytes.slice(0, 5), bytes.slice(5)]),
+    );
+    expect(result).toEqual({ ok: true, value: { title: "chunked" } });
+  });
+});

--- a/workers/share/tsconfig.json
+++ b/workers/share/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "lib": ["ES2022"],
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "types": ["@cloudflare/workers-types/experimental"],
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noFallthroughCasesInSwitch": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/workers/share/tsconfig.test.json
+++ b/workers/share/tsconfig.test.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["bun"]
+  },
+  "include": ["test/**/*.ts", "src/core.ts", "src/validate.ts", "src/auth.ts"]
+}

--- a/workers/share/wrangler.toml
+++ b/workers/share/wrangler.toml
@@ -1,0 +1,41 @@
+# cmux multiplayer workspace share — Cloudflare Worker + Durable Objects.
+#
+# One ShareSession Durable Object per share id (idFromName(shareId)). A host
+# Mac streams one workspace read-only over a WebSocket; authenticated web
+# viewers at cmux.com/share/<id> connect after explicit per-user host approval.
+# The DO is a pure relay for terminal data (it stores no terminal bytes); it
+# durably keeps only the host token hash, per-user join verdicts, and the last
+# 200 chat messages, all deleted when the session ends.
+#
+# The [[migrations]] block below is the service's schema migration story:
+# wrangler applies Durable Object class migrations atomically with every
+# deploy. Never hand-edit past migration tags; append a new one.
+#
+# Stack Auth configuration is intentionally NOT in [vars]: values set here
+# overwrite dashboard-set values on every deploy. They are provisioned once as
+# Worker secrets (see README.md) and survive deploys:
+#   wrangler secret put STACK_PROJECT_ID
+#   wrangler secret put STACK_PUBLISHABLE_CLIENT_KEY
+# Optional plain var STACK_API_URL defaults to https://api.stack-auth.com.
+
+name = "cmux-share"
+main = "src/index.ts"
+compatibility_date = "2026-05-01"
+
+[observability]
+enabled = true
+
+[[durable_objects.bindings]]
+name = "SHARE_SESSION"
+class_name = "ShareSession"
+
+[[migrations]]
+tag = "v1"
+new_sqlite_classes = ["ShareSession"]
+
+# Production custom domain on the cmux.dev zone (same Cloudflare account).
+# `custom_domain = true` provisions the DNS record + TLS cert with the deploy;
+# the workers.dev URL stays as the dev/staging entrypoint.
+[[routes]]
+pattern = "share.cmux.dev"
+custom_domain = true


### PR DESCRIPTION
Share a workspace read-only from the command palette (cmd+shift+p → Share Workspace…). The link (`https://cmux.com/share/<id>`) opens a web viewer where signed-in teammates see the full workspace scaled to their window, live terminals, everyone's colored cursor, and Figma-style cursor chat.

**Relay (`workers/share/`, GPL-3.0-or-later):** new Cloudflare Worker + `ShareSession` Durable Object per share id, following `workers/presence`'s template (Stack Auth verification in the worker, hibernation WebSockets in the DO). The DO is a pure relay: it stores only the SHA-256 of the per-session host token, per-user join verdicts, and the last 200 chat messages, and deletes everything when the session ends (host gone >60s or explicit end). Viewers can only send `cursor` and `chat`; no input path to the Mac exists in the protocol. Cursor fan-out is rate limited to 30/s per sender.

**Access flow:** the viewer must be signed in to Stack first; the page redirects to sign-in otherwise. On connect, the host Mac shows "<email> wants to view this workspace" with Allow/Deny; the verdict is remembered per user for the session.

**macOS host (`Sources/Share/`):** palette actions `Share Workspace…`/`Stop Sharing Workspace` create the session, copy the link, and stream bonsplit layout (normalized pane rects), raw PTY bytes from `MobileTerminalByteTee`, and the workspace textbox with selection. Remote cursors and chat bubbles render over the workspace in a non-activating overlay window using the kite cursor from https://github.com/manaflow-ai/cmux/pull/7151, tinted per participant (host keeps the cmux gradient).

**Web viewer (`web/app/[locale]/share/[id]/`):** terminals render read-only with ghostty-web (Ghostty's VT parser in wasm); the workspace scales with `transform: scale()` so mobile works. `/` opens cursor chat; messages bubble at the sender's cursor for 6s and collect in a floating panel bottom-right. Presence strip top-right. Strings localized (en+ja).

Design doc: `plans/feat-multiplayer-share/DESIGN.md`. Follow-ups noted there: viewer-side textbox carets (true multiplayer editing), smarter scaling, seq-gap resync RPC.

Deploy note: `workers/share` needs one-time `wrangler secret put STACK_PROJECT_ID` / `STACK_PUBLISHABLE_CLIENT_KEY` and a deploy workflow (mirroring `.github/workflows/presence.yml`) before the feature works end to end; until then the palette action reports the create failure.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8360"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786898230&installation_id=133855650&pr_number=8360&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8360&signature=3c7f6c27eaa4b54d95cc578f224190480b952fe11982ac92a9c0e5cfbede95d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a workspace read-only from the command palette and share a link `https://cmux.com/share/<id>` where teammates see the workspace, live colored cursors, terminals, and Figma‑style cursor chat. A new Cloudflare Worker + Durable Object relay (`workers/share`) powers the session with Stack sign‑in and host approvals.

- **New Features**
  - macOS host: “Share Workspace…”/“Stop Sharing Workspace” actions create the session, copy the link, and stream layout, PTY bytes, and textbox state; a non‑activating overlay shows remote cursors and chat.
  - Web viewer: fit‑to‑window workspace with read‑only terminals via `ghostty-web`, “/” to open cursor chat, presence strip, and en/ja copy.
  - Access control: viewers must sign in; host allow/deny per user with remembered verdicts; viewers can only send `cursor` and `chat`; cursor fan‑out rate‑limited.
  - Relay: `workers/share` (GPL‑3.0‑or‑later) with `ShareSession` DO, hibernation WebSockets, and minimal storage (host token SHA‑256, per‑user verdicts, last 200 chat messages), all cleared when the session ends.

- **Migration**
  - Deploy `workers/share` and set secrets `STACK_PROJECT_ID` and `STACK_PUBLISHABLE_CLIENT_KEY` (add a deploy workflow like `.github/workflows/presence.yml`); until then, the palette action will fail to create a share.
  - Web adds `ghostty-web`. No other migrations.

<sup>Written for commit cbf0542a367252fd4a73b46096cfe046d6bfd55a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8360?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added multiplayer workspace sharing with authenticated viewer access.
  * Hosts can share or stop sharing a workspace from the command palette.
  * Viewers can see live terminal, browser, and textbox content in a read-only workspace.
  * Added participant presence, cursor indicators, cursor chat, and shared chat.
  * Added join approval controls and sharing status notifications.
  * Added English and Japanese localization for sharing features.

* **Bug Fixes**
  * Improved handling of reconnects, session endings, terminal replay, and invalid share messages.

* **Tests**
  * Added coverage for sharing protocols, authentication, validation, layout, replay, and connection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->