### PR TITLE
Fix authenticated IndexNow deployment trigger

### DIFF
--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -23,11 +23,12 @@ jobs:
     steps:
       - name: Dispatch authenticated submission
         env:
+          DEFAULT_BRANCH: ${{ github.event.repository.default_branch }}
           GH_TOKEN: ${{ github.token }}
         run: >-
           gh workflow run indexnow.yml
           --repo "$GITHUB_REPOSITORY"
-          --ref "${{ github.event.repository.default_branch }}"
+          --ref "$DEFAULT_BRANCH"
 
   notify:
     name: Notify IndexNow

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -9,11 +9,13 @@ permissions:
 
 jobs:
   dispatch:
+    name: Dispatch notification run
     if: >-
       github.event_name == 'deployment_status' &&
       github.event.deployment_status.state == 'success' &&
       github.event.deployment.environment == 'Production – cmux'
     permissions:
+      # Required to start the secret-bearing workflow_dispatch run.
       actions: write
       contents: read
     runs-on: ubuntu-latest
@@ -22,9 +24,13 @@ jobs:
       - name: Dispatch authenticated submission
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh workflow run indexnow.yml --repo "$GITHUB_REPOSITORY" --ref main
+        run: >-
+          gh workflow run indexnow.yml
+          --repo "$GITHUB_REPOSITORY"
+          --ref "${{ github.event.repository.default_branch }}"
 
   notify:
+    name: Notify IndexNow
     if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2

--- a/.github/workflows/indexnow.yml
+++ b/.github/workflows/indexnow.yml
@@ -2,15 +2,30 @@ name: Notify IndexNow
 
 on:
   deployment_status:
+  workflow_dispatch:
 
 permissions:
   contents: read
 
 jobs:
-  notify:
+  dispatch:
     if: >-
+      github.event_name == 'deployment_status' &&
       github.event.deployment_status.state == 'success' &&
       github.event.deployment.environment == 'Production – cmux'
+    permissions:
+      actions: write
+      contents: read
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Dispatch authenticated submission
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: gh workflow run indexnow.yml --repo "$GITHUB_REPOSITORY" --ref main
+
+  notify:
+    if: github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:


### PR DESCRIPTION
Why

Vercel creates the deployment_status event as vercel[bot], so GitHub withholds repository secrets from that run. The merged workflow therefore received an empty INDEXNOW_TRIGGER_SECRET.

Summary

- dispatch a workflow_dispatch run after a successful production deployment
- keep the secret-bearing POST in the dispatched run
- grant actions:write only to the dispatch job

Testing

- actionlint .github/workflows/indexnow.yml
- production failure reproduced in https://github.com/manaflow-ai/cmux/actions/runs/29619991640

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8384"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786922041&installation_id=133855650&pr_number=8384&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8384&signature=8479b68ea22a7e0f6ac2f4ad70194088418b59efbb36481d2a7aa33fdbfb2f12"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IndexNow notifications after production deploys by moving the secreted submission into an authenticated `workflow_dispatch` run. Prevents empty `INDEXNOW_TRIGGER_SECRET` caused by vercel[bot] `deployment_status` events.

- **Bug Fixes**
  - Added `workflow_dispatch` trigger and split workflow into `dispatch` and `notify` jobs.
  - On successful Production deploy, `dispatch` runs with `actions: write` and `contents: read`, then calls `gh workflow run indexnow.yml` using `GH_TOKEN`, passing `--ref` from env `DEFAULT_BRANCH` to target the repo’s default branch.
  - `notify` runs only on `workflow_dispatch`; added stricter conditions and short timeouts to harden execution.

<sup>Written for commit 4565d2bae107c20e28471e90b107a89ef2ef541a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8384?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a manual trigger for the IndexNow workflow.
  * Automatically re-triggers the IndexNow workflow after successful Production (“cmux”) deployments.
* **Bug Fixes**
  * Corrected notification behavior so it runs only for manual workflow dispatch events, avoiding unintended execution paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->