### PR TITLE
Make update pill installs causal and fail visibly

### DIFF
--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/AttemptUpdateCoordinator.swift
@@ -26,24 +26,20 @@ struct AttemptUpdateCoordinator {
         /// Install the update the model is currently carrying (now known to be the freshly
         /// resolved latest version).
         case confirmInstall
+        /// The accepted install reached a terminal state without starting a download.
+        case installFailed
     }
 
     private enum Phase: Equatable {
         /// Not coordinating an install.
         case inactive
-        /// A fresh check was requested but has not started running yet. The prompt that was on
-        /// screen when the user asked may be stale, and the restart deliberately passes through
-        /// `.idle` one or more times (once when ``UpdateController`` cancels the active prompt, and
-        /// again when Sparkle's `dismissUpdateInstallation` callback fires in response to the
-        /// dismissed prompt), so ignore every state here until the fresh check actually starts —
-        /// signalled unambiguously by `.checking`.
-        case awaitingCheckRestart
-        /// The stale prompt has been dismissed, but Sparkle has not yet surfaced the fresh
-        /// `.checking` state. Duplicate idle notifications in this window are still part of the
-        /// restart path, not a user cancellation.
-        case awaitingCheckStart
-        /// The check has restarted; install the next update it resolves.
+        /// A fresh check was requested but its call into Sparkle has not happened yet.
+        case awaitingFreshCheck
+        /// The controller called Sparkle for the fresh check; install the update it resolves.
         case awaitingResult
+        /// The fresh prompt was answered with `.install`; ownership remains here until Sparkle
+        /// begins downloading or surfaces a visible error.
+        case startingDownload
     }
 
     private var phase: Phase = .inactive
@@ -59,15 +55,22 @@ struct AttemptUpdateCoordinator {
     /// - Parameter currentState: The phase showing when the user requested the install. Its
     ///   captured update is deliberately *not* installed; it only gates the mid-install no-op.
     mutating func requestInstallLatest(currentState: UpdateState) -> Action {
+        guard phase == .inactive else { return .none }
         switch currentState {
-        case .downloading, .extracting, .installing:
+        case .startingDownload, .downloading, .extracting, .installing:
             // An install is already underway; don't interrupt it to re-resolve.
             return .none
-        case .idle, .permissionRequest, .checking, .updateAvailable, .notFound, .error:
+        case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable, .notFound, .error:
             // Ignore any update captured in `currentState`; re-resolve the feed to the latest.
-            phase = .awaitingCheckRestart
+            phase = .awaitingFreshCheck
             return .startFreshCheck
         }
+    }
+
+    /// Records the authoritative moment the controller invokes Sparkle's fresh check.
+    mutating func didStartFreshCheck() {
+        guard phase == .awaitingFreshCheck else { return }
+        phase = .awaitingResult
     }
 
     /// Feed each ``UpdateState`` change observed after a request. Returns the action the controller
@@ -77,55 +80,52 @@ struct AttemptUpdateCoordinator {
         case .inactive:
             return .none
 
-        case .awaitingCheckRestart:
+        case .awaitingFreshCheck:
             switch state {
-            case .updateAvailable:
-                // Still the pre-request prompt (or a coalesced repeat of it); keep waiting for the
-                // fresh check to actually start before trusting an `.updateAvailable`.
+            case .preparingCheck, .permissionRequest:
                 return .none
-            case .idle:
-                // The stale prompt was cleared. Sparkle can emit another idle notification before
-                // the fresh check starts (#7235), so do not treat idle as cancellation yet.
-                phase = .awaitingCheckStart
-                return .none
-            case .checking, .downloading, .extracting, .installing, .permissionRequest:
-                // The check has restarted. Confirm whatever it resolves next.
-                phase = .awaitingResult
-                return .none
-            case .notFound, .error:
-                // The fresh check ended without an update; stop coordinating.
+            case .error:
                 phase = .inactive
                 return .none
-            }
-
-        case .awaitingCheckStart:
-            switch state {
-            case .idle, .updateAvailable:
-                // Duplicate idle/stale-available emissions can arrive while Sparkle is tearing
-                // down the dismissed prompt. Keep waiting for the fresh check to begin.
-                return .none
-            case .checking, .downloading, .extracting, .installing, .permissionRequest:
-                phase = .awaitingResult
-                return .none
-            case .notFound, .error:
+            case .idle, .checking, .updateAvailable, .notFound,
+                    .startingDownload, .downloading, .extracting, .installing:
+                // No model emission can prove that a new Sparkle check started. If the explicit
+                // controller signal never arrived, this accepted attempt ended unexpectedly.
                 phase = .inactive
-                return .none
+                return .installFailed
             }
 
         case .awaitingResult:
             switch state {
             case .updateAvailable:
-                phase = .inactive
+                phase = .startingDownload
                 return .confirmInstall
-            case .idle, .notFound, .error:
-                // The fresh check ended without resolving an update: it was cancelled (the user hit
-                // Cancel in the checking popover, which returns the model to idle), found nothing,
-                // or errored. Stop coordinating so a later unrelated check is not auto-confirmed
-                // without the user asking to install.
+            case .idle, .notFound:
+                phase = .inactive
+                return .installFailed
+            case .error:
                 phase = .inactive
                 return .none
-            case .checking, .downloading, .extracting, .installing, .permissionRequest:
+            case .downloading, .extracting, .installing:
+                phase = .inactive
                 return .none
+            case .preparingCheck, .checking, .permissionRequest, .startingDownload:
+                return .none
+            }
+
+        case .startingDownload:
+            switch state {
+            case .downloading, .extracting, .installing:
+                phase = .inactive
+                return .none
+            case .error:
+                phase = .inactive
+                return .none
+            case .startingDownload:
+                return .none
+            case .idle, .preparingCheck, .checking, .updateAvailable, .notFound, .permissionRequest:
+                phase = .inactive
+                return .installFailed
             }
         }
     }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/DebugUpdateErrorScenario.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/DebugUpdateErrorScenario.swift
@@ -1,0 +1,122 @@
+#if DEBUG
+import Foundation
+@preconcurrency import Sparkle
+
+/// A synthetic update-error scenario that the debug menu can inject so every error popover
+/// variant can be previewed without reproducing the real failure.
+public enum DebugUpdateErrorScenario: String, CaseIterable, Hashable, Sendable {
+    /// Sparkle installation failure wrapping its internal updater-agent timeout.
+    case installerAgentFailure
+    /// Sparkle updater-agent invalidation.
+    case agentInvalidation
+    /// Generic Sparkle installation failure with no nested agent failure.
+    case genericInstallFailure
+    /// Sparkle installation failure wrapping an authorization failure.
+    case installFailureWrappingAuth
+    /// Sparkle update download failure.
+    case downloadFailure
+    /// The app is running from a translocated disk image.
+    case diskImageTranslocation
+    /// Sparkle could not verify the update signature.
+    case signatureError
+    /// The update server is unreachable because the network is offline.
+    case noInternet
+    /// cmux accepted an install but never reached the download callback.
+    case installDidNotStart
+    /// Sparkle did not become ready for a foreground check before the deadline.
+    case updaterNotReady
+
+    /// The label shown for this scenario in the debug menu.
+    public var menuTitle: String {
+        switch self {
+        case .installerAgentFailure:
+            return String(localized: "update.debug.error.installerAgentFailure", defaultValue: "Installer Agent Failure (4005 + timeout)")
+        case .agentInvalidation:
+            return String(localized: "update.debug.error.agentInvalidation", defaultValue: "Agent Invalidation (4010)")
+        case .genericInstallFailure:
+            return String(localized: "update.debug.error.genericInstallFailure", defaultValue: "Generic Install Failure (4005)")
+        case .installFailureWrappingAuth:
+            return String(localized: "update.debug.error.installFailureWrappingAuth", defaultValue: "Install Failure / Auth (4005→4001)")
+        case .downloadFailure:
+            return String(localized: "update.debug.error.downloadFailure", defaultValue: "Download Failure (2001)")
+        case .diskImageTranslocation:
+            return String(localized: "update.debug.error.diskImageTranslocation", defaultValue: "Disk Image / Translocated (1003)")
+        case .signatureError:
+            return String(localized: "update.debug.error.signatureError", defaultValue: "Signature Error (3001)")
+        case .noInternet:
+            return String(localized: "update.debug.error.noInternet", defaultValue: "No Internet")
+        case .installDidNotStart:
+            return String(
+                localized: "update.debug.error.installDidNotStart",
+                defaultValue: "Install Didn’t Start (watchdog)"
+            )
+        case .updaterNotReady:
+            return String(
+                localized: "update.debug.error.updaterNotReady",
+                defaultValue: "Updater Not Ready (readiness timeout)"
+            )
+        }
+    }
+
+    /// Builds the synthetic error for this scenario.
+    var error: NSError {
+        switch self {
+        case .installerAgentFailure:
+            let underlying = NSError(domain: SUSparkleErrorDomain, code: 10, userInfo: [
+                NSLocalizedDescriptionKey: "Timeout: agent connection was never initiated",
+            ])
+            return NSError(domain: SUSparkleErrorDomain, code: 4005, userInfo: [
+                NSLocalizedDescriptionKey: "An error occurred while running the updater. Please try again later.",
+                NSLocalizedFailureReasonErrorKey: "The remote port connection was invalidated from the updater.",
+                NSUnderlyingErrorKey: underlying,
+            ])
+        case .agentInvalidation:
+            return NSError(domain: SUSparkleErrorDomain, code: 4010, userInfo: [
+                NSLocalizedDescriptionKey: "The updater agent was invalidated.",
+            ])
+        case .genericInstallFailure:
+            return NSError(domain: SUSparkleErrorDomain, code: 4005, userInfo: [
+                NSLocalizedDescriptionKey: "The installation failed.",
+            ])
+        case .installFailureWrappingAuth:
+            let underlying = NSError(domain: SUSparkleErrorDomain, code: 4001, userInfo: [
+                NSLocalizedDescriptionKey: "Authorization failed.",
+            ])
+            return NSError(domain: SUSparkleErrorDomain, code: 4005, userInfo: [
+                NSLocalizedDescriptionKey: "An error occurred while installing the update.",
+                NSUnderlyingErrorKey: underlying,
+            ])
+        case .downloadFailure:
+            return NSError(domain: SUSparkleErrorDomain, code: 2001, userInfo: [
+                NSLocalizedDescriptionKey: "The update download failed.",
+            ])
+        case .diskImageTranslocation:
+            return NSError(domain: SUSparkleErrorDomain, code: 1003, userInfo: [
+                NSLocalizedDescriptionKey: "Running from a disk image.",
+            ])
+        case .signatureError:
+            return NSError(domain: SUSparkleErrorDomain, code: 3001, userInfo: [
+                NSLocalizedDescriptionKey: "The update signature is invalid.",
+            ])
+        case .noInternet:
+            return NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: [
+                NSLocalizedDescriptionKey: "The Internet connection appears to be offline.",
+            ])
+        case .installDidNotStart:
+            return NSError(domain: UpdateStateModel.updateErrorDomain, code: UpdateStateModel.installDidNotStartCode, userInfo: [
+                NSLocalizedDescriptionKey: String(
+                    localized: "update.error.didNotStart.message",
+                    defaultValue: "cmux couldn’t start the update. Check your internet connection and try again."
+                ),
+            ])
+        case .updaterNotReady:
+            return NSError(domain: UpdateStateModel.updateErrorDomain, code: UpdateStateModel.updaterNotReadyCode, userInfo: [
+                NSLocalizedDescriptionKey: String(
+                    localized: "update.error.notReady",
+                    defaultValue: "Updater is still starting. Try again in a moment."
+                ),
+            ])
+        }
+    }
+}
+#endif

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/InstallWatchdog.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/InstallWatchdog.swift
@@ -5,9 +5,9 @@ import Foundation
 /// When the user clicks Install, ``UpdateController`` arms this watchdog with a bounded,
 /// cancellable deadline (``installWatchdogTimeout``). If the flow reaches a state
 /// that either progresses the install or communicates a clear outcome, the controller disarms it.
-/// If the deadline elapses while the flow is still merely checking or showing "Update Available"
-/// with nothing downloading, the controller surfaces a visible "Update Didn't Start" error rather
-/// than leaving the user staring at a pill that never advances.
+/// If the deadline elapses before Sparkle reports download progress or another visible terminal,
+/// the controller surfaces a visible "Update Didn't Start" error rather than leaving the user
+/// staring at a pill that never advances.
 ///
 /// The watchdog owns only its timer; the *decision* of what counts as stalled vs. resolved lives
 /// in the two pure, exhaustively-tested static predicates below, and the error-surfacing side
@@ -58,15 +58,14 @@ final class InstallWatchdog {
     /// Whether `state`, observed when the watchdog fires, means the install never got going: the
     /// user asked to install but the flow is still merely checking, showing "Update Available",
     /// or sitting at `.idle` with no download underway. `.idle` counts as stalled because every
-    /// legitimate way to be idle at the deadline disarms first (a user-cancelled fresh check ends
-    /// the attempt via ``attemptEndedWithoutInstall(action:isCoordinatorMonitoring:)``; terminal
-    /// outcomes disarm via ``installAttemptResolved(_:)``) — so an armed deadline firing at idle
-    /// is the pre-check stall where the delayed re-check was dropped and `.checking` never came.
+    /// legitimate way to be idle at the deadline disarms first (causal user-cancel callbacks end
+    /// the attempt; terminal outcomes disarm via ``installAttemptResolved(_:)``) — so an armed
+    /// deadline firing at idle is an unattributed accepted-install failure.
     /// `.permissionRequest` stays not-stalled (a state cmux never surfaces; erroring over it
     /// would be wrong if Sparkle ever did).
     func installAttemptStalled(_ state: UpdateState) -> Bool {
         switch state {
-        case .checking, .updateAvailable, .idle:
+        case .preparingCheck, .checking, .updateAvailable, .startingDownload, .idle:
             return true
         case .permissionRequest, .downloading, .extracting, .installing, .notFound, .error:
             return false
@@ -79,15 +78,14 @@ final class InstallWatchdog {
         switch state {
         case .downloading, .extracting, .installing, .notFound, .error:
             return true
-        case .idle, .permissionRequest, .checking, .updateAvailable:
+        case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable, .startingDownload:
             return false
         }
     }
 
     /// Whether feeding a state change to ``AttemptUpdateCoordinator`` just ended the install
     /// attempt without handing an install to Sparkle: the coordinator stopped monitoring for any
-    /// reason other than `.confirmInstall` (the user cancelled the fresh check back to idle, or
-    /// it terminated in notFound/error). The watchdog is bound to the attempt that armed it, so
+    /// reason other than `.confirmInstall`. The watchdog is bound to the attempt that armed it, so
     /// the controller disarms on this — a deadline that outlives its attempt would otherwise fire
     /// a spurious "Update Didn't Start" over a later, unrelated check that happens to be sitting
     /// in `.checking`/`.updateAvailable`.

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateCheckCancellationSource.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateCheckCancellationSource.swift
@@ -1,0 +1,8 @@
+/// Why cmux ended an in-progress update check.
+///
+/// Explicit cancellation ends user-owned lifecycle state. Superseding a check is an internal
+/// transition and must not be mistaken for the user abandoning an accepted install.
+enum UpdateCheckCancellationSource {
+    case user
+    case superseded
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateCheckIntent.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateCheckIntent.swift
@@ -1,0 +1,11 @@
+/// The user-visible operation a foreground Sparkle check is serving.
+@MainActor
+enum UpdateCheckIntent: String {
+    case manual
+    case installLatest
+
+    /// An accepted install always wins over a coincident plain check.
+    func merged(with newer: UpdateCheckIntent) -> UpdateCheckIntent {
+        self == .installLatest || newer == .installLatest ? .installLatest : .manual
+    }
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -208,16 +208,52 @@ extension UpdateController: UpdateDriverEventDelegate {
             return
         }
 
-        guard finishedIntent == .installLatest, attemptCoordinator.isMonitoring else { return }
-        switch model.state {
-        case .downloading, .extracting, .installing, .error:
+        if finishedIntent == .installLatest, attemptCoordinator.isMonitoring {
+            switch model.state {
+            case .downloading, .extracting, .installing, .error:
+                return
+            case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable,
+                    .notFound, .startingDownload:
+                setInstallDidNotStartError(
+                    diagnostic: "accepted install cycle finished before download (check=\(updateCheck.rawValue), error=\(error.map(driver.formatErrorForLog) ?? "none"))"
+                )
+            }
             return
-        case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable,
-                .notFound, .startingDownload:
-            setInstallDidNotStartError(
-                diagnostic: "accepted install cycle finished before download (check=\(updateCheck.rawValue), error=\(error.map(driver.formatErrorForLog) ?? "none"))"
-            )
         }
+
+        guard finishedIntent == .manual else { return }
+        switch model.state {
+        case .idle, .notFound, .error, .downloading, .extracting, .installing:
+            return
+        case .permissionRequest, .preparingCheck, .checking, .updateAvailable, .startingDownload:
+            setForegroundCycleEndedError(updateCheck: updateCheck, underlyingError: error)
+        }
+    }
+
+    private func setForegroundCycleEndedError(updateCheck: SPUUpdateCheck, underlyingError: NSError?) {
+        let diagnostic = underlyingError.map(driver.formatErrorForLog) ?? "none"
+        log.append(
+            "manual update cycle ended without a visible terminal (check=\(updateCheck.rawValue), state=\(describeLifecycleState(model.state)), error=\(diagnostic))"
+        )
+        let error = underlyingError ?? NSError(
+            domain: UpdateStateModel.updateErrorDomain,
+            code: UpdateStateModel.foregroundCycleEndedCode,
+            userInfo: [NSLocalizedDescriptionKey: String(
+                localized: "update.error.failed.message",
+                defaultValue: "Something went wrong while checking for updates. Try again, or check the update log for details."
+            )]
+        )
+        model.clearDetectedUpdate()
+        model.setState(.error(.init(
+            error: error,
+            retry: { [weak self] in
+                self?.model.setState(.idle)
+                self?.checkForUpdates()
+            },
+            dismiss: { [weak self] in self?.model.setState(.idle) },
+            technicalDetails: underlyingError.map(driver.formatErrorForLog),
+            feedURLString: driver.resolvedFeedURLString()
+        )))
     }
 
     func updateDriverUserDidCancelCheck() {

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -44,7 +44,12 @@ extension UpdateController {
         }
 
         cancelReadinessRetry()
-        startUpdaterIfNeeded()
+        guard startUpdaterIfNeeded(retryAfterFailure: { [weak self] in
+            self?.requestUpdateCheck(intent)
+        }) else {
+            log.append("update check halted because updater startup failed (intent=\(intent.rawValue))")
+            return
+        }
         ensureSparkleInstallationCache()
 
         if mustFinishCurrentCycleBeforeChecking {
@@ -128,6 +133,13 @@ extension UpdateController {
                 remaining -= 1
                 try? await self.clock.sleep(for: self.readyRetryDelay)
                 if Task.isCancelled { return }
+            }
+
+            // Read once more after the final bounded wait. Readiness may have changed during that
+            // last suspension, and reporting a timeout without observing it would drop the check.
+            if self.updater.canCheckForUpdates, !self.updater.sessionInProgress {
+                self.startPendingCheck()
+                return
             }
 
             guard let intent = self.pendingCheckIntent else { return }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+Checking.swift
@@ -1,0 +1,240 @@
+import Foundation
+@preconcurrency import Sparkle
+
+/// Foreground update-check lifecycle. A single owner serializes manual checks and accepted
+/// installs across Sparkle sessions; replacement checks start only after Sparkle's authoritative
+/// cycle-finished callback.
+extension UpdateController {
+    /// Check for updates (used by the menu item).
+    public func checkForUpdates() {
+        requestUpdateCheck(.manual)
+    }
+
+    /// Check for updates using the custom popover-based UI.
+    public func checkForUpdatesInCustomUI() {
+        requestUpdateCheck(.manual)
+    }
+
+    func requestUpdateCheck(_ intent: UpdateCheckIntent) {
+        // A coincident menu check must not downgrade ownership after the user already accepted an
+        // install. It may replace the transport session, but its result still serves that install.
+        let intent = attemptCoordinator.isMonitoring ? UpdateCheckIntent.installLatest : intent
+        log.append(
+            "update check requested (intent=\(intent.rawValue), session=\(updater.sessionInProgress), state=\(describeLifecycleState(model.state)))"
+        )
+
+        switch model.state {
+        case .startingDownload, .downloading, .extracting, .installing:
+            log.append("update check ignored while install is progressing (intent=\(intent.rawValue))")
+            return
+        default:
+            break
+        }
+
+        if isDevLikeBundle {
+            // DEV/staging builds are not on the public release train (#6292).
+            log.append("manual update check suppressed (dev/staging build, intent=\(intent.rawValue))")
+            cancelReadinessRetry()
+            pendingCheckIntent = nil
+            activeCheckIntent = nil
+            attemptCoordinator.cancel()
+            installWatchdog.disarm()
+            model.setState(.notFound(.init(acknowledgement: {})))
+            return
+        }
+
+        cancelReadinessRetry()
+        startUpdaterIfNeeded()
+        ensureSparkleInstallationCache()
+
+        if mustFinishCurrentCycleBeforeChecking {
+            queueReplacementCheck(intent)
+            return
+        }
+
+        beginCheckWhenReady(intent)
+    }
+
+    private var mustFinishCurrentCycleBeforeChecking: Bool {
+        if updater.sessionInProgress || activeCheckIntent != nil {
+            return true
+        }
+        switch model.state {
+        case .checking, .updateAvailable:
+            // The model is also a defensive signal for tests and for any brief lag in Sparkle's
+            // sessionInProgress observation.
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func queueReplacementCheck(_ intent: UpdateCheckIntent) {
+        pendingCheckIntent = pendingCheckIntent?.merged(with: intent) ?? intent
+        log.append(
+            "replacement check queued (intent=\(pendingCheckIntent?.rawValue ?? intent.rawValue), active=\(activeCheckIntent?.rawValue ?? "external"))"
+        )
+
+        guard case .preparingCheck = model.state else {
+            showPreparingCheck()
+            return
+        }
+    }
+
+    private func beginCheckWhenReady(_ intent: UpdateCheckIntent) {
+        pendingCheckIntent = intent
+        let canCheck = updater.canCheckForUpdates
+        log.append(
+            "foreground check readiness (intent=\(intent.rawValue), canCheck=\(canCheck), session=\(updater.sessionInProgress))"
+        )
+        guard canCheck, !updater.sessionInProgress else {
+            showPreparingCheck()
+            waitForReadinessThenCheck()
+            return
+        }
+        startPendingCheck()
+    }
+
+    private func startPendingCheck() {
+        guard let intent = pendingCheckIntent else { return }
+        pendingCheckIntent = nil
+        activeCheckIntent = intent
+        if intent == .installLatest {
+            attemptCoordinator.didStartFreshCheck()
+        }
+        showPreparingCheck()
+        log.append("starting foreground Sparkle check (intent=\(intent.rawValue))")
+        updater.checkForUpdates()
+    }
+
+    private func showPreparingCheck() {
+        if case .preparingCheck = model.state { return }
+        let state = UpdateState.preparingCheck(.init(cancellationHandler: { [weak self] source in
+            guard source == .user else { return }
+            self?.cancelQueuedCheckByUser()
+        }))
+        model.replaceActiveState(with: state)
+    }
+
+    private func waitForReadinessThenCheck() {
+        readyCheckTask = Task { @MainActor [weak self] in
+            guard let self else { return }
+            var remaining = self.readyRetryCount
+            while remaining > 0 {
+                if self.updater.canCheckForUpdates, !self.updater.sessionInProgress {
+                    self.startPendingCheck()
+                    return
+                }
+                remaining -= 1
+                try? await self.clock.sleep(for: self.readyRetryDelay)
+                if Task.isCancelled { return }
+            }
+
+            guard let intent = self.pendingCheckIntent else { return }
+            self.pendingCheckIntent = nil
+            self.log.append(
+                "foreground check readiness timed out (intent=\(intent.rawValue), session=\(self.updater.sessionInProgress))"
+            )
+            if intent == .installLatest {
+                self.attemptCoordinator.cancel()
+                self.installWatchdog.disarm()
+                self.setUpdaterNotReadyError(retry: { [weak self] in self?.attemptUpdate() })
+            } else {
+                self.setUpdaterNotReadyError(retry: { [weak self] in self?.checkForUpdates() })
+            }
+        }
+    }
+
+    private func cancelQueuedCheckByUser() {
+        let intent = pendingCheckIntent
+        log.append("queued update check cancelled by user (intent=\(intent?.rawValue ?? "none"))")
+        pendingCheckIntent = nil
+        activeCheckIntent = nil
+        cancelReadinessRetry()
+        attemptCoordinator.cancel()
+        installWatchdog.disarm()
+        model.setState(.idle)
+    }
+
+    private func setUpdaterNotReadyError(retry: @escaping () -> Void) {
+        let error = NSError(
+            domain: UpdateStateModel.updateErrorDomain,
+            code: UpdateStateModel.updaterNotReadyCode,
+            userInfo: [NSLocalizedDescriptionKey: String(
+                localized: "update.error.notReady",
+                defaultValue: "Updater is still starting. Try again in a moment."
+            )]
+        )
+        model.setState(.error(.init(
+            error: error,
+            retry: retry,
+            dismiss: { [weak self] in self?.model.setState(.idle) }
+        )))
+    }
+
+    func cancelReadinessRetry() {
+        readyCheckTask?.cancel()
+        readyCheckTask = nil
+    }
+
+    private func describeLifecycleState(_ state: UpdateState) -> String {
+        switch state {
+        case .idle: return "idle"
+        case .permissionRequest: return "permissionRequest"
+        case .preparingCheck: return "preparingCheck"
+        case .checking: return "checking"
+        case .updateAvailable: return "updateAvailable"
+        case .notFound: return "notFound"
+        case .error: return "error"
+        case .startingDownload: return "startingDownload"
+        case .downloading: return "downloading"
+        case .extracting: return "extracting"
+        case .installing: return "installing"
+        }
+    }
+}
+
+extension UpdateController: UpdateDriverEventDelegate {
+    func updateDriverDidFinishCycle(_ updateCheck: SPUUpdateCheck, error: NSError?) {
+        let finishedIntent = activeCheckIntent
+        activeCheckIntent = nil
+        log.append(
+            "controller observed cycle finish (check=\(updateCheck.rawValue), active=\(finishedIntent?.rawValue ?? "external"), pending=\(pendingCheckIntent?.rawValue ?? "none"), state=\(describeLifecycleState(model.state)), error=\(error?.code.description ?? "none"))"
+        )
+
+        if pendingCheckIntent != nil {
+            cancelReadinessRetry()
+            beginCheckWhenReady(pendingCheckIntent!)
+            return
+        }
+
+        guard finishedIntent == .installLatest, attemptCoordinator.isMonitoring else { return }
+        switch model.state {
+        case .downloading, .extracting, .installing, .error:
+            return
+        case .idle, .permissionRequest, .preparingCheck, .checking, .updateAvailable,
+                .notFound, .startingDownload:
+            setInstallDidNotStartError(
+                diagnostic: "accepted install cycle finished before download (check=\(updateCheck.rawValue), error=\(error.map(driver.formatErrorForLog) ?? "none"))"
+            )
+        }
+    }
+
+    func updateDriverUserDidCancelCheck() {
+        log.append("controller observed explicit user check cancellation")
+        activeCheckIntent = nil
+        pendingCheckIntent = nil
+        cancelReadinessRetry()
+        attemptCoordinator.cancel()
+        installWatchdog.disarm()
+    }
+
+    func updateDriverUserDidDismissPrompt() {
+        log.append("controller observed explicit user prompt dismissal")
+        activeCheckIntent = nil
+        pendingCheckIntent = nil
+        cancelReadinessRetry()
+        attemptCoordinator.cancel()
+        installWatchdog.disarm()
+    }
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController+InstallAttempt.swift
@@ -26,20 +26,20 @@ extension UpdateController {
 
     private func fireInstallWatchdogIfStalled() {
         installWatchdog.disarm()
-        let attemptWasMonitoring = attemptCoordinator.isMonitoring
-        // The attempt is over regardless of what shows below: a coordinator left monitoring past
-        // its deadline would silently auto-confirm an install off a later, unrelated check.
-        attemptCoordinator.cancel()
         guard installWatchdog.installAttemptStalled(model.state) else { return }
-        log.append("install watchdog fired: update did not start within \(Int(installWatchdog.timeoutSeconds))s")
-        if attemptWasMonitoring {
-            // Resolve the in-flight Sparkle session (reply .dismiss to a pending "Update
-            // Available" prompt / cancel a running check) before replacing the state, so Sparkle
-            // is not left waiting on a dropped callback. Skipped post-confirm: that prompt's
-            // reply was already consumed by `.install`. The driver ignores Sparkle's follow-up
-            // dismiss callback while an error is visible, so the error state set below survives.
-            model.cancelActiveStateForNewCheck()
-        }
+        setInstallDidNotStartError(
+            diagnostic: "install watchdog fired after \(Int(installWatchdog.timeoutSeconds))s (state=\(model.state))"
+        )
+    }
+
+    /// Ends the accepted-install lifecycle with an actionable retry instead of an empty pill.
+    func setInstallDidNotStartError(diagnostic: String) {
+        installWatchdog.disarm()
+        cancelReadinessRetry()
+        attemptCoordinator.cancel()
+        pendingCheckIntent = nil
+        activeCheckIntent = nil
+        log.append("accepted update did not start: \(diagnostic)")
         let error = NSError(
             domain: UpdateStateModel.updateErrorDomain,
             code: UpdateStateModel.installDidNotStartCode,
@@ -48,7 +48,7 @@ extension UpdateController {
                 defaultValue: "cmux couldn’t start the update. Check your internet connection and try again."
             )]
         )
-        model.setState(.error(.init(
+        let errorState = UpdateState.error(.init(
             error: error,
             retry: { [weak self] in
                 self?.model.setState(.idle)
@@ -60,7 +60,12 @@ extension UpdateController {
                 defaultValue: "Install attempt stalled without reaching download."
             ),
             feedURLString: driver.resolvedFeedURLString()
-        )))
+        ))
+        // Publish the actionable terminal before ending whichever Sparkle callback it replaces.
+        // Sparkle may synchronously emit its identity-free dismissal while the reply/cancellation
+        // runs; because the error is already visible and that callback is diagnostic-only, there
+        // is no empty-pill window and no unresolved session left behind.
+        model.replaceActiveState(with: errorState)
     }
 
     func performAttemptAction(_ action: AttemptUpdateCoordinator.Action) {
@@ -68,21 +73,35 @@ extension UpdateController {
         case .none:
             break
         case .startFreshCheck:
-            checkForUpdates()
+            requestUpdateCheck(.installLatest)
         case .confirmInstall:
             // Reactions process drained snapshots, so the live state can have moved past the
             // snapshot that produced this action. Confirm only a live "Update Available" prompt
             // (its reply is unconsumed; a snapshot's may already have been answered). If the
             // prompt vanished in the meantime (e.g. the user dismissed it mid-drain), the
-            // attempt is over — disarm the watchdog so the leftover deadline can't fire a
-            // spurious "Update Didn't Start" over whatever the user does next.
+            // causal source distinguishes that explicit choice from an un-attributed loss.
             if case .updateAvailable(let available) = model.state, !available.reply.isConsumed {
-                log.append("attemptUpdate installing freshly resolved update")
-                model.state.confirm()
-            } else {
-                log.append("attemptUpdate hand-off skipped (prompt no longer showing)")
+                log.append(
+                    "attemptUpdate accepted freshly resolved update (version=\(available.appcastItem.displayVersionString), prompt=\(available.reply.id))"
+                )
+                // Publish ownership before invoking Sparkle because its callbacks may be
+                // synchronous. The pill stays visible until download or a retryable error.
+                model.setState(.startingDownload)
+                available.reply.consume(.install, source: .installAttempt)
+            } else if case .updateAvailable(let available) = model.state,
+                      available.reply.consumedSource == .user {
+                log.append("attemptUpdate hand-off cancelled by explicit user prompt choice")
+                attemptCoordinator.cancel()
                 installWatchdog.disarm()
+            } else {
+                setInstallDidNotStartError(
+                    diagnostic: "fresh prompt disappeared before install reply (state=\(model.state))"
+                )
             }
+        case .installFailed:
+            setInstallDidNotStartError(
+                diagnostic: "accepted install reached unexpected terminal state (state=\(model.state))"
+            )
         }
     }
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -239,8 +239,16 @@ public final class UpdateController {
     // MARK: - Updater lifecycle
 
     /// Start the updater. If startup fails, the error is shown via the custom UI.
-    public func startUpdaterIfNeeded() {
-        guard !didStartUpdater else { return }
+    @discardableResult
+    public func startUpdaterIfNeeded() -> Bool {
+        startUpdaterIfNeeded(retryAfterFailure: { [weak self] in
+            self?.startUpdaterIfNeeded()
+        })
+    }
+
+    @discardableResult
+    func startUpdaterIfNeeded(retryAfterFailure: @escaping () -> Void) -> Bool {
+        guard !didStartUpdater else { return true }
         ensureSparkleInstallationCache()
 #if DEBUG
         // Keep the permission-related defaults resettable for UI tests even though the
@@ -270,18 +278,20 @@ public final class UpdateController {
                 "updater started (autoChecks=\(updater.automaticallyChecksForUpdates), interval=\(interval)s, autoDownloads=\(updater.automaticallyDownloadsUpdates))"
             )
             startLaunchUpdateProbeIfNeeded()
+            return true
         } catch {
             model.setState(.error(.init(
                 error: error,
                 retry: { [weak self] in
                     self?.model.setState(.idle)
                     self?.didStartUpdater = false
-                    self?.startUpdaterIfNeeded()
+                    retryAfterFailure()
                 },
                 dismiss: { [weak self] in
                     self?.model.setState(.idle)
                 }
             )))
+            return false
         }
     }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateController.swift
@@ -17,19 +17,18 @@ public import Foundation
 /// concrete ``UpdateLogging`` and ``UpdateActionDelegate``.
 @MainActor
 public final class UpdateController {
-    private let updater: any UpdaterHandle
+    let updater: any UpdaterHandle
     // `driver` and `log` are internal (not private) so `UpdateController+InstallAttempt.swift`
     // can reach them; they stay module-internal.
     let driver: UpdateDriver
     let log: any UpdateLogging
-    private let clock: any UpdateClock
+    let clock: any UpdateClock
     private let defaults: UserDefaults
     private let fileManager: FileManager
     private let hostBundle: Bundle
-    private let backgroundProbeInterval: TimeInterval
     /// Whether the running build is a cmux DEV/staging build that must never be compared against
     /// the public release appcast. See ``isDevLikeBundleIdentifier(_:)``.
-    private let isDevLikeBundle: Bool
+    let isDevLikeBundle: Bool
 
     /// Host actions the updater delegates upward (retry, relaunch prep). Forwarded to the driver.
     public weak var actionDelegate: (any UpdateActionDelegate)? {
@@ -43,8 +42,8 @@ public final class UpdateController {
     var attemptCoordinator = AttemptUpdateCoordinator()
     private var stateReactionTask: Task<Void, Never>?
     private var noUpdateDismissTask: Task<Void, Never>?
-    private var backgroundProbeTask: Task<Void, Never>?
-    private var recheckTask: Task<Void, Never>?
+    var pendingCheckIntent: UpdateCheckIntent?
+    var activeCheckIntent: UpdateCheckIntent?
     /// Armed when the user asks to install; fires a visible "Update Didn't Start" error if the
     /// flow never reaches downloading/installing (or another visible outcome). See
     /// ``attemptUpdate`` in `UpdateController+InstallAttempt.swift` (internal for that file).
@@ -55,9 +54,9 @@ public final class UpdateController {
     // value into the change handler, and `addObserver(_:forKeyPath:)` is forbidden), so
     // readiness is awaited with a bounded retry on the injected clock — behavior-identical to
     // the original 0.25s x 20 poll, cancellable, and testable with a fake clock.
-    private var readyCheckTask: Task<Void, Never>?
-    private let readyRetryDelay: Duration = .milliseconds(250)
-    private let readyRetryCount = 20
+    var readyCheckTask: Task<Void, Never>?
+    let readyRetryDelay: Duration = .milliseconds(250)
+    let readyRetryCount = 20
 
     private var didStartUpdater = false
 
@@ -120,7 +119,6 @@ public final class UpdateController {
         self.defaults = defaults
         self.fileManager = fileManager
         self.hostBundle = hostBundle
-        self.backgroundProbeInterval = settings.scheduledCheckInterval
         let isDevLikeBundle = isDevLikeBundle ?? Self.isDevLikeBundleIdentifier(hostBundle.bundleIdentifier)
         self.isDevLikeBundle = isDevLikeBundle
         settings.apply(to: defaults)
@@ -129,9 +127,9 @@ public final class UpdateController {
             // builds are produced from local source and are not on the public release train, so
             // they must never query the public appcast. Turning off Sparkle's automatic checks
             // stops the passive vectors: Sparkle never schedules its own background checks, and
-            // cmux's launch/background probe is short-circuited by the `automaticallyChecksForUpdates`
-            // guard in `startLaunchUpdateProbeIfNeeded`. Manual "Check for Updates" is gated
-            // separately in `checkForUpdatesWhenReady`.
+            // cmux's immediate launch probe is short-circuited by the
+            // `automaticallyChecksForUpdates` guard. Foreground checks are gated separately by
+            // `requestUpdateCheck(_:)`.
             defaults.set(false, forKey: UpdateSettings.automaticChecksKey)
         }
 
@@ -140,15 +138,14 @@ public final class UpdateController {
         let driver = UpdateDriver(model: model, log: log, clock: clock, isDevLikeBundle: isDevLikeBundle)
         self.driver = driver
         self.updater = updaterFactory(driver, hostBundle)
+        driver.eventDelegate = self
         startStateReactions()
     }
 
     deinit {
         stateReactionTask?.cancel()
         noUpdateDismissTask?.cancel()
-        backgroundProbeTask?.cancel()
         readyCheckTask?.cancel()
-        recheckTask?.cancel()
         // installWatchdog cancels its own pending timer in its deinit (it is released with self).
     }
 
@@ -158,15 +155,25 @@ public final class UpdateController {
         let changes = model.stateChanges()
         stateReactionTask = Task { @MainActor [weak self] in
             if let self {
-                self.handleStateChange(self.model.state, overrideState: self.model.overrideState)
+                let initialChanges = self.model.drainPendingChanges()
+                if initialChanges.isEmpty {
+                    self.handleStateChange(self.model.state, overrideState: self.model.overrideState)
+                } else {
+                    // Construction and the first external mutation may land in the same actor
+                    // turn. Replay the mailbox instead of also handling the latest state up front;
+                    // doing both processes that state twice and can make an accepted install look
+                    // like a later stale prompt (#8368).
+                    for change in initialChanges {
+                        self.handleStateChange(change.state, overrideState: change.overrideState)
+                    }
+                }
             }
             for await _ in changes {
                 guard let self else { return }
                 // Drain every recorded transition in order rather than re-reading the latest
                 // state: two transitions landing before this task runs would otherwise conflate,
                 // and a control-flow consumer (the attempt coordinator) could miss the
-                // `.checking` restart signal entirely — the same ambiguity family as the
-                // double-idle install loop.
+                // `.checking` restart signal or attribute a stale terminal to the new session.
                 for change in self.model.drainPendingChanges() {
                     self.handleStateChange(change.state, overrideState: change.overrideState)
                 }
@@ -229,114 +236,6 @@ public final class UpdateController {
         }
     }
 
-    // MARK: - Checking
-
-    /// Check for updates (used by the menu item).
-    public func checkForUpdates() {
-        log.append("checkForUpdates invoked (state=\(model.state.isIdle ? "idle" : "busy"))")
-        checkForUpdatesWhenReady()
-    }
-
-    /// Check for updates using the custom popover-based UI.
-    public func checkForUpdatesInCustomUI() {
-        checkForUpdatesWhenReady()
-    }
-
-    private func performCheckForUpdates() {
-        startUpdaterIfNeeded()
-        ensureSparkleInstallationCache()
-        // Cancel any pending deferred re-check on every path so a stale one can't fire a
-        // duplicate checkForUpdates() after this new check starts.
-        recheckTask?.cancel()
-        if model.state == .idle {
-            updater.checkForUpdates()
-            return
-        }
-
-        model.cancelActiveStateForNewCheck()
-
-        // Give Sparkle a beat to tear down the just-dismissed check session before starting a
-        // new one. Without this delay the re-check is coalesced/dropped by Sparkle and the pill
-        // simply hides until the user checks again (a real regression caught in dogfood). This
-        // is a bounded, cancellable delay via the injected clock (matches the prior 100ms).
-        recheckTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            try? await self.clock.sleep(for: .milliseconds(100))
-            guard !Task.isCancelled else { return }
-            self.updater.checkForUpdates()
-        }
-    }
-
-    /// Check for updates once the updater reports it can.
-    private func checkForUpdatesWhenReady() {
-        if isDevLikeBundle {
-            // DEV/staging builds are not on the public release train. A manual check (menu,
-            // custom UI, or attempt-and-install) must not query the public appcast or offer the
-            // public release for install over a locally-built app. Surface "No Updates Available"
-            // without contacting the appcast or starting Sparkle. This is the shared entrypoint
-            // for every manual check path (#6292).
-            log.append("manual update check suppressed (dev/staging build)")
-            cancelReadinessRetry()
-            model.setState(.notFound(.init(acknowledgement: {})))
-            return
-        }
-        cancelReadinessRetry()
-        startUpdaterIfNeeded()
-        ensureSparkleInstallationCache()
-        let canCheck = updater.canCheckForUpdates
-        log.append("checkForUpdatesWhenReady invoked (canCheck=\(canCheck))")
-        if canCheck {
-            performCheckForUpdates()
-            return
-        }
-        if model.state.isIdle, !attemptCoordinator.isMonitoring {
-            model.setState(.checking(.init(cancel: {})))
-        }
-        waitForReadinessThenCheck()
-    }
-
-    private func waitForReadinessThenCheck() {
-        readyCheckTask = Task { @MainActor [weak self] in
-            guard let self else { return }
-            var remaining = self.readyRetryCount
-            while remaining > 0 {
-                if self.updater.canCheckForUpdates {
-                    self.performCheckForUpdates()
-                    return
-                }
-                remaining -= 1
-                // Bounded readiness wait on the injected clock (see property comment).
-                try? await self.clock.sleep(for: self.readyRetryDelay)
-                if Task.isCancelled { return }
-            }
-            self.log.append("checkForUpdatesWhenReady timed out")
-            if self.attemptCoordinator.isMonitoring {
-                self.log.append("updater readiness timed out during install attempt")
-                self.attemptCoordinator.cancel()
-                self.installWatchdog.disarm()
-                self.setUpdaterNotReadyError(retry: { [weak self] in self?.attemptUpdate() })
-                return
-            }
-            if case .checking = self.model.state {
-                self.setUpdaterNotReadyError(retry: { [weak self] in self?.checkForUpdates() })
-            }
-        }
-    }
-
-    private func setUpdaterNotReadyError(retry: @escaping () -> Void) {
-        let error = NSError(
-            domain: UpdateStateModel.updateErrorDomain,
-            code: UpdateStateModel.updaterNotReadyCode,
-            userInfo: [NSLocalizedDescriptionKey: String(localized: "update.error.notReady", defaultValue: "Updater is still starting. Try again in a moment.")]
-        )
-        model.setState(.error(.init(error: error, retry: retry, dismiss: { [weak self] in self?.model.setState(.idle) })))
-    }
-
-    private func cancelReadinessRetry() {
-        readyCheckTask?.cancel()
-        readyCheckTask = nil
-    }
-
     // MARK: - Updater lifecycle
 
     /// Start the updater. If startup fails, the error is shown via the custom UI.
@@ -392,8 +291,6 @@ public final class UpdateController {
             // appcast (init also disables Sparkle's own scheduled checks). Tear down any probe a
             // prior path may have started. See `isDevLikeBundleIdentifier(_:)` (#6292).
             log.append("launch update probe skipped (dev/staging build)")
-            backgroundProbeTask?.cancel()
-            backgroundProbeTask = nil
             return
         }
         guard updater.automaticallyChecksForUpdates else {
@@ -405,20 +302,6 @@ public final class UpdateController {
         // without waiting for Sparkle's scheduled check or opening interactive update UI.
         log.append("starting launch update probe")
         updater.checkForUpdateInformation()
-
-        // Re-probe periodically so the banner appears even if the app has been running for a
-        // while when a new version is published. Genuine periodic schedule via the clock.
-        backgroundProbeTask?.cancel()
-        backgroundProbeTask = Task { @MainActor [weak self] in
-            while !Task.isCancelled {
-                guard let interval = self?.backgroundProbeInterval else { return }
-                try? await self?.clock.sleep(for: .seconds(interval))
-                guard !Task.isCancelled, let self else { return }
-                guard self.updater.automaticallyChecksForUpdates else { continue }
-                self.log.append("periodic background update probe")
-                self.updater.checkForUpdateInformation()
-            }
-        }
     }
 
     private func recordUITestTimestamp(key: String) {
@@ -440,7 +323,7 @@ public final class UpdateController {
 #endif
     }
 
-    private func ensureSparkleInstallationCache() {
+    func ensureSparkleInstallationCache() {
         guard let bundleIdentifier = hostBundle.bundleIdentifier else { return }
         guard let cachesURL = fileManager.urls(for: .cachesDirectory, in: .userDomainMask).first else { return }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -69,7 +69,7 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     func handleDidFindValidUpdate(_ item: SUAppcastItem) {
         if isDevLikeBundle {
             // DEV/staging builds are not on the public release train. ``UpdateController`` already
-            // gates every known path (automatic checks, the launch/background probe, and manual
+            // gates every known path (automatic checks, the launch probe, and manual
             // checks), so this is the last-line defense: if any update is ever found for one of
             // these builds, clear it rather than surfacing the pill (#6292).
             model.clearDetectedUpdate()
@@ -92,7 +92,9 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
 
     /// Handles Sparkle's no-update delegate result without requiring a live `SPUUpdater` in tests.
     func handleDidNotFindUpdate(_ error: any Error) {
-        model.dismissDetectedAvailableUpdate()
+        // Delegate callbacks also arrive for automatic/informational probes. They may clear the
+        // passive detection cache, but must never answer or erase a foreground Sparkle prompt.
+        model.clearDetectedUpdate()
         let nsError = error as NSError
         let reasonValue = (nsError.userInfo[SPUNoUpdateFoundReasonKey] as? NSNumber)?.intValue
         let reason = reasonValue.map { SPUNoUpdateFoundReason(rawValue: OSStatus($0)) } ?? nil
@@ -105,6 +107,20 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
         } else {
             log.append("no update found (reason=\(reasonText), userInitiated=\(userInitiated), latest=\(latestVersion))")
         }
+    }
+
+    func updater(_ updater: SPUUpdater,
+                 didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+                 error: (any Error)?) {
+        handleDidFinishUpdateCycle(updateCheck, error: error)
+    }
+
+    /// Forwards Sparkle's authoritative session-finished signal to the lifecycle owner.
+    /// Extracted so the replacement-check race is testable without constructing `SPUUpdater`.
+    func handleDidFinishUpdateCycle(_ updateCheck: SPUUpdateCheck, error: (any Error)?) {
+        let errorText = error.map(formatErrorForLog) ?? "none"
+        log.append("update cycle finished (check=\(updateCheck.rawValue), error=\(errorText))")
+        eventDelegate?.updateDriverDidFinishCycle(updateCheck, error: error.map { $0 as NSError })
     }
 
     func updater(_ updater: SPUUpdater, userDidMake _: SPUUserUpdateChoice, forUpdate _: SUAppcastItem, state _: SPUUserUpdateState) {

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver+SPUUpdaterDelegate.swift
@@ -87,6 +87,11 @@ extension UpdateDriver: @preconcurrency SPUUpdaterDelegate {
     }
 
     func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: any Error) {
+        handleDidNotFindUpdate(error)
+    }
+
+    /// Handles Sparkle's no-update delegate result without requiring a live `SPUUpdater` in tests.
+    func handleDidNotFindUpdate(_ error: any Error) {
         model.dismissDetectedAvailableUpdate()
         let nsError = error as NSError
         let reasonValue = (nsError.userInfo[SPUNoUpdateFoundReasonKey] as? NSNumber)?.intValue

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -189,9 +189,10 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     }
 
     func dismissUpdateInstallation() {
-        // This callback has no prompt/session identity. Every user-driven terminal action already
-        // updates the model synchronously at its causal boundary, so mutating here could only let
-        // an old session erase a newer prompt or an accepted install (#8368).
+        // This callback has no prompt/session identity. User actions update the model at their
+        // causal boundary, and UpdateController reconciles unexpected active-session termination
+        // from Sparkle's authoritative cycle-finished callback. Mutating here could only let an old
+        // session erase a newer prompt or an accepted install (#8368).
         log.append("dismiss update installation observed (state=\(describe(model.state)); no state mutation)")
     }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -21,6 +21,8 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     let isDevLikeBundle: Bool
     /// Host actions the driver delegates upward. Held weak; set by ``UpdateController``.
     weak var actionDelegate: (any UpdateActionDelegate)?
+    /// Causal lifecycle signals consumed by ``UpdateController``.
+    weak var eventDelegate: (any UpdateDriverEventDelegate)?
 
     private let minimumCheckDuration: TimeInterval = UpdateTiming.minimumCheckDisplayDuration
     private let checkTimeoutDuration: TimeInterval = UpdateTiming.checkTimeoutDuration
@@ -28,7 +30,6 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     private var pendingCheckTransitionTask: Task<Void, Never>?
     private var checkTimeoutTask: Task<Void, Never>?
     private(set) var lastFeedURLString: String?
-    private var pendingPromptDismissCallbacks: [UUID] = []
 
     init(
         model: UpdateStateModel,
@@ -78,8 +79,8 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
                          reply: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
         log.append("show update found: \(appcastItem.displayVersionString)")
         let available = UpdateState.UpdateAvailable(appcastItem: appcastItem) { choice in reply(choice) }
-        available.reply.onDismissConsumed = { [weak self] reply in
-            self?.recordPromptDismissCallbackExpected(for: reply)
+        available.reply.onConsumed = { [weak self] reply, choice, source in
+            self?.handlePromptReply(reply, choice: choice, source: source)
         }
         setStateAfterMinimumCheckDelay(.updateAvailable(available))
     }
@@ -188,53 +189,27 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
     }
 
     func dismissUpdateInstallation() {
-        log.append("dismiss update installation")
-        let promptDismissCallback = takePromptDismissCallbackForCurrentState()
-        if case .error = model.state {
-            log.append("dismiss update installation ignored (error visible)")
+        // This callback has no prompt/session identity. Every user-driven terminal action already
+        // updates the model synchronously at its causal boundary, so mutating here could only let
+        // an old session erase a newer prompt or an accepted install (#8368).
+        log.append("dismiss update installation observed (state=\(describe(model.state)); no state mutation)")
+    }
+
+    func handlePromptReply(_ reply: UpdatePromptReply,
+                           choice: SPUUserUpdateChoice,
+                           source: UpdatePromptReplySource) {
+        log.append("update prompt reply consumed (choice=\(choice.rawValue), source=\(source.rawValue))")
+        guard source == .user, choice == .dismiss || choice == .skip else { return }
+
+        // Tell the lifecycle owner before emitting idle so an explicit user choice cannot be
+        // mistaken for an unattributed prompt loss during an accepted install.
+        eventDelegate?.updateDriverUserDidDismissPrompt()
+        guard case .updateAvailable(let available) = model.state,
+              available.reply.id == reply.id else {
+            log.append("user prompt reply did not match live prompt; preserving current state")
             return
-        }
-        if case .notFound = model.state {
-            log.append("dismiss update installation ignored (notFound visible)")
-            return
-        }
-        if case .checking = model.state {
-            log.append("dismiss update installation ignored (checking)")
-            return
-        }
-        if promptDismissCallback.expected && !promptDismissCallback.currentPrompt {
-            switch model.state {
-            case .updateAvailable(let available)
-                where !available.reply.isConsumed || available.reply.consumedChoice == .install:
-                // Sparkle can deliver a dismissed old prompt's teardown after a fresh check has
-                // already resolved or auto-confirmed a new prompt. Only this tracked callback may
-                // leave the new prompt alive; unexpected dismissals still clear it below.
-                log.append("dismiss update installation ignored (superseded prompt dismissal)")
-                return
-            case .downloading, .extracting, .installing:
-                log.append("dismiss update installation ignored (superseded prompt dismissal)")
-                return
-            default:
-                break
-            }
         }
         setState(.idle)
-    }
-
-    func recordPromptDismissCallbackExpected(for reply: UpdatePromptReply) {
-        pendingPromptDismissCallbacks.append(reply.id)
-    }
-
-    private func takePromptDismissCallbackForCurrentState() -> (expected: Bool, currentPrompt: Bool) {
-        guard !pendingPromptDismissCallbacks.isEmpty else { return (false, false) }
-        if case .updateAvailable(let available) = model.state {
-            if let index = pendingPromptDismissCallbacks.firstIndex(of: available.reply.id) {
-                pendingPromptDismissCallbacks.remove(at: index)
-                return (true, true)
-            }
-        }
-        pendingPromptDismissCallbacks.removeFirst()
-        return (true, false)
     }
 
     // MARK: - State transition helpers
@@ -246,7 +221,20 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
         checkTimeoutTask?.cancel()
         checkTimeoutTask = nil
         lastCheckStart = Date()
-        applyState(.checking(.init(cancel: cancel)))
+        applyState(.checking(.init(cancellationHandler: { [weak self] source in
+            guard let self else {
+                cancel()
+                return
+            }
+            self.log.append("update check cancellation requested (source=\(source))")
+            if source == .user {
+                self.eventDelegate?.updateDriverUserDidCancelCheck()
+            }
+            cancel()
+            if source == .user, case .checking = self.model.state {
+                self.setState(.idle)
+            }
+        })))
         scheduleCheckTimeout()
     }
 
@@ -353,6 +341,8 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
             return "idle"
         case .permissionRequest:
             return "permissionRequest"
+        case .preparingCheck:
+            return "preparingCheck"
         case .checking:
             return "checking"
         case .updateAvailable(let update):
@@ -361,6 +351,8 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
             return "notFound"
         case .error(let err):
             return "error(\(err.error.localizedDescription))"
+        case .startingDownload:
+            return "startingDownload"
         case .downloading(let download):
             if let expected = download.expectedLength, expected > 0 {
                 let percent = Double(download.progress) / Double(expected) * 100

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriver.swift
@@ -202,14 +202,15 @@ final class UpdateDriver: NSObject, @preconcurrency SPUUserDriver {
         log.append("update prompt reply consumed (choice=\(choice.rawValue), source=\(source.rawValue))")
         guard source == .user, choice == .dismiss || choice == .skip else { return }
 
-        // Tell the lifecycle owner before emitting idle so an explicit user choice cannot be
-        // mistaken for an unattributed prompt loss during an accepted install.
-        eventDelegate?.updateDriverUserDidDismissPrompt()
         guard case .updateAvailable(let available) = model.state,
               available.reply.id == reply.id else {
             log.append("user prompt reply did not match live prompt; preserving current state")
             return
         }
+
+        // Tell the lifecycle owner only after the structured prompt identity matches. A delayed
+        // action from an old prompt must not cancel a newer check or accepted install.
+        eventDelegate?.updateDriverUserDidDismissPrompt()
         setState(.idle)
     }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriverEventDelegate.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateDriverEventDelegate.swift
@@ -1,0 +1,18 @@
+import Foundation
+@preconcurrency import Sparkle
+
+/// Causal lifecycle signals that Sparkle exposes outside of `SPUUserDriver`'s display states.
+///
+/// The controller owns check/install intent. The driver forwards these signals so that intent is
+/// advanced by authoritative callbacks instead of inferred from UI state or elapsed time.
+@MainActor
+protocol UpdateDriverEventDelegate: AnyObject {
+    /// Sparkle ended an update session, so a queued replacement check may safely start.
+    func updateDriverDidFinishCycle(_ updateCheck: SPUUpdateCheck, error: NSError?)
+
+    /// The user explicitly cancelled the foreground check.
+    func updateDriverUserDidCancelCheck()
+
+    /// The user explicitly dismissed or skipped a foreground update prompt.
+    func updateDriverUserDidDismissPrompt()
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReply.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReply.swift
@@ -1,18 +1,6 @@
 import Foundation
 @preconcurrency public import Sparkle
 
-/// Why cmux consumed a Sparkle update prompt.
-///
-/// Sparkle's later `dismissUpdateInstallation` callback does not identify the prompt or the
-/// action that caused it. Recording the cause at the reply boundary lets the lifecycle owner
-/// distinguish an explicit user choice from a controller transition or accepted install.
-@MainActor
-enum UpdatePromptReplySource: String {
-    case user
-    case superseded
-    case installAttempt
-}
-
 /// A Sparkle prompt reply that can be sent at most once, with its consumption observable.
 ///
 /// Sparkle's update-choice callback must be invoked exactly once per prompt; double-replying is

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReply.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReply.swift
@@ -1,6 +1,18 @@
 import Foundation
 @preconcurrency public import Sparkle
 
+/// Why cmux consumed a Sparkle update prompt.
+///
+/// Sparkle's later `dismissUpdateInstallation` callback does not identify the prompt or the
+/// action that caused it. Recording the cause at the reply boundary lets the lifecycle owner
+/// distinguish an explicit user choice from a controller transition or accepted install.
+@MainActor
+enum UpdatePromptReplySource: String {
+    case user
+    case superseded
+    case installAttempt
+}
+
 /// A Sparkle prompt reply that can be sent at most once, with its consumption observable.
 ///
 /// Sparkle's update-choice callback must be invoked exactly once per prompt; double-replying is
@@ -12,10 +24,12 @@ import Foundation
 public final class UpdatePromptReply {
     let id = UUID()
     private var handler: (@Sendable (SPUUserUpdateChoice) -> Void)?
-    var onDismissConsumed: ((UpdatePromptReply) -> Void)?
+    var onConsumed: ((UpdatePromptReply, SPUUserUpdateChoice, UpdatePromptReplySource) -> Void)?
 
     /// The first choice sent to Sparkle, or `nil` until this prompt is answered.
     public private(set) var consumedChoice: SPUUserUpdateChoice?
+    /// The cause of the first choice, or `nil` until this prompt is answered.
+    private(set) var consumedSource: UpdatePromptReplySource?
 
     /// Wraps `handler` so it runs on the first call only.
     public init(_ handler: @escaping @Sendable (SPUUserUpdateChoice) -> Void) {
@@ -29,12 +43,16 @@ public final class UpdatePromptReply {
 
     /// Sends `choice` to Sparkle; subsequent calls are no-ops.
     public func callAsFunction(_ choice: SPUUserUpdateChoice) {
+        consume(choice, source: .user)
+    }
+
+    /// Sends an internally-caused choice to Sparkle; subsequent calls are no-ops.
+    func consume(_ choice: SPUUserUpdateChoice, source: UpdatePromptReplySource) {
         guard let handler = self.handler else { return }
         self.handler = nil
         consumedChoice = choice
-        if choice == .dismiss {
-            onDismissConsumed?(self)
-        }
+        consumedSource = source
+        onConsumed?(self, choice, source)
         handler(choice)
     }
 }

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReplySource.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdatePromptReplySource.swift
@@ -1,0 +1,11 @@
+/// Why cmux consumed a Sparkle update prompt.
+///
+/// Sparkle's later `dismissUpdateInstallation` callback does not identify the prompt or the
+/// action that caused it. Recording the cause at the reply boundary lets the lifecycle owner
+/// distinguish an explicit user choice from a controller transition or accepted install.
+@MainActor
+enum UpdatePromptReplySource: String {
+    case user
+    case superseded
+    case installAttempt
+}

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
@@ -1,11 +1,6 @@
 public import Foundation
 @preconcurrency public import Sparkle
 
-enum UpdateCheckCancellationSource {
-    case user
-    case superseded
-}
-
 /// The current phase of the custom (non-Sparkle-UI) update flow, with the per-phase payload
 /// needed to advance, cancel, or describe it.
 ///

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateState.swift
@@ -1,6 +1,11 @@
 public import Foundation
 @preconcurrency public import Sparkle
 
+enum UpdateCheckCancellationSource {
+    case user
+    case superseded
+}
+
 /// The current phase of the custom (non-Sparkle-UI) update flow, with the per-phase payload
 /// needed to advance, cancel, or describe it.
 ///
@@ -14,6 +19,8 @@ public enum UpdateState: Equatable {
     case idle
     /// Sparkle is asking whether to enable automatic checks (cmux suppresses this UI).
     case permissionRequest(PermissionRequest)
+    /// A requested check is waiting for updater readiness or an older Sparkle cycle to finish.
+    case preparingCheck(Checking)
     /// A check is in progress.
     case checking(Checking)
     /// An update was found and is awaiting the user's install/dismiss choice.
@@ -22,6 +29,8 @@ public enum UpdateState: Equatable {
     case notFound(NotFound)
     /// A check or install failed.
     case error(Error)
+    /// The user accepted the freshly resolved update and Sparkle is starting its download.
+    case startingDownload
     /// The update payload is downloading.
     case downloading(Downloading)
     /// The downloaded payload is being extracted/prepared.
@@ -39,8 +48,10 @@ public enum UpdateState: Equatable {
     /// by repeatedly confirming (checking through installing).
     public var isInstallable: Bool {
         switch self {
-        case .checking,
+        case .preparingCheck,
+                .checking,
                 .updateAvailable,
+                .startingDownload,
                 .downloading,
                 .extracting,
                 .installing:
@@ -53,7 +64,7 @@ public enum UpdateState: Equatable {
     /// Invokes the phase-appropriate cancellation/acknowledgement callback.
     @MainActor public func cancel() {
         switch self {
-        case .checking(let checking):
+        case .preparingCheck(let checking), .checking(let checking):
             checking.cancel()
         case .updateAvailable(let available):
             available.reply(.dismiss)
@@ -63,6 +74,20 @@ public enum UpdateState: Equatable {
             notFound.acknowledgement()
         case .error(let err):
             err.dismiss()
+        default:
+            break
+        }
+    }
+
+    /// Causally completes a Sparkle prompt/check after a newer visible state supersedes it.
+    @MainActor func finishAsSuperseded() {
+        switch self {
+        case .preparingCheck(let checking), .checking(let checking):
+            checking.cancelAsSuperseded()
+        case .updateAvailable(let available):
+            available.reply.consume(.dismiss, source: .superseded)
+        case .notFound(let notFound):
+            notFound.acknowledgement()
         default:
             break
         }
@@ -84,6 +109,8 @@ public enum UpdateState: Equatable {
             return true
         case (.permissionRequest, .permissionRequest):
             return true
+        case (.preparingCheck, .preparingCheck):
+            return true
         case (.checking, .checking):
             return true
         case (.updateAvailable(let lUpdate), .updateAvailable(let rUpdate)):
@@ -92,6 +119,8 @@ public enum UpdateState: Equatable {
             return true
         case (.error(let lErr), .error(let rErr)):
             return lErr.error.localizedDescription == rErr.error.localizedDescription
+        case (.startingDownload, .startingDownload):
+            return true
         case (.downloading(let lDown), .downloading(let rDown)):
             return lDown.progress == rDown.progress && lDown.expectedLength == rDown.expectedLength
         case (.extracting(let lExt), .extracting(let rExt)):
@@ -109,6 +138,8 @@ public enum UpdateState: Equatable {
         public let acknowledgement: () -> Void
 
         /// Creates the payload.
+        ///
+        /// - Parameter acknowledgement: Tells Sparkle the result was acknowledged.
         public init(acknowledgement: @escaping () -> Void) {
             self.acknowledgement = acknowledgement
         }
@@ -130,12 +161,27 @@ public enum UpdateState: Equatable {
 
     /// Payload for ``UpdateState/checking(_:)``.
     public struct Checking {
-        /// Cancels the in-progress check.
-        public let cancel: () -> Void
+        private let cancellationHandler: (UpdateCheckCancellationSource) -> Void
 
         /// Creates the payload.
+        ///
+        /// - Parameter cancel: Cancels the in-progress check.
         public init(cancel: @escaping () -> Void) {
-            self.cancel = cancel
+            self.cancellationHandler = { _ in cancel() }
+        }
+
+        init(cancellationHandler: @escaping (UpdateCheckCancellationSource) -> Void) {
+            self.cancellationHandler = cancellationHandler
+        }
+
+        /// Cancels a check at the user's request.
+        public func cancel() {
+            cancellationHandler(.user)
+        }
+
+        /// Cancels a superseded check without treating the controller transition as user intent.
+        func cancelAsSuperseded() {
+            cancellationHandler(.superseded)
         }
     }
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel.swift
@@ -51,6 +51,9 @@ public final class UpdateStateModel {
     /// `updateErrorDomain` code for "the user asked to install but the flow never started
     /// downloading" (the install-watchdog trip).
     public nonisolated static let installDidNotStartCode = 2
+    /// `updateErrorDomain` code for an active foreground check whose Sparkle session ended before
+    /// producing a visible result.
+    public nonisolated static let foregroundCycleEndedCode = 3
 
     // MARK: - Change stream
 

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdateStateModel.swift
@@ -136,12 +136,20 @@ public final class UpdateStateModel {
     /// Cancels whatever phase is active and returns the model to ``UpdateState/idle``,
     /// clearing any override. Used when starting a fresh check.
     public func cancelActiveStateForNewCheck() {
-        state.cancel()
-        // One conceptual transition: update both fields, then emit a single change notification
-        // (avoids two redundant stateChanges() emissions for one logical reset).
-        state = .idle
+        replaceActiveState(with: .idle)
+    }
+
+    /// Replaces the visible phase before causally ending the old Sparkle prompt/check.
+    ///
+    /// The order matters: Sparkle is allowed to synchronously call back while its cancellation
+    /// closure runs. Publishing the replacement first prevents that callback from exposing an
+    /// empty pill between an accepted install and its fresh check.
+    func replaceActiveState(with replacement: UpdateState) {
+        let replacedState = state
+        state = replacement
         overrideState = nil
         notifyStateChanged()
+        replacedState.finishAsSuperseded()
     }
 
     // MARK: - Detected background update
@@ -237,6 +245,8 @@ public final class UpdateStateModel {
             return ""
         case .permissionRequest:
             return String(localized: "update.permissionRequest.text", defaultValue: "Enable Automatic Updates?")
+        case .preparingCheck:
+            return String(localized: "update.preparingCheck", defaultValue: "Preparing Update Check…")
         case .checking:
             return String(localized: "update.checking", defaultValue: "Checking for Updates…")
         case .updateAvailable(let update):
@@ -261,6 +271,8 @@ public final class UpdateStateModel {
             return String(localized: "update.noUpdates.title", defaultValue: "No Updates Available")
         case .error(let err):
             return Self.userFacingErrorTitle(for: err.error)
+        case .startingDownload:
+            return String(localized: "update.startingDownload", defaultValue: "Starting Download…")
         }
     }
 
@@ -290,11 +302,13 @@ public final class UpdateStateModel {
             return nil
         case .permissionRequest:
             return "questionmark.circle"
-        case .checking:
+        case .preparingCheck, .checking:
             return "arrow.triangle.2.circlepath"
         case .updateAvailable:
             return "shippingbox.fill"
         case .downloading:
+            return "arrow.down.circle"
+        case .startingDownload:
             return "arrow.down.circle"
         case .extracting:
             return "shippingbox"
@@ -314,6 +328,8 @@ public final class UpdateStateModel {
             return ""
         case .permissionRequest:
             return String(localized: "update.configureAutoUpdates", defaultValue: "Configure automatic update preferences")
+        case .preparingCheck:
+            return String(localized: "update.preparingCheck.message", defaultValue: "Waiting for the current update session to finish")
         case .checking:
             return String(localized: "update.pleaseWait", defaultValue: "Please wait while we check for available updates")
         case .updateAvailable(let update):
@@ -328,6 +344,8 @@ public final class UpdateStateModel {
             return String(localized: "update.noUpdates.message", defaultValue: "You are running the latest version")
         case .error(let err):
             return Self.userFacingErrorMessage(for: err.error)
+        case .startingDownload:
+            return String(localized: "update.startingDownload.message", defaultValue: "Starting the update download")
         }
     }
 
@@ -362,119 +380,3 @@ public final class UpdateStateModel {
         return trimmed.isEmpty ? nil : trimmed
     }
 }
-
-#if DEBUG
-/// A synthetic update-error scenario that the debug menu can inject so every error popover
-/// variant (title, message, and whether the manual-download button shows) can be previewed
-/// without reproducing the real failure.
-///
-/// Cases map one-to-one to the branches in ``UpdateStateModel/userFacingErrorTitle(for:)`` and
-/// ``UpdateStateModel/userFacingErrorMessage(for:)`` plus ``UpdateManualDownloadRecovery``.
-public enum DebugUpdateErrorScenario: String, CaseIterable, Hashable, Sendable {
-    /// 4005 wrapping the internal IPC-timeout (the wedged-launchd case): "Couldn't Start Updater".
-    case installerAgentFailure
-    /// 4010 `SUAgentInvalidationError`: also "Couldn't Start Updater".
-    case agentInvalidation
-    /// Plain 4005 with no agent signal: "Updater Permission Error" + recovery message + download.
-    case genericInstallFailure
-    /// 4005 wrapping `SUAuthenticationFailure` (4001): must NOT be treated as an agent failure.
-    case installFailureWrappingAuth
-    /// 2001 `SUDownloadError`: "Couldn't Download Update", offers download.
-    case downloadFailure
-    /// 1003 `SURunningFromDiskImageError`: keeps "Move into Applications", no download button.
-    case diskImageTranslocation
-    /// 3001 `SUSignatureError`: signature copy, deliberately no download button.
-    case signatureError
-    /// Offline `NSURLError`: "No Internet Connection".
-    case noInternet
-    /// cmux.update install-watchdog trip: "Update Didn't Start" (the install-loop guard).
-    case installDidNotStart
-    /// cmux.update readiness timeout: "Updater Not Ready".
-    case updaterNotReady
-
-    /// The label shown for this scenario in the debug menu.
-    public var menuTitle: String {
-        switch self {
-        case .installerAgentFailure: return "Installer Agent Failure (4005 + timeout)"
-        case .agentInvalidation: return "Agent Invalidation (4010)"
-        case .genericInstallFailure: return "Generic Install Failure (4005)"
-        case .installFailureWrappingAuth: return "Install Failure / Auth (4005→4001)"
-        case .downloadFailure: return "Download Failure (2001)"
-        case .diskImageTranslocation: return "Disk Image / Translocated (1003)"
-        case .signatureError: return "Signature Error (3001)"
-        case .noInternet: return "No Internet"
-        case .installDidNotStart:
-            return String(
-                localized: "update.debug.error.installDidNotStart",
-                defaultValue: "Install Didn’t Start (watchdog)"
-            )
-        case .updaterNotReady:
-            return String(
-                localized: "update.debug.error.updaterNotReady",
-                defaultValue: "Updater Not Ready (readiness timeout)"
-            )
-        }
-    }
-
-    /// Builds the synthetic error for this scenario.
-    var error: NSError {
-        switch self {
-        case .installerAgentFailure:
-            let underlying = NSError(domain: SUSparkleErrorDomain, code: 10, userInfo: [
-                NSLocalizedDescriptionKey: "Timeout: agent connection was never initiated",
-            ])
-            return NSError(domain: SUSparkleErrorDomain, code: 4005, userInfo: [
-                NSLocalizedDescriptionKey: "An error occurred while running the updater. Please try again later.",
-                NSLocalizedFailureReasonErrorKey: "The remote port connection was invalidated from the updater.",
-                NSUnderlyingErrorKey: underlying,
-            ])
-        case .agentInvalidation:
-            return NSError(domain: SUSparkleErrorDomain, code: 4010, userInfo: [
-                NSLocalizedDescriptionKey: "The updater agent was invalidated.",
-            ])
-        case .genericInstallFailure:
-            return NSError(domain: SUSparkleErrorDomain, code: 4005, userInfo: [
-                NSLocalizedDescriptionKey: "The installation failed.",
-            ])
-        case .installFailureWrappingAuth:
-            let underlying = NSError(domain: SUSparkleErrorDomain, code: 4001, userInfo: [
-                NSLocalizedDescriptionKey: "Authorization failed.",
-            ])
-            return NSError(domain: SUSparkleErrorDomain, code: 4005, userInfo: [
-                NSLocalizedDescriptionKey: "An error occurred while installing the update.",
-                NSUnderlyingErrorKey: underlying,
-            ])
-        case .downloadFailure:
-            return NSError(domain: SUSparkleErrorDomain, code: 2001, userInfo: [
-                NSLocalizedDescriptionKey: "The update download failed.",
-            ])
-        case .diskImageTranslocation:
-            return NSError(domain: SUSparkleErrorDomain, code: 1003, userInfo: [
-                NSLocalizedDescriptionKey: "Running from a disk image.",
-            ])
-        case .signatureError:
-            return NSError(domain: SUSparkleErrorDomain, code: 3001, userInfo: [
-                NSLocalizedDescriptionKey: "The update signature is invalid.",
-            ])
-        case .noInternet:
-            return NSError(domain: NSURLErrorDomain, code: NSURLErrorNotConnectedToInternet, userInfo: [
-                NSLocalizedDescriptionKey: "The Internet connection appears to be offline.",
-            ])
-        case .installDidNotStart:
-            return NSError(domain: UpdateStateModel.updateErrorDomain, code: UpdateStateModel.installDidNotStartCode, userInfo: [
-                NSLocalizedDescriptionKey: String(
-                    localized: "update.error.didNotStart.message",
-                    defaultValue: "cmux couldn’t start the update. Check your internet connection and try again."
-                ),
-            ])
-        case .updaterNotReady:
-            return NSError(domain: UpdateStateModel.updateErrorDomain, code: UpdateStateModel.updaterNotReadyCode, userInfo: [
-                NSLocalizedDescriptionKey: String(
-                    localized: "update.error.notReady",
-                    defaultValue: "Updater is still starting. Try again in a moment."
-                ),
-            ])
-        }
-    }
-}
-#endif

--- a/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdaterHandle.swift
+++ b/Packages/macOS/CmuxUpdater/Sources/CmuxUpdater/UpdaterHandle.swift
@@ -6,11 +6,13 @@ public import Foundation
 /// A seam, not an abstraction: production always passes a real `SPUUpdater`. It exists so the
 /// controller's reaction pipeline (attempt coordinator, install watchdog, prompt dismissal)
 /// can be driven deterministically in tests by a fake — the real Sparkle install path only runs
-/// in release-channel builds, so pipeline regressions like the NIGHTLY double-idle install loop
-/// (https://github.com/manaflow-ai/cmux/pull/7174) are otherwise invisible until a nightly ships.
+/// in release-channel builds, so accepted-install lifecycle regressions are otherwise invisible
+/// until a nightly ships.
 @MainActor
 protocol UpdaterHandle: AnyObject {
     var canCheckForUpdates: Bool { get }
+    /// Whether Sparkle still owns an update-cycle session that must finish before another check.
+    var sessionInProgress: Bool { get }
     var automaticallyChecksForUpdates: Bool { get }
     var automaticallyDownloadsUpdates: Bool { get }
     var updateCheckInterval: TimeInterval { get }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/AttemptUpdateCoordinatorTests.swift
@@ -48,28 +48,25 @@ import Testing
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
 
-        // The active prompt is dismissed and the updater re-checks.
-        #expect(coordinator.handleStateChange(.idle) == .none)
+        // The lifecycle owner invokes Sparkle only after the old cycle finishes.
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
 
         // The fresh check resolves the newer version — install THAT one.
         #expect(coordinator.handleStateChange(updateAvailable("0.64.16")) == .confirmInstall)
+        #expect(coordinator.isMonitoring)
+        #expect(coordinator.handleStateChange(.startingDownload) == .none)
+        #expect(coordinator.handleStateChange(.downloading(.init(cancel: {}, expectedLength: nil, progress: 0))) == .none)
         #expect(!coordinator.isMonitoring)
     }
 
-    /// Regression for #7235: dismissing the stale Sparkle prompt can emit an idle state from
-    /// Sparkle's dismissal callback and then another idle state from cmux's reset path. The second
-    /// idle is still before the fresh check starts, so it must not cancel the install attempt.
-    @Test func duplicateIdleDismissSignalsBeforeFreshCheckDoNotCancelAttempt() {
+    /// An unattributed idle cannot be interpreted as user cancellation. It is a failed accepted
+    /// install that the controller must turn into a retryable error.
+    @Test func unattributedIdleBeforeFreshCheckFailsInstall() {
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
 
-        #expect(coordinator.handleStateChange(.idle) == .none)
-        #expect(coordinator.isMonitoring)
-        #expect(coordinator.handleStateChange(.idle) == .none)
-        #expect(coordinator.isMonitoring)
-        #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
-        #expect(coordinator.handleStateChange(updateAvailable("0.64.16")) == .confirmInstall)
+        #expect(coordinator.handleStateChange(.idle) == .installFailed)
         #expect(!coordinator.isMonitoring)
     }
 
@@ -79,11 +76,9 @@ import Testing
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
 
-        // Same prompt re-emitted before any restart signal: do not install it.
-        #expect(coordinator.handleStateChange(updateAvailable("0.64.15")) == .none)
-        #expect(coordinator.isMonitoring)
-
-        // Once the check restarts and resolves the latest, confirm that one.
+        #expect(coordinator.handleStateChange(.preparingCheck(.init(cancel: {}))) == .none)
+        // Once the controller starts the check and it resolves the latest, confirm that one.
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
         #expect(coordinator.handleStateChange(updateAvailable("0.64.16")) == .confirmInstall)
     }
@@ -92,9 +87,10 @@ import Testing
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: .idle)
 
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
         #expect(coordinator.handleStateChange(updateAvailable("0.64.16")) == .confirmInstall)
-        #expect(!coordinator.isMonitoring)
+        #expect(coordinator.isMonitoring)
     }
 
     @Test func doesNotInterruptAnInProgressInstall() {
@@ -102,6 +98,7 @@ import Testing
             .downloading(.init(cancel: {}, expectedLength: 100, progress: 10)),
             .extracting(.init(progress: 0.5)),
             .installing(.init(retryTerminatingApplication: {}, dismiss: {})),
+            .startingDownload,
         ] {
             var coordinator = AttemptUpdateCoordinator()
             #expect(coordinator.requestInstallLatest(currentState: state) == .none)
@@ -112,9 +109,9 @@ import Testing
     @Test func stopsMonitoringWhenFreshCheckFindsNothing() {
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
-        #expect(coordinator.handleStateChange(.idle) == .none)
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
-        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .none)
+        #expect(coordinator.handleStateChange(.notFound(.init(acknowledgement: {}))) == .installFailed)
         #expect(!coordinator.isMonitoring)
     }
 
@@ -124,10 +121,11 @@ import Testing
     @Test func cancellingFreshCheckStopsMonitoringSoLaterCheckIsNotAutoInstalled() {
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: .idle)
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
 
-        // User cancels the in-flight check → model returns to idle.
-        #expect(coordinator.handleStateChange(.idle) == .none)
+        // The controller receives the causal user-cancel signal before Sparkle emits idle.
+        coordinator.cancel()
         #expect(!coordinator.isMonitoring)
 
         // A later, unrelated check that finds an update must NOT be auto-confirmed.
@@ -139,9 +137,9 @@ import Testing
     @Test func cancellingAfterActivePromptDismissStopsMonitoring() {
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: updateAvailable("0.64.15"))
-        #expect(coordinator.handleStateChange(.idle) == .none)   // stale prompt dismissed
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
-        #expect(coordinator.handleStateChange(.idle) == .none)   // user cancels the fresh check
+        coordinator.cancel()
         #expect(!coordinator.isMonitoring)
         #expect(coordinator.handleStateChange(updateAvailable("0.64.16")) == .none)
     }
@@ -149,6 +147,7 @@ import Testing
     @Test func stopsMonitoringWhenFreshCheckErrors() {
         var coordinator = AttemptUpdateCoordinator()
         _ = coordinator.requestInstallLatest(currentState: .idle)
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
         let error = UpdateState.error(.init(error: NSError(domain: "t", code: 1), retry: {}, dismiss: {}))
         #expect(coordinator.handleStateChange(error) == .none)

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/FakeUpdater.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/FakeUpdater.swift
@@ -4,16 +4,33 @@ import Foundation
 @MainActor
 final class FakeUpdater: UpdaterHandle {
     private(set) var checkForUpdatesCallCount = 0
-    var canCheckForUpdates = true
+    private var canCheckForUpdatesValue = true
+    var scriptedCanCheckForUpdates: [Bool] = []
+    var canCheckForUpdates: Bool {
+        get {
+            if !scriptedCanCheckForUpdates.isEmpty {
+                return scriptedCanCheckForUpdates.removeFirst()
+            }
+            return canCheckForUpdatesValue
+        }
+        set {
+            canCheckForUpdatesValue = newValue
+            scriptedCanCheckForUpdates = []
+        }
+    }
     var sessionInProgress = false
+    var startError: (any Error)?
     // False so the controller skips the background launch probe in tests.
     var automaticallyChecksForUpdates = false
     var automaticallyDownloadsUpdates = false
     var updateCheckInterval: TimeInterval = 3600
 
-    func start() throws {}
+    func start() throws {
+        if let startError { throw startError }
+    }
 
     func checkForUpdates() {
+        sessionInProgress = true
         checkForUpdatesCallCount += 1
     }
 

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/FakeUpdater.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/FakeUpdater.swift
@@ -5,6 +5,7 @@ import Foundation
 final class FakeUpdater: UpdaterHandle {
     private(set) var checkForUpdatesCallCount = 0
     var canCheckForUpdates = true
+    var sessionInProgress = false
     // False so the controller skips the background launch probe in tests.
     var automaticallyChecksForUpdates = false
     var automaticallyDownloadsUpdates = false

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/InstallWatchdogTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/InstallWatchdogTests.swift
@@ -32,25 +32,25 @@ import Testing
         [
             .idle,
             .permissionRequest(.init(request: SPUUpdatePermissionRequest(systemProfile: []), reply: { _ in })),
+            .preparingCheck(.init(cancel: {})),
             .checking(.init(cancel: {})),
             updateAvailable(),
             .notFound(.init(acknowledgement: {})),
             .error(.init(error: NSError(domain: "t", code: 1), retry: {}, dismiss: {})),
+            .startingDownload,
             .downloading(.init(cancel: {}, expectedLength: 100, progress: 10)),
             .extracting(.init(progress: 0.5)),
             .installing(.init(retryTerminatingApplication: {}, dismiss: {})),
         ]
     }
 
-    /// The watchdog reports a stall for the states an armed deadline can legitimately catch the
-    /// flow in with nothing downloading: mid-check, an unacted "Update Available" (the states the
-    /// double-idle bug got stuck in), and `.idle` (the pre-check stall where the delayed re-check
-    /// was dropped — every benign idle disarms before the deadline can fire).
+    /// The watchdog reports a stall for every accepted-install phase that has not reached download
+    /// progress, plus unattributed idle (every causal user cancellation disarms first).
     @Test func stalledForNonProgressingStates() {
         for state in everyState {
             let stalled = watchdog.installAttemptStalled(state)
             switch state {
-            case .checking, .updateAvailable, .idle:
+            case .preparingCheck, .checking, .updateAvailable, .startingDownload, .idle:
                 #expect(stalled, "\(state) should count as stalled")
             default:
                 #expect(!stalled, "\(state) should NOT count as stalled")
@@ -59,7 +59,7 @@ import Testing
     }
 
     /// Download/extract/install progress and clearly-communicated terminals (notFound/error)
-    /// disarm the watchdog; idle/permissionRequest/checking/updateAvailable do not.
+    /// disarm the watchdog; idle/permissionRequest/preparing/checking/starting do not.
     @Test func resolvedForProgressAndVisibleTerminals() {
         for state in everyState {
             let resolved = watchdog.installAttemptResolved(state)
@@ -85,7 +85,7 @@ import Testing
     /// watch too. Only an actual install hand-off — or the coordinator still being mid-flow —
     /// keeps the deadline armed.
     @Test func attemptEndedWithoutInstallTruthTable() {
-        let actions: [AttemptUpdateCoordinator.Action] = [.none, .startFreshCheck, .confirmInstall]
+        let actions: [AttemptUpdateCoordinator.Action] = [.none, .startFreshCheck, .confirmInstall, .installFailed]
         for action in actions {
             // While the coordinator is still monitoring, the attempt is alive regardless of action.
             #expect(!watchdog.attemptEndedWithoutInstall(action: action, isCoordinatorMonitoring: true))
@@ -101,8 +101,10 @@ import Testing
     @Test func cancelledFreshCheckEndsTheWatchdogsWatch() {
         var coordinator = AttemptUpdateCoordinator()
         #expect(coordinator.requestInstallLatest(currentState: updateAvailable()) == .startFreshCheck)
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
-        let action = coordinator.handleStateChange(.idle)
+        coordinator.cancel()
+        let action = AttemptUpdateCoordinator.Action.none
         #expect(action == .none)
         #expect(watchdog.attemptEndedWithoutInstall(
             action: action,
@@ -116,6 +118,7 @@ import Testing
     @Test func confirmInstallHandOffKeepsWatchdogArmed() {
         var coordinator = AttemptUpdateCoordinator()
         #expect(coordinator.requestInstallLatest(currentState: .idle) == .startFreshCheck)
+        coordinator.didStartFreshCheck()
         #expect(coordinator.handleStateChange(.checking(.init(cancel: {}))) == .none)
         let action = coordinator.handleStateChange(updateAvailable())
         #expect(action == .confirmInstall)

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyEventSpy.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyEventSpy.swift
@@ -1,0 +1,13 @@
+import Foundation
+@preconcurrency import Sparkle
+@testable import CmuxUpdater
+
+/// Records prompt-dismiss lifecycle notifications for prompt identity tests.
+@MainActor
+final class PromptReplyEventSpy: UpdateDriverEventDelegate {
+    private(set) var promptDismissalCount = 0
+
+    func updateDriverDidFinishCycle(_ updateCheck: SPUUpdateCheck, error: NSError?) {}
+    func updateDriverUserDidCancelCheck() {}
+    func updateDriverUserDidDismissPrompt() { promptDismissalCount += 1 }
+}

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyTests.swift
@@ -169,6 +169,38 @@ import Testing
         #expect(model.state.isIdle)
     }
 
+    /// A delayed action from a prompt that no longer owns the model cannot cancel the lifecycle
+    /// associated with the current prompt.
+    @Test func stalePromptReplyDoesNotNotifyLifecycleOwner() {
+        let model = UpdateStateModel()
+        let driver = UpdateDriver(
+            model: model,
+            log: NoopUpdateLog(),
+            clock: SystemUpdateClock(),
+            isDevLikeBundle: false
+        )
+        let eventSpy = PromptReplyEventSpy()
+        driver.eventDelegate = eventSpy
+        let staleReply = UpdatePromptReply { _ in }
+        staleReply.onConsumed = { [weak driver] reply, choice, source in
+            driver?.handlePromptReply(reply, choice: choice, source: source)
+        }
+        let currentReply = UpdatePromptReply { _ in }
+        model.setState(.updateAvailable(.init(
+            appcastItem: makeItem("0.64.16"),
+            reply: currentReply
+        )))
+
+        staleReply(.dismiss)
+
+        #expect(eventSpy.promptDismissalCount == 0)
+        guard case .updateAvailable(let available) = model.state else {
+            Issue.record("stale prompt reply cleared the current lifecycle")
+            return
+        }
+        #expect(available.reply.id == currentReply.id)
+    }
+
     /// A causal user dismissal clears its own prompt but cannot authorize a later identity-free
     /// dismissal to clear unrelated progress.
     @Test func userPromptDismissalDoesNotAuthorizeLaterUnscopedDismissal() {

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyTests.swift
@@ -3,12 +3,11 @@ import Testing
 @preconcurrency import Sparkle
 @testable import CmuxUpdater
 
-/// The at-most-once prompt reply and the stale-dismissal guard it enables.
+/// The at-most-once prompt reply and causal dismissal boundaries.
 ///
-/// Sparkle's dismiss callback for a stale session can land after a fresh check has already
-/// resolved a new prompt; without the consumption bit the driver clobbered the live, unanswered
-/// prompt back to idle and the queued install hand-off silently no-oped (the same idle-ambiguity
-/// family as the NIGHTLY double-idle loop).
+/// Sparkle's identity-free dismiss callback can land after a newer prompt or download owns the
+/// UI. Prompt replies record their source at the causal boundary; the later unscoped callback is
+/// diagnostic-only and cannot mutate current state.
 @MainActor
 @Suite struct PromptReplyTests {
     private func makeItem(_ version: String) -> SUAppcastItem {
@@ -41,10 +40,10 @@ import Testing
 
         #expect(received.choices == [.install])
     }
-    /// A stale session's dismissal must not clobber a live prompt nobody has answered yet —
+    /// An old session's unscoped dismissal must not clobber a live prompt nobody has answered —
     /// exactly the late `dismissUpdateInstallation` that would otherwise cancel the freshly
     /// resolved update out from under the attempt coordinator.
-    @Test func staleDismissalDoesNotClobberUnansweredPrompt() {
+    @Test func unscopedDismissalDoesNotClobberUnansweredPrompt() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -53,10 +52,8 @@ import Testing
             isDevLikeBundle: false
         )
 
-        let oldReply = UpdatePromptReply { _ in }
         let freshReply = UpdatePromptReply { _ in }
 
-        driver.recordPromptDismissCallbackExpected(for: oldReply)
         model.setState(.updateAvailable(.init(appcastItem: makeItem("0.64.16"), reply: freshReply)))
         driver.dismissUpdateInstallation()
 
@@ -86,9 +83,9 @@ import Testing
         }
     }
 
-    /// A stale dismissal arriving after the fresh prompt was confirmed must not reset active
+    /// An unscoped dismissal arriving after the fresh prompt was confirmed must not reset active
     /// progress to idle; later progress callbacks depend on the model staying in progress.
-    @Test func staleDismissalDoesNotClobberInstallProgress() {
+    @Test func unscopedDismissalDoesNotClobberInstallProgress() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -96,9 +93,6 @@ import Testing
             clock: SystemUpdateClock(),
             isDevLikeBundle: false
         )
-        let oldReply = UpdatePromptReply { _ in }
-
-        driver.recordPromptDismissCallbackExpected(for: oldReply)
         model.setState(.downloading(.init(cancel: {}, expectedLength: 100, progress: 10)))
         driver.dismissUpdateInstallation()
 
@@ -109,9 +103,9 @@ import Testing
         #expect(download.progress == 10)
     }
 
-    /// A stale dismissal can also land after the fresh prompt was auto-confirmed but before Sparkle
+    /// An unscoped dismissal can also land after the fresh prompt was answered but before Sparkle
     /// reports download progress. That must not tear down the live install hand-off.
-    @Test func staleDismissalDoesNotClobberInstallConfirmedPrompt() {
+    @Test func unscopedDismissalDoesNotClobberAnsweredPrompt() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -119,11 +113,9 @@ import Testing
             clock: SystemUpdateClock(),
             isDevLikeBundle: false
         )
-        let oldReply = UpdatePromptReply { _ in }
         let freshReply = UpdatePromptReply { _ in }
         let available = UpdateState.UpdateAvailable(appcastItem: makeItem("0.64.16"), reply: freshReply)
 
-        driver.recordPromptDismissCallbackExpected(for: oldReply)
         model.setState(.updateAvailable(available))
         available.reply(.install)
         driver.dismissUpdateInstallation()
@@ -134,9 +126,9 @@ import Testing
         }
     }
 
-    /// A normal Sparkle progress teardown still clears the model; only a known superseded prompt
-    /// dismissal may be ignored while progress is visible.
-    @Test func activeProgressDismissalClearsState() {
+    /// Sparkle's identity-free dismissal cannot terminate progress; causal progress callbacks own
+    /// their own cancellation and completion transitions.
+    @Test func unscopedDismissalPreservesActiveProgress() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -148,7 +140,10 @@ import Testing
         model.setState(.extracting(.init(progress: 0.5)))
         driver.dismissUpdateInstallation()
 
-        #expect(model.state.isIdle)
+        guard case .extracting = model.state else {
+            Issue.record("unscoped dismissal cleared active progress")
+            return
+        }
     }
 
     /// The current prompt's own dismissal is not stale and should still clear the prompt.
@@ -163,17 +158,20 @@ import Testing
         let reply = UpdatePromptReply { _ in }
         let available = UpdateState.UpdateAvailable(appcastItem: makeItem("0.64.16"), reply: reply)
 
-        driver.recordPromptDismissCallbackExpected(for: reply)
+        reply.onConsumed = { [weak driver] reply, choice, source in
+            driver?.handlePromptReply(reply, choice: choice, source: source)
+        }
         model.setState(.updateAvailable(available))
         available.reply(.dismiss)
+        #expect(model.state.isIdle)
         driver.dismissUpdateInstallation()
 
         #expect(model.state.isIdle)
     }
 
-    /// If the current prompt's dismiss callback arrives before an older prompt's pending stale
-    /// callback, clearing the current prompt must not spend the old prompt's marker.
-    @Test func currentPromptDismissalDoesNotConsumeOlderStaleMarker() {
+    /// A causal user dismissal clears its own prompt but cannot authorize a later identity-free
+    /// dismissal to clear unrelated progress.
+    @Test func userPromptDismissalDoesNotAuthorizeLaterUnscopedDismissal() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -181,12 +179,12 @@ import Testing
             clock: SystemUpdateClock(),
             isDevLikeBundle: false
         )
-        let oldReply = UpdatePromptReply { _ in }
         let currentReply = UpdatePromptReply { _ in }
         let available = UpdateState.UpdateAvailable(appcastItem: makeItem("0.64.16"), reply: currentReply)
 
-        driver.recordPromptDismissCallbackExpected(for: oldReply)
-        driver.recordPromptDismissCallbackExpected(for: currentReply)
+        currentReply.onConsumed = { [weak driver] reply, choice, source in
+            driver?.handlePromptReply(reply, choice: choice, source: source)
+        }
         model.setState(.updateAvailable(available))
         available.reply(.dismiss)
         driver.dismissUpdateInstallation()
@@ -202,9 +200,8 @@ import Testing
         #expect(download.progress == 10)
     }
 
-    /// If a superseded prompt's Sparkle dismissal arrives while an error is visible, it is drained
-    /// there; it must not make a later real progress dismissal look stale.
-    @Test func promptDismissIgnoredByErrorDoesNotLeakToNextProgress() {
+    /// Identity-free dismissal callbacks cannot mutate either a visible error or later progress.
+    @Test func unscopedDismissalPreservesErrorAndLaterProgress() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -212,8 +209,6 @@ import Testing
             clock: SystemUpdateClock(),
             isDevLikeBundle: false
         )
-        let oldReply = UpdatePromptReply { _ in }
-        driver.recordPromptDismissCallbackExpected(for: oldReply)
         model.setState(.error(.init(
             error: NSError(domain: UpdateStateModel.updateErrorDomain, code: UpdateStateModel.installDidNotStartCode),
             retry: {},
@@ -229,11 +224,13 @@ import Testing
         model.setState(.extracting(.init(progress: 0.5)))
         driver.dismissUpdateInstallation()
 
-        #expect(model.state.isIdle)
+        guard case .extracting = model.state else {
+            Issue.record("unscoped dismissal cleared later progress")
+            return
+        }
     }
 
-    /// A real user download cancel still clears progress immediately; the stale dismissal guard
-    /// only prevents old Sparkle sessions from clearing a still-active progress state.
+    /// A real user download cancel still clears progress immediately at its causal callback.
     @Test func downloadCancelClearsProgress() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
@@ -266,10 +263,11 @@ import Testing
 
         let available = UpdateState.UpdateAvailable(appcastItem: makeItem("0.64.16"), reply: { _ in })
         model.setState(.updateAvailable(available))
-        available.reply(.install)
+        model.setState(.startingDownload)
+        available.reply.consume(.install, source: .installAttempt)
         driver.dismissUpdateInstallation()
 
         #expect(model.showsPill)
-        #expect(!model.state.isIdle)
+        #expect(model.state == .startingDownload)
     }
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/PromptReplyTests.swift
@@ -66,9 +66,9 @@ import Testing
         }
     }
 
-    /// An untracked Sparkle dismissal is the active UI teardown signal and must still clear a
-    /// visible prompt instead of stranding it.
-    @Test func unexpectedDismissalClearsUnansweredPrompt() {
+    /// Regression for #8368: an untracked Sparkle dismissal has no causal link to the currently
+    /// visible prompt. It must not silently clear an unanswered install opportunity.
+    @Test func unexpectedDismissalKeepsUnansweredPromptVisible() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -80,7 +80,10 @@ import Testing
         model.setState(.updateAvailable(.init(appcastItem: makeItem("0.64.16"), reply: { _ in })))
         driver.dismissUpdateInstallation()
 
-        #expect(model.state.isIdle)
+        guard case .updateAvailable = model.state else {
+            Issue.record("unanswered prompt was silently dismissed to \(model.state)")
+            return
+        }
     }
 
     /// A stale dismissal arriving after the fresh prompt was confirmed must not reset active
@@ -250,8 +253,9 @@ import Testing
         #expect(model.state.isIdle)
     }
 
-    /// Once the prompt is answered, its own dismissal passes through and clears the state.
-    @Test func answeredPromptDismissalClearsState() {
+    /// Regression for #8368: after the user accepts an install, a Sparkle dismissal arriving
+    /// before `showDownloadInitiated` must not hide the only visible evidence of that attempt.
+    @Test func acceptedInstallDismissalKeepsAttemptVisible() {
         let model = UpdateStateModel()
         let driver = UpdateDriver(
             model: model,
@@ -265,6 +269,7 @@ import Testing
         available.reply(.install)
         driver.dismissUpdateInstallation()
 
-        #expect(model.state.isIdle)
+        #expect(model.showsPill)
+        #expect(!model.state.isIdle)
     }
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Testing
 @testable import CmuxUpdater
 
 /// Immediate for the sub-second plumbing delays; parks second-or-longer deadlines until the test
@@ -29,10 +30,16 @@ actor TestDeadlineClock: UpdateClock {
 
     func fireDeadlineWhenReady() async {
         // A test may request a deadline and immediately release it before the task running
-        // `sleep(for:)` reaches the actor. Yield until that real signal is registered instead of
-        // adding timing sleeps to the test.
-        while parked.isEmpty {
+        // `sleep(for:)` reaches the actor. Poll that real registration signal without timing
+        // sleeps, but bound the poll so a missing deadline fails instead of hanging the suite.
+        let clock = ContinuousClock()
+        let timeout = clock.now.advanced(by: .seconds(2))
+        while parked.isEmpty, clock.now < timeout {
             await Task.yield()
+        }
+        guard !parked.isEmpty else {
+            Issue.record("timed out waiting for a test deadline to be armed")
+            return
         }
         fireDeadlines()
     }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/TestDeadlineClock.swift
@@ -27,6 +27,16 @@ actor TestDeadlineClock: UpdateClock {
         }
     }
 
+    func fireDeadlineWhenReady() async {
+        // A test may request a deadline and immediately release it before the task running
+        // `sleep(for:)` reaches the actor. Yield until that real signal is registered instead of
+        // adding timing sleeps to the test.
+        while parked.isEmpty {
+            await Task.yield()
+        }
+        fireDeadlines()
+    }
+
     private func cancelParked(_ id: UUID) {
         parked.removeValue(forKey: id)?.resume(throwing: CancellationError())
     }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineHarness.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineHarness.swift
@@ -24,4 +24,9 @@ struct Harness {
             updaterFactory: { _, _ in updater }
         )
     }
+
+    func finishSparkleCycle(error: (any Error)? = nil) {
+        updater.sessionInProgress = false
+        controller.driver.handleDidFinishUpdateCycle(.updates, error: error)
+    }
 }

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -91,6 +91,28 @@ import Testing
         #expect(prompt.choice == nil)
     }
 
+    /// A failed updater start is already an actionable terminal. Check orchestration must not
+    /// replace it with preparation/readiness state, and Retry must preserve the original intent.
+    @Test func updaterStartupFailureStopsCheckAndRetryResumesIntent() {
+        let harness = Harness()
+        let startupError = NSError(domain: "test.updater.start", code: 41)
+        harness.updater.startError = startupError
+
+        harness.controller.checkForUpdates()
+
+        #expect(harness.updater.checkForUpdatesCallCount == 0)
+        guard case .error(let failure) = harness.model.state else {
+            Issue.record("startup failure was overwritten by \(harness.model.state)")
+            return
+        }
+        #expect((failure.error as NSError).domain == startupError.domain)
+
+        harness.updater.startError = nil
+        failure.retry()
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+        #expect(harness.updater.sessionInProgress)
+    }
+
     /// End-to-end accepted-install lifecycle: retire the old prompt, wait for Sparkle's cycle-end
     /// signal, re-resolve the newest nightly, retain visible ownership through the install reply,
     /// and end only when Sparkle starts downloading.
@@ -138,9 +160,6 @@ import Testing
         harness.controller.attemptUpdate()
 
         #expect(stalePrompt.choice == .dismiss)
-        for _ in 0..<100 {
-            await Task.yield()
-        }
 
         // No Sparkle cycle-finished signal has arrived, so starting a new check is not safe yet.
         #expect(harness.updater.checkForUpdatesCallCount == 0)
@@ -255,6 +274,24 @@ import Testing
         #expect(!harness.controller.installWatchdog.isArmed)
     }
 
+    /// Readiness can change during the final bounded suspension. The controller must observe that
+    /// edge before publishing a false timeout.
+    @Test func readinessOnFinalRetryStartsPendingCheck() async {
+        let harness = Harness()
+        // One read before entering the wait, then twenty loop reads, then the final boundary read.
+        harness.updater.scriptedCanCheckForUpdates = Array(repeating: false, count: 21) + [true]
+
+        harness.controller.checkForUpdates()
+
+        await waitUntil("final readiness read to start the check") {
+            harness.updater.checkForUpdatesCallCount == 1
+        }
+        #expect(harness.updater.sessionInProgress)
+        if case .error = harness.model.state {
+            Issue.record("final readiness edge incorrectly surfaced an error")
+        }
+    }
+
     /// If Sparkle accepts the fresh check call but emits no user-driver callback, the watchdog must
     /// turn the stall into a visible error and kill the attempt so a later unrelated resolution is
     /// not auto-installed.
@@ -328,18 +365,10 @@ import Testing
         harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
         harness.model.setState(.idle)
 
-        for _ in 0..<100 {
-            await Task.yield()
+        await waitUntil("prompt-loss error") {
+            errorCode(for: harness.model.state) == UpdateStateModel.installDidNotStartCode
         }
         #expect(freshPrompt.choice == nil)
-        #expect(harness.model.showsPill || harness.controller.installWatchdog.isArmed)
-
-        if harness.controller.installWatchdog.isArmed {
-            await harness.clock.fireDeadlineWhenReady()
-            await waitUntil("prompt-loss error") {
-                errorCode(for: harness.model.state) == UpdateStateModel.installDidNotStartCode
-            }
-        }
     }
 
     /// A retryable accepted-install failure must also resolve the Sparkle terminal it replaces.

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -75,6 +75,26 @@ import Testing
         #expect(!harness.controller.attemptCoordinator.isMonitoring)
     }
 
+    /// Regression for #8368: dismissing the old prompt does not synchronously end Sparkle's
+    /// update cycle. Starting the replacement check before Sparkle reports that the old cycle
+    /// finished is documented to refocus/no-op, which silently strands the accepted install.
+    @Test func installWaitsForDismissedSparkleCycleBeforeStartingFreshCheck() async {
+        let harness = Harness()
+        let stalePrompt = ChoiceBox()
+
+        harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
+        harness.controller.attemptUpdate()
+
+        #expect(stalePrompt.choice == .dismiss)
+        for _ in 0..<100 {
+            await Task.yield()
+        }
+
+        // No Sparkle cycle-finished signal has arrived, so starting a new check is not safe yet.
+        #expect(harness.updater.checkForUpdatesCallCount == 0)
+        #expect(harness.model.showsPill)
+    }
+
     /// Transitions queued before the Install click belong to the prompt-producing check, not the
     /// fresh re-check started by Install. They must be discarded at the attempt boundary so stale
     /// `.checking` / `.updateAvailable` snapshots cannot satisfy and then end the new coordinator
@@ -243,11 +263,10 @@ import Testing
         #expect(!harness.controller.attemptCoordinator.isMonitoring)
     }
 
-    /// If the resolved prompt vanishes before the confirm hand-off runs (the user dismissed it
-    /// mid-drain, so the live state has moved past the drained snapshot), the controller must
-    /// not reply to the already-answered snapshot, and must disarm the watchdog so the leftover
-    /// deadline can't fire a spurious error afterwards.
-    @Test func vanishedPromptSkipsHandOffAndDisarms() async {
+    /// Regression for #8368: an unattributed idle transition can be a stale/background Sparkle
+    /// callback, not a user cancellation. If it removes the freshly resolved prompt before the
+    /// confirm hand-off, the accepted install must remain visible or become a retryable error.
+    @Test func unattributedPromptLossCannotSilentlyEndAcceptedInstall() async {
         let harness = Harness()
         let stalePrompt = ChoiceBox()
 
@@ -255,7 +274,7 @@ import Testing
         harness.controller.attemptUpdate()
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
 
-        // Dismiss callback, fresh check restarts, resolution and the user's dismissal land
+        // Dismiss callback, fresh check restart, resolution, and an unattributed stale idle land
         // back-to-back: by the time the confirm hand-off runs, the prompt is gone.
         harness.model.setState(.idle)
         harness.model.setState(.checking(.init(cancel: {})))
@@ -263,10 +282,18 @@ import Testing
         harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
         harness.model.setState(.idle)
 
-        await waitUntil("watchdog to disarm") { !harness.controller.installWatchdog.isArmed }
+        for _ in 0..<100 {
+            await Task.yield()
+        }
         #expect(freshPrompt.choice == nil)
-        await harness.clock.fireDeadlines()
-        #expect(harness.model.state.isIdle)
+        #expect(harness.model.showsPill || harness.controller.installWatchdog.isArmed)
+
+        if harness.controller.installWatchdog.isArmed {
+            await harness.clock.fireDeadlines()
+            await waitUntil("prompt-loss error") {
+                errorCode(for: harness.model.state) == UpdateStateModel.installDidNotStartCode
+            }
+        }
     }
 
     /// If the live prompt is still visible but already answered before the queued confirm

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -6,11 +6,11 @@ import Testing
 /// Deterministic end-to-end replays of the update reaction pipeline: a real ``UpdateController``
 /// (reaction task, ``AttemptUpdateCoordinator``, ``InstallWatchdog``, prompt dismissal) driven
 /// through a fake ``UpdaterHandle`` and a deadline-controlled clock, with Sparkle's emissions
-/// replayed onto the model exactly as the production `cmux-update.log` recorded them.
+/// replayed onto the model in the same order as Sparkle's production callbacks.
 ///
 /// The real Sparkle install path only runs in release-channel builds (DEV builds suppress the
-/// appcast), so this harness is the only pre-merge way to reproduce pipeline bugs like the
-/// NIGHTLY double-idle install loop (https://github.com/manaflow-ai/cmux/pull/7174).
+/// appcast), so this harness is the pre-merge regression surface for the lifecycle between an
+/// accepted install and Sparkle's download callback.
 @MainActor
 @Suite struct UpdateControllerPipelineTests {
     private func updateAvailable(_ version: String, replyingInto box: ChoiceBox) -> UpdateState {
@@ -46,12 +46,10 @@ import Testing
 
     // MARK: - Replays
 
-    /// The production bug, replayed end to end from the user's `cmux-update.log`: Install is
-    /// pressed while "Update Available" shows, the stale prompt is dismissed (idle #1), Sparkle's
-    /// dismiss callback answers (idle #2), the fresh check restarts and resolves the newer
-    /// nightly. The shipped nightly aborted on idle #2 and never sent any reply; the fixed
-    /// pipeline must dismiss the stale prompt and install the freshly resolved one.
-    @Test func productionDoubleIdleSequenceReachesInstall() async {
+    /// End-to-end accepted-install lifecycle: retire the old prompt, wait for Sparkle's cycle-end
+    /// signal, re-resolve the newest nightly, retain visible ownership through the install reply,
+    /// and end only when Sparkle starts downloading.
+    @Test func dismissedPromptCycleThenFreshInstallReachesDownload() async {
         let harness = Harness()
         let stalePrompt = ChoiceBox()
         let freshPrompt = ChoiceBox()
@@ -59,20 +57,29 @@ import Testing
         harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
         harness.controller.attemptUpdate()
 
-        // The controller dismisses the stale prompt and starts exactly one fresh check.
+        // The controller dismisses the stale prompt but waits for the authoritative cycle end.
+        #expect(harness.updater.checkForUpdatesCallCount == 0)
+        harness.finishSparkleCycle()
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
         #expect(stalePrompt.choice == .dismiss)
 
-        // Sparkle's dismissUpdateInstallation answers the dismissal (idle #2 — the emission that
-        // used to abort the install), then the fresh check runs and resolves the newer nightly.
-        // Emitted back-to-back deliberately: the drain-ordered reactions must observe each one.
-        harness.model.setState(.idle)
+        // The identity-free dismiss callback cannot mutate the new session.
+        harness.controller.driver.dismissUpdateInstallation()
         harness.model.setState(.checking(.init(cancel: {})))
         harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
 
-        // The freshly resolved update is confirmed — the reply the shipped nightly never sent.
+        // Install ownership remains visible until Sparkle actually starts downloading.
         await waitUntil("install confirm") { freshPrompt.choice == .install }
-        #expect(!harness.controller.attemptCoordinator.isMonitoring)
+        #expect(harness.model.state == .startingDownload)
+        #expect(harness.controller.attemptCoordinator.isMonitoring)
+        harness.controller.driver.dismissUpdateInstallation()
+        #expect(harness.model.state == .startingDownload)
+        harness.controller.driver.showDownloadInitiated(cancellation: {})
+        await waitUntil("download ownership") { !harness.controller.attemptCoordinator.isMonitoring }
+        guard case .downloading = harness.model.state else {
+            Issue.record("download callback did not advance startingDownload; state=\(harness.model.state)")
+            return
+        }
     }
 
     /// Regression for #8368: dismissing the old prompt does not synchronously end Sparkle's
@@ -108,6 +115,7 @@ import Testing
         harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
         harness.controller.attemptUpdate()
         #expect(stalePrompt.choice == .dismiss)
+        harness.finishSparkleCycle()
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
 
         for _ in 0..<20 {
@@ -118,7 +126,7 @@ import Testing
         harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
 
         await waitUntil("fresh prompt to be confirmed") { freshPrompt.choice == .install }
-        #expect(!harness.controller.attemptCoordinator.isMonitoring)
+        #expect(harness.controller.attemptCoordinator.isMonitoring)
     }
 
     /// When Sparkle is not ready yet, the readiness placeholder must not look like the fresh check
@@ -138,7 +146,7 @@ import Testing
         harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
 
         await waitUntil("fresh prompt to be confirmed") { freshPrompt.choice == .install }
-        #expect(!harness.controller.attemptCoordinator.isMonitoring)
+        #expect(harness.controller.attemptCoordinator.isMonitoring)
     }
 
     /// If Sparkle never becomes ready during an install attempt, the readiness timeout is the
@@ -153,7 +161,10 @@ import Testing
         #expect(harness.updater.checkForUpdatesCallCount == 0)
         #expect(harness.controller.attemptCoordinator.isMonitoring)
         #expect(harness.controller.installWatchdog.isArmed)
-        #expect(harness.model.state.isIdle)
+        guard case .preparingCheck = harness.model.state else {
+            Issue.record("install readiness wait should stay visible")
+            return
+        }
 
         await waitUntil("not-ready error") {
             errorCode(for: harness.model.state) == UpdateStateModel.updaterNotReadyCode
@@ -186,8 +197,8 @@ import Testing
         harness.updater.canCheckForUpdates = false
         harness.controller.checkForUpdates()
 
-        guard case .checking = harness.model.state else {
-            Issue.record("manual readiness wait should show checking, got \(harness.model.state)")
+        guard case .preparingCheck = harness.model.state else {
+            Issue.record("manual readiness wait should show preparingCheck, got \(harness.model.state)")
             return
         }
         #expect(!harness.controller.attemptCoordinator.isMonitoring)
@@ -199,25 +210,20 @@ import Testing
         #expect(!harness.controller.installWatchdog.isArmed)
     }
 
-    /// If the fresh check never restarts (no `.checking` ever arrives), the watchdog must turn
-    /// the silent stall into a visible "Update Didn't Start" error, resolve the re-emitted stale
-    /// prompt with a proper dismiss reply, and kill the attempt so a later unrelated resolution
-    /// is not auto-installed.
+    /// If Sparkle accepts the fresh check call but emits no user-driver callback, the watchdog must
+    /// turn the stall into a visible error and kill the attempt so a later unrelated resolution is
+    /// not auto-installed.
     @Test func watchdogSurfacesErrorWhenFreshCheckNeverRestarts() async {
         let harness = Harness()
         let stalePrompt = ChoiceBox()
 
         harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
         harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
 
-        // Sparkle answers the dismissal, re-emits the stale prompt… and then nothing.
-        harness.model.setState(.idle)
-        let reEmittedPrompt = ChoiceBox()
-        harness.model.setState(updateAvailable("0.64.15", replyingInto: reEmittedPrompt))
-        await waitUntil("prompt to be observed") { harness.controller.attemptCoordinator.isMonitoring }
-
-        await harness.clock.fireDeadlines()
+        // Sparkle accepted the new check call but never emitted any user-driver callback.
+        await harness.clock.fireDeadlineWhenReady()
 
         await waitUntil("watchdog error") {
             if case .error(let failure) = harness.model.state {
@@ -225,9 +231,6 @@ import Testing
             }
             return false
         }
-        // The pending Sparkle prompt was resolved, not dropped.
-        #expect(reEmittedPrompt.choice == .dismiss)
-
         // The attempt is dead: a later unrelated resolution must not auto-install.
         let laterPrompt = ChoiceBox()
         harness.model.setState(updateAvailable("0.64.17", replyingInto: laterPrompt))
@@ -239,20 +242,18 @@ import Testing
         #expect(!harness.controller.attemptCoordinator.isMonitoring)
     }
 
-    /// If the delayed re-check is dropped outright — the stale prompt is dismissed (idle) and
-    /// then nothing ever emits, not even `.checking` — the watchdog must still surface the
-    /// visible error rather than leaving the user at a silently empty pill.
+    /// If the old Sparkle cycle never finishes, the preparation phase stays visible until the
+    /// watchdog surfaces an error rather than leaving the user at a silently empty pill.
     @Test func watchdogSurfacesErrorWhenRecheckIsDropped() async {
         let harness = Harness()
         let stalePrompt = ChoiceBox()
 
         harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
         harness.controller.attemptUpdate()
-        await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
+        #expect(harness.updater.checkForUpdatesCallCount == 0)
 
-        // Sparkle answers the dismissal… and then nothing at all: the flow sits at idle.
-        harness.model.setState(.idle)
-        await harness.clock.fireDeadlines()
+        // The old cycle never finishes; the visible preparation phase eventually becomes error.
+        await harness.clock.fireDeadlineWhenReady()
 
         await waitUntil("watchdog error") {
             if case .error(let failure) = harness.model.state {
@@ -272,11 +273,11 @@ import Testing
 
         harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
         harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
 
         // Dismiss callback, fresh check restart, resolution, and an unattributed stale idle land
         // back-to-back: by the time the confirm hand-off runs, the prompt is gone.
-        harness.model.setState(.idle)
         harness.model.setState(.checking(.init(cancel: {})))
         let freshPrompt = ChoiceBox()
         harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
@@ -289,11 +290,35 @@ import Testing
         #expect(harness.model.showsPill || harness.controller.installWatchdog.isArmed)
 
         if harness.controller.installWatchdog.isArmed {
-            await harness.clock.fireDeadlines()
+            await harness.clock.fireDeadlineWhenReady()
             await waitUntil("prompt-loss error") {
                 errorCode(for: harness.model.state) == UpdateStateModel.installDidNotStartCode
             }
         }
+    }
+
+    /// A retryable accepted-install failure must also resolve the Sparkle terminal it replaces.
+    /// Otherwise Sparkle still owns an unanswered session and the Retry action can no-op behind
+    /// the visible error.
+    @Test func acceptedInstallFailureAcknowledgesReplacedSparkleTerminal() async {
+        let harness = Harness()
+        let stalePrompt = ChoiceBox()
+        var didAcknowledgeNotFound = false
+
+        harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
+        harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
+        await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
+
+        harness.model.setState(.checking(.init(cancel: {})))
+        harness.model.setState(.notFound(.init(acknowledgement: {
+            didAcknowledgeNotFound = true
+        })))
+
+        await waitUntil("accepted-install error") {
+            errorCode(for: harness.model.state) == UpdateStateModel.installDidNotStartCode
+        }
+        #expect(didAcknowledgeNotFound)
     }
 
     /// If the live prompt is still visible but already answered before the queued confirm
@@ -305,9 +330,9 @@ import Testing
 
         harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
         harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
 
-        harness.model.setState(.idle)
         harness.model.setState(.checking(.init(cancel: {})))
         let freshPrompt = ChoiceBox()
         harness.model.setState(updateAvailable("0.64.16", replyingInto: freshPrompt))
@@ -334,13 +359,17 @@ import Testing
 
         harness.model.setState(updateAvailable("0.64.15", replyingInto: stalePrompt))
         harness.controller.attemptUpdate()
+        harness.finishSparkleCycle()
         await waitUntil("fresh check to start") { harness.updater.checkForUpdatesCallCount == 1 }
         #expect(harness.controller.installWatchdog.isArmed)
 
-        // Dismiss callback, fresh check starts, user hits Cancel in the checking popover.
-        harness.model.setState(.idle)
-        harness.model.setState(.checking(.init(cancel: {})))
-        harness.model.setState(.idle)
+        // The real cancellation closure notifies the lifecycle owner before returning to idle.
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        guard case .checking(let checking) = harness.model.state else {
+            Issue.record("driver did not surface checking")
+            return
+        }
+        checking.cancel()
 
         await waitUntil("watchdog to disarm") { !harness.controller.installWatchdog.isArmed }
         await harness.clock.fireDeadlines()

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateControllerPipelineTests.swift
@@ -46,6 +46,51 @@ import Testing
 
     // MARK: - Replays
 
+    /// Sparkle's dismissal callback is deliberately identity-free, so the authoritative cycle-end
+    /// signal must terminate an aborted manual check instead of leaving its spinner permanently
+    /// visible. The surfaced error remains actionable and starts a genuinely new check on retry.
+    @Test func finishedManualCycleCannotLeaveCheckingStateStale() {
+        let harness = Harness()
+
+        harness.controller.checkForUpdates()
+        #expect(harness.updater.checkForUpdatesCallCount == 1)
+        harness.controller.driver.showUserInitiatedUpdateCheck(cancellation: {})
+        harness.controller.driver.dismissUpdateInstallation()
+        guard case .checking = harness.model.state else {
+            Issue.record("identity-free dismissal unexpectedly mutated the active manual check")
+            return
+        }
+
+        harness.finishSparkleCycle()
+        guard case .error(let failure) = harness.model.state else {
+            Issue.record("finished manual cycle left stale state: \(harness.model.state)")
+            return
+        }
+        #expect((failure.error as NSError).code == UpdateStateModel.foregroundCycleEndedCode)
+
+        failure.retry()
+        #expect(harness.updater.checkForUpdatesCallCount == 2)
+    }
+
+    /// The same terminal reconciliation applies after an update prompt was shown: once Sparkle
+    /// says that manual session is over, cmux must not leave an action backed by the dead session.
+    @Test func finishedManualCycleCannotLeaveUpdatePromptStale() {
+        let harness = Harness()
+        let prompt = ChoiceBox()
+
+        harness.controller.checkForUpdates()
+        harness.model.setState(updateAvailable("0.64.16", replyingInto: prompt))
+        harness.controller.driver.dismissUpdateInstallation()
+        guard case .updateAvailable = harness.model.state else {
+            Issue.record("identity-free dismissal unexpectedly mutated the active prompt")
+            return
+        }
+
+        harness.finishSparkleCycle()
+        #expect(errorCode(for: harness.model.state) == UpdateStateModel.foregroundCycleEndedCode)
+        #expect(prompt.choice == nil)
+    }
+
     /// End-to-end accepted-install lifecycle: retire the old prompt, wait for Sparkle's cycle-end
     /// signal, re-resolve the newest nightly, retain visible ownership through the install reply,
     /// and end only when Sparkle starts downloading.

--- a/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
+++ b/Packages/macOS/CmuxUpdater/Tests/CmuxUpdaterTests/UpdateStateModelTests.swift
@@ -1,9 +1,55 @@
 import Foundation
 import Testing
+@preconcurrency import Sparkle
 @testable import CmuxUpdater
 
 @MainActor
 @Suite struct UpdateStateModelTests {
+    private func makeItem(_ version: String) -> SUAppcastItem {
+        SUAppcastItem(dictionary: [
+            "title": "cmux \(version)",
+            "pubDate": "Wed, 25 Mar 2026 12:00:00 +0000",
+            "enclosure": [
+                "url": "https://example.com/cmux.zip",
+                "length": "1024",
+                "sparkle:version": version,
+                "sparkle:shortVersionString": version,
+            ],
+        ]) ?? SUAppcastItem.empty()
+    }
+
+    /// Regression for #8368: `updaterDidNotFindUpdate` is shared by background probes and
+    /// foreground checks. Clearing passive detection must never answer or remove an unrelated
+    /// foreground prompt.
+    @Test func clearingDetectedUpdateDoesNotDismissForegroundPrompt() {
+        let model = UpdateStateModel()
+        let detected = makeItem("0.64.15")
+        let foreground = makeItem("0.64.16")
+        let reply = ChoiceBox()
+        let driver = UpdateDriver(
+            model: model,
+            log: NoopUpdateLog(),
+            clock: SystemUpdateClock(),
+            isDevLikeBundle: false
+        )
+
+        model.recordDetectedUpdate(detected)
+        model.setState(.updateAvailable(.init(appcastItem: foreground, reply: { choice in
+            MainActor.assumeIsolated { reply.choice = choice }
+        })))
+
+        driver.handleDidNotFindUpdate(NSError(domain: SUSparkleErrorDomain, code: 1001))
+
+        #expect(model.detectedUpdateItem == nil)
+        #expect(model.detectedUpdateVersion == nil)
+        #expect(reply.choice == nil)
+        guard case .updateAvailable(let available) = model.state else {
+            Issue.record("background no-update result dismissed foreground state: \(model.state)")
+            return
+        }
+        #expect(available.appcastItem.displayVersionString == "0.64.16")
+    }
+
     @Test func setStateEmitsOnStateChangesStream() async {
         let model = UpdateStateModel()
         var iterator = model.stateChanges().makeAsyncIterator()

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/PreparingUpdateCheckView.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/PreparingUpdateCheckView.swift
@@ -32,19 +32,3 @@ struct PreparingUpdateCheckView: View {
         .padding(16)
     }
 }
-
-/// Sparkle accepted the install reply and has not yet emitted its download callback.
-struct StartingUpdateDownloadView: View {
-    var body: some View {
-        HStack(spacing: 10) {
-            ProgressView()
-                .controlSize(.small)
-            Text(String(
-                localized: "update.startingDownload",
-                defaultValue: "Starting Download…"
-            ))
-            .cmuxFont(size: 13)
-        }
-        .padding(16)
-    }
-}

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/StartingUpdateDownloadView.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/StartingUpdateDownloadView.swift
@@ -1,0 +1,18 @@
+import SwiftUI
+import CmuxFoundation
+
+/// Sparkle accepted the install reply and has not yet emitted its download callback.
+struct StartingUpdateDownloadView: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .controlSize(.small)
+            Text(String(
+                localized: "update.startingDownload",
+                defaultValue: "Starting Download…"
+            ))
+            .cmuxFont(size: 13)
+        }
+        .padding(16)
+    }
+}

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateAppearance.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateAppearance.swift
@@ -27,11 +27,11 @@ public struct UpdateAppearance: Sendable {
             return .secondary
         case .permissionRequest:
             return .white
-        case .checking:
+        case .preparingCheck, .checking:
             return .secondary
         case .updateAvailable:
             return accent
-        case .downloading, .extracting, .installing:
+        case .startingDownload, .downloading, .extracting, .installing:
             return .secondary
         case .notFound:
             return .secondary

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateBadge.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateBadge.swift
@@ -37,7 +37,7 @@ public struct UpdateBadge: View {
             case .extracting(let extracting):
                 ProgressRingView(progress: min(1, max(0, extracting.progress)))
 
-            case .checking:
+            case .preparingCheck, .checking, .startingDownload:
                 BrowserStyleLoadingSpinner(size: 14, color: appearance.foregroundColor(for: model))
 
             default:

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePopoverView.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdatePopoverView.swift
@@ -39,6 +39,9 @@ public struct UpdatePopoverView: View {
             case .permissionRequest(let request):
                 PermissionRequestView(request: request, dismiss: dismiss)
 
+            case .preparingCheck(let checking):
+                PreparingUpdateCheckView(checking: checking, dismiss: dismiss)
+
             case .checking(let checking):
                 CheckingView(checking: checking, dismiss: dismiss)
 
@@ -47,6 +50,9 @@ public struct UpdatePopoverView: View {
 
             case .downloading(let download):
                 DownloadingView(download: download, dismiss: dismiss)
+
+            case .startingDownload:
+                StartingUpdateDownloadView()
 
             case .extracting(let extracting):
                 ExtractingView(extracting: extracting)

--- a/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateTransitionView.swift
+++ b/Packages/macOS/CmuxUpdaterUI/Sources/CmuxUpdaterUI/UpdateTransitionView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+import CmuxUpdater
+import CmuxFoundation
+
+/// The replacement check is waiting for Sparkle's previous session to finish.
+struct PreparingUpdateCheckView: View {
+    let checking: UpdateState.Checking
+    let dismiss: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(spacing: 10) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(String(
+                    localized: "update.preparingCheck",
+                    defaultValue: "Preparing Update Check…"
+                ))
+                .cmuxFont(size: 13)
+            }
+
+            HStack {
+                Spacer()
+                Button(String(localized: "common.cancel", defaultValue: "Cancel")) {
+                    checking.cancel()
+                    dismiss()
+                }
+                .keyboardShortcut(.cancelAction)
+                .controlSize(.small)
+            }
+        }
+        .padding(16)
+    }
+}
+
+/// Sparkle accepted the install reply and has not yet emitted its download callback.
+struct StartingUpdateDownloadView: View {
+    var body: some View {
+        HStack(spacing: 10) {
+            ProgressView()
+                .controlSize(.small)
+            Text(String(
+                localized: "update.startingDownload",
+                defaultValue: "Starting Download…"
+            ))
+            .cmuxFont(size: 13)
+        }
+        .padding(16)
+    }
+}


### PR DESCRIPTION
## Summary

Fixes the intermittent NIGHTLY update-pill no-op by making `UpdateController` the single causal owner from the accepted install through Sparkle's `showDownloadInitiated` callback.

- serializes replacement checks behind Sparkle's authoritative `didFinishUpdateCycleForUpdateCheck` signal instead of a guessed 100 ms delay
- keeps explicit `preparingCheck` and `startingDownload` phases visible while ownership is in flight
- records whether a prompt/check ended because of the user, a superseding controller transition, or the accepted install
- treats Sparkle's identity-free `dismissUpdateInstallation()` as diagnostic-only, so an old session cannot erase a newer prompt or progress state
- turns every unexpected accepted-install terminal into a retryable **Update Didn't Start** error and causally resolves the Sparkle callback it replaces
- prevents informational/background no-update results from dismissing a foreground prompt
- removes cmux's duplicate periodic information probe; Sparkle remains the periodic scheduler, while cmux retains the immediate launch probe
- adds lifecycle logs for check intent, session replacement, prompt consumption source, cycle completion, download hand-off, and every accepted-install failure

## Root cause and invariant

The previous flow inferred transport lifecycle from UI states. It dismissed the current prompt, slept for 100 ms, started another check, and allowed Sparkle's identity-free dismissal callback to mutate whatever state happened to be current. The install coordinator also stopped owning the operation as soon as it sent `.install`, before Sparkle actually reported that downloading began. A concurrent/background callback or a still-active old Sparkle session could therefore clear the pill without download or error.

The new invariant is: after the user accepts an update, the lifecycle owner remains active until Sparkle starts download/progress, a retryable error is visible, or the user causally cancels. Replaced UI phases are published before their Sparkle callback is completed, so synchronous teardown cannot create an empty-pill window.

This preserves the fresh re-resolution required by #6366, the install routing fixed by #7235, and DEV/staging suppression from #6292.

## Regression proof

The commits intentionally preserve red/green structure:

1. `68c0264887` — adds failing behavioral regressions for the concurrent-cycle wait, identity-free dismissal, unattributed prompt loss, and background no-update isolation.
2. `b2edfcb64c` — implements the causal lifecycle and makes the suite green.

The final package suite contains deterministic callback-level replays for:

- replacement checks waiting for the old Sparkle cycle to finish
- prompt dismissal arriving before and after install acceptance
- accepted install ownership lasting through `showDownloadInitiated`
- updater-readiness timeout and install watchdog recovery
- an unresolved old cycle and a check call that emits no user-driver callback
- unattributed prompt loss becoming a visible error
- retryable failure acknowledging the Sparkle terminal it replaces
- explicit user cancellation remaining non-error
- passive no-update results preserving foreground UI

A real release-channel install is not covered by XCUITest: DEV builds intentionally suppress the public appcast, and the report is intermittent. The package harness exercises the same `UpdateController`, driver callbacks, prompt replies, fake updater session, and injected deadline clock without timing sleeps.

## Validation

- `cd Packages/macOS/CmuxUpdater && arch -arm64 swift test` — 85 tests passed
- `cd Packages/macOS/CmuxUpdaterUI && arch -arm64 swift test` — 4 tests passed
- `./scripts/reload.sh --tag issue-8368-update-pill-noop` — succeeded
- `git diff --check`
- `jq empty Resources/Localizable.xcstrings`
- `python3 scripts/check-package-resolved-policy.py`
- `python3 scripts/check-workspace-package-groups.py --check`
- `./scripts/lint-pbxproj-test-wiring.sh`

The requested `scripts/swift_file_length_budget.py` and `.github/swift-file-length-budget.tsv` do not exist in this checkout/base revision. I checked actual line counts instead: every changed/new Swift file remains below 500 lines; the largest is 461 lines, and the extracted `UpdateController.swift` / `UpdateStateModel.swift` shrink from 497 / 480 lines on `main` to 390 / 385. Neither budget TSV is touched. The warning-budget check reports one unrelated existing warning in `Sources/ContentView+ForkAgentConversation.swift`; the tagged build log contains no warnings from changed updater files and `swift-warning-budget.tsv` is untouched.

## Localization

New visible phases are localized in `Resources/Localizable.xcstrings` for English and Japanese:

- Preparing Update Check
- Starting Download
- both explanatory messages

The eight moved DEBUG error-menu labels are localized as well. The catalog parses successfully, all 12 added keys have translated `en` and `ja` units, and changed Swift files were audited for bare user-facing English. Remaining bare English in `DebugUpdateErrorScenario` is synthetic Sparkle error input used to exercise the existing localized error classifier, not rendered copy.

Issue: https://github.com/manaflow-ai/cmux/issues/8368

Closes #8368

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8375"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786917053&installation_id=133855650&pr_number=8375&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8375&signature=1268acd0c2f6f49c4cd86268075ac98da848c9196b4855809ae9d1fc9ac3a66b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes update installs causal and visible to fix the intermittent update-pill no-op. Replacement checks wait for `Sparkle`’s session to finish, manual checks that abort show a clear error, and we surface “Preparing Update Check” and “Starting Download”. Fixes #8368.

- **Bug Fixes**
  - `UpdateController` owns the flow from Install click through `Sparkle`’s download-start; ownership ends only on progress, a retryable error, or explicit cancel.
  - Replacement checks start only after `Sparkle`’s cycle-finished callback and updater readiness; a waiting phase shows as `preparingCheck` with cancel.
  - Background no-update and stale dismiss/cancel callbacks no longer clear newer prompts or active progress; aborted foreground checks now show a retryable error; a watchdog surfaces “Update Didn’t Start” if no download begins in time.

- **New Features**
  - New `preparingCheck` and `startingDownload` UI in `CmuxUpdaterUI`, with `en`/`ja` strings and badge/spinner support.
  - Manual checks from the menu and custom popover are serialized behind `Sparkle`’s cycle-finished signal; install intent wins over coincident manual checks.
  - Prompt replies record their source (`user`, `superseded`, `installAttempt`) to preserve causal ownership; added a debug-only catalog to preview error popovers.

<sup>Written for commit 059898d25718b52e7501895b61a14a5b3dc9e7bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8375?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer “Preparing Update Check…” and “Starting Download…” UI states, each with progress indicators and cancellation support.
  * Improved foreground update-check behavior so “install latest” takes precedence and doesn’t interfere with an in-progress update session.
  * Added new localized status and diagnostic messages for these flows.

* **Bug Fixes**
  * Prevented stale prompts and out-of-order callback events from interrupting active downloads/installations.
  * Enhanced watchdog stall detection and surfaced consistent “installation didn’t start” errors when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->