### PR TITLE
iOS Dispatch: compose a brief on your phone, an agent starts working on your Mac

### DIFF
--- a/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
+++ b/Packages/iOS/CmuxMobileRPC/Sources/CmuxMobileRPC/MobileCoreRPCClient.swift
@@ -471,6 +471,10 @@ public final class MobileCoreRPCClient: MobileSyncing, Sendable {
             )
         case "mobile.events.subscribe", "mobile.events.unsubscribe":
             return false
+        case "mobile.dispatch.catalog", "mobile.dispatch.fs", "mobile.dispatch.launch":
+            // Dispatch is allowed for workspace-scoped tickets (it creates and
+            // is then granted its own workspace), so keep the ticket context.
+            return false
         default:
             return true
         }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchComposerModel.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchComposerModel.swift
@@ -1,0 +1,225 @@
+public import Foundation
+public import Observation
+
+/// Orchestrates one work order: catalog loading, draft state, validation,
+/// and the launch state machine the stamp UI renders.
+///
+/// Field validation is deliberately lazy — the Dispatch button stays tappable
+/// and a failed attempt marks the first offending field instead of leaving the
+/// user staring at a silently disabled button.
+@MainActor
+@Observable
+public final class DispatchComposerModel {
+    public enum CatalogState: Equatable {
+        case loading
+        case ready(DispatchCatalog)
+        case failed
+    }
+
+    public enum LaunchState: Equatable {
+        case idle
+        case launching
+        case rejected(DispatchLaunchFailure)
+        case dispatched
+    }
+
+    /// The field a failed validation should visually nudge.
+    public enum ValidationField: Equatable {
+        case brief
+        case agent
+    }
+
+    public private(set) var catalogState: CatalogState = .loading
+    public private(set) var launchState: LaunchState = .idle
+    public private(set) var validationNudge: ValidationField?
+    /// Bumped on every repeated nudge so an already-marked field shakes again.
+    public private(set) var validationNudgeGeneration = 0
+
+    public var brief: String {
+        didSet {
+            guard brief != oldValue else { return }
+            clearTransientFeedback()
+            persistDraft()
+        }
+    }
+
+    public private(set) var directoryPath: String?
+    public private(set) var agentID: String?
+
+    /// Serial stamped on this work order (increments only on launch).
+    public private(set) var serial: Int
+
+    public let service: any DispatchComposerServicing
+    private let localStore: DispatchLocalStore
+    private var catalogTask: Task<Void, Never>?
+    private var launchTask: Task<Void, Never>?
+
+    public init(service: any DispatchComposerServicing, localStore: DispatchLocalStore = DispatchLocalStore()) {
+        self.service = service
+        self.localStore = localStore
+        let draft = localStore.draft(macID: service.dispatchMacKey)
+        brief = draft?.brief ?? ""
+        directoryPath = draft?.directoryPath
+        agentID = draft?.agentID
+        serial = localStore.nextSerial(macID: service.dispatchMacKey)
+    }
+
+    // MARK: - Catalog
+
+    public var catalog: DispatchCatalog? {
+        if case let .ready(catalog) = catalogState { return catalog }
+        return nil
+    }
+
+    public var agents: [DispatchAgent] { catalog?.agents ?? [] }
+    public var recentDirectories: [DispatchDirectory] { catalog?.recentDirectories ?? [] }
+    public var homePath: String? { catalog?.home }
+    public var promptByteBudget: Int { catalog?.promptByteBudget ?? 900 }
+
+    public func loadCatalogIfNeeded() {
+        guard catalogTask == nil, catalog == nil else { return }
+        catalogState = .loading
+        catalogTask = Task { [weak self] in
+            guard let self else { return }
+            defer { self.catalogTask = nil }
+            do {
+                let catalog = try await self.service.dispatchCatalog()
+                self.catalogState = .ready(catalog)
+                self.applyCatalogDefaults(catalog)
+            } catch {
+                guard !Task.isCancelled else { return }
+                self.catalogState = .failed
+            }
+        }
+    }
+
+    public func retryCatalog() {
+        catalogTask?.cancel()
+        catalogTask = nil
+        catalogState = .loading
+        loadCatalogIfNeeded()
+    }
+
+    private func applyCatalogDefaults(_ catalog: DispatchCatalog) {
+        if directoryPath == nil {
+            directoryPath = catalog.recentDirectories.first?.path ?? catalog.home
+            persistDraft()
+        }
+        let installedIDs = catalog.agents.filter(\.installed).map(\.id)
+        if agentID == nil || !catalog.agents.contains(where: { $0.id == agentID && $0.installed }) {
+            agentID = installedIDs.first
+            persistDraft()
+        }
+    }
+
+    // MARK: - Draft fields
+
+    public func selectDirectory(_ path: String) {
+        directoryPath = path
+        clearTransientFeedback()
+        persistDraft()
+    }
+
+    public func selectAgent(_ id: String) {
+        guard agents.first(where: { $0.id == id })?.installed == true else { return }
+        agentID = id
+        clearTransientFeedback()
+        persistDraft()
+    }
+
+    private func persistDraft() {
+        localStore.saveDraft(
+            DispatchDraft(brief: brief, directoryPath: directoryPath, agentID: agentID),
+            macID: service.dispatchMacKey
+        )
+    }
+
+    /// Shorten a path for display by abbreviating the Mac's home directory.
+    public func displayPath(_ path: String) -> String {
+        guard let home = homePath, !home.isEmpty else { return path }
+        if path == home { return "~" }
+        if path.hasPrefix(home + "/") {
+            return "~" + path.dropFirst(home.count)
+        }
+        return path
+    }
+
+    // MARK: - Budget
+
+    public var briefByteCount: Int { brief.utf8.count }
+    public var isOverBudget: Bool { briefByteCount > promptByteBudget }
+    /// The counter stays hidden until the brief approaches the wire budget.
+    public var showsBudgetCounter: Bool { briefByteCount * 4 >= promptByteBudget * 3 }
+
+    // MARK: - Launch
+
+    public var selectedAgent: DispatchAgent? {
+        agents.first(where: { $0.id == agentID })
+    }
+
+    public var trimmedBrief: String {
+        brief.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    public var canAttemptDispatch: Bool {
+        if case .launching = launchState { return false }
+        if case .dispatched = launchState { return false }
+        return true
+    }
+
+    /// Validate, then launch. Invalid input nudges the offending field instead
+    /// of failing silently or pre-disabling the button.
+    public func attemptDispatch() {
+        guard canAttemptDispatch else { return }
+        guard !trimmedBrief.isEmpty, !isOverBudget else {
+            nudge(.brief)
+            return
+        }
+        guard let agent = selectedAgent, agent.installed else {
+            nudge(.agent)
+            return
+        }
+        guard let directoryPath else {
+            // No directory can only happen before the catalog resolved a default.
+            nudge(.brief)
+            return
+        }
+        let prompt = trimmedBrief
+        launchState = .launching
+        launchTask = Task { [weak self] in
+            guard let self else { return }
+            defer { self.launchTask = nil }
+            let result = await self.service.dispatchLaunch(
+                directory: directoryPath,
+                agentID: agent.id,
+                prompt: prompt
+            )
+            guard !Task.isCancelled else { return }
+            switch result {
+            case .success:
+                self.localStore.recordCompletedDispatch(macID: self.service.dispatchMacKey)
+                self.localStore.clearDraft(macID: self.service.dispatchMacKey)
+                self.launchState = .dispatched
+            case let .failure(failure):
+                self.launchState = .rejected(failure)
+            }
+        }
+    }
+
+    private func nudge(_ field: ValidationField) {
+        validationNudge = field
+        validationNudgeGeneration &+= 1
+    }
+
+    private func clearTransientFeedback() {
+        validationNudge = nil
+        if case .rejected = launchState {
+            launchState = .idle
+        }
+    }
+
+    public func cancelInFlightWork() {
+        catalogTask?.cancel()
+        launchTask?.cancel()
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchComposerServicing.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchComposerServicing.swift
@@ -1,0 +1,20 @@
+public import Foundation
+
+/// The narrow store surface the Dispatch composer depends on.
+///
+/// `MobileShellComposite` is the production conformer; previews and tests use
+/// lightweight stubs so the composer UI renders without a paired Mac.
+@MainActor
+public protocol DispatchComposerServicing: AnyObject {
+    /// Display name of the connected Mac, for the work-order header.
+    var dispatchHostName: String? { get }
+    /// Whether a launch attempted right now could reach the Mac.
+    var dispatchIsConnected: Bool { get }
+    /// Stable per-Mac key for drafts and serial counters.
+    var dispatchMacKey: String { get }
+
+    func dispatchCatalog() async throws -> DispatchCatalog
+    func dispatchFSList(path: String, includeHidden: Bool) async throws -> DispatchFSList
+    func dispatchFSSearch(query: String) async throws -> DispatchFSSearch
+    func dispatchLaunch(directory: String, agentID: String, prompt: String) async -> Result<Void, DispatchLaunchFailure>
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchLocalStore.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchLocalStore.swift
@@ -1,0 +1,50 @@
+public import Foundation
+
+/// Per-Mac local persistence for the dispatch composer: the in-progress draft
+/// and the serial counter stamped on the work-order header.
+///
+/// Drafts survive dismissing the sheet; the serial increments only when a
+/// dispatch actually launches, so `Nº` numbers real work orders.
+@MainActor
+public struct DispatchLocalStore {
+    private let defaults: UserDefaults
+
+    public init(defaults: UserDefaults = .standard) {
+        self.defaults = defaults
+    }
+
+    private func draftKey(macID: String) -> String { "mobile.dispatch.draft.\(macID)" }
+    private func serialKey(macID: String) -> String { "mobile.dispatch.serial.\(macID)" }
+
+    public func draft(macID: String) -> DispatchDraft? {
+        guard let data = defaults.data(forKey: draftKey(macID: macID)) else { return nil }
+        return try? JSONDecoder().decode(DispatchDraft.self, from: data)
+    }
+
+    public func saveDraft(_ draft: DispatchDraft, macID: String) {
+        if draft.isEmpty {
+            defaults.removeObject(forKey: draftKey(macID: macID))
+            return
+        }
+        guard let data = try? JSONEncoder().encode(draft) else { return }
+        defaults.set(data, forKey: draftKey(macID: macID))
+    }
+
+    public func clearDraft(macID: String) {
+        defaults.removeObject(forKey: draftKey(macID: macID))
+    }
+
+    /// The count of completed dispatches for this Mac.
+    public func completedCount(macID: String) -> Int {
+        defaults.integer(forKey: serialKey(macID: macID))
+    }
+
+    /// The serial shown on the next work order (1-based).
+    public func nextSerial(macID: String) -> Int {
+        completedCount(macID: macID) + 1
+    }
+
+    public func recordCompletedDispatch(macID: String) {
+        defaults.set(completedCount(macID: macID) + 1, forKey: serialKey(macID: macID))
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchProjectPickerModel.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/DispatchProjectPickerModel.swift
@@ -1,0 +1,109 @@
+public import Foundation
+public import Observation
+
+/// Drives the project picker: debounced server-side fuzzy search across the
+/// Mac's directories, plus per-level browse listing.
+///
+/// While the Mac reports its directory index is still building, the model
+/// re-polls the same query a few times so first-run searches fill in without
+/// the user having to retype.
+@MainActor
+@Observable
+public final class DispatchProjectPickerModel {
+    public enum SearchState: Equatable {
+        case idle
+        case searching
+        case results([DispatchDirectory], indexing: Bool, truncated: Bool)
+        case failed
+    }
+
+    public var query: String = "" {
+        didSet {
+            guard query != oldValue else { return }
+            scheduleSearch()
+        }
+    }
+
+    /// Whether browse levels include dot-directories.
+    public var includeHidden = false
+
+    public private(set) var searchState: SearchState = .idle
+
+    private let service: any DispatchComposerServicing
+    private let clock: any Clock<Duration>
+    private var searchTask: Task<Void, Never>?
+
+    private static let debounce: Duration = .milliseconds(200)
+    private static let indexingRepollDelay: Duration = .milliseconds(900)
+    /// First-run index builds on large home folders take tens of seconds;
+    /// keep results filling in for a while before requiring another keystroke.
+    private static let maxIndexingRepolls = 30
+
+    public init(service: any DispatchComposerServicing, clock: any Clock<Duration> = ContinuousClock()) {
+        self.service = service
+        self.clock = clock
+    }
+
+    public var trimmedQuery: String {
+        query.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func scheduleSearch() {
+        searchTask?.cancel()
+        let trimmed = trimmedQuery
+        guard !trimmed.isEmpty else {
+            searchState = .idle
+            return
+        }
+        searchState = .searching
+        searchTask = Task { [weak self, clock] in
+            do {
+                try await clock.sleep(for: Self.debounce)
+            } catch {
+                return
+            }
+            await self?.runSearch(trimmed, repollsLeft: Self.maxIndexingRepolls)
+        }
+    }
+
+    private func runSearch(_ query: String, repollsLeft: Int) async {
+        do {
+            let response = try await service.dispatchFSSearch(query: query)
+            guard !Task.isCancelled, trimmedQuery == query else { return }
+            searchState = .results(response.entries, indexing: response.indexing, truncated: response.truncated)
+            if response.indexing, repollsLeft > 0 {
+                do {
+                    try await clock.sleep(for: Self.indexingRepollDelay)
+                } catch {
+                    return
+                }
+                guard !Task.isCancelled, trimmedQuery == query else { return }
+                await runSearch(query, repollsLeft: repollsLeft - 1)
+            }
+        } catch {
+            guard !Task.isCancelled, trimmedQuery == query else { return }
+            searchState = .failed
+        }
+    }
+
+    public func retrySearch() {
+        scheduleSearch()
+    }
+
+    /// Load one browse level. Level views own the returned state; permission
+    /// notices ride along in the success payload so the list stays usable.
+    public func loadLevel(path: String) async -> Result<DispatchFSList, DispatchLaunchFailure> {
+        do {
+            let list = try await service.dispatchFSList(path: path, includeHidden: includeHidden)
+            return .success(list)
+        } catch let failure as DispatchLaunchFailure {
+            return .failure(failure)
+        } catch {
+            return .failure(MobileShellComposite.dispatchLaunchFailure(from: error))
+        }
+    }
+
+    public func cancelInFlightWork() {
+        searchTask?.cancel()
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileDispatchModels.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileDispatchModels.swift
@@ -1,0 +1,199 @@
+public import Foundation
+
+/// A coding agent the Mac can dispatch, from `mobile.dispatch.catalog`.
+public struct DispatchAgent: Identifiable, Equatable, Sendable, Decodable {
+    public let id: String
+    public let name: String
+    public let installed: Bool
+
+    public init(id: String, name: String, installed: Bool) {
+        self.id = id
+        self.name = name
+        self.installed = installed
+    }
+}
+
+/// A directory candidate from catalog recents or `mobile.dispatch.fs`.
+public struct DispatchDirectory: Identifiable, Equatable, Sendable, Decodable {
+    public var id: String { path }
+    public let path: String
+    public let git: Bool
+
+    public init(path: String, git: Bool) {
+        self.path = path
+        self.git = git
+    }
+
+    /// The last path component, for row titles.
+    public var name: String {
+        let component = (path as NSString).lastPathComponent
+        return component.isEmpty ? path : component
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case git
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try container.decode(String.self, forKey: .path)
+        git = try container.decodeIfPresent(Bool.self, forKey: .git) ?? false
+    }
+}
+
+/// The Mac's dispatch catalog: installed agents, recent project directories,
+/// and the prompt size budget enforced by the launch RPC.
+public struct DispatchCatalog: Equatable, Sendable, Decodable {
+    public let home: String
+    public let agents: [DispatchAgent]
+    public let recentDirectories: [DispatchDirectory]
+    public let promptByteBudget: Int
+
+    public init(home: String, agents: [DispatchAgent], recentDirectories: [DispatchDirectory], promptByteBudget: Int) {
+        self.home = home
+        self.agents = agents
+        self.recentDirectories = recentDirectories
+        self.promptByteBudget = promptByteBudget
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case home
+        case agents
+        case recentDirectories = "recent_dirs"
+        case promptByteBudget = "prompt_byte_budget"
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        home = try container.decode(String.self, forKey: .home)
+        agents = try container.decodeIfPresent([DispatchAgent].self, forKey: .agents) ?? []
+        recentDirectories = try container.decodeIfPresent([DispatchDirectory].self, forKey: .recentDirectories) ?? []
+        promptByteBudget = try container.decodeIfPresent(Int.self, forKey: .promptByteBudget) ?? 900
+    }
+
+    public static func decode(_ data: Data) throws -> DispatchCatalog {
+        try JSONDecoder().decode(DispatchCatalog.self, from: data)
+    }
+}
+
+/// A non-fatal condition attached to an otherwise successful `mobile.dispatch.fs`
+/// response (for example a macOS privacy denial for a protected folder).
+public struct DispatchFSNotice: Equatable, Sendable, Decodable {
+    public let code: String
+    public let message: String
+
+    public init(code: String, message: String) {
+        self.code = code
+        self.message = message
+    }
+
+    public var isPermissionDenied: Bool { code == "permission_denied" }
+}
+
+/// One level of directory browsing from `mobile.dispatch.fs` (`op: list`).
+public struct DispatchFSList: Equatable, Sendable, Decodable {
+    public let path: String
+    public let entries: [DispatchDirectory]
+    public let notice: DispatchFSNotice?
+    public let truncated: Bool
+
+    public init(path: String, entries: [DispatchDirectory], notice: DispatchFSNotice?, truncated: Bool) {
+        self.path = path
+        self.entries = entries
+        self.notice = notice
+        self.truncated = truncated
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case path
+        case entries
+        case notice
+        case truncated
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        path = try container.decode(String.self, forKey: .path)
+        entries = try container.decodeIfPresent([DispatchDirectory].self, forKey: .entries) ?? []
+        notice = try container.decodeIfPresent(DispatchFSNotice.self, forKey: .notice)
+        truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+    }
+
+    public static func decode(_ data: Data) throws -> DispatchFSList {
+        try JSONDecoder().decode(DispatchFSList.self, from: data)
+    }
+}
+
+/// Ranked directory search results from `mobile.dispatch.fs` (`op: search`).
+public struct DispatchFSSearch: Equatable, Sendable, Decodable {
+    public let query: String
+    public let entries: [DispatchDirectory]
+    /// True while the Mac is still building its directory index; results may be partial.
+    public let indexing: Bool
+    public let truncated: Bool
+
+    public init(query: String, entries: [DispatchDirectory], indexing: Bool, truncated: Bool) {
+        self.query = query
+        self.entries = entries
+        self.indexing = indexing
+        self.truncated = truncated
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case query
+        case entries
+        case indexing
+        case truncated
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        query = try container.decodeIfPresent(String.self, forKey: .query) ?? ""
+        entries = try container.decodeIfPresent([DispatchDirectory].self, forKey: .entries) ?? []
+        indexing = try container.decodeIfPresent(Bool.self, forKey: .indexing) ?? false
+        truncated = try container.decodeIfPresent(Bool.self, forKey: .truncated) ?? false
+    }
+
+    public static func decode(_ data: Data) throws -> DispatchFSSearch {
+        try JSONDecoder().decode(DispatchFSSearch.self, from: data)
+    }
+}
+
+/// Why a dispatch launch failed, mapped from wire error codes so the composer
+/// can stamp a concrete, localized rejection reason.
+public enum DispatchLaunchFailure: Error, Equatable, Sendable {
+    /// The target Mac was not connected when the launch was attempted.
+    case notConnected
+    /// The Mac did not answer before the request timeout expired.
+    case requestTimedOut
+    /// The request failed authorization against the target Mac.
+    case authorizationFailed
+    /// The chosen agent's CLI is not installed on the Mac.
+    case agentNotInstalled
+    /// The chosen project directory no longer exists on the Mac.
+    case directoryNotFound
+    /// The brief exceeds the Mac's prompt byte budget.
+    case promptTooLong
+    /// The Mac rejected the launch for another reason (developer message attached).
+    case rejected(message: String?)
+}
+
+/// A saved, per-Mac composer draft so leaving the sheet never loses work.
+public struct DispatchDraft: Equatable, Sendable, Codable {
+    public var brief: String
+    public var directoryPath: String?
+    public var agentID: String?
+
+    public init(brief: String = "", directoryPath: String? = nil, agentID: String? = nil) {
+        self.brief = brief
+        self.directoryPath = directoryPath
+        self.agentID = agentID
+    }
+
+    public var isEmpty: Bool {
+        brief.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+            && directoryPath == nil
+            && agentID == nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacUpdateCapabilityRequirement.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacUpdateCapabilityRequirement.swift
@@ -57,5 +57,6 @@ public struct MobileMacUpdateCapabilityRequirement: Sendable, Equatable {
         .init(capability: "workspace.group_actions.v1", feature: .workspaceGroupActions, firstReleasedMacVersion: nil),
         .init(capability: "workspace.create_in_group.v1", feature: .workspaceCreateInGroup, firstReleasedMacVersion: nil),
         .init(capability: "workspace.group_create.v1", feature: .workspaceGroupCreate, firstReleasedMacVersion: nil),
+        .init(capability: "workspace.dispatch.v1", feature: .agentDispatch, firstReleasedMacVersion: nil),
     ]
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacUpdateFeature.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileMacUpdateFeature.swift
@@ -25,4 +25,7 @@ public enum MobileMacUpdateFeature: String, CaseIterable, Sendable {
 
     /// Creating workspace groups.
     case workspaceGroupCreate
+
+    /// Composing a brief and dispatching an agent workspace.
+    case agentDispatch
 }

--- a/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Dispatch.swift
+++ b/Packages/iOS/CmuxMobileShell/Sources/CmuxMobileShell/MobileShellComposite+Dispatch.swift
@@ -1,0 +1,144 @@
+internal import CmuxMobileRPC
+public import CmuxMobileShellModel
+internal import Foundation
+
+/// The store-side service surface for the iOS Dispatch composer: catalog,
+/// directory search/browse, and the launch request itself.
+///
+/// The client gate for the feature is the host capability ONLY — attach-ticket
+/// scoping is enforced server-side, and workspace-scoped tickets are allowed to
+/// dispatch (matching `workspace.create`).
+extension MobileShellComposite: DispatchComposerServicing {
+    static let agentDispatchCapability = "workspace.dispatch.v1"
+
+    /// Whether the connected Mac supports the Dispatch composer RPCs.
+    public var supportsAgentDispatch: Bool {
+        supportedHostCapabilities.contains(Self.agentDispatchCapability)
+    }
+
+    /// Host name shown on the work-order header.
+    public var dispatchHostName: String? { connectedHostName }
+
+    /// Whether a launch attempted right now could reach the Mac.
+    public var dispatchIsConnected: Bool { connectionState == .connected }
+
+    /// Stable key for per-Mac dispatch drafts and serials.
+    public var dispatchMacKey: String { foregroundMacDeviceID ?? "default" }
+
+    public func dispatchCatalog() async throws -> DispatchCatalog {
+        guard let client = remoteClient else { throw DispatchLaunchFailure.notConnected }
+        let data = try await client.sendRequest(
+            MobileCoreRPCClient.requestData(method: "mobile.dispatch.catalog", params: [:])
+        )
+        return try DispatchCatalog.decode(data)
+    }
+
+    public func dispatchFSList(path: String, includeHidden: Bool) async throws -> DispatchFSList {
+        guard let client = remoteClient else { throw DispatchLaunchFailure.notConnected }
+        let data = try await client.sendRequest(
+            MobileCoreRPCClient.requestData(
+                method: "mobile.dispatch.fs",
+                params: ["op": "list", "path": path, "include_hidden": includeHidden]
+            )
+        )
+        return try DispatchFSList.decode(data)
+    }
+
+    public func dispatchFSSearch(query: String) async throws -> DispatchFSSearch {
+        guard let client = remoteClient else { throw DispatchLaunchFailure.notConnected }
+        let data = try await client.sendRequest(
+            MobileCoreRPCClient.requestData(
+                method: "mobile.dispatch.fs",
+                params: ["op": "search", "query": query]
+            )
+        )
+        return try DispatchFSSearch.decode(data)
+    }
+
+    /// Launch an agent workspace from a composed brief.
+    ///
+    /// On success the Mac's response carries the refreshed workspace list plus
+    /// the created workspace id; this applies the list and selects the new
+    /// workspace so the shell's existing selection-driven navigation pushes
+    /// straight into its live terminal.
+    public func dispatchLaunch(
+        directory: String,
+        agentID: String,
+        prompt: String
+    ) async -> Result<Void, DispatchLaunchFailure> {
+        guard let client = remoteClient else {
+            return .failure(.notConnected)
+        }
+        let generation = connectionGeneration
+        do {
+            let resultData = try await client.sendRequest(
+                MobileCoreRPCClient.requestData(
+                    method: "mobile.dispatch.launch",
+                    params: [
+                        "directory": directory,
+                        "agent_id": agentID,
+                        "prompt": prompt,
+                    ]
+                )
+            )
+            let response = try MobileSyncWorkspaceListResponse.decode(resultData)
+            guard isCurrentRemoteOperation(client: client, generation: generation), !Task.isCancelled else {
+                return .success(())
+            }
+            applyRemoteWorkspaceList(response, mergeExistingWorkspaces: true)
+            if let createdWorkspace = response.createdWorkspaceID.map(MobileWorkspacePreview.ID.init(rawValue:)) {
+                setSelectedWorkspaceID(
+                    rowWorkspaceID(
+                        forRemoteWorkspaceID: createdWorkspace,
+                        macDeviceID: foregroundMacDeviceID
+                    ) ?? createdWorkspace
+                )
+                syncSelectedTerminalForWorkspace()
+                // The dispatched terminal is freshly created and the agent owns it;
+                // opening it must not steal keyboard focus from the user.
+                suppressTerminalAutoFocusOnNextAttach(for: selectedTerminalID)
+            }
+            return .success(())
+        } catch {
+            guard generation == connectionGeneration, !Task.isCancelled else { return .success(()) }
+            if disconnectForAuthorizationFailureIfNeeded(error) {
+                return .failure(.authorizationFailed)
+            }
+            markMacConnectionUnavailableIfNeeded(after: error)
+            return .failure(Self.dispatchLaunchFailure(from: error))
+        }
+    }
+
+    static func dispatchLaunchFailure(from error: any Error) -> DispatchLaunchFailure {
+        guard let connectionError = error as? MobileShellConnectionError else {
+            return .rejected(message: nil)
+        }
+        switch connectionError {
+        case .connectionClosed:
+            return .notConnected
+        case .requestTimedOut:
+            return .requestTimedOut
+        case .attachTicketExpired, .authorizationFailed, .accountMismatch, .insecureManualRoute:
+            return .authorizationFailed
+        case let .rpcError(code, message):
+            let normalizedCode = code?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            switch normalizedCode {
+            case "agent_not_installed":
+                return .agentNotInstalled
+            case "directory_not_found":
+                return .directoryNotFound
+            case "prompt_too_long":
+                return .promptTooLong
+            case "unavailable":
+                return .notConnected
+            case "unauthorized", "forbidden", "invalid_token", "token_expired", "expired_token",
+                 "auth_required", "account_mismatch":
+                return .authorizationFailed
+            default:
+                return .rejected(message: message)
+            }
+        case .invalidResponse:
+            return .rejected(message: nil)
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DispatchComposerTests.swift
+++ b/Packages/iOS/CmuxMobileShell/Tests/CmuxMobileShellTests/DispatchComposerTests.swift
@@ -1,0 +1,187 @@
+import CmuxMobileRPC
+import Foundation
+import Testing
+@testable import CmuxMobileShell
+
+@MainActor
+private final class DispatchStubService: DispatchComposerServicing {
+    var dispatchHostName: String? { "Stub Mac" }
+    var dispatchIsConnected: Bool { true }
+    let dispatchMacKey: String
+
+    var catalog = DispatchCatalog(
+        home: "/Users/stub",
+        agents: [
+            DispatchAgent(id: "claude", name: "Claude Code", installed: true),
+            DispatchAgent(id: "codex", name: "Codex", installed: false),
+        ],
+        recentDirectories: [DispatchDirectory(path: "/Users/stub/Dev/proj", git: true)],
+        promptByteBudget: 900
+    )
+    var catalogError: (any Error)?
+    var launchResult: Result<Void, DispatchLaunchFailure> = .success(())
+    var launchRequests: [(directory: String, agentID: String, prompt: String)] = []
+
+    init(macKey: String = UUID().uuidString) {
+        dispatchMacKey = macKey
+    }
+
+    func dispatchCatalog() async throws -> DispatchCatalog {
+        if let catalogError { throw catalogError }
+        return catalog
+    }
+
+    func dispatchFSList(path: String, includeHidden: Bool) async throws -> DispatchFSList {
+        DispatchFSList(path: path, entries: [], notice: nil, truncated: false)
+    }
+
+    func dispatchFSSearch(query: String) async throws -> DispatchFSSearch {
+        DispatchFSSearch(query: query, entries: [], indexing: false, truncated: false)
+    }
+
+    func dispatchLaunch(directory: String, agentID: String, prompt: String) async -> Result<Void, DispatchLaunchFailure> {
+        launchRequests.append((directory, agentID, prompt))
+        return launchResult
+    }
+}
+
+@MainActor
+@Suite struct DispatchComposerTests {
+    private func makeDefaults() -> UserDefaults {
+        let suite = "dispatch-tests-\(UUID().uuidString)"
+        let defaults = UserDefaults(suiteName: suite)!
+        defaults.removePersistentDomain(forName: suite)
+        return defaults
+    }
+
+    private func settledModel(
+        service: DispatchStubService,
+        defaults: UserDefaults
+    ) async -> DispatchComposerModel {
+        let model = DispatchComposerModel(
+            service: service,
+            localStore: DispatchLocalStore(defaults: defaults)
+        )
+        model.loadCatalogIfNeeded()
+        for _ in 0 ..< 200 {
+            if model.catalog != nil { break }
+            await Task.yield()
+        }
+        return model
+    }
+
+    @Test func catalogDefaultsPickFirstRecentAndInstalledAgent() async {
+        let service = DispatchStubService()
+        let model = await settledModel(service: service, defaults: makeDefaults())
+
+        #expect(model.directoryPath == "/Users/stub/Dev/proj")
+        #expect(model.agentID == "claude")
+    }
+
+    @Test func emptyBriefNudgesBriefInsteadOfLaunching() async {
+        let service = DispatchStubService()
+        let model = await settledModel(service: service, defaults: makeDefaults())
+
+        model.attemptDispatch()
+
+        #expect(model.validationNudge == .brief)
+        #expect(model.launchState == .idle)
+        #expect(service.launchRequests.isEmpty)
+    }
+
+    @Test func overBudgetBriefNudgesBrief() async {
+        let service = DispatchStubService()
+        let model = await settledModel(service: service, defaults: makeDefaults())
+        model.brief = String(repeating: "é", count: 500)
+
+        #expect(model.isOverBudget)
+        model.attemptDispatch()
+        #expect(model.validationNudge == .brief)
+        #expect(service.launchRequests.isEmpty)
+    }
+
+    @Test func successfulDispatchClearsDraftAndIncrementsSerial() async {
+        let service = DispatchStubService()
+        let defaults = makeDefaults()
+        let model = await settledModel(service: service, defaults: defaults)
+        model.brief = "  Ship the thing  "
+        let serialBefore = model.serial
+
+        model.attemptDispatch()
+        for _ in 0 ..< 200 {
+            if model.launchState == .dispatched { break }
+            await Task.yield()
+        }
+
+        #expect(model.launchState == .dispatched)
+        #expect(service.launchRequests.count == 1)
+        #expect(service.launchRequests.first?.prompt == "Ship the thing")
+        #expect(service.launchRequests.first?.directory == "/Users/stub/Dev/proj")
+        let store = DispatchLocalStore(defaults: defaults)
+        #expect(store.draft(macID: service.dispatchMacKey) == nil)
+        #expect(store.nextSerial(macID: service.dispatchMacKey) == serialBefore + 1)
+    }
+
+    @Test func rejectedDispatchKeepsDraftAndClearsOnEdit() async {
+        let service = DispatchStubService()
+        service.launchResult = .failure(.agentNotInstalled)
+        let defaults = makeDefaults()
+        let model = await settledModel(service: service, defaults: defaults)
+        model.brief = "Do the work"
+
+        model.attemptDispatch()
+        for _ in 0 ..< 200 {
+            if case .rejected = model.launchState { break }
+            await Task.yield()
+        }
+
+        #expect(model.launchState == .rejected(.agentNotInstalled))
+        let store = DispatchLocalStore(defaults: defaults)
+        #expect(store.draft(macID: service.dispatchMacKey)?.brief == "Do the work")
+
+        model.brief = "Do the work now"
+        #expect(model.launchState == .idle)
+    }
+
+    @Test func draftRestoresAcrossModelInstances() async {
+        let service = DispatchStubService()
+        let defaults = makeDefaults()
+        let first = await settledModel(service: service, defaults: defaults)
+        first.brief = "Persisted brief"
+        first.selectDirectory("/Users/stub/Elsewhere")
+
+        let second = DispatchComposerModel(
+            service: service,
+            localStore: DispatchLocalStore(defaults: defaults)
+        )
+        #expect(second.brief == "Persisted brief")
+        #expect(second.directoryPath == "/Users/stub/Elsewhere")
+    }
+
+    @Test func uninstalledAgentCannotBeSelected() async {
+        let service = DispatchStubService()
+        let model = await settledModel(service: service, defaults: makeDefaults())
+
+        model.selectAgent("codex")
+
+        #expect(model.agentID == "claude")
+    }
+
+    @Test func launchFailureMapsWireCodes() {
+        func failure(code: String?) -> DispatchLaunchFailure {
+            MobileShellComposite.dispatchLaunchFailure(
+                from: MobileShellConnectionError.rpcError(code, "m")
+            )
+        }
+        #expect(failure(code: "agent_not_installed") == .agentNotInstalled)
+        #expect(failure(code: "directory_not_found") == .directoryNotFound)
+        #expect(failure(code: "prompt_too_long") == .promptTooLong)
+        #expect(failure(code: "unavailable") == .notConnected)
+        #expect(failure(code: "forbidden") == .authorizationFailed)
+        #expect(failure(code: "somethingelse") == .rejected(message: "m"))
+        #expect(
+            MobileShellComposite.dispatchLaunchFailure(from: MobileShellConnectionError.requestTimedOut)
+                == .requestTimedOut
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/CMUXMobileRootView.swift
@@ -78,6 +78,14 @@ struct CMUXMobileRootView: View {
         #endif
     }
 
+    private var shouldShowDispatchComposerPreview: Bool {
+        #if os(iOS) && DEBUG
+        return UITestConfig.dispatchComposerPreviewEnabled
+        #else
+        return false
+        #endif
+    }
+
     private var shouldShowStreamingChatPreview: Bool {
         #if os(iOS) && DEBUG
         return UITestConfig.streamingChatPreviewEnabled
@@ -105,6 +113,14 @@ struct CMUXMobileRootView: View {
     @ViewBuilder private var workspaceListLayoutPreview: some View {
         #if os(iOS) && DEBUG
         WorkspaceListLayoutPreviewView()
+        #else
+        EmptyView()
+        #endif
+    }
+
+    @ViewBuilder private var dispatchComposerPreview: some View {
+        #if os(iOS) && DEBUG
+        DispatchComposerPreviewView()
         #else
         EmptyView()
         #endif
@@ -215,6 +231,8 @@ struct CMUXMobileRootView: View {
             terminalLayoutPreview
         } else if shouldShowWorkspaceListLayoutPreview {
             workspaceListLayoutPreview
+        } else if shouldShowDispatchComposerPreview {
+            dispatchComposerPreview
         } else if shouldShowStreamingChatPreview {
             streamingChatPreview
         } else if !isAuthenticated {

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchBrowseScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchBrowseScreen.swift
@@ -1,0 +1,181 @@
+import CmuxMobileShell
+import CmuxMobileSupport
+import SwiftUI
+
+/// One level of the Mac's directory tree. Every subdirectory is listed (dot
+/// folders behind the Show Hidden toggle), so any path on the Mac is reachable
+/// by descending. macOS privacy denials render as an inline notice with the
+/// fix, and the level stays navigable.
+struct DispatchBrowseScreen: View {
+    let path: String
+    @Bindable var picker: DispatchProjectPickerModel
+    let composer: DispatchComposerModel
+    let select: (String) -> Void
+    let browse: (String) -> Void
+
+    private enum LevelState {
+        case loading
+        case loaded(DispatchFSList)
+        case failed(DispatchLaunchFailure)
+    }
+
+    @State private var level: LevelState = .loading
+
+    private var folderName: String {
+        let component = (path as NSString).lastPathComponent
+        return component.isEmpty ? "/" : component
+    }
+
+    var body: some View {
+        Group {
+            switch level {
+            case .loading:
+                ProgressView()
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            case let .failed(failure):
+                ContentUnavailableView {
+                    Label(
+                        L10n.string("mobile.dispatch.browse.failed", defaultValue: "Couldn't open this folder"),
+                        systemImage: "folder.badge.questionmark"
+                    )
+                } description: {
+                    Text(failure.displayReason(agentName: nil))
+                } actions: {
+                    Button(L10n.string("mobile.dispatch.retry", defaultValue: "Retry")) {
+                        level = .loading
+                        Task { await load() }
+                    }
+                }
+            case let .loaded(list):
+                levelList(list)
+            }
+        }
+        .navigationTitle(folderName)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                Menu {
+                    Toggle(isOn: $picker.includeHidden) {
+                        Label(
+                            L10n.string("mobile.dispatch.picker.showHidden", defaultValue: "Show Hidden Folders"),
+                            systemImage: "eye"
+                        )
+                    }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+        .task(id: picker.includeHidden) {
+            await load()
+        }
+        .accessibilityIdentifier("MobileDispatchBrowse")
+    }
+
+    private func load() async {
+        switch await picker.loadLevel(path: path) {
+        case let .success(list):
+            level = .loaded(list)
+        case let .failure(failure):
+            level = .failed(failure)
+        }
+    }
+
+    private func levelList(_ list: DispatchFSList) -> some View {
+        List {
+            Section {
+                Button {
+                    select(list.path)
+                } label: {
+                    HStack(spacing: 10) {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(Color.accentColor)
+                        VStack(alignment: .leading, spacing: 2) {
+                            Text(L10n.string(
+                                "mobile.dispatch.browse.useFolder",
+                                defaultValue: "Use This Folder"
+                            ))
+                            .font(.body.weight(.medium))
+                            .foregroundStyle(.primary)
+                            Text(composer.displayPath(list.path))
+                                .font(DispatchStyle.monoCaptionFont)
+                                .foregroundStyle(.secondary)
+                                .lineLimit(1)
+                                .truncationMode(.head)
+                        }
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("MobileDispatchUseFolder")
+            }
+
+            if let notice = list.notice {
+                Section {
+                    DispatchInlineNotice(
+                        icon: "lock",
+                        text: noticeText(notice),
+                        actionTitle: L10n.string("mobile.dispatch.retry", defaultValue: "Retry"),
+                        action: {
+                            level = .loading
+                            Task { await load() }
+                        }
+                    )
+                    .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
+                    .listRowBackground(Color.clear)
+                }
+            }
+
+            if !list.entries.isEmpty {
+                Section {
+                    ForEach(list.entries) { directory in
+                        DispatchDirectoryRow(
+                            name: directory.name,
+                            detail: composer.displayPath(directory.path),
+                            isGit: directory.git,
+                            isSelected: composer.directoryPath == directory.path,
+                            primaryAction: { browse(directory.path) },
+                            browseAction: nil
+                        )
+                        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+                            Button {
+                                select(directory.path)
+                            } label: {
+                                Label(
+                                    L10n.string("mobile.dispatch.browse.select", defaultValue: "Select"),
+                                    systemImage: "checkmark.circle"
+                                )
+                            }
+                            .tint(.accentColor)
+                        }
+                    }
+                } footer: {
+                    if list.truncated {
+                        Text(L10n.string(
+                            "mobile.dispatch.browse.truncated",
+                            defaultValue: "This folder has more entries than shown."
+                        ))
+                    }
+                }
+            } else if list.notice == nil {
+                Section {
+                    Text(L10n.string("mobile.dispatch.browse.empty", defaultValue: "No subfolders."))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
+    }
+
+    private func noticeText(_ notice: DispatchFSNotice) -> String {
+        if notice.isPermissionDenied {
+            return String(format: L10n.string(
+                "mobile.dispatch.browse.permissionDenied.format",
+                defaultValue: "macOS blocked cmux from reading “%@”. On the Mac, allow cmux under System Settings › Privacy & Security › Files and Folders, then retry."
+            ), folderName)
+        }
+        return notice.message
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchComposerPreviewView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchComposerPreviewView.swift
@@ -1,0 +1,88 @@
+#if DEBUG
+import CmuxMobileShell
+import SwiftUI
+
+/// Standalone Dispatch composer fixture (`CMUX_UITEST_DISPATCH_PREVIEW=1`):
+/// a stub service with a canned catalog and directory tree so layout and flow
+/// screenshots need no sign-in or paired Mac. Briefs containing "fail"
+/// exercise the REJECTED stamp; anything else stamps DISPATCHED.
+struct DispatchComposerPreviewView: View {
+    @State private var visible = true
+
+    var body: some View {
+        Color.clear
+            .sheet(isPresented: $visible) {
+                DispatchComposerSheet(
+                    service: DispatchPreviewService(),
+                    willLaunch: {},
+                    launchFailed: {},
+                    finished: { visible = false }
+                )
+            }
+    }
+}
+
+@MainActor
+private final class DispatchPreviewService: DispatchComposerServicing {
+    var dispatchHostName: String? { "Preview Mac" }
+    var dispatchIsConnected: Bool { true }
+    var dispatchMacKey: String { "dispatch-preview" }
+
+    private let home = "/Users/preview"
+
+    func dispatchCatalog() async throws -> DispatchCatalog {
+        DispatchCatalog(
+            home: home,
+            agents: [
+                DispatchAgent(id: "claude", name: "Claude Code", installed: true),
+                DispatchAgent(id: "codex", name: "Codex", installed: false),
+            ],
+            recentDirectories: [
+                DispatchDirectory(path: home + "/Dev/cmux", git: true),
+                DispatchDirectory(path: home + "/Dev/zed", git: true),
+                DispatchDirectory(path: home + "/Notes", git: false),
+            ],
+            promptByteBudget: 900
+        )
+    }
+
+    func dispatchFSList(path: String, includeHidden: Bool) async throws -> DispatchFSList {
+        var entries = [
+            DispatchDirectory(path: path + "/Alpha", git: false),
+            DispatchDirectory(path: path + "/cmux", git: true),
+            DispatchDirectory(path: path + "/Documents", git: false),
+            DispatchDirectory(path: path + "/Notes", git: false),
+        ]
+        if includeHidden {
+            entries.insert(DispatchDirectory(path: path + "/.config", git: false), at: 0)
+        }
+        if path.hasSuffix("Documents") {
+            return DispatchFSList(
+                path: path,
+                entries: [],
+                notice: DispatchFSNotice(code: "permission_denied", message: "Operation not permitted"),
+                truncated: false
+            )
+        }
+        return DispatchFSList(path: path, entries: entries, notice: nil, truncated: false)
+    }
+
+    func dispatchFSSearch(query: String) async throws -> DispatchFSSearch {
+        let all = [
+            DispatchDirectory(path: home + "/Dev/cmux", git: true),
+            DispatchDirectory(path: home + "/Dev/cmux-cua", git: true),
+            DispatchDirectory(path: home + "/Downloads/cmyk-assets", git: false),
+        ]
+        let entries = all.filter { $0.name.localizedCaseInsensitiveContains(query) }
+        return DispatchFSSearch(query: query, entries: entries, indexing: false, truncated: false)
+    }
+
+    func dispatchLaunch(directory: String, agentID: String, prompt: String) async -> Result<Void, DispatchLaunchFailure> {
+        try? await ContinuousClock().sleep(for: .milliseconds(700))
+        if prompt.localizedCaseInsensitiveContains("fail") {
+            return .failure(.agentNotInstalled)
+        }
+        return .success(())
+    }
+}
+#endif

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchComposerSheet.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchComposerSheet.swift
@@ -1,0 +1,92 @@
+import CmuxMobileShell
+import CmuxMobileSupport
+import SwiftUI
+
+/// The Dispatch sheet: work-order document at the root, project picker and
+/// browse levels pushed on an in-sheet stack. Dismissing keeps the draft;
+/// a successful dispatch clears it and hands control back to the shell, which
+/// is already navigating into the new workspace's terminal.
+struct DispatchComposerSheet: View {
+    private enum Route: Hashable {
+        case projectPicker
+        case browse(String)
+    }
+
+    let service: any DispatchComposerServicing
+    /// Called just before the launch request so the shell can arm its
+    /// created-workspace navigation (mirrors the New Workspace flow).
+    let willLaunch: () -> Void
+    /// Called when a launch attempt is rejected, so the shell can disarm the
+    /// created-workspace navigation it armed in `willLaunch`.
+    let launchFailed: () -> Void
+    /// Called once the DISPATCHED stamp has landed; the owner dismisses.
+    let finished: () -> Void
+
+    @State private var model: DispatchComposerModel
+    @State private var picker: DispatchProjectPickerModel
+    @State private var path: [Route] = []
+
+    init(
+        service: any DispatchComposerServicing,
+        willLaunch: @escaping () -> Void,
+        launchFailed: @escaping () -> Void,
+        finished: @escaping () -> Void
+    ) {
+        self.service = service
+        self.willLaunch = willLaunch
+        self.launchFailed = launchFailed
+        self.finished = finished
+        _model = State(initialValue: DispatchComposerModel(service: service))
+        _picker = State(initialValue: DispatchProjectPickerModel(service: service))
+    }
+
+    var body: some View {
+        NavigationStack(path: $path) {
+            DispatchDocumentScreen(
+                model: model,
+                openProjectPicker: { path.append(.projectPicker) },
+                cancel: finished,
+                finished: finished
+            )
+            .navigationDestination(for: Route.self) { route in
+                switch route {
+                case .projectPicker:
+                    DispatchProjectPickerScreen(
+                        picker: picker,
+                        composer: model,
+                        select: selectDirectory,
+                        browse: { path.append(.browse($0)) }
+                    )
+                case let .browse(directory):
+                    DispatchBrowseScreen(
+                        path: directory,
+                        picker: picker,
+                        composer: model,
+                        select: selectDirectory,
+                        browse: { path.append(.browse($0)) }
+                    )
+                }
+            }
+        }
+        .onChange(of: model.launchState) { _, state in
+            switch state {
+            case .launching:
+                willLaunch()
+            case .rejected:
+                launchFailed()
+            case .idle, .dispatched:
+                break
+            }
+        }
+        .onDisappear {
+            model.cancelInFlightWork()
+            picker.cancelInFlightWork()
+        }
+        .accessibilityIdentifier("MobileDispatchComposer")
+    }
+
+    private func selectDirectory(_ directory: String) {
+        model.selectDirectory(directory)
+        path = []
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchDocumentScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchDocumentScreen.swift
@@ -1,0 +1,501 @@
+import CmuxMobileShell
+import CmuxMobileSupport
+import SwiftUI
+
+/// The work-order composer: one document with every input visible — brief,
+/// project, agent — a perforated tear line, and the dispatch stub. Launch
+/// verdicts are stamped straight onto the stub.
+struct DispatchDocumentScreen: View {
+    @Bindable var model: DispatchComposerModel
+    let openProjectPicker: () -> Void
+    let cancel: () -> Void
+    /// Called after the DISPATCHED stamp has landed; owner dismisses the sheet.
+    let finished: () -> Void
+
+    @FocusState private var briefFocused: Bool
+
+    private var isConnected: Bool { model.service.dispatchIsConnected }
+
+    private var isLaunching: Bool { model.launchState == .launching }
+    private var isDispatched: Bool { model.launchState == .dispatched }
+
+    private var rejection: DispatchLaunchFailure? {
+        if case let .rejected(failure) = model.launchState { return failure }
+        return nil
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 14) {
+                if !isConnected {
+                    offlineRibbon
+                }
+                documentCard
+                Text(hintText)
+                    .font(DispatchStyle.monoCaptionFont)
+                    .foregroundStyle(.tertiary)
+                    .multilineTextAlignment(.center)
+            }
+            .padding(16)
+        }
+        .scrollDismissesKeyboard(.interactively)
+        .background(DispatchStyle.screenBackground)
+        .toolbar {
+            ToolbarItem(placement: .cancellationAction) {
+                Button(action: cancel) {
+                    Image(systemName: "xmark")
+                }
+                .accessibilityLabel(L10n.string("mobile.dispatch.cancel", defaultValue: "Close"))
+                .accessibilityIdentifier("MobileDispatchCancel")
+            }
+            ToolbarItem(placement: .principal) {
+                Text(L10n.string("mobile.dispatch.title", defaultValue: "New Dispatch"))
+                    .font(DispatchStyle.fieldLabelFont)
+                    .tracking(DispatchStyle.fieldLabelTracking)
+                    .textCase(.uppercase)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .onAppear {
+            model.loadCatalogIfNeeded()
+            briefFocused = true
+        }
+        .sensoryFeedback(trigger: model.launchState) { _, new in
+            switch new {
+            case .dispatched: return .success
+            case .rejected: return .error
+            default: return nil
+            }
+        }
+        .sensoryFeedback(.warning, trigger: model.validationNudgeGeneration)
+        .task(id: isDispatched) {
+            guard isDispatched else { return }
+            // Let the DISPATCHED stamp land before sliding into the workspace.
+            try? await ContinuousClock().sleep(for: .milliseconds(850))
+            guard !Task.isCancelled else { return }
+            finished()
+        }
+    }
+
+    private var hintText: String {
+        let host = model.service.dispatchHostName
+        if let host, !host.isEmpty {
+            return String(
+                format: L10n.string(
+                    "mobile.dispatch.hint.format",
+                    defaultValue: "Runs in a new workspace on %@."
+                ),
+                host
+            )
+        }
+        return L10n.string("mobile.dispatch.hint", defaultValue: "Runs in a new workspace on your Mac.")
+    }
+
+    private var offlineRibbon: some View {
+        HStack(spacing: 8) {
+            ProgressView()
+                .controlSize(.small)
+                .tint(.orange)
+            Text(L10n.string(
+                "mobile.dispatch.offline",
+                defaultValue: "Mac offline. Reconnecting…"
+            ))
+            .font(DispatchStyle.monoCaptionFont)
+        }
+        .foregroundStyle(.orange)
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 10)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(Color.orange.opacity(0.12))
+        )
+        .accessibilityIdentifier("MobileDispatchOfflineRibbon")
+    }
+
+    // MARK: - Document
+
+    private var documentCard: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+                .padding(.horizontal, DispatchStyle.cardPadding)
+                .padding(.top, DispatchStyle.cardPadding)
+                .padding(.bottom, 14)
+            cardRule
+            briefSection
+                .padding(.horizontal, DispatchStyle.cardPadding)
+                .padding(.vertical, 16)
+            cardRule
+            projectSection
+                .padding(.horizontal, DispatchStyle.cardPadding)
+                .padding(.vertical, 16)
+            cardRule
+            agentSection
+                .padding(.horizontal, DispatchStyle.cardPadding)
+                .padding(.vertical, 16)
+            DispatchPerforationDivider()
+            stubSection
+                .padding(.horizontal, DispatchStyle.cardPadding)
+                .padding(.top, 10)
+                .padding(.bottom, DispatchStyle.cardPadding)
+        }
+        .background(
+            RoundedRectangle(cornerRadius: DispatchStyle.cardCornerRadius, style: .continuous)
+                .fill(DispatchStyle.cardBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: DispatchStyle.cardCornerRadius, style: .continuous)
+                .stroke(DispatchStyle.hairline, lineWidth: 0.5)
+        )
+    }
+
+    private var cardRule: some View {
+        Rectangle()
+            .fill(DispatchStyle.hairline)
+            .frame(height: 0.5)
+            .padding(.horizontal, DispatchStyle.cardPadding)
+    }
+
+    private var header: some View {
+        HStack(alignment: .firstTextBaseline) {
+            Text(headerTitle)
+                .lineLimit(1)
+                .truncationMode(.tail)
+            Spacer(minLength: 12)
+            Text(String(format: L10n.string(
+                "mobile.dispatch.serial.format",
+                defaultValue: "Nº %04d"
+            ), model.serial))
+                .foregroundStyle(.secondary)
+                .layoutPriority(1)
+        }
+        .font(DispatchStyle.fieldLabelFont)
+        .tracking(DispatchStyle.fieldLabelTracking)
+        .foregroundStyle(.secondary)
+        .accessibilityIdentifier("MobileDispatchHeader")
+    }
+
+    private var headerTitle: String {
+        let word = L10n.string("mobile.dispatch.header", defaultValue: "Dispatch").uppercased()
+        if let host = model.service.dispatchHostName, !host.isEmpty {
+            return "\(word) / \(host.uppercased())"
+        }
+        return word
+    }
+
+    private func fieldLabel(_ text: String, alerting: Bool) -> some View {
+        Text(text)
+            .font(DispatchStyle.fieldLabelFont)
+            .tracking(DispatchStyle.fieldLabelTracking)
+            .textCase(.uppercase)
+            .foregroundStyle(alerting ? AnyShapeStyle(DispatchStyle.stampRejected) : AnyShapeStyle(.tertiary))
+    }
+
+    // MARK: - Brief
+
+    private var briefNudged: Bool { model.validationNudge == .brief }
+
+    private var briefSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .firstTextBaseline) {
+                fieldLabel(
+                    L10n.string("mobile.dispatch.field.brief", defaultValue: "Brief"),
+                    alerting: briefNudged || model.isOverBudget
+                )
+                Spacer()
+                if model.showsBudgetCounter {
+                    Text(String(format: L10n.string(
+                        "mobile.dispatch.budget.format",
+                        defaultValue: "%1$d / %2$d"
+                    ), model.briefByteCount, model.promptByteBudget))
+                        .font(DispatchStyle.monoCaptionFont)
+                        .foregroundStyle(model.isOverBudget ? AnyShapeStyle(DispatchStyle.stampRejected) : AnyShapeStyle(.secondary))
+                        .accessibilityIdentifier("MobileDispatchBudgetCounter")
+                }
+            }
+            TextField(
+                L10n.string("mobile.dispatch.brief.placeholder", defaultValue: "What should get done?"),
+                text: $model.brief,
+                axis: .vertical
+            )
+            .font(.body)
+            .lineLimit(4 ... 12)
+            .focused($briefFocused)
+            .accessibilityIdentifier("MobileDispatchBriefEditor")
+            if briefNudged {
+                Text(briefNudgeText)
+                    .font(.caption2)
+                    .foregroundStyle(DispatchStyle.stampRejected)
+            }
+        }
+        .modifier(DispatchShakeEffect(
+            animatableData: briefNudged ? CGFloat(model.validationNudgeGeneration) : 0
+        ))
+        .animation(.linear(duration: 0.3), value: model.validationNudgeGeneration)
+    }
+
+    private var briefNudgeText: String {
+        if model.isOverBudget {
+            return String(format: L10n.string(
+                "mobile.dispatch.brief.overBudget",
+                defaultValue: "The brief is over the %d-byte dispatch limit."
+            ), model.promptByteBudget)
+        }
+        return L10n.string("mobile.dispatch.brief.empty", defaultValue: "Write the brief first.")
+    }
+
+    // MARK: - Project
+
+    private var projectSection: some View {
+        Button(action: openProjectPicker) {
+            VStack(alignment: .leading, spacing: 10) {
+                fieldLabel(L10n.string("mobile.dispatch.field.project", defaultValue: "Project"), alerting: false)
+                HStack(spacing: 8) {
+                    Text(projectDisplayText)
+                        .font(DispatchStyle.monoValueFont)
+                        .foregroundStyle(model.directoryPath == nil ? AnyShapeStyle(.secondary) : AnyShapeStyle(.primary))
+                        .lineLimit(1)
+                        .truncationMode(.head)
+                    Spacer(minLength: 8)
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("MobileDispatchProjectRow")
+    }
+
+    private var projectDisplayText: String {
+        if let path = model.directoryPath {
+            return model.displayPath(path)
+        }
+        if case .loading = model.catalogState {
+            return L10n.string("mobile.dispatch.project.loading", defaultValue: "Loading folders…")
+        }
+        return L10n.string("mobile.dispatch.project.choose", defaultValue: "Choose a folder")
+    }
+
+    // MARK: - Agent
+
+    private var agentNudged: Bool { model.validationNudge == .agent }
+
+    private var agentSection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            fieldLabel(L10n.string("mobile.dispatch.field.agent", defaultValue: "Agent"), alerting: agentNudged)
+            switch model.catalogState {
+            case .loading:
+                HStack(spacing: 8) {
+                    agentSkeletonPill
+                    agentSkeletonPill
+                }
+            case .failed:
+                DispatchInlineNotice(
+                    icon: "wifi.exclamationmark",
+                    text: L10n.string(
+                        "mobile.dispatch.catalog.failed",
+                        defaultValue: "Couldn't load agents and folders from the Mac."
+                    ),
+                    actionTitle: L10n.string("mobile.dispatch.retry", defaultValue: "Retry"),
+                    action: { model.retryCatalog() }
+                )
+            case .ready:
+                if model.agents.isEmpty || !model.agents.contains(where: \.installed) {
+                    DispatchInlineNotice(
+                        icon: "exclamationmark.triangle",
+                        text: L10n.string(
+                            "mobile.dispatch.agents.none",
+                            defaultValue: "No agents found on the Mac. Install the claude or codex CLI, then retry."
+                        ),
+                        actionTitle: L10n.string("mobile.dispatch.retry", defaultValue: "Retry"),
+                        action: { model.retryCatalog() }
+                    )
+                } else {
+                    agentPills
+                }
+            }
+        }
+        .modifier(DispatchShakeEffect(
+            animatableData: agentNudged ? CGFloat(model.validationNudgeGeneration) : 0
+        ))
+        .animation(.linear(duration: 0.3), value: model.validationNudgeGeneration)
+    }
+
+    private var agentSkeletonPill: some View {
+        Capsule()
+            .fill(DispatchStyle.hairline.opacity(0.35))
+            .frame(width: 104, height: 33)
+    }
+
+    private var agentPills: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(spacing: 8) {
+                ForEach(model.agents) { agent in
+                    agentPill(agent)
+                }
+            }
+            if let missing = missingAgentsText {
+                Text(missing)
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+    }
+
+    private func agentPill(_ agent: DispatchAgent) -> some View {
+        let selected = model.agentID == agent.id
+        return Button {
+            model.selectAgent(agent.id)
+        } label: {
+            Text(agent.name)
+                .font(.system(.footnote, design: .monospaced).weight(.medium))
+                .padding(.horizontal, 14)
+                .padding(.vertical, 8)
+                .foregroundStyle(
+                    selected
+                        ? AnyShapeStyle(DispatchStyle.inkReversed)
+                        : (agent.installed ? AnyShapeStyle(.primary) : AnyShapeStyle(.tertiary))
+                )
+                .background(
+                    Capsule().fill(selected ? DispatchStyle.ink : Color.clear)
+                )
+                .overlay(
+                    Capsule().stroke(selected ? Color.clear : DispatchStyle.hairline, lineWidth: 1)
+                )
+        }
+        .buttonStyle(.plain)
+        .disabled(!agent.installed)
+        .accessibilityIdentifier("MobileDispatchAgentPill_\(agent.id)")
+    }
+
+    private var missingAgentsText: String? {
+        let missing = model.agents.filter { !$0.installed }
+        guard !missing.isEmpty else { return nil }
+        let names = missing.map(\.name).joined(separator: ", ")
+        return String(format: L10n.string(
+            "mobile.dispatch.agents.notInstalled.format",
+            defaultValue: "%@ (not installed on this Mac)"
+        ), names)
+    }
+
+    // MARK: - Stub
+
+    private var stubSection: some View {
+        VStack(spacing: 12) {
+            Text(summaryText)
+                .font(DispatchStyle.monoCaptionFont)
+                .foregroundStyle(.tertiary)
+                .lineLimit(1)
+                .truncationMode(.head)
+                .frame(maxWidth: .infinity)
+            launchButton
+            if let rejection {
+                Text(rejection.displayReason(agentName: model.selectedAgent?.name))
+                    .font(.caption)
+                    .foregroundStyle(DispatchStyle.stampRejected)
+                    .multilineTextAlignment(.center)
+                    .frame(maxWidth: .infinity)
+                    .accessibilityIdentifier("MobileDispatchRejectionReason")
+            }
+        }
+        .overlay {
+            if isDispatched {
+                DispatchStampView(verdict: .dispatched)
+            } else if rejection != nil {
+                DispatchStampView(verdict: .rejected)
+                    .allowsHitTesting(false)
+            }
+        }
+    }
+
+    private var summaryText: String {
+        let agent = model.selectedAgent?.name
+            ?? L10n.string("mobile.dispatch.summary.noAgent", defaultValue: "no agent")
+        let project = model.directoryPath.map { model.displayPath($0) }
+            ?? L10n.string("mobile.dispatch.summary.noProject", defaultValue: "no folder")
+        return "\(agent) · \(project)"
+    }
+
+    private var launchButton: some View {
+        Button {
+            briefFocused = false
+            model.attemptDispatch()
+        } label: {
+            ZStack {
+                Text(L10n.string("mobile.dispatch.launch", defaultValue: "Dispatch"))
+                    .font(DispatchStyle.stubFont)
+                    .tracking(3)
+                    .textCase(.uppercase)
+                    .opacity(isLaunching || isDispatched || rejection != nil ? 0 : 1)
+                if isLaunching {
+                    ProgressView()
+                        .tint(DispatchStyle.inkReversed)
+                }
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: DispatchStyle.stubButtonHeight)
+            .foregroundStyle(DispatchStyle.inkReversed)
+            .background(
+                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                    .fill(DispatchStyle.ink)
+                    .opacity(stubBackgroundOpacity)
+            )
+        }
+        .buttonStyle(DispatchPressButtonStyle())
+        .disabled(!isConnected || isLaunching || isDispatched)
+        .accessibilityIdentifier("MobileDispatchLaunchButton")
+    }
+
+    /// The stub recedes while a verdict stamp sits on top of it, and while the
+    /// Mac is offline (the ribbon explains why it's not tappable).
+    private var stubBackgroundOpacity: Double {
+        if isDispatched || rejection != nil { return 0.14 }
+        return isConnected ? 1 : 0.35
+    }
+}
+
+/// Slight press-down scale so the stub feels physical.
+struct DispatchPressButtonStyle: ButtonStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .scaleEffect(configuration.isPressed ? 0.98 : 1)
+            .animation(.spring(response: 0.2, dampingFraction: 0.8), value: configuration.isPressed)
+    }
+}
+
+/// Quiet inline notice used inside the document for recoverable problems
+/// (catalog fetch failed, no agents installed). Keeps the error visible where
+/// it applies instead of hiding it behind an alert.
+struct DispatchInlineNotice: View {
+    let icon: String
+    let text: String
+    var actionTitle: String?
+    var action: (() -> Void)?
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 8) {
+            Image(systemName: icon)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(text)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            Spacer(minLength: 0)
+            if let actionTitle, let action {
+                Button(actionTitle, action: action)
+                    .font(.caption.weight(.semibold))
+                    .buttonStyle(.borderless)
+            }
+        }
+        .padding(10)
+        .background(
+            RoundedRectangle(cornerRadius: 10, style: .continuous)
+                .fill(DispatchStyle.hairline.opacity(0.18))
+        )
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchLaunchFailure+Display.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchLaunchFailure+Display.swift
@@ -1,0 +1,55 @@
+import CmuxMobileShell
+import CmuxMobileSupport
+import Foundation
+
+extension DispatchLaunchFailure {
+    /// The human reason printed under a REJECTED stamp. Concrete per failure so
+    /// the user knows what to fix, not just that something went wrong.
+    func displayReason(agentName: String?) -> String {
+        switch self {
+        case .notConnected:
+            return L10n.string(
+                "mobile.dispatch.failure.notConnected",
+                defaultValue: "The Mac is offline. Reconnect and dispatch again."
+            )
+        case .requestTimedOut:
+            return L10n.string(
+                "mobile.dispatch.failure.timedOut",
+                defaultValue: "The Mac didn't answer in time. Dispatch again."
+            )
+        case .authorizationFailed:
+            return L10n.string(
+                "mobile.dispatch.failure.authorization",
+                defaultValue: "This phone is no longer authorized for that Mac."
+            )
+        case .agentNotInstalled:
+            let name = agentName ?? L10n.string("mobile.dispatch.failure.agentFallbackName", defaultValue: "The agent")
+            return String(
+                format: L10n.string(
+                    "mobile.dispatch.failure.agentNotInstalled",
+                    defaultValue: "%@ isn't installed on the Mac."
+                ),
+                name
+            )
+        case .directoryNotFound:
+            return L10n.string(
+                "mobile.dispatch.failure.directoryNotFound",
+                defaultValue: "That folder no longer exists on the Mac."
+            )
+        case .promptTooLong:
+            return L10n.string(
+                "mobile.dispatch.failure.promptTooLong",
+                defaultValue: "The brief is too long to dispatch."
+            )
+        case let .rejected(message):
+            let base = L10n.string(
+                "mobile.dispatch.failure.rejected",
+                defaultValue: "The Mac rejected this dispatch."
+            )
+            if let message, !message.isEmpty {
+                return base + " (\(message))"
+            }
+            return base
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchProjectPickerScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchProjectPickerScreen.swift
@@ -170,7 +170,7 @@ struct DispatchProjectPickerScreen: View {
         } footer: {
             Text(L10n.string(
                 "mobile.dispatch.picker.browseFooter",
-                defaultValue: "Search covers your home folder, skipping caches and Desktop, Documents, and Downloads; Browse reaches every folder."
+                defaultValue: "Search covers your home folder, skipping caches and macOS-protected folders like Documents and Downloads; Browse reaches every folder."
             ))
         }
     }

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchProjectPickerScreen.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchProjectPickerScreen.swift
@@ -1,0 +1,326 @@
+import CmuxMobileShell
+import CmuxMobileSupport
+import SwiftUI
+
+/// Search-first project picker. Typing fuzzy-searches every directory the Mac
+/// has indexed; an empty query offers recent project folders plus browse roots
+/// that can reach ANY directory level by level. Permission problems surface
+/// inline and never dead-end the picker.
+struct DispatchProjectPickerScreen: View {
+    @Bindable var picker: DispatchProjectPickerModel
+    let composer: DispatchComposerModel
+    let select: (String) -> Void
+    let browse: (String) -> Void
+
+    @FocusState private var searchFocused: Bool
+
+    /// Selection is a plain closure call: the picker deliberately uses its own
+    /// search field instead of `.searchable`, whose active presentation
+    /// swallows NavigationStack pops (verified live on iOS 26).
+    private func handleSelect(_ directory: String) {
+        select(directory)
+    }
+
+    var body: some View {
+        List {
+            if picker.trimmedQuery.isEmpty {
+                suggestedSection
+                browseRootsSection
+            } else {
+                searchResultsSection
+            }
+        }
+        .listStyle(.insetGrouped)
+        .safeAreaInset(edge: .top, spacing: 0) {
+            searchField
+        }
+        .navigationTitle(L10n.string("mobile.dispatch.picker.title", defaultValue: "Project"))
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                hiddenFoldersMenu
+            }
+        }
+        .onAppear {
+            searchFocused = true
+        }
+        .accessibilityIdentifier("MobileDispatchProjectPicker")
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "magnifyingglass")
+                .font(.subheadline)
+                .foregroundStyle(.secondary)
+            TextField(searchPrompt, text: $picker.query)
+                .font(.system(.body, design: .monospaced))
+                .autocorrectionDisabled()
+                #if os(iOS)
+                .textInputAutocapitalization(.never)
+                #endif
+                .focused($searchFocused)
+                .submitLabel(.search)
+                .accessibilityIdentifier("MobileDispatchPickerSearchField")
+            if !picker.query.isEmpty {
+                Button {
+                    picker.query = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.subheadline)
+                        .foregroundStyle(.tertiary)
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel(L10n.string("mobile.dispatch.picker.clearSearch", defaultValue: "Clear search"))
+            }
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 40)
+        .background(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .fill(DispatchStyle.cardBackground)
+        )
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .stroke(DispatchStyle.hairline, lineWidth: 0.5)
+        )
+        .padding(.horizontal, 16)
+        .padding(.top, 4)
+        .padding(.bottom, 8)
+        .background(DispatchStyle.screenBackground.opacity(0.94))
+    }
+
+    private var searchPrompt: String {
+        if let host = composer.service.dispatchHostName, !host.isEmpty {
+            return String(format: L10n.string(
+                "mobile.dispatch.picker.searchPrompt.format",
+                defaultValue: "Search folders on %@"
+            ), host)
+        }
+        return L10n.string("mobile.dispatch.picker.searchPrompt", defaultValue: "Search folders")
+    }
+
+    private var hiddenFoldersMenu: some View {
+        Menu {
+            Toggle(isOn: $picker.includeHidden) {
+                Label(
+                    L10n.string("mobile.dispatch.picker.showHidden", defaultValue: "Show Hidden Folders"),
+                    systemImage: "eye"
+                )
+            }
+        } label: {
+            Image(systemName: "ellipsis.circle")
+        }
+        .accessibilityIdentifier("MobileDispatchPickerOptions")
+    }
+
+    // MARK: - Empty query
+
+    private var suggestedSection: some View {
+        Section {
+            if composer.recentDirectories.isEmpty {
+                Text(L10n.string(
+                    "mobile.dispatch.picker.noRecents",
+                    defaultValue: "Folders you open workspaces in will show up here."
+                ))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            } else {
+                ForEach(composer.recentDirectories) { directory in
+                    DispatchDirectoryRow(
+                        name: directory.name,
+                        detail: composer.displayPath(directory.path),
+                        isGit: directory.git,
+                        isSelected: composer.directoryPath == directory.path,
+                        primaryAction: { handleSelect(directory.path) },
+                        browseAction: { browse(directory.path) }
+                    )
+                }
+            }
+        } header: {
+            pickerSectionHeader(L10n.string("mobile.dispatch.picker.suggested", defaultValue: "Suggested"))
+        }
+    }
+
+    private var browseRootsSection: some View {
+        Section {
+            if let home = composer.homePath {
+                DispatchDirectoryRow(
+                    name: L10n.string("mobile.dispatch.picker.home", defaultValue: "Home"),
+                    detail: "~",
+                    isGit: false,
+                    isSelected: false,
+                    systemImage: "house",
+                    primaryAction: { browse(home) },
+                    browseAction: nil
+                )
+            }
+            DispatchDirectoryRow(
+                name: L10n.string("mobile.dispatch.picker.root", defaultValue: "Macintosh HD"),
+                detail: "/",
+                isGit: false,
+                isSelected: false,
+                systemImage: "internaldrive",
+                primaryAction: { browse("/") },
+                browseAction: nil
+            )
+        } header: {
+            pickerSectionHeader(L10n.string("mobile.dispatch.picker.browse", defaultValue: "Browse"))
+        } footer: {
+            Text(L10n.string(
+                "mobile.dispatch.picker.browseFooter",
+                defaultValue: "Search covers your home folder, skipping caches and Desktop, Documents, and Downloads; Browse reaches every folder."
+            ))
+        }
+    }
+
+    // MARK: - Search results
+
+    @ViewBuilder
+    private var searchResultsSection: some View {
+        switch picker.searchState {
+        case .idle, .searching:
+            Section {
+                HStack(spacing: 10) {
+                    ProgressView()
+                        .controlSize(.small)
+                    Text(L10n.string("mobile.dispatch.picker.searching", defaultValue: "Searching…"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+        case .failed:
+            Section {
+                DispatchInlineNotice(
+                    icon: "wifi.exclamationmark",
+                    text: L10n.string(
+                        "mobile.dispatch.picker.searchFailed",
+                        defaultValue: "Search didn't reach the Mac."
+                    ),
+                    actionTitle: L10n.string("mobile.dispatch.retry", defaultValue: "Retry"),
+                    action: { picker.retrySearch() }
+                )
+                .listRowInsets(EdgeInsets(top: 4, leading: 8, bottom: 4, trailing: 8))
+                .listRowBackground(Color.clear)
+            }
+        case let .results(entries, indexing, truncated):
+            Section {
+                if entries.isEmpty, !indexing {
+                    Text(L10n.string(
+                        "mobile.dispatch.picker.noMatches",
+                        defaultValue: "No folders match. Try Browse for folders outside home."
+                    ))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                } else {
+                    ForEach(entries) { directory in
+                        DispatchDirectoryRow(
+                            name: directory.name,
+                            detail: composer.displayPath(directory.path),
+                            isGit: directory.git,
+                            isSelected: composer.directoryPath == directory.path,
+                            primaryAction: { handleSelect(directory.path) },
+                            browseAction: { browse(directory.path) }
+                        )
+                    }
+                }
+            } footer: {
+                if indexing {
+                    HStack(spacing: 6) {
+                        ProgressView()
+                            .controlSize(.mini)
+                        Text(L10n.string(
+                            "mobile.dispatch.picker.indexing",
+                            defaultValue: "The Mac is still indexing folders. Results are filling in."
+                        ))
+                    }
+                } else if truncated {
+                    Text(L10n.string(
+                        "mobile.dispatch.picker.truncated",
+                        defaultValue: "Showing the closest matches. Keep typing to narrow down."
+                    ))
+                }
+            }
+        }
+    }
+
+    private func pickerSectionHeader(_ text: String) -> some View {
+        Text(text)
+            .font(DispatchStyle.fieldLabelFont)
+            .tracking(DispatchStyle.fieldLabelTracking)
+            .textCase(.uppercase)
+    }
+}
+
+/// One directory row shared by search results, suggestions, and browse levels.
+/// Tapping the row is the primary action; the trailing chevron button descends
+/// into the folder when both actions are available.
+struct DispatchDirectoryRow: View {
+    let name: String
+    let detail: String
+    let isGit: Bool
+    let isSelected: Bool
+    var systemImage: String = "folder"
+    let primaryAction: () -> Void
+    let browseAction: (() -> Void)?
+
+    var body: some View {
+        // Sibling buttons, never nested: a Button whose label contains another
+        // Button stops receiving row taps inside a List.
+        HStack(spacing: 8) {
+            Button(action: primaryAction) {
+                HStack(spacing: 10) {
+                    Image(systemName: systemImage)
+                        .font(.body)
+                        .foregroundStyle(.secondary)
+                        .frame(width: 22)
+                    VStack(alignment: .leading, spacing: 2) {
+                        HStack(spacing: 6) {
+                            Text(name)
+                                .font(.body)
+                                .foregroundStyle(.primary)
+                                .lineLimit(1)
+                            if isGit {
+                                Image(systemName: "arrow.triangle.branch")
+                                    .font(.caption2)
+                                    .foregroundStyle(.secondary)
+                                    .accessibilityLabel(L10n.string(
+                                        "mobile.dispatch.picker.gitBadge",
+                                        defaultValue: "Git repository"
+                                    ))
+                            }
+                        }
+                        Text(detail)
+                            .font(DispatchStyle.monoCaptionFont)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                            .truncationMode(.head)
+                    }
+                    Spacer(minLength: 8)
+                    if isSelected {
+                        Image(systemName: "checkmark")
+                            .font(.subheadline.weight(.semibold))
+                            .foregroundStyle(Color.accentColor)
+                    }
+                }
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            if let browseAction {
+                Button(action: browseAction) {
+                    Image(systemName: "chevron.right")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(.tertiary)
+                        .frame(width: 30, height: 30)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel(L10n.string(
+                    "mobile.dispatch.picker.browseInto",
+                    defaultValue: "Browse folder"
+                ))
+            }
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchStampView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchStampView.swift
@@ -1,0 +1,91 @@
+import CmuxMobileSupport
+import SwiftUI
+
+/// The rubber-stamp verdict pressed onto the work order's stub: green
+/// DISPATCHED on success, red REJECTED on failure. Springs in slightly
+/// oversized and rotated, like it was actually stamped.
+struct DispatchStampView: View {
+    enum Verdict {
+        case dispatched
+        case rejected
+    }
+
+    let verdict: Verdict
+    @State private var pressed = false
+
+    private var text: String {
+        switch verdict {
+        case .dispatched:
+            return L10n.string("mobile.dispatch.stamp.dispatched", defaultValue: "DISPATCHED")
+        case .rejected:
+            return L10n.string("mobile.dispatch.stamp.rejected", defaultValue: "REJECTED")
+        }
+    }
+
+    private var color: Color {
+        switch verdict {
+        case .dispatched: return DispatchStyle.stampApproved
+        case .rejected: return DispatchStyle.stampRejected
+        }
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.system(.body, design: .monospaced).weight(.heavy))
+            .tracking(3)
+            .foregroundStyle(color)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(color, lineWidth: 2.5)
+            )
+            .rotationEffect(.degrees(-8))
+            .opacity(pressed ? 0.92 : 0)
+            .scaleEffect(pressed ? 1 : 1.6)
+            .onAppear {
+                withAnimation(.spring(response: 0.28, dampingFraction: 0.6)) {
+                    pressed = true
+                }
+            }
+            .accessibilityIdentifier("MobileDispatchStamp")
+    }
+}
+
+/// A ticket tear line: dashed hairline with half-round notches at both edges.
+/// Sits between the order's fields and its launch stub.
+struct DispatchPerforationDivider: View {
+    private let notchRadius: CGFloat = 7
+
+    var body: some View {
+        HStack(spacing: 0) {
+            notch(cutTrailing: true)
+            Line()
+                .stroke(style: StrokeStyle(lineWidth: 1, dash: [5, 5]))
+                .foregroundStyle(DispatchStyle.hairline)
+                .frame(height: 1)
+            notch(cutTrailing: false)
+        }
+        .frame(height: notchRadius * 2)
+        .accessibilityHidden(true)
+    }
+
+    private func notch(cutTrailing: Bool) -> some View {
+        Circle()
+            .fill(DispatchStyle.screenBackground)
+            .overlay(
+                Circle().stroke(DispatchStyle.hairline, lineWidth: 0.5)
+            )
+            .frame(width: notchRadius * 2, height: notchRadius * 2)
+            .offset(x: cutTrailing ? -notchRadius : notchRadius)
+    }
+
+    private struct Line: Shape {
+        func path(in rect: CGRect) -> Path {
+            var path = Path()
+            path.move(to: CGPoint(x: rect.minX, y: rect.midY))
+            path.addLine(to: CGPoint(x: rect.maxX, y: rect.midY))
+            return path
+        }
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchStyle.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/DispatchStyle.swift
@@ -1,0 +1,89 @@
+import SwiftUI
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+/// Visual vocabulary of the Dispatch work order: monospaced caps field labels,
+/// hairline rules, and a paper-like card. Everything else on the surface uses
+/// the app's semantic colors so the document reads as part of cmux.
+enum DispatchStyle {
+    /// Height of the launch stub button.
+    static let stubButtonHeight: CGFloat = 52
+    /// Corner radius of the document card.
+    static let cardCornerRadius: CGFloat = 16
+    /// Horizontal content padding inside the card.
+    static let cardPadding: CGFloat = 20
+
+    static var screenBackground: Color {
+        #if canImport(UIKit)
+        Color(uiColor: .systemGroupedBackground)
+        #else
+        Color(nsColor: .windowBackgroundColor)
+        #endif
+    }
+
+    static var cardBackground: Color {
+        #if canImport(UIKit)
+        Color(uiColor: .secondarySystemGroupedBackground)
+        #else
+        Color(nsColor: .controlBackgroundColor)
+        #endif
+    }
+
+    static var hairline: Color {
+        #if canImport(UIKit)
+        Color(uiColor: .separator)
+        #else
+        Color(nsColor: .separatorColor)
+        #endif
+    }
+
+    /// The high-contrast ink used for the launch stub and selected agent pill.
+    static var ink: Color { .primary }
+
+    /// Text color on top of `ink` fills.
+    static var inkReversed: Color {
+        #if canImport(UIKit)
+        Color(uiColor: .systemBackground)
+        #else
+        Color(nsColor: .windowBackgroundColor)
+        #endif
+    }
+
+    static var stampApproved: Color { .green }
+    static var stampRejected: Color { .red }
+
+    /// Monospaced caps micro-label ("BRIEF", "PROJECT", …).
+    static var fieldLabelFont: Font {
+        .system(.caption2, design: .monospaced).weight(.semibold)
+    }
+
+    static let fieldLabelTracking: CGFloat = 1.4
+
+    /// Monospaced value text (paths, summary line, serial).
+    static var monoValueFont: Font {
+        .system(.footnote, design: .monospaced)
+    }
+
+    static var monoCaptionFont: Font {
+        .system(.caption2, design: .monospaced)
+    }
+
+    /// The launch stub's label.
+    static var stubFont: Font {
+        .system(.callout, design: .monospaced).weight(.semibold)
+    }
+}
+
+/// Horizontal-shake effect for inline validation nudges; retriggers whenever
+/// the generation changes so a repeated invalid attempt shakes again.
+struct DispatchShakeEffect: GeometryEffect {
+    var animatableData: CGFloat
+
+    func effectValue(size: CGSize) -> ProjectionTransform {
+        let translation = sin(animatableData * .pi * 3) * 6
+        return ProjectionTransform(CGAffineTransform(translationX: translation, y: 0))
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacUpdateHint+Display.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/MobileMacUpdateHint+Display.swift
@@ -22,6 +22,8 @@ extension MobileMacUpdateFeature {
             L10n.string("mobile.macUpdateHint.feature.workspaceCreateInGroup", defaultValue: "Create workspaces inside groups")
         case .workspaceGroupCreate:
             L10n.string("mobile.macUpdateHint.feature.workspaceGroupCreate", defaultValue: "Create workspace groups")
+        case .agentDispatch:
+            L10n.string("mobile.macUpdateHint.feature.agentDispatch", defaultValue: "Dispatch agents from your phone")
         }
     }
 

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Actions.swift
@@ -21,6 +21,12 @@ extension WorkspaceListView {
                 }
                 .accessibilityIdentifier("MobileNewWorkspaceGroupMenuItem")
             }
+            if let composeDispatch {
+                Button(action: composeDispatch) {
+                    Label(L10n.string("mobile.dispatch.new", defaultValue: "New Dispatch"), systemImage: "square.and.pencil")
+                }
+                .accessibilityIdentifier("MobileNewDispatchMenuItem")
+            }
         } label: {
             Image(systemName: "plus")
         } primaryAction: {
@@ -30,6 +36,17 @@ extension WorkspaceListView {
         .disabled(!canCreateWorkspaceForMacSelection)
         .accessibilityLabel(L10n.string("mobile.workspace.new", defaultValue: "New Workspace"))
         .accessibilityIdentifier("MobileNewWorkspaceButton")
+    }
+
+    /// Mail-style bottom-bar compose entry for the Dispatch composer.
+    var dispatchComposeButton: some View {
+        Button {
+            composeDispatch?()
+        } label: {
+            Image(systemName: "square.and.pencil")
+        }
+        .accessibilityLabel(L10n.string("mobile.dispatch.new", defaultValue: "New Dispatch"))
+        .accessibilityIdentifier("MobileDispatchComposeButton")
     }
 
     @discardableResult

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView+Toolbar.swift
@@ -36,6 +36,12 @@ extension WorkspaceListView {
                                 newWorkspaceButton
                             }
                         }
+                        if composeDispatch != nil {
+                            ToolbarItemGroup(placement: .bottomBar) {
+                                Spacer()
+                                dispatchComposeButton
+                            }
+                        }
                     }
             } else {
                 content

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceListView.swift
@@ -36,6 +36,10 @@ struct WorkspaceListView: View {
     var createWorkspaceInGroup: ((MobileWorkspaceGroupPreview.ID) -> Void)? = nil
     var createWorkspaceGroup: (() -> Void)? = nil
     var canCreateWorkspace = true
+    /// Optional: open the Dispatch composer (compose a brief, launch an agent
+    /// workspace on the Mac). `nil` hides the compose affordances — previews,
+    /// or a Mac whose cmux predates `workspace.dispatch.v1`.
+    var composeDispatch: (() -> Void)? = nil
     /// Which Mac's workspaces the list is focused on. Owned by the shell so
     /// every create-workspace entrypoint shares the same selected-Mac gate.
     @Binding var macSelection: WorkspaceMacSelection

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+Dispatch.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView+Dispatch.swift
@@ -1,0 +1,34 @@
+import CmuxMobileShell
+import CmuxMobileShellModel
+import SwiftUI
+
+extension WorkspaceShellView {
+    /// Entry availability for the Dispatch composer: the connected Mac must
+    /// advertise the capability, and workspace creation must be possible for
+    /// the current Mac selection. `nil` hides the affordances.
+    var composeDispatchClosure: (() -> Void)? {
+        guard store.supportsAgentDispatch, canCreateWorkspaceForMacSelection else { return nil }
+        return { showingDispatchComposer = true }
+    }
+
+    var dispatchComposerSheet: some View {
+        DispatchComposerSheet(
+            service: store,
+            willLaunch: armDispatchCreatedWorkspaceNavigation,
+            launchFailed: disarmDispatchCreatedWorkspaceNavigation,
+            finished: { showingDispatchComposer = false }
+        )
+        .interactiveDismissDisabled(false)
+    }
+
+    /// Mirrors the New Workspace flow: snapshot the current workspace ids so
+    /// the selection change caused by the created workspace pushes exactly the
+    /// new one on the compact stack (under the sheet; revealed on dismiss).
+    private func armDispatchCreatedWorkspaceNavigation() {
+        pendingCompactCreateNavigationWorkspaceIDs = Set(store.workspaces.map(\.id))
+    }
+
+    private func disarmDispatchCreatedWorkspaceNavigation() {
+        pendingCompactCreateNavigationWorkspaceIDs = nil
+    }
+}

--- a/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
+++ b/Packages/iOS/CmuxMobileShellUI/Sources/CmuxMobileShellUI/WorkspaceShellView.swift
@@ -26,6 +26,7 @@ struct WorkspaceShellView: View {
     @State private var splitColumnVisibility: NavigationSplitViewVisibility = .automatic
     @State private var macSelection: WorkspaceMacSelection = .all
     @State var workspaceActionToast: WorkspaceActionToastContent?
+    @State var showingDispatchComposer = false
     @State private var pendingMacSwitchID: String?
     @State private var pendingMacSwitchGeneration: UInt64 = 0
     var workspaceActionToastClock: any Clock<Duration> = ContinuousClock()
@@ -100,6 +101,9 @@ struct WorkspaceShellView: View {
         .onAppear {
             consumeDeeplinkNavigationRequestIfNeeded()
         }
+        .sheet(isPresented: $showingDispatchComposer) {
+            dispatchComposerSheet
+        }
         .accessibilityIdentifier("MobileWorkspaceShell")
     }
 
@@ -126,6 +130,7 @@ struct WorkspaceShellView: View {
                 createWorkspaceInGroup: createWorkspaceInGroupInCompactStackClosure,
                 createWorkspaceGroup: createWorkspaceGroupInCompactStackClosure,
                 canCreateWorkspace: canCreateWorkspaceForMacSelection,
+                composeDispatch: composeDispatchClosure,
                 macSelection: $macSelection,
                 switchMac: { macDeviceID in
                     await switchMacFromWorkspacePicker(macDeviceID: macDeviceID)
@@ -233,6 +238,7 @@ struct WorkspaceShellView: View {
                 createWorkspaceInGroup: createWorkspaceInGroupIfConnectedClosure,
                 createWorkspaceGroup: createWorkspaceGroupIfConnectedClosure,
                 canCreateWorkspace: canCreateWorkspaceForMacSelection,
+                composeDispatch: composeDispatchClosure,
                 macSelection: $macSelection,
                 switchMac: { macDeviceID in
                     await switchMacFromWorkspacePicker(macDeviceID: macDeviceID)

--- a/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
+++ b/Packages/iOS/CmuxMobileSupport/Sources/CmuxMobileSupport/UITestConfig.swift
@@ -97,6 +97,21 @@ public struct UITestConfig {
         #endif
     }
 
+    /// Whether the standalone Dispatch composer preview is enabled.
+    ///
+    /// When `CMUX_UITEST_DISPATCH_PREVIEW=1`, the root view renders the
+    /// Dispatch composer against a stubbed catalog and filesystem so layout
+    /// screenshots need no sign-in or Mac pairing. A brief containing "fail"
+    /// exercises the REJECTED stamp. DEBUG-only.
+    public static var dispatchComposerPreviewEnabled: Bool {
+        #if DEBUG
+        return ProcessInfo.processInfo.environment["CMUX_UITEST_DISPATCH_PREVIEW"] == "1"
+            || ProcessInfo.processInfo.arguments.contains("CMUX_UITEST_DISPATCH_PREVIEW=1")
+        #else
+        return false
+        #endif
+    }
+
     /// Whether the workspace detail delayed-terminal lifecycle preview is enabled.
     ///
     /// When `CMUX_UITEST_WORKSPACE_DETAIL_DELAYED_TERMINAL=1`, the root view renders

--- a/Sources/DispatchAgentCommandBuilder.swift
+++ b/Sources/DispatchAgentCommandBuilder.swift
@@ -1,0 +1,25 @@
+import Foundation
+
+/// Builds the shell input used to start a supported agent from Dispatch.
+struct DispatchAgentCommandBuilder {
+    static let promptByteBudget = 900
+
+    enum CommandError: Error, Equatable {
+        case unsupportedAgent
+        case emptyPrompt
+        case promptTooLong
+    }
+
+    func command(agent: AgentSessionProviderID, prompt: String) throws -> String {
+        guard agent == .claude || agent == .codex else {
+            throw CommandError.unsupportedAgent
+        }
+        guard !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw CommandError.emptyPrompt
+        }
+        guard prompt.utf8.count <= Self.promptByteBudget else {
+            throw CommandError.promptTooLong
+        }
+        return "\(agent.executableName) \(TerminalStartupShellQuoting.singleQuoted(prompt))\n"
+    }
+}

--- a/Sources/Mobile/DispatchDirectoryIndex.swift
+++ b/Sources/Mobile/DispatchDirectoryIndex.swift
@@ -34,7 +34,7 @@ actor DispatchDirectoryIndex {
     }
 
     private struct ScanNode: Sendable {
-        let url: URL
+        let path: String
         let depth: Int
     }
 
@@ -216,11 +216,14 @@ actor DispatchDirectoryIndex {
         _ entry: Entry,
         homePath: String
     ) -> CommandPaletteSearchCorpusEntry<Entry> {
+        // The name is not repeated in searchableTexts: the prepared title
+        // already scores it (with a bonus), and corpus-entry preparation is
+        // the scan's dominant cost at home-directory scale.
         CommandPaletteSearchCorpusEntry(
             payload: entry,
             rank: entry.depth,
             title: entry.name,
-            searchableTexts: [relativePath(entry.path, homePath: homePath), entry.name]
+            searchableTexts: [relativePath(entry.path, homePath: homePath)]
         )
     }
 
@@ -242,13 +245,12 @@ actor DispatchDirectoryIndex {
         generation: Int,
         index: DispatchDirectoryIndex
     ) async -> ScanResult {
-        let fileManager = FileManager()
-        let homeURL = URL(fileURLWithPath: homePath, isDirectory: true).standardizedFileURL
+        let home = URL(fileURLWithPath: homePath, isDirectory: true).standardizedFileURL.path
         // Breadth-first, so every top-level tree is represented before the
         // directory cap can bite. A depth-first walk exhausted the whole cap
         // inside the first few huge sibling trees and left entire top-level
         // folders (and their projects) unsearchable.
-        var queue = [ScanNode(url: homeURL, depth: 0)]
+        var queue = [ScanNode(path: home, depth: 0)]
         var queueHead = 0
         var batch: [CommandPaletteSearchCorpusEntry<Entry>] = []
         batch.reserveCapacity(publishBatchSize)
@@ -260,24 +262,13 @@ actor DispatchDirectoryIndex {
             queueHead += 1
             if Task.isCancelled { break }
             guard node.depth < maximumDepth else { continue }
-            let children: [URL]
-            do {
-                children = try fileManager.contentsOfDirectory(
-                    at: node.url,
-                    includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
-                    options: []
-                )
-            } catch {
-                continue
-            }
-
-            for child in children.sorted(by: { $0.path < $1.path }) {
-                guard let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
-                      values.isDirectory == true,
-                      values.isSymbolicLink != true else {
-                    continue
-                }
-                let components = relativeComponents(child.path, homePath: homePath)
+            // readdir with d_type instead of FileManager URL enumeration: the
+            // resource-key variant open()s every child (files included), which
+            // took tens of minutes on a large real home directory (sampled).
+            // d_type identifies subdirectories with zero per-child syscalls.
+            for name in childDirectoryNames(of: node.path).sorted() {
+                let childPath = node.path + "/" + name
+                let components = relativeComponents(childPath, homePath: home)
                 if shouldSkip(components) {
                     continue
                 }
@@ -289,11 +280,16 @@ actor DispatchDirectoryIndex {
                 }
                 let depth = node.depth + 1
                 batch.append(preparedCorpusEntry(
-                    entry(url: child, depth: depth, fileManager: fileManager),
-                    homePath: homePath
+                    Entry(
+                        path: childPath,
+                        name: name,
+                        git: access(childPath + "/.git", F_OK) == 0,
+                        depth: depth
+                    ),
+                    homePath: home
                 ))
                 if depth < maximumDepth {
-                    queue.append(ScanNode(url: child, depth: depth))
+                    queue.append(ScanNode(path: childPath, depth: depth))
                 }
                 if batch.count >= publishBatchSize {
                     await index.publish(batch, generation: generation)
@@ -309,6 +305,8 @@ actor DispatchDirectoryIndex {
         return ScanResult(truncated: truncated)
     }
 
+    /// Single-level entry construction for browse listings (which keep the
+    /// FileManager URL path: one level at a time is cheap).
     private nonisolated static func entry(url: URL, depth: Int, fileManager: FileManager) -> Entry {
         Entry(
             path: url.standardizedFileURL.path,
@@ -316,6 +314,31 @@ actor DispatchDirectoryIndex {
             git: fileManager.fileExists(atPath: url.appendingPathComponent(".git").path),
             depth: depth
         )
+    }
+
+    /// Names of `node`'s immediate subdirectories via `readdir`'s `d_type`,
+    /// so classifying children costs no stat/open per entry. `DT_UNKNOWN`
+    /// (some filesystems) falls back to one `lstat`; symlinks are excluded.
+    private nonisolated static func childDirectoryNames(of path: String) -> [String] {
+        guard let dir = opendir(path) else { return [] }
+        defer { closedir(dir) }
+        var names: [String] = []
+        while let rawEntry = readdir(dir) {
+            let type = rawEntry.pointee.d_type
+            guard type == DT_DIR || type == DT_UNKNOWN else { continue }
+            let name = withUnsafeBytes(of: rawEntry.pointee.d_name) { rawBuffer -> String? in
+                guard let base = rawBuffer.baseAddress else { return nil }
+                return String(cString: base.assumingMemoryBound(to: CChar.self))
+            }
+            guard let name, name != ".", name != ".." else { continue }
+            if type == DT_UNKNOWN {
+                var status = stat()
+                guard lstat(path + "/" + name, &status) == 0,
+                      (status.st_mode & S_IFMT) == S_IFDIR else { continue }
+            }
+            names.append(name)
+        }
+        return names
     }
 
     private nonisolated static func relativePath(_ path: String, homePath: String) -> String {
@@ -335,9 +358,11 @@ actor DispatchDirectoryIndex {
             return true
         }
         // TCC-protected roots: enumerating them from a background scan pops a
-        // surprise macOS privacy dialog. Browse-into still reaches them, which
-        // prompts at a user-intentional moment instead.
-        if components.count == 1, ["Desktop", "Documents", "Downloads"].contains(name) {
+        // surprise macOS privacy dialog, and a raw readdir() BLOCKS inside the
+        // syscall until the user answers it, freezing the whole walk (hit
+        // live: the scan froze at ~/Movies). Browse-into still reaches them,
+        // prompting at a user-intentional moment instead.
+        if components.count == 1, ["Desktop", "Documents", "Downloads", "Movies", "Music", "Pictures"].contains(name) {
             return true
         }
         // Top-level dot-trees (~/.claude, ~/.npm, …) are tool state, not

--- a/Sources/Mobile/DispatchDirectoryIndex.swift
+++ b/Sources/Mobile/DispatchDirectoryIndex.swift
@@ -1,0 +1,367 @@
+import CmuxCommandPalette
+import Foundation
+
+/// Lazily indexes directories under a home folder for the mobile Dispatch picker.
+actor DispatchDirectoryIndex {
+    struct Entry: Sendable, Equatable {
+        let path: String
+        let name: String
+        let git: Bool
+        let depth: Int
+    }
+
+    struct SearchResult: Sendable {
+        let entries: [Entry]
+        let indexing: Bool
+        let truncated: Bool
+    }
+
+    struct DirectoryListing: Sendable {
+        let path: String
+        let entries: [Entry]
+        let truncated: Bool
+        let notice: Notice?
+    }
+
+    struct Notice: Sendable {
+        let code: String
+        let message: String
+    }
+
+    enum ListingError: Error, Sendable {
+        case notFound(path: String)
+        case unavailable(path: String, message: String)
+    }
+
+    private struct ScanNode: Sendable {
+        let url: URL
+        let depth: Int
+    }
+
+    private struct ScanResult: Sendable {
+        let truncated: Bool
+    }
+
+    nonisolated let homeDirectoryPath: String
+
+    private static let maximumDepth = 8
+    private static let maximumDirectoryCount = 60_000
+    private static let listingLimit = 400
+    private static let refreshInterval: TimeInterval = 10 * 60
+    private static let publishBatchSize = 64
+
+    /// Prepared once per directory at publish time: corpus-entry preparation
+    /// (normalization, prefix score maps) is far too expensive to redo per
+    /// query over tens of thousands of directories.
+    private var corpus: [CommandPaletteSearchCorpusEntry<Entry>] = []
+    private var buildingCorpus: [CommandPaletteSearchCorpusEntry<Entry>] = []
+    /// Rust nucleo index over the completed corpus. The pure-Swift fuzzy
+    /// engine's stitched-prefix scoring is quadratic-ish over path words and
+    /// takes seconds at home-directory scale (verified by sampling); nucleo
+    /// answers the same corpus in milliseconds. Built once per completed scan.
+    private var nucleoIndex: CommandPaletteNucleoSearchIndex<Entry>?
+    private var builtAt: Date?
+    private var indexWasTruncated = false
+    private var buildTask: Task<Void, Never>?
+    private var buildGeneration = 0
+
+    init(homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser) {
+        homeDirectoryPath = homeDirectory.standardizedFileURL.path
+    }
+
+    func list(path rawPath: String, includeHidden: Bool) -> Result<DirectoryListing, ListingError> {
+        let path = resolvedPath(rawPath)
+        let fileManager = FileManager()
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: path, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return .failure(.notFound(path: path))
+        }
+
+        do {
+            let urls = try fileManager.contentsOfDirectory(
+                at: URL(fileURLWithPath: path, isDirectory: true),
+                includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+                options: []
+            )
+            var entries: [Entry] = []
+            entries.reserveCapacity(min(urls.count, Self.listingLimit + 1))
+            for url in urls {
+                if !includeHidden, url.lastPathComponent.hasPrefix(".") { continue }
+                let values = try url.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+                guard values.isDirectory == true, values.isSymbolicLink != true else { continue }
+                entries.append(Self.entry(url: url, depth: 1, fileManager: fileManager))
+            }
+            entries.sort { lhs, rhs in
+                let comparison = lhs.name.localizedCaseInsensitiveCompare(rhs.name)
+                if comparison != .orderedSame { return comparison == .orderedAscending }
+                return lhs.path < rhs.path
+            }
+            let truncated = entries.count > Self.listingLimit
+            return .success(DirectoryListing(
+                path: path,
+                entries: Array(entries.prefix(Self.listingLimit)),
+                truncated: truncated,
+                notice: nil
+            ))
+        } catch {
+            if Self.isPermissionDenied(error) {
+                return .success(DirectoryListing(
+                    path: path,
+                    entries: [],
+                    truncated: false,
+                    notice: Notice(code: "permission_denied", message: error.localizedDescription)
+                ))
+            }
+            return .failure(.unavailable(path: path, message: error.localizedDescription))
+        }
+    }
+
+    func search(query: String, limit requestedLimit: Int = 50, now: Date = Date()) -> SearchResult {
+        let needsRefresh = builtAt.map { now.timeIntervalSince($0) >= Self.refreshInterval } ?? true
+        if needsRefresh, buildTask == nil {
+            startBuild()
+        }
+
+        let limit = min(max(requestedLimit, 1), 100)
+        let matchedEntries: [Entry]
+        if let nucleoIndex,
+           let nucleoRanked = nucleoIndex.search(
+               query: query,
+               resultLimit: limit + 1,
+               historyBoost: { entry, _ in entry.git ? 350 : 0 }
+           ) {
+            matchedEntries = nucleoRanked.map(\.payload)
+        } else {
+            matchedEntries = Self.fallbackRanked(
+                corpus: corpus.isEmpty ? buildingCorpus : corpus,
+                query: query,
+                limit: limit + 1
+            )
+        }
+        return SearchResult(
+            entries: Array(matchedEntries.prefix(limit)),
+            indexing: buildTask != nil,
+            truncated: indexWasTruncated || matchedEntries.count > limit
+        )
+    }
+
+    /// Mid-build (or nucleo-unavailable) ranking: a cheap case-insensitive
+    /// substring prefilter bounds the candidate set before the expensive Swift
+    /// fuzzy engine runs, so searches stay responsive while results fill in.
+    private nonisolated static func fallbackRanked(
+        corpus: [CommandPaletteSearchCorpusEntry<Entry>],
+        query: String,
+        limit: Int
+    ) -> [Entry] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return [] }
+        var survivors: [CommandPaletteSearchCorpusEntry<Entry>] = []
+        let survivorCap = 1500
+        for entry in corpus {
+            if entry.nucleoSearchText.range(of: needle, options: .caseInsensitive) != nil {
+                survivors.append(entry)
+                if survivors.count >= survivorCap { break }
+            }
+        }
+        guard !survivors.isEmpty else { return [] }
+        return CommandPaletteSearchEngine(entries: survivors).search(
+            query: needle,
+            resultLimit: limit,
+            historyBoost: { entry, _ in entry.git ? 350 : 0 }
+        ).map(\.payload)
+    }
+
+    /// Completes the current build, or starts one when the index is idle.
+    func rebuild() async {
+        if buildTask == nil {
+            startBuild()
+        }
+        await buildTask?.value
+    }
+
+    private func startBuild() {
+        buildGeneration += 1
+        let generation = buildGeneration
+        buildingCorpus = []
+        let homePath = homeDirectoryPath
+        buildTask = Task.detached(priority: .utility) { [self] in
+            let result = await Self.scan(
+                homePath: homePath,
+                generation: generation,
+                index: self
+            )
+            await finishBuild(generation: generation, result: result)
+        }
+    }
+
+    private func publish(_ prepared: [CommandPaletteSearchCorpusEntry<Entry>], generation: Int) {
+        guard generation == buildGeneration else { return }
+        buildingCorpus.append(contentsOf: prepared)
+    }
+
+    private func finishBuild(generation: Int, result: ScanResult) {
+        guard generation == buildGeneration else { return }
+        corpus = buildingCorpus
+        buildingCorpus = []
+        nucleoIndex = corpus.count >= 32 ? CommandPaletteNucleoSearchIndex(entries: corpus) : nil
+        builtAt = Date()
+        indexWasTruncated = result.truncated
+        buildTask = nil
+    }
+
+    /// Corpus-entry preparation happens on the detached scan task, off both the
+    /// main actor and this actor, so neither RPC handling nor searches stall
+    /// behind text normalization.
+    private nonisolated static func preparedCorpusEntry(
+        _ entry: Entry,
+        homePath: String
+    ) -> CommandPaletteSearchCorpusEntry<Entry> {
+        CommandPaletteSearchCorpusEntry(
+            payload: entry,
+            rank: entry.depth,
+            title: entry.name,
+            searchableTexts: [relativePath(entry.path, homePath: homePath), entry.name]
+        )
+    }
+
+    private func resolvedPath(_ rawPath: String) -> String {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expanded: String
+        if trimmed == "~" {
+            expanded = homeDirectoryPath
+        } else if trimmed.hasPrefix("~/") {
+            expanded = homeDirectoryPath + String(trimmed.dropFirst())
+        } else {
+            expanded = trimmed
+        }
+        return URL(fileURLWithPath: expanded, isDirectory: true).standardizedFileURL.path
+    }
+
+    private nonisolated static func scan(
+        homePath: String,
+        generation: Int,
+        index: DispatchDirectoryIndex
+    ) async -> ScanResult {
+        let fileManager = FileManager()
+        let homeURL = URL(fileURLWithPath: homePath, isDirectory: true).standardizedFileURL
+        // Breadth-first, so every top-level tree is represented before the
+        // directory cap can bite. A depth-first walk exhausted the whole cap
+        // inside the first few huge sibling trees and left entire top-level
+        // folders (and their projects) unsearchable.
+        var queue = [ScanNode(url: homeURL, depth: 0)]
+        var queueHead = 0
+        var batch: [CommandPaletteSearchCorpusEntry<Entry>] = []
+        batch.reserveCapacity(publishBatchSize)
+        var directoryCount = 0
+        var truncated = false
+
+        while queueHead < queue.count {
+            let node = queue[queueHead]
+            queueHead += 1
+            if Task.isCancelled { break }
+            guard node.depth < maximumDepth else { continue }
+            let children: [URL]
+            do {
+                children = try fileManager.contentsOfDirectory(
+                    at: node.url,
+                    includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey],
+                    options: []
+                )
+            } catch {
+                continue
+            }
+
+            for child in children.sorted(by: { $0.path < $1.path }) {
+                guard let values = try? child.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey]),
+                      values.isDirectory == true,
+                      values.isSymbolicLink != true else {
+                    continue
+                }
+                let components = relativeComponents(child.path, homePath: homePath)
+                if shouldSkip(components) {
+                    continue
+                }
+
+                directoryCount += 1
+                if directoryCount > maximumDirectoryCount {
+                    truncated = true
+                    break
+                }
+                let depth = node.depth + 1
+                batch.append(preparedCorpusEntry(
+                    entry(url: child, depth: depth, fileManager: fileManager),
+                    homePath: homePath
+                ))
+                if depth < maximumDepth {
+                    queue.append(ScanNode(url: child, depth: depth))
+                }
+                if batch.count >= publishBatchSize {
+                    await index.publish(batch, generation: generation)
+                    batch.removeAll(keepingCapacity: true)
+                }
+            }
+            if truncated { break }
+        }
+
+        if !batch.isEmpty {
+            await index.publish(batch, generation: generation)
+        }
+        return ScanResult(truncated: truncated)
+    }
+
+    private nonisolated static func entry(url: URL, depth: Int, fileManager: FileManager) -> Entry {
+        Entry(
+            path: url.standardizedFileURL.path,
+            name: url.lastPathComponent,
+            git: fileManager.fileExists(atPath: url.appendingPathComponent(".git").path),
+            depth: depth
+        )
+    }
+
+    private nonisolated static func relativePath(_ path: String, homePath: String) -> String {
+        relativeComponents(path, homePath: homePath).joined(separator: "/")
+    }
+
+    private nonisolated static func relativeComponents(_ path: String, homePath: String) -> [String] {
+        let pathComponents = URL(fileURLWithPath: path).standardizedFileURL.pathComponents
+        let homeComponents = URL(fileURLWithPath: homePath).standardizedFileURL.pathComponents
+        guard pathComponents.starts(with: homeComponents) else { return pathComponents }
+        return Array(pathComponents.dropFirst(homeComponents.count))
+    }
+
+    private nonisolated static func shouldSkip(_ components: [String]) -> Bool {
+        guard let name = components.last else { return false }
+        if [".git", "node_modules", ".Trash", ".cache", ".npm", ".gradle", "DerivedData"].contains(name) {
+            return true
+        }
+        // TCC-protected roots: enumerating them from a background scan pops a
+        // surprise macOS privacy dialog. Browse-into still reaches them, which
+        // prompts at a user-intentional moment instead.
+        if components.count == 1, ["Desktop", "Documents", "Downloads"].contains(name) {
+            return true
+        }
+        // Top-level dot-trees (~/.claude, ~/.npm, …) are tool state, not
+        // projects; they flood search with noise. Browse still reaches them.
+        if components.count == 1, name.hasPrefix(".") {
+            return true
+        }
+        if components == ["Library"] { return true }
+        if components.count >= 2,
+           components[components.count - 2] == ".cargo",
+           name == "registry" {
+            return true
+        }
+        return false
+    }
+
+    private nonisolated static func isPermissionDenied(_ error: Error) -> Bool {
+        var currentError: NSError? = error as NSError
+        while let current = currentError {
+            if current.domain == NSCocoaErrorDomain, current.code == NSFileReadNoPermissionError {
+                return true
+            }
+            currentError = current.userInfo[NSUnderlyingErrorKey] as? NSError
+        }
+        return false
+    }
+}

--- a/Sources/Mobile/MobileHostService+Capabilities.swift
+++ b/Sources/Mobile/MobileHostService+Capabilities.swift
@@ -33,6 +33,7 @@ extension MobileHostService {
             "workspace.group_actions.v1",
             "workspace.group_create.v1",
             "workspace.create_in_group.v1",
+            "workspace.dispatch.v1",
             "chat.artifact.v1",
             "chat.artifact.folders.v1",
             "chat.artifact.gallery.v1",

--- a/Sources/Mobile/MobileHostService+TicketAuthorization.swift
+++ b/Sources/Mobile/MobileHostService+TicketAuthorization.swift
@@ -45,6 +45,8 @@ extension MobileHostService {
                 return ticketMacScopedWorkspaceMutationAuthorizationError(authorization: authorization)
             }
             return nil
+        case "mobile.dispatch.catalog", "mobile.dispatch.fs", "mobile.dispatch.launch":
+            return nil
         case "workspace.move":
             return ticketMacScopedWorkspaceMutationAuthorizationError(
                 authorization: authorization,

--- a/Sources/Mobile/MobileHostService.swift
+++ b/Sources/Mobile/MobileHostService.swift
@@ -1347,7 +1347,7 @@ final class MobileHostService {
               let object = payload as? [String: Any] else { return }
 
         switch request.method {
-        case "workspace.create":
+        case "workspace.create", "mobile.dispatch.launch":
             ticketStore.recordCreatedResources(
                 authToken: attachToken,
                 workspaceID: object["created_workspace_id"] as? String,

--- a/Sources/TerminalController+MobileDispatch.swift
+++ b/Sources/TerminalController+MobileDispatch.swift
@@ -1,0 +1,219 @@
+import Foundation
+
+/// `mobile.dispatch.*` RPC handlers for catalog, filesystem, and agent launch.
+extension TerminalController {
+    func v2MobileDispatch(method: String, params: [String: Any]) async -> V2CallResult {
+        switch method {
+        case "mobile.dispatch.catalog":
+            return v2MobileDispatchCatalog()
+        case "mobile.dispatch.fs":
+            return await v2MobileDispatchFilesystem(params: params)
+        case "mobile.dispatch.launch":
+            return await v2MobileDispatchLaunch(params: params)
+        default:
+            return .err(code: "method_not_found", message: "Unknown mobile method", data: [
+                "method": method
+            ])
+        }
+    }
+
+    private func v2MobileDispatchCatalog() -> V2CallResult {
+        let home = dispatchDirectoryIndex.homeDirectoryPath
+        let providers: [AgentSessionProviderID] = [.claude, .codex]
+        let resolver = AgentExecutableResolver(
+            configuredExecutablePaths: AgentExecutableResolver.cmuxConfiguredExecutablePaths()
+        )
+        let agents = providers.map { provider -> [String: Any] in
+            [
+                "id": provider.rawValue,
+                "name": provider.displayName,
+                "installed": (try? resolver.resolve(provider)) != nil,
+            ]
+        }
+
+        var seenDirectories: Set<String> = []
+        var recentDirectories: [[String: Any]] = []
+        let fileManager = FileManager.default
+        if let tabManager = v2ResolveTabManager(params: [:]) {
+            for workspace in tabManager.tabs {
+                for candidate in [workspace.presentedCurrentDirectory, workspace.currentDirectory].compactMap({ $0 }) {
+                    let path = URL(fileURLWithPath: candidate, isDirectory: true).standardizedFileURL.path
+                    var isDirectory: ObjCBool = false
+                    guard path != home,
+                          seenDirectories.insert(path).inserted,
+                          fileManager.fileExists(atPath: path, isDirectory: &isDirectory),
+                          isDirectory.boolValue else {
+                        continue
+                    }
+                    recentDirectories.append([
+                        "path": path,
+                        "git": fileManager.fileExists(atPath: URL(fileURLWithPath: path).appendingPathComponent(".git").path),
+                    ])
+                    if recentDirectories.count == 8 { break }
+                }
+                if recentDirectories.count == 8 { break }
+            }
+        }
+
+        return .ok([
+            "home": home,
+            "agents": agents,
+            "recent_dirs": recentDirectories,
+            "prompt_byte_budget": DispatchAgentCommandBuilder.promptByteBudget,
+        ])
+    }
+
+    private func v2MobileDispatchFilesystem(params: [String: Any]) async -> V2CallResult {
+        guard let operation = v2String(params, "op") else {
+            return .err(code: "invalid_params", message: "Missing dispatch filesystem operation", data: nil)
+        }
+        switch operation {
+        case "list":
+            guard let path = v2RawString(params, "path"), !path.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                return .err(code: "invalid_params", message: "Missing path", data: nil)
+            }
+            let result = await dispatchDirectoryIndex.list(
+                path: path,
+                includeHidden: v2Bool(params, "include_hidden") ?? false
+            )
+            switch result {
+            case let .success(listing):
+                var payload: [String: Any] = [
+                    "path": listing.path,
+                    "entries": listing.entries.map(Self.mobileDispatchEntryPayload),
+                    "truncated": listing.truncated,
+                ]
+                if let notice = listing.notice {
+                    payload["notice"] = ["code": notice.code, "message": notice.message]
+                }
+                return .ok(payload)
+            case let .failure(.notFound(resolvedPath)):
+                return .err(code: "not_found", message: "Directory not found", data: ["path": resolvedPath])
+            case let .failure(.unavailable(resolvedPath, message)):
+                return .err(code: "unavailable", message: message, data: ["path": resolvedPath])
+            }
+        case "search":
+            guard let query = v2RawString(params, "query") else {
+                return .err(code: "invalid_params", message: "Missing query", data: nil)
+            }
+            let limit = min(max(v2Int(params, "limit") ?? 50, 1), 100)
+            let result = await dispatchDirectoryIndex.search(query: query, limit: limit)
+            return .ok([
+                "query": query,
+                "entries": result.entries.map(Self.mobileDispatchEntryPayload),
+                "indexing": result.indexing,
+                "truncated": result.truncated,
+            ])
+        default:
+            return .err(code: "invalid_params", message: "Unsupported dispatch filesystem operation", data: [
+                "op": operation
+            ])
+        }
+    }
+
+    private func v2MobileDispatchLaunch(params: [String: Any]) async -> V2CallResult {
+        guard let rawDirectory = v2RawString(params, "directory"),
+              !rawDirectory.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .err(code: "directory_not_found", message: "Directory not found", data: nil)
+        }
+        let directory = Self.mobileDispatchExpandedPath(
+            rawDirectory,
+            home: dispatchDirectoryIndex.homeDirectoryPath
+        )
+        var isDirectory: ObjCBool = false
+        guard FileManager.default.fileExists(atPath: directory, isDirectory: &isDirectory), isDirectory.boolValue else {
+            return .err(code: "directory_not_found", message: "Directory not found", data: ["directory": directory])
+        }
+        guard let rawAgentID = v2String(params, "agent_id"),
+              let agent = AgentSessionProviderID(rawValue: rawAgentID),
+              agent == .claude || agent == .codex else {
+            return .err(code: "invalid_params", message: "Unsupported agent_id", data: nil)
+        }
+        guard let prompt = v2RawString(params, "prompt"),
+              !prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            return .err(code: "invalid_params", message: "Prompt must not be empty", data: nil)
+        }
+        guard prompt.utf8.count <= DispatchAgentCommandBuilder.promptByteBudget else {
+            return .err(code: "prompt_too_long", message: "Prompt exceeds the byte budget", data: [
+                "prompt_byte_budget": DispatchAgentCommandBuilder.promptByteBudget
+            ])
+        }
+
+        let resolver = AgentExecutableResolver(
+            configuredExecutablePaths: AgentExecutableResolver.cmuxConfiguredExecutablePaths()
+        )
+        guard (try? resolver.resolve(agent)) != nil else {
+            return .err(
+                code: "agent_not_installed",
+                message: "\(agent.displayName) is not installed on this Mac",
+                data: ["agent_id": agent.rawValue]
+            )
+        }
+        guard let tabManager = v2ResolveTabManager(params: params) else {
+            return .err(code: "unavailable", message: "Workspace context is unavailable", data: nil)
+        }
+
+        let command: String
+        do {
+            command = try DispatchAgentCommandBuilder().command(agent: agent, prompt: prompt)
+        } catch {
+            return .err(code: "invalid_params", message: "Invalid dispatch prompt", data: nil)
+        }
+        var createParams: [String: Any] = [
+            "working_directory": directory,
+            "title": Self.mobileDispatchWorkspaceTitle(prompt),
+            "focus": false,
+            "eager_load_terminal": true,
+            "initial_input": command,
+        ]
+        let createResult = v2WorkspaceCreate(params: createParams, tabManager: tabManager)
+        switch createResult {
+        case let .ok(rawPayload):
+            guard let payload = rawPayload as? [String: Any],
+                  let createdWorkspaceID = payload["workspace_id"] as? String,
+                  let workspaceID = UUID(uuidString: createdWorkspaceID) else {
+                return .err(code: "internal_error", message: "Failed to create dispatch workspace", data: nil)
+            }
+            tabManager.handlePromptSubmit(workspaceId: workspaceID, message: prompt)
+            createParams["workspace_id"] = createdWorkspaceID
+            return v2MobileWorkspaceList(
+                params: createParams,
+                tabManager: tabManager,
+                createdWorkspaceID: createdWorkspaceID
+            )
+        case .err:
+            return createResult
+        }
+    }
+
+    private nonisolated static func mobileDispatchEntryPayload(
+        _ entry: DispatchDirectoryIndex.Entry
+    ) -> [String: Any] {
+        ["path": entry.path, "name": entry.name, "git": entry.git]
+    }
+
+    private nonisolated static func mobileDispatchExpandedPath(_ rawPath: String, home: String) -> String {
+        let trimmed = rawPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let expanded: String
+        if trimmed == "~" {
+            expanded = home
+        } else if trimmed.hasPrefix("~/") {
+            expanded = home + String(trimmed.dropFirst())
+        } else {
+            expanded = trimmed
+        }
+        return URL(fileURLWithPath: expanded, isDirectory: true).standardizedFileURL.path
+    }
+
+    private nonisolated static func mobileDispatchWorkspaceTitle(_ prompt: String) -> String {
+        let firstLine = prompt.firstIndex(where: \.isNewline).map { String(prompt[..<$0]) } ?? prompt
+        let trimmed = firstLine.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.count > 60 else { return trimmed }
+        let prefix = String(trimmed.prefix(60))
+        if let boundary = prefix.lastIndex(where: \.isWhitespace) {
+            let wordBounded = prefix[..<boundary].trimmingCharacters(in: .whitespacesAndNewlines)
+            if !wordBounded.isEmpty { return wordBounded + "…" }
+        }
+        return prefix + "…"
+    }
+}

--- a/Sources/TerminalController+WorkspaceCreate.swift
+++ b/Sources/TerminalController+WorkspaceCreate.swift
@@ -18,6 +18,7 @@ extension TerminalController {
 
         let requestedInitialCommand = v2RawString(params, "initial_command")?.trimmingCharacters(in: .whitespacesAndNewlines)
         let initialCommand = (requestedInitialCommand?.isEmpty == false) ? requestedInitialCommand : nil
+        let initialInput = v2RawString(params, "initial_input")
 
         let rawInitialEnv = v2StringMap(params, "initial_env") ?? [:]
         let initialEnv = rawInitialEnv.reduce(into: [String: String]()) { result, pair in
@@ -133,6 +134,7 @@ extension TerminalController {
                 title: title,
                 workingDirectory: cwd,
                 initialTerminalCommand: layoutNode == nil ? initialCommand : nil,
+                initialTerminalInput: layoutNode == nil ? initialInput : nil,
                 initialTerminalEnvironment: layoutNode == nil ? initialEnv : [:],
                 workspaceEnvironment: workspaceEnv,
                 select: shouldFocus,

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -126,6 +126,7 @@ class TerminalController {
     @MainActor private(set) var authCoordinator: AuthCoordinator?
     @MainActor private(set) var browserSignInFlow: HostBrowserSignInFlow?
     @MainActor var agentChatTranscriptService: AgentChatTranscriptService?
+    nonisolated let dispatchDirectoryIndex: DispatchDirectoryIndex
     nonisolated let terminalArtifactAuthorizationStore: TerminalArtifactAuthorizationStore
     // Sendable value type; injected at construction so socket auth never reaches a global.
     nonisolated let passwordStore: SocketControlPasswordStore
@@ -353,6 +354,7 @@ class TerminalController {
         socketClientPreauthorizationLimiter: SocketClientPreauthorizationLimiter = .init(
             maximumConcurrentClaims: 32
         ),
+        dispatchDirectoryIndex: DispatchDirectoryIndex = DispatchDirectoryIndex(),
         terminalArtifactAuthorizationStore: TerminalArtifactAuthorizationStore = .init(),
         remoteProxyBroker: any RemoteProxyBrokering = RemoteProxyBroker(
             tunnelProvider: RemoteDaemonProxyTunnelProvider(strings: .appLocalized, ptyBridgeStrings: AppRemotePTYBridgeStrings())
@@ -365,6 +367,7 @@ class TerminalController {
         self.socketPasswordFileWatcher = socketPasswordFileWatcher
         self.socketClientCapabilityAuthority = Self.makeSocketClientCapabilityAuthority()
         self.socketClientPreauthorizationLimiter = socketClientPreauthorizationLimiter
+        self.dispatchDirectoryIndex = dispatchDirectoryIndex
         self.terminalArtifactAuthorizationStore = terminalArtifactAuthorizationStore
         self.transport = transport
         self.remoteProxyBroker = remoteProxyBroker
@@ -13835,6 +13838,8 @@ class TerminalController {
             result = request.method == "workspace.group.create" ? v2MobileWorkspaceGroupCreate(params: request.params) : v2MobileWorkspaceGroupAction(params: request.params)
         case let method where method.hasPrefix("mobile.chat."):
             result = await v2MobileChatDispatch(method: method, params: request.params)
+        case let method where method.hasPrefix("mobile.dispatch."):
+            result = await v2MobileDispatch(method: method, params: request.params)
         case "workspace.close":
             result = v2MobileWorkspaceClose(params: request.params)
         case "workspace.group.collapse":

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -753,6 +753,8 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A28B087F0000000000000017 /* DiffViewerNavigationDocumentSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F0000000000000016 /* DiffViewerNavigationDocumentSnapshot.swift */; };
 		A28B087F000000000000000D /* DiffViewerNavigationDocumentState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F000000000000000E /* DiffViewerNavigationDocumentState.swift */; };
 		A28B087F0000000000000009 /* DiffViewerSessionTrustRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = A28B087F000000000000000A /* DiffViewerSessionTrustRegistry.swift */; };
+		D15A00000000000000000001 /* DispatchAgentCommandBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A00000000000000000002 /* DispatchAgentCommandBuilder.swift */; };
+		D15A00000000000000000003 /* DispatchDirectoryIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A00000000000000000004 /* DispatchDirectoryIndex.swift */; };
 		B8F266266A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */; };
 		DCDC1000000000000000B003 /* DockConfigFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B004 /* DockConfigFile.swift */; };
 		DCDC1000000000000000B005 /* DockConfigIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = DCDC1000000000000000B006 /* DockConfigIdentity.swift */; };
@@ -1053,6 +1055,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A7C0F0030000000000000001 /* MobileAttachTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C0F0030000000000000002 /* MobileAttachTarget.swift */; };
 		284FD21ACF8BD1ED6AEBD7A0 /* MobileAttachTicketStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */; };
 		C0DEA7710000000000000009 /* MobileConnectTitlebarAccessory.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0DEA771000000000000000A /* MobileConnectTitlebarAccessory.swift */; };
+		D15A00000000000000000007 /* MobileDispatchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A00000000000000000008 /* MobileDispatchTests.swift */; };
 		C1A070000000000000000001 /* MobileHostAuthorizationSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A070000000000000000011 /* MobileHostAuthorizationSupport.swift */; };
 		6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */; };
 		C7A50B000000000000000016 /* MobileHostBuildIdentity.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */; };
@@ -1738,6 +1741,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A7C0F0020000000000000002 /* TerminalController+MobileAttachTicket.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7C0F0020000000000000001 /* TerminalController+MobileAttachTicket.swift */; };
 		ACA7C4A7000000000000000D /* TerminalController+MobileChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = ACA7C4A7000000000000000E /* TerminalController+MobileChat.swift */; };
 		C7AF10000000000000000003 /* TerminalController+MobileChatArtifacts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF10000000000000000004 /* TerminalController+MobileChatArtifacts.swift */; };
+		D15A00000000000000000005 /* TerminalController+MobileDispatch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D15A00000000000000000006 /* TerminalController+MobileDispatch.swift */; };
 		D7AB00000000000000B001 /* TerminalController+MobileNotificationSync.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B000 /* TerminalController+MobileNotificationSync.swift */; };
 		D7AB00000000000000B011 /* TerminalController+MobileScrollPrefetch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7AB00000000000000B010 /* TerminalController+MobileScrollPrefetch.swift */; };
 		C7AF20000000000000000001 /* TerminalController+MobileTerminalArtifacts.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7AF20000000000000000002 /* TerminalController+MobileTerminalArtifacts.swift */; };
@@ -2792,6 +2796,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A28B087F0000000000000016 /* DiffViewerNavigationDocumentSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DiffViewerNavigationDocumentSnapshot.swift; sourceTree = "<group>"; };
 		A28B087F000000000000000E /* DiffViewerNavigationDocumentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DiffViewerNavigationDocumentState.swift; sourceTree = "<group>"; };
 		A28B087F000000000000000A /* DiffViewerSessionTrustRegistry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/DiffViewerSessionTrustRegistry.swift; sourceTree = "<group>"; };
+		D15A00000000000000000002 /* DispatchAgentCommandBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchAgentCommandBuilder.swift; sourceTree = "<group>"; };
+		D15A00000000000000000004 /* DispatchDirectoryIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DispatchDirectoryIndex.swift; sourceTree = "<group>"; };
 		B8F266276A1A3D9A45BD840F /* DisplayResolutionRegressionUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayResolutionRegressionUITests.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B004 /* DockConfigFile.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigFile.swift; sourceTree = "<group>"; };
 		DCDC1000000000000000B006 /* DockConfigIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DockConfigIdentity.swift; sourceTree = "<group>"; };
@@ -3088,6 +3094,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A7C0F0030000000000000002 /* MobileAttachTarget.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileAttachTarget.swift; sourceTree = "<group>"; };
 		8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileAttachTicketStore.swift; sourceTree = "<group>"; };
 		C0DEA771000000000000000A /* MobileConnectTitlebarAccessory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileConnectTitlebarAccessory.swift; sourceTree = "<group>"; };
+		D15A00000000000000000008 /* MobileDispatchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileDispatchTests.swift; sourceTree = "<group>"; };
 		C1A070000000000000000011 /* MobileHostAuthorizationSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostAuthorizationSupport.swift; sourceTree = "<group>"; };
 		9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostAuthorizationTests.swift; sourceTree = "<group>"; };
 		C7A50B000000000000000015 /* MobileHostBuildIdentity.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MobileHostBuildIdentity.swift; sourceTree = "<group>"; };
@@ -3758,6 +3765,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A7C0F0020000000000000001 /* TerminalController+MobileAttachTicket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileAttachTicket.swift"; sourceTree = "<group>"; };
 		ACA7C4A7000000000000000E /* TerminalController+MobileChat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileChat.swift"; sourceTree = "<group>"; };
 		C7AF10000000000000000004 /* TerminalController+MobileChatArtifacts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileChatArtifacts.swift"; sourceTree = "<group>"; };
+		D15A00000000000000000006 /* TerminalController+MobileDispatch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileDispatch.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000B000 /* TerminalController+MobileNotificationSync.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileNotificationSync.swift"; sourceTree = "<group>"; };
 		D7AB00000000000000B010 /* TerminalController+MobileScrollPrefetch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileScrollPrefetch.swift"; sourceTree = "<group>"; };
 		C7AF20000000000000000002 /* TerminalController+MobileTerminalArtifacts.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "TerminalController+MobileTerminalArtifacts.swift"; sourceTree = "<group>"; };
@@ -4286,6 +4294,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		59065015952E1B5BE5E23519 /* Mobile */ = {
 			isa = PBXGroup;
 			children = (
+				D15A00000000000000000004 /* DispatchDirectoryIndex.swift */,
 				A7C0F0030000000000000002 /* MobileAttachTarget.swift */,
 				8D6D2AC715764ECC1F6B26A2 /* MobileAttachTicketStore.swift */,
 				B8B056D90000000000000002 /* MobileHostIdentity.swift */,
@@ -4831,6 +4840,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C13519000000000000000006 /* RestorableAgentTypes.swift */,
 				0A1107110000000000000011 /* AgentNotificationDelivery.swift */,
 				0A1107110000000000000013 /* AgentRelaunchCommandBuilder.swift */,
+				D15A00000000000000000002 /* DispatchAgentCommandBuilder.swift */,
 				0A1107110000000000000015 /* AgentRestoreMode.swift */,
 				0A1107110000000000000017 /* CmuxTaskManagerCodingAgentDefinition+BuiltIns.swift */,
 				0A1107110000000000000019 /* CmuxTopProcessSnapshot+PromptAgentDetection.swift */,
@@ -4925,6 +4935,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C0DE00000000000000000C51 /* TerminalController+ControlMobileHostContext.swift */,
 				A7C0F0020000000000000001 /* TerminalController+MobileAttachTicket.swift */,
 				ACA7C4A7000000000000000E /* TerminalController+MobileChat.swift */,
+				D15A00000000000000000006 /* TerminalController+MobileDispatch.swift */,
 				C7AF10000000000000000004 /* TerminalController+MobileChatArtifacts.swift */,
 				C7AF20000000000000000002 /* TerminalController+MobileTerminalArtifacts.swift */,
 				C0DE00000000000000000C53 /* TerminalController+ControlWorkspaceGroupContext.swift */,
@@ -6200,6 +6211,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				FE002010 /* FileExplorerDoubleClickActionTests.swift */,
 				FE002003 /* FileSearchRipgrepParserTests.swift */,
 				9BD519CFE74530A46DF0925D /* MobileHostAuthorizationTests.swift */,
+				D15A00000000000000000008 /* MobileDispatchTests.swift */,
 				7A1B2C3D4E5F60718293A4B5 /* MobileHostTerminalThemeTests.swift */,
 				C1A071000000000000000011 /* MobileHostIrohAdmissionTests.swift */,
 				C1A071000000000000000012 /* MobileHostConnectionEventLaneTests.swift */,
@@ -7080,6 +7092,8 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A28B087F0000000000000017 /* DiffViewerNavigationDocumentSnapshot.swift in Sources */,
 				A28B087F000000000000000D /* DiffViewerNavigationDocumentState.swift in Sources */,
 				A28B087F0000000000000009 /* DiffViewerSessionTrustRegistry.swift in Sources */,
+				D15A00000000000000000001 /* DispatchAgentCommandBuilder.swift in Sources */,
+				D15A00000000000000000003 /* DispatchDirectoryIndex.swift in Sources */,
 				DCDC1000000000000000B003 /* DockConfigFile.swift in Sources */,
 				DCDC1000000000000000B005 /* DockConfigIdentity.swift in Sources */,
 				DCDC1000000000000000B007 /* DockConfigResolution.swift in Sources */,
@@ -7742,6 +7756,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				A7C0F0020000000000000002 /* TerminalController+MobileAttachTicket.swift in Sources */,
 				ACA7C4A7000000000000000D /* TerminalController+MobileChat.swift in Sources */,
 				C7AF10000000000000000003 /* TerminalController+MobileChatArtifacts.swift in Sources */,
+				D15A00000000000000000005 /* TerminalController+MobileDispatch.swift in Sources */,
 				D7AB00000000000000B001 /* TerminalController+MobileNotificationSync.swift in Sources */,
 				D7AB00000000000000B011 /* TerminalController+MobileScrollPrefetch.swift in Sources */,
 				C7AF20000000000000000001 /* TerminalController+MobileTerminalArtifacts.swift in Sources */,
@@ -8395,6 +8410,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					7490A0017490A0017490A001 /* MemoryPressureMonitorTests.swift in Sources */,
 				606500010000000000000001 /* MenuBarOnlyActivationPolicyTests.swift in Sources */,
 					C0DE70520000000000000002 /* MenuBarProfilingLauncherTests.swift in Sources */,
+				D15A00000000000000000007 /* MobileDispatchTests.swift in Sources */,
 				6AA2F2E8BEB19ED6B8E125DB /* MobileHostAuthorizationTests.swift in Sources */,
 				C1A071000000000000000002 /* MobileHostConnectionEventLaneTests.swift in Sources */,
 				C1A071000000000000000003 /* MobileHostConnectionLifecycleTests.swift in Sources */,

--- a/cmuxTests/MobileDispatchTests.swift
+++ b/cmuxTests/MobileDispatchTests.swift
@@ -1,0 +1,171 @@
+import CMUXMobileCore
+import Foundation
+import Testing
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+@MainActor
+struct MobileDispatchTests {
+    @Test func commandBuilderPreservesPromptAsOneArgument() throws {
+        let prompt = "it's a \"test\" $HOME `pwd`\nsecond line"
+        let command = try DispatchAgentCommandBuilder().command(agent: .claude, prompt: prompt)
+        #expect(command.hasSuffix("\n"))
+
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", "claude() { printf '%s\\0' \"$@\"; }\n" + command]
+        process.standardOutput = output
+        try process.run()
+        process.waitUntilExit()
+
+        var expected = Data(prompt.utf8)
+        expected.append(0)
+        #expect(process.terminationStatus == 0)
+        #expect(output.fileHandleForReading.readDataToEndOfFile() == expected)
+    }
+
+    @Test func commandBuilderEnforcesUTF8ByteBudget() throws {
+        let accepted = String(repeating: "a", count: DispatchAgentCommandBuilder.promptByteBudget)
+        let command = try DispatchAgentCommandBuilder().command(agent: .codex, prompt: accepted)
+        #expect(command.hasSuffix("\n"))
+
+        let rejected = String(repeating: "é", count: 451)
+        do {
+            _ = try DispatchAgentCommandBuilder().command(agent: .codex, prompt: rejected)
+            Issue.record("Expected a prompt larger than 900 UTF-8 bytes to be rejected")
+        } catch let error as DispatchAgentCommandBuilder.CommandError {
+            #expect(error == .promptTooLong)
+        }
+    }
+
+    @Test func workspaceScopedTicketAllowsDispatchMethods() throws {
+        let ticket = try scopedAttachTicket()
+        for method in ["mobile.dispatch.catalog", "mobile.dispatch.fs", "mobile.dispatch.launch"] {
+            let request = MobileHostRPCRequest(
+                id: method,
+                method: method,
+                params: [:],
+                auth: MobileHostRPCAuth(attachToken: ticket.authToken, stackAccessToken: nil)
+            )
+            #expect(MobileHostService.ticketAuthorizationError(ticket: ticket, request: request) == nil)
+        }
+    }
+
+    @Test func filesystemListReturnsOnlySortedVisibleDirectories() async throws {
+        let root = try temporaryDirectory(named: "list")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let alpha = root.appendingPathComponent("Alpha", isDirectory: true)
+        let zeta = root.appendingPathComponent("zeta", isDirectory: true)
+        let hidden = root.appendingPathComponent(".hidden", isDirectory: true)
+        try FileManager.default.createDirectory(at: alpha.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: zeta, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: hidden, withIntermediateDirectories: true)
+        try Data("file".utf8).write(to: root.appendingPathComponent("note.txt"))
+
+        let response = await TerminalController.shared.mobileHostHandleRPC(MobileHostRPCRequest(
+            id: "list",
+            method: "mobile.dispatch.fs",
+            params: ["op": "list", "path": root.path, "include_hidden": false],
+            auth: nil
+        ))
+        guard case let .ok(rawPayload) = response,
+              let payload = rawPayload as? [String: Any],
+              let entries = payload["entries"] as? [[String: Any]] else {
+            return Issue.record("Expected directory list response")
+        }
+        #expect(entries.compactMap { $0["name"] as? String } == ["Alpha", "zeta"])
+        #expect(entries.first?["path"] as? String == alpha.path)
+        #expect(entries.first?["git"] as? Bool == true)
+        #expect(payload["truncated"] as? Bool == false)
+
+        let missing = await TerminalController.shared.mobileHostHandleRPC(MobileHostRPCRequest(
+            id: "missing",
+            method: "mobile.dispatch.fs",
+            params: ["op": "list", "path": root.appendingPathComponent("absent").path],
+            auth: nil
+        ))
+        #expect(errorCode(missing) == "not_found")
+    }
+
+    @Test func launchValidationReturnsStableErrorsWithoutSpawning() async throws {
+        let previousManager = TerminalController.shared.activeTabManagerForCallerNotification()
+        let manager = TabManager()
+        TerminalController.shared.setActiveTabManager(manager)
+        defer { TerminalController.shared.setActiveTabManager(previousManager) }
+
+        let root = try temporaryDirectory(named: "launch")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let missing = await dispatchLaunch(directory: root.appendingPathComponent("absent").path, prompt: "Fix it")
+        #expect(errorCode(missing) == "directory_not_found")
+
+        let empty = await dispatchLaunch(directory: root.path, prompt: "  \n ")
+        #expect(errorCode(empty) == "invalid_params")
+
+        let oversized = await dispatchLaunch(directory: root.path, prompt: String(repeating: "é", count: 451))
+        #expect(errorCode(oversized) == "prompt_too_long")
+    }
+
+    @Test func directoryIndexRanksAndSkipsExpectedDirectories() async throws {
+        let root = try temporaryDirectory(named: "index")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root.appendingPathComponent("cmux"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: root.appendingPathComponent("nested/cmux"), withIntermediateDirectories: true)
+        let gitProject = root.appendingPathComponent("git-parent/project", isDirectory: true)
+        try FileManager.default.createDirectory(at: gitProject.appendingPathComponent(".git"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: root.appendingPathComponent("plain-parent/project"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: root.appendingPathComponent("node_modules/secret-cmux"), withIntermediateDirectories: true)
+
+        let index = DispatchDirectoryIndex(homeDirectory: root)
+        await index.rebuild()
+
+        let exact = await index.search(query: "cmux", limit: 10)
+        #expect(exact.entries.first?.path == root.appendingPathComponent("cmux").path)
+        let boosted = await index.search(query: "project", limit: 10)
+        #expect(boosted.entries.first?.path == gitProject.path)
+        let skipped = await index.search(query: "secret-cmux", limit: 10)
+        #expect(skipped.entries.isEmpty)
+    }
+
+    private func dispatchLaunch(directory: String, prompt: String) async -> MobileHostRPCResult {
+        await TerminalController.shared.mobileHostHandleRPC(MobileHostRPCRequest(
+            id: "launch",
+            method: "mobile.dispatch.launch",
+            params: ["directory": directory, "agent_id": "claude", "prompt": prompt],
+            auth: nil
+        ))
+    }
+
+    private func errorCode(_ result: MobileHostRPCResult) -> String? {
+        guard case let .failure(error) = result else { return nil }
+        return error.code
+    }
+
+    private func temporaryDirectory(named name: String) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cmux-mobile-dispatch-\(name)-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        return url
+    }
+
+    private func scopedAttachTicket() throws -> CmxAttachTicket {
+        let route = try CmxAttachRoute(
+            id: "debug",
+            kind: .debugLoopback,
+            endpoint: .hostPort(host: "127.0.0.1", port: 58465)
+        )
+        return try CmxAttachTicket(
+            workspaceID: "workspace",
+            terminalID: "terminal",
+            macDeviceID: "test-mac",
+            macDisplayName: "Test Mac",
+            routes: [route],
+            expiresAt: Date().addingTimeInterval(3600),
+            authToken: "ticket-secret"
+        )
+    }
+}

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2948,13 +2948,13 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Search covers your home folder, skipping caches and Desktop, Documents, and Downloads; Browse reaches every folder."
+            "value": "Search covers your home folder, skipping caches and macOS-protected folders like Documents and Downloads; Browse reaches every folder."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "検索の対象はホームフォルダで、キャッシュとデスクトップ・書類・ダウンロードは除外されます。ブラウズではすべてのフォルダに移動できます。"
+            "value": "検索の対象はホームフォルダで、キャッシュと書類・ダウンロードなど macOS 保護フォルダは除外されます。ブラウズではすべてのフォルダに移動できます。"
           }
         }
       }

--- a/ios/cmux/Resources/Localizable.xcstrings
+++ b/ios/cmux/Resources/Localizable.xcstrings
@@ -2398,6 +2398,1009 @@
         }
       }
     },
+    "mobile.dispatch.agents.none": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No agents found on the Mac. Install the claude or codex CLI, then retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac にエージェントが見つかりません。claude または codex CLI をインストールして再試行してください。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.agents.notInstalled.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ (not installed on this Mac)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@（この Mac には未インストール）"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.brief.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Write the brief first."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "まず依頼内容を書いてください。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.brief.overBudget": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The brief is over the %d-byte dispatch limit."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依頼内容がディスパッチ上限の %d バイトを超えています。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.brief.placeholder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "What should get done?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "何をしてもらいますか？"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.browse.empty": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No subfolders."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "サブフォルダはありません。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.browse.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't open this folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダを開けませんでした"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.browse.permissionDenied.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS blocked cmux from reading “%@”. On the Mac, allow cmux under System Settings › Privacy & Security › Files and Folders, then retry."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "macOS が cmux による「%@」の読み取りをブロックしました。Mac のシステム設定 › プライバシーとセキュリティ › ファイルとフォルダで cmux を許可して、再試行してください。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.browse.select": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Select"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.browse.truncated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This folder has more entries than shown."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダには表示されている以上の項目があります。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.browse.useFolder": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use This Folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフォルダを使用"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.budget.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$d / %2$d"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$d / %2$d"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.cancel": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Close"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "閉じる"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.catalog.failed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Couldn't load agents and folders from the Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac からエージェントとフォルダを読み込めませんでした。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.agentFallbackName": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.agentNotInstalled": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ isn't installed on the Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ は Mac にインストールされていません。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.authorization": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This phone is no longer authorized for that Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "この端末はもうその Mac で認証されていません。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.directoryNotFound": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "That folder no longer exists on the Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "そのフォルダは Mac 上に存在しません。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.notConnected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac is offline. Reconnect and dispatch again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac がオフラインです。再接続してからもう一度派遣してください。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.promptTooLong": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The brief is too long to dispatch."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依頼内容が長すぎて派遣できません。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.rejected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac rejected this dispatch."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac がこのディスパッチを拒否しました。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.failure.timedOut": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac didn't answer in time. Dispatch again."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac が時間内に応答しませんでした。もう一度派遣してください。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.field.agent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.field.brief": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Brief"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "依頼内容"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.field.project": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Project"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロジェクト"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.header": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dispatch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ディスパッチ"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.hint": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs in a new workspace on your Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac の新しいワークスペースで実行されます。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.hint.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs in a new workspace on %@."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ の新しいワークスペースで実行されます。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.launch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dispatch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "派遣する"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.new": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Dispatch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ディスパッチ"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.offline": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac offline. Reconnecting…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac がオフラインです。再接続中…"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.browse": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ブラウズ"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.browseFooter": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search covers your home folder, skipping caches and Desktop, Documents, and Downloads; Browse reaches every folder."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索の対象はホームフォルダで、キャッシュとデスクトップ・書類・ダウンロードは除外されます。ブラウズではすべてのフォルダに移動できます。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.browseInto": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Browse folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを開く"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.clearSearch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Clear search"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索をクリア"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.gitBadge": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git repository"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Git リポジトリ"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.home": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Home"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ホーム"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.indexing": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The Mac is still indexing folders. Results are filling in."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Mac がフォルダの索引を作成中です。結果は順次表示されます。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.noMatches": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No folders match. Try Browse for folders outside home."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一致するフォルダがありません。ホーム外のフォルダはブラウズを使ってください。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.noRecents": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Folders you open workspaces in will show up here."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを開いたフォルダがここに表示されます。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.root": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macintosh HD"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Macintosh HD"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.searchFailed": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search didn't reach the Mac."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索が Mac に届きませんでした。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.searchPrompt": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search folders"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを検索"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.searchPrompt.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Search folders on %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ のフォルダを検索"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.searching": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Searching…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "検索中…"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.showHidden": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show Hidden Folders"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "隠しフォルダを表示"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.suggested": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Suggested"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "候補"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Project"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロジェクト"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.picker.truncated": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Showing the closest matches. Keep typing to narrow down."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "近い候補のみ表示しています。入力を続けて絞り込んでください。"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.project.choose": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを選択"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.project.loading": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Loading folders…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダを読み込み中…"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.retry": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Retry"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "再試行"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.serial.format": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nº %04d"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nº %04d"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.stamp.dispatched": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "DISPATCHED"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "派遣済"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.stamp.rejected": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "REJECTED"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "却下"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.summary.noAgent": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no agent"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エージェント未選択"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.summary.noProject": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "no folder"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォルダ未選択"
+          }
+        }
+      }
+    },
+    "mobile.dispatch.title": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "New Dispatch"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新規ディスパッチ"
+          }
+        }
+      }
+    },
+    "mobile.macUpdateHint.feature.agentDispatch": {
+      "extractionState": "manual",
+      "localizations": {
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Dispatch agents from your phone"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "スマートフォンからエージェントを派遣"
+          }
+        }
+      }
+    },
     "mobile.feedback.cancel": {
       "extractionState": "manual",
       "localizations": {


### PR DESCRIPTION
## Dispatch: compose a brief on your phone, an agent starts working on your Mac

New iOS surface for the core phone job: you have an idea, you send an agent off to do it. Tap compose (bottom bar on the workspace list, or the + menu), write a brief, pick a project folder and an agent, hit DISPATCH. The Mac creates a background workspace at that folder, types `claude '<brief>'` (or codex) at a fresh login shell, and the phone lands directly in the live terminal. The brief becomes the workspace title and its recorded prompt.

The composer is a work order, not a chat box: every input is visible on one document (BRIEF / PROJECT / AGENT), with a perforated tear-line above the dispatch stub, a per-Mac serial (`Nº 0042`), and stamp verdicts: green DISPATCHED with success haptics, red REJECTED with the concrete reason printed under the stub and your draft intact. Drafts persist per Mac across dismissals; the serial only increments on a real launch.

### Directory picker

Search-first over every directory the Mac indexes (home walk, git repos boosted, cache/`node_modules` trees skipped), with re-polling while the Mac reports the index still building. Browse mode reaches ANY folder level by level from Home or `/`, including hidden folders via a toggle. macOS privacy denials (Documents/Desktop/Downloads TCC) surface as an inline notice naming the folder and the exact System Settings fix, and the picker keeps working.

### Error surfacing

Tiered by context: field validation shakes and marks the offending field inline (the button never sits mysteriously disabled); launch failures stamp REJECTED with a per-code reason (`agent_not_installed`, `directory_not_found`, `prompt_too_long`, offline, unauthorized); connectivity problems show a live reconnecting ribbon above the document; catalog/search failures render inline with Retry; an old Mac build is handled by the capability gate plus a Mac-update-hint registry entry.

### Wire (capability `workspace.dispatch.v1`)

- `mobile.dispatch.catalog`: installed agents (claude/codex via `AgentExecutableResolver`), recent workspace cwds, home, prompt byte budget (900).
- `mobile.dispatch.fs`: `op:list` (all subdirectories of a path, hidden filter, permission notices) and `op:search` (lazily built `DispatchDirectoryIndex` actor + `CommandPaletteFuzzyMatcher` ranking, partial results flagged `indexing`).
- `mobile.dispatch.launch`: validates directory/agent/prompt budget, then goes through the shared `v2WorkspaceCreate` with the newly wired `initial_input` param (already present at the `TabManager.addWorkspace`/Ghostty surface layer; control-socket `workspace.create` gains it too), `eager_load_terminal: true`, `focus: false`; returns the refreshed workspace list + `created_workspace_id` so workspace-scoped tickets are granted their own workspace (same recording path as `workspace.create`).

### Testing

- Mac: `cmuxTests/MobileDispatchTests.swift`: quoting through a real `/bin/sh` argv round-trip, byte budget, ticket authorization for all three methods, fs list on temp trees, launch validation errors, index ranking/skips.
- iOS: `DispatchComposerTests` (8 tests, green): catalog defaults, validation nudges, launch success clears draft + increments serial, rejection keeps draft, wire-code → failure mapping, draft restore.
- Preview fixture `CMUX_UITEST_DISPATCH_PREVIEW=1` renders the composer against a stubbed Mac (a brief containing "fail" exercises the REJECTED stamp).

Localization: all 58 new strings shipped in en + ja.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8385"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786924074&installation_id=133855650&pr_number=8385&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8385&signature=12e2600f6f87b18744c234b37ce6a5e3bb06ae5d09adad197e7227c11a82e1ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Compose a brief on your phone and dispatch an agent to your Mac. This adds an iOS work‑order composer that launches a background workspace on the Mac and drops you into the live terminal.

- **New Features**
  - iOS Dispatch composer: BRIEF / PROJECT / AGENT document, per‑Mac serial, and green “DISPATCHED” or red “REJECTED” stamps; drafts persist per Mac.
  - Project picker: fuzzy search across indexed directories and level‑by‑level browse with hidden toggle and inline macOS privacy notices; faster indexing via readdir walk that skips TCC‑protected media roots (browse still reaches them), avoids UI stalls, and streams partial results while the index builds.
  - Clear errors: inline field nudges; concrete launch failures (agent not installed, directory not found, prompt too long, offline, unauthorized).
  - Wire: capability `workspace.dispatch.v1`; RPCs `mobile.dispatch.catalog`, `mobile.dispatch.fs`, `mobile.dispatch.launch`; 900‑byte prompt budget; keeps attach‑ticket context; uses `initial_input`, returns `created_workspace_id`, no focus steal.
  - Mac: `DispatchDirectoryIndex` for search/browse; `DispatchAgentCommandBuilder` ensures single‑arg quoting; workspace‑scoped tickets allowed for dispatch.
  - Tests: iOS `DispatchComposerTests` and Mac `MobileDispatchTests` cover catalog, validation, launch, and indexing; 58 new strings (en, ja).

- **Migration**
  - Requires a Mac advertising `workspace.dispatch.v1` (update the Mac app); the UI hides dispatch on older builds.
  - Optional preview for UI tests: set `CMUX_UITEST_DISPATCH_PREVIEW=1` to render the composer against a stubbed Mac.

<sup>Written for commit 04800a81878161f87a6de64f6725047bdaf4c6fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8385?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added mobile “New Dispatch” workflow to compose and launch agent work orders from the workspace list.
  * Includes searchable/browse directory picking (hidden folders toggle), directory indexing, and recent/favorites-style suggestions.
  * Local draft persistence with brief budget counter/validation, retry flows, and detailed localized failure reasons with dispatched/rejected status stamps.
  * Added a DEBUG-only dispatch composer preview option for UI testing.
* **Bug Fixes**
  * Dispatch requests for catalog, filesystem, and launch now correctly keep the existing attach-ticket authorization context and avoid unnecessary fallback authentication.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->