### PR TITLE
feat(open): route .md files to cmux's markdown viewer

### DIFF
--- a/Resources/bin/open
+++ b/Resources/bin/open
@@ -142,6 +142,59 @@ is_html_extension() {
     return 1
 }
 
+is_markdown_extension() {
+    local value
+    value="$(to_lower_ascii "$(trim "$1")")"
+    case "$value" in
+        *.md|*.markdown)
+            return 0
+            ;;
+    esac
+    return 1
+}
+
+# Decode a file:// URL to a local filesystem path (cmux markdown open wants a
+# path, not a URL). Python-first with a Bash fallback; empty output on failure.
+file_url_to_path() {
+    local value="$1"
+    if [[ -n "$PYTHON3_BIN" ]]; then
+        local decoded
+        if decoded="$("$PYTHON3_BIN" - "$value" <<'PY' 2>/dev/null
+import sys
+from urllib.parse import unquote, urlsplit
+
+parts = urlsplit(sys.argv[1].strip())
+path = unquote(parts.path or "")
+if not path:
+    raise SystemExit(1)
+sys.stdout.write(path)
+PY
+        )"; then
+            printf '%s' "$decoded"
+            return 0
+        fi
+    fi
+    # Bash fallback: strip scheme + optional host, percent-decode.
+    local without_fragment="${value%%\#*}"
+    local without_query="${without_fragment%%\?*}"
+    local remainder="${without_query#*://}"
+    local path_part
+    if [[ "$remainder" == /* ]]; then
+        path_part="$remainder"
+    elif [[ "$remainder" == */* ]]; then
+        path_part="/${remainder#*/}"
+    else
+        return 1
+    fi
+    printf '%b' "${path_part//%/\\x}"
+}
+
+file_url_points_to_markdown() {
+    local path
+    path="$(file_url_to_path "$1")" || return 1
+    [[ -n "$path" ]] && is_markdown_extension "$path"
+}
+
 is_explicit_local_path() {
     local value="$1"
     case "$value" in
@@ -389,6 +442,7 @@ fi
 # Also collect non-flag arguments and route eligible browser targets to cmux.
 passthrough=false
 cmux_targets=()
+cmux_markdown_targets=()
 passthrough_args=()
 for arg in "$@"; do
     case "$arg" in
@@ -407,6 +461,12 @@ for arg in "$@"; do
             elif is_file_url "$arg"; then
                 if file_url_points_to_html "$arg"; then
                     cmux_targets+=("$arg")
+                elif file_url_points_to_markdown "$arg"; then
+                    if md_path="$(file_url_to_path "$arg")"; then
+                        cmux_markdown_targets+=("$md_path")
+                    else
+                        passthrough_args+=("$arg")
+                    fi
                 else
                     passthrough_args+=("$arg")
                 fi
@@ -422,6 +482,14 @@ for arg in "$@"; do
                 else
                     passthrough_args+=("$arg")
                 fi
+            elif is_markdown_extension "$arg"; then
+                # Markdown opens in cmux's formatted viewer (live reload), not the
+                # browser. Pass the filesystem path straight to `cmux markdown open`.
+                if is_explicit_local_path "$arg" || [[ -e "$arg" ]]; then
+                    cmux_markdown_targets+=("$arg")
+                else
+                    passthrough_args+=("$arg")
+                fi
             else
                 passthrough_args+=("$arg")
             fi
@@ -429,9 +497,30 @@ for arg in "$@"; do
     esac
 done
 
-if [[ "$passthrough" == true ]] || [[ ${#cmux_targets[@]} -eq 0 ]]; then
+if [[ "$passthrough" == true ]] || { [[ ${#cmux_targets[@]} -eq 0 ]] && [[ ${#cmux_markdown_targets[@]} -eq 0 ]]; }; then
     system_open "$@"
     exit $?
+fi
+
+# Markdown → cmux's formatted viewer (live reload). The viewer is NOT the in-app
+# browser, so this is independent of the browser interception settings below.
+if [[ ${#cmux_markdown_targets[@]} -gt 0 ]]; then
+    md_cli="$(cd "$(dirname "$0")" && pwd)/cmux"
+    if [[ -x "$md_cli" ]]; then
+        for md in "${cmux_markdown_targets[@]}"; do
+            "$md_cli" markdown open "$md" 2>/dev/null || passthrough_args+=("$md")
+        done
+    else
+        passthrough_args+=("${cmux_markdown_targets[@]}")
+    fi
+    # If markdown was the only kind of target, we're done (system-open any leftovers).
+    if [[ ${#cmux_targets[@]} -eq 0 ]]; then
+        if [[ ${#passthrough_args[@]} -gt 0 ]]; then
+            system_open "${passthrough_args[@]}"
+            exit $?
+        fi
+        exit 0
+    fi
 fi
 
 # Respect the same settings used for terminal link clicks.


### PR DESCRIPTION
## Summary

The `open` wrapper (`Resources/bin/open`) already special-cases `.html`/`.htm` and routes them to the in-app browser. This does the symmetric thing for **Markdown**: `.md`/`.markdown` targets are routed to **`cmux markdown open`** (the formatted viewer with live reload) instead of falling through to `/usr/bin/open` — which on most machines opens Markdown in a web browser.

## Motivation

Clicking a `.md` link in a cmux terminal (or running `open foo.md`) currently opens it in the system default handler (a browser), even though cmux ships a first-class Markdown viewer (`cmux markdown open`). This makes the viewer reachable the same way `.html` already reaches the in-app browser.

## What changed

- New helpers `is_markdown_extension`, `file_url_to_path`, `file_url_points_to_markdown`.
- The argument loop collects `.md`/`.markdown` targets (local paths **and** `file://` URLs) into a separate `cmux_markdown_targets` list.
- A dispatch block runs `cmux markdown open <path>` for those targets. Markdown routing is **intentionally independent of the browser interception settings** (the viewer is not the in-app browser); if `cmux` isn't found or the command fails, it falls back to system open.

Additive and symmetric to the existing HTML handling — all other extensions, HTTP(S) URLs, `file://` non-markdown, and explicit `open` flags pass through unchanged.

## Testing

Validated the routing logic in isolation (mock `cmux` CLI + mock system open, `CMUX_SOCKET_PATH` set):

| Input | Routed to |
|-------|-----------|
| `doc.md` (local path) | `cmux markdown open <path>` |
| `file:///…/doc.md` | `cmux markdown open <decoded path>` |
| `page.html` | `cmux browser open file://…` (unchanged) |
| `https://…` | `cmux browser open` (unchanged) |
| `file.pdf` | system open (unchanged) |

`bash -n` clean. I couldn't run the full app build (Xcode/Zig/VM) locally — happy to adjust to fit conventions, add a dedicated enable/disable setting, or add a test if you'd like.

*Disclosure: change drafted with Claude Code.*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8369"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786913475&installation_id=133855650&pr_number=8369&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8369&signature=222f82a70cc53a24aa4196e422e1f1d7d4bb7d8811915e49cf8d511aa029c063"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Route `.md` and `.markdown` files through the Markdown viewer by default, using `cmux markdown open` with live reload instead of the system app. Works for local paths and `file://` URLs, and falls back to system open if `cmux` isn’t available.

- **New Features**
  - Added `is_markdown_extension`, `file_url_to_path`, `file_url_points_to_markdown`.
  - Collects Markdown targets and runs `cmux markdown open <path>`.
  - Mirrors existing HTML routing; independent of browser interception; everything else passes through unchanged.

<sup>Written for commit 1235c96b3c5bcdc7c42c542e842c2b4c566cdee9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8369?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Markdown files and supported Markdown URLs now open in the dedicated Markdown viewer.
  * Local file URLs are decoded before being displayed when possible.
  * Multiple Markdown targets can be opened in a single command.

* **Bug Fixes**
  * Added fallback handling so Markdown files continue opening normally if the dedicated viewer is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->