### PR TITLE
Match legacy sidebar highlight width: use .plain table style (Lawrence Sidebar)

### DIFF
--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -44,7 +44,12 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         table.dataSource = self
         table.delegate = self
         table.headerView = nil
-        table.style = .fullWidth
+        // .plain, not .fullWidth: fullWidth still insets cell frames by
+        // ~6pt per side, which pushed the whole row (selection background
+        // and content) 6pt inboard of the legacy sidebar's geometry. The
+        // cell owns its own 6pt outer padding (rowOuterHorizontalPadding),
+        // so the table must hand it the full row width.
+        table.style = .plain
         table.backgroundColor = .clear
         table.enclosingScrollView?.backgroundColor = .clear
         table.focusRingType = .none


### PR DESCRIPTION
Dogfood report: the Lawrence Sidebar's selection highlight was narrower than the legacy sidebar's. Measured cause: NSTableView's `.fullWidth` style still insets cell frames ~6pt per side, stacking with the cell's own 6pt outer padding (12pt total vs legacy's 6pt) and shifting all row content 6pt inboard. `.plain` hands cells the full row width so the cell's padding is the only inset. Verified on tag `sbak`: selection left inset now exactly 6.0pt, matching legacy. Flag-ON only (`sidebar-appkit-list-experiment`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8364"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786904420&installation_id=133855650&pr_number=8364&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8364&signature=2bef1d82fd383009845aca00e0f91f8d9693e997d54bf7c8bc762637c15d7722"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Match the legacy sidebar’s selection highlight width by switching the Lawrence Sidebar table style from .fullWidth to .plain. This removes the extra ~6pt per-side inset so the selection background and row content align with legacy; gated by `sidebar-appkit-list-experiment`.

<sup>Written for commit a220cd647ac5bc40816b9c82eaea5ab1ddaca435. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8364?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sidebar row layout so selection highlights and backgrounds align correctly across the full row width.
  * Preserved consistent spacing and appearance in the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->