### PR TITLE
chore(web): apply weekly SEO and AEO research

### DIFF
--- a/web/app/[locale]/(landing)/wall-of-love/page.tsx
+++ b/web/app/[locale]/(landing)/wall-of-love/page.tsx
@@ -1,6 +1,7 @@
 import { useTranslations, useLocale } from "next-intl";
 import { getTranslations } from "next-intl/server";
-import { buildAlternates, openGraphDefaults, seoDescription, twitterSummary } from "@/i18n/seo";
+import { buildAlternates, openGraphDefaults, twitterSummary } from "@/i18n/seo";
+import { wallOfLoveSeoCopy } from "@/i18n/audited-seo";
 import { SiteHeader } from "@/app/[locale]/components/site-header";
 import {
   testimonials,
@@ -13,8 +14,7 @@ export async function generateMetadata({ params }: { params: Promise<{ locale: s
   const { locale } = await params;
   const t = await getTranslations({ locale, namespace: "wallOfLove" });
   const alternates = buildAlternates(locale, "/wall-of-love");
-  const title = t("metaTitle");
-  const description = seoDescription(locale, t("metaDescription"));
+  const { title, description } = wallOfLoveSeoCopy(locale, t);
   return {
     title,
     description,

--- a/web/i18n/audited-seo.ts
+++ b/web/i18n/audited-seo.ts
@@ -258,6 +258,20 @@ export function assetsSeoCopy(
   };
 }
 
+export function wallOfLoveSeoCopy(
+  locale: string,
+  t: SeoMessageLookup,
+) {
+  const title = locale === "en" ? t("metaTitle") : `${t("title")} — cmux`;
+  const description =
+    locale === "en" ? t("metaDescription") : t("description");
+
+  return {
+    title: seoTitle(locale, title, { minLength: 0 }),
+    description: seoDescription(locale, description),
+  };
+}
+
 export function blogIndexSeoCopy(
   locale: string,
   t: SeoMessageLookup,

--- a/web/tests/seo.test.ts
+++ b/web/tests/seo.test.ts
@@ -34,6 +34,7 @@ import {
   landingPageSeoCopy,
   ohMyPiSeoCopy,
   pricingSeoCopy,
+  wallOfLoveSeoCopy,
 } from "../i18n/audited-seo";
 import { englishFallbackContentLocales } from "../i18n/locale-availability";
 import { locales } from "../i18n/routing";
@@ -227,6 +228,37 @@ describe("SEO metadata helpers", () => {
       expect(detailedDescription).not.toContain("…");
       expect(searchSnippetLength(standardDescription)).toBeLessThanOrEqual(160);
       expect(detailedLength).toBeLessThanOrEqual(160);
+    }
+  });
+
+  test("builds Wall of Love metadata from authored copy in every locale", async () => {
+    const englishMessages = await messagesFor("en");
+
+    for (const locale of locales) {
+      const messages = await messagesFor(locale);
+      const copy = wallOfLoveSeoCopy(
+        locale,
+        messageLookup(messages.wallOfLove),
+      );
+      const expectedTitle =
+        locale === "en"
+          ? englishMessages.wallOfLove.metaTitle
+          : messages.wallOfLove.title;
+      const expectedDescription =
+        locale === "en"
+          ? englishMessages.wallOfLove.metaDescription
+          : messages.wallOfLove.description;
+
+      expect(copy.title).toContain(expectedTitle);
+      expect(copy.description).toStartWith(expectedDescription);
+      expect(searchSnippetLength(copy.title)).toBeLessThanOrEqual(60);
+      expect(searchSnippetLength(copy.description)).toBeLessThanOrEqual(160);
+
+      if (locale !== "en") {
+        expect(copy.description).not.toContain(
+          englishMessages.wallOfLove.metaDescription,
+        );
+      }
     }
   });
 


### PR DESCRIPTION
Automated weekly SEO and AEO research from cmuxterm-hq.

Codex researched current primary sources, audited the existing cmux web implementation, applied one scoped improvement, and passed the web typecheck and test suite.

Run: https://github.com/manaflow-ai/cmuxterm-hq/actions/runs/29641110288

## Codex report

STATUS: changed

Opportunity: 18 of 20 live `/wall-of-love` locale routes emitted English metadata despite localized page copy. This can weaken locale relevance and produce mismatched search titles/snippets.

Mechanism: metadata, Open Graph, and Twitter fields now use each locale’s authored title and description through the existing bounded SEO helpers. Canonicals and hreflang remain unchanged; no visible copy or catalogs changed.

Tests and validation:

- Added coverage iterating all 20 locales from `web/i18n/routing.ts`.
- Asserted localized descriptions never inherit English metadata and titles/descriptions remain within snippet bounds.
- `bun test tests/seo.test.ts`: 34 passed.
- Web typecheck and targeted ESLint passed.
- Parsed all 20 locale catalogs; `git diff --check` passed.
- Three files changed, all under `web/`.

Primary sources accessed 2026-07-18:

- https://developers.google.com/search/docs/appearance/title-link
- https://developers.google.com/search/docs/appearance/snippet
- https://developers.google.com/search/docs/specialty/international/localized-versions
- https://www.bing.com/webmasters/help/sitemaps-3b5cf6ed
- https://schema.org/WebPage
- https://developers.openai.com/api/docs/bots
- https://docs.perplexity.ai/docs/resources/perplexity-crawlers
- https://support.claude.com/en/articles/8896518-does-anthropic-crawl-data-from-the-web-and-how-can-site-owners-block-the-crawler

Residual risk: search engines may independently rewrite titles or snippets; no implementation-specific risk was identified.
