### PR TITLE
Unify dock.json for right and Floating Docks

### DIFF
--- a/CLI/CMUXCLI+WorkspaceFloatingDock.swift
+++ b/CLI/CMUXCLI+WorkspaceFloatingDock.swift
@@ -1,0 +1,281 @@
+import Foundation
+
+/// `cmux workspace float`: agent-visible control for workspace-scoped floating Docks.
+extension CMUXCLI {
+    func runWorkspaceFloatingDock(
+        commandArgs: [String], client: SocketClient, jsonOutput: Bool,
+        idFormat: CLIIDFormat, windowOverride: String?
+    ) throws {
+        if hasHelpRequest(beforeSeparator: commandArgs) {
+            print(Self.workspaceFloatingDockUsage)
+            return
+        }
+        guard let subcommand = commandArgs.first?.lowercased() else {
+            throw CLIError(message: floatingDockCLIString(
+                "cli.workspace.float.error.subcommandRequired",
+                defaultValue: "workspace float requires a subcommand. Try: list, create, show, hide, focus, close, frame, note, surface, pane"
+            ))
+        }
+        let target = try workspaceFloatingDockTarget(
+            Array(commandArgs.dropFirst()), client: client, windowOverride: windowOverride
+        )
+        var params = target.params
+        let args = target.rest
+
+        switch subcommand {
+        case "list", "ls":
+            let payload = try client.sendV2(method: "workspace.float.list", params: params)
+            printFloatingDockList(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+        case "create":
+            let (title, rem0) = parseOption(args, name: "--title")
+            if let title { params["title"] = title }
+            params["focus"] = hasFlag(rem0, name: "--focus")
+            try addFloatingDockFrameParams(from: rem0, to: &params, required: false)
+            let payload = try client.sendV2(method: "workspace.float.create", params: params)
+            printFloatingDockMutation(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+        case "show", "hide", "focus", "close":
+            let (selector, remaining) = try floatingDockSelector(from: args)
+            params["float"] = selector
+            if subcommand == "show" { params["focus"] = hasFlag(remaining, name: "--focus") }
+            let payload = try client.sendV2(method: "workspace.float.\(subcommand)", params: params)
+            printFloatingDockMutation(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+        case "frame":
+            let (selector, remaining) = try floatingDockSelector(from: args)
+            params["float"] = selector
+            try addFloatingDockFrameParams(from: remaining, to: &params, required: true)
+            let payload = try client.sendV2(method: "workspace.float.set_frame", params: params)
+            printFloatingDockMutation(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+        case "note":
+            try runWorkspaceFloatingDockNote(
+                args: args, params: params, client: client, jsonOutput: jsonOutput, idFormat: idFormat
+            )
+        case "surface":
+            try runWorkspaceFloatingDockSurface(
+                args: args, params: params, client: client, jsonOutput: jsonOutput, idFormat: idFormat
+            )
+        case "pane":
+            try runWorkspaceFloatingDockPane(
+                args: args, params: params, client: client, jsonOutput: jsonOutput, idFormat: idFormat
+            )
+        default:
+            throw CLIError(message: String(
+                format: floatingDockCLIString(
+                    "cli.workspace.float.error.subcommandUnknown",
+                    defaultValue: "Unknown workspace float subcommand: %@"
+                ),
+                locale: .current,
+                subcommand
+            ))
+        }
+    }
+
+    private func workspaceFloatingDockTarget(
+        _ args: [String], client: SocketClient, windowOverride: String?
+    ) throws -> (params: [String: Any], rest: [String]) {
+        let (workspaceRaw, rem0) = parseOption(args, name: "--workspace")
+        let (windowRaw, rem1) = parseOption(rem0, name: "--window")
+        var params: [String: Any] = [:]
+        let window = try normalizeWindowHandle(windowRaw ?? windowOverride, client: client)
+        if let window { params["window_id"] = window }
+        if let workspace = try normalizeWorkspaceHandle(
+            workspaceRaw, client: client, windowHandle: window, allowCurrent: true
+        ) { params["workspace_id"] = workspace }
+        return (params, rem1.filter { $0 != "--json" })
+    }
+
+    private func floatingDockSelector(from args: [String]) throws -> (String, [String]) {
+        let (option, remaining) = parseOption(args, name: "--float")
+        if let option { return (option, remaining) }
+        guard let index = remaining.firstIndex(where: { !$0.hasPrefix("-") }) else {
+            throw CLIError(message: floatingDockCLIString(
+                "cli.workspace.float.error.selectorRequired",
+                defaultValue: "A floating Dock selector is required (UUID, float:N, or 1-based index)"
+            ))
+        }
+        var rest = remaining
+        return (rest.remove(at: index), rest)
+    }
+
+    private func addFloatingDockFrameParams(
+        from args: [String], to params: inout [String: Any], required: Bool
+    ) throws {
+        var rest = args
+        var values: [String: Double] = [:]
+        for key in ["x", "y", "width", "height"] {
+            let (raw, next) = parseOption(rest, name: "--\(key)")
+            rest = next
+            if let raw {
+                guard let value = Double(raw), value.isFinite else {
+                    throw CLIError(message: String(
+                        format: floatingDockCLIString(
+                            "cli.workspace.float.error.finiteNumber",
+                            defaultValue: "--%@ must be a finite number"
+                        ),
+                        locale: .current,
+                        key
+                    ))
+                }
+                values[key] = value
+            }
+        }
+        guard required || !values.isEmpty else { return }
+        guard values.count == 4 else {
+            throw CLIError(message: floatingDockCLIString(
+                "cli.workspace.float.error.completeFrame",
+                defaultValue: "--x, --y, --width, and --height must be supplied together"
+            ))
+        }
+        for (key, value) in values { params[key] = value }
+    }
+
+    private func runWorkspaceFloatingDockNote(
+        args: [String], params initialParams: [String: Any], client: SocketClient,
+        jsonOutput: Bool, idFormat: CLIIDFormat
+    ) throws {
+        guard let verb = args.first?.lowercased(), verb == "get" || verb == "set" else {
+            throw CLIError(message: floatingDockCLIString(
+                "cli.workspace.float.error.noteUsage",
+                defaultValue: "Usage: cmux workspace float note <get|set> <float> [text]"
+            ))
+        }
+        let (selector, remaining) = try floatingDockSelector(from: Array(args.dropFirst()))
+        var params = initialParams
+        params["float"] = selector
+        if verb == "set" {
+            let positional = remaining.filter { !$0.hasPrefix("--") }
+            let text: String
+            if !positional.isEmpty {
+                text = positional.joined(separator: " ")
+            } else if isatty(STDIN_FILENO) == 0 {
+                var lines: [String] = []
+                while let line = readLine(strippingNewline: false) { lines.append(line) }
+                text = lines.joined()
+            } else {
+                throw CLIError(message: floatingDockCLIString(
+                    "cli.workspace.float.error.noteSetUsage",
+                    defaultValue: "Usage: cmux workspace float note set <float> <text> (or pipe text on stdin)"
+                ))
+            }
+            params["text"] = text
+        }
+        let payload = try client.sendV2(method: "workspace.float.note.\(verb)", params: params)
+        if jsonOutput { print(jsonString(formatIDs(payload, mode: idFormat))) }
+        else if verb == "get" { print(payload["text"] as? String ?? "") }
+        else { print("OK") }
+    }
+
+    private func runWorkspaceFloatingDockSurface(
+        args: [String], params initialParams: [String: Any], client: SocketClient,
+        jsonOutput: Bool, idFormat: CLIIDFormat
+    ) throws {
+        guard args.first?.lowercased() == "create" else {
+            throw CLIError(message: floatingDockCLIString(
+                "cli.workspace.float.error.surfaceUsage",
+                defaultValue: "Usage: cmux workspace float surface create <float> --type <terminal|browser>"
+            ))
+        }
+        let (selector, selectorRest) = try floatingDockSelector(from: Array(args.dropFirst()))
+        let (kind, rem0) = parseOption(selectorRest, name: "--type")
+        let (pane, rem1) = parseOption(rem0, name: "--pane")
+        let (url, rem2) = parseOption(rem1, name: "--url")
+        guard let kind else { throw CLIError(message: floatingDockCLIString(
+            "cli.workspace.float.error.typeRequired",
+            defaultValue: "--type terminal|browser is required"
+        )) }
+        var params = initialParams
+        params["float"] = selector; params["kind"] = kind
+        if let pane { params["pane_id"] = pane }
+        if let url { params["url"] = url }
+        params["focus"] = hasFlag(rem2, name: "--focus")
+        let payload = try client.sendV2(method: "workspace.float.surface.create", params: params)
+        printFloatingDockMutation(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    private func runWorkspaceFloatingDockPane(
+        args: [String], params initialParams: [String: Any], client: SocketClient,
+        jsonOutput: Bool, idFormat: CLIIDFormat
+    ) throws {
+        guard args.first?.lowercased() == "create" else {
+            throw CLIError(message: floatingDockCLIString(
+                "cli.workspace.float.error.paneUsage",
+                defaultValue: "Usage: cmux workspace float pane create <float> --type <terminal|browser> [--direction right]"
+            ))
+        }
+        let (selector, selectorRest) = try floatingDockSelector(from: Array(args.dropFirst()))
+        let (kind, rem0) = parseOption(selectorRest, name: "--type")
+        let (direction, rem1) = parseOption(rem0, name: "--direction")
+        let (surface, rem2) = parseOption(rem1, name: "--surface")
+        let (url, rem3) = parseOption(rem2, name: "--url")
+        guard let kind else { throw CLIError(message: floatingDockCLIString(
+            "cli.workspace.float.error.typeRequired",
+            defaultValue: "--type terminal|browser is required"
+        )) }
+        var params = initialParams
+        params["float"] = selector; params["kind"] = kind
+        params["direction"] = direction ?? "right"
+        if let surface { params["surface_id"] = surface }
+        if let url { params["url"] = url }
+        params["focus"] = hasFlag(rem3, name: "--focus")
+        let payload = try client.sendV2(method: "workspace.float.pane.create", params: params)
+        printFloatingDockMutation(payload, jsonOutput: jsonOutput, idFormat: idFormat)
+    }
+
+    private func printFloatingDockList(_ payload: [String: Any], jsonOutput: Bool, idFormat: CLIIDFormat) {
+        if jsonOutput { print(jsonString(formatIDs(payload, mode: idFormat))); return }
+        let floats = payload["floats"] as? [[String: Any]] ?? []
+        guard !floats.isEmpty else {
+            print(floatingDockCLIString(
+                "cli.workspace.float.output.empty",
+                defaultValue: "No floating Docks."
+            ))
+            return
+        }
+        for item in floats {
+            let ref = item["ref"] as? String ?? "float:?"
+            let title = item["title"] as? String ?? String(
+                localized: "floatingDock.defaultTitle", defaultValue: "Notes"
+            )
+            let state = (item["visible"] as? Bool) == true
+                ? floatingDockCLIString("cli.workspace.float.output.visible", defaultValue: "visible")
+                : floatingDockCLIString("cli.workspace.float.output.hidden", defaultValue: "hidden")
+            let panes = (item["panes"] as? [[String: Any]])?.count ?? 0
+            let format = floatingDockCLIString(
+                "cli.workspace.float.output.row",
+                defaultValue: "%1$@  %2$@  %3$@  %4$d pane(s)"
+            )
+            print(String(format: format, locale: .current, ref, title, state, panes))
+        }
+    }
+
+    private func printFloatingDockMutation(_ payload: [String: Any], jsonOutput: Bool, idFormat: CLIIDFormat) {
+        let fallback = (payload["ref"] as? String).map { "OK \($0)" } ?? "OK"
+        printV2Payload(payload, jsonOutput: jsonOutput, idFormat: idFormat, fallbackText: fallback)
+    }
+
+    private func floatingDockCLIString(
+        _ key: StaticString,
+        defaultValue: String.LocalizationValue
+    ) -> String {
+        String(localized: key, defaultValue: defaultValue)
+    }
+
+    static let workspaceFloatingDockUsage = String(localized: "cli.workspace.float.usage", defaultValue: """
+    Usage: cmux workspace float <subcommand> [flags]
+
+    Manage window-like Bonsplit containers scoped to one workspace. Targets the
+    caller's workspace by default. A float selector is a UUID, float:N, or the
+    1-based index printed by list. Mutations preserve focus unless --focus is set.
+
+    Subcommands:
+      list
+      create [--title <title>] [--x N --y N --width N --height N] [--focus]
+      show <float> [--focus] | hide <float> | focus <float> | close <float>
+      frame <float> --x N --y N --width N --height N
+      note get <float> | note set <float> <text>
+      surface create <float> --type terminal|browser [--pane <UUID>] [--url <URL>] [--focus]
+      pane create <float> --type terminal|browser [--surface <UUID>]
+                  [--direction left|right|up|down] [--url <URL>] [--focus]
+
+    Shared flags: --workspace <id|ref|index>, --window <id|ref|index>, --json
+    """)
+}

--- a/CLI/CMUXCLI+WorkspaceTodo.swift
+++ b/CLI/CMUXCLI+WorkspaceTodo.swift
@@ -303,6 +303,7 @@ extension CMUXCLI {
       select <workspace>      Make a workspace active
       status [set <lane|auto>]
                               Show or pin the workspace todo status
+      float <subcommand>      Manage workspace-scoped floating Docks
       reconnect [workspace]   Reconnect a remote (SSH) workspace, including one
                               whose automatic reconnect paused because the host
                               was unreachable

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -8140,11 +8140,19 @@ struct CMUXCLI {
         guard let sub = commandArgs.first?.lowercased() else {
             throw CLIError(message: String(
                 localized: "cli.error.workspaceSubcommandRequired",
-                defaultValue: "workspace requires a subcommand. Try: list, create, env, close, rename, select, status, reconnect, disconnect, loading, group"
+                defaultValue: "workspace requires a subcommand. Try: list, create, env, close, rename, select, status, float, reconnect, disconnect, loading, group"
             ))
         }
         let rest = Array(commandArgs.dropFirst())
         switch sub {
+        case "float":
+            try runWorkspaceFloatingDock(
+                commandArgs: rest,
+                client: client,
+                jsonOutput: jsonOutput,
+                idFormat: idFormat,
+                windowOverride: windowOverride
+            )
         case "group":
             try runWorkspaceGroup(
                 commandArgs: rest,
@@ -8243,7 +8251,7 @@ struct CMUXCLI {
             throw CLIError(message: String(
                 format: String(
                     localized: "cli.error.workspaceSubcommandUnknown",
-                    defaultValue: "Unknown workspace subcommand: %@. Try: list, create, env, close, rename, select, status, reconnect, disconnect, loading, group"
+                    defaultValue: "Unknown workspace subcommand: %@. Try: list, create, env, close, rename, select, status, float, reconnect, disconnect, loading, group"
                 ),
                 locale: .current,
                 sub

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandContext.swift
@@ -21,6 +21,7 @@ public protocol ControlCommandContext:
     ControlLayoutContext,
     ControlWorkspaceGroupContext,
     ControlWorkspaceTodoContext,
+    ControlWorkspaceFloatingDockContext,
     ControlPaneContext,
     ControlCanvasContext,
     ControlMobileHostContext,

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/ControlCommandCoordinator.swift
@@ -74,6 +74,7 @@ public final class ControlCommandCoordinator {
         if let result = handleLayout(request) { return result }
         if let result = handleWorkspaceGroup(request) { return result }
         if let result = handleWorkspaceTodo(request) { return result }
+        if let result = handleWorkspaceFloatingDock(request) { return result }
         if let result = handlePane(request) { return result }
         if let result = handleCanvas(request) { return result }
         if let result = handleMobileHost(request) { return result }

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlCommandCoordinator+WorkspaceFloatingDock.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlCommandCoordinator+WorkspaceFloatingDock.swift
@@ -1,0 +1,144 @@
+internal import Foundation
+
+extension ControlCommandCoordinator {
+    func handleWorkspaceFloatingDock(_ request: ControlRequest) -> ControlCallResult? {
+        let action: ControlWorkspaceFloatingDockAction
+        switch request.method {
+        case "workspace.float.list":
+            action = .list
+        case "workspace.float.create":
+            let frame = floatingDockFrame(request.params, required: false)
+            if let error = frame.error { return error }
+            action = .create(
+                title: optionalTrimmedRawString(request.params, "title"),
+                frame: frame.value,
+                focus: bool(request.params, "focus") ?? false
+            )
+        case "workspace.float.show", "workspace.float.hide":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            action = .setPresented(
+                selector: selector,
+                presented: request.method == "workspace.float.show",
+                focus: bool(request.params, "focus") ?? false
+            )
+        case "workspace.float.focus":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            action = .focus(selector: selector)
+        case "workspace.float.close":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            action = .close(selector: selector)
+        case "workspace.float.set_frame":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            let frame = floatingDockFrame(request.params, required: true)
+            if let error = frame.error { return error }
+            guard let value = frame.value else {
+                return .err(code: "invalid_params", message: "x, y, width, and height are required", data: nil)
+            }
+            action = .setFrame(selector: selector, frame: value)
+        case "workspace.float.note.get":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            action = .noteGet(selector: selector)
+        case "workspace.float.note.set":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            guard let text = rawString(request.params, "text") else {
+                return .err(code: "invalid_params", message: "Missing or invalid text", data: nil)
+            }
+            action = .noteSet(selector: selector, text: text)
+        case "workspace.float.surface.create":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            guard let kind = string(request.params, "kind") else {
+                return .err(code: "invalid_params", message: "Missing or invalid kind", data: nil)
+            }
+            action = .surfaceCreate(
+                selector: selector,
+                paneID: uuid(request.params, "pane_id"),
+                kind: kind,
+                url: optionalTrimmedRawString(request.params, "url"),
+                focus: bool(request.params, "focus") ?? false
+            )
+        case "workspace.float.pane.create":
+            guard let selector = floatingDockSelector(request.params) else { return missingFloatingDock() }
+            guard let kind = string(request.params, "kind") else {
+                return .err(code: "invalid_params", message: "Missing or invalid kind", data: nil)
+            }
+            action = .paneCreate(
+                selector: selector,
+                sourceSurfaceID: uuid(request.params, "surface_id"),
+                kind: kind,
+                direction: string(request.params, "direction") ?? "right",
+                url: optionalTrimmedRawString(request.params, "url"),
+                focus: bool(request.params, "focus") ?? false
+            )
+        default:
+            return nil
+        }
+
+        let resolution = context?.controlWorkspaceFloatingDock(
+            routing: routingSelectors(request.params),
+            workspaceID: uuid(request.params, "workspace_id"),
+            action: action
+        ) ?? .tabManagerUnavailable
+        return floatingDockResult(resolution)
+    }
+
+    private func floatingDockSelector(_ params: [String: JSONValue]) -> String? {
+        string(params, "float") ?? string(params, "float_id")
+    }
+
+    private func floatingDockFrame(
+        _ params: [String: JSONValue],
+        required: Bool
+    ) -> (value: ControlWorkspaceFloatingDockAction.Frame?, error: ControlCallResult?) {
+        let keys = ["x", "y", "width", "height"]
+        let hasAny = keys.contains { hasNonNull(params, $0) }
+        guard required || hasAny else { return (nil, nil) }
+        guard let x = double(params, "x"), x.isFinite,
+              let y = double(params, "y"), y.isFinite,
+              let width = double(params, "width"), width.isFinite,
+              let height = double(params, "height"), height.isFinite else {
+            return (nil, .err(
+                code: "invalid_params",
+                message: "x, y, width, and height must be finite numbers",
+                data: nil
+            ))
+        }
+        return (.init(x: x, y: y, width: width, height: height), nil)
+    }
+
+    private func missingFloatingDock() -> ControlCallResult {
+        .err(code: "invalid_params", message: "Missing floating Dock selector", data: nil)
+    }
+
+    private func floatingDockResult(
+        _ resolution: ControlWorkspaceFloatingDockResolution
+    ) -> ControlCallResult {
+        switch resolution {
+        case .tabManagerUnavailable:
+            return .err(code: "unavailable", message: "TabManager not available", data: nil)
+        case .workspaceNotFound:
+            return .err(code: "not_found", message: "Workspace not found", data: nil)
+        case .floatingDockNotFound:
+            return .err(code: "not_found", message: "Floating Dock not found", data: nil)
+        case .paneNotFound:
+            return .err(code: "not_found", message: "Floating Dock pane not found", data: nil)
+        case .surfaceNotFound:
+            return .err(code: "not_found", message: "Floating Dock surface not found", data: nil)
+        case .invalidSurfaceKind(let kind):
+            return .err(
+                code: "invalid_params",
+                message: "kind must be terminal or browser",
+                data: .object(["kind": .string(kind)])
+            )
+        case .invalidDirection(let direction):
+            return .err(
+                code: "invalid_params",
+                message: "direction must be left, right, up, or down",
+                data: .object(["direction": .string(direction)])
+            )
+        case .operationFailed(let message):
+            return .err(code: "internal_error", message: message, data: nil)
+        case .resolved(let payload):
+            return .ok(payload)
+        }
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlWorkspaceFloatingDockAction.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlWorkspaceFloatingDockAction.swift
@@ -1,0 +1,36 @@
+public import Foundation
+
+/// One operation in the workspace-scoped floating Dock control domain.
+public enum ControlWorkspaceFloatingDockAction: Sendable, Equatable {
+    public struct Frame: Sendable, Equatable {
+        public let x: Double
+        public let y: Double
+        public let width: Double
+        public let height: Double
+
+        public init(x: Double, y: Double, width: Double, height: Double) {
+            self.x = x
+            self.y = y
+            self.width = width
+            self.height = height
+        }
+    }
+
+    case list
+    case create(title: String?, frame: Frame?, focus: Bool)
+    case setPresented(selector: String, presented: Bool, focus: Bool)
+    case focus(selector: String)
+    case close(selector: String)
+    case setFrame(selector: String, frame: Frame)
+    case noteGet(selector: String)
+    case noteSet(selector: String, text: String)
+    case surfaceCreate(selector: String, paneID: UUID?, kind: String, url: String?, focus: Bool)
+    case paneCreate(
+        selector: String,
+        sourceSurfaceID: UUID?,
+        kind: String,
+        direction: String,
+        url: String?,
+        focus: Bool
+    )
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlWorkspaceFloatingDockContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlWorkspaceFloatingDockContext.swift
@@ -1,0 +1,21 @@
+public import Foundation
+
+/// The workspace floating Dock slice of the control-command seam.
+@MainActor
+public protocol ControlWorkspaceFloatingDockContext: AnyObject {
+    func controlWorkspaceFloatingDock(
+        routing: ControlRoutingSelectors,
+        workspaceID: UUID?,
+        action: ControlWorkspaceFloatingDockAction
+    ) -> ControlWorkspaceFloatingDockResolution
+}
+
+public extension ControlWorkspaceFloatingDockContext {
+    func controlWorkspaceFloatingDock(
+        routing: ControlRoutingSelectors,
+        workspaceID: UUID?,
+        action: ControlWorkspaceFloatingDockAction
+    ) -> ControlWorkspaceFloatingDockResolution {
+        .tabManagerUnavailable
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlWorkspaceFloatingDockResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/WorkspaceFloatingDock/ControlWorkspaceFloatingDockResolution.swift
@@ -1,0 +1,14 @@
+public import Foundation
+
+/// App-side resolution of a workspace floating Dock operation.
+public enum ControlWorkspaceFloatingDockResolution: Sendable, Equatable {
+    case tabManagerUnavailable
+    case workspaceNotFound
+    case floatingDockNotFound
+    case paneNotFound
+    case surfaceNotFound
+    case invalidSurfaceKind(String)
+    case invalidDirection(String)
+    case operationFailed(String)
+    case resolved(JSONValue)
+}

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorWorkspaceFloatingDockTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorWorkspaceFloatingDockTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import CmuxControlSocket
+
+@MainActor
+private final class FakeWorkspaceFloatingDockControlContext: ControlCommandContext {
+    var resolution: ControlWorkspaceFloatingDockResolution = .resolved(.object(["ok": .bool(true)]))
+    var lastWorkspaceID: UUID?
+    var lastAction: ControlWorkspaceFloatingDockAction?
+
+    func controlWorkspaceFloatingDock(
+        routing: ControlRoutingSelectors,
+        workspaceID: UUID?,
+        action: ControlWorkspaceFloatingDockAction
+    ) -> ControlWorkspaceFloatingDockResolution {
+        lastWorkspaceID = workspaceID
+        lastAction = action
+        return resolution
+    }
+}
+
+@MainActor
+@Suite("ControlCommandCoordinator workspace floating Dock domain")
+struct ControlCommandCoordinatorWorkspaceFloatingDockTests {
+    private func makeCoordinator() -> (ControlCommandCoordinator, FakeWorkspaceFloatingDockControlContext) {
+        let context = FakeWorkspaceFloatingDockControlContext()
+        return (ControlCommandCoordinator(context: context), context)
+    }
+
+    private func request(_ method: String, _ params: [String: JSONValue] = [:]) -> ControlRequest {
+        ControlRequest(id: .int(1), method: method, params: params)
+    }
+
+    @Test func createParsesOptionalFrameAndPreservesFocusByDefault() {
+        let (coordinator, context) = makeCoordinator()
+        let result = coordinator.handle(request("workspace.float.create", [
+            "title": .string("Scratch"),
+            "x": .int(12),
+            "y": .int(24),
+            "width": .int(640),
+            "height": .int(480),
+        ]))
+
+        #expect(result == .ok(.object(["ok": .bool(true)])))
+        guard case .create(let title, let frame, let focus) = context.lastAction else {
+            Issue.record("Expected create action")
+            return
+        }
+        #expect(title == "Scratch")
+        #expect(frame == .init(x: 12, y: 24, width: 640, height: 480))
+        #expect(focus == false)
+    }
+
+    @Test func createRejectsPartialFrameBeforeMutation() {
+        let (coordinator, context) = makeCoordinator()
+        let result = coordinator.handle(request("workspace.float.create", ["width": .int(500)]))
+
+        guard case .err(let code, _, _) = result else {
+            Issue.record("Expected invalid params")
+            return
+        }
+        #expect(code == "invalid_params")
+        #expect(context.lastAction == nil)
+    }
+
+    @Test func paneCreateForwardsTopologyInputs() {
+        let (coordinator, context) = makeCoordinator()
+        let workspaceID = UUID()
+        let surfaceID = UUID()
+        _ = coordinator.handle(request("workspace.float.pane.create", [
+            "workspace_id": .string(workspaceID.uuidString),
+            "float": .string("float:2"),
+            "surface_id": .string(surfaceID.uuidString),
+            "kind": .string("browser"),
+            "direction": .string("down"),
+            "url": .string("https://cmux.com"),
+            "focus": .bool(true),
+        ]))
+
+        #expect(context.lastWorkspaceID == workspaceID)
+        #expect(context.lastAction == .paneCreate(
+            selector: "float:2",
+            sourceSurfaceID: surfaceID,
+            kind: "browser",
+            direction: "down",
+            url: "https://cmux.com",
+            focus: true
+        ))
+    }
+
+    @Test func domainErrorsKeepStableWireCodes() {
+        let (coordinator, context) = makeCoordinator()
+        context.resolution = .floatingDockNotFound
+        let result = coordinator.handle(request("workspace.float.note.get", ["float": .string("9")]))
+
+        guard case .err(let code, let message, _) = result else {
+            Issue.record("Expected not found")
+            return
+        }
+        #expect(code == "not_found")
+        #expect(message == "Floating Dock not found")
+    }
+}

--- a/Sources/App/CmuxMainWindow.swift
+++ b/Sources/App/CmuxMainWindow.swift
@@ -1,15 +1,18 @@
 import AppKit
 import SwiftUI
 
-final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
+/// Hosts SwiftUI inside a window whose frame belongs to the user or explicit
+/// window management. SwiftUI content measurement must never resize the host.
+class UserSizedWindowHostingView<Content: View>: NSHostingView<Content> {
     private let zeroSafeAreaLayoutGuide = NSLayoutGuide()
+    private let minimumContentSize: NSSize
 
     override var safeAreaInsets: NSEdgeInsets { NSEdgeInsetsZero }
     override var safeAreaRect: NSRect { bounds }
     override var safeAreaLayoutGuide: NSLayoutGuide { zeroSafeAreaLayoutGuide }
     override var mouseDownCanMoveWindow: Bool { false }
-    override var fittingSize: NSSize { CmuxMainWindow.minimumContentSize }
-    override var intrinsicContentSize: NSSize { CmuxMainWindow.minimumContentSize }
+    override var fittingSize: NSSize { minimumContentSize }
+    override var intrinsicContentSize: NSSize { minimumContentSize }
 
     /// Lets a click on an interactive titlebar control (the sidebar toggle, the
     /// right-sidebar mode bar, the session-index header controls, etc.) both
@@ -65,7 +68,8 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
         super.setFrameSize(size)
     }
 
-    required init(rootView: Content) {
+    init(rootView: Content, minimumContentSize: NSSize) {
+        self.minimumContentSize = minimumContentSize
         super.init(rootView: rootView)
         // Belt with the suspenders above: keep the hosting view from creating
         // any content-derived sizing constraints either.
@@ -79,7 +83,22 @@ final class MainWindowHostingView<Content: View>: NSHostingView<Content> {
         ])
     }
 
+    required convenience init(rootView: Content) {
+        self.init(rootView: rootView, minimumContentSize: .zero)
+    }
+
     deinit {}
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+final class MainWindowHostingView<Content: View>: UserSizedWindowHostingView<Content> {
+    required init(rootView: Content) {
+        super.init(rootView: rootView, minimumContentSize: CmuxMainWindow.minimumContentSize)
+    }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) {

--- a/Sources/AppDelegate+DockSurfaceMove.swift
+++ b/Sources/AppDelegate+DockSurfaceMove.swift
@@ -61,34 +61,15 @@ extension AppDelegate {
     /// owns a pane. Used by the portal drop target to route a tab dropped on a
     /// Dock pane to the Dock's own controller instead of the workspace's.
     func dockForPane(_ paneId: PaneID) -> DockSplitStore? {
-        if let windowDock = windowDockContainingPane(paneId.id) {
-            return windowDock
-        }
-        for context in mainWindowContexts.values {
-            for workspace in context.tabManager.tabs {
-                if let dock = workspace._dockSplit, dock.containsPane(paneId.id) {
-                    return dock
-                }
-            }
-        }
-        return nil
+        DockSplitStore.liveStores.first(where: { $0.containsPane(paneId.id) })
     }
 
     /// Finds a Dock-hosted source for a Bonsplit tab (ignoring workspace panes).
     /// Used by `moveBonsplitTab` to route a Dock→main-area drop.
     func locateDockSurface(tabId: UUID) -> (dock: DockSplitStore, panelId: UUID)? {
         let bonsplitTabId = TabID(uuid: tabId)
-        // Per-window Docks first (they have no owning workspace), then each
-        // workspace's local Dock.
-        for windowDock in existingWindowDocks {
-            if let panel = windowDock.panel(for: bonsplitTabId) {
-                return (windowDock, panel.id)
-            }
-        }
-        for context in mainWindowContexts.values {
-            for workspace in context.tabManager.tabs {
-                guard let dock = workspace._dockSplit,
-                      let panel = dock.panel(for: bonsplitTabId) else { continue }
+        for dock in DockSplitStore.liveStores {
+            if let panel = dock.panel(for: bonsplitTabId) {
                 return (dock, panel.id)
             }
         }

--- a/Sources/AppDelegate+WorkspaceFloatingDocks.swift
+++ b/Sources/AppDelegate+WorkspaceFloatingDocks.swift
@@ -1,0 +1,55 @@
+import AppKit
+
+extension AppDelegate.MainWindowContext {
+    func installWorkspaceFloatingDockPresenterIfNeeded() {
+        guard let window else { return }
+        if let workspaceFloatingDockPresenter,
+           workspaceFloatingDockPresenter.isAttached(to: window) {
+            return
+        }
+        workspaceFloatingDockPresenter?.teardown()
+        workspaceFloatingDockPresenter = WorkspaceFloatingDockPresenter(
+            parentWindow: window,
+            tabManager: tabManager
+        )
+    }
+
+    func teardownWorkspaceFloatingDockPresenter() {
+        workspaceFloatingDockPresenter?.teardown()
+        workspaceFloatingDockPresenter = nil
+    }
+}
+
+extension AppDelegate {
+    @discardableResult
+    func createWorkspaceFloatingDock(
+        in tabManager: TabManager,
+        title: String? = nil,
+        focus: Bool
+    ) -> WorkspaceFloatingDock? {
+        guard let workspace = tabManager.selectedWorkspace else { return nil }
+        let cascade = CGFloat(workspace.floatingDocks.count % 6) * 24
+        guard let dock = workspace.createFloatingDock(
+            title: title,
+            frame: CGRect(x: 36 + cascade, y: 80 - cascade, width: 520, height: 380)
+        ) else { return nil }
+        refreshWorkspaceFloatingDocks(for: tabManager, focusDockId: focus ? dock.id : nil)
+        return dock
+    }
+
+    func refreshWorkspaceFloatingDocks(
+        for tabManager: TabManager,
+        focusDockId: UUID? = nil
+    ) {
+        guard let context = mainWindowContexts.values.first(where: { $0.tabManager === tabManager }) else { return }
+        context.installWorkspaceFloatingDockPresenterIfNeeded()
+        context.workspaceFloatingDockPresenter?.refresh(focusDockId: focusDockId)
+    }
+
+    func refreshAllWorkspaceFloatingDocks() {
+        for context in mainWindowContexts.values {
+            context.installWorkspaceFloatingDockPresenterIfNeeded()
+            context.workspaceFloatingDockPresenter?.refresh()
+        }
+    }
+}

--- a/Sources/AppDelegate.swift
+++ b/Sources/AppDelegate.swift
@@ -552,6 +552,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         weak var window: NSWindow?
         /// Per-window Dock owned by this context and torn down with it.
         var windowDock: DockSplitStore?
+        var workspaceFloatingDockPresenter: WorkspaceFloatingDockPresenter?
 
         init(
             windowId: UUID,
@@ -4473,6 +4474,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
     // (cmuxTests/AppDelegateMainWindowTestingSupport.swift, via @testable
     // import) drive the same registration paths.
     func notifyMainWindowContextsDidChange() {
+        refreshAllWorkspaceFloatingDocks()
         NotificationCenter.default.post(name: .mainWindowContextsDidChange, object: self)
     }
 
@@ -4591,6 +4593,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
         }
 
         let didApplyStartupSessionRestore = attemptStartupSessionRestoreIfNeeded(primaryWindow: window)
+        if let context = mainWindowContexts.values.first(where: { $0.tabManager === tabManager }) {
+            context.installWorkspaceFloatingDockPresenterIfNeeded()
+            context.workspaceFloatingDockPresenter?.refresh()
+        }
         if Self.shouldSaveSessionSnapshotAfterMainWindowRegistration(
             isTerminatingApp: isTerminatingApp,
             didApplyStartupSessionRestore: didApplyStartupSessionRestore,
@@ -5868,6 +5874,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     private func unregisterMainWindowContext(for window: NSWindow) -> MainWindowContext? {
         guard let removed = contextForMainTerminalWindow(window, reindex: false) else { return nil }
+        removed.teardownWorkspaceFloatingDockPresenter()
         removed.teardownWindowDock()
         let removedKeys = mainWindowContexts.compactMap { key, value in
             value === removed ? key : nil
@@ -5883,6 +5890,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCent
 
     // Internal (not private): see notifyMainWindowContextsDidChange.
     func discardOrphanedMainWindowContext(_ context: MainWindowContext, allowWindowlessFallback: Bool = false) {
+        context.teardownWorkspaceFloatingDockPresenter()
         context.teardownWindowDock()
         let contextKeys = mainWindowContexts.compactMap { key, value in
             value === context ? key : nil

--- a/Sources/ContentView+ViewCommandPalette.swift
+++ b/Sources/ContentView+ViewCommandPalette.swift
@@ -26,6 +26,15 @@ extension ContentView {
                 subtitle: constant(String(localized: "command.sleepyMode.subtitle", defaultValue: "View")),
                 keywords: ["sleepy", "screensaver", "caffeinate", "keep awake", "do not sleep", "lock", "pets", "night"]
             ),
+            CommandPaletteCommandContribution(
+                commandId: "palette.newWorkspaceFloatingDock",
+                title: constant(String(
+                    localized: "command.newWorkspaceFloatingDock.title",
+                    defaultValue: "New Floating Dock"
+                )),
+                subtitle: constant(String(localized: "command.workspace.subtitle", defaultValue: "Workspace")),
+                keywords: ["notes", "floating", "dock", "workspace", "window", "scratchpad"]
+            ),
         ]
     }
 
@@ -80,6 +89,12 @@ extension ContentView {
         }
         registry.register(commandId: "palette.sleepyMode") {
             SleepyModeController.shared.activate()
+        }
+        registry.register(commandId: "palette.newWorkspaceFloatingDock") {
+            _ = AppDelegate.shared?.createWorkspaceFloatingDock(
+                in: tabManager,
+                focus: true
+            )
         }
     }
 }

--- a/Sources/Decoder+DockConfigValidation.swift
+++ b/Sources/Decoder+DockConfigValidation.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+extension Decoder {
+    func rejectUnknownDockConfigKeys(allowedKeys: Set<String>) throws {
+        let container = try container(keyedBy: DockConfigCodingKey.self)
+        guard container.allKeys.contains(where: { !allowedKeys.contains($0.stringValue) }) else {
+            return
+        }
+        throw DockConfigValidationError(
+            message: String(
+                localized: "dock.error.unknownKey",
+                defaultValue: "Dock config contains an unknown key. Check dock.json and try again."
+            )
+        )
+    }
+}

--- a/Sources/DockConfigCodingKey.swift
+++ b/Sources/DockConfigCodingKey.swift
@@ -1,0 +1,14 @@
+struct DockConfigCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int?
+
+    init?(stringValue: String) {
+        self.stringValue = stringValue
+        intValue = nil
+    }
+
+    init?(intValue: Int) {
+        stringValue = String(intValue)
+        self.intValue = intValue
+    }
+}

--- a/Sources/DockConfigFile.swift
+++ b/Sources/DockConfigFile.swift
@@ -1,3 +1,87 @@
+import Foundation
+
 struct DockConfigFile: Codable, Sendable {
     let controls: [DockControlDefinition]
+    let floats: [DockFloatingDockDefinition]
+
+    init(
+        controls: [DockControlDefinition] = [],
+        floats: [DockFloatingDockDefinition] = []
+    ) {
+        self.controls = controls
+        self.floats = floats
+    }
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case controls
+        case floats
+    }
+
+    init(from decoder: Decoder) throws {
+        try decoder.rejectUnknownDockConfigKeys(
+            allowedKeys: Set(CodingKeys.allCases.map(\.stringValue))
+        )
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if container.contains(.controls) {
+            controls = try container.decode([DockControlDefinition].self, forKey: .controls)
+        } else {
+            controls = []
+        }
+        if container.contains(.floats) {
+            floats = try container.decode([DockFloatingDockDefinition].self, forKey: .floats)
+        } else {
+            floats = []
+        }
+        try validateSchema()
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(controls, forKey: .controls)
+        if !floats.isEmpty {
+            try container.encode(floats, forKey: .floats)
+        }
+    }
+
+    func validate(isProjectSource: Bool) throws {
+        try validateSchema()
+        guard isProjectSource || floats.isEmpty else {
+            throw DockConfigValidationError(
+                message: String(
+                    localized: "dock.error.globalFloatsUnsupported",
+                    defaultValue: "Floating Docks are supported only in project .cmux/dock.json files."
+                )
+            )
+        }
+    }
+
+    private func validateSchema() throws {
+        var controlIDs = Set<String>()
+        guard controls.allSatisfy({ controlIDs.insert($0.id).inserted }) else {
+            throw DockConfigValidationError(
+                message: String(
+                    localized: "dock.error.duplicateControl",
+                    defaultValue: "Dock control ids must be unique."
+                )
+            )
+        }
+        guard controls.allSatisfy({ $0.kind != .note }) else {
+            throw DockConfigValidationError(
+                message: String(
+                    localized: "dock.error.unknownControlType",
+                    defaultValue: "Dock control type must be terminal or browser."
+                )
+            )
+        }
+
+        var floatIDs = Set<String>()
+        guard floats.allSatisfy({ floatIDs.insert($0.id).inserted }) else {
+            throw DockConfigValidationError(
+                message: String(
+                    localized: "dock.error.duplicateFloat",
+                    defaultValue: "Floating Dock ids must be unique."
+                )
+            )
+        }
+    }
 }

--- a/Sources/DockConfigResolution.swift
+++ b/Sources/DockConfigResolution.swift
@@ -2,7 +2,28 @@ import Foundation
 
 struct DockConfigResolution: Sendable {
     let controls: [DockControlDefinition]
+    let floats: [DockFloatingDockDefinition]
     let sourceURL: URL?
     let baseDirectory: String
     let isProjectSource: Bool
+    /// Durable source component used by seed identities. Source-aware resolvers
+    /// pass a transport-qualified canonical identifier for remote configs.
+    let floatingDockSeedSourceIdentifier: String?
+
+    init(
+        controls: [DockControlDefinition],
+        floats: [DockFloatingDockDefinition] = [],
+        sourceURL: URL?,
+        baseDirectory: String,
+        isProjectSource: Bool,
+        floatingDockSeedSourceIdentifier: String? = nil
+    ) {
+        self.controls = controls
+        self.floats = floats
+        self.sourceURL = sourceURL
+        self.baseDirectory = baseDirectory
+        self.isProjectSource = isProjectSource
+        self.floatingDockSeedSourceIdentifier = floatingDockSeedSourceIdentifier
+            ?? sourceURL?.standardizedFileURL.path
+    }
 }

--- a/Sources/DockConfigValidationError.swift
+++ b/Sources/DockConfigValidationError.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+struct DockConfigValidationError: Error, LocalizedError, Sendable {
+    let message: String
+
+    var errorDescription: String? { message }
+}

--- a/Sources/DockControlDefinition.swift
+++ b/Sources/DockControlDefinition.swift
@@ -100,6 +100,11 @@ struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
             }
             url = normalizedURL
             command = nil
+        case .note:
+            throw Self.validationError(
+                code: 3,
+                message: String(localized: "dock.error.unknownControlType", defaultValue: "Dock control type must be terminal or browser.")
+            )
         }
 
         id = normalizedID
@@ -140,6 +145,12 @@ struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
                 throw EncodingError.invalidValue(url as Any, context)
             }
             try container.encode(url, forKey: .url)
+        case .note:
+            let context = EncodingError.Context(
+                codingPath: container.codingPath + [CodingKeys.type],
+                debugDescription: String(localized: "dock.error.unknownControlType", defaultValue: "Dock control type must be terminal or browser.")
+            )
+            throw EncodingError.invalidValue(kind.rawValue, context)
         }
         try container.encodeIfPresent(cwd, forKey: .cwd)
         try container.encodeIfPresent(height, forKey: .height)

--- a/Sources/DockControlDefinition.swift
+++ b/Sources/DockControlDefinition.swift
@@ -4,7 +4,8 @@ import Foundation
 ///
 /// Back-compat: existing terminal-only configs omit `type`/`url` and require
 /// `command`; those decode unchanged as `.terminal` entries. New configs may add
-/// `"type": "browser"` with a `url` to seed a browser pane.
+/// `"type": "browser"` with a `url` to seed a browser pane. Floating Dock
+/// content may also use `"type": "note"`; top-level right-Dock controls reject it.
 struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
     let id: String
     let title: String
@@ -35,7 +36,7 @@ struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
         self.env = env
     }
 
-    private enum CodingKeys: String, CodingKey {
+    private enum CodingKeys: String, CodingKey, CaseIterable {
         case id
         case title
         case type
@@ -47,6 +48,9 @@ struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
     }
 
     init(from decoder: Decoder) throws {
+        try decoder.rejectUnknownDockConfigKeys(
+            allowedKeys: Set(CodingKeys.allCases.map(\.stringValue))
+        )
         let container = try decoder.container(keyedBy: CodingKeys.self)
         let rawID = try container.decode(String.self, forKey: .id)
         let normalizedID = rawID.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -65,7 +69,7 @@ struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
             guard let parsed = DockSurfaceKind(rawValue: rawType) else {
                 throw Self.validationError(
                     code: 3,
-                    message: String(localized: "dock.error.unknownControlType", defaultValue: "Dock control type must be terminal or browser.")
+                    message: String(localized: "dock.error.unknownContentType", defaultValue: "Dock content type must be terminal, browser, or note.")
                 )
             }
             resolvedKind = parsed
@@ -101,10 +105,18 @@ struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
             url = normalizedURL
             command = nil
         case .note:
-            throw Self.validationError(
-                code: 3,
-                message: String(localized: "dock.error.unknownControlType", defaultValue: "Dock control type must be terminal or browser.")
-            )
+            let unsupportedKeys: [CodingKeys] = [.command, .url, .cwd, .height, .env]
+            guard !unsupportedKeys.contains(where: container.contains) else {
+                throw Self.validationError(
+                    code: 6,
+                    message: String(
+                        localized: "dock.error.noteFieldsUnsupported",
+                        defaultValue: "Dock note content cannot include command, url, cwd, height, or env."
+                    )
+                )
+            }
+            command = nil
+            url = nil
         }
 
         id = normalizedID
@@ -146,11 +158,17 @@ struct DockControlDefinition: Codable, Equatable, Identifiable, Sendable {
             }
             try container.encode(url, forKey: .url)
         case .note:
-            let context = EncodingError.Context(
-                codingPath: container.codingPath + [CodingKeys.type],
-                debugDescription: String(localized: "dock.error.unknownControlType", defaultValue: "Dock control type must be terminal or browser.")
-            )
-            throw EncodingError.invalidValue(kind.rawValue, context)
+            guard command == nil, url == nil, cwd == nil, height == nil, env.isEmpty else {
+                let context = EncodingError.Context(
+                    codingPath: container.codingPath,
+                    debugDescription: String(
+                        localized: "dock.error.noteFieldsUnsupported",
+                        defaultValue: "Dock note content cannot include command, url, cwd, height, or env."
+                    )
+                )
+                throw EncodingError.invalidValue(self, context)
+            }
+            try container.encode(DockSurfaceKind.note.rawValue, forKey: .type)
         }
         try container.encodeIfPresent(cwd, forKey: .cwd)
         try container.encodeIfPresent(height, forKey: .height)

--- a/Sources/DockFloatingDockDefinition.swift
+++ b/Sources/DockFloatingDockDefinition.swift
@@ -1,0 +1,70 @@
+import CoreGraphics
+import Foundation
+
+struct DockFloatingDockDefinition: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let title: String
+    let frame: DockFloatingDockFrameDefinition?
+    let content: DockControlDefinition?
+
+    init(
+        id: String,
+        title: String,
+        frame: DockFloatingDockFrameDefinition? = nil,
+        content: DockControlDefinition? = nil
+    ) {
+        self.id = id
+        self.title = title
+        self.frame = frame
+        self.content = content
+    }
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case id
+        case title
+        case frame
+        case content
+    }
+
+    init(from decoder: Decoder) throws {
+        try decoder.rejectUnknownDockConfigKeys(
+            allowedKeys: Set(CodingKeys.allCases.map(\.stringValue))
+        )
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let decodedID = try container.decode(String.self, forKey: .id)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !decodedID.isEmpty else {
+            throw DockConfigValidationError(
+                message: String(
+                    localized: "dock.error.blankFloatID",
+                    defaultValue: "Floating Dock id must not be blank."
+                )
+            )
+        }
+        let decodedTitle = try container.decode(String.self, forKey: .title)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !decodedTitle.isEmpty else {
+            throw DockConfigValidationError(
+                message: String(
+                    localized: "dock.error.blankFloatTitle",
+                    defaultValue: "Floating Dock title must not be blank."
+                )
+            )
+        }
+
+        id = decodedID
+        title = decodedTitle
+        frame = try container.decodeIfPresent(DockFloatingDockFrameDefinition.self, forKey: .frame)
+        content = try container.decodeIfPresent(DockControlDefinition.self, forKey: .content)
+    }
+
+    func resolvedFrame(cascadeIndex: Int) -> CGRect {
+        let cascade = Double(max(0, cascadeIndex) % 6) * 24
+        return CGRect(
+            x: frame?.x ?? 36 + cascade,
+            y: frame?.y ?? 80 - cascade,
+            width: frame?.width ?? 520,
+            height: frame?.height ?? 380
+        )
+    }
+}

--- a/Sources/DockFloatingDockFrameDefinition.swift
+++ b/Sources/DockFloatingDockFrameDefinition.swift
@@ -1,0 +1,49 @@
+import CoreGraphics
+import Foundation
+
+struct DockFloatingDockFrameDefinition: Codable, Equatable, Sendable {
+    let x: Double?
+    let y: Double?
+    let width: Double?
+    let height: Double?
+
+    init(
+        x: Double? = nil,
+        y: Double? = nil,
+        width: Double? = nil,
+        height: Double? = nil
+    ) {
+        self.x = x
+        self.y = y
+        self.width = width
+        self.height = height
+    }
+
+    private enum CodingKeys: String, CodingKey, CaseIterable {
+        case x
+        case y
+        case width
+        case height
+    }
+
+    init(from decoder: Decoder) throws {
+        try decoder.rejectUnknownDockConfigKeys(
+            allowedKeys: Set(CodingKeys.allCases.map(\.stringValue))
+        )
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        x = try container.decodeIfPresent(Double.self, forKey: .x)
+        y = try container.decodeIfPresent(Double.self, forKey: .y)
+        width = try container.decodeIfPresent(Double.self, forKey: .width)
+        height = try container.decodeIfPresent(Double.self, forKey: .height)
+
+        guard width.map({ $0 >= 320 }) ?? true,
+              height.map({ $0 >= 220 }) ?? true else {
+            throw DockConfigValidationError(
+                message: String(
+                    localized: "dock.error.floatFrameMinimum",
+                    defaultValue: "Floating Dock frames must be at least 320 points wide and 220 points tall."
+                )
+            )
+        }
+    }
+}

--- a/Sources/DockPanelView.swift
+++ b/Sources/DockPanelView.swift
@@ -18,6 +18,7 @@ struct DockPanelView: View {
     /// dims its focus ring when false so Dock and main-pane focus are mutually
     /// exclusive (the main pane dims its ring when this is true).
     var rightSidebarOwnsInputFocus: Bool = false
+    var onKeyboardFocusIntent: (() -> Void)? = nil
 
     @State private var appearanceConfig = WorkspaceContentView.resolveGhosttyAppearanceConfig(reason: "dock.initial")
     @State private var visibilityHostId = UUID()
@@ -80,7 +81,8 @@ struct DockPanelView: View {
                 store: store,
                 appearance: appearance,
                 windowAppearance: windowAppearance,
-                rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus
+                rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus,
+                onKeyboardFocusIntent: onKeyboardFocusIntent
             )
         }
     }
@@ -93,6 +95,7 @@ private struct DockSplitContentView: View {
     let appearance: PanelAppearance
     let windowAppearance: WindowAppearanceSnapshot
     let rightSidebarOwnsInputFocus: Bool
+    let onKeyboardFocusIntent: (() -> Void)?
 
     /// Portal z-priority for Dock-hosted terminal/browser surfaces. Kept low so
     /// Dock surfaces never overlay main-area surfaces.
@@ -138,10 +141,12 @@ private struct DockSplitContentView: View {
                 },
                 onFocus: {
                     store.bonsplitController.focusPane(paneId)
-                    store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
+                    if let onKeyboardFocusIntent { onKeyboardFocusIntent() }
+                    else { store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow) }
                 },
                 onRequestPanelFocus: {
-                    store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow)
+                    if let onKeyboardFocusIntent { onKeyboardFocusIntent() }
+                    else { store.noteKeyboardFocusIntent(window: NSApp.keyWindow ?? NSApp.mainWindow) }
                     store.focusPanel(panel.id)
                 },
                 onResumeAgentHibernation: {},

--- a/Sources/DockSplitStore+Config.swift
+++ b/Sources/DockSplitStore+Config.swift
@@ -128,6 +128,9 @@ extension DockSplitStore {
     }
 
     nonisolated static func configurationLoadErrorMessage(for error: Error) -> String {
+        if let validationError = error as? DockConfigValidationError {
+            return validationError.message
+        }
         if let message = dockValidationErrorMessage(for: error) {
             return message
         }
@@ -138,6 +141,9 @@ extension DockSplitStore {
     }
 
     nonisolated static func configurationOpenErrorMessage(for error: Error) -> String {
+        if let validationError = error as? DockConfigValidationError {
+            return validationError.message
+        }
         if let message = dockValidationErrorMessage(for: error) {
             return message
         }
@@ -161,7 +167,10 @@ extension DockSplitStore {
     nonisolated static func trustDescriptor(for resolution: DockConfigResolution) -> CmuxActionTrustDescriptor {
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
-        let data = (try? encoder.encode(DockConfigFile(controls: resolution.controls))) ?? Data()
+        let data = (try? encoder.encode(DockConfigFile(
+            controls: resolution.controls,
+            floats: resolution.floats
+        ))) ?? Data()
         let commandFingerprint = String(data: data, encoding: .utf8) ?? ""
         return CmuxActionTrustDescriptor(
             actionID: "cmux.dock",
@@ -182,23 +191,10 @@ extension DockSplitStore {
     ) throws -> DockConfigResolution {
         let data = try Data(contentsOf: url)
         let file = try JSONDecoder().decode(DockConfigFile.self, from: data)
-        var seen = Set<String>()
-        for control in file.controls {
-            guard seen.insert(control.id).inserted else {
-                throw NSError(
-                    domain: "cmux.dock",
-                    code: 1,
-                    userInfo: [
-                        NSLocalizedDescriptionKey: String(
-                            localized: "dock.error.duplicateControl",
-                            defaultValue: "Dock control ids must be unique."
-                        )
-                    ]
-                )
-            }
-        }
+        try file.validate(isProjectSource: isProjectSource)
         return DockConfigResolution(
             controls: file.controls,
+            floats: file.floats,
             sourceURL: url,
             baseDirectory: baseDirectory,
             isProjectSource: isProjectSource

--- a/Sources/DockSplitStore+PortalReconcile.swift
+++ b/Sources/DockSplitStore+PortalReconcile.swift
@@ -16,6 +16,7 @@ final class DockPortalReconcileState {
     var isAttempting = false
     var layoutWakeAttemptsRemaining = 0
     var scheduledRequestCount = 0
+    var reconcilePassCount = 0
 
     deinit {
         (portalObservers + layoutObservers).forEach { NotificationCenter.default.removeObserver($0) }
@@ -32,6 +33,11 @@ extension DockSplitStore {
         state.scheduledRequestCount += 1
         state.reason = reason
         removeDockPortalReconcileObservers()
+        guard isVisibleInUI, !selectedVisibleDockPortalPanels().isEmpty else {
+            state.layoutWakeAttemptsRemaining = 0
+            state.reason = nil
+            return
+        }
         state.layoutWakeAttemptsRemaining = Self.maxDockPortalLayoutWakeAttempts
         installDockPortalReconcileObservers()
         installDockPortalLayoutObservers()
@@ -160,6 +166,7 @@ extension DockSplitStore {
 
     @discardableResult
     func reconcileDockPortalPass(reason: String) -> Bool {
+        dockPortalReconcileState.reconcilePassCount += 1
         var needsFollowUpPass = false
         flushDockWindowLayouts()
         let visiblePanels = selectedVisibleDockPortalPanels()
@@ -188,7 +195,9 @@ extension DockSplitStore {
         let paneIds = bonsplitController.zoomedPaneId.map { [$0] } ?? bonsplitController.allPaneIds
         return paneIds.compactMap { paneId in
             guard let tabId = bonsplitController.selectedTab(inPane: paneId)?.id else { return nil }
-            return panel(for: tabId)
+            guard let panel = panel(for: tabId),
+                  panel is TerminalPanel || panel is BrowserPanel else { return nil }
+            return panel
         }
     }
 

--- a/Sources/DockSplitStore+SurfaceTransfer.swift
+++ b/Sources/DockSplitStore+SurfaceTransfer.swift
@@ -70,7 +70,7 @@ extension DockSplitStore {
     func detachSurface(panelId: UUID) -> Workspace.DetachedSurfaceTransfer? {
         guard let tabId = surfaceId(forPanelId: panelId), let panel = panels[panelId] else { return nil }
         let preservedTransfer = detachedSurfaceTransfersByPanelId.removeValue(forKey: panelId)
-        let kind = (panel.panelType == .browser) ? "browser" : "terminal"
+        let kind = panel.panelType.rawValue
         let icon = panel.displayIcon
         let browser = panel as? BrowserPanel
         let iconImageData = browser?.faviconPNGData

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -33,6 +33,7 @@ final class DockSplitStore: BonsplitDelegate {
     private let baseDirectoryProvider: () -> String?
     private let remoteBrowserSettingsProvider: () -> DockRemoteBrowserSettings
     private let browserAvailabilityProvider: () -> Bool
+    private let loadsConfiguration: Bool
     var panels: [UUID: any Panel] = [:]
     var surfaceIdToPanelId: [TabID: UUID] = [:]
     var panelCancellables: [UUID: AnyCancellable] = [:]
@@ -74,12 +75,14 @@ final class DockSplitStore: BonsplitDelegate {
     init(
         workspaceId: UUID,
         scope: DockScope = .workspace,
+        loadsConfiguration: Bool = true,
         baseDirectoryProvider: @escaping () -> String?,
         remoteBrowserSettingsProvider: @escaping () -> DockRemoteBrowserSettings = { .local },
         browserAvailabilityProvider: @escaping () -> Bool = { BrowserAvailabilitySettings.isEnabled() }
     ) {
         self.workspaceId = workspaceId
         self.scope = scope
+        self.loadsConfiguration = loadsConfiguration
         self.baseDirectoryProvider = baseDirectoryProvider
         self.remoteBrowserSettingsProvider = remoteBrowserSettingsProvider
         self.browserAvailabilityProvider = browserAvailabilityProvider
@@ -117,6 +120,9 @@ final class DockSplitStore: BonsplitDelegate {
         }
         focusHistoryNavigation.attach(host: self)
         Self.liveStoresTable.add(self)
+        if !loadsConfiguration {
+            hasLoadedConfiguration = true
+        }
     }
 
     // MARK: - Lookups
@@ -180,7 +186,7 @@ final class DockSplitStore: BonsplitDelegate {
     }
 
     private func reloadIfBaseDirectoryChanged() {
-        guard hasLoadedConfiguration else { return }
+        guard loadsConfiguration, hasLoadedConfiguration else { return }
         let rootDirectory = currentBaseDirectory()
         if configurationLoadTask != nil, rootDirectory != configurationLoadRootDirectory { reload(); return }
         guard configurationLoadTask == nil else { return }
@@ -227,6 +233,7 @@ final class DockSplitStore: BonsplitDelegate {
     func ensureLoaded() {
         guard !hasLoadedConfiguration else { return }
         hasLoadedConfiguration = true
+        guard loadsConfiguration else { return }
         startConfigurationLoad(replacingPanels: false)
     }
 
@@ -254,6 +261,8 @@ final class DockSplitStore: BonsplitDelegate {
         workingDirectory: String? = nil,
         environment: [String: String] = [:],
         tmuxStartCommand: String? = nil,
+        noteFilePath: String? = nil,
+        noteTitle: String? = nil,
         focus: Bool = true,
         preferredProfileID: UUID? = nil,
         bypassInsecureHTTPHostOnce: String? = nil
@@ -267,6 +276,8 @@ final class DockSplitStore: BonsplitDelegate {
             environment: environment,
             workingDirectory: workingDirectory ?? currentBaseDirectory(),
             tmuxStartCommand: tmuxStartCommand,
+            noteFilePath: noteFilePath,
+            noteTitle: noteTitle,
             preferredProfileID: preferredProfileID,
             bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce
         ) else { return nil }
@@ -299,6 +310,8 @@ final class DockSplitStore: BonsplitDelegate {
         workingDirectory: String? = nil,
         environment: [String: String] = [:],
         tmuxStartCommand: String? = nil,
+        noteFilePath: String? = nil,
+        noteTitle: String? = nil,
         initialDividerPosition: CGFloat? = nil,
         focus: Bool = true
     ) -> UUID? {
@@ -309,7 +322,9 @@ final class DockSplitStore: BonsplitDelegate {
             url: url,
             environment: environment,
             workingDirectory: workingDirectory ?? currentBaseDirectory(),
-            tmuxStartCommand: tmuxStartCommand
+            tmuxStartCommand: tmuxStartCommand,
+            noteFilePath: noteFilePath,
+            noteTitle: noteTitle
         ) else { return nil }
 
         guard let source = resolveSourcePanelId(sourcePanelId), let sourcePaneId = paneId(forPanelId: source) else {
@@ -420,6 +435,10 @@ final class DockSplitStore: BonsplitDelegate {
     }
 
 #if DEBUG
+    var hasPendingConfigurationWorkForTesting: Bool {
+        configurationLoadTask != nil || configurationIdentityTask != nil
+    }
+
     func markConfigurationLoadInFlightForTesting(rootDirectory: String?) -> Int {
         hasLoadedConfiguration = true; configurationLoadGeneration += 1
         configurationLoadRootDirectory = rootDirectory; configurationLoadTask = Task {}
@@ -437,6 +456,8 @@ final class DockSplitStore: BonsplitDelegate {
         environment: [String: String],
         workingDirectory: String,
         tmuxStartCommand: String? = nil,
+        noteFilePath: String? = nil,
+        noteTitle: String? = nil,
         preferredProfileID: UUID? = nil,
         bypassInsecureHTTPHostOnce: String? = nil
     ) -> (any Panel)? {
@@ -462,6 +483,15 @@ final class DockSplitStore: BonsplitDelegate {
                 preferredProfileID: preferredProfileID,
                 bypassInsecureHTTPHostOnce: bypassInsecureHTTPHostOnce
             )
+        case .note:
+            guard let noteFilePath else { return nil }
+            return FilePreviewPanel(
+                workspaceId: workspaceId,
+                filePath: noteFilePath,
+                presentation: .note(
+                    title: noteTitle ?? String(localized: "floatingDock.note.title", defaultValue: "Notes")
+                )
+            )
         }
     }
 
@@ -480,6 +510,8 @@ final class DockSplitStore: BonsplitDelegate {
         case .browser:
             guard browserAvailabilityProvider() else { return nil }
             return makeBrowserPanel(url: def.url.flatMap { URL(string: $0) })
+        case .note:
+            return nil
         }
     }
 
@@ -520,6 +552,7 @@ final class DockSplitStore: BonsplitDelegate {
         switch kind {
         case .terminal: return "terminal"
         case .browser: return "browser"
+        case .note: return "filepreview"
         }
     }
 

--- a/Sources/DockSplitStore.swift
+++ b/Sources/DockSplitStore.swift
@@ -34,6 +34,8 @@ final class DockSplitStore: BonsplitDelegate {
     private let remoteBrowserSettingsProvider: () -> DockRemoteBrowserSettings
     private let browserAvailabilityProvider: () -> Bool
     private let loadsConfiguration: Bool
+    private let appliesControlSeed: Bool
+    private let onConfigurationResolved: ((DockConfigResolution) -> Void)?
     var panels: [UUID: any Panel] = [:]
     var surfaceIdToPanelId: [TabID: UUID] = [:]
     var panelCancellables: [UUID: AnyCancellable] = [:]
@@ -76,16 +78,21 @@ final class DockSplitStore: BonsplitDelegate {
         workspaceId: UUID,
         scope: DockScope = .workspace,
         loadsConfiguration: Bool = true,
+        appliesControlSeed: Bool = true,
+        registersForRouting: Bool = true,
         baseDirectoryProvider: @escaping () -> String?,
         remoteBrowserSettingsProvider: @escaping () -> DockRemoteBrowserSettings = { .local },
-        browserAvailabilityProvider: @escaping () -> Bool = { BrowserAvailabilitySettings.isEnabled() }
+        browserAvailabilityProvider: @escaping () -> Bool = { BrowserAvailabilitySettings.isEnabled() },
+        onConfigurationResolved: ((DockConfigResolution) -> Void)? = nil
     ) {
         self.workspaceId = workspaceId
         self.scope = scope
         self.loadsConfiguration = loadsConfiguration
+        self.appliesControlSeed = appliesControlSeed
         self.baseDirectoryProvider = baseDirectoryProvider
         self.remoteBrowserSettingsProvider = remoteBrowserSettingsProvider
         self.browserAvailabilityProvider = browserAvailabilityProvider
+        self.onConfigurationResolved = onConfigurationResolved
         self.bonsplitController = BonsplitController(configuration: Self.makeConfiguration())
         self.sourceLabel = String(localized: "dock.source.title", defaultValue: "Dock")
         self.bonsplitController.delegate = self
@@ -119,7 +126,9 @@ final class DockSplitStore: BonsplitDelegate {
             _ = bonsplitController.closeTab(tabId)
         }
         focusHistoryNavigation.attach(host: self)
-        Self.liveStoresTable.add(self)
+        if registersForRouting {
+            Self.liveStoresTable.add(self)
+        }
         if !loadsConfiguration {
             hasLoadedConfiguration = true
         }
@@ -183,6 +192,11 @@ final class DockSplitStore: BonsplitDelegate {
 
     func setRootDirectory(_ directory: String?) {
         rootDirectoryOverride = Self.normalizedBaseDirectory(directory)
+    }
+
+    func configurationContextDidChange() {
+        guard loadsConfiguration, hasLoadedConfiguration else { return }
+        reloadIfBaseDirectoryChanged()
     }
 
     private func reloadIfBaseDirectoryChanged() {
@@ -768,9 +782,10 @@ final class DockSplitStore: BonsplitDelegate {
                 return
             }
             sourceLabel = Self.sourceLabel(for: resolution)
+            onConfigurationResolved?(resolution)
             let shouldSeed = configurationSeedSuppressionGeneration != generation && (replacingPanels || !hasAppliedConfigurationSeed)
-            if shouldSeed {
-                seed(definitions: resolution.controls, baseDirectory: resolution.baseDirectory)
+            if shouldSeed, appliesControlSeed {
+                seedConfiguration(definitions: resolution.controls, baseDirectory: resolution.baseDirectory)
             }
             if configurationSeedSuppressionGeneration == generation { configurationSeedSuppressionGeneration = nil }
             hasAppliedConfigurationSeed = true
@@ -795,7 +810,7 @@ final class DockSplitStore: BonsplitDelegate {
     /// initial divider is set from the requested-height ratios (a fractional
     /// Bonsplit tree cannot pin absolute point heights, but the proportions are
     /// preserved and remain user-resizable).
-    private func seed(definitions: [DockControlDefinition], baseDirectory: String) {
+    func seedConfiguration(definitions: [DockControlDefinition], baseDirectory: String) {
         // Build panels first so divider math runs over the entries actually
         // created (e.g. browser entries are skipped when the browser is disabled).
         let created: [(definition: DockControlDefinition, panel: any Panel)] = definitions.compactMap { definition in
@@ -859,6 +874,7 @@ final class DockSplitStore: BonsplitDelegate {
 
     private func trustRequestIfNeeded(for resolution: DockConfigResolution) -> DockTrustRequest? {
         guard resolution.isProjectSource, let sourceURL = resolution.sourceURL else { return nil }
+        guard appliesControlSeed || !resolution.floats.isEmpty else { return nil }
         let descriptor = Self.trustDescriptor(for: resolution)
         guard !CmuxActionTrust.shared.isTrusted(descriptor) else { return nil }
         return DockTrustRequest(descriptor: descriptor, configPath: sourceURL.path)

--- a/Sources/DockSurfaceKind.swift
+++ b/Sources/DockSurfaceKind.swift
@@ -4,4 +4,5 @@
 enum DockSurfaceKind: String, Codable, Equatable, Sendable {
     case terminal
     case browser
+    case note
 }

--- a/Sources/FilePreviewPresentation.swift
+++ b/Sources/FilePreviewPresentation.swift
@@ -1,0 +1,27 @@
+import Foundation
+
+/// Presentation behavior for a file-preview panel.
+enum FilePreviewPresentation: Equatable, Sendable {
+    case file
+    case note(title: String)
+
+    var displayTitle: String? {
+        guard case .note(let title) = self else { return nil }
+        return title
+    }
+
+    var hidesFileHeader: Bool {
+        if case .note = self { return true }
+        return false
+    }
+
+    var autosavesTextChanges: Bool {
+        if case .note = self { return true }
+        return false
+    }
+
+    var noteTitle: String? {
+        guard case .note(let title) = self else { return nil }
+        return title
+    }
+}

--- a/Sources/Panels/FilePreviewPanel.swift
+++ b/Sources/Panels/FilePreviewPanel.swift
@@ -990,6 +990,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     @Published private(set) var isSaving = false
     @Published private(set) var focusFlashToken = 0
     @Published private(set) var previewMode: FilePreviewMode
+    let presentation: FilePreviewPresentation
 
     let nativeViewSessions = FilePreviewNativeViewSessions()
 
@@ -999,6 +1000,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     private var textLoadGeneration = 0
     private var saveGeneration = 0
     private var activeSaveGeneration: Int?
+    private var autosaveRequested = false
     weak var textView: NSTextView?
     let focusCoordinator: FilePreviewFocusCoordinator
     private let textLoader: @Sendable (URL) async -> FilePreviewTextLoader.Result
@@ -1010,6 +1012,7 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     init(
         workspaceId: UUID,
         filePath: String,
+        presentation: FilePreviewPresentation = .file,
         textLoader: @escaping @Sendable (URL) async -> FilePreviewTextLoader.Result = { url in
             await FilePreviewTextLoader.load(url: url)
         }
@@ -1017,7 +1020,8 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         self.id = UUID()
         self.workspaceId = workspaceId
         self.filePath = filePath
-        self.displayTitle = URL(fileURLWithPath: filePath).lastPathComponent
+        self.presentation = presentation
+        self.displayTitle = presentation.displayTitle ?? URL(fileURLWithPath: filePath).lastPathComponent
         self.textLoader = textLoader
         let fileURL = URL(fileURLWithPath: filePath)
         let initialPreviewMode = FilePreviewKindResolver.initialMode(for: fileURL)
@@ -1040,6 +1044,9 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
     }
 
     func close() {
+        if presentation.autosavesTextChanges {
+            requestAutosave()
+        }
         nativeViewSessions.closeAll()
         textView = nil
         focusCoordinator.unregisterAll()
@@ -1140,6 +1147,43 @@ final class FilePreviewPanel: Panel, ObservableObject, FilePreviewTextEditingPan
         guard textContent != nextContent else { return }
         textContent = nextContent
         isDirty = nextContent != originalTextContent
+        if presentation.autosavesTextChanges {
+            requestAutosave()
+        }
+    }
+
+    /// Replaces an autosaving note from a synchronous control-socket mutation.
+    /// The write completes before the command replies, and the live editor is
+    /// updated in the same main-actor transaction.
+    func replaceAutosavedTextContent(_ nextContent: String) throws {
+        guard presentation.autosavesTextChanges, previewMode == .text else { return }
+        guard let data = nextContent.data(using: textEncoding) else {
+            throw CocoaError(.fileWriteInapplicableStringEncoding)
+        }
+        textLoadGeneration += 1
+        if isSaving {
+            // The in-flight write may land after this synchronous one. Its
+            // autosave continuation must write this newer editor value again.
+            autosaveRequested = true
+        }
+        try data.write(to: fileURL, options: .atomic)
+        textView?.string = nextContent
+        textContent = nextContent
+        originalTextContent = nextContent
+        isDirty = false
+        isFileUnavailable = false
+    }
+
+    private func requestAutosave() {
+        autosaveRequested = true
+        guard !isSaving else { return }
+        autosaveRequested = false
+        guard let task = saveTextContent() else { return }
+        Task { [weak self] in
+            await task.value
+            guard let self, self.autosaveRequested || self.isDirty else { return }
+            self.requestAutosave()
+        }
     }
 
     private func prepareContentForPreviewMode() {
@@ -1299,7 +1343,7 @@ struct FilePreviewPanelView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            if panel.previewMode != .pdf {
+            if panel.previewMode != .pdf, !panel.presentation.hidesFileHeader {
                 header
                 Divider()
             }

--- a/Sources/RightSidebarPanelView.swift
+++ b/Sources/RightSidebarPanelView.swift
@@ -418,15 +418,20 @@ struct RightSidebarPanelView: View {
     @ViewBuilder
     private func dockPanel(windowAppearance: WindowAppearanceSnapshot) -> some View {
         if let app = AppDelegate.shared, let dock = app.windowDock(for: tabManager) {
-            DockPanelView(
-                store: dock,
-                isSidebarVisible: fileExplorerState.isVisible,
-                mode: fileExplorerState.mode,
-                rootDirectory: nil,
-                windowAppearance: windowAppearance,
-                rightSidebarOwnsInputFocus: fileExplorerState.rightSidebarOwnsInputFocus
-            )
-            .id("dock.window.\(dock.workspaceId.uuidString)")
+            if let workspace = tabManager.selectedWorkspace {
+                WorkspaceFloatingDockConfigurationStatusHost(
+                    workspace: workspace,
+                    windowDockStore: dock,
+                    isSidebarVisible: fileExplorerState.isVisible,
+                    mode: fileExplorerState.mode,
+                    rootDirectory: workspace.currentDirectory,
+                    windowAppearance: windowAppearance,
+                    rightSidebarOwnsInputFocus: fileExplorerState.rightSidebarOwnsInputFocus
+                )
+                .id("dock.window.\(dock.workspaceId.uuidString).workspace.\(workspace.id.uuidString)")
+            } else {
+                Color.clear
+            }
         } else {
             Color.clear
         }

--- a/Sources/SessionFloatingDockSnapshot.swift
+++ b/Sources/SessionFloatingDockSnapshot.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+/// Persisted geometry and visibility for one workspace floating Dock.
+struct SessionFloatingDockSnapshot: Codable, Sendable {
+    var id: UUID
+    var title: String
+    var x: Double
+    var y: Double
+    var width: Double
+    var height: Double
+    var isPresented: Bool
+}

--- a/Sources/SessionFloatingDockSnapshot.swift
+++ b/Sources/SessionFloatingDockSnapshot.swift
@@ -9,4 +9,7 @@ struct SessionFloatingDockSnapshot: Codable, Sendable {
     var width: Double
     var height: Double
     var isPresented: Bool
+    var configurationSeedIdentity: String? = nil
+    var configurationContent: DockControlDefinition? = nil
+    var configurationBaseDirectory: String? = nil
 }

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1589,6 +1589,8 @@ struct SessionMarkdownPanelSnapshot: Codable, Sendable {
 }
 struct SessionFilePreviewPanelSnapshot: Codable, Sendable {
     var filePath: String
+    /// Present when this file preview is an autosaving Floating Dock note.
+    var noteTitle: String? = nil
 }
 struct SessionCustomSidebarPanelSnapshot: Codable, Sendable { var name: String }
 /// Marker for a workspace todo pane; the pane has no content of its own (the checklist
@@ -1763,6 +1765,8 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     /// Canvas pane frames in z-order; persisted whenever any exist so
     /// positions survive toggling back to splits across restarts.
     var canvasPanes: [SessionCanvasPaneSnapshot]? = nil
+    /// Workspace-scoped window-like Dock containers.
+    var floatingDocks: [SessionFloatingDockSnapshot]? = nil
     var panels: [SessionPanelSnapshot]
     var statusEntries: [SessionStatusEntrySnapshot]
     var logEntries: [SessionLogEntrySnapshot]

--- a/Sources/SessionPersistence.swift
+++ b/Sources/SessionPersistence.swift
@@ -1767,6 +1767,8 @@ struct SessionWorkspaceSnapshot: Codable, Sendable {
     var canvasPanes: [SessionCanvasPaneSnapshot]? = nil
     /// Workspace-scoped window-like Dock containers.
     var floatingDocks: [SessionFloatingDockSnapshot]? = nil
+    /// Config seeds already considered for this workspace, including closed floats.
+    var seededFloatingDockConfigurationIdentities: [String]? = nil
     var panels: [SessionPanelSnapshot]
     var statusEntries: [SessionStatusEntrySnapshot]
     var logEntries: [SessionLogEntrySnapshot]

--- a/Sources/TabManager.swift
+++ b/Sources/TabManager.swift
@@ -323,6 +323,7 @@ class TabManager: ObservableObject {
                 }
             }
             publishCmuxWorkspaceSelectedChange(from: previousTabId)
+            AppDelegate.shared?.refreshWorkspaceFloatingDocks(for: self)
             let notificationDismissalContext = notificationDismissal.takePendingSelectionContext() ?? .activeFocus
 #if DEBUG
             let switchId = debugWorkspaceSwitchId

--- a/Sources/TerminalController+ControlSurfaceContext3.swift
+++ b/Sources/TerminalController+ControlSurfaceContext3.swift
@@ -86,7 +86,7 @@ extension TerminalController {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        if let dock = windowDockForRouting(routing, tabManager: tabManager) {
+        if let dock = containerDockForSurfaceRouting(routing, tabManager: tabManager) {
             var refreshedCount = 0
             for panel in dock.panels.values {
                 if let terminalPanel = panel as? TerminalPanel {
@@ -127,7 +127,7 @@ extension TerminalController {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        if let dock = windowDockForRouting(routing, tabManager: tabManager) {
+        if let dock = containerDockForSurfaceRouting(routing, tabManager: tabManager) {
             let target = terminalPanel(
                 in: dock,
                 explicitSurfaceID: surfaceID,
@@ -191,7 +191,7 @@ extension TerminalController {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        if let dock = windowDockForRouting(routing, tabManager: tabManager) {
+        if let dock = containerDockForSurfaceRouting(routing, tabManager: tabManager) {
             let surfaceId = surfaceID ?? dock.focusedPanelId
             guard let surfaceId else {
                 return .noFocusedSurface
@@ -290,7 +290,7 @@ extension TerminalController {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        if let dock = windowDockForRouting(routing, tabManager: tabManager) {
+        if let dock = containerDockForSurfaceRouting(routing, tabManager: tabManager) {
             let target = terminalPanel(
                 in: dock,
                 explicitSurfaceID: surfaceID,
@@ -384,7 +384,7 @@ extension TerminalController {
         guard let tabManager = resolveTabManager(routing: routing) else {
             return .tabManagerUnavailable
         }
-        if let dock = windowDockForRouting(routing, tabManager: tabManager) {
+        if let dock = containerDockForSurfaceRouting(routing, tabManager: tabManager) {
             let target = terminalPanel(
                 in: dock,
                 explicitSurfaceID: surfaceID,

--- a/Sources/TerminalController+ControlSurfaceDock.swift
+++ b/Sources/TerminalController+ControlSurfaceDock.swift
@@ -181,6 +181,31 @@ extension TerminalController {
         return nil
     }
 
+    /// Resolves a Dock-hosted surface or pane across every Bonsplit container.
+    ///
+    /// Window-Dock aliases still use the existing owner-aware routing above.
+    /// Explicit surface and pane selectors additionally recognize workspace
+    /// Docks and floating Docks through the live-store index, while rejecting a
+    /// selector whose owning window disagrees with the routed TabManager.
+    func containerDockForSurfaceRouting(
+        _ routing: ControlRoutingSelectors,
+        tabManager: TabManager
+    ) -> DockSplitStore? {
+        if let surfaceID = routing.surfaceID,
+           let dock = DockSplitStore.liveStores.first(where: { $0.containsPanel(surfaceID) }) {
+            guard let location = locateDockSurface(surfaceID),
+                  location.tabManager === tabManager else { return nil }
+            return dock
+        }
+        if let paneID = routing.paneID,
+           let dock = DockSplitStore.liveStores.first(where: { $0.containsPane(paneID) }) {
+            guard let location = locateDockPane(paneID),
+                  location.tabManager === tabManager else { return nil }
+            return dock
+        }
+        return windowDockForRouting(routing, tabManager: tabManager)
+    }
+
     /// The window Dock owner targeted by a Dock create request. Explicit Dock-owner
     /// selectors (including the legacy alias pinned to the caller window) still
     /// choose the owner first, but a non-Dock `workspace_id` can be an injected

--- a/Sources/TerminalController+ControlWorkspaceFloatingDockContext.swift
+++ b/Sources/TerminalController+ControlWorkspaceFloatingDockContext.swift
@@ -1,0 +1,319 @@
+import Bonsplit
+import CmuxControlSocket
+import Foundation
+
+extension TerminalController: ControlWorkspaceFloatingDockContext {
+    private enum FloatingDockWorkspaceResolution {
+        case tabManagerUnavailable
+        case notFound
+        case found(tabManager: TabManager, workspace: Workspace)
+    }
+
+    private func resolveFloatingDockWorkspace(
+        routing: ControlRoutingSelectors,
+        workspaceID: UUID?
+    ) -> FloatingDockWorkspaceResolution {
+        if let workspaceID {
+            if let owner = AppDelegate.shared?.tabManagerFor(tabId: workspaceID),
+               let workspace = owner.tabs.first(where: { $0.id == workspaceID }) {
+                return .found(tabManager: owner, workspace: workspace)
+            }
+            guard let tabManager = resolveTabManager(routing: routing) else {
+                return .tabManagerUnavailable
+            }
+            guard let workspace = tabManager.tabs.first(where: { $0.id == workspaceID }) else {
+                return .notFound
+            }
+            return .found(tabManager: tabManager, workspace: workspace)
+        }
+        guard let tabManager = resolveTabManager(routing: routing) else {
+            return .tabManagerUnavailable
+        }
+        guard let workspace = tabManager.selectedWorkspace else { return .notFound }
+        return .found(tabManager: tabManager, workspace: workspace)
+    }
+
+    func controlWorkspaceFloatingDock(
+        routing: ControlRoutingSelectors,
+        workspaceID: UUID?,
+        action: ControlWorkspaceFloatingDockAction
+    ) -> ControlWorkspaceFloatingDockResolution {
+        switch resolveFloatingDockWorkspace(routing: routing, workspaceID: workspaceID) {
+        case .tabManagerUnavailable:
+            return .tabManagerUnavailable
+        case .notFound:
+            return .workspaceNotFound
+        case .found(let tabManager, let workspace):
+            return performFloatingDockAction(action, tabManager: tabManager, workspace: workspace)
+        }
+    }
+
+    private func performFloatingDockAction(
+        _ action: ControlWorkspaceFloatingDockAction,
+        tabManager: TabManager,
+        workspace: Workspace
+    ) -> ControlWorkspaceFloatingDockResolution {
+        switch action {
+        case .list:
+            return .resolved(floatingDockListPayload(workspace: workspace, tabManager: tabManager))
+        case .create(let title, let frame, let focus):
+            let resolvedFrame = frame.map(CGRect.init(controlFrame:)) ?? floatingDockCascadeFrame(workspace)
+            guard let dock = workspace.createFloatingDock(title: title, frame: resolvedFrame) else {
+                return .operationFailed("Failed to create floating Dock")
+            }
+            refreshFloatingDockUI(dock: dock, workspace: workspace, tabManager: tabManager, focus: focus)
+            return .resolved(floatingDockMutationPayload(dock: dock, workspace: workspace, tabManager: tabManager))
+        case .setPresented(let selector, let presented, let focus):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            dock.isPresented = presented
+            refreshFloatingDockUI(dock: dock, workspace: workspace, tabManager: tabManager, focus: focus && presented)
+            return .resolved(floatingDockMutationPayload(dock: dock, workspace: workspace, tabManager: tabManager))
+        case .focus(let selector):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            dock.isPresented = true
+            refreshFloatingDockUI(dock: dock, workspace: workspace, tabManager: tabManager, focus: true)
+            return .resolved(floatingDockMutationPayload(dock: dock, workspace: workspace, tabManager: tabManager))
+        case .close(let selector):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            let payload = floatingDockMutationPayload(dock: dock, workspace: workspace, tabManager: tabManager)
+            _ = workspace.closeFloatingDock(id: dock.id)
+            AppDelegate.shared?.refreshWorkspaceFloatingDocks(for: tabManager)
+            return .resolved(payload)
+        case .setFrame(let selector, let frame):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            dock.frame = CGRect(controlFrame: frame).floatingDockSanitized
+            AppDelegate.shared?.refreshWorkspaceFloatingDocks(for: tabManager)
+            return .resolved(floatingDockMutationPayload(dock: dock, workspace: workspace, tabManager: tabManager))
+        case .noteGet(let selector):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            let notePanel = floatingDockNotePanel(for: dock, tabManager: tabManager)
+            let text = (try? String(contentsOfFile: dock.noteFilePath, encoding: .utf8)) ?? notePanel?.textContent ?? ""
+            return .resolved(floatingDockNotePayload(
+                dock: dock, workspace: workspace, notePanel: notePanel, text: text
+            ))
+        case .noteSet(let selector, let text):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            let notePanel = floatingDockNotePanel(for: dock, tabManager: tabManager)
+            do {
+                if let notePanel {
+                    try notePanel.replaceAutosavedTextContent(text)
+                } else {
+                    try Data(text.utf8).write(to: URL(fileURLWithPath: dock.noteFilePath), options: .atomic)
+                }
+            } catch {
+                return .operationFailed("Failed to save floating Dock note: \(error.localizedDescription)")
+            }
+            return .resolved(floatingDockNotePayload(
+                dock: dock, workspace: workspace, notePanel: notePanel, text: text
+            ))
+        case .surfaceCreate(let selector, let paneID, let kindRaw, let urlRaw, let focus):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            guard let kind = floatingDockSurfaceKind(kindRaw) else { return .invalidSurfaceKind(kindRaw) }
+            guard let pane = dock.store.resolvePane(requestedPaneID: paneID) else { return .paneNotFound }
+            guard let panelID = dock.store.newSurface(
+                kind: kind,
+                inPane: pane,
+                url: floatingDockURL(urlRaw, kind: kind),
+                focus: focus
+            ) else { return .operationFailed("Failed to create floating Dock surface") }
+            refreshFloatingDockUI(dock: dock, workspace: workspace, tabManager: tabManager, focus: focus)
+            return floatingDockSurfaceMutationPayload(
+                dock: dock, workspace: workspace, tabManager: tabManager, panelID: panelID
+            )
+        case .paneCreate(let selector, let sourceSurfaceID, let kindRaw, let directionRaw, let urlRaw, let focus):
+            guard let dock = workspace.floatingDock(selector: selector) else { return .floatingDockNotFound }
+            guard let kind = floatingDockSurfaceKind(kindRaw) else { return .invalidSurfaceKind(kindRaw) }
+            guard let direction = floatingDockSplitDirection(directionRaw) else { return .invalidDirection(directionRaw) }
+            if let sourceSurfaceID, !dock.store.containsPanel(sourceSurfaceID) { return .surfaceNotFound }
+            guard let panelID = dock.store.newSplit(
+                kind: kind,
+                orientation: direction.orientation,
+                insertFirst: direction.insertFirst,
+                sourcePanelId: sourceSurfaceID,
+                url: floatingDockURL(urlRaw, kind: kind),
+                focus: focus
+            ) else { return .operationFailed("Failed to create floating Dock pane") }
+            refreshFloatingDockUI(dock: dock, workspace: workspace, tabManager: tabManager, focus: focus)
+            return floatingDockSurfaceMutationPayload(
+                dock: dock, workspace: workspace, tabManager: tabManager, panelID: panelID
+            )
+        }
+    }
+
+    private func floatingDockSurfaceKind(_ raw: String) -> DockSurfaceKind? {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "terminal": return .terminal
+        case "browser": return .browser
+        default: return nil
+        }
+    }
+
+    private func floatingDockSplitDirection(
+        _ raw: String
+    ) -> (orientation: SplitOrientation, insertFirst: Bool)? {
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "left": return (.horizontal, true)
+        case "right": return (.horizontal, false)
+        case "up", "top": return (.vertical, true)
+        case "down", "bottom": return (.vertical, false)
+        default: return nil
+        }
+    }
+
+    private func floatingDockURL(_ raw: String?, kind: DockSurfaceKind) -> URL? {
+        guard kind == .browser, let raw else { return nil }
+        if let url = URL(string: raw), url.scheme != nil { return url }
+        return URL(string: "https://\(raw)")
+    }
+
+    private func floatingDockCascadeFrame(_ workspace: Workspace) -> CGRect {
+        let cascade = CGFloat(workspace.floatingDocks.count % 6) * 24
+        return CGRect(x: 36 + cascade, y: 80 - cascade, width: 520, height: 380)
+    }
+
+    private func refreshFloatingDockUI(
+        dock: WorkspaceFloatingDock,
+        workspace: Workspace,
+        tabManager: TabManager,
+        focus: Bool
+    ) {
+        if focus, tabManager.selectedTabId != workspace.id {
+            tabManager.selectWorkspace(workspace)
+        }
+        AppDelegate.shared?.refreshWorkspaceFloatingDocks(
+            for: tabManager,
+            focusDockId: focus ? dock.id : nil
+        )
+    }
+
+    private func floatingDockListPayload(workspace: Workspace, tabManager: TabManager) -> JSONValue {
+        .object([
+            "workspace_id": .string(workspace.id.uuidString),
+            "selected": .bool(tabManager.selectedTabId == workspace.id),
+            "floats": .array(workspace.floatingDocks.enumerated().map { index, dock in
+                floatingDockPayload(dock: dock, index: index, workspace: workspace, tabManager: tabManager)
+            }),
+        ])
+    }
+
+    private func floatingDockMutationPayload(
+        dock: WorkspaceFloatingDock,
+        workspace: Workspace,
+        tabManager: TabManager
+    ) -> JSONValue {
+        let index = workspace.floatingDocks.firstIndex(where: { $0.id == dock.id }) ?? 0
+        return floatingDockPayload(dock: dock, index: index, workspace: workspace, tabManager: tabManager)
+    }
+
+    private func floatingDockPayload(
+        dock: WorkspaceFloatingDock,
+        index: Int,
+        workspace: Workspace,
+        tabManager: TabManager
+    ) -> JSONValue {
+        let controller = dock.store.bonsplitController
+        let focusedPaneID = controller.focusedPaneId?.id
+        let panes: [JSONValue] = controller.allPaneIds.map { paneID in
+            let selectedTabID = controller.selectedTab(inPane: paneID)?.id
+            let surfaces: [JSONValue] = controller.tabs(inPane: paneID).compactMap { tab in
+                guard let panel = dock.store.panel(for: tab.id) else { return nil }
+                return .object([
+                    "id": .string(panel.id.uuidString),
+                    "title": .string(panel.displayTitle),
+                    "kind": .string(panel === dock.notePanel ? "note" : panel.panelType.rawValue),
+                    "selected": .bool(tab.id == selectedTabID),
+                ])
+            }
+            return .object([
+                "id": .string(paneID.id.uuidString),
+                "focused": .bool(paneID.id == focusedPaneID),
+                "surfaces": .array(surfaces),
+            ])
+        }
+        return .object([
+            "id": .string(dock.id.uuidString),
+            "ref": .string("float:\(index + 1)"),
+            "title": .string(dock.title),
+            "presented": .bool(dock.isPresented),
+            "visible": .bool(dock.isPresented && tabManager.selectedTabId == workspace.id),
+            "focused": .bool(dock.ownsInputFocus),
+            "frame": .object([
+                "x": .double(dock.frame.origin.x),
+                "y": .double(dock.frame.origin.y),
+                "width": .double(dock.frame.width),
+                "height": .double(dock.frame.height),
+            ]),
+            "panes": .array(panes),
+        ])
+    }
+
+    private func floatingDockNotePayload(
+        dock: WorkspaceFloatingDock,
+        workspace: Workspace,
+        notePanel: FilePreviewPanel?,
+        text: String
+    ) -> JSONValue {
+        .object([
+            "workspace_id": .string(workspace.id.uuidString),
+            "float_id": .string(dock.id.uuidString),
+            "surface_id": notePanel.map { .string($0.id.uuidString) } ?? .null,
+            "text": .string(text),
+        ])
+    }
+
+    private func floatingDockNotePanel(
+        for dock: WorkspaceFloatingDock,
+        tabManager: TabManager
+    ) -> FilePreviewPanel? {
+        if let panel = dock.notePanel { return panel }
+        for workspace in tabManager.tabs {
+            if let panel = workspace.panels.values
+                .compactMap({ $0 as? FilePreviewPanel })
+                .first(where: { $0.filePath == dock.noteFilePath }) {
+                return panel
+            }
+        }
+        for store in DockSplitStore.liveStores {
+            if let panel = store.panels.values
+                .compactMap({ $0 as? FilePreviewPanel })
+                .first(where: { $0.filePath == dock.noteFilePath }) {
+                return panel
+            }
+        }
+        return nil
+    }
+
+    private func floatingDockSurfaceMutationPayload(
+        dock: WorkspaceFloatingDock,
+        workspace: Workspace,
+        tabManager: TabManager,
+        panelID: UUID
+    ) -> ControlWorkspaceFloatingDockResolution {
+        let index = workspace.floatingDocks.firstIndex(where: { $0.id == dock.id }) ?? 0
+        guard let paneID = dock.store.paneId(forPanelId: panelID),
+              let panel = dock.store.panels[panelID] else { return .operationFailed("Created surface was not attached") }
+        return .resolved(.object([
+            "float": floatingDockPayload(
+                dock: dock, index: index, workspace: workspace, tabManager: tabManager
+            ),
+            "pane_id": .string(paneID.id.uuidString),
+            "surface_id": .string(panelID.uuidString),
+            "kind": .string(panel.panelType.rawValue),
+        ]))
+    }
+}
+
+private extension CGRect {
+    init(controlFrame: ControlWorkspaceFloatingDockAction.Frame) {
+        self.init(
+            x: controlFrame.x,
+            y: controlFrame.y,
+            width: controlFrame.width,
+            height: controlFrame.height
+        )
+    }
+
+    var floatingDockSanitized: CGRect {
+        CGRect(x: origin.x, y: origin.y, width: max(320, width), height: max(220, height))
+    }
+}

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -5285,7 +5285,7 @@ class TerminalController {
             // routed TabManager otherwise — mirroring the coordinator
             // witnesses' post-#7144 shape.
             let resolvedWindowID: UUID?
-            if let dock = self.windowDockForRouting(routing, tabManager: tabManager) {
+            if let dock = self.containerDockForSurfaceRouting(routing, tabManager: tabManager) {
                 let target = self.terminalPanel(
                     in: dock,
                     explicitSurfaceID: explicitSurfaceID,

--- a/Sources/Workspace+FloatingDockConfiguration.swift
+++ b/Sources/Workspace+FloatingDockConfiguration.swift
@@ -1,0 +1,68 @@
+import Foundation
+
+extension Workspace {
+    func ensureFloatingDockConfigurationLoaded() {
+        let store = floatingDockConfigurationStore()
+        store.setRootDirectory(currentDirectory)
+        store.ensureLoaded()
+    }
+
+    func floatingDockConfigurationStore() -> DockSplitStore {
+        if let existing = _floatingDockConfigurationStore {
+            return existing
+        }
+        let store = DockSplitStore(
+            workspaceId: id,
+            scope: .workspace,
+            appliesControlSeed: false,
+            registersForRouting: false,
+            baseDirectoryProvider: { [weak self] in self?.currentDirectory },
+            remoteBrowserSettingsProvider: { [weak self] in
+                self?.dockRemoteBrowserSettingsSnapshot() ?? .local
+            },
+            onConfigurationResolved: { [weak self] resolution in
+                guard let self else { return }
+                self.applyFloatingDockConfiguration(resolution)
+                if let owningTabManager {
+                    AppDelegate.shared?.refreshWorkspaceFloatingDocks(for: owningTabManager)
+                }
+            }
+        )
+        _floatingDockConfigurationStore = store
+        return store
+    }
+
+    func applyFloatingDockConfiguration(_ resolution: DockConfigResolution) {
+        guard resolution.isProjectSource,
+              let sourceIdentifier = resolution.floatingDockSeedSourceIdentifier else {
+            return
+        }
+
+        for (index, definition) in resolution.floats.enumerated() {
+            let identity = Self.floatingDockConfigurationSeedIdentity(
+                sourceIdentifier: sourceIdentifier,
+                floatID: definition.id
+            )
+            guard !seededFloatingDockConfigurationIdentities.contains(identity) else {
+                continue
+            }
+            guard createFloatingDock(
+                title: definition.title,
+                frame: definition.resolvedFrame(cascadeIndex: index),
+                configurationSeedIdentity: identity,
+                configurationContent: definition.content,
+                configurationBaseDirectory: resolution.baseDirectory
+            ) != nil else {
+                continue
+            }
+            seededFloatingDockConfigurationIdentities.insert(identity)
+        }
+    }
+
+    private static func floatingDockConfigurationSeedIdentity(
+        sourceIdentifier: String,
+        floatID: String
+    ) -> String {
+        "\(sourceIdentifier.utf8.count):\(sourceIdentifier)\(floatID)"
+    }
+}

--- a/Sources/Workspace+FloatingDocks.swift
+++ b/Sources/Workspace+FloatingDocks.swift
@@ -8,7 +8,10 @@ extension Workspace {
         id: UUID = UUID(),
         title: String? = nil,
         frame: CGRect = CGRect(x: 36, y: 80, width: 520, height: 380),
-        isPresented: Bool = true
+        isPresented: Bool = true,
+        configurationSeedIdentity: String? = nil,
+        configurationContent: DockControlDefinition? = nil,
+        configurationBaseDirectory: String? = nil
     ) -> WorkspaceFloatingDock? {
         let resolvedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
         let displayTitle = resolvedTitle?.isEmpty == false
@@ -29,6 +32,9 @@ extension Workspace {
             isPresented: isPresented,
             noteFilePath: noteFileURL.path,
             existingNotePanelId: existingNotePanel?.id,
+            configurationSeedIdentity: configurationSeedIdentity,
+            configurationContent: configurationContent,
+            configurationBaseDirectory: configurationBaseDirectory,
             baseDirectoryProvider: { [weak self] in self?.currentDirectory },
             remoteBrowserSettingsProvider: { [weak self] in
                 self?.dockRemoteBrowserSettingsSnapshot() ?? .local
@@ -75,15 +81,25 @@ extension Workspace {
                 y: dock.frame.origin.y,
                 width: dock.frame.width,
                 height: dock.frame.height,
-                isPresented: dock.isPresented
+                isPresented: dock.isPresented,
+                configurationSeedIdentity: dock.configurationSeedIdentity,
+                configurationContent: dock.configurationContent,
+                configurationBaseDirectory: dock.configurationBaseDirectory
             )
         }
         return snapshots.isEmpty ? nil : snapshots
     }
 
-    func restoreFloatingDocks(from snapshots: [SessionFloatingDockSnapshot]?) {
+    func restoreFloatingDocks(
+        from snapshots: [SessionFloatingDockSnapshot]?,
+        seededConfigurationIdentities: [String]?
+    ) {
         floatingDocks.forEach { $0.close() }
         floatingDocks.removeAll()
+        seededFloatingDockConfigurationIdentities = Set(seededConfigurationIdentities ?? [])
+        seededFloatingDockConfigurationIdentities.formUnion(
+            (snapshots ?? []).compactMap(\.configurationSeedIdentity)
+        )
         for snapshot in snapshots ?? [] {
             _ = createFloatingDock(
                 id: snapshot.id,
@@ -94,7 +110,10 @@ extension Workspace {
                     width: snapshot.width,
                     height: snapshot.height
                 ),
-                isPresented: snapshot.isPresented
+                isPresented: snapshot.isPresented,
+                configurationSeedIdentity: snapshot.configurationSeedIdentity,
+                configurationContent: snapshot.configurationContent,
+                configurationBaseDirectory: snapshot.configurationBaseDirectory
             )
         }
     }

--- a/Sources/Workspace+FloatingDocks.swift
+++ b/Sources/Workspace+FloatingDocks.swift
@@ -1,0 +1,132 @@
+import CoreGraphics
+import Foundation
+
+extension Workspace {
+    /// Creates a workspace-scoped floating Dock with a native autosaving note.
+    @discardableResult
+    func createFloatingDock(
+        id: UUID = UUID(),
+        title: String? = nil,
+        frame: CGRect = CGRect(x: 36, y: 80, width: 520, height: 380),
+        isPresented: Bool = true
+    ) -> WorkspaceFloatingDock? {
+        let resolvedTitle = title?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let displayTitle = resolvedTitle?.isEmpty == false
+            ? resolvedTitle!
+            : String(localized: "floatingDock.defaultTitle", defaultValue: "Notes")
+        guard let noteFileURL = floatingDockNoteFileURL(dockId: id) else { return nil }
+        let existingNotePanel = panels.values
+            .compactMap { $0 as? FilePreviewPanel }
+            .first { panel in
+                panel.presentation.autosavesTextChanges &&
+                    URL(fileURLWithPath: panel.filePath).standardizedFileURL == noteFileURL.standardizedFileURL
+            }
+        let dock = WorkspaceFloatingDock(
+            id: id,
+            workspaceId: self.id,
+            title: displayTitle,
+            frame: Self.sanitizedFloatingDockFrame(frame),
+            isPresented: isPresented,
+            noteFilePath: noteFileURL.path,
+            existingNotePanelId: existingNotePanel?.id,
+            baseDirectoryProvider: { [weak self] in self?.currentDirectory },
+            remoteBrowserSettingsProvider: { [weak self] in
+                self?.dockRemoteBrowserSettingsSnapshot() ?? .local
+            }
+        )
+        floatingDocks.append(dock)
+        return dock
+    }
+
+    func floatingDock(id: UUID) -> WorkspaceFloatingDock? {
+        floatingDocks.first(where: { $0.id == id })
+    }
+
+    func floatingDock(selector: String?) -> WorkspaceFloatingDock? {
+        guard let selector = selector?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !selector.isEmpty else {
+            return floatingDocks.first
+        }
+        if let id = UUID(uuidString: selector) {
+            return floatingDock(id: id)
+        }
+        let normalized = selector.lowercased()
+        let numeric = normalized.hasPrefix("float:")
+            ? Int(normalized.dropFirst("float:".count))
+            : Int(normalized)
+        guard let numeric, numeric > 0, floatingDocks.indices.contains(numeric - 1) else { return nil }
+        return floatingDocks[numeric - 1]
+    }
+
+    @discardableResult
+    func closeFloatingDock(id: UUID) -> Bool {
+        guard let index = floatingDocks.firstIndex(where: { $0.id == id }) else { return false }
+        let dock = floatingDocks.remove(at: index)
+        dock.close()
+        return true
+    }
+
+    func floatingDockSessionSnapshots() -> [SessionFloatingDockSnapshot]? {
+        let snapshots = floatingDocks.map { dock in
+            SessionFloatingDockSnapshot(
+                id: dock.id,
+                title: dock.title,
+                x: dock.frame.origin.x,
+                y: dock.frame.origin.y,
+                width: dock.frame.width,
+                height: dock.frame.height,
+                isPresented: dock.isPresented
+            )
+        }
+        return snapshots.isEmpty ? nil : snapshots
+    }
+
+    func restoreFloatingDocks(from snapshots: [SessionFloatingDockSnapshot]?) {
+        floatingDocks.forEach { $0.close() }
+        floatingDocks.removeAll()
+        for snapshot in snapshots ?? [] {
+            _ = createFloatingDock(
+                id: snapshot.id,
+                title: snapshot.title,
+                frame: CGRect(
+                    x: snapshot.x,
+                    y: snapshot.y,
+                    width: snapshot.width,
+                    height: snapshot.height
+                ),
+                isPresented: snapshot.isPresented
+            )
+        }
+    }
+
+    private func floatingDockNoteFileURL(dockId: UUID) -> URL? {
+        guard let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first else { return nil }
+        let directory = applicationSupport
+            .appendingPathComponent("cmux", isDirectory: true)
+            .appendingPathComponent("workspace-notes", isDirectory: true)
+            .appendingPathComponent(stableId.uuidString.lowercased(), isDirectory: true)
+        do {
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            let fileURL = directory.appendingPathComponent("\(dockId.uuidString.lowercased()).md")
+            if !FileManager.default.fileExists(atPath: fileURL.path) {
+                try Data().write(to: fileURL, options: .atomic)
+            }
+            return fileURL
+        } catch {
+            cmuxDebugLog("floatingDock.noteFile.error workspace=\(id) dock=\(dockId) error=\(error)")
+            return nil
+        }
+    }
+
+    private static func sanitizedFloatingDockFrame(_ frame: CGRect) -> CGRect {
+        CGRect(
+            x: frame.origin.x.isFinite ? frame.origin.x : 36,
+            y: frame.origin.y.isFinite ? frame.origin.y : 80,
+            width: max(320, frame.width.isFinite ? frame.width : 520),
+            height: max(220, frame.height.isFinite ? frame.height : 380)
+        )
+    }
+}

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -138,6 +138,7 @@ extension Workspace {
             layoutMode: layoutMode.rawValue,
             canvasPanes: canvasSessionPaneSnapshots(),
             floatingDocks: floatingDockSessionSnapshots(),
+            seededFloatingDockConfigurationIdentities: seededFloatingDockConfigurationIdentities.sorted(),
             panels: panelSnapshots,
             statusEntries: statusSnapshots,
             logEntries: logSnapshots,
@@ -235,7 +236,10 @@ extension Workspace {
         isPinned = snapshot.isPinned
         groupId = snapshot.groupId
         restoreTodoState(from: snapshot)
-        restoreFloatingDocks(from: snapshot.floatingDocks)
+        restoreFloatingDocks(
+            from: snapshot.floatingDocks,
+            seededConfigurationIdentities: snapshot.seededFloatingDockConfigurationIdentities
+        )
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -2012,6 +2016,8 @@ final class Workspace: Identifiable, ObservableObject {
             let oldDirectory = oldValue.trimmingCharacters(in: .whitespacesAndNewlines)
             let newDirectory = currentDirectory.trimmingCharacters(in: .whitespacesAndNewlines)
             guard oldDirectory != newDirectory else { return }
+            _floatingDockConfigurationStore?.setRootDirectory(currentDirectory)
+            _floatingDockConfigurationStore?.configurationContextDidChange()
             scheduleExtensionSidebarProjectRootRefresh(for: currentDirectory)
             // Notify the sidebar so anchor-cwd-driven group config (color,
             // icon, context menu, newWorkspacePlacement) refreshes even
@@ -2045,6 +2051,8 @@ final class Workspace: Identifiable, ObservableObject {
     /// Window-like Bonsplit containers scoped to this workspace.
     /// Mutated by the shared lifecycle methods in `Workspace+FloatingDocks`.
     var floatingDocks: [WorkspaceFloatingDock] = []
+    var seededFloatingDockConfigurationIdentities: Set<String> = []
+    var _floatingDockConfigurationStore: DockSplitStore?
 
     /// The right-sidebar Dock for this workspace: its own Bonsplit tree of
     /// terminal/browser panels, separate from the main-area `bonsplitController`.
@@ -8695,6 +8703,8 @@ final class Workspace: Identifiable, ObservableObject {
         // Tear down the right-sidebar Dock's own panels (terminals/browsers) too,
         // but only if the Dock was ever opened for this workspace.
         _dockSplit?.closeAllPanels()
+        _floatingDockConfigurationStore?.closeAllPanels()
+        _floatingDockConfigurationStore = nil
         floatingDocks.forEach { $0.close() }
         floatingDocks.removeAll()
     }

--- a/Sources/Workspace.swift
+++ b/Sources/Workspace.swift
@@ -137,6 +137,7 @@ extension Workspace {
             layout: layout,
             layoutMode: layoutMode.rawValue,
             canvasPanes: canvasSessionPaneSnapshots(),
+            floatingDocks: floatingDockSessionSnapshots(),
             panels: panelSnapshots,
             statusEntries: statusSnapshots,
             logEntries: logSnapshots,
@@ -234,6 +235,7 @@ extension Workspace {
         isPinned = snapshot.isPinned
         groupId = snapshot.groupId
         restoreTodoState(from: snapshot)
+        restoreFloatingDocks(from: snapshot.floatingDocks)
 
         // Status entries and agent PIDs are ephemeral runtime state tied to running
         // processes (e.g. claude_code "Running"). Don't restore them across app
@@ -625,7 +627,10 @@ extension Workspace {
             terminalSnapshot = nil
             browserSnapshot = nil
             markdownSnapshot = nil
-            filePreviewSnapshot = SessionFilePreviewPanelSnapshot(filePath: filePreviewPanel.filePath)
+            filePreviewSnapshot = SessionFilePreviewPanelSnapshot(
+                filePath: filePreviewPanel.filePath,
+                noteTitle: filePreviewPanel.presentation.noteTitle
+            )
             rightSidebarToolSnapshot = nil
             agentSessionSnapshot = nil
             projectSnapshot = nil
@@ -1621,6 +1626,7 @@ extension Workspace {
                   let filePreviewPanel = newFilePreviewSurface(
                     inPane: paneId,
                     filePath: filePath,
+                    presentation: snapshot.filePreview?.noteTitle.map(FilePreviewPresentation.note) ?? .file,
                     focus: false
                   ) else {
                 return nil
@@ -2036,6 +2042,10 @@ final class Workspace: Identifiable, ObservableObject {
     /// (and so reading it during teardown does not lazily create one).
     private(set) var _dockSplit: DockSplitStore?
 
+    /// Window-like Bonsplit containers scoped to this workspace.
+    /// Mutated by the shared lifecycle methods in `Workspace+FloatingDocks`.
+    var floatingDocks: [WorkspaceFloatingDock] = []
+
     /// The right-sidebar Dock for this workspace: its own Bonsplit tree of
     /// terminal/browser panels, separate from the main-area `bonsplitController`.
     /// Created on first access so workspaces that never open the Dock pay nothing.
@@ -2045,14 +2055,7 @@ final class Workspace: Identifiable, ObservableObject {
             workspaceId: id,
             baseDirectoryProvider: { [weak self] in self?.currentDirectory },
             remoteBrowserSettingsProvider: { [weak self] in
-                guard let self else { return .local }
-                return DockRemoteBrowserSettings(
-                    proxyEndpoint: self.remoteProxyEndpoint,
-                    bypassRemoteProxy: false,
-                    isRemoteWorkspace: self.isRemoteWorkspace,
-                    remoteWebsiteDataStoreIdentifier: self.isRemoteWorkspace ? self.id : nil,
-                    remoteStatus: self.browserRemoteWorkspaceStatusSnapshot()
-                )
+                self?.dockRemoteBrowserSettingsSnapshot() ?? .local
             }
         )
         _dockSplit = store
@@ -3867,10 +3870,21 @@ final class Workspace: Identifiable, ObservableObject {
         )
     }
 
+    func dockRemoteBrowserSettingsSnapshot() -> DockRemoteBrowserSettings {
+        DockRemoteBrowserSettings(
+            proxyEndpoint: remoteProxyEndpoint,
+            bypassRemoteProxy: false,
+            isRemoteWorkspace: isRemoteWorkspace,
+            remoteWebsiteDataStoreIdentifier: isRemoteWorkspace ? id : nil,
+            remoteStatus: browserRemoteWorkspaceStatusSnapshot()
+        )
+    }
+
     func applyBrowserRemoteWorkspaceStatusToPanels() {
         let snapshot = browserRemoteWorkspaceStatusSnapshot()
         for panel in panels.values { (panel as? BrowserPanel)?.setRemoteWorkspaceStatus(snapshot) }
         _dockSplit?.applyRemoteWorkspaceStatus(snapshot)
+        floatingDocks.forEach { $0.store.applyRemoteWorkspaceStatus(snapshot) }
     }
 
     // MARK: - Panel Access
@@ -6524,6 +6538,7 @@ final class Workspace: Identifiable, ObservableObject {
             (panel as? BrowserPanel)?.setRemoteProxyEndpoint(endpoint)
         }
         _dockSplit?.applyRemoteProxyEndpointUpdate(endpoint)
+        floatingDocks.forEach { $0.store.applyRemoteProxyEndpointUpdate(endpoint) }
         applyBrowserRemoteWorkspaceStatusToPanels()
     }
 
@@ -8406,6 +8421,7 @@ final class Workspace: Identifiable, ObservableObject {
     func newFilePreviewSurface(
         inPane paneId: PaneID,
         filePath: String,
+        presentation: FilePreviewPresentation = .file,
         focus: Bool? = nil,
         targetIndex: Int? = nil
     ) -> FilePreviewPanel? {
@@ -8413,7 +8429,11 @@ final class Workspace: Identifiable, ObservableObject {
         let previousFocusedPanelId = focusedPanelId
         let previousHostedView = focusedTerminalPanel?.hostedView
 
-        let filePreviewPanel = FilePreviewPanel(workspaceId: id, filePath: filePath)
+        let filePreviewPanel = FilePreviewPanel(
+            workspaceId: id,
+            filePath: filePath,
+            presentation: presentation
+        )
         panels[filePreviewPanel.id] = filePreviewPanel
         panelTitles[filePreviewPanel.id] = filePreviewPanel.displayTitle
 
@@ -8675,6 +8695,8 @@ final class Workspace: Identifiable, ObservableObject {
         // Tear down the right-sidebar Dock's own panels (terminals/browsers) too,
         // but only if the Dock was ever opened for this workspace.
         _dockSplit?.closeAllPanels()
+        floatingDocks.forEach { $0.close() }
+        floatingDocks.removeAll()
     }
 
     /// Close a panel.

--- a/Sources/WorkspaceFloatingDock.swift
+++ b/Sources/WorkspaceFloatingDock.swift
@@ -15,6 +15,9 @@ final class WorkspaceFloatingDock: Identifiable {
 
     @ObservationIgnored let store: DockSplitStore
     @ObservationIgnored let noteFilePath: String
+    @ObservationIgnored let configurationSeedIdentity: String?
+    @ObservationIgnored let configurationContent: DockControlDefinition?
+    @ObservationIgnored let configurationBaseDirectory: String?
     @ObservationIgnored private(set) var notePanelId: UUID?
 
     init(
@@ -25,6 +28,9 @@ final class WorkspaceFloatingDock: Identifiable {
         isPresented: Bool,
         noteFilePath: String,
         existingNotePanelId: UUID? = nil,
+        configurationSeedIdentity: String? = nil,
+        configurationContent: DockControlDefinition? = nil,
+        configurationBaseDirectory: String? = nil,
         baseDirectoryProvider: @escaping () -> String?,
         remoteBrowserSettingsProvider: @escaping () -> DockRemoteBrowserSettings
     ) {
@@ -34,6 +40,9 @@ final class WorkspaceFloatingDock: Identifiable {
         self.frame = frame
         self.isPresented = isPresented
         self.noteFilePath = noteFilePath
+        self.configurationSeedIdentity = configurationSeedIdentity
+        self.configurationContent = configurationContent
+        self.configurationBaseDirectory = configurationBaseDirectory
         self.store = DockSplitStore(
             workspaceId: workspaceId,
             scope: .workspace,
@@ -42,16 +51,26 @@ final class WorkspaceFloatingDock: Identifiable {
             remoteBrowserSettingsProvider: remoteBrowserSettingsProvider
         )
 
-        if let existingNotePanelId {
-            notePanelId = existingNotePanelId
-        } else if let rootPane = store.bonsplitController.allPaneIds.first {
-            notePanelId = store.newSurface(
-                kind: .note,
-                inPane: rootPane,
-                noteFilePath: noteFilePath,
-                noteTitle: String(localized: "floatingDock.note.title", defaultValue: "Notes"),
-                focus: false
+        if let configurationContent, configurationContent.kind != .note {
+            store.seedConfiguration(
+                definitions: [configurationContent],
+                baseDirectory: configurationBaseDirectory
+                    ?? baseDirectoryProvider()
+                    ?? FileManager.default.homeDirectoryForCurrentUser.path
             )
+        } else {
+            if let existingNotePanelId {
+                notePanelId = existingNotePanelId
+            } else if let rootPane = store.bonsplitController.allPaneIds.first {
+                notePanelId = store.newSurface(
+                    kind: .note,
+                    inPane: rootPane,
+                    noteFilePath: noteFilePath,
+                    noteTitle: configurationContent?.title
+                        ?? String(localized: "floatingDock.note.title", defaultValue: "Notes"),
+                    focus: false
+                )
+            }
         }
     }
 

--- a/Sources/WorkspaceFloatingDock.swift
+++ b/Sources/WorkspaceFloatingDock.swift
@@ -1,0 +1,69 @@
+import CoreGraphics
+import Foundation
+import Observation
+
+/// One window-like Bonsplit container owned by a workspace.
+@MainActor
+@Observable
+final class WorkspaceFloatingDock: Identifiable {
+    let id: UUID
+    let workspaceId: UUID
+    var title: String
+    var frame: CGRect
+    var isPresented: Bool
+    var ownsInputFocus = false
+
+    @ObservationIgnored let store: DockSplitStore
+    @ObservationIgnored let noteFilePath: String
+    @ObservationIgnored private(set) var notePanelId: UUID?
+
+    init(
+        id: UUID,
+        workspaceId: UUID,
+        title: String,
+        frame: CGRect,
+        isPresented: Bool,
+        noteFilePath: String,
+        existingNotePanelId: UUID? = nil,
+        baseDirectoryProvider: @escaping () -> String?,
+        remoteBrowserSettingsProvider: @escaping () -> DockRemoteBrowserSettings
+    ) {
+        self.id = id
+        self.workspaceId = workspaceId
+        self.title = title
+        self.frame = frame
+        self.isPresented = isPresented
+        self.noteFilePath = noteFilePath
+        self.store = DockSplitStore(
+            workspaceId: workspaceId,
+            scope: .workspace,
+            loadsConfiguration: false,
+            baseDirectoryProvider: baseDirectoryProvider,
+            remoteBrowserSettingsProvider: remoteBrowserSettingsProvider
+        )
+
+        if let existingNotePanelId {
+            notePanelId = existingNotePanelId
+        } else if let rootPane = store.bonsplitController.allPaneIds.first {
+            notePanelId = store.newSurface(
+                kind: .note,
+                inPane: rootPane,
+                noteFilePath: noteFilePath,
+                noteTitle: String(localized: "floatingDock.note.title", defaultValue: "Notes"),
+                focus: false
+            )
+        }
+    }
+
+    var notePanel: FilePreviewPanel? {
+        if let notePanelId, let panel = store.panels[notePanelId] as? FilePreviewPanel {
+            return panel
+        }
+        return store.panels.values.first(where: { $0 is FilePreviewPanel }) as? FilePreviewPanel
+    }
+
+    func close() {
+        ownsInputFocus = false
+        store.closeAllPanels()
+    }
+}

--- a/Sources/WorkspaceFloatingDockConfigurationStatusHost.swift
+++ b/Sources/WorkspaceFloatingDockConfigurationStatusHost.swift
@@ -1,0 +1,42 @@
+import SwiftUI
+
+/// Reuses the right Dock's trust and error presentation for project float config loading.
+struct WorkspaceFloatingDockConfigurationStatusHost: View {
+    let workspace: Workspace
+    let windowDockStore: DockSplitStore
+    let isSidebarVisible: Bool
+    let mode: RightSidebarMode
+    let rootDirectory: String
+    let windowAppearance: WindowAppearanceSnapshot
+    let rightSidebarOwnsInputFocus: Bool
+    @State private var configurationStore: DockSplitStore?
+
+    var body: some View {
+        Group {
+            if let configurationStore,
+               configurationStore.trustRequest != nil || configurationStore.errorMessage != nil {
+                DockPanelView(
+                    store: configurationStore,
+                    isSidebarVisible: isSidebarVisible,
+                    mode: mode,
+                    rootDirectory: rootDirectory,
+                    windowAppearance: windowAppearance,
+                    rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus
+                )
+            } else {
+                DockPanelView(
+                    store: windowDockStore,
+                    isSidebarVisible: isSidebarVisible,
+                    mode: mode,
+                    rootDirectory: nil,
+                    windowAppearance: windowAppearance,
+                    rightSidebarOwnsInputFocus: rightSidebarOwnsInputFocus
+                )
+            }
+        }
+        .onAppear {
+            configurationStore = workspace.floatingDockConfigurationStore()
+            workspace.ensureFloatingDockConfigurationLoaded()
+        }
+    }
+}

--- a/Sources/WorkspaceFloatingDockContentView.swift
+++ b/Sources/WorkspaceFloatingDockContentView.swift
@@ -1,0 +1,21 @@
+import CmuxAppKitSupportUI
+import SwiftUI
+
+/// SwiftUI root mounted inside a workspace floating Dock window.
+struct WorkspaceFloatingDockContentView: View {
+    let dock: WorkspaceFloatingDock
+
+    var body: some View {
+        DockPanelView(
+            store: dock.store,
+            isSidebarVisible: dock.isPresented,
+            mode: .dock,
+            rootDirectory: nil,
+            windowAppearance: AppWindowChromeComposition().appearanceSnapshotFromUserDefaults(),
+            rightSidebarOwnsInputFocus: dock.ownsInputFocus,
+            onKeyboardFocusIntent: {}
+        )
+        .frame(minWidth: 320, minHeight: 220)
+        .accessibilityIdentifier("WorkspaceFloatingDock")
+    }
+}

--- a/Sources/WorkspaceFloatingDockPresenter.swift
+++ b/Sources/WorkspaceFloatingDockPresenter.swift
@@ -1,0 +1,57 @@
+import AppKit
+
+/// Keeps one main window's native floating Dock windows in sync with its selected workspace.
+@MainActor
+final class WorkspaceFloatingDockPresenter {
+    private weak var parentWindow: NSWindow?
+    private weak var tabManager: TabManager?
+    private var controllers: [UUID: WorkspaceFloatingDockWindowController] = [:]
+
+    init(parentWindow: NSWindow, tabManager: TabManager) {
+        self.parentWindow = parentWindow
+        self.tabManager = tabManager
+    }
+
+    func refresh(focusDockId: UUID? = nil) {
+        guard let parentWindow, let tabManager else { return }
+        let allDocks = tabManager.tabs.flatMap(\.floatingDocks)
+        let liveIds = Set(allDocks.map(\.id))
+        let staleIds = controllers.keys.filter { !liveIds.contains($0) }
+        for id in staleIds {
+            controllers.removeValue(forKey: id)?.teardown()
+        }
+
+        let selectedWorkspaceId = tabManager.selectedTabId
+        for workspace in tabManager.tabs {
+            for dock in workspace.floatingDocks {
+                let controller = controllers[dock.id] ?? {
+                    let created = WorkspaceFloatingDockWindowController(
+                        dock: dock,
+                        parentWindow: parentWindow,
+                        onCloseRequest: { [weak self, weak workspace] dockId in
+                            guard let workspace else { return }
+                            _ = workspace.closeFloatingDock(id: dockId)
+                            self?.refresh()
+                        }
+                    )
+                    controllers[dock.id] = created
+                    return created
+                }()
+                if workspace.id == selectedWorkspaceId, dock.isPresented {
+                    controller.show(focus: focusDockId == dock.id)
+                } else {
+                    controller.hide()
+                }
+            }
+        }
+    }
+
+    func teardown() {
+        controllers.values.forEach { $0.teardown() }
+        controllers.removeAll()
+    }
+
+    func isAttached(to window: NSWindow) -> Bool {
+        parentWindow === window
+    }
+}

--- a/Sources/WorkspaceFloatingDockPresenter.swift
+++ b/Sources/WorkspaceFloatingDockPresenter.swift
@@ -14,6 +14,7 @@ final class WorkspaceFloatingDockPresenter {
 
     func refresh(focusDockId: UUID? = nil) {
         guard let parentWindow, let tabManager else { return }
+        tabManager.selectedWorkspace?.ensureFloatingDockConfigurationLoaded()
         let allDocks = tabManager.tabs.flatMap(\.floatingDocks)
         let liveIds = Set(allDocks.map(\.id))
         let staleIds = controllers.keys.filter { !liveIds.contains($0) }

--- a/Sources/WorkspaceFloatingDockWindowController.swift
+++ b/Sources/WorkspaceFloatingDockWindowController.swift
@@ -1,0 +1,127 @@
+import AppKit
+import SwiftUI
+
+/// Owns the native child panel for one workspace floating Dock.
+@MainActor
+final class WorkspaceFloatingDockWindowController: NSWindowController, NSWindowDelegate {
+    let dock: WorkspaceFloatingDock
+    private weak var parentWindow: NSWindow?
+    private let onCloseRequest: (UUID) -> Void
+    private var isApplyingModelFrame = false
+
+    init(
+        dock: WorkspaceFloatingDock,
+        parentWindow: NSWindow,
+        onCloseRequest: @escaping (UUID) -> Void
+    ) {
+        self.dock = dock
+        self.parentWindow = parentWindow
+        self.onCloseRequest = onCloseRequest
+
+        let panel = NSPanel(
+            contentRect: Self.screenFrame(relativeFrame: dock.frame, parentWindow: parentWindow),
+            styleMask: [.titled, .closable, .resizable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        panel.title = dock.title
+        panel.identifier = NSUserInterfaceItemIdentifier("cmux.workspace.float.\(dock.id.uuidString)")
+        panel.isReleasedWhenClosed = false
+        panel.isFloatingPanel = false
+        panel.hidesOnDeactivate = false
+        panel.level = .normal
+        panel.collectionBehavior = [.fullScreenAuxiliary]
+        panel.minSize = NSSize(width: 320, height: 220)
+        panel.contentView = UserSizedWindowHostingView(
+            rootView: WorkspaceFloatingDockContentView(dock: dock),
+            minimumContentSize: NSSize(width: 320, height: 220)
+        )
+        super.init(window: panel)
+        panel.delegate = self
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    func show(focus: Bool) {
+        guard let panel = window, let parentWindow else { return }
+        panel.title = dock.title
+        if !panel.isVisible {
+            if panel.parent !== parentWindow {
+                parentWindow.addChildWindow(panel, ordered: .above)
+            }
+            applyModelFrame()
+            panel.orderFront(nil)
+        }
+        dock.isPresented = true
+        dock.store.setVisibleInUI(true)
+        if focus {
+            panel.makeKeyAndOrderFront(nil)
+            _ = dock.store.focusFirstControl()
+        }
+    }
+
+    func hide() {
+        dock.ownsInputFocus = false
+        dock.store.setVisibleInUI(false)
+        window?.orderOut(nil)
+    }
+
+    func teardown() {
+        dock.ownsInputFocus = false
+        dock.store.setVisibleInUI(false)
+        if let window, let parent = window.parent {
+            parent.removeChildWindow(window)
+        }
+        window?.orderOut(nil)
+        window?.delegate = nil
+    }
+
+    func windowShouldClose(_ sender: NSWindow) -> Bool {
+        onCloseRequest(dock.id)
+        return false
+    }
+
+    func windowDidMove(_ notification: Notification) {
+        captureModelFrame()
+    }
+
+    func windowDidResize(_ notification: Notification) {
+        captureModelFrame()
+    }
+
+    func windowDidBecomeKey(_ notification: Notification) {
+        dock.ownsInputFocus = true
+    }
+
+    func windowDidResignKey(_ notification: Notification) {
+        dock.ownsInputFocus = false
+    }
+
+    private func applyModelFrame() {
+        guard let panel = window, let parentWindow else { return }
+        isApplyingModelFrame = true
+        panel.setFrame(Self.screenFrame(relativeFrame: dock.frame, parentWindow: parentWindow), display: false)
+        isApplyingModelFrame = false
+    }
+
+    private func captureModelFrame() {
+        guard !isApplyingModelFrame, let panel = window, let parentWindow else { return }
+        dock.frame = CGRect(
+            x: panel.frame.minX - parentWindow.frame.minX,
+            y: panel.frame.minY - parentWindow.frame.minY,
+            width: panel.frame.width,
+            height: panel.frame.height
+        )
+    }
+
+    private static func screenFrame(relativeFrame: CGRect, parentWindow: NSWindow) -> CGRect {
+        CGRect(
+            x: parentWindow.frame.minX + relativeFrame.minX,
+            y: parentWindow.frame.minY + relativeFrame.minY,
+            width: relativeFrame.width,
+            height: relativeFrame.height
+        )
+    }
+}

--- a/Sources/WorkspaceFloatingDockWindowController.swift
+++ b/Sources/WorkspaceFloatingDockWindowController.swift
@@ -4,6 +4,8 @@ import SwiftUI
 /// Owns the native child panel for one workspace floating Dock.
 @MainActor
 final class WorkspaceFloatingDockWindowController: NSWindowController, NSWindowDelegate {
+    static let windowIdentifier = "cmux.workspace.float"
+
     let dock: WorkspaceFloatingDock
     private weak var parentWindow: NSWindow?
     private let onCloseRequest: (UUID) -> Void
@@ -25,7 +27,7 @@ final class WorkspaceFloatingDockWindowController: NSWindowController, NSWindowD
             defer: false
         )
         panel.title = dock.title
-        panel.identifier = NSUserInterfaceItemIdentifier("cmux.workspace.float.\(dock.id.uuidString)")
+        panel.identifier = NSUserInterfaceItemIdentifier(Self.windowIdentifier)
         panel.isReleasedWhenClosed = false
         panel.isFloatingPanel = false
         panel.hidesOnDeactivate = false

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -1468,6 +1468,7 @@ private let cmuxAuxiliaryWindowIdentifiers: Set<String> = [
     "cmux.titlebarLayoutDebug",
     "cmux.devWindowDisplay",
     "cmux.mobilePairingWindow",
+    "cmux.workspace.float",
 ]
 
 /// Returns whether the given window should handle the standard close shortcut

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -736,6 +736,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		DEBDADADADADADADAD000003 /* DebugDogfoodCredentialResolverTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */; };
 		C0DE31410000000000000103 /* DebugEventLogSerializedAppendTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31410000000000000104 /* DebugEventLogSerializedAppendTests.swift */; };
 		A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */ = {isa = PBXBuildFile; fileRef = A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */; };
+		8370D0010000000000000001 /* Decoder+DockConfigValidation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370D0010000000000000002 /* Decoder+DockConfigValidation.swift */; };
 		C0DE75890000000000000003 /* DeflatedAssetTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE75890000000000000004 /* DeflatedAssetTestSupport.swift */; };
 		A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001F000000000000000002 /* DetachedFolderDragIcon.swift */; };
 		B05553C10000000000000001 /* DetachedFolderPathLookupCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = B05553C10000000000000002 /* DetachedFolderPathLookupCache.swift */; };
@@ -756,14 +757,18 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A28B087F000000000000000D /* DiffViewerNavigationDocumentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F000000000000000E /* DiffViewerNavigationDocumentState.swift */; };
 		A28B087F0000000000000009 /* DiffViewerSessionTrustRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F000000000000000A /* DiffViewerSessionTrustRegistry.swift */; };
 		B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
+		8370D0020000000000000001 /* DockConfigCodingKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370D0020000000000000002 /* DockConfigCodingKey.swift */; };
 		DCDC1000000000000000B003 /* DockConfigFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B004 /* DockConfigFile.swift */; };
 		8370F10A0000000000000001 /* DockConfigFloatingDockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370F10A0000000000000002 /* DockConfigFloatingDockTests.swift */; };
 		DCDC1000000000000000B005 /* DockConfigIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B006 /* DockConfigIdentity.swift */; };
 		DCDC1000000000000000B007 /* DockConfigResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B008 /* DockConfigResolution.swift */; };
 		DCDC1000000000000000B001 /* DockConfigurationLoadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B002 /* DockConfigurationLoadResult.swift */; };
+		8370D0030000000000000001 /* DockConfigValidationError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370D0030000000000000002 /* DockConfigValidationError.swift */; };
 		DCDC1000000000000000B009 /* DockControlDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B00A /* DockControlDefinition.swift */; };
 		DCDC0000000000000000B001 /* DockControlDefinitionDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */; };
+		8370D0040000000000000001 /* DockFloatingDockDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370D0040000000000000002 /* DockFloatingDockDefinition.swift */; };
+		8370D0050000000000000001 /* DockFloatingDockFrameDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370D0050000000000000002 /* DockFloatingDockFrameDefinition.swift */; };
 		D7529001A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */; };
 		D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */; };
 		D77800010000000000000001 /* DockPortalReconcileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D77800010000000000000002 /* DockPortalReconcileTests.swift */; };
@@ -1942,6 +1947,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */; };
 		DCDC1000000000000000B013 /* Workspace+DockBrowserLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B014 /* Workspace+DockBrowserLookup.swift */; };
 		E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A06 /* Workspace+EqualizeSplitsSupport.swift */; };
+		8370D0060000000000000001 /* Workspace+FloatingDockConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370D0060000000000000002 /* Workspace+FloatingDockConfiguration.swift */; };
 		F10A00000000000000000004 /* Workspace+FloatingDocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000004 /* Workspace+FloatingDocks.swift */; };
 		F0ACC0DE0000000000000009 /* Workspace+ForkAgentConversationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE000000000000000A /* Workspace+ForkAgentConversationAvailability.swift */; };
 		F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */; };
@@ -1985,6 +1991,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */; };
 		C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */; };
 		F10A00000000000000000005 /* WorkspaceFloatingDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000005 /* WorkspaceFloatingDock.swift */; };
+		8370D0070000000000000001 /* WorkspaceFloatingDockConfigurationStatusHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370D0070000000000000002 /* WorkspaceFloatingDockConfigurationStatusHost.swift */; };
 		F10A00000000000000000006 /* WorkspaceFloatingDockContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000006 /* WorkspaceFloatingDockContentView.swift */; };
 		F10A00000000000000000007 /* WorkspaceFloatingDockPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000007 /* WorkspaceFloatingDockPresenter.swift */; };
 		F10A00000000000000000008 /* WorkspaceFloatingDockWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000008 /* WorkspaceFloatingDockWindowController.swift */; };
@@ -2786,6 +2793,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		DEBDADADADADADADAD000004 /* DebugDogfoodCredentialResolverTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugDogfoodCredentialResolverTests.swift; sourceTree = "<group>"; };
 		C0DE31410000000000000104 /* DebugEventLogSerializedAppendTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugEventLogSerializedAppendTests.swift; sourceTree = "<group>"; };
 		A500D011A1B2C3D4E5F60718 /* DebugLogging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/DebugLogging.swift; sourceTree = "<group>"; };
+		8370D0010000000000000002 /* Decoder+DockConfigValidation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Decoder+DockConfigValidation.swift"; sourceTree = "<group>"; };
 		C0DE75890000000000000004 /* DeflatedAssetTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeflatedAssetTestSupport.swift; sourceTree = "<group>"; };
 		A5001F000000000000000002 /* DetachedFolderDragIcon.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetachedFolderDragIcon.swift; sourceTree = "<group>"; };
 		B05553C10000000000000002 /* DetachedFolderPathLookupCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetachedFolderPathLookupCache.swift; sourceTree = "<group>"; };
@@ -2806,14 +2814,18 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A28B087F000000000000000E /* DiffViewerNavigationDocumentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DiffViewerNavigationDocumentState.swift; sourceTree = "<group>"; };
 		A28B087F000000000000000A /* DiffViewerSessionTrustRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DiffViewerSessionTrustRegistry.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
+		8370D0020000000000000002 /* DockConfigCodingKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigCodingKey.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B004 /* DockConfigFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigFile.swift; sourceTree = "<group>"; };
 		8370F10A0000000000000002 /* DockConfigFloatingDockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigFloatingDockTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B006 /* DockConfigIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigIdentity.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B008 /* DockConfigResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigResolution.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B002 /* DockConfigurationLoadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigurationLoadResult.swift; sourceTree = "<group>"; };
+		8370D0030000000000000002 /* DockConfigValidationError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigValidationError.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B00A /* DockControlDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockControlDefinition.swift; sourceTree = "<group>"; };
 		DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockControlDefinitionDecodingTests.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D004 /* DockEmptyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockEmptyView.swift; sourceTree = "<group>"; };
+		8370D0040000000000000002 /* DockFloatingDockDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockFloatingDockDefinition.swift; sourceTree = "<group>"; };
+		8370D0050000000000000002 /* DockFloatingDockFrameDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockFloatingDockFrameDefinition.swift; sourceTree = "<group>"; };
 		D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPaneDropUnfocusedRoutingTests.swift; sourceTree = "<group>"; };
 		D0C0D0C0D0C0D0C0D0C0D002 /* DockPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPanelView.swift; sourceTree = "<group>"; };
 		D77800010000000000000002 /* DockPortalReconcileTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockPortalReconcileTests.swift; sourceTree = "<group>"; };
@@ -3973,6 +3985,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DetachedSurfaceTransfer.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B014 /* Workspace+DockBrowserLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DockBrowserLookup.swift"; sourceTree = "<group>"; };
 		E3309A06 /* Workspace+EqualizeSplitsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+EqualizeSplitsSupport.swift"; sourceTree = "<group>"; };
+		8370D0060000000000000002 /* Workspace+FloatingDockConfiguration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FloatingDockConfiguration.swift"; sourceTree = "<group>"; };
 		F10B00000000000000000004 /* Workspace+FloatingDocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FloatingDocks.swift"; sourceTree = "<group>"; };
 		F0ACC0DE000000000000000A /* Workspace+ForkAgentConversationAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+ForkAgentConversationAvailability.swift"; sourceTree = "<group>"; };
 		F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+ForkConversationContextMenu.swift"; sourceTree = "<group>"; };
@@ -4016,6 +4029,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceEnvironmentTests.swift; sourceTree = "<group>"; };
 		C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFinderDirectoryResolver.swift; sourceTree = "<group>"; };
 		F10B00000000000000000005 /* WorkspaceFloatingDock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDock.swift; sourceTree = "<group>"; };
+		8370D0070000000000000002 /* WorkspaceFloatingDockConfigurationStatusHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDockConfigurationStatusHost.swift; sourceTree = "<group>"; };
 		F10B00000000000000000006 /* WorkspaceFloatingDockContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDockContentView.swift; sourceTree = "<group>"; };
 		F10B00000000000000000007 /* WorkspaceFloatingDockPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDockPresenter.swift; sourceTree = "<group>"; };
 		F10B00000000000000000008 /* WorkspaceFloatingDockWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDockWindowController.swift; sourceTree = "<group>"; };
@@ -5555,6 +5569,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE0030A3 /* RightSidebarToolPanel.swift */,
 				DCDC1000000000000000B002 /* DockConfigurationLoadResult.swift */,
 				DCDC1000000000000000B004 /* DockConfigFile.swift */,
+				8370D0010000000000000002 /* Decoder+DockConfigValidation.swift */,
+				8370D0020000000000000002 /* DockConfigCodingKey.swift */,
+				8370D0030000000000000002 /* DockConfigValidationError.swift */,
+				8370D0040000000000000002 /* DockFloatingDockDefinition.swift */,
+				8370D0050000000000000002 /* DockFloatingDockFrameDefinition.swift */,
 				DCDC1000000000000000B006 /* DockConfigIdentity.swift */,
 				DCDC1000000000000000B008 /* DockConfigResolution.swift */,
 				DCDC1000000000000000B00A /* DockControlDefinition.swift */,
@@ -5572,9 +5591,11 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				F10B00000000000000000002 /* FilePreviewPresentation.swift */,
 				F10B00000000000000000003 /* SessionFloatingDockSnapshot.swift */,
 				F10B00000000000000000004 /* Workspace+FloatingDocks.swift */,
+				8370D0060000000000000002 /* Workspace+FloatingDockConfiguration.swift */,
 				F10B00000000000000000005 /* WorkspaceFloatingDock.swift */,
 				F10B00000000000000000006 /* WorkspaceFloatingDockContentView.swift */,
 				F10B00000000000000000007 /* WorkspaceFloatingDockPresenter.swift */,
+				8370D0070000000000000002 /* WorkspaceFloatingDockConfigurationStatusHost.swift */,
 				F10B00000000000000000008 /* WorkspaceFloatingDockWindowController.swift */,
 				F10B00000000000000000009 /* TerminalController+ControlWorkspaceFloatingDockContext.swift */,
 				D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */,
@@ -7099,6 +7120,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C57B00090000000000000001 /* CustomSidebarPanelView.swift in Sources */,
 				DEBDADADADADADADAD000001 /* DebugDogfoodCredentialResolver.swift in Sources */,
 				A500D010A1B2C3D4E5F60718 /* DebugLogging.swift in Sources */,
+				8370D0010000000000000001 /* Decoder+DockConfigValidation.swift in Sources */,
 				A5001F000000000000000001 /* DetachedFolderDragIcon.swift in Sources */,
 				B05553C10000000000000001 /* DetachedFolderPathLookupCache.swift in Sources */,
 				DE71CE000000000000000004 /* DeviceRegistryClient.swift in Sources */,
@@ -7114,12 +7136,16 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A28B087F0000000000000017 /* DiffViewerNavigationDocumentSnapshot.swift in Sources */,
 				A28B087F000000000000000D /* DiffViewerNavigationDocumentState.swift in Sources */,
 				A28B087F0000000000000009 /* DiffViewerSessionTrustRegistry.swift in Sources */,
+				8370D0020000000000000001 /* DockConfigCodingKey.swift in Sources */,
 				DCDC1000000000000000B003 /* DockConfigFile.swift in Sources */,
 				DCDC1000000000000000B005 /* DockConfigIdentity.swift in Sources */,
 				DCDC1000000000000000B007 /* DockConfigResolution.swift in Sources */,
 				DCDC1000000000000000B001 /* DockConfigurationLoadResult.swift in Sources */,
+				8370D0030000000000000001 /* DockConfigValidationError.swift in Sources */,
 				DCDC1000000000000000B009 /* DockControlDefinition.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D003 /* DockEmptyView.swift in Sources */,
+				8370D0040000000000000001 /* DockFloatingDockDefinition.swift in Sources */,
+				8370D0050000000000000001 /* DockFloatingDockFrameDefinition.swift in Sources */,
 				D0C0D0C0D0C0D0C0D0C0D001 /* DockPanelView.swift in Sources */,
 				DCDC1000000000000000B00B /* DockRemoteBrowserSettings.swift in Sources */,
 				DCDC1000000000000000C020 /* DockScope.swift in Sources */,
@@ -7932,6 +7958,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */,
 				DCDC1000000000000000B013 /* Workspace+DockBrowserLookup.swift in Sources */,
 				E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */,
+				8370D0060000000000000001 /* Workspace+FloatingDockConfiguration.swift in Sources */,
 				F10A00000000000000000004 /* Workspace+FloatingDocks.swift in Sources */,
 				F0ACC0DE0000000000000009 /* Workspace+ForkAgentConversationAvailability.swift in Sources */,
 				F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */,
@@ -7966,6 +7993,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001407 /* WorkspaceContentView.swift in Sources */,
 				C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */,
 				F10A00000000000000000005 /* WorkspaceFloatingDock.swift in Sources */,
+				8370D0070000000000000001 /* WorkspaceFloatingDockConfigurationStatusHost.swift in Sources */,
 				F10A00000000000000000006 /* WorkspaceFloatingDockContentView.swift in Sources */,
 				F10A00000000000000000007 /* WorkspaceFloatingDockPresenter.swift in Sources */,
 				F10A00000000000000000008 /* WorkspaceFloatingDockWindowController.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -757,6 +757,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A28B087F0000000000000009 /* DiffViewerSessionTrustRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F000000000000000A /* DiffViewerSessionTrustRegistry.swift */; };
 		B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
 		DCDC1000000000000000B003 /* DockConfigFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B004 /* DockConfigFile.swift */; };
+		8370F10A0000000000000001 /* DockConfigFloatingDockTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8370F10A0000000000000002 /* DockConfigFloatingDockTests.swift */; };
 		DCDC1000000000000000B005 /* DockConfigIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B006 /* DockConfigIdentity.swift */; };
 		DCDC1000000000000000B007 /* DockConfigResolution.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B008 /* DockConfigResolution.swift */; };
 		DCDC1000000000000000B001 /* DockConfigurationLoadResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B002 /* DockConfigurationLoadResult.swift */; };
@@ -2806,6 +2807,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A28B087F000000000000000A /* DiffViewerSessionTrustRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DiffViewerSessionTrustRegistry.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B004 /* DockConfigFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigFile.swift; sourceTree = "<group>"; };
+		8370F10A0000000000000002 /* DockConfigFloatingDockTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigFloatingDockTests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B006 /* DockConfigIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigIdentity.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B008 /* DockConfigResolution.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigResolution.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B002 /* DockConfigurationLoadResult.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigurationLoadResult.swift; sourceTree = "<group>"; };
@@ -5785,6 +5787,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D36A00050000000000000002 /* RendererRealizationPlannerTests.swift */,
 				C58410010000000000000002 /* RenderableSystemSymbolTests.swift */,
 				DCDC0000000000000000B002 /* DockControlDefinitionDecodingTests.swift */,
+				8370F10A0000000000000002 /* DockConfigFloatingDockTests.swift */,
 				D7529002A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift */,
 				D77800010000000000000002 /* DockPortalReconcileTests.swift */,
 				D81390010000000000000002 /* DockShortcutRoutingTests.swift */,
@@ -8357,6 +8360,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B0555303B0555303B0555303 /* DetachedFolderPathLookupCacheTests.swift in Sources */,
 				DE71CE000000000000000002 /* DeviceRegistryClientTests.swift in Sources */,
 				D1FFC0DE000000000000C002 /* DiffCommentStoreTests.swift in Sources */,
+				8370F10A0000000000000001 /* DockConfigFloatingDockTests.swift in Sources */,
 				DCDC0000000000000000B001 /* DockControlDefinitionDecodingTests.swift in Sources */,
 				D7529001A1B2C3D4E5F60718 /* DockPaneDropUnfocusedRoutingTests.swift in Sources */,
 				D77800010000000000000001 /* DockPortalReconcileTests.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		4805E1513D104D02B52A9807 /* AppDelegate+WindowFramePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4085E612770476FA272C012 /* AppDelegate+WindowFramePolicy.swift */; };
 		604500100000000000000005 /* AppDelegate+WindowIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 604500100000000000000006 /* AppDelegate+WindowIdentity.swift */; };
 		A5FB1207 /* AppDelegate+WorkspaceActionSave.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5FB1208 /* AppDelegate+WorkspaceActionSave.swift */; };
+		F10A00000000000000000001 /* AppDelegate+WorkspaceFloatingDocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000001 /* AppDelegate+WorkspaceFloatingDocks.swift */; };
 		357DF9BBBB0D71C5EE23D997 /* AppDelegate+WorkspaceTodoShortcut.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7E213BAD49ECD0698B3471B /* AppDelegate+WorkspaceTodoShortcut.swift */; };
 		A5001093 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001090 /* AppDelegate.swift */; };
 		725746692D9647948561044D /* AppDelegateBareSpaceShortcutRoutingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17FCD4CC61D54A2F8F2F463D /* AppDelegateBareSpaceShortcutRoutingTests.swift */; };
@@ -545,6 +546,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */; };
 		B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */; };
 		D1FF52000000000000000001 /* CMUXCLI+TypedDiffViewer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */; };
+		F20A00000000000000000001 /* CMUXCLI+WorkspaceFloatingDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F20B00000000000000000001 /* CMUXCLI+WorkspaceFloatingDock.swift */; };
 		06CC2F6C1340C7424D1C7E0A /* CMUXCLI+WorkspaceTodo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */; };
 		C0DE31390000000000000105 /* CMUXCLIErrorOutputRegressionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */; };
 		A72C9F4179B54DF38E99A021 /* CmuxCLIPathInstaller.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */; };
@@ -846,6 +848,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A5001434A5001434A5001434 /* FilePreviewPDFThumbnailCollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001433A5001433A5001433 /* FilePreviewPDFThumbnailCollectionView.swift */; };
 		A5001436A5001436A5001436 /* FilePreviewPDFThumbnailSidebarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */; };
 		A5001429 /* FilePreviewPDFViewport.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5001428 /* FilePreviewPDFViewport.swift */; };
+		F10A00000000000000000002 /* FilePreviewPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000002 /* FilePreviewPresentation.swift */; };
 		C0DE64020000000000001002 /* FilePreviewQuickLookContainerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE64020000000000001001 /* FilePreviewQuickLookContainerView.swift */; };
 		DD62AFF1D95A1D5D1850AC10 /* FilePreviewQuickLookSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A02623202562490B3E88372 /* FilePreviewQuickLookSession.swift */; };
 		C0DE31390000000000000103 /* FilePreviewReviewFeedbackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */; };
@@ -1405,6 +1408,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C71500040000000000000001 /* SessionContentWidthPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71500030000000000000001 /* SessionContentWidthPresentation.swift */; };
 		C71510010000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C71510020000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift */; };
 		A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A74770010000000000000004 /* SessionDisplaySnapshot.swift */; };
+		F10A00000000000000000003 /* SessionFloatingDockSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000003 /* SessionFloatingDockSnapshot.swift */; };
 		B3575000000000000000000C /* SessionIndexModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3575000000000000000000B /* SessionIndexModels.swift */; };
 		B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */ = {isa = PBXBuildFile; fileRef = B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */; };
 		FE003108 /* SessionIndexSectionPopoverHost.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE003008 /* SessionIndexSectionPopoverHost.swift */; };
@@ -1727,6 +1731,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C0DE00000000000000000C7A /* TerminalController+ControlSystemContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C79 /* TerminalController+ControlSystemContext.swift */; };
 		C0DE00000000000000000C7C /* TerminalController+ControlSystemContext2.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C7B /* TerminalController+ControlSystemContext2.swift */; };
 		C0DE00000000000000000C62 /* TerminalController+ControlWorkspaceContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C61 /* TerminalController+ControlWorkspaceContext.swift */; };
+		F10A00000000000000000009 /* TerminalController+ControlWorkspaceFloatingDockContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000009 /* TerminalController+ControlWorkspaceFloatingDockContext.swift */; };
 		C0DE00000000000000000C54 /* TerminalController+ControlWorkspaceGroupContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE00000000000000000C53 /* TerminalController+ControlWorkspaceGroupContext.swift */; };
 		7371B0010000000000000001 /* TerminalController+ControlWorkspaceStrings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7371B0010000000000000002 /* TerminalController+ControlWorkspaceStrings.swift */; };
 		66B951C8D7A92BABC4A6FFB8 /* TerminalController+ControlWorkspaceTodoContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 466DEB47603469A59697D418 /* TerminalController+ControlWorkspaceTodoContext.swift */; };
@@ -1934,6 +1939,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */; };
 		DCDC1000000000000000B013 /* Workspace+DockBrowserLookup.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B014 /* Workspace+DockBrowserLookup.swift */; };
 		E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3309A06 /* Workspace+EqualizeSplitsSupport.swift */; };
+		F10A00000000000000000004 /* Workspace+FloatingDocks.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000004 /* Workspace+FloatingDocks.swift */; };
 		F0ACC0DE0000000000000009 /* Workspace+ForkAgentConversationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE000000000000000A /* Workspace+ForkAgentConversationAvailability.swift */; };
 		F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */; };
 		F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17F00000000000000000006 /* Workspace+FullWidthTab.swift */; };
@@ -1975,6 +1981,10 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		E6FA9084A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */; };
 		72DB1838A0F1B710BFB45DC1 /* WorkspaceEnvironmentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */; };
 		C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */; };
+		F10A00000000000000000005 /* WorkspaceFloatingDock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000005 /* WorkspaceFloatingDock.swift */; };
+		F10A00000000000000000006 /* WorkspaceFloatingDockContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000006 /* WorkspaceFloatingDockContentView.swift */; };
+		F10A00000000000000000007 /* WorkspaceFloatingDockPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000007 /* WorkspaceFloatingDockPresenter.swift */; };
+		F10A00000000000000000008 /* WorkspaceFloatingDockWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F10B00000000000000000008 /* WorkspaceFloatingDockWindowController.swift */; };
 		F0ACC0DE000000000000000B /* WorkspaceForkAgentConversationAvailability.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE000000000000000C /* WorkspaceForkAgentConversationAvailability.swift */; };
 		F0ACC0DE0000000000000005 /* WorkspaceForkConversationContextMenuTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0ACC0DE0000000000000006 /* WorkspaceForkConversationContextMenuTests.swift */; };
 		C9A57203C9A57203C9A57203 /* WorkspaceGroupMenuSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */; };
@@ -2264,6 +2274,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B4085E612770476FA272C012 /* AppDelegate+WindowFramePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WindowFramePolicy.swift"; sourceTree = "<group>"; };
 		604500100000000000000006 /* AppDelegate+WindowIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WindowIdentity.swift"; sourceTree = "<group>"; };
 		A5FB1208 /* AppDelegate+WorkspaceActionSave.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WorkspaceActionSave.swift"; sourceTree = "<group>"; };
+		F10B00000000000000000001 /* AppDelegate+WorkspaceFloatingDocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WorkspaceFloatingDocks.swift"; sourceTree = "<group>"; };
 		D7E213BAD49ECD0698B3471B /* AppDelegate+WorkspaceTodoShortcut.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "AppDelegate+WorkspaceTodoShortcut.swift"; sourceTree = "<group>"; };
 		A5001090 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		17FCD4CC61D54A2F8F2F463D /* AppDelegateBareSpaceShortcutRoutingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegateBareSpaceShortcutRoutingTests.swift; sourceTree = "<group>"; };
@@ -2631,6 +2642,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		B9000045A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TmuxCompatSupport.swift"; sourceTree = "<group>"; };
 		B9000032A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TopRendering.swift"; sourceTree = "<group>"; };
 		D1FF52000000000000000002 /* CMUXCLI+TypedDiffViewer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+TypedDiffViewer.swift"; sourceTree = "<group>"; };
+		F20B00000000000000000001 /* CMUXCLI+WorkspaceFloatingDock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+WorkspaceFloatingDock.swift"; sourceTree = "<group>"; };
 		7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "CMUXCLI+WorkspaceTodo.swift"; sourceTree = "<group>"; };
 		C0DE31390000000000000106 /* CMUXCLIErrorOutputRegressionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CMUXCLIErrorOutputRegressionTests.swift; sourceTree = "<group>"; };
 		8A4FE96C3F394FC6A6D4B018 /* CmuxCLIPathInstaller.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = App/CmuxCLIPathInstaller.swift; sourceTree = "<group>"; };
@@ -2882,6 +2894,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A5001433A5001433A5001433 /* FilePreviewPDFThumbnailCollectionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewPDFThumbnailCollectionView.swift; sourceTree = "<group>"; };
 		A5001435A5001435A5001435 /* FilePreviewPDFThumbnailSidebarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewPDFThumbnailSidebarTests.swift; sourceTree = "<group>"; };
 		A5001428 /* FilePreviewPDFViewport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewPDFViewport.swift; sourceTree = "<group>"; };
+		F10B00000000000000000002 /* FilePreviewPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewPresentation.swift; sourceTree = "<group>"; };
 		C0DE64020000000000001001 /* FilePreviewQuickLookContainerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewQuickLookContainerView.swift; sourceTree = "<group>"; };
 		0A02623202562490B3E88372 /* FilePreviewQuickLookSession.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/FilePreviewQuickLookSession.swift; sourceTree = "<group>"; };
 		C0DE31390000000000000104 /* FilePreviewReviewFeedbackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilePreviewReviewFeedbackTests.swift; sourceTree = "<group>"; };
@@ -3431,6 +3444,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C71500030000000000000001 /* SessionContentWidthPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/SessionContentWidthPresentation.swift; sourceTree = "<group>"; };
 		C71510020000000000000001 /* SessionContentWidthSettingsFileStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionContentWidthSettingsFileStoreTests.swift; sourceTree = "<group>"; };
 		A74770010000000000000004 /* SessionDisplaySnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionDisplaySnapshot.swift; sourceTree = "<group>"; };
+		F10B00000000000000000003 /* SessionFloatingDockSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionFloatingDockSnapshot.swift; sourceTree = "<group>"; };
 		B3575000000000000000000B /* SessionIndexModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexModels.swift; sourceTree = "<group>"; };
 		B35750000000000000000007 /* SessionIndexRegisteredAgents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexRegisteredAgents.swift; sourceTree = "<group>"; };
 		FE003008 /* SessionIndexSectionPopoverHost.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionIndexSectionPopoverHost.swift; sourceTree = "<group>"; };
@@ -3745,6 +3759,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C0DE00000000000000000C79 /* TerminalController+ControlSystemContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSystemContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C7B /* TerminalController+ControlSystemContext2.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlSystemContext2.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C61 /* TerminalController+ControlWorkspaceContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlWorkspaceContext.swift"; sourceTree = "<group>"; };
+		F10B00000000000000000009 /* TerminalController+ControlWorkspaceFloatingDockContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlWorkspaceFloatingDockContext.swift"; sourceTree = "<group>"; };
 		C0DE00000000000000000C53 /* TerminalController+ControlWorkspaceGroupContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlWorkspaceGroupContext.swift"; sourceTree = "<group>"; };
 		7371B0010000000000000002 /* TerminalController+ControlWorkspaceStrings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlWorkspaceStrings.swift"; sourceTree = "<group>"; };
 		466DEB47603469A59697D418 /* TerminalController+ControlWorkspaceTodoContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+ControlWorkspaceTodoContext.swift"; sourceTree = "<group>"; };
@@ -3952,6 +3967,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7AB00000000000000000016 /* Workspace+DetachedSurfaceTransfer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DetachedSurfaceTransfer.swift"; sourceTree = "<group>"; };
 		DCDC1000000000000000B014 /* Workspace+DockBrowserLookup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+DockBrowserLookup.swift"; sourceTree = "<group>"; };
 		E3309A06 /* Workspace+EqualizeSplitsSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+EqualizeSplitsSupport.swift"; sourceTree = "<group>"; };
+		F10B00000000000000000004 /* Workspace+FloatingDocks.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FloatingDocks.swift"; sourceTree = "<group>"; };
 		F0ACC0DE000000000000000A /* Workspace+ForkAgentConversationAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+ForkAgentConversationAvailability.swift"; sourceTree = "<group>"; };
 		F0ACC0DE0000000000000004 /* Workspace+ForkConversationContextMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+ForkConversationContextMenu.swift"; sourceTree = "<group>"; };
 		F17F00000000000000000006 /* Workspace+FullWidthTab.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Workspace+FullWidthTab.swift"; sourceTree = "<group>"; };
@@ -3993,6 +4009,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		E6FA9085A1B2C3D4E5F60718 /* WorkspaceDescriptionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceDescriptionUITests.swift; sourceTree = "<group>"; };
 		B561A95C6DC21BA9C4B2BCDD /* WorkspaceEnvironmentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceEnvironmentTests.swift; sourceTree = "<group>"; };
 		C0DE36230000000000000002 /* WorkspaceFinderDirectoryResolver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFinderDirectoryResolver.swift; sourceTree = "<group>"; };
+		F10B00000000000000000005 /* WorkspaceFloatingDock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDock.swift; sourceTree = "<group>"; };
+		F10B00000000000000000006 /* WorkspaceFloatingDockContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDockContentView.swift; sourceTree = "<group>"; };
+		F10B00000000000000000007 /* WorkspaceFloatingDockPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDockPresenter.swift; sourceTree = "<group>"; };
+		F10B00000000000000000008 /* WorkspaceFloatingDockWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceFloatingDockWindowController.swift; sourceTree = "<group>"; };
 		F0ACC0DE000000000000000C /* WorkspaceForkAgentConversationAvailability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceForkAgentConversationAvailability.swift; sourceTree = "<group>"; };
 		F0ACC0DE0000000000000006 /* WorkspaceForkConversationContextMenuTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceForkConversationContextMenuTests.swift; sourceTree = "<group>"; };
 		C9A57204C9A57204C9A57204 /* WorkspaceGroupMenuSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceGroupMenuSnapshot.swift; sourceTree = "<group>"; };
@@ -5540,6 +5560,15 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				DCDC1000000000000000C001 /* AppDelegate+DockSurfaceMove.swift */,
 				DCDC1000000000000000C021 /* DockScope.swift */,
 				DCDC1000000000000000C031 /* AppDelegate+WindowDock.swift */,
+				F10B00000000000000000001 /* AppDelegate+WorkspaceFloatingDocks.swift */,
+				F10B00000000000000000002 /* FilePreviewPresentation.swift */,
+				F10B00000000000000000003 /* SessionFloatingDockSnapshot.swift */,
+				F10B00000000000000000004 /* Workspace+FloatingDocks.swift */,
+				F10B00000000000000000005 /* WorkspaceFloatingDock.swift */,
+				F10B00000000000000000006 /* WorkspaceFloatingDockContentView.swift */,
+				F10B00000000000000000007 /* WorkspaceFloatingDockPresenter.swift */,
+				F10B00000000000000000008 /* WorkspaceFloatingDockWindowController.swift */,
+				F10B00000000000000000009 /* TerminalController+ControlWorkspaceFloatingDockContext.swift */,
 				D6212D0C00000000000000D4 /* TerminalController+WindowDockBrowserRouting.swift */,
 				DCDC1000000000000000C011 /* DockSplitStore+SurfaceTransfer.swift */,
 				DCDC1000000000000000C041 /* DockSplitStore+PortalDrop.swift */,
@@ -5627,6 +5656,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B9000049A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatHUDSupport.swift */,
 				B9000051A1B2C3D4E5F60719 /* CMUXCLI+Config.swift */,
 				7E5D35CC62B0F252F9EC2AD1 /* CMUXCLI+WorkspaceTodo.swift */,
+				F20B00000000000000000001 /* CMUXCLI+WorkspaceFloatingDock.swift */,
 				B9000053A1B2C3D4E5F60719 /* CMUXCLI+InstallPreview.swift */,
 				B9000060A1B2C3D4E5F60719 /* CMUXCLI+HermesAgentHooks.swift */,
 				B9000062A1B2C3D4E5F60719 /* CMUXCLI+AgentHookDefinitions.swift */,
@@ -6808,6 +6838,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				4805E1513D104D02B52A9807 /* AppDelegate+WindowFramePolicy.swift in Sources */,
 				604500100000000000000005 /* AppDelegate+WindowIdentity.swift in Sources */,
 				A5FB1207 /* AppDelegate+WorkspaceActionSave.swift in Sources */,
+				F10A00000000000000000001 /* AppDelegate+WorkspaceFloatingDocks.swift in Sources */,
 				357DF9BBBB0D71C5EE23D997 /* AppDelegate+WorkspaceTodoShortcut.swift in Sources */,
 				A5001093 /* AppDelegate.swift in Sources */,
 				B1F0C0080000000000000001 /* AppDelegateDetachedInspectorClose.swift in Sources */,
@@ -7142,6 +7173,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A5001427 /* FilePreviewPDFSizing.swift in Sources */,
 				A5001434A5001434A5001434 /* FilePreviewPDFThumbnailCollectionView.swift in Sources */,
 				A5001429 /* FilePreviewPDFViewport.swift in Sources */,
+				F10A00000000000000000002 /* FilePreviewPresentation.swift in Sources */,
 				C0DE64020000000000001002 /* FilePreviewQuickLookContainerView.swift in Sources */,
 				DD62AFF1D95A1D5D1850AC10 /* FilePreviewQuickLookSession.swift in Sources */,
 				D0B10016A1B2C3D4E5F60001 /* FilePreviewTextEditor.swift in Sources */,
@@ -7504,6 +7536,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C71500020000000000000001 /* SessionContentWidthModifier.swift in Sources */,
 				C71500040000000000000001 /* SessionContentWidthPresentation.swift in Sources */,
 				A74770010000000000000003 /* SessionDisplaySnapshot.swift in Sources */,
+				F10A00000000000000000003 /* SessionFloatingDockSnapshot.swift in Sources */,
 				B3575000000000000000000C /* SessionIndexModels.swift in Sources */,
 				B35750000000000000000008 /* SessionIndexRegisteredAgents.swift in Sources */,
 				FE003108 /* SessionIndexSectionPopoverHost.swift in Sources */,
@@ -7725,6 +7758,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE00000000000000000C7A /* TerminalController+ControlSystemContext.swift in Sources */,
 				C0DE00000000000000000C7C /* TerminalController+ControlSystemContext2.swift in Sources */,
 				C0DE00000000000000000C62 /* TerminalController+ControlWorkspaceContext.swift in Sources */,
+				F10A00000000000000000009 /* TerminalController+ControlWorkspaceFloatingDockContext.swift in Sources */,
 				C0DE00000000000000000C54 /* TerminalController+ControlWorkspaceGroupContext.swift in Sources */,
 				7371B0010000000000000001 /* TerminalController+ControlWorkspaceStrings.swift in Sources */,
 				66B951C8D7A92BABC4A6FFB8 /* TerminalController+ControlWorkspaceTodoContext.swift in Sources */,
@@ -7887,6 +7921,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7AB00000000000000000015 /* Workspace+DetachedSurfaceTransfer.swift in Sources */,
 				DCDC1000000000000000B013 /* Workspace+DockBrowserLookup.swift in Sources */,
 				E3309A05 /* Workspace+EqualizeSplitsSupport.swift in Sources */,
+				F10A00000000000000000004 /* Workspace+FloatingDocks.swift in Sources */,
 				F0ACC0DE0000000000000009 /* Workspace+ForkAgentConversationAvailability.swift in Sources */,
 				F0ACC0DE0000000000000003 /* Workspace+ForkConversationContextMenu.swift in Sources */,
 				F17F00000000000000000005 /* Workspace+FullWidthTab.swift in Sources */,
@@ -7919,6 +7954,10 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					5732A0045732A0045732A004 /* WorkspaceContentMinimalModeSafeAreaModifier.swift in Sources */,
 				A5001407 /* WorkspaceContentView.swift in Sources */,
 				C0DE36230000000000000001 /* WorkspaceFinderDirectoryResolver.swift in Sources */,
+				F10A00000000000000000005 /* WorkspaceFloatingDock.swift in Sources */,
+				F10A00000000000000000006 /* WorkspaceFloatingDockContentView.swift in Sources */,
+				F10A00000000000000000007 /* WorkspaceFloatingDockPresenter.swift in Sources */,
+				F10A00000000000000000008 /* WorkspaceFloatingDockWindowController.swift in Sources */,
 				F0ACC0DE000000000000000B /* WorkspaceForkAgentConversationAvailability.swift in Sources */,
 				C9A57203C9A57203C9A57203 /* WorkspaceGroupMenuSnapshot.swift in Sources */,
 				C9A57206C9A57206C9A57206 /* WorkspaceGroupMoveToMenuState.swift in Sources */,
@@ -8026,6 +8065,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B9000044A1B2C3D4E5F60719 /* CMUXCLI+TmuxCompatSupport.swift in Sources */,
 				B9000033A1B2C3D4E5F60719 /* CMUXCLI+TopRendering.swift in Sources */,
 				D1FF52000000000000000001 /* CMUXCLI+TypedDiffViewer.swift in Sources */,
+				F20A00000000000000000001 /* CMUXCLI+WorkspaceFloatingDock.swift in Sources */,
 				06CC2F6C1340C7424D1C7E0A /* CMUXCLI+WorkspaceTodo.swift in Sources */,
 				C0DECAFE0000000000000001 /* CodexTeamsApprovalBridge.swift in Sources */,
 				FEEDC1A50000000000000001 /* FeedEventClassifier.swift in Sources */,

--- a/cmuxTests/DockConfigFloatingDockTests.swift
+++ b/cmuxTests/DockConfigFloatingDockTests.swift
@@ -1,0 +1,248 @@
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite("Dock config Floating Docks", .serialized)
+struct DockConfigFloatingDockTests {
+    private func decode(_ json: String) throws -> DockConfigFile {
+        try JSONDecoder().decode(DockConfigFile.self, from: Data(json.utf8))
+    }
+
+    private func resolution(
+        sourcePath: String = "/repo/.cmux/dock.json",
+        floats: [DockFloatingDockDefinition]
+    ) -> DockConfigResolution {
+        DockConfigResolution(
+            controls: [],
+            floats: floats,
+            sourceURL: URL(fileURLWithPath: sourcePath),
+            baseDirectory: URL(fileURLWithPath: sourcePath).deletingLastPathComponent()
+                .deletingLastPathComponent().path,
+            isProjectSource: true
+        )
+    }
+
+    private func noteFloat(
+        id: String,
+        title: String,
+        frame: DockFloatingDockFrameDefinition? = nil
+    ) -> DockFloatingDockDefinition {
+        DockFloatingDockDefinition(
+            id: id,
+            title: title,
+            frame: frame,
+            content: DockControlDefinition(
+                id: "note",
+                title: "Notes",
+                kind: .note
+            )
+        )
+    }
+
+    @Test("Legacy controls-only files decode and encode unchanged")
+    func legacyControlsOnlyFileRoundTripsWithoutFloats() throws {
+        let file = try decode(
+            #"{"controls":[{"id":"git","title":"Git","command":"lazygit"}]}"#
+        )
+
+        #expect(file.controls.count == 1)
+        #expect(file.floats.isEmpty)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let encoded = try #require(String(data: try encoder.encode(file), encoding: .utf8))
+        #expect(encoded == #"{"controls":[{"command":"lazygit","id":"git","title":"Git"}]}"#)
+    }
+
+    @Test("Unified files decode terminal, browser, and note float content")
+    func unifiedFileDecodesAllFloatContentKinds() throws {
+        let file = try decode(
+            #"""
+            {
+              "controls": [{"id": "git", "title": "Git", "command": "lazygit"}],
+              "floats": [
+                {
+                  "id": "server",
+                  "title": "Server",
+                  "frame": {"x": 44, "y": 72, "width": 640, "height": 420},
+                  "content": {"id": "dev", "title": "Dev", "command": "pnpm dev", "cwd": "."}
+                },
+                {
+                  "id": "preview",
+                  "title": "Preview",
+                  "content": {"id": "web", "title": "Web", "type": "browser", "url": "https://example.com"}
+                },
+                {
+                  "id": "notes",
+                  "title": "Notes",
+                  "content": {"id": "scratch", "title": "Scratch", "type": "note"}
+                }
+              ]
+            }
+            """#
+        )
+
+        #expect(file.controls.count == 1)
+        #expect(file.floats.map(\.id) == ["server", "preview", "notes"])
+        #expect(file.floats[0].content?.kind == .terminal)
+        #expect(file.floats[1].content?.kind == .browser)
+        #expect(file.floats[2].content?.kind == .note)
+        #expect(file.floats[0].frame?.width == 640)
+        #expect(file.floats[0].frame?.height == 420)
+    }
+
+    @Test("Float frame and content have sane defaults")
+    func floatDefaultsDecode() throws {
+        let file = try decode(#"{"floats":[{"id":"scratch","title":"Scratch"}]}"#)
+        let definition = try #require(file.floats.first)
+
+        #expect(definition.content == nil)
+        #expect(definition.resolvedFrame(cascadeIndex: 2) == CGRect(
+            x: 84,
+            y: 32,
+            width: 520,
+            height: 380
+        ))
+    }
+
+    @Test("Unknown and malformed Dock config sections throw")
+    func unknownAndMalformedSectionsThrow() {
+        let invalidDocuments = [
+            #"{"controls":[],"floatingDocks":[]}"#,
+            #"{"floats":{}}"#,
+            #"{"floats":[{"id":"x","title":"X","widht":500}]}"#,
+            #"{"floats":[{"id":"x","title":"X","frame":{"w":500}}]}"#,
+            #"{"floats":[{"id":"x","title":"X","content":{"id":"n","type":"note","script":"echo"}}]}"#,
+            #"{"floats":[{"id":"x","title":"X","frame":{"width":100,"height":300}}]}"#,
+        ]
+
+        for json in invalidDocuments {
+            #expect(throws: (any Error).self) {
+                _ = try decode(json)
+            }
+        }
+    }
+
+    @Test("Duplicate float ids and note controls in the right Dock throw")
+    func invalidIdentitiesAndRightDockNoteThrow() {
+        #expect(throws: (any Error).self) {
+            _ = try decode(
+                #"{"floats":[{"id":"same","title":"One"},{"id":"same","title":"Two"}]}"#
+            )
+        }
+        #expect(throws: (any Error).self) {
+            _ = try decode(
+                #"{"controls":[{"id":"note","title":"Note","type":"note"}]}"#
+            )
+        }
+    }
+
+    @Test("Global config rejects Floating Docks loudly")
+    func globalConfigRejectsFloats() throws {
+        let file = try decode(#"{"floats":[{"id":"scratch","title":"Scratch"}]}"#)
+
+        #expect(throws: (any Error).self) {
+            try file.validate(isProjectSource: false)
+        }
+    }
+
+    @Test("Applying the same seed is idempotent and newly added ids seed later")
+    @MainActor
+    func seedOnceAndAddNewIDs() throws {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let first = noteFloat(
+            id: "scratch",
+            title: "Scratch",
+            frame: DockFloatingDockFrameDefinition(x: 12, y: 34, width: 700, height: 500)
+        )
+
+        workspace.applyFloatingDockConfiguration(resolution(floats: [first]))
+        let seeded = try #require(workspace.floatingDocks.first)
+        seeded.title = "My Scratch"
+        seeded.frame = CGRect(x: 101, y: 202, width: 801, height: 602)
+
+        workspace.applyFloatingDockConfiguration(resolution(floats: [first]))
+        #expect(workspace.floatingDocks.count == 1)
+        #expect(workspace.floatingDocks[0].title == "My Scratch")
+        #expect(workspace.floatingDocks[0].frame == CGRect(x: 101, y: 202, width: 801, height: 602))
+
+        workspace.applyFloatingDockConfiguration(resolution(floats: [
+            first,
+            noteFloat(id: "preview", title: "Preview"),
+        ]))
+        #expect(workspace.floatingDocks.count == 2)
+        #expect(workspace.floatingDocks[1].frame == CGRect(x: 60, y: 56, width: 520, height: 380))
+    }
+
+    @Test("Session-restored config floats keep user state and do not duplicate")
+    @MainActor
+    func sessionRestoreWinsOverConfigSeed() throws {
+        let source = Workspace()
+        defer { source.teardownAllPanels() }
+        let config = resolution(floats: [noteFloat(id: "scratch", title: "Scratch")])
+        source.applyFloatingDockConfiguration(config)
+        let sourceDock = try #require(source.floatingDocks.first)
+        sourceDock.title = "User Title"
+        sourceDock.frame = CGRect(x: 123, y: 234, width: 777, height: 555)
+        sourceDock.isPresented = false
+
+        let encoded = try JSONEncoder().encode(source.sessionSnapshot(includeScrollback: false))
+        let snapshot = try JSONDecoder().decode(SessionWorkspaceSnapshot.self, from: encoded)
+        let restored = Workspace()
+        defer { restored.teardownAllPanels() }
+        _ = restored.restoreSessionSnapshot(snapshot)
+
+        restored.applyFloatingDockConfiguration(config)
+
+        let restoredDock = try #require(restored.floatingDocks.first)
+        #expect(restored.floatingDocks.count == 1)
+        #expect(restoredDock.title == "User Title")
+        #expect(restoredDock.frame == CGRect(x: 123, y: 234, width: 777, height: 555))
+        #expect(!restoredDock.isPresented)
+    }
+
+    @Test("A closed config float stays closed after session restore")
+    @MainActor
+    func closedSeedStaysClosed() throws {
+        let source = Workspace()
+        defer { source.teardownAllPanels() }
+        let config = resolution(floats: [noteFloat(id: "scratch", title: "Scratch")])
+        source.applyFloatingDockConfiguration(config)
+        let dockID = try #require(source.floatingDocks.first?.id)
+        #expect(source.closeFloatingDock(id: dockID))
+
+        let encoded = try JSONEncoder().encode(source.sessionSnapshot(includeScrollback: false))
+        let snapshot = try JSONDecoder().decode(SessionWorkspaceSnapshot.self, from: encoded)
+        let restored = Workspace()
+        defer { restored.teardownAllPanels() }
+        _ = restored.restoreSessionSnapshot(snapshot)
+
+        restored.applyFloatingDockConfiguration(config)
+        #expect(restored.floatingDocks.isEmpty)
+    }
+
+    @Test("The same float id in a different config source is a new seed")
+    @MainActor
+    func seedIdentityIncludesConfigSource() {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+        let definition = noteFloat(id: "scratch", title: "Scratch")
+
+        workspace.applyFloatingDockConfiguration(resolution(
+            sourcePath: "/repo-a/.cmux/dock.json",
+            floats: [definition]
+        ))
+        workspace.applyFloatingDockConfiguration(resolution(
+            sourcePath: "/repo-b/.cmux/dock.json",
+            floats: [definition]
+        ))
+
+        #expect(workspace.floatingDocks.count == 2)
+    }
+}

--- a/cmuxTests/DockConfigFloatingDockTests.swift
+++ b/cmuxTests/DockConfigFloatingDockTests.swift
@@ -252,4 +252,15 @@ struct DockConfigFloatingDockTests {
 
         #expect(workspace.floatingDocks.count == 2)
     }
+
+    @Test("The config-only loader is not exposed as a routable Dock")
+    @MainActor
+    func configurationLoaderDoesNotRegisterForDockRouting() {
+        let workspace = Workspace()
+        defer { workspace.teardownAllPanels() }
+
+        let store = workspace.floatingDockConfigurationStore()
+
+        #expect(!DockSplitStore.liveStores.contains(where: { $0 === store }))
+    }
 }

--- a/cmuxTests/DockConfigFloatingDockTests.swift
+++ b/cmuxTests/DockConfigFloatingDockTests.swift
@@ -120,6 +120,7 @@ struct DockConfigFloatingDockTests {
             #"{"floats":[{"id":"x","title":"X","widht":500}]}"#,
             #"{"floats":[{"id":"x","title":"X","frame":{"w":500}}]}"#,
             #"{"floats":[{"id":"x","title":"X","content":{"id":"n","type":"note","script":"echo"}}]}"#,
+            #"{"floats":[{"id":"x","title":"X","content":{"id":"n","type":"note","command":"echo"}}]}"#,
             #"{"floats":[{"id":"x","title":"X","frame":{"width":100,"height":300}}]}"#,
         ]
 

--- a/cmuxTests/DockConfigFloatingDockTests.swift
+++ b/cmuxTests/DockConfigFloatingDockTests.swift
@@ -114,6 +114,8 @@ struct DockConfigFloatingDockTests {
     func unknownAndMalformedSectionsThrow() {
         let invalidDocuments = [
             #"{"controls":[],"floatingDocks":[]}"#,
+            #"{"controls":null}"#,
+            #"{"floats":null}"#,
             #"{"floats":{}}"#,
             #"{"floats":[{"id":"x","title":"X","widht":500}]}"#,
             #"{"floats":[{"id":"x","title":"X","frame":{"w":500}}]}"#,
@@ -162,12 +164,17 @@ struct DockConfigFloatingDockTests {
             frame: DockFloatingDockFrameDefinition(x: 12, y: 34, width: 700, height: 500)
         )
 
+        let edited = noteFloat(
+            id: "scratch",
+            title: "Edited Config Title",
+            frame: DockFloatingDockFrameDefinition(x: 1, y: 2, width: 500, height: 400)
+        )
         workspace.applyFloatingDockConfiguration(resolution(floats: [first]))
         let seeded = try #require(workspace.floatingDocks.first)
         seeded.title = "My Scratch"
         seeded.frame = CGRect(x: 101, y: 202, width: 801, height: 602)
 
-        workspace.applyFloatingDockConfiguration(resolution(floats: [first]))
+        workspace.applyFloatingDockConfiguration(resolution(floats: [edited]))
         #expect(workspace.floatingDocks.count == 1)
         #expect(workspace.floatingDocks[0].title == "My Scratch")
         #expect(workspace.floatingDocks[0].frame == CGRect(x: 101, y: 202, width: 801, height: 602))

--- a/cmuxTests/MainWindowSelfSizingTests.swift
+++ b/cmuxTests/MainWindowSelfSizingTests.swift
@@ -10,6 +10,35 @@ import SwiftUI
 
 @MainActor
 final class MainWindowSelfSizingTests: XCTestCase {
+    func testUserSizedHostKeepsFloatingWindowFrameAuthoritative() {
+        let window = NSPanel(
+            contentRect: NSRect(x: 0, y: 0, width: 420, height: 300),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        defer { window.orderOut(nil) }
+        let overReporting = Color.clear
+            .frame(width: 4_000, height: 3_000)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        window.contentView = UserSizedWindowHostingView(
+            rootView: AnyView(overReporting),
+            minimumContentSize: NSSize(width: 320, height: 220)
+        )
+        window.makeKeyAndOrderFront(nil)
+
+        for _ in 0..<5 {
+            window.displayIfNeeded()
+            window.contentView?.layoutSubtreeIfNeeded()
+            RunLoop.current.run(until: Date().addingTimeInterval(0.02))
+        }
+
+        XCTAssertEqual(window.frame.width, 420, accuracy: 1.0)
+        XCTAssertEqual(window.frame.height, 300, accuracy: 1.0)
+        XCTAssertLessThanOrEqual(window.contentView?.frame.width ?? .infinity, window.frame.width + 1)
+        XCTAssertLessThanOrEqual(window.contentView?.frame.height ?? .infinity, window.frame.height + 1)
+    }
+
     /// The main window must never resize itself to fit its SwiftUI content.
     /// NSHostingView watches window layout and calls NSWindow.setFrame when
     /// the measured content size disagrees with the window

--- a/cmuxTests/WindowAndDragTests.swift
+++ b/cmuxTests/WindowAndDragTests.swift
@@ -2941,6 +2941,59 @@ final class FilePreviewDragPasteboardWriterTests: XCTestCase {
 
 @MainActor
 final class FilePreviewPanelTextSavingTests: XCTestCase {
+    func testWorkspaceFloatingDockSeedsNativeNoteSurface() throws {
+        let url = try temporaryTextFile(contents: "", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let dock = WorkspaceFloatingDock(
+            id: UUID(),
+            workspaceId: UUID(),
+            title: "Notes",
+            frame: CGRect(x: 20, y: 20, width: 500, height: 360),
+            isPresented: true,
+            noteFilePath: url.path,
+            baseDirectoryProvider: { nil },
+            remoteBrowserSettingsProvider: { .local }
+        )
+        defer { dock.close() }
+
+        dock.store.setActive(
+            isVisible: true,
+            mode: .dock,
+            visibilityHostId: UUID()
+        )
+
+        let notePanel = try XCTUnwrap(dock.notePanel)
+        XCTAssertEqual(notePanel.filePath, url.path)
+        XCTAssertEqual(dock.store.panels.count, 1)
+        XCTAssertNotNil(dock.store.paneId(forPanelId: notePanel.id))
+        XCTAssertFalse(dock.store.hasPendingConfigurationWorkForTesting)
+        XCTAssertEqual(dock.store.dockPortalReconcileState.reconcilePassCount, 0)
+    }
+
+    func testFloatingDockNoteControlWriteIsSynchronousAndUpdatesEditor() async throws {
+        let url = try temporaryTextFile(contents: "original", encoding: .utf8)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let panel = FilePreviewPanel(
+            workspaceId: UUID(),
+            filePath: url.path,
+            presentation: .note(title: "Notes")
+        )
+        defer { panel.close() }
+        await panel.loadTextContent().value
+        let textView = NSTextView()
+        textView.string = panel.textContent
+        panel.attachTextView(textView)
+
+        try panel.replaceAutosavedTextContent("agent-visible note")
+
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "agent-visible note")
+        XCTAssertEqual(panel.textContent, "agent-visible note")
+        XCTAssertEqual(textView.string, "agent-visible note")
+        XCTAssertFalse(panel.isDirty)
+    }
+
     func testNativePreviewSessionsDetachAndManageViewsAcrossRecreation() throws {
         let url = try temporaryTextFile(contents: "preview", encoding: .utf8)
         defer { try? FileManager.default.removeItem(at: url) }

--- a/docs/dock.md
+++ b/docs/dock.md
@@ -1,6 +1,6 @@
 # Dock
 
-Dock is the cmux right sidebar rendered as a full panel container. It uses the **same surface and split system as the main content area** — terminals *and* browsers, tiled with the same split affordances — just docked on the right. Each Dock terminal runs in its own Ghostty-backed surface, so TUIs keep normal keyboard behavior such as arrow keys, `j` / `k`, and `Ctrl-C`. Dock browsers share the same browser stack as main-area browser panes (cookies, profile, devtools, navigation).
+Dock is the cmux right sidebar rendered as a full panel container. It uses the **same surface and split system as the main content area** — terminals *and* browsers, tiled with the same split affordances — just docked on the right. Each Dock terminal runs in its own Ghostty-backed surface, so TUIs keep normal keyboard behavior such as arrow keys, `j` / `k`, and `Ctrl-C`. Dock browsers share the same browser stack as main-area browser panes (cookies, profile, devtools, navigation). Workspace-scoped, movable containers use the same configuration file; see [Floating Docks](floating-docks.md).
 
 Dock is useful for project dashboards, git views, logs, queues, local services, test watchers, dev servers, custom TUIs, and reference web pages. Feed can be added as one optional terminal with `cmux feed tui --opentui`, but Dock is not limited to Feed.
 
@@ -69,11 +69,42 @@ Dock is configured with JSON:
       "type": "browser",
       "url": "https://example.com"
     }
+  ],
+  "floats": [
+    {
+      "id": "scratch",
+      "title": "Scratch",
+      "frame": {
+        "x": 36,
+        "y": 80,
+        "width": 520,
+        "height": 380
+      },
+      "content": {
+        "id": "scratch-note",
+        "title": "Notes",
+        "type": "note"
+      }
+    },
+    {
+      "id": "preview",
+      "title": "Preview",
+      "frame": {
+        "width": 640,
+        "height": 480
+      },
+      "content": {
+        "id": "preview-browser",
+        "title": "App",
+        "type": "browser",
+        "url": "http://localhost:3000"
+      }
+    }
   ]
 }
 ```
 
-Fields:
+Right-Dock `controls` fields:
 
 - `id`: stable unique identifier for the control.
 - `title`: label shown on the Dock tab.
@@ -86,6 +117,27 @@ Fields:
 
 Existing terminal-only configs (no `type`) keep loading unchanged. The order of `controls` seeds the initial Dock layout top-to-bottom; once open, you can re-tile, add, and close Dock panes in-app without editing the file.
 
+The top-level `floats` array is optional. An existing file containing only `{"controls": [...]}` decodes and seeds the right Dock exactly as before; no migration or new key is required. Each float supports:
+
+- `id`: stable config seed identifier, unique within `floats`. It is not the runtime Floating Dock UUID or `float:N` CLI selector.
+- `title`: Floating Dock window title.
+- `frame`: optional initial `x`, `y`, `width`, and `height` in screen points. Missing values use a cascaded origin and a `520` × `380` size. Width must be at least `320`; height must be at least `220`.
+- `content`: optional initial content using the same control fields above. `terminal` uses `command`, `cwd`, and `env`; `browser` uses `url`; `note` creates an autosaving note. Omitting `content` also creates an autosaving note.
+
+Unknown keys, duplicate IDs, invalid content, malformed `floats`/`frame` sections, and undersized frames produce the existing **Dock Config Error** UI. They are never ignored silently.
+
+### Floating Dock seeding and identity
+
+Floating Dock config is seed-only, not continuously reconciled. A seed identity combines the resolved project config source with the float's config `id` and is persisted in the workspace session snapshot; runtime UUIDs and `float:N` selectors remain independent.
+
+- A restored float with the same seed identity is kept; config does not duplicate it or overwrite its saved title, frame, or visibility.
+- Closing a configured float records that its identity was already seeded, so it stays closed after restart.
+- Adding a new float `id` to the same config seeds that new float the next time the config is loaded.
+- Editing or removing an already-seeded entry does not rewrite or close the user's existing float. Use a new `id` when a deliberately new seed is required.
+- Initial terminal/browser content is recreated from the seed stored in the session snapshot. Note text continues to autosave in its note file. Live interactive and CLI changes win for the rest of the session.
+
+See [Floating Docks](floating-docks.md) for interactive and CLI usage.
+
 ## Config Precedence
 
 cmux looks for Dock config in this order:
@@ -96,6 +148,8 @@ cmux looks for Dock config in this order:
 Use `.cmux/dock.json` for repo-specific controls that should be shared with teammates. Commit it to the repo when the commands are safe and portable.
 
 Use `~/.config/cmux/dock.json` for personal defaults, machines without a repo, or controls that are specific to your local setup.
+
+Floating Docks are workspace-scoped and, in this first schema version, are supported only by project `.cmux/dock.json`. A global config containing a non-empty `floats` array fails with **Dock Config Error** instead of ignoring it. Keep global files controls-only.
 
 Nested project configs apply to their directory tree. If a nested project has its own `.cmux/dock.json`, use that nearest config for work inside the nested project. Do not put unrelated project controls into the global config just because a repo is absent.
 

--- a/docs/floating-docks.md
+++ b/docs/floating-docks.md
@@ -1,0 +1,19 @@
+# Floating Docks
+
+A Floating Dock is a movable, resizable Bonsplit container owned by one workspace. It appears above that workspace's main content and hides when another workspace is selected. A workspace may own multiple Floating Docks.
+
+New Floating Docks start with an autosaving note. Their tabs and panes use the same Bonsplit drag behavior as the existing right Dock, so terminals and browsers can move between the main workspace, right Dock, and Floating Docks without recreating the surface.
+
+Create one from the command palette with `New Floating Dock`, or from the CLI:
+
+```sh
+cmux workspace float create --title Scratch --focus
+cmux workspace float list --json
+cmux workspace float note set float:1 "release checklist"
+cmux workspace float pane create float:1 --type browser --direction right --url https://cmux.com
+cmux workspace float hide float:1
+```
+
+`list --json` returns every Floating Dock in the target workspace, including its frame, presentation and focus state, panes, selected tabs, and surface identifiers. Mutations preserve the user's current focus unless `--focus` is explicit.
+
+Run `cmux workspace float --help` for the complete command set. The target workspace defaults to the caller's `CMUX_WORKSPACE_ID`; use `--workspace <id|ref|index>` to inspect another workspace.

--- a/docs/floating-docks.md
+++ b/docs/floating-docks.md
@@ -17,3 +17,42 @@ cmux workspace float hide float:1
 `list --json` returns every Floating Dock in the target workspace, including its frame, presentation and focus state, panes, selected tabs, and surface identifiers. Mutations preserve the user's current focus unless `--focus` is explicit.
 
 Run `cmux workspace float --help` for the complete command set. The target workspace defaults to the caller's `CMUX_WORKSPACE_ID`; use `--workspace <id|ref|index>` to inspect another workspace.
+
+## Configuration
+
+Project `.cmux/dock.json` can seed Floating Docks and the right Dock from one schema. The top-level `controls` array remains the backwards-compatible right-Dock schema; the optional top-level `floats` array declares workspace floats:
+
+```json
+{
+  "controls": [
+    { "id": "git", "title": "Git", "command": "lazygit" }
+  ],
+  "floats": [
+    {
+      "id": "scratch",
+      "title": "Scratch",
+      "frame": { "x": 36, "y": 80, "width": 520, "height": 380 },
+      "content": { "id": "note", "title": "Notes", "type": "note" }
+    },
+    {
+      "id": "preview",
+      "title": "Preview",
+      "frame": { "width": 640, "height": 480 },
+      "content": {
+        "id": "browser",
+        "title": "App",
+        "type": "browser",
+        "url": "http://localhost:3000"
+      }
+    }
+  ]
+}
+```
+
+`content` reuses the Dock control schema: omit `type` for a terminal with `command`, use `browser` with `url`, or use `note`. Omitting `content` creates the normal autosaving note. Missing frame values use a cascaded origin and a `520` × `380` size; minimum size is `320` × `220`.
+
+Config seeds only the initial state. Identity is the resolved project config source plus the float's config `id`, persisted with the workspace session. The config `id` is separate from runtime UUIDs and `float:N` CLI selectors. A matching restored float is not duplicated or overwritten; saved title, frame, and visibility win. Closing a seeded float keeps it closed after restart. Adding a new ID seeds only the new entry, while editing or removing an old ID does not reconcile the existing float.
+
+Global `~/.config/cmux/dock.json` does not support `floats` in this version because floats belong to a project workspace. A non-empty global `floats` array produces **Dock Config Error** rather than being ignored. Unknown keys and malformed sections use the same error path.
+
+See [Dock](dock.md) for the complete unified schema, trust behavior, config precedence, and the backwards-compatibility guarantee.

--- a/skills/cmux-customization/SKILL.md
+++ b/skills/cmux-customization/SKILL.md
@@ -13,7 +13,7 @@ Use this skill for user-facing cmux customization. Keep the user's config intact
 - New workspace button: set `ui.newWorkspace.action` to replace the normal plus-button click, and `ui.newWorkspace.contextMenu` to control right-click actions. `ui.newWorkspace.rightClick` is accepted as an alias, but new examples should use `contextMenu`.
 - Surface tab bar buttons: set `ui.surfaceTabBar.buttons` to replace the default tab bar buttons. Include built-in IDs such as `cmux.newTerminal`, `cmux.newBrowser`, `cmux.splitRight`, and `cmux.splitDown` only when they should stay visible.
 - Workflows and layouts: use `commands` with workspace definitions to open a worktree, multiple checkouts, local services, browser previews, or SSH sessions in a deliberate split layout.
-- Dock controls: create `.cmux/dock.json` or `~/.config/cmux/dock.json` for right-sidebar terminal controls such as logs, test watchers, git TUIs, dev servers, queues, or `cmux feed tui --opentui`.
+- Dock configuration: create `.cmux/dock.json` for right-sidebar `controls` and workspace-scoped `floats`, or `~/.config/cmux/dock.json` for global right-sidebar controls. Global Floating Docks are not supported.
 - Sidebar and app behavior: use `cmux-settings` for supported settings such as appearance, sidebar display, notification behavior, browser routing, automation, shortcuts, and new-workspace placement.
 - Workspace metadata: use the cmux CLI or `cmux-workspace` for workspace names, descriptions, colors, read state, and sidebar metadata updates.
 - Feed and notifications: use `cmux hooks setup` for Feed event sources, notification settings for delivery behavior, and notification hooks in `cmux.json` for filtering or post-processing banners.
@@ -25,7 +25,7 @@ Use this skill for user-facing cmux customization. Keep the user's config intact
 
 - cmux app preferences: use `cmux-settings` for global `~/.config/cmux/cmux.json` settings such as appearance, sidebar, notifications, browser behavior, automation, and shortcuts.
 - Custom actions, workspace layouts, tab bar buttons, plus-button behavior, and Command Palette entries: edit `~/.config/cmux/cmux.json` globally or `.cmux/cmux.json` in the project. Project-local actions and commands override global entries with the same ID or name.
-- Dock controls: edit `.cmux/dock.json` in the project or `~/.config/cmux/dock.json` globally. Run `cmux docs dock` when available.
+- Dock controls and Floating Dock seeds: edit `.cmux/dock.json` in the project. Global `~/.config/cmux/dock.json` supports right-Dock `controls` only. Run `cmux docs dock` when available.
 - Terminal rendering and terminal keybindings: use Ghostty config, usually `~/.config/ghostty/config`. This includes fonts, cursor style, copy-on-select, shell integration, themes, and terminal keybindings.
 - Project-specific behavior: prefer `.cmux/cmux.json` in the project so actions, commands, UI action wiring, and notification hooks travel with the repo. Do not put global app preferences there.
 
@@ -217,11 +217,29 @@ Add project Dock controls:
 }
 ```
 
+Add a project Floating Dock seed alongside right-Dock controls:
+
+```json
+{
+  "controls": [],
+  "floats": [
+    {
+      "id": "scratch",
+      "title": "Scratch",
+      "frame": { "width": 520, "height": 380 },
+      "content": { "id": "note", "title": "Notes", "type": "note" }
+    }
+  ]
+}
+```
+
+Float IDs are config seed identities, not runtime UUIDs or `float:N` CLI selectors. Session-restored or previously closed seeds are not recreated or overwritten; use a new ID for a deliberately new seed. Omit `content` for the default autosaving note, or reuse a terminal/browser Dock control definition. Keep `floats` out of the global config; cmux reports a Dock config error instead of ignoring it.
+
 ## Validation
 
 - App settings: run `cmux-settings validate`.
 - JSONC shape: keep valid JSONC and avoid duplicate keys.
-- Dock JSON: parse `.cmux/dock.json` or `~/.config/cmux/dock.json` with a JSON parser before reporting completion.
+- Dock JSON: parse `.cmux/dock.json` or `~/.config/cmux/dock.json` with a JSON parser before reporting completion. Use `floats` only in the project file and reject unknown keys instead of assuming cmux will ignore them.
 - Runtime reload: run `cmux reload-config` when the CLI is available.
 - User-facing action: confirm the action title, shortcut, plus-button behavior, context-menu entry, or tab bar placement the user asked for.
 

--- a/skills/cmux-customization/references/examples.md
+++ b/skills/cmux-customization/references/examples.md
@@ -125,6 +125,14 @@ controls for repeated local development.
   "controls": [
     { "id": "git", "title": "Git", "command": "lazygit", "cwd": ".", "height": 320 },
     { "id": "feed", "title": "Feed", "command": "cmux feed tui --opentui", "height": 260 }
+  ],
+  "floats": [
+    {
+      "id": "scratch",
+      "title": "Scratch",
+      "frame": { "width": 520, "height": 380 },
+      "content": { "id": "note", "title": "Notes", "type": "note" }
+    }
   ]
 }
 ```
@@ -331,6 +339,8 @@ or release-monitoring commands. Prefer Dock controls for long-running monitors.
 ## Validation Checklist
 
 - Parse any changed JSON or JSONC before reporting success.
+- Keep Floating Dock `floats` in project `.cmux/dock.json`; global Dock config supports `controls` only.
+- Treat float IDs as config seed identities, separate from runtime UUIDs and `float:N` selectors: reuse preserves session state, while a new ID creates a new seed.
 - Keep `cwd` inside the `workspace` object for workspace commands.
 - Confirm `workspaceCommand.commandName` matches a `commands[].name`.
 - Use `ui.newWorkspace.contextMenu` in new examples, not the alias.


### PR DESCRIPTION
> [!IMPORTANT]
> **Stacked on #8351 (`feat-floating-panels`).** This Draft PR includes that branch and must merge only after #8351. Until #8351 lands, the diff and mergeability against `main` include the dependency. I will re-merge `feat-floating-panels`, or `main` after #8351 lands, as needed.

Closes #8370

Issue: https://github.com/manaflow-ai/cmux/issues/8370

## Summary

- Extends the existing `dock.json` schema with an optional top-level `floats` array while preserving controls-only files through the canonical encoder.
- Reuses `DockControlDefinition` for terminal/browser content and adds note content for Floating Docks.
- Routes project Floating Dock config through the existing Dock resolution, trust, and error pipeline; `Workspace` remains the single `@MainActor` lifecycle owner for floats.
- Rejects unknown keys, malformed/null sections, duplicate IDs, invalid note fields, and unsupported global floats through the existing Dock Config Error UX.
- Documents the unified schema in both Dock guides and the cmux customization skill/examples.

## Architecture and ownership

The root cause was two independent creation stories: `DockSplitStore` resolved and trusted `dock.json` for the right Dock, while `Workspace` created/restored Floating Docks only from UI/CLI/session state.

This change keeps one schema and one resolution/trust/error path with two consumers:

1. Right-Dock `controls` continue through the existing control seed path.
2. Trusted project `floats` are handed to the owning `Workspace`, which alone creates, restores, closes, and snapshots Floating Docks.

The config-only loader is excluded from the live Dock routing registry, and sidebar trust/error presentation attaches during view lifecycle rather than mutating workspace state from a SwiftUI body computation.

## Backwards compatibility

An existing controls-only file continues to decode and encode without a `floats` key. Existing right-Dock control ordering, terminal defaults, and trust fingerprints remain unchanged. No migration is required.

## Floating Dock seed identity

A seed identity is the resolved config source identifier plus the config float `id`. The per-workspace session snapshot persists identities already considered (including closed floats), the identity on live configured floats, and the configured initial content/base directory needed by #8351's intentionally limited container snapshot.

Semantics are seed-once, not reconciliation:

- a matching restored float keeps its saved title, frame, and visibility;
- a closed configured float stays closed after restart;
- a newly added config ID seeds once;
- edits/removals do not overwrite or close an already-seeded float;
- changing config source makes the same config ID a distinct seed.

#8351 intentionally persists float identity/title/frame/visibility and note files, not arbitrary interior panel layouts. This PR does not pretend otherwise; configured terminal/browser seed content is stored with the float snapshot so it can be recreated without reapplying the current config.

## Scope and related resolution work

Floating Dock config is project-only in v1. A non-empty `floats` array in `~/.config/cmux/dock.json` fails loudly instead of being ignored.

I reviewed #8307. This PR does not duplicate its remote resolver. `DockConfigResolution` carries a dedicated durable seed-source identifier seam so the source-aware resolver can provide its transport-qualified canonical identifier when #8307 lands; the same Workspace consumer remains usable when its remote context/execution changes are merged.

## Testing

Test-only commits precede the implementation commit and cover:

- legacy controls-only decode/encode compatibility;
- terminal, browser, and note float content;
- defaults, strict unknown-key/malformed/null validation, duplicate IDs, global rejection, and ignored note-field rejection;
- idempotent seeding, config edits not clobbering user state, incremental IDs, source-qualified identity, session restore, and closed-seed tombstones;
- keeping the config-only loader out of Dock control routing.

Permitted local verification:

- `swiftc -frontend -parse` for every changed Swift/test file
- standalone `swiftc -typecheck` for the schema/model layer
- `scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- parsed `Resources/Localizable.xcstrings`
- parsed 16 JSON examples across the changed docs/skill files
- `git diff --check`

Per task instructions, I did not run local Xcode tests or any app build. The native NSPanel placement path is therefore not claimed as locally dogfooded; model frame defaults and snapshot preservation are covered by unit tests.

The requested Swift file-length budget script/TSV do not exist on this checkout, so neither budget TSV was created or modified. Every new Swift file is under 500 lines.

## Localization

New runtime Dock config errors use `String(localized:defaultValue:)`. All new keys have explicit English and Japanese entries in `Resources/Localizable.xcstrings`; the catalog and changed documentation JSON examples parse successfully.

## Demo Video

Not recorded: this PR is Draft/stacked and the task explicitly prohibits running the cloud build until requested.

## Review Trigger (after the dependency/build handoff)

```text
@codex review
@coderabbitai review
@greptile-apps review
@cubic-dev-ai review
```

## Latest-head review and CI closeout

- Stack-compatibility fix `f0dbc76f0c`: all Floating Dock panels now use the stable `cmux.workspace.float` window-kind identifier, registered in `cmuxAuxiliaryWindowIdentifiers`, so Cmd-W closes the key float instead of falling through to a terminal tab. The focused auxiliary-window lint passes.
- Canonical authored-range review: `/Users/austinwang/manaflow/cmuxterm-hq/skills/autoreview/scripts/autoreview --mode branch --base 5f6a662d6f` exited 0 at the latest HEAD; both the structured Codex review and Aziz policy phase reported no actionable findings.
- Greptile reviewed `f0dbc76f0c`. Its findings were verified by exact blame as dependency-owned lines from #8351 commit `5cfadf0eaa`, absent from the authored range `5f6a662d6f..HEAD`; all Greptile threads were answered and resolved.
- CodeRabbit completed its review and posted ten inline findings. Exact blame likewise assigns every flagged hunk to #8351 commit `5cfadf0eaa`; all ten were answered with stack provenance and resolved. GitHub reports zero unresolved review threads. CodeRabbit's aggregate status remains stuck `PENDING` after review completion with no new activity, so it is recorded as stale external status rather than a code finding.
- Full CI run [29615815198](https://github.com/manaflow-ai/cmux/actions/runs/29615815198) at `f0dbc76f0c` is not green. Its sole root failure is the unchanged current-`main` feature-flag lint (`sidebar-appkit-list-experiment` is evaluated in both `Sources/ContentView.swift` and `Sources/TerminalWindowPortal.swift`); the authored PR range changes neither file nor the lint. `linux-preflight`, `tests`, and `ci-status` are downstream cascades. This PR's previously failing auxiliary-window lint is fixed and passed before the baseline failure surfaced.

## Checklist

- [ ] App build/dogfood (intentionally deferred by task instructions)
- [x] Added behavior-level regression tests before the implementation commit
- [x] Updated Dock and Floating Dock docs plus customization skill examples
- [x] Audited English/Japanese runtime localization
- [x] Requested bot reviews after latest commit
- [x] Triaged and resolved all review threads (dependency-only findings routed to #8351)
- [ ] Required CI green (blocked by unchanged current-main feature-flag lint; see run 29615815198)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8374"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786915775&installation_id=133855650&pr_number=8374&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8374&signature=e062ad82e2a18fccadafed71a5e747b8cb0acd401c94c9001d6c7b7ca229069a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies `dock.json` for the right Dock and Floating Docks by adding a `floats` array, and seeds workspace-scoped Floating Docks from project config with strict validation. Adds CLI/control-socket control, registers Floating Dock windows as auxiliary, and keeps user-set window frames authoritative. Addresses #8370.

- **New Features**
  - `dock.json`: adds optional top-level `floats` with `id`, `title`, optional `frame`, and optional `content` (`terminal`, `browser`, or `note`); rejects unknown keys with clear errors.
  - Workspace Floating Docks: movable, resizable windows owned by a workspace; default to an autosaving note; survive workspace switches; reuse existing trust/error flow.
  - Seed-once semantics: config IDs seed once and preserve user state; source-aware seed identities included.
  - CLI/control socket: `cmux workspace float` (list, create, show/hide, focus, close, frame, note get/set, surface/pane ops); new workspace float actions in `CmuxControlSocket`.
  - Routing: surfaces/panes resolve across main area, right Dock, and Floating Docks without recreating the surface.
  - Windowing + docs: registers `cmux.workspace.float` as an auxiliary window kind and prevents content-based resizing; updated docs and localized messages (EN/JA).

- **Migration**
  - No migration; controls-only files continue to work without `floats`.
  - `floats` are project-only; `~/.config/cmux/dock.json` with `floats` errors on load.

<sup>Written for commit f0dbc76f0c60ceae943ac631108694f38df7d60d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8374?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added movable, resizable workspace Floating Docks with show/hide, focus, close, frame updates, and note content (autosaving + persistence).
  * Added `cmux workspace float` CLI support for listing and creating/editing docks, surfaces, panes, and notes (including JSON output).
  * Added project `.cmux/dock.json` “floats” seeding with stable float identity and session restore behavior.
* **Bug Fixes**
  * Improved floating dock routing, refresh, focus handling, and frame sizing behavior.
  * Added stricter validation for unsupported configs, invalid frames, duplicate IDs, and unknown keys.
* **Documentation**
  * Updated Floating Dock docs and CLI help, including examples and configuration rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->