### PR TITLE
Add AppKit signal todo lab

### DIFF
--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AboutTitlebarDebug/Coordinator/DebugWindowsCoordinator.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AboutTitlebarDebug/Coordinator/DebugWindowsCoordinator.swift
@@ -25,6 +25,9 @@ public final class DebugWindowsCoordinator {
     @ObservationIgnored
     private var aboutTitlebarController: AboutTitlebarDebugWindowController?
 
+    @ObservationIgnored
+    private var appKitSignalLabController: AppKitSignalLabWindowController?
+
     /// Creates the coordinator.
     ///
     /// - Parameter decorator: The window-decoration seam. Held weakly because the
@@ -42,6 +45,13 @@ public final class DebugWindowsCoordinator {
             decorator: decorator
         )
         aboutTitlebarController = controller
+        controller.show()
+    }
+
+    /// Presents the native AppKit signal experiment, creating its graph and window on first use.
+    public func showAppKitSignalLabWindow() {
+        let controller = appKitSignalLabController ?? AppKitSignalLabWindowController()
+        appKitSignalLabController = controller
         controller.show()
     }
 }

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabFilter.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabFilter.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum AppKitSignalLabFilter: Equatable {
+    case all
+    case active
+    case blocked
+    case complete
+
+    var title: String {
+        switch self {
+        case .all:
+            String(localized: "debug.signalLab.filter.all", defaultValue: "All work")
+        case .active:
+            String(localized: "debug.signalLab.filter.active", defaultValue: "Active")
+        case .blocked:
+            String(localized: "debug.signalLab.filter.blocked", defaultValue: "Blocked")
+        case .complete:
+            String(localized: "debug.signalLab.filter.complete", defaultValue: "Complete")
+        }
+    }
+
+    func includes(_ status: AppKitSignalLabStatus) -> Bool {
+        switch self {
+        case .all:
+            true
+        case .active:
+            status == .running || status == .review
+        case .blocked:
+            status == .blocked
+        case .complete:
+            status == .complete
+        }
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabFilter.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabFilter.swift
@@ -9,13 +9,13 @@ enum AppKitSignalLabFilter: Equatable {
     var title: String {
         switch self {
         case .all:
-            String(localized: "debug.signalLab.filter.all", defaultValue: "All work")
+            String(localized: "debug.signalLab.filter.all", defaultValue: "All todos")
         case .active:
-            String(localized: "debug.signalLab.filter.active", defaultValue: "Active")
+            String(localized: "debug.signalLab.filter.active", defaultValue: "Open")
         case .blocked:
             String(localized: "debug.signalLab.filter.blocked", defaultValue: "Blocked")
         case .complete:
-            String(localized: "debug.signalLab.filter.complete", defaultValue: "Complete")
+            String(localized: "debug.signalLab.filter.complete", defaultValue: "Done")
         }
     }
 
@@ -24,7 +24,7 @@ enum AppKitSignalLabFilter: Equatable {
         case .all:
             true
         case .active:
-            status == .running || status == .review
+            status == .queued || status == .running || status == .review
         case .blocked:
             status == .blocked
         case .complete:

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabMetrics.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabMetrics.swift
@@ -1,0 +1,10 @@
+struct AppKitSignalLabMetrics: Equatable {
+    let activeCount: Int
+    let blockedCount: Int
+    let completedCount: Int
+    let averageProgress: Double
+    let throughput: Int
+    let health: Double
+    let capacity: Double
+    let automationEnabled: Bool
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabModel.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabModel.swift
@@ -1,0 +1,232 @@
+import Foundation
+
+@MainActor
+final class AppKitSignalLabModel {
+    let graph: SignalGraph
+    let tasks: Signal<[AppKitSignalLabTask]>
+    let query: Signal<String>
+    let filter: Signal<AppKitSignalLabFilter>
+    let selectedTaskID: Signal<UUID?>
+    let capacity: Signal<Double>
+    let automationEnabled: Signal<Bool>
+    let activity: Signal<[String]>
+    let filteredTasks: SignalMemo<[AppKitSignalLabTask]>
+    let selectedTask: SignalMemo<AppKitSignalLabTask?>
+    let metrics: SignalMemo<AppKitSignalLabMetrics>
+
+    init() {
+        let graph = SignalGraph()
+        let initialTasks = Self.makeFixtureTasks()
+        let tasks = graph.createSignal(initialTasks)
+        let query = graph.createSignal("")
+        let filter = graph.createSignal(AppKitSignalLabFilter.all)
+        let selectedTaskID = graph.createSignal(initialTasks.first?.id)
+        let capacity = graph.createSignal(0.74)
+        let automationEnabled = graph.createSignal(true)
+
+        self.graph = graph
+        self.tasks = tasks
+        self.query = query
+        self.filter = filter
+        self.selectedTaskID = selectedTaskID
+        self.capacity = capacity
+        self.automationEnabled = automationEnabled
+        self.activity = graph.createSignal([
+            String(localized: "debug.signalLab.activity.seeded", defaultValue: "Signal graph seeded with eight work items."),
+            String(localized: "debug.signalLab.activity.ready", defaultValue: "Fine-grained AppKit bindings are live."),
+        ])
+
+        self.filteredTasks = graph.createMemo { [tasks, query, filter] in
+            let normalizedQuery = query.get().trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+            return tasks.get().filter { task in
+                filter.get().includes(task.status)
+                    && (normalizedQuery.isEmpty
+                        || task.title.lowercased().contains(normalizedQuery)
+                        || task.owner.lowercased().contains(normalizedQuery))
+            }
+        }
+        self.selectedTask = graph.createMemo { [tasks, selectedTaskID] in
+            guard let identifier = selectedTaskID.get() else { return nil }
+            return tasks.get().first { $0.id == identifier }
+        }
+        self.metrics = graph.createMemo { [tasks, capacity, automationEnabled] in
+            let values = tasks.get()
+            let activeCount = values.filter { $0.status == .running || $0.status == .review }.count
+            let blockedCount = values.filter { $0.status == .blocked }.count
+            let completedCount = values.filter { $0.status == .complete }.count
+            let averageProgress = values.isEmpty
+                ? 0
+                : values.reduce(0) { $0 + $1.progress } / Double(values.count)
+            let utilization = capacity.get()
+            let automation = automationEnabled.get()
+            let throughput = completedCount * 12 + activeCount * (automation ? 4 : 2)
+            let health = max(0, min(1, 0.96 - Double(blockedCount) * 0.12 - abs(utilization - 0.75) * 0.35))
+            return AppKitSignalLabMetrics(
+                activeCount: activeCount,
+                blockedCount: blockedCount,
+                completedCount: completedCount,
+                averageProgress: averageProgress,
+                throughput: throughput,
+                health: health,
+                capacity: utilization,
+                automationEnabled: automation
+            )
+        }
+    }
+
+    func selectTask(at filteredIndex: Int) {
+        let visibleTasks = filteredTasks.get()
+        guard visibleTasks.indices.contains(filteredIndex) else {
+            selectedTaskID.set(nil)
+            return
+        }
+        selectedTaskID.set(visibleTasks[filteredIndex].id)
+    }
+
+    func advanceSelectedTask() {
+        guard let selectedID = selectedTaskID.get() else { return }
+        graph.batch {
+            tasks.update { tasks in
+                tasks.map { task in
+                    guard task.id == selectedID else { return task }
+                    var updatedTask = task
+                    updatedTask.progress = min(1, task.progress + 0.18)
+                    updatedTask.status = Self.nextStatus(after: task.status, progress: updatedTask.progress)
+                    return updatedTask
+                }
+            }
+            appendActivity(String(localized: "debug.signalLab.activity.advanced", defaultValue: "Selected work item advanced in one batch."))
+        }
+    }
+
+    func toggleBlockedForSelectedTask() {
+        guard let selectedID = selectedTaskID.get() else { return }
+        graph.batch {
+            tasks.update { tasks in
+                tasks.map { task in
+                    guard task.id == selectedID else { return task }
+                    var updatedTask = task
+                    updatedTask.status = task.status == .blocked ? .running : .blocked
+                    return updatedTask
+                }
+            }
+            appendActivity(String(localized: "debug.signalLab.activity.blockToggled", defaultValue: "Selected work item's blocked state changed."))
+        }
+    }
+
+    func setSelectedPriority(_ priority: Int) {
+        guard let selectedID = selectedTaskID.get() else { return }
+        tasks.update { tasks in
+            tasks.map { task in
+                guard task.id == selectedID else { return task }
+                var updatedTask = task
+                updatedTask.priority = priority
+                return updatedTask
+            }
+        }
+    }
+
+    func runSimulationStep() {
+        graph.batch {
+            tasks.update { tasks in
+                tasks.map { task in
+                    guard task.status == .running else { return task }
+                    var updatedTask = task
+                    updatedTask.progress = min(1, task.progress + 0.07)
+                    if updatedTask.progress >= 1 {
+                        updatedTask.status = .complete
+                    }
+                    return updatedTask
+                }
+            }
+            capacity.update { value in value > 0.88 ? 0.62 : value + 0.06 }
+            appendActivity(String(localized: "debug.signalLab.activity.simulated", defaultValue: "Simulation updated progress and capacity atomically."))
+        }
+    }
+
+    private func appendActivity(_ message: String) {
+        activity.update { entries in
+            Array(([message] + entries).prefix(5))
+        }
+    }
+
+    private static func nextStatus(after status: AppKitSignalLabStatus, progress: Double) -> AppKitSignalLabStatus {
+        if progress >= 1 { return .complete }
+        switch status {
+        case .queued: return .running
+        case .running: return .review
+        case .review: return .complete
+        case .blocked: return .running
+        case .complete: return .complete
+        }
+    }
+
+    private static func makeFixtureTasks() -> [AppKitSignalLabTask] {
+        [
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.renderPipeline", defaultValue: "Rebuild render pipeline"),
+                owner: String(localized: "debug.signalLab.owner.runtime", defaultValue: "Runtime"),
+                status: .running,
+                progress: 0.68,
+                priority: 1
+            ),
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.indexWorkspace", defaultValue: "Index workspace history"),
+                owner: String(localized: "debug.signalLab.owner.search", defaultValue: "Search"),
+                status: .review,
+                progress: 0.86,
+                priority: 2
+            ),
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.notarizeBuild", defaultValue: "Notarize release build"),
+                owner: String(localized: "debug.signalLab.owner.release", defaultValue: "Release"),
+                status: .blocked,
+                progress: 0.41,
+                priority: 1
+            ),
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.syncSessions", defaultValue: "Sync remote sessions"),
+                owner: String(localized: "debug.signalLab.owner.cloud", defaultValue: "Cloud"),
+                status: .running,
+                progress: 0.54,
+                priority: 2
+            ),
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.auditShortcuts", defaultValue: "Audit command shortcuts"),
+                owner: String(localized: "debug.signalLab.owner.desktop", defaultValue: "Desktop"),
+                status: .queued,
+                progress: 0.12,
+                priority: 3
+            ),
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.profileStartup", defaultValue: "Profile startup path"),
+                owner: String(localized: "debug.signalLab.owner.performance", defaultValue: "Performance"),
+                status: .complete,
+                progress: 1,
+                priority: 2
+            ),
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.validateThemes", defaultValue: "Validate terminal themes"),
+                owner: String(localized: "debug.signalLab.owner.design", defaultValue: "Design"),
+                status: .complete,
+                progress: 1,
+                priority: 3
+            ),
+            AppKitSignalLabTask(
+                id: UUID(),
+                title: String(localized: "debug.signalLab.task.compressSnapshots", defaultValue: "Compress session snapshots"),
+                owner: String(localized: "debug.signalLab.owner.storage", defaultValue: "Storage"),
+                status: .queued,
+                progress: 0.05,
+                priority: 2
+            ),
+        ]
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabModel.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabModel.swift
@@ -5,6 +5,7 @@ final class AppKitSignalLabModel {
     let graph: SignalGraph
     let tasks: Signal<[AppKitSignalLabTask]>
     let query: Signal<String>
+    let draftTaskTitle: Signal<String>
     let filter: Signal<AppKitSignalLabFilter>
     let selectedTaskID: Signal<UUID?>
     let capacity: Signal<Double>
@@ -13,12 +14,14 @@ final class AppKitSignalLabModel {
     let filteredTasks: SignalMemo<[AppKitSignalLabTask]>
     let selectedTask: SignalMemo<AppKitSignalLabTask?>
     let metrics: SignalMemo<AppKitSignalLabMetrics>
+    let canAddTask: SignalMemo<Bool>
 
     init() {
         let graph = SignalGraph()
         let initialTasks = Self.makeFixtureTasks()
         let tasks = graph.createSignal(initialTasks)
         let query = graph.createSignal("")
+        let draftTaskTitle = graph.createSignal("")
         let filter = graph.createSignal(AppKitSignalLabFilter.all)
         let selectedTaskID = graph.createSignal(initialTasks.first?.id)
         let capacity = graph.createSignal(0.74)
@@ -27,13 +30,14 @@ final class AppKitSignalLabModel {
         self.graph = graph
         self.tasks = tasks
         self.query = query
+        self.draftTaskTitle = draftTaskTitle
         self.filter = filter
         self.selectedTaskID = selectedTaskID
         self.capacity = capacity
         self.automationEnabled = automationEnabled
         self.activity = graph.createSignal([
-            String(localized: "debug.signalLab.activity.seeded", defaultValue: "Signal graph seeded with eight work items."),
-            String(localized: "debug.signalLab.activity.ready", defaultValue: "Fine-grained AppKit bindings are live."),
+            String(localized: "debug.signalLab.activity.seeded", defaultValue: "Signal graph seeded with eight todos."),
+            String(localized: "debug.signalLab.activity.ready", defaultValue: "Fine-grained todo bindings are live."),
         ])
 
         self.filteredTasks = graph.createMemo { [tasks, query, filter] in
@@ -72,6 +76,64 @@ final class AppKitSignalLabModel {
                 automationEnabled: automation
             )
         }
+        self.canAddTask = graph.createMemo { [draftTaskTitle] in
+            !draftTaskTitle.get().trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        }
+    }
+
+    func addDraftTask() {
+        let title = draftTaskTitle.get().trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty else { return }
+        let task = AppKitSignalLabTask(
+            id: UUID(),
+            title: title,
+            owner: String(localized: "debug.signalLab.owner.personal", defaultValue: "Personal"),
+            status: .queued,
+            progress: 0,
+            priority: 2
+        )
+        graph.batch {
+            tasks.update { [task] + $0 }
+            selectedTaskID.set(task.id)
+            draftTaskTitle.set("")
+            appendActivity(String(localized: "debug.signalLab.activity.added", defaultValue: "Added a new todo in one batch."))
+        }
+    }
+
+    func toggleCompletion(at filteredIndex: Int) {
+        let visibleTasks = filteredTasks.get()
+        guard visibleTasks.indices.contains(filteredIndex) else { return }
+        let identifier = visibleTasks[filteredIndex].id
+        graph.batch {
+            tasks.update { tasks in
+                tasks.map { task in
+                    guard task.id == identifier else { return task }
+                    var updatedTask = task
+                    if task.status == .complete {
+                        updatedTask.status = .queued
+                        updatedTask.progress = 0
+                    } else {
+                        updatedTask.status = .complete
+                        updatedTask.progress = 1
+                    }
+                    return updatedTask
+                }
+            }
+            selectedTaskID.set(identifier)
+            appendActivity(String(localized: "debug.signalLab.activity.completionToggled", defaultValue: "Toggled a todo's completion state."))
+        }
+    }
+
+    func clearCompletedTasks() {
+        let completedIDs = Set(tasks.get().filter { $0.status == .complete }.map(\.id))
+        guard !completedIDs.isEmpty else { return }
+        graph.batch {
+            tasks.update { $0.filter { !completedIDs.contains($0.id) } }
+            if let selectedID = selectedTaskID.get(), completedIDs.contains(selectedID) {
+                selectedTaskID.set(tasks.get().first?.id)
+            }
+            appendActivity(String(localized: "debug.signalLab.activity.cleared", defaultValue: "Cleared completed todos."))
+        }
     }
 
     func selectTask(at filteredIndex: Int) {
@@ -95,7 +157,7 @@ final class AppKitSignalLabModel {
                     return updatedTask
                 }
             }
-            appendActivity(String(localized: "debug.signalLab.activity.advanced", defaultValue: "Selected work item advanced in one batch."))
+            appendActivity(String(localized: "debug.signalLab.activity.advanced", defaultValue: "Selected todo advanced in one batch."))
         }
     }
 
@@ -110,7 +172,7 @@ final class AppKitSignalLabModel {
                     return updatedTask
                 }
             }
-            appendActivity(String(localized: "debug.signalLab.activity.blockToggled", defaultValue: "Selected work item's blocked state changed."))
+            appendActivity(String(localized: "debug.signalLab.activity.blockToggled", defaultValue: "Selected todo's blocked state changed."))
         }
     }
 
@@ -140,7 +202,7 @@ final class AppKitSignalLabModel {
                 }
             }
             capacity.update { value in value > 0.88 ? 0.62 : value + 0.06 }
-            appendActivity(String(localized: "debug.signalLab.activity.simulated", defaultValue: "Simulation updated progress and capacity atomically."))
+            appendActivity(String(localized: "debug.signalLab.activity.simulated", defaultValue: "Demo step updated todo progress atomically."))
         }
     }
 

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabStatus.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabStatus.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+enum AppKitSignalLabStatus: String, CaseIterable, Equatable {
+    case queued
+    case running
+    case review
+    case blocked
+    case complete
+
+    var title: String {
+        switch self {
+        case .queued:
+            String(localized: "debug.signalLab.status.queued", defaultValue: "Queued")
+        case .running:
+            String(localized: "debug.signalLab.status.running", defaultValue: "Running")
+        case .review:
+            String(localized: "debug.signalLab.status.review", defaultValue: "Review")
+        case .blocked:
+            String(localized: "debug.signalLab.status.blocked", defaultValue: "Blocked")
+        case .complete:
+            String(localized: "debug.signalLab.status.complete", defaultValue: "Complete")
+        }
+    }
+
+    var systemImageName: String {
+        switch self {
+        case .queued: "clock"
+        case .running: "bolt.fill"
+        case .review: "eye.fill"
+        case .blocked: "exclamationmark.triangle.fill"
+        case .complete: "checkmark.circle.fill"
+        }
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabTask.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Model/AppKitSignalLabTask.swift
@@ -1,0 +1,10 @@
+import Foundation
+
+struct AppKitSignalLabTask: Equatable, Identifiable {
+    let id: UUID
+    var title: String
+    var owner: String
+    var status: AppKitSignalLabStatus
+    var progress: Double
+    var priority: Int
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/Signal.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/Signal.swift
@@ -1,0 +1,63 @@
+/// A writable fine-grained reactive value.
+///
+/// Call ``get()`` inside a ``SignalEffect`` or ``SignalMemo`` computation to
+/// subscribe that observer. Equal writes are ignored.
+@MainActor
+public final class Signal<Value: Equatable>: SignalDependency {
+    private let graph: SignalGraph
+    private var value: Value
+    private var observers: [ObjectIdentifier: WeakSignalObserver] = [:]
+
+    init(graph: SignalGraph, initialValue: Value) {
+        self.graph = graph
+        self.value = initialValue
+    }
+
+    /// Reads the current value and records a dependency in the active tracking scope.
+    ///
+    /// - Returns: The current signal value.
+    public func get() -> Value {
+        graph.track(self)
+        return value
+    }
+
+    /// Replaces the value and notifies subscribers when it changed.
+    ///
+    /// - Parameter newValue: The next signal value.
+    public func set(_ newValue: Value) {
+        guard newValue != value else { return }
+        value = newValue
+        graph.schedule(liveObservers())
+    }
+
+    /// Replaces the value using its previous value.
+    ///
+    /// - Parameter update: A pure transformation from the old value to the new value.
+    public func update(_ update: (Value) -> Value) {
+        set(update(value))
+    }
+
+    func addObserver(_ observer: any SignalObserver) {
+        observers[ObjectIdentifier(observer)] = WeakSignalObserver(observer)
+    }
+
+    func removeObserver(_ observer: any SignalObserver) {
+        observers.removeValue(forKey: ObjectIdentifier(observer))
+    }
+
+    private func liveObservers() -> [any SignalObserver] {
+        var live: [any SignalObserver] = []
+        var staleIdentifiers: [ObjectIdentifier] = []
+        for (identifier, observer) in observers {
+            if let value = observer.value {
+                live.append(value)
+            } else {
+                staleIdentifiers.append(identifier)
+            }
+        }
+        for identifier in staleIdentifiers {
+            observers.removeValue(forKey: identifier)
+        }
+        return live
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalDependency.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalDependency.swift
@@ -1,0 +1,5 @@
+@MainActor
+protocol SignalDependency: AnyObject {
+    func addObserver(_ observer: any SignalObserver)
+    func removeObserver(_ observer: any SignalObserver)
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalEffect.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalEffect.swift
@@ -1,0 +1,68 @@
+/// A disposable side effect that automatically follows the signals it reads.
+@MainActor
+public final class SignalEffect: SignalObserver {
+    let schedulingPriority = 1
+
+    private let graph: SignalGraph
+    private let body: @MainActor (SignalEffectContext) -> Void
+    private var dependencies: [ObjectIdentifier: any SignalDependency] = [:]
+    private var cleanups: [@MainActor () -> Void] = []
+    private var isDisposed = false
+
+    init(
+        graph: SignalGraph,
+        body: @escaping @MainActor (SignalEffectContext) -> Void
+    ) {
+        self.graph = graph
+        self.body = body
+    }
+
+    /// Stops future executions, detaches dependencies, and runs registered cleanup.
+    public func dispose() {
+        guard !isDisposed else { return }
+        isDisposed = true
+        runCleanups()
+        detachDependencies()
+    }
+
+    func observe(_ dependency: any SignalDependency) {
+        let identifier = ObjectIdentifier(dependency)
+        guard dependencies[identifier] == nil else { return }
+        dependencies[identifier] = dependency
+        dependency.addObserver(self)
+    }
+
+    func run() {
+        guard !isDisposed else { return }
+        runCleanups()
+        detachDependencies()
+        let context = SignalEffectContext { [weak self] cleanup in
+            self?.cleanups.append(cleanup)
+        }
+        graph.withObserver(self) {
+            body(context)
+        }
+    }
+
+    private func runCleanups() {
+        let pendingCleanups = cleanups
+        cleanups.removeAll(keepingCapacity: true)
+        for cleanup in pendingCleanups {
+            cleanup()
+        }
+    }
+
+    private func detachDependencies() {
+        for dependency in dependencies.values {
+            dependency.removeObserver(self)
+        }
+        dependencies.removeAll(keepingCapacity: true)
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            runCleanups()
+            detachDependencies()
+        }
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalEffectContext.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalEffectContext.swift
@@ -1,0 +1,16 @@
+/// Registers cleanup work for the currently executing signal effect.
+@MainActor
+public struct SignalEffectContext {
+    private let registerCleanup: (@escaping @MainActor () -> Void) -> Void
+
+    init(registerCleanup: @escaping (@escaping @MainActor () -> Void) -> Void) {
+        self.registerCleanup = registerCleanup
+    }
+
+    /// Runs `cleanup` before the effect's next execution and when it is disposed.
+    ///
+    /// - Parameter cleanup: Main-actor work that releases the prior side effect.
+    public func onCleanup(_ cleanup: @escaping @MainActor () -> Void) {
+        registerCleanup(cleanup)
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalGraph.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalGraph.swift
@@ -1,0 +1,103 @@
+/// Owns synchronous dependency tracking and batched propagation for signals.
+///
+/// `SignalGraph` follows Solid's fine-grained model: reading a signal inside an
+/// effect or memo records the dependency automatically, and writing a distinct
+/// value schedules only the observers that read it. All access is main-actor
+/// isolated so AppKit controls can be updated directly without locks.
+@MainActor
+public final class SignalGraph {
+    private weak var activeObserver: (any SignalObserver)?
+    private var pendingObservers: [ObjectIdentifier: any SignalObserver] = [:]
+    private var batchDepth = 0
+    private var isFlushing = false
+
+    /// Creates an empty signal graph.
+    public init() {}
+
+    /// Creates a writable signal with an initial value.
+    ///
+    /// - Parameter initialValue: The signal's value before its first write.
+    /// - Returns: A signal owned by this graph.
+    public func createSignal<Value: Equatable>(_ initialValue: Value) -> Signal<Value> {
+        Signal(graph: self, initialValue: initialValue)
+    }
+
+    /// Creates a cached read-only value whose dependencies are tracked automatically.
+    ///
+    /// The computation runs once immediately and then once per dependency change,
+    /// with batched writes coalesced into one recomputation.
+    ///
+    /// - Parameter compute: A pure computation that reads signals or other memos.
+    /// - Returns: A memo owned by this graph.
+    public func createMemo<Value: Equatable>(_ compute: @escaping @MainActor () -> Value) -> SignalMemo<Value> {
+        let memo = SignalMemo(graph: self, compute: compute)
+        memo.prime()
+        return memo
+    }
+
+    /// Creates and immediately runs a reactive side effect.
+    ///
+    /// Keep the returned token alive for as long as the effect should remain
+    /// subscribed. Releasing or disposing it detaches every dependency.
+    ///
+    /// - Parameter body: The side effect. Reads made synchronously by this closure
+    ///   become dependencies for its next run.
+    /// - Returns: A disposable effect token.
+    @discardableResult
+    public func createEffect(
+        _ body: @escaping @MainActor (SignalEffectContext) -> Void
+    ) -> SignalEffect {
+        let effect = SignalEffect(graph: self, body: body)
+        effect.run()
+        return effect
+    }
+
+    /// Coalesces all writes in `updates` before recomputing memos and effects.
+    ///
+    /// - Parameter updates: Synchronous signal mutations to perform as one batch.
+    public func batch(_ updates: () -> Void) {
+        batchDepth += 1
+        updates()
+        batchDepth -= 1
+        if batchDepth == 0 {
+            flush()
+        }
+    }
+
+    func track(_ dependency: any SignalDependency) {
+        activeObserver?.observe(dependency)
+    }
+
+    func withObserver<Value>(
+        _ observer: any SignalObserver,
+        _ body: @MainActor () -> Value
+    ) -> Value {
+        let previousObserver = activeObserver
+        activeObserver = observer
+        defer { activeObserver = previousObserver }
+        return body()
+    }
+
+    func schedule(_ observers: [any SignalObserver]) {
+        for observer in observers {
+            pendingObservers[ObjectIdentifier(observer)] = observer
+        }
+        if batchDepth == 0 {
+            flush()
+        }
+    }
+
+    private func flush() {
+        guard !isFlushing else { return }
+        isFlushing = true
+        defer { isFlushing = false }
+
+        while !pendingObservers.isEmpty {
+            guard let observer = pendingObservers.values.min(by: {
+                $0.schedulingPriority < $1.schedulingPriority
+            }) else { return }
+            pendingObservers.removeValue(forKey: ObjectIdentifier(observer))
+            observer.run()
+        }
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalMemo.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalMemo.swift
@@ -1,0 +1,84 @@
+/// A cached read-only reactive value derived from other signals or memos.
+@MainActor
+public final class SignalMemo<Value: Equatable>: SignalDependency, SignalObserver {
+    let schedulingPriority = 0
+
+    private let graph: SignalGraph
+    private let compute: @MainActor () -> Value
+    private var dependencies: [ObjectIdentifier: any SignalDependency] = [:]
+    private var observers: [ObjectIdentifier: WeakSignalObserver] = [:]
+    private var isPrimed = false
+    private lazy var cachedValue: Value = graph.withObserver(self, compute)
+
+    init(graph: SignalGraph, compute: @escaping @MainActor () -> Value) {
+        self.graph = graph
+        self.compute = compute
+    }
+
+    /// Reads the cached value and records this memo as a dependency.
+    ///
+    /// - Returns: The most recently computed value.
+    public func get() -> Value {
+        graph.track(self)
+        return cachedValue
+    }
+
+    func prime() {
+        isPrimed = true
+        _ = cachedValue
+    }
+
+    func observe(_ dependency: any SignalDependency) {
+        let identifier = ObjectIdentifier(dependency)
+        guard dependencies[identifier] == nil else { return }
+        dependencies[identifier] = dependency
+        dependency.addObserver(self)
+    }
+
+    func run() {
+        guard isPrimed else { return }
+        let previousValue = cachedValue
+        detachDependencies()
+        let newValue = graph.withObserver(self, compute)
+        guard newValue != previousValue else { return }
+        cachedValue = newValue
+        graph.schedule(liveObservers())
+    }
+
+    func addObserver(_ observer: any SignalObserver) {
+        observers[ObjectIdentifier(observer)] = WeakSignalObserver(observer)
+    }
+
+    func removeObserver(_ observer: any SignalObserver) {
+        observers.removeValue(forKey: ObjectIdentifier(observer))
+    }
+
+    private func detachDependencies() {
+        for dependency in dependencies.values {
+            dependency.removeObserver(self)
+        }
+        dependencies.removeAll(keepingCapacity: true)
+    }
+
+    private func liveObservers() -> [any SignalObserver] {
+        var live: [any SignalObserver] = []
+        var staleIdentifiers: [ObjectIdentifier] = []
+        for (identifier, observer) in observers {
+            if let value = observer.value {
+                live.append(value)
+            } else {
+                staleIdentifiers.append(identifier)
+            }
+        }
+        for identifier in staleIdentifiers {
+            observers.removeValue(forKey: identifier)
+        }
+        return live
+    }
+
+    deinit {
+        MainActor.assumeIsolated {
+            detachDependencies()
+        }
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalObserver.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/SignalObserver.swift
@@ -1,0 +1,7 @@
+@MainActor
+protocol SignalObserver: AnyObject {
+    var schedulingPriority: Int { get }
+
+    func observe(_ dependency: any SignalDependency)
+    func run()
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/WeakSignalObserver.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Reactive/WeakSignalObserver.swift
@@ -1,0 +1,8 @@
+@MainActor
+final class WeakSignalObserver {
+    weak var value: (any SignalObserver)?
+
+    init(_ value: any SignalObserver) {
+        self.value = value
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Views/AppKitSignalLabViewController.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Views/AppKitSignalLabViewController.swift
@@ -1,0 +1,605 @@
+#if canImport(AppKit)
+
+import AppKit
+
+@MainActor
+final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate, NSSearchFieldDelegate {
+    private let model: AppKitSignalLabModel
+    private var effects: [SignalEffect] = []
+
+    private let tableView = NSTableView()
+    private let searchField = NSSearchField()
+    private let filterControl = NSSegmentedControl()
+    private let visibleCountLabel = NSTextField(labelWithString: "")
+    private let activeValueLabel = NSTextField(labelWithString: "")
+    private let throughputValueLabel = NSTextField(labelWithString: "")
+    private let healthValueLabel = NSTextField(labelWithString: "")
+    private let progressValueLabel = NSTextField(labelWithString: "")
+    private let selectionTitleLabel = NSTextField(labelWithString: "")
+    private let selectionOwnerLabel = NSTextField(labelWithString: "")
+    private let selectionStatusLabel = NSTextField(labelWithString: "")
+    private let selectionProgressLabel = NSTextField(labelWithString: "")
+    private let selectionProgressIndicator = NSProgressIndicator()
+    private let capacitySlider = NSSlider(value: 0.74, minValue: 0.25, maxValue: 1, target: nil, action: nil)
+    private let automationSwitch = NSButton(checkboxWithTitle: "", target: nil, action: nil)
+    private let priorityPopup = NSPopUpButton()
+    private let advanceButton = NSButton()
+    private let blockButton = NSButton()
+    private let activityLabel = NSTextField(wrappingLabelWithString: "")
+    private let pulseView = SignalLabPulseView()
+    private let allFilterButton = NSButton()
+    private let activeFilterButton = NSButton()
+    private let blockedFilterButton = NSButton()
+    private let completeFilterButton = NSButton()
+    private let percentFormatter: NumberFormatter = {
+        let formatter = NumberFormatter()
+        formatter.numberStyle = .percent
+        formatter.maximumFractionDigits = 0
+        return formatter
+    }()
+
+    init(model: AppKitSignalLabModel) {
+        self.model = model
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override func loadView() {
+        view = NSView()
+        view.wantsLayer = true
+        view.layer?.backgroundColor = NSColor.windowBackgroundColor.cgColor
+        buildInterface()
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        installBindings()
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+        model.filteredTasks.get().count
+    }
+
+    func tableView(
+        _ tableView: NSTableView,
+        viewFor tableColumn: NSTableColumn?,
+        row: Int
+    ) -> NSView? {
+        let tasks = model.filteredTasks.get()
+        guard tasks.indices.contains(row), let tableColumn else { return nil }
+        let task = tasks[row]
+        let identifier = tableColumn.identifier
+        let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? NSTableCellView
+            ?? makeCell(identifier: identifier)
+
+        switch identifier.rawValue {
+        case "work":
+            cell.textField?.stringValue = task.title
+            cell.imageView?.image = NSImage(systemSymbolName: task.status.systemImageName, accessibilityDescription: task.status.title)
+            cell.imageView?.contentTintColor = statusColor(task.status)
+        case "owner":
+            cell.textField?.stringValue = task.owner
+        case "status":
+            cell.textField?.stringValue = task.status.title
+            cell.textField?.textColor = statusColor(task.status)
+        case "progress":
+            cell.textField?.stringValue = formattedPercent(task.progress)
+            cell.textField?.alignment = .right
+        default:
+            break
+        }
+        return cell
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+        model.selectTask(at: tableView.selectedRow)
+    }
+
+    func controlTextDidChange(_ obj: Notification) {
+        model.query.set(searchField.stringValue)
+    }
+
+    private func buildInterface() {
+        let rootStack = NSStackView()
+        rootStack.orientation = .vertical
+        rootStack.alignment = .leading
+        rootStack.spacing = 18
+        rootStack.edgeInsets = NSEdgeInsets(top: 22, left: 22, bottom: 22, right: 22)
+        rootStack.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(rootStack)
+        NSLayoutConstraint.activate([
+            rootStack.leadingAnchor.constraint(equalTo: view.leadingAnchor),
+            rootStack.trailingAnchor.constraint(equalTo: view.trailingAnchor),
+            rootStack.topAnchor.constraint(equalTo: view.topAnchor),
+            rootStack.bottomAnchor.constraint(equalTo: view.bottomAnchor),
+        ])
+
+        rootStack.addArrangedSubview(makeHeader())
+        rootStack.addArrangedSubview(makeMetricStrip())
+        let splitView = makeSplitView()
+        rootStack.addArrangedSubview(splitView)
+        splitView.widthAnchor.constraint(equalTo: rootStack.widthAnchor, constant: -44).isActive = true
+        splitView.setContentHuggingPriority(.defaultLow, for: .vertical)
+    }
+
+    private func makeHeader() -> NSView {
+        let title = NSTextField(labelWithString: String(localized: "debug.signalLab.title", defaultValue: "Operations control center"))
+        title.font = .systemFont(ofSize: 26, weight: .bold)
+        let subtitle = NSTextField(labelWithString: String(localized: "debug.signalLab.subtitle", defaultValue: "Solid-style signals driving native AppKit controls with targeted effects."))
+        subtitle.textColor = .secondaryLabelColor
+
+        let titleStack = NSStackView(views: [title, subtitle])
+        titleStack.orientation = .vertical
+        titleStack.alignment = .leading
+        titleStack.spacing = 4
+
+        let simulateButton = NSButton(
+            title: String(localized: "debug.signalLab.simulate", defaultValue: "Run simulation step"),
+            target: self,
+            action: #selector(runSimulationStep)
+        )
+        simulateButton.bezelStyle = .rounded
+        simulateButton.controlSize = .large
+        simulateButton.image = NSImage(systemSymbolName: "play.fill", accessibilityDescription: nil)
+
+        let spacer = NSView()
+        let header = NSStackView(views: [titleStack, spacer, simulateButton])
+        header.orientation = .horizontal
+        header.alignment = .centerY
+        header.spacing = 14
+        spacer.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        header.widthAnchor.constraint(greaterThanOrEqualToConstant: 700).isActive = true
+        return header
+    }
+
+    private func makeMetricStrip() -> NSView {
+        let metrics = NSStackView(views: [
+            makeMetricCard(
+                title: String(localized: "debug.signalLab.metric.active", defaultValue: "ACTIVE NODES"),
+                valueLabel: activeValueLabel
+            ),
+            makeMetricCard(
+                title: String(localized: "debug.signalLab.metric.throughput", defaultValue: "THROUGHPUT"),
+                valueLabel: throughputValueLabel
+            ),
+            makeMetricCard(
+                title: String(localized: "debug.signalLab.metric.health", defaultValue: "GRAPH HEALTH"),
+                valueLabel: healthValueLabel
+            ),
+            makeMetricCard(
+                title: String(localized: "debug.signalLab.metric.progress", defaultValue: "AVG PROGRESS"),
+                valueLabel: progressValueLabel
+            ),
+        ])
+        metrics.orientation = .horizontal
+        metrics.distribution = .fillEqually
+        metrics.spacing = 12
+        return metrics
+    }
+
+    private func makeMetricCard(title: String, valueLabel: NSTextField) -> NSView {
+        let box = NSBox()
+        box.boxType = .custom
+        box.cornerRadius = 10
+        box.borderWidth = 1
+        box.borderColor = NSColor.separatorColor
+        box.fillColor = NSColor.controlBackgroundColor
+
+        let titleLabel = NSTextField(labelWithString: title)
+        titleLabel.font = .systemFont(ofSize: 11, weight: .semibold)
+        titleLabel.textColor = .secondaryLabelColor
+        valueLabel.font = .monospacedDigitSystemFont(ofSize: 22, weight: .bold)
+
+        let stack = NSStackView(views: [titleLabel, valueLabel])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 5
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        box.contentView?.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: box.leadingAnchor, constant: 14),
+            stack.trailingAnchor.constraint(lessThanOrEqualTo: box.trailingAnchor, constant: -14),
+            stack.topAnchor.constraint(equalTo: box.topAnchor, constant: 11),
+            stack.bottomAnchor.constraint(equalTo: box.bottomAnchor, constant: -11),
+            box.heightAnchor.constraint(equalToConstant: 72),
+        ])
+        return box
+    }
+
+    private func makeSplitView() -> NSSplitView {
+        let splitView = NSSplitView()
+        splitView.isVertical = true
+        splitView.dividerStyle = .thin
+        splitView.addArrangedSubview(makeSidebar())
+        splitView.addArrangedSubview(makeWorkList())
+        splitView.addArrangedSubview(makeInspector())
+        splitView.subviews[0].widthAnchor.constraint(equalToConstant: 185).isActive = true
+        splitView.subviews[2].widthAnchor.constraint(equalToConstant: 275).isActive = true
+        return splitView
+    }
+
+    private func makeSidebar() -> NSView {
+        let container = NSVisualEffectView()
+        container.material = .sidebar
+        container.blendingMode = .withinWindow
+        container.state = .active
+
+        let heading = NSTextField(labelWithString: String(localized: "debug.signalLab.sidebar.heading", defaultValue: "PIPELINES"))
+        heading.font = .systemFont(ofSize: 11, weight: .bold)
+        heading.textColor = .secondaryLabelColor
+
+        configureFilterButton(allFilterButton, filter: .all, tag: 0)
+        configureFilterButton(activeFilterButton, filter: .active, tag: 1)
+        configureFilterButton(blockedFilterButton, filter: .blocked, tag: 2)
+        configureFilterButton(completeFilterButton, filter: .complete, tag: 3)
+
+        let stack = NSStackView(views: [heading, allFilterButton, activeFilterButton, blockedFilterButton, completeFilterButton])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 8
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stack)
+        NSLayoutConstraint.activate([
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 14),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -14),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+        ])
+        return container
+    }
+
+    private func configureFilterButton(_ button: NSButton, filter: AppKitSignalLabFilter, tag: Int) {
+        button.title = filter.title
+        button.tag = tag
+        button.target = self
+        button.action = #selector(selectFilter(_:))
+        button.bezelStyle = .recessed
+        button.alignment = .left
+        button.imagePosition = .imageLeading
+        button.image = NSImage(systemSymbolName: tag == 0 ? "square.grid.2x2" : "circle.fill", accessibilityDescription: nil)
+        button.widthAnchor.constraint(equalToConstant: 157).isActive = true
+    }
+
+    private func makeWorkList() -> NSView {
+        searchField.placeholderString = String(localized: "debug.signalLab.search.placeholder", defaultValue: "Search work or owner")
+        searchField.delegate = self
+
+        filterControl.segmentCount = 4
+        filterControl.setLabel(String(localized: "debug.signalLab.filter.all.short", defaultValue: "All"), forSegment: 0)
+        filterControl.setLabel(String(localized: "debug.signalLab.filter.active", defaultValue: "Active"), forSegment: 1)
+        filterControl.setLabel(String(localized: "debug.signalLab.filter.blocked", defaultValue: "Blocked"), forSegment: 2)
+        filterControl.setLabel(String(localized: "debug.signalLab.filter.complete", defaultValue: "Complete"), forSegment: 3)
+        filterControl.selectedSegment = 0
+        filterControl.target = self
+        filterControl.action = #selector(selectSegment(_:))
+        filterControl.segmentStyle = .capsule
+
+        visibleCountLabel.textColor = .secondaryLabelColor
+        visibleCountLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .medium)
+
+        let toolbar = NSStackView(views: [searchField, filterControl, visibleCountLabel])
+        toolbar.orientation = .horizontal
+        toolbar.alignment = .centerY
+        toolbar.spacing = 10
+        searchField.widthAnchor.constraint(greaterThanOrEqualToConstant: 190).isActive = true
+
+        configureTable()
+        let scrollView = NSScrollView()
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+        scrollView.documentView = tableView
+
+        let stack = NSStackView(views: [toolbar, scrollView])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 10
+        stack.edgeInsets = NSEdgeInsets(top: 0, left: 14, bottom: 0, right: 14)
+        scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -28).isActive = true
+        scrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: 360).isActive = true
+        return stack
+    }
+
+    private func configureTable() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.headerView = NSTableHeaderView()
+        tableView.rowHeight = 36
+        tableView.usesAlternatingRowBackgroundColors = true
+        tableView.allowsEmptySelection = true
+        tableView.doubleAction = #selector(advanceSelected)
+        tableView.target = self
+
+        let columns: [(String, String, CGFloat)] = [
+            ("work", String(localized: "debug.signalLab.column.work", defaultValue: "Work item"), 230),
+            ("owner", String(localized: "debug.signalLab.column.owner", defaultValue: "Owner"), 85),
+            ("status", String(localized: "debug.signalLab.column.status", defaultValue: "Status"), 75),
+            ("progress", String(localized: "debug.signalLab.column.progress", defaultValue: "Progress"), 64),
+        ]
+        for (identifier, title, width) in columns {
+            let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(identifier))
+            column.title = title
+            column.width = width
+            column.minWidth = identifier == "work" ? 150 : 60
+            tableView.addTableColumn(column)
+        }
+    }
+
+    private func makeCell(identifier: NSUserInterfaceItemIdentifier) -> NSTableCellView {
+        let cell = NSTableCellView()
+        cell.identifier = identifier
+        let label = NSTextField(labelWithString: "")
+        label.lineBreakMode = .byTruncatingTail
+        label.translatesAutoresizingMaskIntoConstraints = false
+        cell.addSubview(label)
+        cell.textField = label
+
+        if identifier.rawValue == "work" {
+            let imageView = NSImageView()
+            imageView.symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 12, weight: .semibold)
+            imageView.translatesAutoresizingMaskIntoConstraints = false
+            cell.addSubview(imageView)
+            cell.imageView = imageView
+            NSLayoutConstraint.activate([
+                imageView.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 6),
+                imageView.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+                imageView.widthAnchor.constraint(equalToConstant: 16),
+                label.leadingAnchor.constraint(equalTo: imageView.trailingAnchor, constant: 7),
+            ])
+        } else {
+            label.leadingAnchor.constraint(equalTo: cell.leadingAnchor, constant: 6).isActive = true
+        }
+        NSLayoutConstraint.activate([
+            label.trailingAnchor.constraint(equalTo: cell.trailingAnchor, constant: -6),
+            label.centerYAnchor.constraint(equalTo: cell.centerYAnchor),
+        ])
+        return cell
+    }
+
+    private func makeInspector() -> NSView {
+        let scrollView = NSScrollView()
+        scrollView.drawsBackground = false
+        scrollView.hasVerticalScroller = true
+        scrollView.autohidesScrollers = true
+
+        let container = NSVisualEffectView()
+        container.material = .contentBackground
+        container.blendingMode = .withinWindow
+
+        let heading = NSTextField(labelWithString: String(localized: "debug.signalLab.inspector.heading", defaultValue: "INSPECTOR"))
+        heading.font = .systemFont(ofSize: 11, weight: .bold)
+        heading.textColor = .secondaryLabelColor
+        selectionTitleLabel.font = .systemFont(ofSize: 17, weight: .semibold)
+        selectionTitleLabel.maximumNumberOfLines = 2
+        selectionOwnerLabel.textColor = .secondaryLabelColor
+        selectionStatusLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+
+        selectionProgressIndicator.minValue = 0
+        selectionProgressIndicator.maxValue = 1
+        selectionProgressIndicator.style = .bar
+        selectionProgressLabel.font = .monospacedDigitSystemFont(ofSize: 12, weight: .medium)
+
+        let progressHeader = NSStackView(views: [
+            NSTextField(labelWithString: String(localized: "debug.signalLab.inspector.progress", defaultValue: "Progress")),
+            NSView(),
+            selectionProgressLabel,
+        ])
+        progressHeader.orientation = .horizontal
+
+        priorityPopup.addItems(withTitles: [
+            String(localized: "debug.signalLab.priority.critical", defaultValue: "Critical priority"),
+            String(localized: "debug.signalLab.priority.high", defaultValue: "High priority"),
+            String(localized: "debug.signalLab.priority.normal", defaultValue: "Normal priority"),
+        ])
+        priorityPopup.target = self
+        priorityPopup.action = #selector(changePriority(_:))
+
+        capacitySlider.target = self
+        capacitySlider.action = #selector(changeCapacity(_:))
+        capacitySlider.isContinuous = true
+        let capacityLabel = NSTextField(labelWithString: String(localized: "debug.signalLab.capacity", defaultValue: "Fleet capacity"))
+
+        automationSwitch.title = String(localized: "debug.signalLab.automation", defaultValue: "Auto-schedule dependencies")
+        automationSwitch.target = self
+        automationSwitch.action = #selector(toggleAutomation(_:))
+
+        advanceButton.title = String(localized: "debug.signalLab.advance", defaultValue: "Advance")
+        advanceButton.target = self
+        advanceButton.action = #selector(advanceSelected)
+        advanceButton.bezelStyle = .rounded
+        blockButton.title = String(localized: "debug.signalLab.toggleBlock", defaultValue: "Toggle block")
+        blockButton.target = self
+        blockButton.action = #selector(toggleBlock)
+        blockButton.bezelStyle = .rounded
+        let actionStack = NSStackView(views: [advanceButton, blockButton])
+        actionStack.orientation = .horizontal
+        actionStack.distribution = .fillEqually
+
+        let pulseTitle = NSTextField(labelWithString: String(localized: "debug.signalLab.pulse", defaultValue: "WORK PULSE"))
+        pulseTitle.font = .systemFont(ofSize: 11, weight: .bold)
+        pulseTitle.textColor = .secondaryLabelColor
+        pulseView.heightAnchor.constraint(equalToConstant: 58).isActive = true
+
+        let activityTitle = NSTextField(labelWithString: String(localized: "debug.signalLab.activity.heading", defaultValue: "RECENT EFFECTS"))
+        activityTitle.font = .systemFont(ofSize: 11, weight: .bold)
+        activityTitle.textColor = .secondaryLabelColor
+        activityLabel.font = .systemFont(ofSize: 11)
+        activityLabel.textColor = .secondaryLabelColor
+
+        let stack = NSStackView(views: [
+            heading,
+            selectionTitleLabel,
+            selectionOwnerLabel,
+            selectionStatusLabel,
+            separator(),
+            progressHeader,
+            selectionProgressIndicator,
+            priorityPopup,
+            capacityLabel,
+            capacitySlider,
+            automationSwitch,
+            actionStack,
+            separator(),
+            pulseTitle,
+            pulseView,
+            activityTitle,
+            activityLabel,
+        ])
+        stack.orientation = .vertical
+        stack.alignment = .leading
+        stack.spacing = 9
+        stack.translatesAutoresizingMaskIntoConstraints = false
+        container.addSubview(stack)
+        container.translatesAutoresizingMaskIntoConstraints = false
+        scrollView.documentView = container
+        NSLayoutConstraint.activate([
+            container.leadingAnchor.constraint(equalTo: scrollView.contentView.leadingAnchor),
+            container.trailingAnchor.constraint(equalTo: scrollView.contentView.trailingAnchor),
+            container.topAnchor.constraint(equalTo: scrollView.contentView.topAnchor),
+            container.widthAnchor.constraint(equalTo: scrollView.contentView.widthAnchor),
+            stack.leadingAnchor.constraint(equalTo: container.leadingAnchor, constant: 16),
+            stack.trailingAnchor.constraint(equalTo: container.trailingAnchor, constant: -16),
+            stack.topAnchor.constraint(equalTo: container.topAnchor, constant: 16),
+            stack.bottomAnchor.constraint(equalTo: container.bottomAnchor, constant: -16),
+            selectionProgressIndicator.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            priorityPopup.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            capacitySlider.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            actionStack.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            pulseView.widthAnchor.constraint(equalTo: stack.widthAnchor),
+            activityLabel.widthAnchor.constraint(equalTo: stack.widthAnchor),
+        ])
+        return scrollView
+    }
+
+    private func separator() -> NSView {
+        let separator = NSBox()
+        separator.boxType = .separator
+        separator.heightAnchor.constraint(equalToConstant: 1).isActive = true
+        return separator
+    }
+
+    private func installBindings() {
+        effects.append(model.graph.createEffect { [weak self] _ in
+            guard let self else { return }
+            let tasks = model.filteredTasks.get()
+            tableView.reloadData()
+            visibleCountLabel.stringValue = String(
+                format: String(localized: "debug.signalLab.visibleCount", defaultValue: "%lld visible"),
+                Int64(tasks.count)
+            )
+            pulseView.samples = tasks.map(\.progress)
+            if let selectedID = model.selectedTaskID.get(),
+               let index = tasks.firstIndex(where: { $0.id == selectedID }) {
+                tableView.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
+            } else {
+                tableView.deselectAll(nil)
+            }
+        })
+
+        effects.append(model.graph.createEffect { [weak self] _ in
+            guard let self else { return }
+            let metrics = model.metrics.get()
+            let allTasks = model.tasks.get()
+            activeValueLabel.stringValue = "\(metrics.activeCount)"
+            throughputValueLabel.stringValue = String(
+                format: String(localized: "debug.signalLab.throughputValue", defaultValue: "%lld/h"),
+                Int64(metrics.throughput)
+            )
+            healthValueLabel.stringValue = formattedPercent(metrics.health)
+            progressValueLabel.stringValue = formattedPercent(metrics.averageProgress)
+            capacitySlider.doubleValue = metrics.capacity
+            automationSwitch.state = metrics.automationEnabled ? .on : .off
+            allFilterButton.title = "\(AppKitSignalLabFilter.all.title)  \(allTasks.count)"
+            activeFilterButton.title = "\(AppKitSignalLabFilter.active.title)  \(metrics.activeCount)"
+            blockedFilterButton.title = "\(AppKitSignalLabFilter.blocked.title)  \(metrics.blockedCount)"
+            completeFilterButton.title = "\(AppKitSignalLabFilter.complete.title)  \(metrics.completedCount)"
+        })
+
+        effects.append(model.graph.createEffect { [weak self] _ in
+            guard let self else { return }
+            guard let task = model.selectedTask.get() else {
+                selectionTitleLabel.stringValue = String(localized: "debug.signalLab.inspector.none", defaultValue: "No work selected")
+                selectionOwnerLabel.stringValue = ""
+                selectionStatusLabel.stringValue = ""
+                selectionProgressLabel.stringValue = ""
+                selectionProgressIndicator.doubleValue = 0
+                priorityPopup.isEnabled = false
+                advanceButton.isEnabled = false
+                blockButton.isEnabled = false
+                return
+            }
+            selectionTitleLabel.stringValue = task.title
+            selectionOwnerLabel.stringValue = task.owner
+            selectionStatusLabel.stringValue = task.status.title
+            selectionStatusLabel.textColor = statusColor(task.status)
+            selectionProgressLabel.stringValue = formattedPercent(task.progress)
+            selectionProgressIndicator.doubleValue = task.progress
+            priorityPopup.selectItem(at: max(0, min(2, task.priority - 1)))
+            priorityPopup.isEnabled = true
+            advanceButton.isEnabled = task.status != .complete
+            blockButton.isEnabled = task.status != .complete
+        })
+
+        effects.append(model.graph.createEffect { [weak self] _ in
+            guard let self else { return }
+            activityLabel.stringValue = model.activity.get().map { "• \($0)" }.joined(separator: "\n")
+        })
+    }
+
+    private func statusColor(_ status: AppKitSignalLabStatus) -> NSColor {
+        switch status {
+        case .queued: .secondaryLabelColor
+        case .running: .systemBlue
+        case .review: .systemPurple
+        case .blocked: .systemOrange
+        case .complete: .systemGreen
+        }
+    }
+
+    private func formattedPercent(_ value: Double) -> String {
+        percentFormatter.string(from: NSNumber(value: value)) ?? ""
+    }
+
+    @objc private func selectFilter(_ sender: NSButton) {
+        filterControl.selectedSegment = sender.tag
+        applyFilter(index: sender.tag)
+    }
+
+    @objc private func selectSegment(_ sender: NSSegmentedControl) {
+        applyFilter(index: sender.selectedSegment)
+    }
+
+    private func applyFilter(index: Int) {
+        let filters: [AppKitSignalLabFilter] = [.all, .active, .blocked, .complete]
+        guard filters.indices.contains(index) else { return }
+        model.filter.set(filters[index])
+    }
+
+    @objc private func runSimulationStep() {
+        model.runSimulationStep()
+    }
+
+    @objc private func advanceSelected() {
+        model.advanceSelectedTask()
+    }
+
+    @objc private func toggleBlock() {
+        model.toggleBlockedForSelectedTask()
+    }
+
+    @objc private func changeCapacity(_ sender: NSSlider) {
+        model.capacity.set(sender.doubleValue)
+    }
+
+    @objc private func toggleAutomation(_ sender: NSButton) {
+        model.automationEnabled.set(sender.state == .on)
+    }
+
+    @objc private func changePriority(_ sender: NSPopUpButton) {
+        model.setSelectedPriority(sender.indexOfSelectedItem + 1)
+    }
+}
+
+#endif

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Views/AppKitSignalLabViewController.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Views/AppKitSignalLabViewController.swift
@@ -8,6 +8,9 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
     private var effects: [SignalEffect] = []
 
     private let tableView = NSTableView()
+    private let newTaskField = NSTextField()
+    private let addTaskButton = NSButton()
+    private let clearCompletedButton = NSButton()
     private let searchField = NSSearchField()
     private let filterControl = NSSegmentedControl()
     private let visibleCountLabel = NSTextField(labelWithString: "")
@@ -73,6 +76,14 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         guard tasks.indices.contains(row), let tableColumn else { return nil }
         let task = tasks[row]
         let identifier = tableColumn.identifier
+        if identifier.rawValue == "done" {
+            let button = tableView.makeView(withIdentifier: identifier, owner: self) as? NSButton
+                ?? makeCompletionButton(identifier: identifier)
+            button.tag = row
+            button.state = task.status == .complete ? .on : .off
+            button.toolTip = String(localized: "debug.signalLab.todo.toggle", defaultValue: "Toggle completion")
+            return button
+        }
         let cell = tableView.makeView(withIdentifier: identifier, owner: self) as? NSTableCellView
             ?? makeCell(identifier: identifier)
 
@@ -100,7 +111,12 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
     }
 
     func controlTextDidChange(_ obj: Notification) {
-        model.query.set(searchField.stringValue)
+        guard let field = obj.object as? NSTextField else { return }
+        if field === newTaskField {
+            model.draftTaskTitle.set(field.stringValue)
+        } else if field === searchField {
+            model.query.set(field.stringValue)
+        }
     }
 
     private func buildInterface() {
@@ -119,6 +135,7 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         ])
 
         rootStack.addArrangedSubview(makeHeader())
+        rootStack.addArrangedSubview(makeComposer())
         rootStack.addArrangedSubview(makeMetricStrip())
         let splitView = makeSplitView()
         rootStack.addArrangedSubview(splitView)
@@ -127,9 +144,9 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
     }
 
     private func makeHeader() -> NSView {
-        let title = NSTextField(labelWithString: String(localized: "debug.signalLab.title", defaultValue: "Operations control center"))
+        let title = NSTextField(labelWithString: String(localized: "debug.signalLab.title", defaultValue: "Signal Todo List"))
         title.font = .systemFont(ofSize: 26, weight: .bold)
-        let subtitle = NSTextField(labelWithString: String(localized: "debug.signalLab.subtitle", defaultValue: "Solid-style signals driving native AppKit controls with targeted effects."))
+        let subtitle = NSTextField(labelWithString: String(localized: "debug.signalLab.subtitle", defaultValue: "A native AppKit todo app driven by Solid-style signals."))
         subtitle.textColor = .secondaryLabelColor
 
         let titleStack = NSStackView(views: [title, subtitle])
@@ -138,7 +155,7 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         titleStack.spacing = 4
 
         let simulateButton = NSButton(
-            title: String(localized: "debug.signalLab.simulate", defaultValue: "Run simulation step"),
+            title: String(localized: "debug.signalLab.simulate", defaultValue: "Run demo step"),
             target: self,
             action: #selector(runSimulationStep)
         )
@@ -156,18 +173,50 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         return header
     }
 
+    private func makeComposer() -> NSView {
+        newTaskField.placeholderString = String(
+            localized: "debug.signalLab.todo.placeholder",
+            defaultValue: "What needs to be done?"
+        )
+        newTaskField.delegate = self
+        newTaskField.target = self
+        newTaskField.action = #selector(addDraftTask)
+
+        addTaskButton.title = String(localized: "debug.signalLab.todo.add", defaultValue: "Add Todo")
+        addTaskButton.image = NSImage(systemSymbolName: "plus", accessibilityDescription: nil)
+        addTaskButton.imagePosition = .imageLeading
+        addTaskButton.bezelStyle = .rounded
+        addTaskButton.target = self
+        addTaskButton.action = #selector(addDraftTask)
+
+        clearCompletedButton.title = String(
+            localized: "debug.signalLab.todo.clearCompleted",
+            defaultValue: "Clear Completed"
+        )
+        clearCompletedButton.bezelStyle = .rounded
+        clearCompletedButton.target = self
+        clearCompletedButton.action = #selector(clearCompleted)
+
+        let composer = NSStackView(views: [newTaskField, addTaskButton, clearCompletedButton])
+        composer.orientation = .horizontal
+        composer.spacing = 10
+        newTaskField.setContentHuggingPriority(.defaultLow, for: .horizontal)
+        composer.widthAnchor.constraint(greaterThanOrEqualToConstant: 700).isActive = true
+        return composer
+    }
+
     private func makeMetricStrip() -> NSView {
         let metrics = NSStackView(views: [
             makeMetricCard(
-                title: String(localized: "debug.signalLab.metric.active", defaultValue: "ACTIVE NODES"),
+                title: String(localized: "debug.signalLab.metric.active", defaultValue: "REMAINING"),
                 valueLabel: activeValueLabel
             ),
             makeMetricCard(
-                title: String(localized: "debug.signalLab.metric.throughput", defaultValue: "THROUGHPUT"),
+                title: String(localized: "debug.signalLab.metric.throughput", defaultValue: "COMPLETED"),
                 valueLabel: throughputValueLabel
             ),
             makeMetricCard(
-                title: String(localized: "debug.signalLab.metric.health", defaultValue: "GRAPH HEALTH"),
+                title: String(localized: "debug.signalLab.metric.health", defaultValue: "COMPLETION"),
                 valueLabel: healthValueLabel
             ),
             makeMetricCard(
@@ -228,7 +277,7 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         container.blendingMode = .withinWindow
         container.state = .active
 
-        let heading = NSTextField(labelWithString: String(localized: "debug.signalLab.sidebar.heading", defaultValue: "PIPELINES"))
+        let heading = NSTextField(labelWithString: String(localized: "debug.signalLab.sidebar.heading", defaultValue: "TODO LISTS"))
         heading.font = .systemFont(ofSize: 11, weight: .bold)
         heading.textColor = .secondaryLabelColor
 
@@ -264,14 +313,14 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
     }
 
     private func makeWorkList() -> NSView {
-        searchField.placeholderString = String(localized: "debug.signalLab.search.placeholder", defaultValue: "Search work or owner")
+        searchField.placeholderString = String(localized: "debug.signalLab.search.placeholder", defaultValue: "Search todos or lists")
         searchField.delegate = self
 
         filterControl.segmentCount = 4
         filterControl.setLabel(String(localized: "debug.signalLab.filter.all.short", defaultValue: "All"), forSegment: 0)
-        filterControl.setLabel(String(localized: "debug.signalLab.filter.active", defaultValue: "Active"), forSegment: 1)
+        filterControl.setLabel(String(localized: "debug.signalLab.filter.active", defaultValue: "Open"), forSegment: 1)
         filterControl.setLabel(String(localized: "debug.signalLab.filter.blocked", defaultValue: "Blocked"), forSegment: 2)
-        filterControl.setLabel(String(localized: "debug.signalLab.filter.complete", defaultValue: "Complete"), forSegment: 3)
+        filterControl.setLabel(String(localized: "debug.signalLab.filter.complete", defaultValue: "Done"), forSegment: 3)
         filterControl.selectedSegment = 0
         filterControl.target = self
         filterControl.action = #selector(selectSegment(_:))
@@ -298,7 +347,7 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         stack.spacing = 10
         stack.edgeInsets = NSEdgeInsets(top: 0, left: 14, bottom: 0, right: 14)
         scrollView.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -28).isActive = true
-        scrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: 360).isActive = true
+        scrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: 280).isActive = true
         return stack
     }
 
@@ -313,18 +362,26 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         tableView.target = self
 
         let columns: [(String, String, CGFloat)] = [
-            ("work", String(localized: "debug.signalLab.column.work", defaultValue: "Work item"), 230),
-            ("owner", String(localized: "debug.signalLab.column.owner", defaultValue: "Owner"), 85),
+            ("done", "", 32),
+            ("work", String(localized: "debug.signalLab.column.work", defaultValue: "Todo"), 210),
+            ("owner", String(localized: "debug.signalLab.column.owner", defaultValue: "List"), 85),
             ("status", String(localized: "debug.signalLab.column.status", defaultValue: "Status"), 75),
-            ("progress", String(localized: "debug.signalLab.column.progress", defaultValue: "Progress"), 64),
         ]
         for (identifier, title, width) in columns {
             let column = NSTableColumn(identifier: NSUserInterfaceItemIdentifier(identifier))
             column.title = title
             column.width = width
-            column.minWidth = identifier == "work" ? 150 : 60
+            column.minWidth = identifier == "done" ? 32 : (identifier == "work" ? 150 : 60)
+            column.maxWidth = identifier == "done" ? 32 : .greatestFiniteMagnitude
             tableView.addTableColumn(column)
         }
+    }
+
+    private func makeCompletionButton(identifier: NSUserInterfaceItemIdentifier) -> NSButton {
+        let button = NSButton(checkboxWithTitle: "", target: self, action: #selector(toggleTodoCompletion(_:)))
+        button.identifier = identifier
+        button.setButtonType(.switch)
+        return button
     }
 
     private func makeCell(identifier: NSUserInterfaceItemIdentifier) -> NSTableCellView {
@@ -368,7 +425,7 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         container.material = .contentBackground
         container.blendingMode = .withinWindow
 
-        let heading = NSTextField(labelWithString: String(localized: "debug.signalLab.inspector.heading", defaultValue: "INSPECTOR"))
+        let heading = NSTextField(labelWithString: String(localized: "debug.signalLab.inspector.heading", defaultValue: "TODO DETAILS"))
         heading.font = .systemFont(ofSize: 11, weight: .bold)
         heading.textColor = .secondaryLabelColor
         selectionTitleLabel.font = .systemFont(ofSize: 17, weight: .semibold)
@@ -399,17 +456,17 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         capacitySlider.target = self
         capacitySlider.action = #selector(changeCapacity(_:))
         capacitySlider.isContinuous = true
-        let capacityLabel = NSTextField(labelWithString: String(localized: "debug.signalLab.capacity", defaultValue: "Fleet capacity"))
+        let capacityLabel = NSTextField(labelWithString: String(localized: "debug.signalLab.capacity", defaultValue: "Focus capacity"))
 
         automationSwitch.title = String(localized: "debug.signalLab.automation", defaultValue: "Auto-schedule dependencies")
         automationSwitch.target = self
         automationSwitch.action = #selector(toggleAutomation(_:))
 
-        advanceButton.title = String(localized: "debug.signalLab.advance", defaultValue: "Advance")
+        advanceButton.title = String(localized: "debug.signalLab.advance", defaultValue: "Advance Todo")
         advanceButton.target = self
         advanceButton.action = #selector(advanceSelected)
         advanceButton.bezelStyle = .rounded
-        blockButton.title = String(localized: "debug.signalLab.toggleBlock", defaultValue: "Toggle block")
+        blockButton.title = String(localized: "debug.signalLab.toggleBlock", defaultValue: "Toggle Blocked")
         blockButton.target = self
         blockButton.action = #selector(toggleBlock)
         blockButton.bezelStyle = .rounded
@@ -417,7 +474,7 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
         actionStack.orientation = .horizontal
         actionStack.distribution = .fillEqually
 
-        let pulseTitle = NSTextField(labelWithString: String(localized: "debug.signalLab.pulse", defaultValue: "WORK PULSE"))
+        let pulseTitle = NSTextField(labelWithString: String(localized: "debug.signalLab.pulse", defaultValue: "TODO PULSE"))
         pulseTitle.font = .systemFont(ofSize: 11, weight: .bold)
         pulseTitle.textColor = .secondaryLabelColor
         pulseView.heightAnchor.constraint(equalToConstant: 58).isActive = true
@@ -502,25 +559,36 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
             guard let self else { return }
             let metrics = model.metrics.get()
             let allTasks = model.tasks.get()
-            activeValueLabel.stringValue = "\(metrics.activeCount)"
-            throughputValueLabel.stringValue = String(
-                format: String(localized: "debug.signalLab.throughputValue", defaultValue: "%lld/h"),
-                Int64(metrics.throughput)
+            let remainingCount = allTasks.count - metrics.completedCount
+            activeValueLabel.stringValue = "\(remainingCount)"
+            throughputValueLabel.stringValue = "\(metrics.completedCount)"
+            healthValueLabel.stringValue = formattedPercent(
+                allTasks.isEmpty ? 0 : Double(metrics.completedCount) / Double(allTasks.count)
             )
-            healthValueLabel.stringValue = formattedPercent(metrics.health)
             progressValueLabel.stringValue = formattedPercent(metrics.averageProgress)
             capacitySlider.doubleValue = metrics.capacity
             automationSwitch.state = metrics.automationEnabled ? .on : .off
             allFilterButton.title = "\(AppKitSignalLabFilter.all.title)  \(allTasks.count)"
-            activeFilterButton.title = "\(AppKitSignalLabFilter.active.title)  \(metrics.activeCount)"
+            let openCount = allTasks.filter { AppKitSignalLabFilter.active.includes($0.status) }.count
+            activeFilterButton.title = "\(AppKitSignalLabFilter.active.title)  \(openCount)"
             blockedFilterButton.title = "\(AppKitSignalLabFilter.blocked.title)  \(metrics.blockedCount)"
             completeFilterButton.title = "\(AppKitSignalLabFilter.complete.title)  \(metrics.completedCount)"
+            clearCompletedButton.isEnabled = metrics.completedCount > 0
+        })
+
+        effects.append(model.graph.createEffect { [weak self] _ in
+            guard let self else { return }
+            let draft = model.draftTaskTitle.get()
+            if newTaskField.stringValue != draft {
+                newTaskField.stringValue = draft
+            }
+            addTaskButton.isEnabled = model.canAddTask.get()
         })
 
         effects.append(model.graph.createEffect { [weak self] _ in
             guard let self else { return }
             guard let task = model.selectedTask.get() else {
-                selectionTitleLabel.stringValue = String(localized: "debug.signalLab.inspector.none", defaultValue: "No work selected")
+                selectionTitleLabel.stringValue = String(localized: "debug.signalLab.inspector.none", defaultValue: "No todo selected")
                 selectionOwnerLabel.stringValue = ""
                 selectionStatusLabel.stringValue = ""
                 selectionProgressLabel.stringValue = ""
@@ -579,6 +647,19 @@ final class AppKitSignalLabViewController: NSViewController, NSTableViewDataSour
 
     @objc private func runSimulationStep() {
         model.runSimulationStep()
+    }
+
+    @objc private func addDraftTask() {
+        model.draftTaskTitle.set(newTaskField.stringValue)
+        model.addDraftTask()
+    }
+
+    @objc private func clearCompleted() {
+        model.clearCompletedTasks()
+    }
+
+    @objc private func toggleTodoCompletion(_ sender: NSButton) {
+        model.toggleCompletion(at: sender.tag)
     }
 
     @objc private func advanceSelected() {

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Views/SignalLabPulseView.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Views/SignalLabPulseView.swift
@@ -1,0 +1,37 @@
+#if canImport(AppKit)
+
+import AppKit
+
+@MainActor
+final class SignalLabPulseView: NSView {
+    var samples: [Double] = [] {
+        didSet { needsDisplay = true }
+    }
+
+    override var isFlipped: Bool { true }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        guard !samples.isEmpty else { return }
+
+        let gap: CGFloat = 5
+        let availableWidth = bounds.width - gap * CGFloat(samples.count - 1)
+        let barWidth = max(3, availableWidth / CGFloat(samples.count))
+        let color = NSColor.controlAccentColor
+
+        for (index, sample) in samples.enumerated() {
+            let clampedSample = max(0.08, min(1, sample))
+            let height = bounds.height * clampedSample
+            let rect = NSRect(
+                x: CGFloat(index) * (barWidth + gap),
+                y: bounds.height - height,
+                width: barWidth,
+                height: height
+            )
+            color.withAlphaComponent(0.35 + clampedSample * 0.55).setFill()
+            NSBezierPath(roundedRect: rect, xRadius: 3, yRadius: 3).fill()
+        }
+    }
+}
+
+#endif

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Windows/AppKitSignalLabWindowController.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Windows/AppKitSignalLabWindowController.swift
@@ -14,7 +14,7 @@ final class AppKitSignalLabWindowController: NSWindowController, NSWindowDelegat
             backing: .buffered,
             defer: false
         )
-        window.title = String(localized: "debug.signalLab.windowTitle", defaultValue: "AppKit Signals Lab")
+        window.title = String(localized: "debug.signalLab.windowTitle", defaultValue: "Signal Todo List")
         window.identifier = NSUserInterfaceItemIdentifier("cmux.appKitSignalsLab")
         window.minSize = NSSize(width: 960, height: 640)
         window.isReleasedWhenClosed = false

--- a/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Windows/AppKitSignalLabWindowController.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Sources/CmuxAppKitSupportUI/AppKitSignalLab/Windows/AppKitSignalLabWindowController.swift
@@ -1,0 +1,40 @@
+#if canImport(AppKit)
+
+import AppKit
+
+@MainActor
+final class AppKitSignalLabWindowController: NSWindowController, NSWindowDelegate {
+    private let model: AppKitSignalLabModel
+
+    init(model: AppKitSignalLabModel = AppKitSignalLabModel()) {
+        self.model = model
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 1180, height: 760),
+            styleMask: [.titled, .closable, .miniaturizable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = String(localized: "debug.signalLab.windowTitle", defaultValue: "AppKit Signals Lab")
+        window.identifier = NSUserInterfaceItemIdentifier("cmux.appKitSignalsLab")
+        window.minSize = NSSize(width: 960, height: 640)
+        window.isReleasedWhenClosed = false
+        window.contentViewController = AppKitSignalLabViewController(model: model)
+        window.center()
+        super.init(window: window)
+        window.delegate = self
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    func show() {
+        guard let window else { return }
+        showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+    }
+}
+
+#endif

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/AppKitSignalLabModelTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/AppKitSignalLabModelTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import CmuxAppKitSupportUI
+
+@MainActor
+@Suite("AppKit signal todo model")
+struct AppKitSignalLabModelTests {
+    @Test func addDraftTaskTrimsSelectsAndClearsComposer() {
+        let model = AppKitSignalLabModel()
+        let initialCount = model.tasks.get().count
+
+        #expect(model.canAddTask.get() == false)
+        model.draftTaskTitle.set("  Write signal demo  ")
+        #expect(model.canAddTask.get() == true)
+
+        model.addDraftTask()
+
+        #expect(model.tasks.get().count == initialCount + 1)
+        #expect(model.tasks.get().first?.title == "Write signal demo")
+        #expect(model.tasks.get().first?.status == .queued)
+        #expect(model.selectedTask.get()?.title == "Write signal demo")
+        #expect(model.draftTaskTitle.get().isEmpty)
+        #expect(model.canAddTask.get() == false)
+    }
+
+    @Test func emptyDraftDoesNotAddTask() {
+        let model = AppKitSignalLabModel()
+        let initialTasks = model.tasks.get()
+
+        model.draftTaskTitle.set("   ")
+        model.addDraftTask()
+
+        #expect(model.tasks.get() == initialTasks)
+    }
+
+    @Test func completionToggleUpdatesTaskAndDerivedMetrics() {
+        let model = AppKitSignalLabModel()
+        let initialCompleted = model.metrics.get().completedCount
+
+        model.toggleCompletion(at: 0)
+
+        #expect(model.tasks.get().first?.status == .complete)
+        #expect(model.tasks.get().first?.progress == 1)
+        #expect(model.metrics.get().completedCount == initialCompleted + 1)
+
+        model.toggleCompletion(at: 0)
+
+        #expect(model.tasks.get().first?.status == .queued)
+        #expect(model.tasks.get().first?.progress == 0)
+        #expect(model.metrics.get().completedCount == initialCompleted)
+    }
+
+    @Test func clearCompletedRemovesTodosAndRepairsSelection() {
+        let model = AppKitSignalLabModel()
+        model.selectTask(at: 5)
+        let removedID = model.selectedTaskID.get()
+
+        model.clearCompletedTasks()
+
+        #expect(model.tasks.get().count == 6)
+        #expect(model.tasks.get().allSatisfy { $0.status != .complete })
+        #expect(model.selectedTaskID.get() != removedID)
+        #expect(model.selectedTask.get() != nil)
+        #expect(model.metrics.get().completedCount == 0)
+    }
+}

--- a/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/SignalGraphTests.swift
+++ b/Packages/macOS/CmuxAppKitSupportUI/Tests/CmuxAppKitSupportUITests/SignalGraphTests.swift
@@ -1,0 +1,116 @@
+import Testing
+@testable import CmuxAppKitSupportUI
+
+@MainActor
+@Suite struct SignalGraphTests {
+    @Test func effectsTrackReadsAndIgnoreEqualWrites() {
+        let graph = SignalGraph()
+        let count = graph.createSignal(0)
+        var observedValues: [Int] = []
+        let effect = graph.createEffect { _ in
+            observedValues.append(count.get())
+        }
+
+        count.set(1)
+        count.set(1)
+        count.update { $0 + 1 }
+
+        #expect(observedValues == [0, 1, 2])
+        withExtendedLifetime(effect) {}
+    }
+
+    @Test func effectsReplaceConditionalDependencies() {
+        let graph = SignalGraph()
+        let usePrimary = graph.createSignal(true)
+        let primary = graph.createSignal("primary")
+        let fallback = graph.createSignal("fallback")
+        var observedValues: [String] = []
+        let effect = graph.createEffect { _ in
+            observedValues.append(usePrimary.get() ? primary.get() : fallback.get())
+        }
+
+        fallback.set("ignored")
+        usePrimary.set(false)
+        primary.set("also ignored")
+        fallback.set("visible")
+
+        #expect(observedValues == ["primary", "ignored", "visible"])
+        withExtendedLifetime(effect) {}
+    }
+
+    @Test func batchCoalescesMemoAndEffectWork() {
+        let graph = SignalGraph()
+        let left = graph.createSignal(1)
+        let right = graph.createSignal(2)
+        var memoRuns = 0
+        let sum = graph.createMemo {
+            memoRuns += 1
+            return left.get() + right.get()
+        }
+        var observedValues: [Int] = []
+        let effect = graph.createEffect { _ in
+            observedValues.append(sum.get())
+        }
+
+        graph.batch {
+            left.set(3)
+            right.set(4)
+        }
+
+        #expect(memoRuns == 2)
+        #expect(observedValues == [3, 7])
+        withExtendedLifetime(effect) {}
+    }
+
+    @Test func unchangedMemoValueDoesNotRunDownstreamEffect() {
+        let graph = SignalGraph()
+        let count = graph.createSignal(0)
+        let isEven = graph.createMemo { count.get().isMultiple(of: 2) }
+        var effectRuns = 0
+        let effect = graph.createEffect { _ in
+            _ = isEven.get()
+            effectRuns += 1
+        }
+
+        count.set(2)
+        count.set(3)
+
+        #expect(effectRuns == 2)
+        withExtendedLifetime(effect) {}
+    }
+
+    @Test func diamondDependencyRunsEffectOncePerWrite() {
+        let graph = SignalGraph()
+        let source = graph.createSignal(1)
+        let doubled = graph.createMemo { source.get() * 2 }
+        var observedValues: [(Int, Int)] = []
+        let effect = graph.createEffect { _ in
+            observedValues.append((source.get(), doubled.get()))
+        }
+
+        source.set(2)
+
+        #expect(observedValues.count == 2)
+        #expect(observedValues.last?.0 == 2)
+        #expect(observedValues.last?.1 == 4)
+        withExtendedLifetime(effect) {}
+    }
+
+    @Test func cleanupRunsBeforeRerunAndOnDispose() {
+        let graph = SignalGraph()
+        let value = graph.createSignal(0)
+        var cleanupValues: [Int] = []
+        let effect = graph.createEffect { context in
+            let capturedValue = value.get()
+            context.onCleanup {
+                cleanupValues.append(capturedValue)
+            }
+        }
+
+        value.set(1)
+        effect.dispose()
+        value.set(2)
+
+        #expect(cleanupValues == [0, 1])
+    }
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug.swift
@@ -34,6 +34,8 @@ extension ControlCommandCoordinator {
             return debugTextBoxInteract(request.params)
         case "debug.app.activate":
             return debugActivateApp()
+        case "debug.appkit_signal_lab.show":
+            return debugShowAppKitSignalLab()
         case "debug.workspace_todo.checklist_add_field":
             return debugWorkspaceTodoChecklistAddField()
         case "debug.pro_welcome_checklist.show":
@@ -221,6 +223,14 @@ extension ControlCommandCoordinator {
             return .err(code: "unavailable", message: "Control context unavailable", data: nil)
         }
         debugContext.controlDebugShowProWelcomeChecklist()
+        return .ok(.object(["shown": .bool(true)]))
+    }
+
+    /// `debug.appkit_signal_lab.show` — present the AppKit-only signals experiment.
+    func debugShowAppKitSignalLab() -> ControlCallResult {
+        guard debugContext?.controlDebugShowAppKitSignalLab() == true else {
+            return .err(code: "unavailable", message: "AppKit Signals Lab unavailable", data: nil)
+        }
         return .ok(.object(["shown": .bool(true)]))
     }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug2.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+Debug2.swift
@@ -407,11 +407,15 @@ extension ControlCommandCoordinator {
 
     // MARK: - debug.window.screenshot
 
-    /// `debug.window.screenshot` — capture a window screenshot (shared v1
-    /// body; the coordinator parses its 2-field response line).
+    /// `debug.window.screenshot` — capture a window screenshot, optionally
+    /// targeting an auxiliary window by its AppKit identifier.
     func debugScreenshot(_ params: [String: JSONValue]) -> ControlCallResult {
         let label = string(params, "label") ?? ""
-        let resp = debugContext?.controlDebugCaptureScreenshot(label: label)
+        let windowIdentifier = string(params, "window_identifier")
+        let resp = debugContext?.controlDebugCaptureScreenshot(
+            label: label,
+            windowIdentifier: windowIdentifier
+        )
             ?? Self.debugContextUnavailableResponse
         guard resp.hasPrefix("OK ") else {
             return .err(code: "internal_error", message: resp, data: nil)

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+DebugV1.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlCommandCoordinator+DebugV1.swift
@@ -81,7 +81,10 @@ extension ControlCommandCoordinator {
             return debugContext?.controlDebugPanelSnapshotReset(surfaceArgument: args)
                 ?? Self.debugContextUnavailableResponse
         case "screenshot":
-            return debugContext?.controlDebugCaptureScreenshot(label: args)
+            return debugContext?.controlDebugCaptureScreenshot(
+                label: args,
+                windowIdentifier: nil
+            )
                 ?? Self.debugContextUnavailableResponse
         default:
             return nil

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Debug/ControlDebugContext.swift
@@ -68,6 +68,10 @@ public protocol ControlDebugContext: AnyObject {
     /// `debug.pro_welcome_checklist.show`.
     func controlDebugShowProWelcomeChecklist()
 
+    /// Shows the native AppKit signals experiment for
+    /// `debug.appkit_signal_lab.show`.
+    func controlDebugShowAppKitSignalLab() -> Bool
+
     /// Runs the shared v1 `is_terminal_focused` body for
     /// `debug.terminal.is_focused`.
     ///
@@ -149,9 +153,12 @@ public protocol ControlDebugContext: AnyObject {
 
     /// Runs the shared v1 `screenshot` body for `debug.window.screenshot`.
     ///
-    /// - Parameter label: The optional screenshot label (may be empty).
+    /// - Parameters:
+    ///   - label: The optional screenshot label (may be empty).
+    ///   - windowIdentifier: An optional `NSWindow.identifier` raw value used
+    ///     to target an auxiliary window instead of the current key window.
     /// - Returns: The raw v1 response (`"OK <id> <path>"` or an `ERROR:` line).
-    func controlDebugCaptureScreenshot(label: String) -> String
+    func controlDebugCaptureScreenshot(label: String, windowIdentifier: String?) -> String
 
     /// Shows the canvas Command+scroll discovery hint for
     /// `debug.canvas.command_scroll_hint`.

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandContextTestStubs+Debug.swift
@@ -16,6 +16,7 @@ extension ControlDebugContext {
     func controlDebugActivateApp() -> String { "ERROR: not implemented" }
     func controlDebugRequestWorkspaceTodoChecklistAddField() -> UUID? { nil }
     func controlDebugShowProWelcomeChecklist() {}
+    func controlDebugShowAppKitSignalLab() -> Bool { false }
     func controlDebugIsTerminalFocused(surfaceArgument: String) -> String { "ERROR: not implemented" }
     func controlDebugReadTerminalText(surfaceArgument: String) -> String { "ERROR: not implemented" }
     func controlDebugRenderStats(surfaceArgument: String) -> String { "ERROR: not implemented" }
@@ -29,7 +30,9 @@ extension ControlDebugContext {
     func controlDebugResetFlashCounts() -> String { "ERROR: not implemented" }
     func controlDebugPanelSnapshot(arguments: String) -> String { "ERROR: not implemented" }
     func controlDebugPanelSnapshotReset(surfaceArgument: String) -> String { "ERROR: not implemented" }
-    func controlDebugCaptureScreenshot(label: String) -> String { "ERROR: not implemented" }
+    func controlDebugCaptureScreenshot(label: String, windowIdentifier: String?) -> String {
+        "ERROR: not implemented"
+    }
     func controlDebugShowCanvasCommandScrollHint(
         routing: ControlRoutingSelectors
     ) -> ControlCanvasActionResolution { .tabManagerUnavailable }

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorDebugV1Tests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorDebugV1Tests.swift
@@ -16,6 +16,9 @@ private final class FakeDebugV1ControlCommandContext: ControlCommandContext {
     var rightSidebarFocusFirstItem: Bool?
     var rightSidebarResolution: ControlDebugRightSidebarFocusResolution = .windowNotFound
     var remoteTmuxSizingPayload: JSONValue?
+    var appKitSignalLabAvailable = true
+    var screenshotLabel: String?
+    var screenshotWindowIdentifier: String?
 
     func controlDebugSetShortcut(arguments: String) -> String {
         setShortcutArguments = arguments
@@ -34,6 +37,16 @@ private final class FakeDebugV1ControlCommandContext: ControlCommandContext {
 
     func controlDebugRemoteTmuxSizingSettled() -> JSONValue? {
         remoteTmuxSizingPayload
+    }
+
+    func controlDebugShowAppKitSignalLab() -> Bool {
+        appKitSignalLabAvailable
+    }
+
+    func controlDebugCaptureScreenshot(label: String, windowIdentifier: String?) -> String {
+        screenshotLabel = label
+        screenshotWindowIdentifier = windowIdentifier
+        return "OK capture-1 /tmp/capture.png"
     }
 }
 
@@ -64,6 +77,39 @@ struct ControlCommandCoordinatorDebugV1Tests {
         let (coordinator, _) = makeCoordinator()
         #expect(coordinator.handleDebugV1(command: "ping", args: "") == nil)
         #expect(coordinator.handleDebugV1(command: "simulate_type", args: "hi") == nil)
+    }
+
+    @Test func appKitSignalLabShowRoutesThroughDebugSeam() {
+        let (coordinator, context) = makeCoordinator()
+        let request = ControlRequest(
+            id: .int(1), method: "debug.appkit_signal_lab.show", params: [:]
+        )
+        #expect(coordinator.handle(request) == .ok(.object(["shown": .bool(true)])))
+
+        context.appKitSignalLabAvailable = false
+        #expect(coordinator.handle(request) == .err(
+            code: "unavailable",
+            message: "AppKit Signals Lab unavailable",
+            data: nil
+        ))
+    }
+
+    @Test func screenshotForwardsAuxiliaryWindowIdentifier() {
+        let (coordinator, context) = makeCoordinator()
+        let request = ControlRequest(
+            id: .int(1),
+            method: "debug.window.screenshot",
+            params: [
+                "label": .string("signals-lab"),
+                "window_identifier": .string("cmux.appKitSignalsLab"),
+            ]
+        )
+        #expect(coordinator.handle(request) == .ok(.object([
+            "screenshot_id": .string("capture-1"),
+            "path": .string("/tmp/capture.png"),
+        ])))
+        #expect(context.screenshotLabel == "signals-lab")
+        #expect(context.screenshotWindowIdentifier == "cmux.appKitSignalsLab")
     }
 
     @Test func remoteTmuxSizingSettlementUsesMainActorDebugSeam() {

--- a/Sources/TerminalController+ControlDebugContext.swift
+++ b/Sources/TerminalController+ControlDebugContext.swift
@@ -84,6 +84,12 @@ extension TerminalController: ControlDebugContext {
         ProWelcomeChecklistPresenter.present()
     }
 
+    func controlDebugShowAppKitSignalLab() -> Bool {
+        guard let coordinator = AppDelegate.shared?.debugWindowsCoordinator else { return false }
+        coordinator.showAppKitSignalLabWindow()
+        return true
+    }
+
     func controlDebugIsTerminalFocused(surfaceArgument: String) -> String {
         isTerminalFocused(surfaceArgument)
     }
@@ -120,7 +126,9 @@ extension TerminalController: ControlDebugContext {
         panelSnapshotReset(surfaceArgument)
     }
 
-    func controlDebugCaptureScreenshot(label: String) -> String { captureScreenshot(label) }
+    func controlDebugCaptureScreenshot(label: String, windowIdentifier: String?) -> String {
+        captureScreenshot(label: label, windowIdentifier: windowIdentifier)
+    }
 
     func controlDebugShowCanvasCommandScrollHint(
         routing: ControlRoutingSelectors

--- a/Sources/TerminalController+DebugMethodNames.swift
+++ b/Sources/TerminalController+DebugMethodNames.swift
@@ -11,6 +11,7 @@ extension TerminalController {
         "debug.textbox.inline_fixture",
         "debug.textbox.interact",
         "debug.app.activate",
+        "debug.appkit_signal_lab.show",
         "debug.workspace_todo.checklist_add_field",
         "debug.pro_welcome_checklist.show",
         "debug.command_palette.toggle",

--- a/Sources/TerminalController.swift
+++ b/Sources/TerminalController.swift
@@ -12807,8 +12807,11 @@ class TerminalController {
     }
 
     func captureScreenshot(_ args: String) -> String {
-        // Parse optional label from args
         let label = args.trimmingCharacters(in: .whitespacesAndNewlines)
+        return captureScreenshot(label: label, windowIdentifier: nil)
+    }
+
+    func captureScreenshot(label: String, windowIdentifier: String?) -> String {
 
         // Generate unique ID for this screenshot
         let timestamp = ISO8601DateFormatter().string(from: Date())
@@ -12825,7 +12828,7 @@ class TerminalController {
         let filename = label.isEmpty ? "\(screenshotId).png" : "\(label)_\(screenshotId).png"
         let outputPath = outputDir.appendingPathComponent(filename)
 
-        // Capture the main window on main thread
+        // Capture the requested or foreground window on the main thread.
         var captureError: String?
         v2MainSync {
             let candidateWindows = NSApp.windows.filter { window in
@@ -12834,10 +12837,13 @@ class TerminalController {
                 window.contentView != nil &&
                 !window.frame.isEmpty
             }
+            let explicitlyTargetedWindow = windowIdentifier.flatMap { identifier in
+                candidateWindows.first { $0.identifier?.rawValue == identifier }
+            }
             let preferredWindow = [NSApp.keyWindow, NSApp.mainWindow]
                 .compactMap { $0 }
                 .first { candidateWindows.contains($0) }
-            let window = preferredWindow ?? candidateWindows.max { lhs, rhs in
+            let window = explicitlyTargetedWindow ?? preferredWindow ?? candidateWindows.max { lhs, rhs in
                 (lhs.frame.width * lhs.frame.height) < (rhs.frame.width * rhs.frame.height)
             } ?? NSApp.mainWindow ?? NSApp.windows.first
 

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -613,6 +613,14 @@ struct cmuxApp: App {
                     }
                     Button(
                         String(
+                            localized: "debug.menu.appKitSignalLab",
+                            defaultValue: "AppKit Signals Lab…"
+                        )
+                    ) {
+                        AppDelegate.shared?.debugWindowsCoordinator.showAppKitSignalLabWindow()
+                    }
+                    Button(
+                        String(
                             localized: "debug.menu.titlebarLayoutDebug",
                             defaultValue: "Titlebar Layout Debug..."
                         )

--- a/Sources/cmuxApp.swift
+++ b/Sources/cmuxApp.swift
@@ -614,7 +614,7 @@ struct cmuxApp: App {
                     Button(
                         String(
                             localized: "debug.menu.appKitSignalLab",
-                            defaultValue: "AppKit Signals Lab…"
+                            defaultValue: "Signal Todo List…"
                         )
                     ) {
                         AppDelegate.shared?.debugWindowsCoordinator.showAppKitSignalLabWindow()


### PR DESCRIPTION
Implements a DEBUG-only native AppKit experiment based on Solid’s signal model: https://docs.solidjs.com/concepts/signals

The new main-actor signal graph provides writable signals, cached memos, effects with cleanup, equality suppression, dynamic dependency replacement, and batched propagation. A three-pane operations dashboard exercises the graph through filters, search, metrics, task selection, controls, a pulse chart, and an activity feed. The experiment contains no SwiftUI, Observation, or Combine dependencies.

Adds a Debug menu entry and `debug.appkit_signal_lab.show` command. `debug.window.screenshot` now accepts `window_identifier` so auxiliary AppKit windows can be captured directly.

Verification:
- `swift test --package-path Packages/macOS/CmuxAppKitSupportUI --filter SignalGraphTests`
- `swift test --package-path Packages/macOS/CmuxControlSocket`
- Tagged cloud build `siglab`
- Opened the lab through its debug command, captured its window, and exercised the simulation button through Accessibility

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8388"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786927703&installation_id=133855650&pr_number=8388&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8388&signature=1e5ae7fe00d98ed4c0bd3798b633bbc4176706458e6665742a7a74d986c0bea5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a DEBUG-only AppKit Signals Lab as a native “Signal Todo List” driven by a main-actor reactive graph (Solid-style signals) for fine-grained UI updates. Adds a debug menu item, `debug.appkit_signal_lab.show`, and targeted window screenshots via `debug.window.screenshot`.

- **New Features**
  - Reactive core: writable signals, cached memos, effects with cleanup, dynamic dependency tracking, equality suppression, and batched propagation (tests included).
  - Lab UI: AppKit window with a three-pane todo dashboard (filters/search, work list table, inspector with progress/priority/capacity/automation), pulse chart, and activity feed; localized in EN/JA.
  - Debug integration: `DebugWindowsCoordinator.showAppKitSignalLabWindow()` and localized “Signal Todo List…” menu entry; control command `debug.appkit_signal_lab.show`; `debug.window.screenshot` accepts `window_identifier` to capture auxiliary windows.
  - Tests: `SignalGraphTests`, `AppKitSignalLabModelTests`, and coordinator tests for command routing and screenshot targeting.

<sup>Written for commit cd43859cc306a077e9b5687085be028814bc6158. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8388?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an AppKit “Signal Todo List” (Signals Lab) debug window with searchable task list, status filtering, live metrics, task inspection, and progress/control actions.
  * Added a Debug menu item and a corresponding debug command to open the Signals Lab.
* **Debugging**
  * Screenshot debugging can now target an optional auxiliary window.
* **Tests**
  * Added/expanded test coverage for the Signals Lab model, reactive update behavior (including batching and cleanup), debug command routing for opening the lab, and targeted screenshot handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->