### PR TITLE
Refine design mode annotations and context pill removal

### DIFF
--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCapture.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCapture.swift
@@ -1,0 +1,35 @@
+/// Derives a context-rich annotation capture rectangle from freehand stroke bounds.
+public nonisolated struct BrowserDesignModeAnnotationCapture: Equatable, Sendable {
+    /// The number of CSS viewport points added around every side of a stroke.
+    public let contextPadding: Double
+
+    /// Creates annotation capture geometry with a caller-selected padding.
+    /// - Parameter contextPadding: Context added to each edge before viewport clamping.
+    public init(contextPadding: Double) {
+        self.contextPadding = max(0, contextPadding)
+    }
+
+    /// Expands stroke bounds and clamps the result to the visible viewport.
+    /// - Parameters:
+    ///   - strokeBounds: The freehand stroke's bounds in CSS viewport points.
+    ///   - viewport: The viewport associated with the stroke.
+    /// - Returns: A nonnegative context rectangle contained by `viewport`.
+    public func contextRect(
+        around strokeBounds: BrowserDesignModeRect,
+        in viewport: BrowserDesignModeViewport
+    ) -> BrowserDesignModeRect {
+        guard viewport.width > 0, viewport.height > 0 else {
+            return BrowserDesignModeRect(x: 0, y: 0, width: 0, height: 0)
+        }
+        let minX = max(0, min(viewport.width, strokeBounds.x - contextPadding))
+        let minY = max(0, min(viewport.height, strokeBounds.y - contextPadding))
+        let maxX = max(minX, min(viewport.width, strokeBounds.x + max(0, strokeBounds.width) + contextPadding))
+        let maxY = max(minY, min(viewport.height, strokeBounds.y + max(0, strokeBounds.height) + contextPadding))
+        return BrowserDesignModeRect(
+            x: minX,
+            y: minY,
+            width: maxX - minX,
+            height: maxY - minY
+        )
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCaptureRequest.swift
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/DesignMode/BrowserDesignModeAnnotationCaptureRequest.swift
@@ -1,0 +1,42 @@
+/// A page-runtime request to turn one completed freehand stroke into a snapshot card.
+public nonisolated struct BrowserDesignModeAnnotationCaptureRequest: Codable, Equatable, Sendable {
+    /// Stable identity for the stroke and its eventual context selection.
+    public let id: String
+    /// The stroke bounds in CSS viewport points at the reported scroll position.
+    public let strokeBounds: BrowserDesignModeRect
+    /// The viewport associated with ``strokeBounds``.
+    public let viewport: BrowserDesignModeViewport
+    /// Horizontal page scroll in CSS points when the descriptor was produced.
+    public let scrollX: Double
+    /// Vertical page scroll in CSS points when the descriptor was produced.
+    public let scrollY: Double
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case strokeBounds = "stroke_bounds"
+        case viewport
+        case scrollX = "scroll_x"
+        case scrollY = "scroll_y"
+    }
+
+    /// Creates an annotation capture request.
+    /// - Parameters:
+    ///   - id: Stable stroke identity.
+    ///   - strokeBounds: Stroke bounds in CSS viewport points.
+    ///   - viewport: Visible page viewport.
+    ///   - scrollX: Horizontal page scroll.
+    ///   - scrollY: Vertical page scroll.
+    public init(
+        id: String,
+        strokeBounds: BrowserDesignModeRect,
+        viewport: BrowserDesignModeViewport,
+        scrollX: Double,
+        scrollY: Double
+    ) {
+        self.id = id
+        self.strokeBounds = strokeBounds
+        self.viewport = viewport
+        self.scrollX = scrollX
+        self.scrollY = scrollY
+    }
+}

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
@@ -45,6 +45,7 @@
   let selectedIdentity = null;
   let activeReference = null;
   let hoveredElement = null;
+  let hoveredSelectionIndex = null;
   let overlayHost = null;
   let overlay = null;
   let observer = null;
@@ -1077,7 +1078,7 @@
       position: "fixed",
       pointerEvents: "none",
       boxSizing: "border-box",
-      border: "2px solid rgba(72, 72, 74, 0.82)",
+      border: "1.5px dashed rgb(10, 132, 255)",
       borderRadius: "14px",
       backgroundColor: "white",
       backgroundPosition: "center",
@@ -1105,7 +1106,11 @@
         continue;
       }
       // The selection's lifetime color, matching its composer pill.
-      outline.style.borderColor = selectionColor(reference.colorIndex || 0);
+      const tint = selectionColor(reference.colorIndex || 0);
+      outline.style.borderColor = tint;
+      const isHovered = hoveredSelectionIndex === index;
+      outline.style.background = isHovered ? colorWithAlpha(tint, 0.13) : "transparent";
+      outline.style.boxShadow = isHovered ? `0 0 0 4px ${colorWithAlpha(tint, 0.55)}` : "none";
       place(outline, element.getBoundingClientRect());
     }
     refreshRegionOutlines();
@@ -1125,6 +1130,12 @@
         outline.style.display = "none";
         continue;
       }
+      const tint = selectionColor(region.colorIndex || 0);
+      const isHovered = hoveredSelectionIndex === selectedReferences.length + index;
+      outline.style.borderColor = tint;
+      outline.style.boxShadow = isHovered
+        ? `0 0 0 4px ${colorWithAlpha(tint, 0.55)}, 0 8px 24px rgba(0, 0, 0, 0.18)`
+        : "0 8px 24px rgba(0, 0, 0, 0.18)";
       outline.style.backgroundImage = `url("${region.imageURL}")`;
       place(outline, {
         x: region.pageX - (globalThis.scrollX || 0),
@@ -1421,6 +1432,7 @@
     // instead of restarting at blue.
     setActiveReference(null);
     hoveredElement = null;
+    hoveredSelectionIndex = null;
     selectionIdentityNeedsRefresh = false;
     selectionRecoveryAttemptsRemaining = 0;
     captureSelectionValid = true;
@@ -1436,6 +1448,7 @@
     if (Number.isInteger(index) && index >= selectedReferences.length
         && index < selectedReferences.length + regionReferences.length) {
       regionReferences.splice(index - selectedReferences.length, 1);
+      hoveredSelectionIndex = null;
       revision += 1;
       scheduleOverlayRefresh();
       return emit();
@@ -1446,6 +1459,7 @@
     const reference = selectedReferences[index];
     if (reference === activeReference && edits.size) restoreAll();
     selectedReferences.splice(index, 1);
+    hoveredSelectionIndex = null;
     if (reference === activeReference) {
       setActiveReference(selectedReferences[selectedReferences.length - 1]);
       selectionIdentityNeedsRefresh = false;
@@ -1455,6 +1469,18 @@
     revision += 1;
     scheduleOverlayRefresh();
     return emit();
+  };
+
+  const selectionIndex = (selection) => {
+    if (typeof selection !== "string") return Number(selection);
+    const elementIndex = selectedReferences.findIndex(
+      (reference) => reference.baseline?.selector === selection,
+    );
+    if (elementIndex >= 0) return elementIndex;
+    const regionIndex = regionReferences.findIndex(
+      (region) => regionSnapshotFor(region).selector === selection,
+    );
+    return regionIndex >= 0 ? selectedReferences.length + regionIndex : -1;
   };
 
   const selectElement = (element, stack = false) => {
@@ -1525,11 +1551,22 @@
       }
       return;
     }
-    if (pendingPointer && interactionMode === "draw") {
+    if (pendingPointer) {
       const dx = event.clientX - pendingPointer.x;
       const dy = event.clientY - pendingPointer.y;
       if (marqueeActive || Math.hypot(dx, dy) > marqueeThresholdPixels) {
-        if (!marqueeActive) marqueePoints = [{ x: pendingPointer.x, y: pendingPointer.y }];
+        if (!marqueeActive) {
+          if (!pendingPointer.annotationID) {
+            interactionMode = "draw";
+            pendingPointer.annotationID = String(++annotationSequence);
+            annotationPhase = "drawing";
+            try { handler?.postMessage({ type: "interaction_mode_changed", mode: "draw" }); } catch (_) {}
+            try {
+              handler?.postMessage({ type: "annotation_drawing", id: pendingPointer.annotationID });
+            } catch (_) {}
+          }
+          marqueePoints = [{ x: pendingPointer.x, y: pendingPointer.y }];
+        }
         marqueeActive = true;
         hoveredElement = null;
         marqueePoints.push({ x: event.clientX, y: event.clientY });
@@ -1829,6 +1866,7 @@
       selectionRecoveryAttemptsRemaining = 0;
       cancelSelectionRecovery();
       hoveredElement = null;
+      hoveredSelectionIndex = null;
       overlayHost?.remove();
       overlayHost = null;
       overlay = null;
@@ -1902,6 +1940,17 @@
       return snapshot();
     },
 
+    setSelectionHover(selection) {
+      const position = selection == null ? null : selectionIndex(selection);
+      const selectionCount = selectedReferences.length + regionReferences.length;
+      hoveredSelectionIndex = Number.isInteger(position) && position >= 0 && position < selectionCount
+        ? position
+        : null;
+      hoveredElement = null;
+      refreshOverlay();
+      return snapshot();
+    },
+
     setMode(value) {
       const mode = value === "draw" ? "draw" : "select";
       if (mode !== interactionMode) {
@@ -1911,6 +1960,7 @@
         marqueeActive = false;
         marqueePoints = [];
         hoveredElement = null;
+        hoveredSelectionIndex = null;
         if (overlay) {
           overlay.marqueeBox.style.display = "none";
           overlay.strokeSvg.style.display = "none";
@@ -1929,8 +1979,8 @@
 
     composerState,
 
-    removeSelection(index) {
-      return removeSelectionAt(Number(index));
+    removeSelection(selection) {
+      return removeSelectionAt(selectionIndex(selection));
     },
 
     applyStyle(property, value) {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
@@ -93,12 +93,15 @@
     return (0.299 * r + 0.587 * g + 0.114 * b) / 255 > 0.62 ? "rgba(0, 0, 0, 0.88)" : "white";
   };
 
-  // Marquee region captures: page-anchored rects drawn by dragging.
+  // Captured annotation cards: one immutable context artifact per stroke.
   const regionReferences = [];
   const marqueeThresholdPixels = 5;
   let pendingPointer = null;
   let marqueeActive = false;
   let marqueePoints = [];
+  let annotationSequence = 0;
+  let pendingAnnotation = null;
+  let annotationPhase = "idle";
   let suppressClicksUntil = 0;
   // Exclusive interaction modes: "select" picks elements, "draw" captures
   // freehand regions. Never both at once.
@@ -624,13 +627,13 @@
     };
   };
 
-  // Region snapshots translate page-anchored rects to current viewport
-  // coordinates so capture crops stay correct after scrolling.
+  // Annotation snapshots translate page-anchored cards to current viewport
+  // coordinates while keeping a stable identity across scrolling.
   const regionSnapshotFor = (region) => {
     const x = region.pageX - (globalThis.scrollX || 0);
     const y = region.pageY - (globalThis.scrollY || 0);
     return {
-      selector: `@region(${Math.round(x)},${Math.round(y)},${Math.round(region.width)},${Math.round(region.height)})`,
+      selector: `@annotation(${region.id})`,
       selectors: [],
       xpath: "",
       tag_name: "region",
@@ -1007,8 +1010,8 @@
       background: "rgba(10, 132, 255, 0.07)",
     });
 
-    // Freehand pen stroke rendered while dragging a capture region,
-    // Cursor-style; the region is the stroke's bounding box.
+    // Freehand ink is the only visible feedback until native capture returns
+    // the context-rich composited card.
     const svgNS = "http://www.w3.org/2000/svg";
     const strokeSvg = document.createElementNS(svgNS, "svg");
     Object.assign(strokeSvg.style, {
@@ -1067,6 +1070,25 @@
     return element;
   };
 
+  const annotationCard = () => {
+    const element = document.createElement("div");
+    Object.assign(element.style, {
+      display: "none",
+      position: "fixed",
+      pointerEvents: "none",
+      boxSizing: "border-box",
+      border: "2px solid rgba(72, 72, 74, 0.82)",
+      borderRadius: "14px",
+      backgroundColor: "white",
+      backgroundPosition: "center",
+      backgroundRepeat: "no-repeat",
+      backgroundSize: "100% 100%",
+      boxShadow: "0 8px 24px rgba(0, 0, 0, 0.18)",
+      overflow: "hidden",
+    });
+    return element;
+  };
+
   const refreshSelectedOutlines = () => {
     if (!overlay) return;
     while (overlay.selectionOutlines.length < selectedReferences.length) {
@@ -1092,9 +1114,7 @@
   const refreshRegionOutlines = () => {
     if (!overlay) return;
     while (overlay.regionOutlines.length < regionReferences.length) {
-      const outline = selectedOutline();
-      outline.style.borderStyle = "dashed";
-      outline.style.borderWidth = "1.5px";
+      const outline = annotationCard();
       overlay.regionOutlines.push(outline);
       overlay.selectionLayer.append(outline);
     }
@@ -1105,7 +1125,7 @@
         outline.style.display = "none";
         continue;
       }
-      outline.style.borderColor = selectionColor(region.colorIndex || 0);
+      outline.style.backgroundImage = `url("${region.imageURL}")`;
       place(outline, {
         x: region.pageX - (globalThis.scrollX || 0),
         y: region.pageY - (globalThis.scrollY || 0),
@@ -1113,6 +1133,33 @@
         height: region.height,
       });
     }
+  };
+
+  const annotationInkPoints = () => {
+    if (!pendingAnnotation) return marqueePoints;
+    const scrollX = globalThis.scrollX || 0;
+    const scrollY = globalThis.scrollY || 0;
+    return pendingAnnotation.pagePoints.map((point) => ({
+      x: point.x - scrollX,
+      y: point.y - scrollY,
+    }));
+  };
+
+  const showAnnotationInkOnly = () => {
+    createOverlay();
+    if (!overlay) return;
+    for (const name of ["margin", "border", "padding", "content", "badge", "marqueeBox"]) {
+      overlay[name].style.display = "none";
+    }
+    for (const outline of overlay.selectionOutlines) outline.style.display = "none";
+    for (const outline of overlay.regionOutlines) outline.style.display = "none";
+    const points = annotationInkPoints();
+    overlay.strokePath.setAttribute(
+      "points",
+      points.map((point) => `${point.x},${point.y}`).join(" "),
+    );
+    overlay.strokeSvg.style.display = points.length > 1 ? "block" : "none";
+    overlay.shield.style.display = enabled ? "block" : "none";
   };
 
   const displaySelectorFor = (element) => {
@@ -1133,6 +1180,7 @@
     hovered_selector: displaySelectorFor(hoveredElement),
     can_copy: Boolean(selectedReferences.length && selectedBaseline) || regionReferences.length > 0,
     focused: false,
+    annotation_phase: annotationPhase,
   });
 
   const refreshOverlay = () => {
@@ -1142,6 +1190,10 @@
       return;
     }
     createOverlay();
+    if (["drawing", "ink_only", "capturing"].includes(annotationPhase)) {
+      showAnnotationInkOnly();
+      return;
+    }
     if (hoveredElement && !hoveredElement.isConnected) hoveredElement = null;
     const selected = resolveSelectedElement();
     refreshSelectedOutlines();
@@ -1338,7 +1390,27 @@
     if (touchesSelection) scheduleMutationRefresh();
   };
 
+  const resetPendingAnnotation = (notifyNative) => {
+    const id = pendingAnnotation?.id || pendingPointer?.annotationID || null;
+    pendingAnnotation = null;
+    pendingPointer = null;
+    marqueeActive = false;
+    marqueePoints = [];
+    annotationPhase = "idle";
+    if (overlay) {
+      overlay.marqueeBox.style.display = "none";
+      overlay.strokeSvg.style.display = "none";
+      overlay.strokePath.setAttribute("points", "");
+    }
+    if (notifyNative && id) {
+      try { handler?.postMessage({ type: "annotation_cancelled", id }); } catch (_) {}
+    }
+    scheduleOverlayRefresh();
+    return id;
+  };
+
   const clearSelection = () => {
+    resetPendingAnnotation(true);
     if (!selectedReferences.length && !regionReferences.length) return snapshot();
     restoreAll();
     selectedReferences.length = 0;
@@ -1386,6 +1458,7 @@
 
   const selectElement = (element, stack = false) => {
     if (!element || element === overlayHost || overlayHost?.contains(element)) return snapshot();
+    annotationPhase = "idle";
     cancelSelectionRecovery();
     cancelMutationEmission();
     const elementIndex = selectedReferences.findIndex((reference) => reference.element === element);
@@ -1431,7 +1504,7 @@
   };
 
   const onPointerMove = (event) => {
-    if (!enabled || captureHidden) return;
+    if (!enabled || captureHidden || pendingAnnotation) return;
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
@@ -1472,9 +1545,9 @@
 
   // The captured region is the bounding box of the whole freehand stroke,
   // not just its endpoints, so circling or scribbling over an area crops it.
-  const marqueeBounds = () => {
+  const boundsForPoints = (points) => {
     let minX = Infinity; let minY = Infinity; let maxX = -Infinity; let maxY = -Infinity;
-    for (const point of marqueePoints) {
+    for (const point of points) {
       minX = Math.min(minX, point.x);
       minY = Math.min(minY, point.y);
       maxX = Math.max(maxX, point.x);
@@ -1484,6 +1557,25 @@
     return { x: minX, y: minY, width: maxX - minX, height: maxY - minY };
   };
 
+  const marqueeBounds = () => boundsForPoints(marqueePoints);
+
+  const annotationCaptureDescriptor = (id) => {
+    if (!pendingAnnotation || pendingAnnotation.id !== String(id || "")) return null;
+    const scrollX = globalThis.scrollX || 0;
+    const scrollY = globalThis.scrollY || 0;
+    const viewportPoints = pendingAnnotation.pagePoints.map((point) => ({
+      x: point.x - scrollX,
+      y: point.y - scrollY,
+    }));
+    return {
+      id: pendingAnnotation.id,
+      stroke_bounds: boundsForPoints(viewportPoints),
+      viewport: { width: globalThis.innerWidth || 0, height: globalThis.innerHeight || 0 },
+      scroll_x: scrollX,
+      scroll_y: scrollY,
+    };
+  };
+
   const updateMarqueeBox = () => {
     createOverlay();
     if (!overlay) return;
@@ -1491,13 +1583,14 @@
     overlay.marqueeBox.style.border = `1.5px dashed ${colorWithAlpha(tint, 0.85)}`;
     overlay.marqueeBox.style.background = colorWithAlpha(tint, 0.07);
     overlay.strokePath.setAttribute("stroke", tint);
-    place(overlay.marqueeBox, marqueeBounds());
+    overlay.marqueeBox.style.display = "none";
     overlay.strokePath.setAttribute(
       "points",
       marqueePoints.map((point) => `${point.x},${point.y}`).join(" "),
     );
     overlay.strokeSvg.style.display = "block";
     hideHoverFeedback();
+    showAnnotationInkOnly();
   };
 
   const hideHoverFeedback = () => {
@@ -1530,17 +1623,29 @@
   // selects the element. Real pointer sequences suppress the trailing click;
   // a standalone synthetic click still selects (fallback for tests/automation).
   const onPointerDown = (event) => {
-    if (!enabled || captureHidden) return;
+    if (!enabled || captureHidden || pendingAnnotation) return;
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
     if (event.button !== 0) return;
-    pendingPointer = { x: event.clientX, y: event.clientY, shift: event.shiftKey === true };
+    const annotationID = interactionMode === "draw" ? String(++annotationSequence) : null;
+    pendingPointer = {
+      x: event.clientX,
+      y: event.clientY,
+      shift: event.shiftKey === true,
+      annotationID,
+    };
     marqueeActive = false;
+    if (annotationID) {
+      annotationPhase = "drawing";
+      try { handler?.postMessage({ type: "annotation_drawing", id: annotationID }); } catch (_) {}
+      scheduleOverlayRefresh();
+      showAnnotationInkOnly();
+    }
   };
 
   const onPointerUp = (event) => {
-    if (!enabled || captureHidden) return;
+    if (!enabled || captureHidden || pendingAnnotation) return;
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
@@ -1552,39 +1657,57 @@
     suppressClicksUntil = (globalThis.performance?.now?.() || 0) + 500;
     if (overlay) {
       overlay.marqueeBox.style.display = "none";
-      overlay.strokeSvg.style.display = "none";
-      overlay.strokePath.setAttribute("points", "");
     }
     if (wasMarquee) {
       marqueePoints.push({ x: event.clientX, y: event.clientY });
+      updateMarqueeBox();
       const bounds = marqueeBounds();
-      marqueePoints = [];
-      finalizeRegion(bounds);
+      finalizeRegion(bounds, armed.annotationID);
       return;
     }
     // Draw mode never element-selects; a tap there is a no-op.
-    if (interactionMode === "draw") return;
+    if (interactionMode === "draw") {
+      marqueePoints = [];
+      annotationPhase = "idle";
+      if (overlay) {
+        overlay.strokeSvg.style.display = "none";
+        overlay.strokePath.setAttribute("points", "");
+      }
+      try { handler?.postMessage({ type: "annotation_cancelled", id: armed.annotationID }); } catch (_) {}
+      return;
+    }
     // Clicks always stack: every picked element becomes another prompt
     // token; tokens are removed in the composer (backspace or click-out).
     const candidate = elementUnderPoint(armed.x, armed.y);
     if (candidate) selectElement(candidate, true);
   };
 
-  const finalizeRegion = (rect) => {
-    if (rect.width < 8 || rect.height < 8) return;
-    // Draws stack like clicks: every capture becomes another prompt token
-    // and existing element/region selections persist.
-    regionReferences.push({
-      pageX: rect.x + (globalThis.scrollX || 0),
-      pageY: rect.y + (globalThis.scrollY || 0),
-      width: rect.width,
-      height: rect.height,
-      colorIndex: colorSequence++,
-    });
+  const finalizeRegion = (rect, id) => {
+    // Accept deliberate strokes in any direction, including horizontal or
+    // vertical marks whose bounding box has a zero-sized minor axis.
+    if (!id || Math.max(rect.width, rect.height) < 8) {
+      annotationPhase = "idle";
+      marqueePoints = [];
+      if (overlay) {
+        overlay.strokeSvg.style.display = "none";
+        overlay.strokePath.setAttribute("points", "");
+      }
+      try { handler?.postMessage({ type: "annotation_cancelled", id }); } catch (_) {}
+      return;
+    }
+    const scrollX = globalThis.scrollX || 0;
+    const scrollY = globalThis.scrollY || 0;
+    pendingAnnotation = {
+      id,
+      pagePoints: marqueePoints.map((point) => ({ x: point.x + scrollX, y: point.y + scrollY })),
+      colorIndex: colorSequence,
+    };
+    marqueePoints = [];
+    annotationPhase = "ink_only";
     hoveredElement = null;
-    revision += 1;
     scheduleOverlayRefresh();
-    emit();
+    const request = annotationCaptureDescriptor(id);
+    try { handler?.postMessage({ type: "annotation_capture_requested", request }); } catch (_) {}
   };
 
   const onClickFallback = (event) => {
@@ -1611,7 +1734,7 @@
     event.preventDefault();
     event.stopPropagation();
     event.stopImmediatePropagation();
-    if (selectedBaseline || regionReferences.length) {
+    if (pendingAnnotation || pendingPointer?.annotationID || selectedBaseline || regionReferences.length) {
       // First Escape resets the whole prompt: selections here, and the
       // composer clears its typed text on this message.
       clearSelection();
@@ -1698,6 +1821,8 @@
       restoreAll();
       selectedReferences.length = 0;
       regionReferences.length = 0;
+      pendingAnnotation = null;
+      annotationPhase = "idle";
       setActiveReference(null);
       selectionIdentityNeedsRefresh = false;
       selectionRecoveryAttemptsRemaining = 0;
@@ -1779,6 +1904,7 @@
     setMode(value) {
       const mode = value === "draw" ? "draw" : "select";
       if (mode !== interactionMode) {
+        resetPendingAnnotation(true);
         interactionMode = mode;
         pendingPointer = null;
         marqueeActive = false;
@@ -1860,6 +1986,71 @@
       revision += 1;
       scheduleOverlayRefresh();
       return emit();
+    },
+
+    prepareAnnotationCapture(id) {
+      const descriptor = annotationCaptureDescriptor(id);
+      if (!descriptor) return null;
+      annotationPhase = "capturing";
+      showAnnotationInkOnly();
+      // Synchronize page layout before WebKit snapshots the ink-only frame.
+      document.documentElement.getBoundingClientRect();
+      return annotationCaptureDescriptor(id);
+    },
+
+    annotationCaptureDescriptor(id) {
+      return annotationCaptureDescriptor(id);
+    },
+
+    completeAnnotationCapture(
+      id,
+      x,
+      y,
+      width,
+      height,
+      imageURL,
+      expectedScrollX,
+      expectedScrollY,
+      expectedViewportWidth,
+      expectedViewportHeight,
+    ) {
+      const descriptor = annotationCaptureDescriptor(id);
+      const values = [x, y, width, height, expectedScrollX, expectedScrollY,
+        expectedViewportWidth, expectedViewportHeight];
+      if (!descriptor || !values.every(Number.isFinite)
+          || width <= 0 || height <= 0
+          || descriptor.scroll_x !== expectedScrollX
+          || descriptor.scroll_y !== expectedScrollY
+          || descriptor.viewport.width !== expectedViewportWidth
+          || descriptor.viewport.height !== expectedViewportHeight
+          || !String(imageURL || "").startsWith("data:image/png;base64,")) {
+        return null;
+      }
+      regionReferences.push({
+        id: pendingAnnotation.id,
+        pageX: x + expectedScrollX,
+        pageY: y + expectedScrollY,
+        width,
+        height,
+        imageURL: String(imageURL),
+        colorIndex: pendingAnnotation.colorIndex,
+      });
+      colorSequence += 1;
+      pendingAnnotation = null;
+      annotationPhase = "captured";
+      if (overlay) {
+        overlay.strokeSvg.style.display = "none";
+        overlay.strokePath.setAttribute("points", "");
+      }
+      revision += 1;
+      scheduleOverlayRefresh();
+      return emit();
+    },
+
+    cancelAnnotationCapture(id) {
+      if (pendingAnnotation?.id !== String(id || "")) return snapshot();
+      resetPendingAnnotation(false);
+      return snapshot();
     },
 
     prepareCapture() {

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
@@ -1184,6 +1184,7 @@
   });
 
   const refreshOverlay = () => {
+    if (overlayFrame) cancelAnimationFrame(overlayFrame);
     overlayFrame = 0;
     if (!enabled || captureHidden) {
       hideOverlay();
@@ -2043,7 +2044,10 @@
         overlay.strokePath.setAttribute("points", "");
       }
       revision += 1;
-      scheduleOverlayRefresh();
+      // Native capture completion is the authoritative phase transition.
+      // Reconcile it directly so a frame request paused during WebKit's
+      // snapshot cannot strand the card behind an outstanding frame token.
+      refreshOverlay();
       return emit();
     },
 

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
@@ -32,6 +32,7 @@
   const maxSnippetCharacters = 2400;
   const maxSnippetNodes = 512;
   const maxSelectionRecoveryAttempts = 8;
+  const maxAnnotationReferences = 8;
   const mutationEmissionInterval = 100;
   const redactedValue = "<redacted>";
   const sensitiveNamePattern = /(?:^|[-_:])(api[-_]?key|auth|authorization|credential|csrf|password|passwd|secret|session|token)(?:$|[-_:])/i;
@@ -2086,6 +2087,13 @@
         imageURL: String(imageURL),
         colorIndex: pendingAnnotation.colorIndex,
       });
+      // Each card retains screenshot-sized encoded and decoded image data.
+      // Keep a useful multi-stroke stack while evicting the oldest card so a
+      // long drawing session has a fixed memory ceiling.
+      if (regionReferences.length > maxAnnotationReferences) {
+        regionReferences.splice(0, regionReferences.length - maxAnnotationReferences);
+        hoveredSelectionIndex = null;
+      }
       colorSequence += 1;
       pendingAnnotation = null;
       annotationPhase = "captured";

--- a/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
+++ b/Packages/macOS/CmuxBrowser/Sources/CmuxBrowser/Resources/BrowserDesignModeRuntime.js
@@ -2119,7 +2119,10 @@
     finishCapture() {
       captureHidden = false;
       captureSelectionValid = true;
-      scheduleOverlayRefresh();
+      // Restore synchronously. Native keeps a visual shield above the webview
+      // until an after-screen-updates snapshot confirms this state has painted.
+      refreshOverlay();
+      document.documentElement.getBoundingClientRect();
       return snapshot();
     },
   };

--- a/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/DesignMode/BrowserDesignModeAnnotationCaptureTests.swift
+++ b/Packages/macOS/CmuxBrowser/Tests/CmuxBrowserTests/DesignMode/BrowserDesignModeAnnotationCaptureTests.swift
@@ -1,0 +1,38 @@
+import Testing
+
+@testable import CmuxBrowser
+
+@Suite struct BrowserDesignModeAnnotationCaptureTests {
+    @Test func expandsStrokeBoundsWithComfortableContextPadding() {
+        let capture = BrowserDesignModeAnnotationCapture(contextPadding: 48)
+
+        let rect = capture.contextRect(
+            around: BrowserDesignModeRect(x: 120, y: 90, width: 240, height: 160),
+            in: BrowserDesignModeViewport(width: 800, height: 600)
+        )
+
+        #expect(rect == BrowserDesignModeRect(x: 72, y: 42, width: 336, height: 256))
+    }
+
+    @Test func clampsExpandedContextToEveryViewportEdge() {
+        let capture = BrowserDesignModeAnnotationCapture(contextPadding: 48)
+
+        let rect = capture.contextRect(
+            around: BrowserDesignModeRect(x: 12, y: 18, width: 780, height: 570),
+            in: BrowserDesignModeViewport(width: 800, height: 600)
+        )
+
+        #expect(rect == BrowserDesignModeRect(x: 0, y: 0, width: 800, height: 600))
+    }
+
+    @Test func returnsAnEmptyRectForAnInvalidViewport() {
+        let capture = BrowserDesignModeAnnotationCapture(contextPadding: 48)
+
+        let rect = capture.contextRect(
+            around: BrowserDesignModeRect(x: 10, y: 10, width: 100, height: 100),
+            in: BrowserDesignModeViewport(width: 0, height: 600)
+        )
+
+        #expect(rect == BrowserDesignModeRect(x: 0, y: 0, width: 0, height: 0))
+    }
+}

--- a/Sources/Panels/BrowserDesignModeCaptureShield.swift
+++ b/Sources/Panels/BrowserDesignModeCaptureShield.swift
@@ -1,0 +1,42 @@
+import AppKit
+import WebKit
+
+/// Keeps the visible design-mode overlays stable while WebKit captures the clean page beneath them.
+@MainActor
+final class BrowserDesignModeCaptureShield {
+    private let imageView: NSImageView
+    private let constraints: [NSLayoutConstraint]
+
+    private init(imageView: NSImageView, constraints: [NSLayoutConstraint]) {
+        self.imageView = imageView
+        self.constraints = constraints
+    }
+
+    static func install(image: NSImage, over webView: WKWebView) -> BrowserDesignModeCaptureShield? {
+        guard let container = webView.superview else { return nil }
+
+        let imageView = NSImageView()
+        imageView.translatesAutoresizingMaskIntoConstraints = false
+        imageView.image = image
+        imageView.imageAlignment = .alignCenter
+        imageView.imageFrameStyle = .none
+        imageView.imageScaling = .scaleAxesIndependently
+        imageView.isEditable = false
+        imageView.setAccessibilityElement(false)
+        container.addSubview(imageView, positioned: .above, relativeTo: webView)
+
+        let constraints = [
+            imageView.leadingAnchor.constraint(equalTo: webView.leadingAnchor),
+            imageView.trailingAnchor.constraint(equalTo: webView.trailingAnchor),
+            imageView.topAnchor.constraint(equalTo: webView.topAnchor),
+            imageView.bottomAnchor.constraint(equalTo: webView.bottomAnchor),
+        ]
+        NSLayoutConstraint.activate(constraints)
+        return BrowserDesignModeCaptureShield(imageView: imageView, constraints: constraints)
+    }
+
+    func remove() {
+        NSLayoutConstraint.deactivate(constraints)
+        imageView.removeFromSuperview()
+    }
+}

--- a/Sources/Panels/BrowserDesignModeController+Capture.swift
+++ b/Sources/Panels/BrowserDesignModeController+Capture.swift
@@ -110,7 +110,11 @@ extension BrowserDesignModeController {
                 viewBounds: capture.viewBounds
             )
             let pngData = try BrowserScreenshotPasteboardWriter.pngData(for: crop)
-            let screenshotURL = try await screenshotStore.save(pngData, surfaceID: surfaceID)
+            let screenshotURL = try await screenshotStore.save(
+                pngData,
+                surfaceID: surfaceID,
+                retention: .liveContext
+            )
             unregisteredScreenshotURL = screenshotURL
             guard operation == operationRevision else {
                 await screenshotStore.remove(screenshotURL)

--- a/Sources/Panels/BrowserDesignModeController+Capture.swift
+++ b/Sources/Panels/BrowserDesignModeController+Capture.swift
@@ -1,0 +1,233 @@
+import AppKit
+import CmuxBrowser
+import Foundation
+import WebKit
+
+extension BrowserDesignModeController {
+    /// Starts the synchronous ink lifecycle before any capture work exists.
+    func beginAnnotationDrawing(id: String) {
+        guard phase.isEnabled, !id.isEmpty else { return }
+        phase = .active(annotation: .drawing(id: id))
+        errorMessage = nil
+    }
+
+    /// Returns an abandoned sub-threshold stroke to the normal active phase.
+    func cancelAnnotationDrawing(id: String) {
+        guard phase.isEnabled else { return }
+        switch phase.annotation {
+        case .drawing(let activeID) where activeID == id:
+            phase = .active(annotation: .idle)
+        case .inkOnly(let request) where request.id == id,
+             .capturing(let request) where request.id == id:
+            annotationCaptureTask?.cancel()
+            annotationCaptureTask = nil
+            annotationCaptureTaskID = nil
+            screenshotEvaluator.cancelAll()
+            phase = .active(annotation: .idle)
+        default:
+            break
+        }
+    }
+
+    /// Accepts the completed ink descriptor and begins capture on the next task turn.
+    func receiveAnnotationCaptureRequestData(_ data: Data) {
+        guard phase.isEnabled,
+              let request = try? JSONDecoder().decode(
+                  BrowserDesignModeAnnotationCaptureRequest.self,
+                  from: data
+              ), !request.id.isEmpty else { return }
+        phase = .active(annotation: .inkOnly(request))
+        annotationCaptureTask?.cancel()
+        let taskID = UUID()
+        annotationCaptureTaskID = taskID
+        annotationCaptureTask = Task { @MainActor [weak self] in
+            await self?.captureAnnotation(request, taskID: taskID)
+        }
+    }
+
+    func captureStableSelection(
+        in webView: WKWebView
+    ) async throws -> (snapshot: BrowserDesignModeSnapshot, image: NSImage, viewBounds: NSRect) {
+        for _ in 0..<2 {
+            let candidate = try await captureSelectionCandidate(in: webView)
+            if BrowserDesignModeSupport.captureMatches(
+                before: candidate.before,
+                after: candidate.after,
+                beforeViewBounds: candidate.beforeViewBounds,
+                afterViewBounds: candidate.afterViewBounds
+            ) {
+                return (candidate.after, candidate.image, candidate.afterViewBounds)
+            }
+        }
+        throw BrowserDesignModeError.captureChanged
+    }
+
+    private func captureAnnotation(
+        _ request: BrowserDesignModeAnnotationCaptureRequest,
+        taskID: UUID
+    ) async {
+        defer {
+            if annotationCaptureTaskID == taskID {
+                annotationCaptureTask = nil
+                annotationCaptureTaskID = nil
+            }
+        }
+        guard phase.annotation == .inkOnly(request), let webView else { return }
+        phase = .active(annotation: .capturing(request))
+        let operation = operationRevision
+        do {
+            let capture = try await captureStableAnnotation(id: request.id, in: webView)
+            guard operation == operationRevision else { return }
+            let crop = try BrowserScreenshotCrop.croppedImage(
+                from: capture.image,
+                selectionInView: BrowserDesignModeSupport.captureRect(
+                    selection: capture.contextRect,
+                    viewport: capture.descriptor.viewport,
+                    viewBounds: capture.viewBounds
+                ),
+                viewBounds: capture.viewBounds
+            )
+            let pngData = try BrowserScreenshotPasteboardWriter.pngData(for: crop)
+            let screenshotURL = try await screenshotStore.save(pngData, surfaceID: surfaceID)
+            guard operation == operationRevision else { return }
+            let value = try await evaluate(
+                """
+                return globalThis.__cmuxDesignMode?.completeAnnotationCapture(
+                    id, x, y, width, height, imageURL,
+                    scrollX, scrollY, viewportWidth, viewportHeight
+                );
+                """,
+                arguments: [
+                    "id": request.id,
+                    "x": capture.contextRect.x,
+                    "y": capture.contextRect.y,
+                    "width": capture.contextRect.width,
+                    "height": capture.contextRect.height,
+                    "imageURL": "data:image/png;base64,\(pngData.base64EncodedString())",
+                    "scrollX": capture.descriptor.scrollX,
+                    "scrollY": capture.descriptor.scrollY,
+                    "viewportWidth": capture.descriptor.viewport.width,
+                    "viewportHeight": capture.descriptor.viewport.height,
+                ],
+                in: webView
+            )
+            guard operation == operationRevision else { return }
+            let next = try BrowserDesignModeSupport.decodeSnapshot(value)
+            let selector = "@annotation(\(request.id))"
+            annotationScreenshotPaths[selector] = screenshotURL.path
+            apply(next)
+            phase = .active(annotation: .captured(id: request.id, selector: selector))
+            errorMessage = nil
+            isComposerPresented = true
+        } catch is CancellationError {
+            await cancelAnnotationCapture(id: request.id, in: webView, reportError: false)
+        } catch {
+            BrowserDesignModeSupport.record(error, operation: "annotationCapture")
+            await cancelAnnotationCapture(id: request.id, in: webView, reportError: true)
+        }
+    }
+
+    private func captureStableAnnotation(
+        id: String,
+        in webView: WKWebView
+    ) async throws -> (
+        descriptor: BrowserDesignModeAnnotationCaptureRequest,
+        contextRect: BrowserDesignModeRect,
+        image: NSImage,
+        viewBounds: NSRect
+    ) {
+        let geometry = BrowserDesignModeAnnotationCapture(contextPadding: 48)
+        for _ in 0..<2 {
+            let prepared = try await evaluate(
+                "return globalThis.__cmuxDesignMode?.prepareAnnotationCapture(id);",
+                arguments: ["id": id],
+                in: webView
+            )
+            let before = try BrowserDesignModeSupport.decodeAnnotationCaptureRequest(prepared)
+            let contextRect = geometry.contextRect(around: before.strokeBounds, in: before.viewport)
+            guard contextRect.width > 0, contextRect.height > 0 else {
+                throw BrowserScreenshotError.invalidSelection
+            }
+            let beforeViewBounds = webView.bounds
+            let image = try await screenshotEvaluator.captureVisibleViewport(from: webView)
+            let after = try BrowserDesignModeSupport.decodeAnnotationCaptureRequest(
+                try await evaluate(
+                    "return globalThis.__cmuxDesignMode?.annotationCaptureDescriptor(id);",
+                    arguments: ["id": id],
+                    in: webView
+                )
+            )
+            let afterViewBounds = webView.bounds
+            if before == after, beforeViewBounds == afterViewBounds {
+                return (after, contextRect, image, afterViewBounds)
+            }
+        }
+        throw BrowserDesignModeError.captureChanged
+    }
+
+    private func captureSelectionCandidate(
+        in webView: WKWebView
+    ) async throws -> (
+        before: BrowserDesignModeSnapshot,
+        after: BrowserDesignModeSnapshot,
+        image: NSImage,
+        beforeViewBounds: NSRect,
+        afterViewBounds: NSRect
+    ) {
+        do {
+            let prepared = try await evaluate("return globalThis.__cmuxDesignMode?.prepareCapture();", in: webView)
+            let before = try BrowserDesignModeSupport.decodeSnapshot(prepared)
+            let beforeViewBounds = webView.bounds
+            let image = try await screenshotEvaluator.captureVisibleViewport(from: webView)
+            let after = try BrowserDesignModeSupport.decodeSnapshot(
+                try await evaluate("return globalThis.__cmuxDesignMode?.snapshot();", in: webView)
+            )
+            let afterViewBounds = webView.bounds
+            _ = try await evaluate("return globalThis.__cmuxDesignMode?.finishCapture();", in: webView)
+            return (before, after, image, beforeViewBounds, afterViewBounds)
+        } catch {
+            // Run cleanup in a fresh task so cancellation of the capture task
+            // cannot strand the page runtime with its overlays hidden.
+            let cleanup = Task { @MainActor [weak self, weak webView] in
+                guard let self, let webView else { return }
+                _ = try? await self.evaluate(
+                    "return globalThis.__cmuxDesignMode?.finishCapture();",
+                    in: webView
+                )
+            }
+            await cleanup.value
+            throw error
+        }
+    }
+
+    private func cancelAnnotationCapture(
+        id: String,
+        in webView: WKWebView,
+        reportError: Bool
+    ) async {
+        _ = try? await evaluate(
+            "return globalThis.__cmuxDesignMode?.cancelAnnotationCapture(id);",
+            arguments: ["id": id],
+            in: webView
+        )
+        guard phase.isEnabled, phase.annotation?.id == id else { return }
+        phase = .active(annotation: .idle)
+        if reportError {
+            errorMessage = String(
+                localized: "browser.designMode.error.annotationCapture",
+                defaultValue: "Could not capture the annotation. Draw it again."
+            )
+            isComposerPresented = true
+        }
+    }
+}
+
+private extension BrowserDesignModeAnnotationPhase {
+    var id: String? {
+        switch self {
+        case .idle: nil
+        case .drawing(let id), .captured(let id, _): id
+        case .inkOnly(let request), .capturing(let request): request.id
+        }
+    }
+}

--- a/Sources/Panels/BrowserDesignModeController+Capture.swift
+++ b/Sources/Panels/BrowserDesignModeController+Capture.swift
@@ -6,7 +6,13 @@ import WebKit
 extension BrowserDesignModeController {
     /// Starts the synchronous ink lifecycle before any capture work exists.
     func beginAnnotationDrawing(id: String) {
-        guard phase.isEnabled, !id.isEmpty else { return }
+        guard phase.isEnabled, interactionMode == .draw, !id.isEmpty else { return }
+        switch phase.annotation {
+        case .idle, .captured:
+            break
+        case .drawing, .inkOnly, .capturing, nil:
+            return
+        }
         phase = .active(annotation: .drawing(id: id))
         errorMessage = nil
     }
@@ -36,6 +42,17 @@ extension BrowserDesignModeController {
                   BrowserDesignModeAnnotationCaptureRequest.self,
                   from: data
               ), !request.id.isEmpty else { return }
+        guard interactionMode == .draw,
+              case .drawing(let activeID)? = phase.annotation,
+              activeID == request.id else {
+            if let webView {
+                Task { @MainActor [weak self, weak webView] in
+                    guard let self, let webView else { return }
+                    await self.cancelAnnotationCapture(id: request.id, in: webView, reportError: false)
+                }
+            }
+            return
+        }
         phase = .active(annotation: .inkOnly(request))
         annotationCaptureTask?.cancel()
         let taskID = UUID()
@@ -75,6 +92,7 @@ extension BrowserDesignModeController {
         guard phase.annotation == .inkOnly(request), let webView else { return }
         phase = .active(annotation: .capturing(request))
         let operation = operationRevision
+        var unregisteredScreenshotURL: URL?
         do {
             let capture = try await captureStableAnnotation(id: request.id, in: webView)
             guard operation == operationRevision else { return }
@@ -89,7 +107,11 @@ extension BrowserDesignModeController {
             )
             let pngData = try BrowserScreenshotPasteboardWriter.pngData(for: crop)
             let screenshotURL = try await screenshotStore.save(pngData, surfaceID: surfaceID)
-            guard operation == operationRevision else { return }
+            unregisteredScreenshotURL = screenshotURL
+            guard operation == operationRevision else {
+                await screenshotStore.remove(screenshotURL)
+                return
+            }
             let value = try await evaluate(
                 """
                 return globalThis.__cmuxDesignMode?.completeAnnotationCapture(
@@ -111,17 +133,27 @@ extension BrowserDesignModeController {
                 ],
                 in: webView
             )
-            guard operation == operationRevision else { return }
+            guard operation == operationRevision else {
+                await screenshotStore.remove(screenshotURL)
+                return
+            }
             let next = try BrowserDesignModeSupport.decodeSnapshot(value)
             let selector = "@annotation(\(request.id))"
             annotationScreenshotPaths[selector] = screenshotURL.path
+            unregisteredScreenshotURL = nil
             apply(next)
             phase = .active(annotation: .captured(id: request.id, selector: selector))
             errorMessage = nil
             isComposerPresented = true
         } catch is CancellationError {
+            if let unregisteredScreenshotURL {
+                await screenshotStore.remove(unregisteredScreenshotURL)
+            }
             await cancelAnnotationCapture(id: request.id, in: webView, reportError: false)
         } catch {
+            if let unregisteredScreenshotURL {
+                await screenshotStore.remove(unregisteredScreenshotURL)
+            }
             BrowserDesignModeSupport.record(error, operation: "annotationCapture")
             await cancelAnnotationCapture(id: request.id, in: webView, reportError: true)
         }

--- a/Sources/Panels/BrowserDesignModeController+Capture.swift
+++ b/Sources/Panels/BrowserDesignModeController+Capture.swift
@@ -65,6 +65,10 @@ extension BrowserDesignModeController {
     func captureStableSelection(
         in webView: WKWebView
     ) async throws -> (snapshot: BrowserDesignModeSnapshot, image: NSImage, viewBounds: NSRect) {
+        let visibleImage = try await screenshotEvaluator.captureVisibleViewport(from: webView)
+        let captureShield = BrowserDesignModeCaptureShield.install(image: visibleImage, over: webView)
+        defer { captureShield?.remove() }
+
         for _ in 0..<2 {
             let candidate = try await captureSelectionCandidate(in: webView)
             if BrowserDesignModeSupport.captureMatches(
@@ -215,7 +219,7 @@ extension BrowserDesignModeController {
                 try await evaluate("return globalThis.__cmuxDesignMode?.snapshot();", in: webView)
             )
             let afterViewBounds = webView.bounds
-            _ = try await evaluate("return globalThis.__cmuxDesignMode?.finishCapture();", in: webView)
+            try await restoreCapturePresentation(in: webView)
             return (before, after, image, beforeViewBounds, afterViewBounds)
         } catch {
             // Run cleanup in a fresh task so cancellation of the capture task
@@ -226,10 +230,21 @@ extension BrowserDesignModeController {
                     "return globalThis.__cmuxDesignMode?.finishCapture();",
                     in: webView
                 )
+                _ = try? await self.screenshotEvaluator.captureVisibleViewport(from: webView)
             }
             await cleanup.value
             throw error
         }
+    }
+
+    private func restoreCapturePresentation(in webView: WKWebView) async throws {
+        _ = try await evaluate(
+            "return globalThis.__cmuxDesignMode?.finishCapture();",
+            in: webView
+        )
+        // `afterScreenUpdates` makes this callback the paint-completion signal;
+        // the image is intentionally discarded while the native shield remains visible.
+        _ = try await screenshotEvaluator.captureVisibleViewport(from: webView)
     }
 
     private func cancelAnnotationCapture(

--- a/Sources/Panels/BrowserDesignModeController.swift
+++ b/Sources/Panels/BrowserDesignModeController.swift
@@ -409,6 +409,9 @@ final class BrowserDesignModeController {
         guard phase.isEnabled, mode != interactionMode, let webView else { return }
         interactionMode = mode
         if mode == .select {
+            // Cancellation releases suspension points, while the revision
+            // prevents any already-returning capture from committing a card.
+            operationRevision &+= 1
             if annotationCaptureTask != nil {
                 annotationCaptureTask?.cancel()
                 annotationCaptureTask = nil

--- a/Sources/Panels/BrowserDesignModeController.swift
+++ b/Sources/Panels/BrowserDesignModeController.swift
@@ -133,6 +133,9 @@ final class BrowserDesignModeController {
                 self.didCopy = false
                 self.errorMessage = nil
             },
+            onInteractionModeChanged: { [weak self] mode in
+                self?.adoptInteractionModeFromRuntime(mode)
+            },
             onAnnotationDrawing: { [weak self] id in
                 self?.beginAnnotationDrawing(id: id)
             },
@@ -303,7 +306,10 @@ final class BrowserDesignModeController {
     /// Design Mode.
     func handleEscape() async {
         guard phase.isEnabled else { return }
-        let hasContent = snapshot?.selections.isEmpty == false || !requestedChange.isEmpty
+        let hasInFlightAnnotation = phase.annotation?.permitsHandoff == false
+        let hasContent = snapshot?.selections.isEmpty == false
+            || !requestedChange.isEmpty
+            || hasInFlightAnnotation
         if hasContent {
             requestedChange = ""
             promptRuns = []
@@ -380,6 +386,25 @@ final class BrowserDesignModeController {
         )
     }
 
+    /// Keeps page emphasis aligned with the token currently under the pointer.
+    func setSelectionHover(identity: String?) async {
+        guard phase.isEnabled, let webView else { return }
+        if let identity,
+           snapshot?.selections.contains(where: { $0.selector == identity }) != true { return }
+        _ = try? await evaluate(
+            "return globalThis.__cmuxDesignMode?.setSelectionHover(identity);",
+            arguments: ["identity": identity ?? NSNull()],
+            in: webView
+        )
+    }
+
+    /// Mirrors an automatic page-side mode transition before its drawing event arrives.
+    func adoptInteractionModeFromRuntime(_ rawValue: String) {
+        guard phase.isEnabled,
+              let mode = BrowserDesignModeInteractionMode(rawValue: rawValue) else { return }
+        interactionMode = mode
+    }
+
     func setInteractionMode(_ mode: BrowserDesignModeInteractionMode) async {
         guard phase.isEnabled, mode != interactionMode, let webView else { return }
         interactionMode = mode
@@ -404,20 +429,24 @@ final class BrowserDesignModeController {
         }
     }
 
-    func removeSelection(at index: Int) async {
+    @discardableResult
+    func removeSelection(at index: Int) async -> Bool {
         guard phase.isEnabled,
-              snapshot?.selections.indices.contains(index) == true,
-              let webView else { return }
+              let selections = snapshot?.selections,
+              selections.indices.contains(index),
+              let webView else { return false }
+        let identity = selections[index].selector
         do {
             let value = try await evaluate(
-                "return globalThis.__cmuxDesignMode?.removeSelection(index);",
-                arguments: ["index": index],
+                "return globalThis.__cmuxDesignMode?.removeSelection(identity);",
+                arguments: ["identity": identity],
                 in: webView
             )
             let next = try BrowserDesignModeSupport.decodeSnapshot(value)
             apply(next)
             didCopy = false
             errorMessage = nil
+            return true
         } catch {
             BrowserDesignModeSupport.record(error, operation: "removeSelection")
             errorMessage = BrowserDesignModeSupport.productMessage(
@@ -428,6 +457,7 @@ final class BrowserDesignModeController {
                 )
             )
             isComposerPresented = true
+            return false
         }
     }
 

--- a/Sources/Panels/BrowserDesignModeController.swift
+++ b/Sources/Panels/BrowserDesignModeController.swift
@@ -581,7 +581,17 @@ final class BrowserDesignModeController {
         guard next.revision >= (snapshot?.revision ?? -1) else { return }
         snapshot = next
         let liveSelectors = Set(next.selections.map(\.selector))
+        let releasedPaths = annotationScreenshotPaths.compactMap { selector, path in
+            liveSelectors.contains(selector) ? nil : path
+        }
         annotationScreenshotPaths = annotationScreenshotPaths.filter { liveSelectors.contains($0.key) }
+        if !releasedPaths.isEmpty {
+            Task { [screenshotStore] in
+                for path in releasedPaths {
+                    await screenshotStore.release(URL(fileURLWithPath: path))
+                }
+            }
+        }
         if case .captured(_, let selector)? = phase.annotation,
            !liveSelectors.contains(selector) {
             phase = .active(annotation: .idle)
@@ -631,7 +641,15 @@ final class BrowserDesignModeController {
         annotationCaptureTask?.cancel()
         annotationCaptureTask = nil
         annotationCaptureTaskID = nil
+        let releasedPaths = Array(annotationScreenshotPaths.values)
         annotationScreenshotPaths.removeAll()
+        if !releasedPaths.isEmpty {
+            Task { [screenshotStore] in
+                for path in releasedPaths {
+                    await screenshotStore.release(URL(fileURLWithPath: path))
+                }
+            }
+        }
     }
 
     private func beginOperation() -> UInt {

--- a/Sources/Panels/BrowserDesignModeController.swift
+++ b/Sources/Panels/BrowserDesignModeController.swift
@@ -13,14 +13,14 @@ final class BrowserDesignModeController {
     static let messageHandlerName = BrowserDesignModeMessageHandler.name
     private static let maximumRequestedChangeCharacters = 4_000
 
-    private(set) var phase: BrowserDesignModePhase = .inactive {
+    var phase: BrowserDesignModePhase = .inactive {
         didSet {
             guard oldValue != phase else { return }
             onActivityChanged()
         }
     }
     private(set) var snapshot: BrowserDesignModeSnapshot?
-    private(set) var errorMessage: String?
+    var errorMessage: String?
     var isComposerPresented = false
     /// Exclusive interaction mode: element selection or freehand region draw.
     private(set) var interactionMode: BrowserDesignModeInteractionMode = .select
@@ -46,29 +46,33 @@ final class BrowserDesignModeController {
     private(set) var isCopying = false
     private(set) var didCopy = false
 
-    @ObservationIgnored private let surfaceID: UUID
+    @ObservationIgnored let surfaceID: UUID
     @ObservationIgnored private let script: BrowserDesignModeScript
     @ObservationIgnored private let promptFormatter: BrowserDesignModePromptFormatter
-    @ObservationIgnored private let screenshotStore: BrowserDesignModeScreenshotStore
+    @ObservationIgnored let screenshotStore: BrowserDesignModeScreenshotStore
     @ObservationIgnored private let javaScriptEvaluator: BrowserDesignModeJavaScriptEvaluator
-    @ObservationIgnored private let screenshotEvaluator: BrowserDesignModeScreenshotEvaluator
+    @ObservationIgnored let screenshotEvaluator: BrowserDesignModeScreenshotEvaluator
     @ObservationIgnored private let canEnable: @MainActor @Sendable () -> Bool
     @ObservationIgnored private let clipboardWriter: ClipboardWriter
     @ObservationIgnored private let onActivityChanged: @MainActor @Sendable () -> Void
-    @ObservationIgnored private weak var webView: WKWebView?
+    @ObservationIgnored weak var webView: WKWebView?
     @ObservationIgnored private var messageHandler: BrowserDesignModeMessageHandler?
-    @ObservationIgnored private var operationRevision: UInt = 0
+    @ObservationIgnored var operationRevision: UInt = 0
     @ObservationIgnored private var activePageURL: URL?
     @ObservationIgnored private var copyTask: Task<Void, Never>?
     @ObservationIgnored private var copyTaskID: UUID?
-    var isActive: Bool { phase == .active || phase == .activating }
+    @ObservationIgnored var annotationCaptureTask: Task<Void, Never>?
+    @ObservationIgnored var annotationCaptureTaskID: UUID?
+    @ObservationIgnored var annotationScreenshotPaths: [String: String] = [:]
+    var isActive: Bool { phase.isEnabled || phase == .activating }
     var protectsFromDiscard: Bool { phase != .inactive }
     var canToggle: Bool {
-        guard phase != .activating, phase != .deactivating else { return false }
-        return phase == .active || canEnable()
+        guard !phase.isTransitioning else { return false }
+        return phase.isEnabled || canEnable()
     }
     var canCopy: Bool {
-        phase == .active
+        phase.isEnabled
+            && phase.annotation?.permitsHandoff == true
             && snapshot?.selections.isEmpty == false
             && copyTask == nil
             && !isCopying
@@ -128,6 +132,15 @@ final class BrowserDesignModeController {
                 self.promptResetGeneration &+= 1
                 self.didCopy = false
                 self.errorMessage = nil
+            },
+            onAnnotationDrawing: { [weak self] id in
+                self?.beginAnnotationDrawing(id: id)
+            },
+            onAnnotationCancelled: { [weak self] id in
+                self?.cancelAnnotationDrawing(id: id)
+            },
+            onAnnotationCaptureRequested: { [weak self] data in
+                self?.receiveAnnotationCaptureRequestData(data)
             }
         )
         messageHandler = handler
@@ -171,9 +184,9 @@ final class BrowserDesignModeController {
     @discardableResult
     func setEnabled(_ enabled: Bool, reason: String) async -> Bool {
         _ = reason
-        guard phase != .activating, phase != .deactivating else { return false }
+        guard !phase.isTransitioning else { return false }
         if enabled {
-            guard phase != .active else { return true }
+            guard !phase.isEnabled else { return true }
             guard canEnable(), let webView else {
                 errorMessage = String(
                     localized: "browser.designMode.error.noPage",
@@ -199,7 +212,7 @@ final class BrowserDesignModeController {
                 guard operation == operationRevision else { return false }
                 let next = try BrowserDesignModeSupport.decodeSnapshot(value)
                 apply(next)
-                phase = .active
+                phase = .active(annotation: .idle)
                 // The composer docks bottom-center from the moment Design
                 // Mode activates and stays until Escape or deactivation.
                 isComposerPresented = true
@@ -228,7 +241,7 @@ final class BrowserDesignModeController {
                 if cleanupSucceeded {
                     resetNativeState()
                 } else {
-                    phase = .active
+                    phase = .active(annotation: .idle)
                 }
                 BrowserDesignModeSupport.record(enableError, operation: "enable")
                 errorMessage = String(
@@ -252,7 +265,7 @@ final class BrowserDesignModeController {
             return true
         } catch let disableError {
             guard operation == operationRevision else { return false }
-            phase = .active
+            phase = .active(annotation: .idle)
             BrowserDesignModeSupport.record(disableError, operation: "disable")
             errorMessage = String(
                 localized: "browser.designMode.error.disable",
@@ -289,7 +302,7 @@ final class BrowserDesignModeController {
     /// or typed text, reset the whole prompt; with a clean slate, leave
     /// Design Mode.
     func handleEscape() async {
-        guard phase == .active else { return }
+        guard phase.isEnabled else { return }
         let hasContent = snapshot?.selections.isEmpty == false || !requestedChange.isEmpty
         if hasContent {
             requestedChange = ""
@@ -313,7 +326,7 @@ final class BrowserDesignModeController {
     /// Clears the page-side hover highlight (used when the pointer enters the
     /// native composer card, which the page cannot observe).
     func clearPageHover() async {
-        guard phase == .active, let webView else { return }
+        guard phase.isEnabled, let webView else { return }
         _ = try? await evaluate(
             "return globalThis.__cmuxDesignMode?.clearHover();",
             arguments: [:],
@@ -339,7 +352,7 @@ final class BrowserDesignModeController {
     func updateComposerFrame(_ frame: CGRect) {
         guard frame != lastPublishedComposerFrame else { return }
         lastPublishedComposerFrame = frame
-        guard phase == .active, let webView else { return }
+        guard phase.isEnabled, let webView else { return }
         Task { @MainActor in
             _ = try? await self.evaluate(
                 "return globalThis.__cmuxDesignMode?.setComposerFrame(x, y, w, h);",
@@ -357,7 +370,7 @@ final class BrowserDesignModeController {
 
     /// Flashes the outline of the selection at `index` on the page.
     func revealSelection(at index: Int) async {
-        guard phase == .active,
+        guard phase.isEnabled,
               snapshot?.selections.indices.contains(index) == true,
               let webView else { return }
         _ = try? await evaluate(
@@ -368,8 +381,17 @@ final class BrowserDesignModeController {
     }
 
     func setInteractionMode(_ mode: BrowserDesignModeInteractionMode) async {
-        guard phase == .active, mode != interactionMode, let webView else { return }
+        guard phase.isEnabled, mode != interactionMode, let webView else { return }
         interactionMode = mode
+        if mode == .select {
+            if annotationCaptureTask != nil {
+                annotationCaptureTask?.cancel()
+                annotationCaptureTask = nil
+                annotationCaptureTaskID = nil
+                screenshotEvaluator.cancelAll()
+            }
+            phase = .active(annotation: .idle)
+        }
         do {
             let value = try await evaluate(
                 "return globalThis.__cmuxDesignMode?.setMode(mode);",
@@ -383,7 +405,7 @@ final class BrowserDesignModeController {
     }
 
     func removeSelection(at index: Int) async {
-        guard phase == .active,
+        guard phase.isEnabled,
               snapshot?.selections.indices.contains(index) == true,
               let webView else { return }
         do {
@@ -420,7 +442,7 @@ final class BrowserDesignModeController {
 
     private func performCopySelection() async {
         let requestedChange = requestedChange.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard phase == .active,
+        guard phase.isEnabled,
               snapshot?.selections.isEmpty == false,
               let webView else { return }
         let operation = beginOperation()
@@ -435,6 +457,10 @@ final class BrowserDesignModeController {
             }
             var screenshotPaths: [String?] = []
             for selection in capture.snapshot.selections {
+                if let annotationPath = annotationScreenshotPaths[selection.selector] {
+                    screenshotPaths.append(annotationPath)
+                    continue
+                }
                 do {
                     let crop = try BrowserScreenshotCrop.croppedImage(
                         from: capture.image,
@@ -489,65 +515,11 @@ final class BrowserDesignModeController {
         }
     }
 
-    private func captureStableSelection(
-        in webView: WKWebView
-    ) async throws -> (snapshot: BrowserDesignModeSnapshot, image: NSImage, viewBounds: NSRect) {
-        for _ in 0..<2 {
-            let candidate = try await captureCandidate(in: webView)
-            if BrowserDesignModeSupport.captureMatches(
-                before: candidate.before,
-                after: candidate.after,
-                beforeViewBounds: candidate.beforeViewBounds,
-                afterViewBounds: candidate.afterViewBounds
-            ) {
-                return (candidate.after, candidate.image, candidate.afterViewBounds)
-            }
-        }
-        throw BrowserDesignModeError.captureChanged
-    }
-
-    private func captureCandidate(
-        in webView: WKWebView
-    ) async throws -> (
-        before: BrowserDesignModeSnapshot,
-        after: BrowserDesignModeSnapshot,
-        image: NSImage,
-        beforeViewBounds: NSRect,
-        afterViewBounds: NSRect
-    ) {
-        do {
-            let prepared = try await evaluate("return globalThis.__cmuxDesignMode?.prepareCapture();", in: webView)
-            let before = try BrowserDesignModeSupport.decodeSnapshot(prepared)
-            let beforeViewBounds = webView.bounds
-            let image = try await screenshotEvaluator.captureVisibleViewport(from: webView)
-            let after = try BrowserDesignModeSupport.decodeSnapshot(
-                try await evaluate("return globalThis.__cmuxDesignMode?.snapshot();", in: webView)
-            )
-            let afterViewBounds = webView.bounds
-            try await finishCapture(in: webView)
-            return (before, after, image, beforeViewBounds, afterViewBounds)
-        } catch {
-            let cleanup = Task { @MainActor [weak self, weak webView] in
-                guard let self, let webView else { return }
-                _ = try? await self.evaluate(
-                    "return globalThis.__cmuxDesignMode?.finishCapture();",
-                    in: webView
-                )
-            }
-            await cleanup.value
-            throw error
-        }
-    }
-
-    private func finishCapture(in webView: WKWebView) async throws {
-        _ = try await evaluate("return globalThis.__cmuxDesignMode?.finishCapture();", in: webView)
-    }
-
     private func destroyRuntime(in webView: WKWebView) async throws {
         _ = try await evaluate("return globalThis.__cmuxDesignMode?.destroy();", in: webView)
     }
 
-    private func evaluate(
+    func evaluate(
         _ body: String,
         arguments: [String: Any] = [:],
         in webView: WKWebView
@@ -561,11 +533,11 @@ final class BrowserDesignModeController {
     }
 
     private func receiveSnapshotData(_ data: Data) {
-        guard phase == .active || phase == .activating else { return }
+        guard phase.isEnabled || phase == .activating else { return }
         guard let next = try? JSONDecoder().decode(BrowserDesignModeSnapshot.self, from: data) else { return }
         let previousSelectors = snapshot?.selections.map(\.selector)
         apply(next)
-        if next.enabled { phase = .active }
+        if next.enabled, !phase.isEnabled { phase = .active(annotation: .idle) }
         if next.selections.map(\.selector) != previousSelectors {
             errorMessage = nil
             didCopy = false
@@ -575,9 +547,15 @@ final class BrowserDesignModeController {
         }
     }
 
-    private func apply(_ next: BrowserDesignModeSnapshot) {
+    func apply(_ next: BrowserDesignModeSnapshot) {
         guard next.revision >= (snapshot?.revision ?? -1) else { return }
         snapshot = next
+        let liveSelectors = Set(next.selections.map(\.selector))
+        annotationScreenshotPaths = annotationScreenshotPaths.filter { liveSelectors.contains($0.key) }
+        if case .captured(_, let selector)? = phase.annotation,
+           !liveSelectors.contains(selector) {
+            phase = .active(annotation: .idle)
+        }
     }
 
     private func uninstall(from webView: WKWebView) {
@@ -620,6 +598,10 @@ final class BrowserDesignModeController {
         // leaves the reset state untouched.
         copyTask = nil
         copyTaskID = nil
+        annotationCaptureTask?.cancel()
+        annotationCaptureTask = nil
+        annotationCaptureTaskID = nil
+        annotationScreenshotPaths.removeAll()
     }
 
     private func beginOperation() -> UInt {
@@ -630,6 +612,9 @@ final class BrowserDesignModeController {
     private func invalidateOperation() {
         operationRevision &+= 1
         copyTask?.cancel()
+        annotationCaptureTask?.cancel()
+        annotationCaptureTask = nil
+        annotationCaptureTaskID = nil
         javaScriptEvaluator.cancelAll()
         screenshotEvaluator.cancelAll()
     }

--- a/Sources/Panels/BrowserDesignModeController.swift
+++ b/Sources/Panels/BrowserDesignModeController.swift
@@ -407,26 +407,29 @@ final class BrowserDesignModeController {
 
     func setInteractionMode(_ mode: BrowserDesignModeInteractionMode) async {
         guard phase.isEnabled, mode != interactionMode, let webView else { return }
-        interactionMode = mode
-        if mode == .select {
-            // Cancellation releases suspension points, while the revision
-            // prevents any already-returning capture from committing a card.
-            operationRevision &+= 1
-            if annotationCaptureTask != nil {
-                annotationCaptureTask?.cancel()
-                annotationCaptureTask = nil
-                annotationCaptureTaskID = nil
-                screenshotEvaluator.cancelAll()
-            }
-            phase = .active(annotation: .idle)
-        }
         do {
             let value = try await evaluate(
                 "return globalThis.__cmuxDesignMode?.setMode(mode);",
                 arguments: ["mode": mode.rawValue],
                 in: webView
             )
-            apply(try BrowserDesignModeSupport.decodeSnapshot(value))
+            let next = try BrowserDesignModeSupport.decodeSnapshot(value)
+            guard phase.isEnabled else { return }
+            interactionMode = mode
+            if mode == .select {
+                // The page runtime has now abandoned its annotation. Mirror
+                // that authoritative transition and prevent an older native
+                // capture continuation from committing afterward.
+                operationRevision &+= 1
+                if annotationCaptureTask != nil {
+                    annotationCaptureTask?.cancel()
+                    annotationCaptureTask = nil
+                    annotationCaptureTaskID = nil
+                    screenshotEvaluator.cancelAll()
+                }
+                phase = .active(annotation: .idle)
+            }
+            apply(next)
         } catch {
             BrowserDesignModeSupport.record(error, operation: "setMode")
         }

--- a/Sources/Panels/BrowserDesignModeMessageHandler.swift
+++ b/Sources/Panels/BrowserDesignModeMessageHandler.swift
@@ -8,6 +8,7 @@ final class BrowserDesignModeMessageHandler: NSObject, WKScriptMessageHandler {
     private let onSnapshot: @MainActor @Sendable (Data) -> Void
     private let onExitRequested: @MainActor @Sendable () -> Void
     private let onPromptReset: @MainActor @Sendable () -> Void
+    private let onInteractionModeChanged: @MainActor @Sendable (String) -> Void
     private let onAnnotationDrawing: @MainActor @Sendable (String) -> Void
     private let onAnnotationCancelled: @MainActor @Sendable (String) -> Void
     private let onAnnotationCaptureRequested: @MainActor @Sendable (Data) -> Void
@@ -16,6 +17,7 @@ final class BrowserDesignModeMessageHandler: NSObject, WKScriptMessageHandler {
         onSnapshot: @escaping @MainActor @Sendable (Data) -> Void,
         onExitRequested: @escaping @MainActor @Sendable () -> Void = {},
         onPromptReset: @escaping @MainActor @Sendable () -> Void = {},
+        onInteractionModeChanged: @escaping @MainActor @Sendable (String) -> Void = { _ in },
         onAnnotationDrawing: @escaping @MainActor @Sendable (String) -> Void = { _ in },
         onAnnotationCancelled: @escaping @MainActor @Sendable (String) -> Void = { _ in },
         onAnnotationCaptureRequested: @escaping @MainActor @Sendable (Data) -> Void = { _ in }
@@ -23,6 +25,7 @@ final class BrowserDesignModeMessageHandler: NSObject, WKScriptMessageHandler {
         self.onSnapshot = onSnapshot
         self.onExitRequested = onExitRequested
         self.onPromptReset = onPromptReset
+        self.onInteractionModeChanged = onInteractionModeChanged
         self.onAnnotationDrawing = onAnnotationDrawing
         self.onAnnotationCancelled = onAnnotationCancelled
         self.onAnnotationCaptureRequested = onAnnotationCaptureRequested
@@ -45,6 +48,12 @@ final class BrowserDesignModeMessageHandler: NSObject, WKScriptMessageHandler {
         if type == "prompt_reset" {
             MainActor.assumeIsolated { [onPromptReset] in
                 onPromptReset()
+            }
+            return
+        }
+        if type == "interaction_mode_changed", let mode = body["mode"] as? String {
+            MainActor.assumeIsolated { [onInteractionModeChanged] in
+                onInteractionModeChanged(mode)
             }
             return
         }

--- a/Sources/Panels/BrowserDesignModeMessageHandler.swift
+++ b/Sources/Panels/BrowserDesignModeMessageHandler.swift
@@ -8,15 +8,24 @@ final class BrowserDesignModeMessageHandler: NSObject, WKScriptMessageHandler {
     private let onSnapshot: @MainActor @Sendable (Data) -> Void
     private let onExitRequested: @MainActor @Sendable () -> Void
     private let onPromptReset: @MainActor @Sendable () -> Void
+    private let onAnnotationDrawing: @MainActor @Sendable (String) -> Void
+    private let onAnnotationCancelled: @MainActor @Sendable (String) -> Void
+    private let onAnnotationCaptureRequested: @MainActor @Sendable (Data) -> Void
 
     init(
         onSnapshot: @escaping @MainActor @Sendable (Data) -> Void,
         onExitRequested: @escaping @MainActor @Sendable () -> Void = {},
-        onPromptReset: @escaping @MainActor @Sendable () -> Void = {}
+        onPromptReset: @escaping @MainActor @Sendable () -> Void = {},
+        onAnnotationDrawing: @escaping @MainActor @Sendable (String) -> Void = { _ in },
+        onAnnotationCancelled: @escaping @MainActor @Sendable (String) -> Void = { _ in },
+        onAnnotationCaptureRequested: @escaping @MainActor @Sendable (Data) -> Void = { _ in }
     ) {
         self.onSnapshot = onSnapshot
         self.onExitRequested = onExitRequested
         self.onPromptReset = onPromptReset
+        self.onAnnotationDrawing = onAnnotationDrawing
+        self.onAnnotationCancelled = onAnnotationCancelled
+        self.onAnnotationCaptureRequested = onAnnotationCaptureRequested
     }
 
     func userContentController(
@@ -36,6 +45,27 @@ final class BrowserDesignModeMessageHandler: NSObject, WKScriptMessageHandler {
         if type == "prompt_reset" {
             MainActor.assumeIsolated { [onPromptReset] in
                 onPromptReset()
+            }
+            return
+        }
+        if type == "annotation_drawing", let id = body["id"] as? String {
+            MainActor.assumeIsolated { [onAnnotationDrawing] in
+                onAnnotationDrawing(id)
+            }
+            return
+        }
+        if type == "annotation_cancelled", let id = body["id"] as? String {
+            MainActor.assumeIsolated { [onAnnotationCancelled] in
+                onAnnotationCancelled(id)
+            }
+            return
+        }
+        if type == "annotation_capture_requested",
+           let request = body["request"],
+           JSONSerialization.isValidJSONObject(request),
+           let data = try? JSONSerialization.data(withJSONObject: request) {
+            MainActor.assumeIsolated { [onAnnotationCaptureRequested] in
+                onAnnotationCaptureRequested(data)
             }
             return
         }

--- a/Sources/Panels/BrowserDesignModePhase.swift
+++ b/Sources/Panels/BrowserDesignModePhase.swift
@@ -1,14 +1,46 @@
+import CmuxBrowser
+
 /// Exclusive design-mode interaction: pick elements or draw capture regions.
 enum BrowserDesignModeInteractionMode: String, Equatable {
     case select
     case draw
 }
 
+/// The one in-flight freehand annotation transaction owned by Design Mode.
+enum BrowserDesignModeAnnotationPhase: Equatable {
+    case idle
+    case drawing(id: String)
+    case inkOnly(BrowserDesignModeAnnotationCaptureRequest)
+    case capturing(BrowserDesignModeAnnotationCaptureRequest)
+    case captured(id: String, selector: String)
+
+    var permitsHandoff: Bool {
+        switch self {
+        case .idle, .captured: true
+        case .drawing, .inkOnly, .capturing: false
+        }
+    }
+}
+
 enum BrowserDesignModePhase: Equatable {
     case inactive
     case activating
-    case active
+    case active(annotation: BrowserDesignModeAnnotationPhase)
     case deactivating
+
+    var isEnabled: Bool {
+        if case .active = self { return true }
+        return false
+    }
+
+    var isTransitioning: Bool {
+        self == .activating || self == .deactivating
+    }
+
+    var annotation: BrowserDesignModeAnnotationPhase? {
+        guard case .active(let annotation) = self else { return nil }
+        return annotation
+    }
 
     var commandValue: String {
         switch self {

--- a/Sources/Panels/BrowserDesignModePopover.swift
+++ b/Sources/Panels/BrowserDesignModePopover.swift
@@ -603,6 +603,11 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
 /// change text has been typed yet.
 final class BrowserDesignModeTokenTextView: NSTextView {
     private var tokenTrackingArea: NSTrackingArea?
+    private var hoveredTokenHit: (
+        identity: String,
+        cell: BrowserDesignModeTokenCell,
+        frame: NSRect
+    )?
     var onHoveredTokenIdentityChanged: ((String?) -> Void)?
     private(set) var hoveredTokenIdentity: String? {
         didSet {
@@ -627,45 +632,51 @@ final class BrowserDesignModeTokenTextView: NSTextView {
     }
 
     override func mouseMoved(with event: NSEvent) {
-        hoveredTokenIdentity = tokenFrames().first(where: {
-            $0.frame.insetBy(dx: -2, dy: -2).contains(convert(event.locationInWindow, from: nil))
-        })?.identity
+        let previousFrame = hoveredTokenHit?.frame
+        let hit = tokenHit(at: convert(event.locationInWindow, from: nil))
+        hoveredTokenHit = hit
+        if previousFrame != hit?.frame {
+            window?.invalidateCursorRects(for: self)
+        }
+        hoveredTokenIdentity = hit?.identity
         super.mouseMoved(with: event)
     }
 
     override func mouseExited(with event: NSEvent) {
+        hoveredTokenHit = nil
         hoveredTokenIdentity = nil
         super.mouseExited(with: event)
     }
 
     override func resetCursorRects() {
         super.resetCursorRects()
-        for token in tokenFrames() where token.identity == hoveredTokenIdentity {
-            addCursorRect(token.cell.deleteHitRect(in: token.frame), cursor: .pointingHand)
+        if let hit = hoveredTokenHit, hit.identity == hoveredTokenIdentity {
+            addCursorRect(hit.cell.deleteHitRect(in: hit.frame), cursor: .pointingHand)
         }
     }
 
-    private func tokenFrames() -> [(identity: String, cell: BrowserDesignModeTokenCell, frame: NSRect)] {
-        guard let storage = textStorage, let layoutManager, let textContainer else { return [] }
-        var tokens: [(String, BrowserDesignModeTokenCell, NSRect)] = []
-        storage.enumerateAttribute(
-            .attachment,
-            in: NSRange(location: 0, length: storage.length)
-        ) { value, range, _ in
-            guard let attachment = value as? BrowserDesignModeTokenAttachment,
-                  let cell = attachment.attachmentCell as? BrowserDesignModeTokenCell else { return }
-            let glyphRange = layoutManager.glyphRange(
-                forCharacterRange: range,
-                actualCharacterRange: nil
-            )
-            let containerFrame = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
-            tokens.append((
-                attachment.identity,
-                cell,
-                containerFrame.offsetBy(dx: textContainerInset.width, dy: textContainerInset.height)
-            ))
-        }
-        return tokens
+    func tokenHit(
+        at point: NSPoint
+    ) -> (identity: String, cell: BrowserDesignModeTokenCell, frame: NSRect)? {
+        guard let storage = textStorage, storage.length > 0,
+              let layoutManager, let textContainer else { return nil }
+        let origin = textContainerOrigin
+        let containerPoint = NSPoint(x: point.x - origin.x, y: point.y - origin.y)
+        let glyphIndex = layoutManager.glyphIndex(for: containerPoint, in: textContainer)
+        let characterIndex = layoutManager.characterIndexForGlyph(at: glyphIndex)
+        guard characterIndex < storage.length,
+              let attachment = storage.attribute(
+                  .attachment,
+                  at: characterIndex,
+                  effectiveRange: nil
+              ) as? BrowserDesignModeTokenAttachment,
+              let cell = attachment.attachmentCell as? BrowserDesignModeTokenCell else { return nil }
+        let frame = layoutManager.boundingRect(
+            forGlyphRange: NSRange(location: glyphIndex, length: 1),
+            in: textContainer
+        ).offsetBy(dx: origin.x, dy: origin.y)
+        guard frame.insetBy(dx: -2, dy: -2).contains(point) else { return nil }
+        return (attachment.identity, cell, frame)
     }
 
     override func draw(_ dirtyRect: NSRect) {

--- a/Sources/Panels/BrowserDesignModePopover.swift
+++ b/Sources/Panels/BrowserDesignModePopover.swift
@@ -176,6 +176,9 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
     func makeNSView(context: Context) -> NSScrollView {
         let textView = BrowserDesignModeTokenTextView()
         textView.delegate = context.coordinator
+        textView.onHoveredTokenIdentityChanged = { [weak coordinator = context.coordinator] identity in
+            coordinator?.hoverToken(identity)
+        }
         textView.drawsBackground = false
         textView.isRichText = false
         textView.allowsUndo = true
@@ -246,6 +249,13 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
         context.coordinator.sync(selections: selections, requestedChange: controller.requestedChange)
     }
 
+    static func dismantleNSView(_ scrollView: NSScrollView, coordinator: Coordinator) {
+        if let textView = scrollView.documentView as? BrowserDesignModeTokenTextView {
+            textView.onHoveredTokenIdentityChanged = nil
+        }
+        coordinator.hoverToken(nil)
+    }
+
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         private let controller: BrowserDesignModeController
@@ -253,11 +263,8 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
         weak var textView: BrowserDesignModeTokenTextView?
         private var syncing = false
         var frameObserver: (any NSObjectProtocol)?
-        /// Identities the user deleted locally whose page-side removal has
-        /// not been confirmed by a snapshot yet. sync() must treat these as
-        /// gone, or it would re-append every just-deleted pill and rapid
-        /// backspaces would cascade into mass deletions.
-        private var pendingRemovals: Set<String> = []
+        /// Debounces repeated delete actions while the runtime owns the mutation.
+        private var removalRequests: Set<String> = []
         private var lastResetGeneration: UInt = 0
 
         deinit {
@@ -285,7 +292,7 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             storage.setAttributedString(NSAttributedString(string: "", attributes: typingAttributes))
             syncing = false
             lastIdentities = []
-            pendingRemovals.removeAll()
+            removalRequests.removeAll()
             controller.requestedChange = ""
             controller.promptRuns = []
             // Runs inside updateNSView; a synchronous @State write would be
@@ -302,11 +309,7 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
         /// lands after a newly appended token to continue typing.
         func sync(selections: [BrowserDesignModeSelection], requestedChange: String) {
             guard let textView, let storage = textView.textStorage else { return }
-            // Snapshots confirm removals by dropping the identity; anything
-            // still pending stays masked out of the reconciliation.
-            pendingRemovals.formIntersection(selections.map(\.selector))
-            let effective = selections.filter { !pendingRemovals.contains($0.selector) }
-            let identities = effective.map(\.selector)
+            let identities = selections.map(\.selector)
             let current = attachmentIdentities(in: storage)
             guard identities.sorted() != current.sorted()
                 || plainText(of: storage) != requestedChange else {
@@ -342,7 +345,7 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             // pills always deletes a pill, never an invisible space.
             let present = Set(attachmentIdentities(in: storage))
             var appended = false
-            for selection in effective where !present.contains(selection.selector) {
+            for selection in selections where !present.contains(selection.selector) {
                 storage.append(attributedToken(for: selection))
                 appended = true
             }
@@ -392,17 +395,11 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             guard replacementString?.isEmpty == true,
                   affectedRange.length > 0,
                   let storage = textView.textStorage else { return true }
-            let content = storage.string as NSString
-            guard content.substring(with: affectedRange).contains("\u{FFFC}") else { return true }
-            var expanded = affectedRange
-            if expanded.upperBound < content.length,
-               content.character(at: expanded.upperBound) == 0x20 {
-                expanded.length += 1
+            let identities = attachmentIdentities(in: storage, range: affectedRange)
+            guard !identities.isEmpty else { return true }
+            for identity in identities {
+                requestTokenRemoval(identity: identity)
             }
-            guard expanded != affectedRange else { return true }
-            storage.deleteCharacters(in: expanded)
-            textView.setSelectedRange(NSRange(location: expanded.location, length: 0))
-            textView.didChangeText()
             return false
         }
 
@@ -412,31 +409,14 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             controller.requestedChange = plainText(of: textView.textStorage)
             archivePrompt()
             if identities != lastIdentities {
-                // Tokens were deleted through editing. Storage order can
-                // diverge from the runtime's click order (tokens may be
-                // moved around in the text), so map each removed identity to
-                // its index in the controller's selections, highest first.
-                var remaining = identities
-                var removedIdentities: [String] = []
-                for identity in lastIdentities {
-                    if let position = remaining.firstIndex(of: identity) {
-                        remaining.remove(at: position)
-                    } else {
-                        removedIdentities.append(identity)
-                    }
-                }
-                lastIdentities = identities
-                pendingRemovals.formUnion(removedIdentities)
-                let toRemove = removedIdentities
-                Task { @MainActor [controller] in
-                    // Resolve each index at removal time: every removal
-                    // shifts the indices of the remaining selections.
-                    for identity in toRemove {
-                        guard let index = controller.snapshot?.selections
-                            .firstIndex(where: { $0.selector == identity }) else { continue }
-                        await controller.removeSelection(at: index)
-                    }
-                }
+                // Every supported removal is intercepted before AppKit edits
+                // storage. If another mutation path removes a pill, restore
+                // it from the authoritative runtime snapshot.
+                sync(
+                    selections: controller.snapshot?.selections ?? [],
+                    requestedChange: controller.requestedChange
+                )
+                return
             }
             reportHeight()
         }
@@ -516,10 +496,14 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             onHeightChange(height)
         }
 
-        private func attachmentIdentities(in storage: NSTextStorage?) -> [String] {
+        private func attachmentIdentities(
+            in storage: NSTextStorage?,
+            range: NSRange? = nil
+        ) -> [String] {
             guard let storage else { return [] }
             var identities: [String] = []
-            storage.enumerateAttribute(.attachment, in: NSRange(location: 0, length: storage.length)) { value, _, _ in
+            let enumerationRange = range ?? NSRange(location: 0, length: storage.length)
+            storage.enumerateAttribute(.attachment, in: enumerationRange) { value, _, _ in
                 if let attachment = value as? BrowserDesignModeTokenAttachment {
                     identities.append(attachment.identity)
                 }
@@ -580,27 +564,25 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
 
         private func attributedToken(for selection: BrowserDesignModeSelection) -> NSAttributedString {
             BrowserDesignModeTokenAttachment.attributedToken(for: selection) { [weak self] identity in
-                self?.removeToken(identity: identity)
+                self?.requestTokenRemoval(identity: identity)
             }
         }
 
-        private func removeToken(identity: String) {
-            guard let textView, let storage = textView.textStorage else { return }
-            var tokenRange: NSRange?
-            storage.enumerateAttribute(
-                .attachment,
-                in: NSRange(location: 0, length: storage.length)
-            ) { value, range, stop in
-                guard let attachment = value as? BrowserDesignModeTokenAttachment,
-                      attachment.identity == identity else { return }
-                tokenRange = range
-                stop.pointee = true
+        private func requestTokenRemoval(identity: String) {
+            guard removalRequests.insert(identity).inserted else { return }
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                defer { removalRequests.remove(identity) }
+                guard let index = controller.snapshot?.selections
+                    .firstIndex(where: { $0.selector == identity }) else { return }
+                _ = await controller.removeSelection(at: index)
             }
-            guard let tokenRange,
-                  textView.shouldChangeText(in: tokenRange, replacementString: "") else { return }
-            storage.deleteCharacters(in: tokenRange)
-            textView.setSelectedRange(NSRange(location: tokenRange.location, length: 0))
-            textView.didChangeText()
+        }
+
+        func hoverToken(_ identity: String?) {
+            Task { @MainActor [controller] in
+                await controller.setSelectionHover(identity: identity)
+            }
         }
     }
 }
@@ -609,11 +591,13 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
 /// change text has been typed yet.
 final class BrowserDesignModeTokenTextView: NSTextView {
     private var tokenTrackingArea: NSTrackingArea?
+    var onHoveredTokenIdentityChanged: ((String?) -> Void)?
     private(set) var hoveredTokenIdentity: String? {
         didSet {
             guard oldValue != hoveredTokenIdentity else { return }
             needsDisplay = true
             window?.invalidateCursorRects(for: self)
+            onHoveredTokenIdentityChanged?(hoveredTokenIdentity)
         }
     }
 

--- a/Sources/Panels/BrowserDesignModePopover.swift
+++ b/Sources/Panels/BrowserDesignModePopover.swift
@@ -384,9 +384,8 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             ]
         }
 
-        /// A deletion that removes a pill also absorbs the pill's trailing
-        /// separator space; otherwise every removed token strands one space
-        /// and the prompt accumulates gaps.
+        /// Plain text follows normal editing semantics immediately. Pills wait
+        /// for the authoritative page-runtime mutation before storage changes.
         func textView(
             _ textView: NSTextView,
             shouldChangeTextIn affectedRange: NSRange,
@@ -397,6 +396,19 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
                   let storage = textView.textStorage else { return true }
             let identities = attachmentIdentities(in: storage, range: affectedRange)
             guard !identities.isEmpty else { return true }
+            let textRanges = BrowserDesignModeTokenDeletion.textRangesOutsideAttachments(
+                in: storage,
+                range: affectedRange
+            )
+            for range in textRanges.reversed() {
+                storage.deleteCharacters(in: range)
+            }
+            if !textRanges.isEmpty {
+                textView.setSelectedRange(
+                    NSRange(location: min(affectedRange.location, storage.length), length: 0)
+                )
+                textView.didChangeText()
+            }
             for identity in identities {
                 requestTokenRemoval(identity: identity)
             }

--- a/Sources/Panels/BrowserDesignModePopover.swift
+++ b/Sources/Panels/BrowserDesignModePopover.swift
@@ -343,7 +343,7 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             let present = Set(attachmentIdentities(in: storage))
             var appended = false
             for selection in effective where !present.contains(selection.selector) {
-                storage.append(BrowserDesignModeTokenAttachment.attributedToken(for: selection, at: 0))
+                storage.append(attributedToken(for: selection))
                 appended = true
             }
 
@@ -474,6 +474,13 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
                   let selections = controller.snapshot?.selections,
                   let position = selections.firstIndex(where: { $0.selector == token.identity })
             else { return }
+            if let event = NSApp.currentEvent {
+                let point = view.convert(event.locationInWindow, from: nil)
+                if token.deleteHitRect(in: cellFrame).contains(point) {
+                    token.performRemoval()
+                    return
+                }
+            }
             // The XPath is the element's copyable identity: clicking a pill
             // puts the full path on the clipboard and flashes the element.
             let selection = selections[position]
@@ -553,7 +560,7 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
                     storage.append(NSAttributedString(string: string, attributes: typingAttributes))
                 case .token(let identity):
                     guard let selection = selections.first(where: { $0.selector == identity }) else { continue }
-                    storage.append(BrowserDesignModeTokenAttachment.attributedToken(for: selection, at: 0))
+                    storage.append(attributedToken(for: selection))
                 }
             }
             syncing = false
@@ -570,12 +577,101 @@ private struct BrowserDesignModeTokenField: NSViewRepresentable {
             let text = storage.string.replacingOccurrences(of: "\u{FFFC}", with: "")
             return String(text.drop(while: { $0 == " " }))
         }
+
+        private func attributedToken(for selection: BrowserDesignModeSelection) -> NSAttributedString {
+            BrowserDesignModeTokenAttachment.attributedToken(for: selection) { [weak self] identity in
+                self?.removeToken(identity: identity)
+            }
+        }
+
+        private func removeToken(identity: String) {
+            guard let textView, let storage = textView.textStorage else { return }
+            var tokenRange: NSRange?
+            storage.enumerateAttribute(
+                .attachment,
+                in: NSRange(location: 0, length: storage.length)
+            ) { value, range, stop in
+                guard let attachment = value as? BrowserDesignModeTokenAttachment,
+                      attachment.identity == identity else { return }
+                tokenRange = range
+                stop.pointee = true
+            }
+            guard let tokenRange,
+                  textView.shouldChangeText(in: tokenRange, replacementString: "") else { return }
+            storage.deleteCharacters(in: tokenRange)
+            textView.setSelectedRange(NSRange(location: tokenRange.location, length: 0))
+            textView.didChangeText()
+        }
     }
 }
 
 /// Text view that draws the placeholder after the trailing token when no
 /// change text has been typed yet.
 final class BrowserDesignModeTokenTextView: NSTextView {
+    private var tokenTrackingArea: NSTrackingArea?
+    private(set) var hoveredTokenIdentity: String? {
+        didSet {
+            guard oldValue != hoveredTokenIdentity else { return }
+            needsDisplay = true
+            window?.invalidateCursorRects(for: self)
+        }
+    }
+
+    override func updateTrackingAreas() {
+        super.updateTrackingAreas()
+        if let tokenTrackingArea { removeTrackingArea(tokenTrackingArea) }
+        let trackingArea = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseMoved, .mouseEnteredAndExited, .activeInKeyWindow, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        addTrackingArea(trackingArea)
+        tokenTrackingArea = trackingArea
+    }
+
+    override func mouseMoved(with event: NSEvent) {
+        hoveredTokenIdentity = tokenFrames().first(where: {
+            $0.frame.insetBy(dx: -2, dy: -2).contains(convert(event.locationInWindow, from: nil))
+        })?.identity
+        super.mouseMoved(with: event)
+    }
+
+    override func mouseExited(with event: NSEvent) {
+        hoveredTokenIdentity = nil
+        super.mouseExited(with: event)
+    }
+
+    override func resetCursorRects() {
+        super.resetCursorRects()
+        for token in tokenFrames() where token.identity == hoveredTokenIdentity {
+            addCursorRect(token.cell.deleteHitRect(in: token.frame), cursor: .pointingHand)
+        }
+    }
+
+    private func tokenFrames() -> [(identity: String, cell: BrowserDesignModeTokenCell, frame: NSRect)] {
+        guard let storage = textStorage, let layoutManager, let textContainer else { return [] }
+        var tokens: [(String, BrowserDesignModeTokenCell, NSRect)] = []
+        storage.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: storage.length)
+        ) { value, range, _ in
+            guard let attachment = value as? BrowserDesignModeTokenAttachment,
+                  let cell = attachment.attachmentCell as? BrowserDesignModeTokenCell else { return }
+            let glyphRange = layoutManager.glyphRange(
+                forCharacterRange: range,
+                actualCharacterRange: nil
+            )
+            let containerFrame = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            tokens.append((
+                attachment.identity,
+                cell,
+                containerFrame.offsetBy(dx: textContainerInset.width, dy: textContainerInset.height)
+            ))
+        }
+        return tokens
+    }
+
     override func draw(_ dirtyRect: NSRect) {
         super.draw(dirtyRect)
         guard let storage = textStorage,
@@ -642,18 +738,24 @@ enum BrowserDesignModeTokenStyle {
 final class BrowserDesignModeTokenAttachment: NSTextAttachment {
     let identity: String
 
-    init(selection: BrowserDesignModeSelection) {
+    init(
+        selection: BrowserDesignModeSelection,
+        onRemove: @escaping @MainActor (String) -> Void
+    ) {
         identity = selection.selector
         super.init(data: nil, ofType: nil)
-        attachmentCell = BrowserDesignModeTokenCell(selection: selection)
+        attachmentCell = BrowserDesignModeTokenCell(selection: selection, onRemove: onRemove)
     }
 
     @available(*, unavailable)
     required init?(coder: NSCoder) { nil }
 
-    static func attributedToken(for selection: BrowserDesignModeSelection, at index: Int) -> NSAttributedString {
+    static func attributedToken(
+        for selection: BrowserDesignModeSelection,
+        onRemove: @escaping @MainActor (String) -> Void
+    ) -> NSAttributedString {
         let token = NSMutableAttributedString(
-            attachment: BrowserDesignModeTokenAttachment(selection: selection)
+            attachment: BrowserDesignModeTokenAttachment(selection: selection, onRemove: onRemove)
         )
         // Hovering a pill shows its (middle-truncated) XPath; clicking the
         // pill copies the full path.
@@ -680,109 +782,5 @@ final class BrowserDesignModeTokenAttachment: NSTextAttachment {
             range: NSRange(location: 0, length: token.length)
         )
         return token
-    }
-}
-
-/// Draws a token as an inline pill: element-kind glyph plus tag name in blue.
-final class BrowserDesignModeTokenCell: NSTextAttachmentCell {
-    let identity: String
-    private let tagTitle: String
-    private let icon: NSImage?
-    private let tint: NSColor
-    private let titleAttributes: [NSAttributedString.Key: Any]
-
-    /// Parses the runtime's palette hex (#RRGGBB); falls back to accent blue.
-    private static func tintColor(fromHex hex: String) -> NSColor {
-        var value: UInt64 = 0
-        let trimmed = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
-        guard trimmed.count == 6, Scanner(string: trimmed).scanHexInt64(&value) else {
-            return BrowserDesignModeTokenStyle.blue
-        }
-        return NSColor(
-            calibratedRed: CGFloat((value >> 16) & 0xFF) / 255,
-            green: CGFloat((value >> 8) & 0xFF) / 255,
-            blue: CGFloat(value & 0xFF) / 255,
-            alpha: 1
-        )
-    }
-
-    init(selection: BrowserDesignModeSelection) {
-        identity = selection.selector
-        tagTitle = selection.tagName
-        let tint = Self.tintColor(fromHex: selection.color)
-        self.tint = tint
-        titleAttributes = [
-            // Same point size as the typed text so pills read as inline words;
-            // medium weight alone marks them as tags.
-            .font: NSFont.systemFont(ofSize: 13.5, weight: .medium),
-            .foregroundColor: tint,
-        ]
-        let configuration = NSImage.SymbolConfiguration(pointSize: 9, weight: .semibold)
-        let symbol = NSImage(
-            systemSymbolName: BrowserDesignModeTagSymbol.symbol(forTag: selection.tagName),
-            accessibilityDescription: selection.tagName
-        )?.withSymbolConfiguration(configuration)
-        // Tint once; draw(withFrame:in:) runs on every text-view redraw.
-        icon = symbol.map { base in
-            NSImage(size: base.size, flipped: false) { rect in
-                base.draw(in: rect)
-                tint.set()
-                rect.fill(using: .sourceAtop)
-                return true
-            }
-        }
-        super.init(textCell: "")
-        setAccessibilityLabel(selection.tagName)
-    }
-
-    @available(*, unavailable)
-    required init(coder: NSCoder) { fatalError("unsupported") }
-
-    private var titleSize: NSSize {
-        (tagTitle as NSString).size(withAttributes: titleAttributes)
-    }
-
-    override func cellSize() -> NSSize {
-        // Width includes the visual breathing room between pills (no literal
-        // space characters live in the storage).
-        let iconWidth: CGFloat = icon == nil ? 0 : 13
-        return NSSize(
-            width: titleSize.width + iconWidth + 16,
-            height: BrowserDesignModeTokenStyle.naturalLineHeight
-        )
-    }
-
-    override func cellBaselineOffset() -> NSPoint {
-        // With the field's fixed 20pt lines, AppKit pins each baseline at
-        // AppKit pins each baseline at fragmentBottom - maxDescent, so a cell
-        // descending deeper than the font shifts text on rows that gain or
-        // lose a pill. With the cell sized to naturalLineHeight, this offset
-        // makes its ascent and descent match the font's exactly — pill rows
-        // and text rows keep identical fragments and baselines.
-        NSPoint(x: 0, y: BrowserDesignModeTokenStyle.font.descender)
-    }
-
-    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
-        // Cursor-style: plain tinted icon + tag name, no pill background.
-        // Share the surrounding text's baseline so pills read as inline words.
-        let baseline = cellFrame.minY + cellFrame.height
-            + BrowserDesignModeTokenStyle.font.descender
-        let titleFont = titleAttributes[.font] as? NSFont
-            ?? BrowserDesignModeTokenStyle.font
-        var textX = cellFrame.minX + 8
-        if let icon {
-            let iconRect = NSRect(
-                x: textX,
-                y: baseline - titleFont.capHeight / 2 - icon.size.height / 2,
-                width: icon.size.width,
-                height: icon.size.height
-            )
-            icon.draw(in: iconRect)
-            textX = iconRect.maxX + 3
-        }
-        (tagTitle as NSString).draw(
-            at: NSPoint(x: textX, y: baseline - titleFont.ascender),
-            withAttributes: titleAttributes
-        )
     }
 }

--- a/Sources/Panels/BrowserDesignModeScreenshotStore.swift
+++ b/Sources/Panels/BrowserDesignModeScreenshotStore.swift
@@ -26,6 +26,8 @@ private actor BrowserDesignModeScreenshotPinRegistry {
 
 /// Persists bounded screenshot crops away from the main actor.
 actor BrowserDesignModeScreenshotStore {
+    private static let fileLimit = 100
+
     private let directory: URL
     private let fileManager: FileManager
     private let pinRegistry = BrowserDesignModeScreenshotPinRegistry.shared
@@ -53,7 +55,7 @@ actor BrowserDesignModeScreenshotStore {
             await pinRegistry.release(url)
             throw error
         }
-        await pruneKeepingNewest(limit: 100)
+        await pruneKeepingNewest(limit: Self.fileLimit)
         return url
     }
 
@@ -66,6 +68,7 @@ actor BrowserDesignModeScreenshotStore {
     /// Returns a former live-context file to normal recency-based pruning.
     func release(_ url: URL) async {
         await pinRegistry.release(url)
+        await pruneKeepingNewest(limit: Self.fileLimit)
     }
 
     private func pruneKeepingNewest(limit: Int) async {

--- a/Sources/Panels/BrowserDesignModeScreenshotStore.swift
+++ b/Sources/Panels/BrowserDesignModeScreenshotStore.swift
@@ -1,42 +1,92 @@
 import Foundation
 
+enum BrowserDesignModeScreenshotRetention: Equatable, Sendable {
+    case prunable
+    case liveContext
+}
+
+/// Coordinates live-context files across per-panel stores sharing one directory.
+private actor BrowserDesignModeScreenshotPinRegistry {
+    static let shared = BrowserDesignModeScreenshotPinRegistry()
+
+    private var paths: Set<String> = []
+
+    func retain(_ url: URL) {
+        paths.insert(url.standardizedFileURL.path)
+    }
+
+    func release(_ url: URL) {
+        paths.remove(url.standardizedFileURL.path)
+    }
+
+    func snapshot() -> Set<String> {
+        paths
+    }
+}
+
 /// Persists bounded screenshot crops away from the main actor.
 actor BrowserDesignModeScreenshotStore {
     private let directory: URL
     private let fileManager: FileManager
+    private let pinRegistry = BrowserDesignModeScreenshotPinRegistry.shared
 
     init(directory: URL, fileManager: FileManager = .default) {
         self.directory = directory
         self.fileManager = fileManager
     }
 
-    func save(_ pngData: Data, surfaceID: UUID) throws -> URL {
-        try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+    func save(
+        _ pngData: Data,
+        surfaceID: UUID,
+        retention: BrowserDesignModeScreenshotRetention = .prunable
+    ) async throws -> URL {
         let timestamp = Int(Date().timeIntervalSince1970 * 1_000)
         let filename = "surface-\(surfaceID.uuidString.prefix(8))-\(timestamp)-\(UUID().uuidString.prefix(8)).png"
         let url = directory.appendingPathComponent(filename, isDirectory: false)
-        try pngData.write(to: url, options: .atomic)
-        pruneKeepingNewest(limit: 100)
+        if retention == .liveContext {
+            await pinRegistry.retain(url)
+        }
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try pngData.write(to: url, options: .atomic)
+        } catch {
+            await pinRegistry.release(url)
+            throw error
+        }
+        await pruneKeepingNewest(limit: 100)
         return url
     }
 
     /// Deletes a capture that never became part of authoritative prompt context.
-    func remove(_ url: URL) {
+    func remove(_ url: URL) async {
+        await pinRegistry.release(url)
         try? fileManager.removeItem(at: url)
     }
 
-    private func pruneKeepingNewest(limit: Int) {
+    /// Returns a former live-context file to normal recency-based pruning.
+    func release(_ url: URL) async {
+        await pinRegistry.release(url)
+    }
+
+    private func pruneKeepingNewest(limit: Int) async {
         guard let urls = try? fileManager.contentsOfDirectory(
             at: directory,
             includingPropertiesForKeys: [.contentModificationDateKey],
             options: [.skipsHiddenFiles]
         ), urls.count > limit else { return }
-        let ordered = urls.sorted { lhs, rhs in
+        let pinnedPaths = await pinRegistry.snapshot()
+        let pinnedCount = urls.reduce(into: 0) { count, url in
+            if pinnedPaths.contains(url.standardizedFileURL.path) { count += 1 }
+        }
+        let prunableLimit = max(0, limit - pinnedCount)
+        let ordered = urls.filter {
+            !pinnedPaths.contains($0.standardizedFileURL.path)
+        }.sorted { lhs, rhs in
             let lhsDate = (try? lhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
             let rhsDate = (try? rhs.resourceValues(forKeys: [.contentModificationDateKey]).contentModificationDate) ?? .distantPast
             return lhsDate > rhsDate
         }
-        for staleURL in ordered.dropFirst(limit) {
+        for staleURL in ordered.dropFirst(prunableLimit) {
             try? fileManager.removeItem(at: staleURL)
         }
     }

--- a/Sources/Panels/BrowserDesignModeScreenshotStore.swift
+++ b/Sources/Panels/BrowserDesignModeScreenshotStore.swift
@@ -20,6 +20,11 @@ actor BrowserDesignModeScreenshotStore {
         return url
     }
 
+    /// Deletes a capture that never became part of authoritative prompt context.
+    func remove(_ url: URL) {
+        try? fileManager.removeItem(at: url)
+    }
+
     private func pruneKeepingNewest(limit: Int) {
         guard let urls = try? fileManager.contentsOfDirectory(
             at: directory,

--- a/Sources/Panels/BrowserDesignModeSupport.swift
+++ b/Sources/Panels/BrowserDesignModeSupport.swift
@@ -11,6 +11,16 @@ enum BrowserDesignModeSupport {
         return try JSONDecoder().decode(BrowserDesignModeSnapshot.self, from: data)
     }
 
+    static func decodeAnnotationCaptureRequest(
+        _ value: Any?
+    ) throws -> BrowserDesignModeAnnotationCaptureRequest {
+        guard let value, JSONSerialization.isValidJSONObject(value) else {
+            throw BrowserDesignModeError.invalidRuntimeResponse
+        }
+        let data = try JSONSerialization.data(withJSONObject: value)
+        return try JSONDecoder().decode(BrowserDesignModeAnnotationCaptureRequest.self, from: data)
+    }
+
     static func captureMatches(
         before: BrowserDesignModeSnapshot,
         after: BrowserDesignModeSnapshot,

--- a/Sources/Panels/BrowserDesignModeTokenCell.swift
+++ b/Sources/Panels/BrowserDesignModeTokenCell.swift
@@ -1,6 +1,33 @@
 import AppKit
 import CmuxBrowser
 
+/// Splits a composer deletion around authoritative context-token attachments.
+enum BrowserDesignModeTokenDeletion {
+    static func textRangesOutsideAttachments(
+        in content: NSAttributedString,
+        range: NSRange
+    ) -> [NSRange] {
+        let validRange = NSIntersectionRange(
+            range,
+            NSRange(location: 0, length: content.length)
+        )
+        guard validRange.length > 0 else { return [] }
+        var textRanges: [NSRange] = []
+        var cursor = validRange.location
+        content.enumerateAttribute(.attachment, in: validRange) { value, attachmentRange, _ in
+            guard value != nil else { return }
+            if cursor < attachmentRange.location {
+                textRanges.append(NSRange(location: cursor, length: attachmentRange.location - cursor))
+            }
+            cursor = max(cursor, attachmentRange.upperBound)
+        }
+        if cursor < validRange.upperBound {
+            textRanges.append(NSRange(location: cursor, length: validRange.upperBound - cursor))
+        }
+        return textRanges
+    }
+}
+
 /// Draws a context token with a stable leading column that becomes a delete affordance on hover.
 final class BrowserDesignModeTokenCell: NSTextAttachmentCell {
     let identity: String

--- a/Sources/Panels/BrowserDesignModeTokenCell.swift
+++ b/Sources/Panels/BrowserDesignModeTokenCell.swift
@@ -1,0 +1,130 @@
+import AppKit
+import CmuxBrowser
+
+/// Draws a context token with a stable leading column that becomes a delete affordance on hover.
+final class BrowserDesignModeTokenCell: NSTextAttachmentCell {
+    let identity: String
+    private let tagTitle: String
+    private let icon: NSImage?
+    private let deleteIcon: NSImage?
+    private let titleAttributes: [NSAttributedString.Key: Any]
+    private let onRemove: @MainActor (String) -> Void
+
+    /// Parses the runtime's palette hex (#RRGGBB); falls back to accent blue.
+    private static func tintColor(fromHex hex: String) -> NSColor {
+        var value: UInt64 = 0
+        let trimmed = hex.hasPrefix("#") ? String(hex.dropFirst()) : hex
+        guard trimmed.count == 6, Scanner(string: trimmed).scanHexInt64(&value) else {
+            return BrowserDesignModeTokenStyle.blue
+        }
+        return NSColor(
+            calibratedRed: CGFloat((value >> 16) & 0xFF) / 255,
+            green: CGFloat((value >> 8) & 0xFF) / 255,
+            blue: CGFloat(value & 0xFF) / 255,
+            alpha: 1
+        )
+    }
+
+    init(
+        selection: BrowserDesignModeSelection,
+        onRemove: @escaping @MainActor (String) -> Void
+    ) {
+        identity = selection.selector
+        tagTitle = selection.tagName
+        self.onRemove = onRemove
+        let tint = Self.tintColor(fromHex: selection.color)
+        titleAttributes = [
+            // Same point size as the typed text so pills read as inline words;
+            // medium weight alone marks them as tags.
+            .font: NSFont.systemFont(ofSize: 13.5, weight: .medium),
+            .foregroundColor: tint,
+        ]
+        let configuration = NSImage.SymbolConfiguration(pointSize: 9, weight: .semibold)
+        let symbol = NSImage(
+            systemSymbolName: BrowserDesignModeTagSymbol.symbol(forTag: selection.tagName),
+            accessibilityDescription: selection.tagName
+        )?.withSymbolConfiguration(configuration)
+        let removeSymbol = NSImage(
+            systemSymbolName: "xmark",
+            accessibilityDescription: nil
+        )?.withSymbolConfiguration(configuration)
+        // Tint once; draw(withFrame:in:) runs on every text-view redraw.
+        let tintImage: (NSImage?) -> NSImage? = { source in
+            source.map { base in
+                NSImage(size: base.size, flipped: false) { rect in
+                    base.draw(in: rect)
+                    tint.set()
+                    rect.fill(using: .sourceAtop)
+                    return true
+                }
+            }
+        }
+        icon = tintImage(symbol)
+        deleteIcon = tintImage(removeSymbol)
+        super.init(textCell: "")
+        setAccessibilityElement(true)
+        setAccessibilityRole(.button)
+        setAccessibilityLabel(
+            String(
+                localized: "browser.designMode.context.remove",
+                defaultValue: "Remove \(selection.tagName) context"
+            )
+        )
+    }
+
+    @available(*, unavailable)
+    required init(coder: NSCoder) { fatalError("unsupported") }
+
+    func performRemoval() {
+        onRemove(identity)
+    }
+
+    func deleteHitRect(in cellFrame: NSRect) -> NSRect {
+        NSRect(x: cellFrame.minX + 3, y: cellFrame.minY, width: 19, height: cellFrame.height)
+    }
+
+    override func accessibilityPerformPress() -> Bool {
+        performRemoval()
+        return true
+    }
+
+    private var titleSize: NSSize {
+        (tagTitle as NSString).size(withAttributes: titleAttributes)
+    }
+
+    override func cellSize() -> NSSize {
+        // Reserve a stable leading glyph column so hover never reflows text.
+        let iconWidth: CGFloat = icon == nil && deleteIcon == nil ? 0 : 13
+        return NSSize(
+            width: titleSize.width + iconWidth + 16,
+            height: BrowserDesignModeTokenStyle.naturalLineHeight
+        )
+    }
+
+    override func cellBaselineOffset() -> NSPoint {
+        NSPoint(x: 0, y: BrowserDesignModeTokenStyle.font.descender)
+    }
+
+    override func draw(withFrame cellFrame: NSRect, in controlView: NSView?) {
+        let baseline = cellFrame.minY + cellFrame.height
+            + BrowserDesignModeTokenStyle.font.descender
+        let titleFont = titleAttributes[.font] as? NSFont
+            ?? BrowserDesignModeTokenStyle.font
+        let hovering = (controlView as? BrowserDesignModeTokenTextView)?.hoveredTokenIdentity == identity
+        var textX = cellFrame.minX + 8
+        if let leadingIcon = hovering ? deleteIcon : icon {
+            let iconRect = NSRect(
+                x: textX,
+                y: baseline - titleFont.capHeight / 2 - leadingIcon.size.height / 2,
+                width: leadingIcon.size.width,
+                height: leadingIcon.size.height
+            )
+            leadingIcon.draw(in: iconRect)
+            textX = iconRect.maxX + 3
+        }
+        (tagTitle as NSString).draw(
+            at: NSPoint(x: textX, y: baseline - titleFont.ascender),
+            withAttributes: titleAttributes
+        )
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -221,6 +221,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7032A050000000000000001 /* BrowserClientCertificateCredentialPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A050000000000000002 /* BrowserClientCertificateCredentialPicker.swift */; };
 		D7032A030000000000000001 /* BrowserClientCertificateCredentialPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */; };
 		E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */; };
+		D35A0000000000000000001E /* BrowserDesignModeCaptureShield.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000001E /* BrowserDesignModeCaptureShield.swift */; };
 		D35C00000000000000000002 /* BrowserDesignModeComposerHostingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35D00000000000000000002 /* BrowserDesignModeComposerHostingViewTests.swift */; };
 		D35A0000000000000000001C /* BrowserDesignModeController+Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000001C /* BrowserDesignModeController+Capture.swift */; };
 		D35A00000000000000000003 /* BrowserDesignModeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000003 /* BrowserDesignModeController.swift */; };
@@ -2326,6 +2327,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7032A050000000000000002 /* BrowserClientCertificateCredentialPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserClientCertificateCredentialPicker.swift; sourceTree = "<group>"; };
 		D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserClientCertificateCredentialPickerTests.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
+		D35B0000000000000000001E /* BrowserDesignModeCaptureShield.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeCaptureShield.swift; sourceTree = "<group>"; };
 		D35D00000000000000000002 /* BrowserDesignModeComposerHostingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDesignModeComposerHostingViewTests.swift; sourceTree = "<group>"; };
 		D35B0000000000000000001C /* BrowserDesignModeController+Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserDesignModeController+Capture.swift"; sourceTree = "<group>"; };
 		D35B00000000000000000003 /* BrowserDesignModeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeController.swift; sourceTree = "<group>"; };
@@ -5027,6 +5029,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */,
 				D35B00000000000000000013 /* TerminalController+BrowserWorkerSupport.swift */,
 				D35B00000000000000000001 /* AppDelegate+BrowserDesignMode.swift */,
+				D35B0000000000000000001E /* BrowserDesignModeCaptureShield.swift */,
 				D35B0000000000000000001C /* BrowserDesignModeController+Capture.swift */,
 				D35B00000000000000000003 /* BrowserDesignModeController.swift */,
 				D35B00000000000000000017 /* BrowserDesignModePopover.swift */,
@@ -6849,6 +6852,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,
 				D7032A020000000000000001 /* BrowserClientCertificateAuthenticationController.swift in Sources */,
 				D7032A050000000000000001 /* BrowserClientCertificateCredentialPicker.swift in Sources */,
+				D35A0000000000000000001E /* BrowserDesignModeCaptureShield.swift in Sources */,
 				D35A0000000000000000001C /* BrowserDesignModeController+Capture.swift in Sources */,
 				D35A00000000000000000003 /* BrowserDesignModeController.swift in Sources */,
 				D35A0000000000000000000A /* BrowserDesignModeError.swift in Sources */,

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -222,6 +222,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D7032A030000000000000001 /* BrowserClientCertificateCredentialPickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */; };
 		E12E88F82733EC42F32C36A3 /* BrowserConfigTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */; };
 		D35C00000000000000000002 /* BrowserDesignModeComposerHostingViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35D00000000000000000002 /* BrowserDesignModeComposerHostingViewTests.swift */; };
+		D35A0000000000000000001C /* BrowserDesignModeController+Capture.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000001C /* BrowserDesignModeController+Capture.swift */; };
 		D35A00000000000000000003 /* BrowserDesignModeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000003 /* BrowserDesignModeController.swift */; };
 		D35A0000000000000000000A /* BrowserDesignModeError.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000000A /* BrowserDesignModeError.swift */; };
 		D35A00000000000000000015 /* BrowserDesignModeJavaScriptEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000015 /* BrowserDesignModeJavaScriptEvaluator.swift */; };
@@ -235,6 +236,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		D35A00000000000000000009 /* BrowserDesignModeScreenshotStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000009 /* BrowserDesignModeScreenshotStore.swift */; };
 		D35A00000000000000000019 /* BrowserDesignModeSelectionChip.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B00000000000000000019 /* BrowserDesignModeSelectionChip.swift */; };
 		D35A0000000000000000001B /* BrowserDesignModeSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000001B /* BrowserDesignModeSupport.swift */; };
+		D35A0000000000000000001D /* BrowserDesignModeTokenCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000001D /* BrowserDesignModeTokenCell.swift */; };
 		D35A0000000000000000000B /* BrowserDesignModeToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D35B0000000000000000000B /* BrowserDesignModeToolbarButton.swift */; };
 		B1F0C0050000000000000001 /* BrowserDeveloperToolsDockControlNormalizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0050000000000000002 /* BrowserDeveloperToolsDockControlNormalizer.swift */; };
 		B1F0C0060000000000000001 /* BrowserDeveloperToolsDockControlNormalizerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B1F0C0060000000000000002 /* BrowserDeveloperToolsDockControlNormalizerTests.swift */; };
@@ -2323,6 +2325,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D7032A030000000000000002 /* BrowserClientCertificateCredentialPickerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserClientCertificateCredentialPickerTests.swift; sourceTree = "<group>"; };
 		970226F3C99D0D937CD00539 /* BrowserConfigTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserConfigTests.swift; sourceTree = "<group>"; };
 		D35D00000000000000000002 /* BrowserDesignModeComposerHostingViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDesignModeComposerHostingViewTests.swift; sourceTree = "<group>"; };
+		D35B0000000000000000001C /* BrowserDesignModeController+Capture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Panels/BrowserDesignModeController+Capture.swift"; sourceTree = "<group>"; };
 		D35B00000000000000000003 /* BrowserDesignModeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeController.swift; sourceTree = "<group>"; };
 		D35B0000000000000000000A /* BrowserDesignModeError.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeError.swift; sourceTree = "<group>"; };
 		D35B00000000000000000015 /* BrowserDesignModeJavaScriptEvaluator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeJavaScriptEvaluator.swift; sourceTree = "<group>"; };
@@ -2336,6 +2339,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D35B00000000000000000009 /* BrowserDesignModeScreenshotStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeScreenshotStore.swift; sourceTree = "<group>"; };
 		D35B00000000000000000019 /* BrowserDesignModeSelectionChip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeSelectionChip.swift; sourceTree = "<group>"; };
 		D35B0000000000000000001B /* BrowserDesignModeSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeSupport.swift; sourceTree = "<group>"; };
+		D35B0000000000000000001D /* BrowserDesignModeTokenCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeTokenCell.swift; sourceTree = "<group>"; };
 		D35B0000000000000000000B /* BrowserDesignModeToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDesignModeToolbarButton.swift; sourceTree = "<group>"; };
 		B1F0C0050000000000000002 /* BrowserDeveloperToolsDockControlNormalizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Panels/BrowserDeveloperToolsDockControlNormalizer.swift; sourceTree = "<group>"; };
 		B1F0C0060000000000000002 /* BrowserDeveloperToolsDockControlNormalizerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BrowserDeveloperToolsDockControlNormalizerTests.swift; sourceTree = "<group>"; };
@@ -5019,6 +5023,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D35B00000000000000000014 /* TerminalController+AgentPromptDelivery.swift */,
 				D35B00000000000000000013 /* TerminalController+BrowserWorkerSupport.swift */,
 				D35B00000000000000000001 /* AppDelegate+BrowserDesignMode.swift */,
+				D35B0000000000000000001C /* BrowserDesignModeController+Capture.swift */,
 				D35B00000000000000000003 /* BrowserDesignModeController.swift */,
 				D35B00000000000000000017 /* BrowserDesignModePopover.swift */,
 				D35B00000000000000000018 /* BrowserDesignModePopoverHost.swift */,
@@ -5033,6 +5038,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D35B00000000000000000009 /* BrowserDesignModeScreenshotStore.swift */,
 				D35B0000000000000000000A /* BrowserDesignModeError.swift */,
 				D35B0000000000000000000B /* BrowserDesignModeToolbarButton.swift */,
+				D35B0000000000000000001D /* BrowserDesignModeTokenCell.swift */,
 				D35B0000000000000000000E /* BrowserPortalAnchorView.swift */,
 				D35B0000000000000000000F /* BrowserInsecureHTTPNavigationResolution.swift */,
 				D35B00000000000000000010 /* ShortcutRecorderRejectedAttempt.swift */,
@@ -6837,6 +6843,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				BCBC0A0E0000000000000C01 /* BrowserChromeMetrics.swift in Sources */,
 				D7032A020000000000000001 /* BrowserClientCertificateAuthenticationController.swift in Sources */,
 				D7032A050000000000000001 /* BrowserClientCertificateCredentialPicker.swift in Sources */,
+				D35A0000000000000000001C /* BrowserDesignModeController+Capture.swift in Sources */,
 				D35A00000000000000000003 /* BrowserDesignModeController.swift in Sources */,
 				D35A0000000000000000000A /* BrowserDesignModeError.swift in Sources */,
 				D35A00000000000000000015 /* BrowserDesignModeJavaScriptEvaluator.swift in Sources */,
@@ -6849,6 +6856,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D35A00000000000000000009 /* BrowserDesignModeScreenshotStore.swift in Sources */,
 				D35A00000000000000000019 /* BrowserDesignModeSelectionChip.swift in Sources */,
 				D35A0000000000000000001B /* BrowserDesignModeSupport.swift in Sources */,
+				D35A0000000000000000001D /* BrowserDesignModeTokenCell.swift in Sources */,
 				D35A0000000000000000000B /* BrowserDesignModeToolbarButton.swift in Sources */,
 				B1F0C0050000000000000001 /* BrowserDeveloperToolsDockControlNormalizer.swift in Sources */,
 				B75040010000000000000001 /* BrowserDiscardRestoreHeal.swift in Sources */,

--- a/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
+++ b/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
@@ -137,4 +137,23 @@ struct BrowserDesignModeComposerHostingViewTests {
         #expect(!removed)
         #expect(controller.snapshot?.selections == [selection])
     }
+
+    @Test func mixedTokenDeletionPreservesOnlyTheAttachmentRange() {
+        let content = NSMutableAttributedString(string: "A\u{FFFC}BC")
+        content.addAttribute(
+            .attachment,
+            value: NSTextAttachment(),
+            range: NSRange(location: 1, length: 1)
+        )
+
+        let ranges = BrowserDesignModeTokenDeletion.textRangesOutsideAttachments(
+            in: content,
+            range: NSRange(location: 0, length: content.length)
+        )
+
+        #expect(ranges == [
+            NSRange(location: 0, length: 1),
+            NSRange(location: 2, length: 2),
+        ])
+    }
 }

--- a/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
+++ b/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
@@ -108,6 +108,39 @@ struct BrowserDesignModeComposerHostingViewTests {
         #expect(removedIdentity == "#hero")
     }
 
+    @Test func tokenHitTestingResolvesOnlyTheGlyphUnderThePointer() throws {
+        let selection = BrowserDesignModeSelection(
+            selector: "#hero",
+            selectors: ["#hero"],
+            tagName: "h1",
+            domSnippet: "<h1 id=\"hero\">Hero</h1>",
+            textContent: "Hero",
+            textEditable: true,
+            bounds: BrowserDesignModeRect(x: 10, y: 20, width: 200, height: 60),
+            viewport: BrowserDesignModeViewport(width: 800, height: 600),
+            computedStyles: [:]
+        )
+        let textView = BrowserDesignModeTokenTextView(
+            frame: NSRect(x: 0, y: 0, width: 320, height: 40)
+        )
+        let storage = try #require(textView.textStorage)
+        storage.setAttributedString(
+            BrowserDesignModeTokenAttachment.attributedToken(for: selection) { _ in }
+        )
+        let layoutManager = try #require(textView.layoutManager)
+        let textContainer = try #require(textView.textContainer)
+        layoutManager.ensureLayout(for: textContainer)
+        let glyphRange = layoutManager.glyphRange(
+            forCharacterRange: NSRange(location: 0, length: 1),
+            actualCharacterRange: nil
+        )
+        let tokenFrame = layoutManager.boundingRect(forGlyphRange: glyphRange, in: textContainer)
+            .offsetBy(dx: textView.textContainerOrigin.x, dy: textView.textContainerOrigin.y)
+
+        #expect(textView.tokenHit(at: NSPoint(x: tokenFrame.midX, y: tokenFrame.midY))?.identity == "#hero")
+        #expect(textView.tokenHit(at: NSPoint(x: 300, y: tokenFrame.midY)) == nil)
+    }
+
     @Test func failedRuntimeRemovalKeepsAuthoritativeSelection() async {
         let controller = makeController()
         controller.phase = .active(annotation: .idle)

--- a/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
+++ b/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
@@ -79,4 +79,32 @@ struct BrowserDesignModeComposerHostingViewTests {
             "Events outside the composer card must pass through to the page"
         )
     }
+
+    @Test func selectionTokenExposesAnAccessibleRemovalAction() {
+        let selection = BrowserDesignModeSelection(
+            selector: "#hero",
+            selectors: ["#hero"],
+            tagName: "h1",
+            domSnippet: "<h1 id=\"hero\">Hero</h1>",
+            textContent: "Hero",
+            textEditable: true,
+            bounds: BrowserDesignModeRect(x: 10, y: 20, width: 200, height: 60),
+            viewport: BrowserDesignModeViewport(width: 800, height: 600),
+            computedStyles: [:]
+        )
+        var removedIdentity: String?
+        let cell = BrowserDesignModeTokenCell(selection: selection) { identity in
+            removedIdentity = identity
+        }
+
+        #expect(cell.accessibilityRole() == .button)
+        #expect(
+            cell.accessibilityLabel() == String(
+                localized: "browser.designMode.context.remove",
+                defaultValue: "Remove h1 context"
+            )
+        )
+        #expect(cell.accessibilityPerformPress())
+        #expect(removedIdentity == "#hero")
+    }
 }

--- a/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
+++ b/cmuxTests/BrowserDesignModeComposerHostingViewTests.swift
@@ -107,4 +107,34 @@ struct BrowserDesignModeComposerHostingViewTests {
         #expect(cell.accessibilityPerformPress())
         #expect(removedIdentity == "#hero")
     }
+
+    @Test func failedRuntimeRemovalKeepsAuthoritativeSelection() async {
+        let controller = makeController()
+        controller.phase = .active(annotation: .idle)
+        let selection = BrowserDesignModeSelection(
+            selector: "#hero",
+            selectors: ["#hero"],
+            tagName: "h1",
+            domSnippet: "<h1 id=\"hero\">Hero</h1>",
+            textContent: "Hero",
+            textEditable: true,
+            bounds: BrowserDesignModeRect(x: 10, y: 20, width: 200, height: 60),
+            viewport: BrowserDesignModeViewport(width: 800, height: 600),
+            computedStyles: [:]
+        )
+        controller.apply(
+            BrowserDesignModeSnapshot(
+                revision: 1,
+                enabled: true,
+                selection: selection,
+                edits: [],
+                cssDiff: ""
+            )
+        )
+
+        let removed = await controller.removeSelection(at: 0)
+
+        #expect(!removed)
+        #expect(controller.snapshot?.selections == [selection])
+    }
 }

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -82,6 +82,32 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         #expect(!FileManager.default.fileExists(atPath: pinned.path))
     }
 
+    @Test func releasingLiveAnnotationImmediatelyRestoresScreenshotLimit() async throws {
+        let directory = URL.temporaryDirectory
+            .appendingPathComponent("cmux-design-mode-release-pruning-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = BrowserDesignModeScreenshotStore(directory: directory)
+        let surfaceID = UUID()
+        var pinned: [URL] = []
+
+        for value in 0...100 {
+            pinned.append(try await store.save(
+                Data([UInt8(value)]),
+                surfaceID: surfaceID,
+                retention: .liveContext
+            ))
+        }
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).count == 101)
+
+        await store.release(pinned[0])
+
+        #expect(!FileManager.default.fileExists(atPath: pinned[0].path))
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path).count == 100)
+        for url in pinned.dropFirst() {
+            await store.remove(url)
+        }
+    }
+
     @Test func synthesizedClickKeepsPageRuntimeOutOfTheNativeComposerInputPath() async throws {
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
         let controller = BrowserDesignModeController(

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -56,6 +56,32 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         }
     }
 
+    @Test func screenshotPruningPinsOnlyLiveAnnotationContext() async throws {
+        let directory = URL.temporaryDirectory
+            .appendingPathComponent("cmux-design-mode-pinning-test-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = BrowserDesignModeScreenshotStore(directory: directory)
+        let surfaceID = UUID()
+        let pinned = try await store.save(
+            Data([0]),
+            surfaceID: surfaceID,
+            retention: .liveContext
+        )
+        try FileManager.default.setAttributes(
+            [.modificationDate: Date(timeIntervalSince1970: 0)],
+            ofItemAtPath: pinned.path
+        )
+
+        for value in 1...101 {
+            _ = try await store.save(Data([UInt8(value)]), surfaceID: surfaceID)
+        }
+        #expect(FileManager.default.fileExists(atPath: pinned.path))
+
+        await store.release(pinned)
+        _ = try await store.save(Data([255]), surfaceID: surfaceID)
+        #expect(!FileManager.default.fileExists(atPath: pinned.path))
+    }
+
     @Test func synthesizedClickKeepsPageRuntimeOutOfTheNativeComposerInputPath() async throws {
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
         let controller = BrowserDesignModeController(

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -289,6 +289,20 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         #expect((elements[0]["selection"] as? [String: Any])?["selector"] as? String == "#first")
         #expect((elements[1]["selection"] as? [String: Any])?["selector"] as? String == "#second")
         #expect(elements.allSatisfy { ($0["screenshot_path"] as? String)?.isEmpty == false })
+
+        controller.requestedChange = "Keep the second selection"
+        await controller.removeSelection(at: 0)
+        #expect(controller.snapshot?.selections.map(\.selector) == ["#second"])
+        #expect(controller.requestedChange == "Keep the second selection")
+
+        await controller.copySelection()
+
+        let reducedPrompt = try #require(copiedPrompt)
+        let reducedPayload = try payload(from: reducedPrompt)
+        let reducedElements = try #require(reducedPayload["elements"] as? [[String: Any]])
+        #expect(reducedElements.count == 1)
+        #expect((reducedElements[0]["selection"] as? [String: Any])?["selector"] as? String == "#second")
+        #expect(reducedPayload["requested_change"] as? String == "Keep the second selection")
         _ = navigationDelegate
     }
 

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -133,6 +133,42 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         #expect(!panel.designModeController.isActive)
     }
 
+    @Test func nativeAnnotationLifecycleRejectsDrawMessagesOutsideDrawMode() {
+        let controller = makeDetachedController()
+        controller.phase = .active(annotation: .idle)
+
+        controller.beginAnnotationDrawing(id: "stale-stroke")
+
+        #expect(controller.phase == .active(annotation: .idle))
+    }
+
+    @Test func annotationCaptureRequestMustMatchTheActiveStroke() throws {
+        let controller = makeDetachedController()
+        controller.phase = .active(annotation: .idle)
+        controller.adoptInteractionModeFromRuntime("draw")
+        controller.beginAnnotationDrawing(id: "active-stroke")
+        let staleRequest = BrowserDesignModeAnnotationCaptureRequest(
+            id: "stale-stroke",
+            strokeBounds: BrowserDesignModeRect(x: 10, y: 20, width: 100, height: 80),
+            viewport: BrowserDesignModeViewport(width: 800, height: 600),
+            scrollX: 0,
+            scrollY: 0
+        )
+
+        controller.receiveAnnotationCaptureRequestData(try JSONEncoder().encode(staleRequest))
+
+        #expect(controller.phase == .active(annotation: .drawing(id: "active-stroke")))
+    }
+
+    @Test func escapeTreatsInFlightInkAsPromptContent() async {
+        let controller = makeDetachedController()
+        controller.phase = .active(annotation: .drawing(id: "active-stroke"))
+
+        await controller.handleEscape()
+
+        #expect(controller.phase == .active(annotation: .drawing(id: "active-stroke")))
+    }
+
     @Test func composerCopyRequestWritesSelectedContextWithoutDescriptionOrRuntimeEdits() async throws {
         let image = NSImage(size: NSSize(width: 640, height: 480))
         image.lockFocus()
@@ -308,6 +344,20 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
 
     private func requestedChange(from prompt: String) throws -> String? {
         try payload(from: prompt)["requested_change"] as? String
+    }
+
+    private func makeDetachedController() -> BrowserDesignModeController {
+        BrowserDesignModeController(
+            surfaceID: UUID(),
+            script: BrowserDesignModeScript(),
+            promptFormatter: BrowserDesignModePromptFormatter(),
+            screenshotStore: BrowserDesignModeScreenshotStore(directory: URL.temporaryDirectory),
+            javaScriptEvaluator: BrowserDesignModeJavaScriptEvaluator(),
+            screenshotEvaluator: BrowserDesignModeScreenshotEvaluator(),
+            canEnable: { true },
+            clipboardWriter: { _ in true },
+            onActivityChanged: {}
+        )
     }
 
     private func payload(from prompt: String) throws -> [String: Any] {

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -195,7 +195,7 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         #expect(controller.phase == .active(annotation: .drawing(id: "active-stroke")))
     }
 
-    @Test func switchingToSelectInvalidatesAnInFlightAnnotationCommit() async {
+    @Test func failedModeSwitchPreservesAnInFlightAnnotationCommit() async {
         let controller = makeDetachedController()
         let webView = WKWebView()
         controller.install(on: webView)
@@ -212,8 +212,9 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
 
         await controller.setInteractionMode(.select)
 
-        #expect(controller.operationRevision > captureRevision)
-        #expect(controller.phase == .active(annotation: .idle))
+        #expect(controller.operationRevision == captureRevision)
+        #expect(controller.interactionMode == .draw)
+        #expect(controller.phase == .active(annotation: .capturing(request)))
     }
 
     @Test func composerCopyRequestWritesSelectedContextWithoutDescriptionOrRuntimeEdits() async throws {

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -180,14 +180,20 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
             .appendingPathComponent("cmux-design-mode-copy-test-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: directory) }
         var copiedPrompt: String?
+        var captureCoverStates: [Bool] = []
+        let container = NSView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
         let webView = WKWebView(frame: NSRect(x: 0, y: 0, width: 640, height: 480))
+        container.addSubview(webView)
         let controller = BrowserDesignModeController(
             surfaceID: UUID(),
             script: BrowserDesignModeScript(),
             promptFormatter: BrowserDesignModePromptFormatter(),
             screenshotStore: BrowserDesignModeScreenshotStore(directory: directory),
             javaScriptEvaluator: BrowserDesignModeJavaScriptEvaluator(),
-            screenshotEvaluator: BrowserDesignModeScreenshotEvaluator(timeout: 1) { _, completion in
+            screenshotEvaluator: BrowserDesignModeScreenshotEvaluator(timeout: 1) { capturedWebView, completion in
+                captureCoverStates.append(
+                    capturedWebView.superview?.subviews.contains(where: { $0 !== capturedWebView }) == true
+                )
                 completion(.success(image))
             },
             canEnable: { true },
@@ -226,6 +232,8 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
 
         await controller.copySelection()
 
+        #expect(captureCoverStates == [false, true, true])
+        #expect(container.subviews == [webView])
         let prompt = try #require(copiedPrompt)
         #expect(prompt.contains("<cmux_design_mode>"))
         #expect(try requestedChange(from: prompt) == "")

--- a/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
+++ b/cmuxTests/BrowserDesignModeScreenshotEvaluatorTests.swift
@@ -195,6 +195,27 @@ struct BrowserDesignModeScreenshotEvaluatorTests {
         #expect(controller.phase == .active(annotation: .drawing(id: "active-stroke")))
     }
 
+    @Test func switchingToSelectInvalidatesAnInFlightAnnotationCommit() async {
+        let controller = makeDetachedController()
+        let webView = WKWebView()
+        controller.install(on: webView)
+        let request = BrowserDesignModeAnnotationCaptureRequest(
+            id: "active-stroke",
+            strokeBounds: BrowserDesignModeRect(x: 10, y: 10, width: 100, height: 100),
+            viewport: BrowserDesignModeViewport(width: 800, height: 600),
+            scrollX: 0,
+            scrollY: 0
+        )
+        controller.phase = .active(annotation: .capturing(request))
+        controller.adoptInteractionModeFromRuntime("draw")
+        let captureRevision = controller.operationRevision
+
+        await controller.setInteractionMode(.select)
+
+        #expect(controller.operationRevision > captureRevision)
+        #expect(controller.phase == .active(annotation: .idle))
+    }
+
     @Test func composerCopyRequestWritesSelectedContextWithoutDescriptionOrRuntimeEdits() async throws {
         let image = NSImage(size: NSSize(width: 640, height: 480))
         image.lockFocus()

--- a/webviews/src/browser-design-mode-runtime.test.ts
+++ b/webviews/src/browser-design-mode-runtime.test.ts
@@ -853,6 +853,48 @@ describe("browser design-mode runtime", () => {
     expect(card?.style.boxShadow).not.toContain("rgba(10, 132, 255, 0.55)");
   });
 
+  test("annotation cards evict the oldest retained image after the bounded stack fills", () => {
+    const { dom, messages, runtime } = fixture(`<main><button>B</button></main>`);
+    const doc = dom.window.document;
+    const at = (name: string, x: number, y: number) => doc.dispatchEvent(
+      new dom.window.MouseEvent(name, { bubbles: true, cancelable: true, button: 0, clientX: x, clientY: y }),
+    );
+
+    runtime.setMode("draw");
+    let firstSelector = "";
+    let lastSelector = "";
+    for (let index = 0; index < 10; index += 1) {
+      at("pointerdown", 20 + index, 20 + index);
+      at("pointermove", 60 + index, 60 + index);
+      at("pointerup", 60 + index, 60 + index);
+      const request = messages.slice().reverse().find(
+        (message) => (message as { type?: string }).type === "annotation_capture_requested",
+      ) as { request: { id: string } } | undefined;
+      const annotationID = request?.request.id ?? "";
+      const descriptor = runtime.prepareAnnotationCapture(annotationID);
+      const snapshot = runtime.completeAnnotationCapture(
+        annotationID,
+        0,
+        0,
+        128,
+        128,
+        `data:image/png;base64,Y2FyZC0${index}`,
+        descriptor?.scroll_x ?? 0,
+        descriptor?.scroll_y ?? 0,
+        descriptor?.viewport.width ?? 0,
+        descriptor?.viewport.height ?? 0,
+      );
+      const selector = snapshot.selections?.at(-1)?.selector ?? "";
+      if (index === 0) firstSelector = selector;
+      lastSelector = selector;
+    }
+
+    const selectors = runtime.snapshot().selections?.map((selection) => selection.selector) ?? [];
+    expect(selectors).toHaveLength(8);
+    expect(selectors).not.toContain(firstSelector);
+    expect(selectors).toContain(lastSelector);
+  });
+
   test("a drag switches select mode to draw while clicks remain element picks", () => {
     const { dom, messages, runtime } = fixture(`<main><button id="b">B</button></main>`);
     const doc = dom.window.document;

--- a/webviews/src/browser-design-mode-runtime.test.ts
+++ b/webviews/src/browser-design-mode-runtime.test.ts
@@ -733,7 +733,7 @@ describe("browser design-mode runtime", () => {
     expect(inkOnly.annotation_phase).toBe("ink_only");
     expect(inkOnly.selection_count).toBe(0);
     expect(inkOnly.can_copy).toBe(false);
-    const requestMessage = messages.findLast(
+    const requestMessage = messages.slice().reverse().find(
       (message) => (message as { type?: string }).type === "annotation_capture_requested",
     ) as { request: { id: string } } | undefined;
     expect(requestMessage).toBeDefined();
@@ -774,7 +774,7 @@ describe("browser design-mode runtime", () => {
     at("pointerdown", 300, 300);
     at("pointermove", 360, 300);
     at("pointerup", 360, 300);
-    const secondRequest = messages.findLast(
+    const secondRequest = messages.slice().reverse().find(
       (message) => (message as { type?: string }).type === "annotation_capture_requested"
         && (message as { request?: { id?: string } }).request?.id !== annotationID,
     ) as { request: { id: string } } | undefined;
@@ -818,7 +818,7 @@ describe("browser design-mode runtime", () => {
     at("pointerdown", 50, 60);
     at("pointermove", 150, 160);
     at("pointerup", 150, 160);
-    const request = messages.findLast(
+    const request = messages.slice().reverse().find(
       (message) => (message as { type?: string }).type === "annotation_capture_requested",
     ) as { request: { id: string } } | undefined;
     const descriptor = runtime.prepareAnnotationCapture(request?.request.id ?? "");
@@ -890,7 +890,7 @@ describe("browser design-mode runtime", () => {
     at("pointerdown", 30, 30);
     at("pointerup", 31, 31);
     expect(runtime.composerState().selection_count).toBe(1);
-    const request = messages.findLast(
+    const request = messages.slice().reverse().find(
       (message) => (message as { type?: string }).type === "annotation_capture_requested",
     ) as { request: { id: string } } | undefined;
     const descriptor = runtime.prepareAnnotationCapture(request?.request.id ?? "");

--- a/webviews/src/browser-design-mode-runtime.test.ts
+++ b/webviews/src/browser-design-mode-runtime.test.ts
@@ -49,7 +49,14 @@ type DesignRuntime = {
   destroy(): Snapshot;
   snapshot(): Snapshot;
   select(selector: string, stack?: boolean): Snapshot;
-  composerState(): { selection_count: number; selectors: string[]; can_copy: boolean; mode: string; hovered_selector: string | null };
+  composerState(): {
+    selection_count: number;
+    selectors: string[];
+    can_copy: boolean;
+    mode: string;
+    hovered_selector: string | null;
+    annotation_phase: "idle" | "drawing" | "ink_only" | "capturing" | "captured";
+  };
   setMode(mode: string): Snapshot;
   clearHover(): Snapshot;
   flashSelection(index: number): Snapshot;
@@ -59,6 +66,21 @@ type DesignRuntime = {
   revertAll(): Snapshot;
   prepareCapture(): Snapshot;
   finishCapture(): Snapshot;
+  prepareAnnotationCapture(id: string): {
+    id: string;
+    stroke_bounds: { x: number; y: number; width: number; height: number };
+    viewport: { width: number; height: number };
+    scroll_x: number;
+    scroll_y: number;
+  } | null;
+  completeAnnotationCapture(
+    id: string,
+    x: number,
+    y: number,
+    width: number,
+    height: number,
+    imageURL: string,
+  ): Snapshot;
 };
 
 afterEach(() => {
@@ -660,8 +682,8 @@ describe("browser design-mode runtime", () => {
     expect(dom.window.document.querySelector(selector)).toBe(second);
   });
 
-  test("dragging draws a marquee that captures a screenshot region", () => {
-    const { dom, runtime } = fixture(`<main><button id="b">B</button></main>`);
+  test("freehand ink becomes a captured context card only after native capture completes", () => {
+    const { dom, messages, runtime } = fixture(`<main><button id="b">B</button></main>`);
     const doc = dom.window.document;
     const at = (name: string, x: number, y: number) => doc.dispatchEvent(
       new dom.window.MouseEvent(name, { bubbles: true, cancelable: true, button: 0, clientX: x, clientY: y }),
@@ -673,28 +695,68 @@ describe("browser design-mode runtime", () => {
     // A freehand stroke whose farthest sweep goes beyond where the pointer is
     // released: the region must bound the WHOLE stroke, not the endpoints.
     at("pointerdown", 10, 20);
+    expect(runtime.composerState().annotation_phase).toBe("drawing");
     at("pointermove", 40, 50);
     at("pointermove", 210, 340);
     at("pointerup", 110, 140);
 
-    const state = runtime.composerState();
-    expect(state.selection_count).toBe(1);
-    expect(state.can_copy).toBe(true);
-    const selection = runtime.snapshot().selections?.[0];
+    // Completion is ink-only: no region token/card exists until the native
+    // screenshot callback returns the exact composited artifact.
+    const inkOnly = runtime.composerState();
+    expect(inkOnly.annotation_phase).toBe("ink_only");
+    expect(inkOnly.selection_count).toBe(0);
+    expect(inkOnly.can_copy).toBe(false);
+    const requestMessage = messages.findLast(
+      (message) => (message as { type?: string }).type === "annotation_capture_requested",
+    ) as { request: { id: string } } | undefined;
+    expect(requestMessage).toBeDefined();
+    const annotationID = requestMessage?.request.id ?? "";
+
+    const descriptor = runtime.prepareAnnotationCapture(annotationID);
+    expect(runtime.composerState().annotation_phase).toBe("capturing");
+    expect(descriptor?.stroke_bounds).toEqual({ x: 10, y: 20, width: 200, height: 320 });
+    const completed = runtime.completeAnnotationCapture(
+      annotationID,
+      0,
+      0,
+      258,
+      408,
+      "data:image/png;base64,Y2FyZA==",
+    );
+
+    expect(runtime.composerState().annotation_phase).toBe("captured");
+    expect(runtime.composerState().selection_count).toBe(1);
+    expect(runtime.composerState().can_copy).toBe(true);
+    const selection = completed.selections?.[0];
     expect(selection?.tag_name).toBe("region");
-    expect(selection?.bounds).toEqual({ x: 10, y: 20, width: 200, height: 320 });
+    expect(selection?.selector).toBe(`@annotation(${annotationID})`);
+    expect(selection?.bounds).toEqual({ x: 0, y: 0, width: 258, height: 408 });
 
     // The trailing click from the same gesture must not add an element selection.
     at("click", 110, 140);
     expect(runtime.composerState().selection_count).toBe(1);
 
-    // Every draw stacks another region token; earlier captures persist.
+    // One stroke is one immutable context artifact. A later stroke stacks a
+    // new request/card rather than merging into or replacing the first.
     at("pointerdown", 300, 300);
     at("pointermove", 360, 360);
     at("pointerup", 360, 360);
-    const regions = runtime.snapshot().selections ?? [];
+    const secondRequest = messages.findLast(
+      (message) => (message as { type?: string }).type === "annotation_capture_requested"
+        && (message as { request?: { id?: string } }).request?.id !== annotationID,
+    ) as { request: { id: string } } | undefined;
+    expect(secondRequest).toBeDefined();
+    runtime.prepareAnnotationCapture(secondRequest?.request.id ?? "");
+    const regions = runtime.completeAnnotationCapture(
+      secondRequest?.request.id ?? "",
+      252,
+      252,
+      156,
+      156,
+      "data:image/png;base64,Y2FyZDI=",
+    ).selections ?? [];
     expect(regions).toHaveLength(2);
-    expect(regions[1]?.bounds?.x).toBe(300);
+    expect(regions[1]?.bounds?.x).toBe(252);
 
     // Escape clears regions before exiting design mode.
     doc.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));

--- a/webviews/src/browser-design-mode-runtime.test.ts
+++ b/webviews/src/browser-design-mode-runtime.test.ts
@@ -599,9 +599,15 @@ describe("browser design-mode runtime", () => {
     expect(inputEvents).toBe(0);
   });
 
-  test("prepares capture without depending on animation-frame delivery", () => {
-    const { dom, runtime } = fixture(`<main><h1 id="hero">Hello</h1></main>`);
+  test("prepares and restores capture without depending on animation-frame delivery", () => {
+    const { dom, overlayShadowRoot, runtime } = fixture(`<main><h1 id="hero">Hello</h1></main>`);
     runtime.select("#hero");
+    runtime.setSelectionHover(0);
+    const outline = Array.from(overlayShadowRoot()?.querySelectorAll("div") ?? []).find(
+      (element) => element.style.borderColor === "rgb(10, 132, 255)"
+        && element.style.position === "fixed",
+    );
+    expect(outline?.style.display).toBe("block");
     let requestedFrames = 0;
     Object.defineProperty(dom.window, "requestAnimationFrame", {
       value: () => {
@@ -612,8 +618,13 @@ describe("browser design-mode runtime", () => {
 
     const prepared = runtime.prepareCapture();
     expect(prepared.selection?.selector).toBe("#hero");
+    expect(outline?.style.display).toBe("none");
     expect(requestedFrames).toBe(0);
     runtime.finishCapture();
+    // Copy restoration must be synchronous so native can keep its visual
+    // shield up until WebKit confirms the restored overlay has painted.
+    expect(outline?.style.display).toBe("block");
+    expect(requestedFrames).toBe(0);
   });
 
   test("revalidates selector uniqueness immediately before capture", () => {

--- a/webviews/src/browser-design-mode-runtime.test.ts
+++ b/webviews/src/browser-design-mode-runtime.test.ts
@@ -9,17 +9,27 @@ const runtimeSource = readFileSync(
 
 const doms: JSDOM[] = [];
 
-function fixture(html: string) {
+function fixture(html: string, options: { stallAnimationFrames?: boolean } = {}) {
   const messages: unknown[] = [];
   const dom = new JSDOM(html, { runScripts: "dangerously", pretendToBeVisual: true, url: "http://localhost:3000" });
   doms.push(dom);
+  let overlayShadowRoot: ShadowRoot | null = null;
+  const attachShadow = dom.window.Element.prototype.attachShadow;
+  dom.window.Element.prototype.attachShadow = function(init: ShadowRootInit) {
+    const root = attachShadow.call(this, init);
+    if (this.getAttribute("data-cmux-design-mode") === "overlay") overlayShadowRoot = root;
+    return root;
+  };
+  if (options.stallAnimationFrames) {
+    Object.defineProperty(dom.window, "requestAnimationFrame", { value: () => 1 });
+  }
   Object.defineProperty(dom.window, "webkit", {
     value: { messageHandlers: { cmuxDesignMode: { postMessage: (value: unknown) => messages.push(value) } } },
   });
   dom.window.eval(runtimeSource);
   const runtime = (dom.window as unknown as { __cmuxDesignMode: DesignRuntime }).__cmuxDesignMode;
   runtime.enable();
-  return { dom, messages, runtime };
+  return { dom, messages, overlayShadowRoot: () => overlayShadowRoot, runtime };
 }
 
 type SnapshotSelection = {
@@ -780,6 +790,48 @@ describe("browser design-mode runtime", () => {
     // Escape clears regions before exiting design mode.
     doc.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
     expect(runtime.composerState().selection_count).toBe(0);
+  });
+
+  test("native annotation completion presents the card when an earlier animation frame is stalled", () => {
+    const { dom, messages, overlayShadowRoot, runtime } = fixture(
+      `<main><button id="b">B</button></main>`,
+      { stallAnimationFrames: true },
+    );
+    const doc = dom.window.document;
+    const at = (name: string, x: number, y: number) => doc.dispatchEvent(
+      new dom.window.MouseEvent(name, { bubbles: true, cancelable: true, button: 0, clientX: x, clientY: y }),
+    );
+
+    runtime.setMode("draw");
+    at("pointerdown", 50, 60);
+    at("pointermove", 150, 160);
+    at("pointerup", 150, 160);
+    const request = messages.findLast(
+      (message) => (message as { type?: string }).type === "annotation_capture_requested",
+    ) as { request: { id: string } } | undefined;
+    const descriptor = runtime.prepareAnnotationCapture(request?.request.id ?? "");
+    runtime.completeAnnotationCapture(
+      request?.request.id ?? "",
+      2,
+      12,
+      196,
+      196,
+      "data:image/png;base64,Y2FyZA==",
+      descriptor?.scroll_x ?? 0,
+      descriptor?.scroll_y ?? 0,
+      descriptor?.viewport.width ?? 0,
+      descriptor?.viewport.height ?? 0,
+    );
+
+    const card = Array.from(overlayShadowRoot()?.querySelectorAll("div") ?? []).find(
+      (element) => element.style.backgroundImage.includes("Y2FyZA=="),
+    );
+    expect(card).toBeDefined();
+    expect(card?.style.display).toBe("block");
+    expect(card?.style.left).toBe("2px");
+    expect(card?.style.top).toBe("12px");
+    expect(card?.style.width).toBe("196px");
+    expect(card?.style.height).toBe("196px");
   });
 
   test("modes are exclusive: no marquee in select mode, no element picks in draw mode", () => {

--- a/webviews/src/browser-design-mode-runtime.test.ts
+++ b/webviews/src/browser-design-mode-runtime.test.ts
@@ -68,9 +68,10 @@ type DesignRuntime = {
     annotation_phase: "idle" | "drawing" | "ink_only" | "capturing" | "captured";
   };
   setMode(mode: string): Snapshot;
+  setSelectionHover(selection: number | string | null): Snapshot;
   clearHover(): Snapshot;
   flashSelection(index: number): Snapshot;
-  removeSelection(index: number): Snapshot;
+  removeSelection(selection: number | string): Snapshot;
   applyStyle(property: string, value: string): Snapshot;
   applyText(value: string): Snapshot;
   revert(id: string): Snapshot;
@@ -783,7 +784,7 @@ describe("browser design-mode runtime", () => {
     expect(regions).toHaveLength(2);
     expect(regions[1]?.bounds?.x).toBe(252);
 
-    const remaining = runtime.removeSelection(0).selections ?? [];
+    const remaining = runtime.removeSelection(regions[0]?.selector ?? "").selections ?? [];
     expect(remaining).toHaveLength(1);
     expect(remaining[0]?.selector).toBe(regions[1]?.selector);
 
@@ -810,7 +811,7 @@ describe("browser design-mode runtime", () => {
       (message) => (message as { type?: string }).type === "annotation_capture_requested",
     ) as { request: { id: string } } | undefined;
     const descriptor = runtime.prepareAnnotationCapture(request?.request.id ?? "");
-    runtime.completeAnnotationCapture(
+    const completed = runtime.completeAnnotationCapture(
       request?.request.id ?? "",
       2,
       12,
@@ -832,9 +833,16 @@ describe("browser design-mode runtime", () => {
     expect(card?.style.top).toBe("12px");
     expect(card?.style.width).toBe("196px");
     expect(card?.style.height).toBe("196px");
+    expect(card?.style.borderStyle).toBe("dashed");
+    expect(card?.style.borderColor).toBe("rgb(10, 132, 255)");
+
+    runtime.setSelectionHover(completed.selections?.[0]?.selector ?? "");
+    expect(card?.style.boxShadow).toContain("rgba(10, 132, 255, 0.55)");
+    runtime.setSelectionHover(null);
+    expect(card?.style.boxShadow).not.toContain("rgba(10, 132, 255, 0.55)");
   });
 
-  test("modes are exclusive: no marquee in select mode, no element picks in draw mode", () => {
+  test("a drag switches select mode to draw while clicks remain element picks", () => {
     const { dom, messages, runtime } = fixture(`<main><button id="b">B</button></main>`);
     const doc = dom.window.document;
     const button = doc.querySelector("#b") as HTMLElement;
@@ -843,24 +851,34 @@ describe("browser design-mode runtime", () => {
       new dom.window.MouseEvent(name, { bubbles: true, cancelable: true, button: 0, clientX: x, clientY: y }),
     );
 
-    // Select mode: a drag never creates a region; pointerup picks the element.
+    // A click in select mode remains an element pick.
     at("pointerdown", 10, 10);
-    at("pointermove", 200, 200);
-    at("pointerup", 200, 200);
+    at("pointerup", 10, 10);
     expect(runtime.snapshot().selection?.selector).toBe("#b");
     expect(runtime.snapshot().selections?.every((entry) => entry.tag_name !== "region")).toBe(true);
 
-    // Draw mode: taps never pick elements; strokes capture regions, and
-    // element pills selected earlier persist across the mode switch.
-    runtime.setMode("draw");
-    expect(runtime.composerState().mode).toBe("draw");
-    expect(runtime.composerState().selection_count).toBe(1);
-    at("pointerdown", 30, 30);
-    at("pointerup", 31, 31);
-    expect(runtime.composerState().selection_count).toBe(1);
+    // Crossing the drag threshold automatically enters draw mode before the
+    // drawing transaction begins, with the existing element pill preserved.
     at("pointerdown", 40, 40);
     at("pointermove", 140, 140);
     at("pointerup", 140, 140);
+    expect(runtime.composerState().mode).toBe("draw");
+    expect(runtime.composerState().selection_count).toBe(1);
+    const modeMessageIndex = messages.findIndex(
+      (message) => (message as { type?: string; mode?: string }).type === "interaction_mode_changed"
+        && (message as { mode?: string }).mode === "draw",
+    );
+    const drawingMessageIndex = messages.findIndex(
+      (message) => (message as { type?: string }).type === "annotation_drawing",
+    );
+    expect(modeMessageIndex).toBeGreaterThanOrEqual(0);
+    expect(drawingMessageIndex).toBeGreaterThan(modeMessageIndex);
+
+    // Draw-mode taps remain no-ops; the stroke above becomes a second,
+    // region context only after native capture completion.
+    at("pointerdown", 30, 30);
+    at("pointerup", 31, 31);
+    expect(runtime.composerState().selection_count).toBe(1);
     const request = messages.findLast(
       (message) => (message as { type?: string }).type === "annotation_capture_requested",
     ) as { request: { id: string } } | undefined;

--- a/webviews/src/browser-design-mode-runtime.test.ts
+++ b/webviews/src/browser-design-mode-runtime.test.ts
@@ -60,6 +60,7 @@ type DesignRuntime = {
   setMode(mode: string): Snapshot;
   clearHover(): Snapshot;
   flashSelection(index: number): Snapshot;
+  removeSelection(index: number): Snapshot;
   applyStyle(property: string, value: string): Snapshot;
   applyText(value: string): Snapshot;
   revert(id: string): Snapshot;
@@ -80,6 +81,10 @@ type DesignRuntime = {
     width: number,
     height: number,
     imageURL: string,
+    expectedScrollX: number,
+    expectedScrollY: number,
+    expectedViewportWidth: number,
+    expectedViewportHeight: number,
   ): Snapshot;
 };
 
@@ -722,6 +727,10 @@ describe("browser design-mode runtime", () => {
       258,
       408,
       "data:image/png;base64,Y2FyZA==",
+      descriptor?.scroll_x ?? 0,
+      descriptor?.scroll_y ?? 0,
+      descriptor?.viewport.width ?? 0,
+      descriptor?.viewport.height ?? 0,
     );
 
     expect(runtime.composerState().annotation_phase).toBe("captured");
@@ -738,25 +747,35 @@ describe("browser design-mode runtime", () => {
 
     // One stroke is one immutable context artifact. A later stroke stacks a
     // new request/card rather than merging into or replacing the first.
+    // A deliberate one-axis stroke is still an annotation; it does not need
+    // circle-like width and height to become a context artifact.
     at("pointerdown", 300, 300);
-    at("pointermove", 360, 360);
-    at("pointerup", 360, 360);
+    at("pointermove", 360, 300);
+    at("pointerup", 360, 300);
     const secondRequest = messages.findLast(
       (message) => (message as { type?: string }).type === "annotation_capture_requested"
         && (message as { request?: { id?: string } }).request?.id !== annotationID,
     ) as { request: { id: string } } | undefined;
     expect(secondRequest).toBeDefined();
-    runtime.prepareAnnotationCapture(secondRequest?.request.id ?? "");
+    const secondDescriptor = runtime.prepareAnnotationCapture(secondRequest?.request.id ?? "");
     const regions = runtime.completeAnnotationCapture(
       secondRequest?.request.id ?? "",
       252,
       252,
       156,
-      156,
+      96,
       "data:image/png;base64,Y2FyZDI=",
+      secondDescriptor?.scroll_x ?? 0,
+      secondDescriptor?.scroll_y ?? 0,
+      secondDescriptor?.viewport.width ?? 0,
+      secondDescriptor?.viewport.height ?? 0,
     ).selections ?? [];
     expect(regions).toHaveLength(2);
     expect(regions[1]?.bounds?.x).toBe(252);
+
+    const remaining = runtime.removeSelection(0).selections ?? [];
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0]?.selector).toBe(regions[1]?.selector);
 
     // Escape clears regions before exiting design mode.
     doc.dispatchEvent(new dom.window.KeyboardEvent("keydown", { key: "Escape", bubbles: true, cancelable: true }));
@@ -764,7 +783,7 @@ describe("browser design-mode runtime", () => {
   });
 
   test("modes are exclusive: no marquee in select mode, no element picks in draw mode", () => {
-    const { dom, runtime } = fixture(`<main><button id="b">B</button></main>`);
+    const { dom, messages, runtime } = fixture(`<main><button id="b">B</button></main>`);
     const doc = dom.window.document;
     const button = doc.querySelector("#b") as HTMLElement;
     Object.defineProperty(doc, "elementFromPoint", { value: () => button });
@@ -790,7 +809,22 @@ describe("browser design-mode runtime", () => {
     at("pointerdown", 40, 40);
     at("pointermove", 140, 140);
     at("pointerup", 140, 140);
-    const selections = runtime.snapshot().selections ?? [];
+    const request = messages.findLast(
+      (message) => (message as { type?: string }).type === "annotation_capture_requested",
+    ) as { request: { id: string } } | undefined;
+    const descriptor = runtime.prepareAnnotationCapture(request?.request.id ?? "");
+    const selections = runtime.completeAnnotationCapture(
+      request?.request.id ?? "",
+      0,
+      0,
+      188,
+      188,
+      "data:image/png;base64,Y2FyZA==",
+      descriptor?.scroll_x ?? 0,
+      descriptor?.scroll_y ?? 0,
+      descriptor?.viewport.width ?? 0,
+      descriptor?.viewport.height ?? 0,
+    ).selections ?? [];
     expect(selections).toHaveLength(2);
     expect(selections[0]?.selector).toBe("#b");
     expect(selections[1]?.tag_name).toBe("region");


### PR DESCRIPTION
## Summary

- model freehand annotation as an explicit `drawing → ink only → capturing → captured card` lifecycle, driven by WebKit capture completion rather than timing delays
- capture one immutable context card per deliberate stroke with 48-point padding, viewport clamping, scroll/resize revalidation, and the composited PNG reused in the agent handoff
- reveal a leading delete X on hovered context pills and route mouse/accessibility removal through the same authoritative selection mutation while preserving other pills and composer text

Closes #8387

Issue: https://github.com/manaflow-ai/cmux/issues/8387

## Visual verification

### Annotation: ink-only phase → captured context card

Ink-only frame immediately after the stroke:

![Red freehand ink over the live page before capture chrome appears](https://github.com/user-attachments/assets/437cd2f1-e24a-4ba1-ab06-b5e5f8d57b9a)

Captured card after native snapshot completion:

![Rounded bordered annotation card containing the page region, surrounding context, and composited red ink](https://github.com/user-attachments/assets/f361ea12-67a4-4091-b847-47b907cd0e4d)

The saved handoff PNG is the same composited page-region + ink artifact shown in the captured card. Each later stroke creates another stable card; strokes are not time-merged.

### Context pill: rest → hovered delete X → removed

Rest:

<img width="900" height="180" alt="Context pills at rest" src="https://github.com/user-attachments/assets/611168c6-4025-419d-829c-66fbbf1c01ec" />

Hover:

<img width="900" height="180" alt="Hovered h1 context pill revealing its leading delete X" src="https://github.com/user-attachments/assets/b3d10a41-5fb7-45b0-bbc2-5d41f1cb4552" />

Removed:

<img width="900" height="180" alt="Region context preserved with composer text after removing only the h1 pill" src="https://github.com/user-attachments/assets/67cfd08b-c629-4be8-81b7-4aed895c540d" />

The `h1` removal leaves the `region` context and `Keep this text` composer text intact.

## Tests

- `cd webviews && bun test src/browser-design-mode-runtime.test.ts` — 37 passed
- `cd Packages/macOS/CmuxBrowser && swift build`
- `./scripts/check-pbxproj.sh`
- `./scripts/lint-pbxproj-test-wiring.sh`
- `python3 scripts/check-workspace-package-groups.py --check`
- `python3 scripts/check-package-resolved-policy.py`
- tagged macOS build and local visual dogfood: https://github.com/manaflow-ai/cmux/actions/runs/29626138281

The stalled-animation-frame card regression is split into a red test commit (`9c64c340f1`) and green fix commit (`5eafc97016`). Per the issue instructions, I did not run local Xcode tests; GitHub Actions owns the Xcode test target. Package geometry tests compiled and reported their assertions, but this Mac's x86_64 shell cannot load the arm64 Swift Testing bundle, so I am not claiming that local `swift test` invocation as green.

## Localization audit

- added `browser.designMode.context.remove` and `browser.designMode.error.annotationCapture` to `Resources/Localizable.xcstrings`
- verified English and Japanese translations for both keys and parsed the catalog with `python3 -m json.tool`
- audited added Swift string literals; the only new user-facing defaults are the localized pill-removal label and annotation-capture error

## Notes

- no sleep/timer synchronization was added; the native snapshot completion is the authoritative transition that presents the card
- no keyboard shortcut was added
- the requested `$swift-guidance` skill was unavailable in this environment; the implementation follows repo `CLAUDE.md` plus `cmux-architecture` concurrency/state ownership guidance instead
- clean cloud-Mac verification was attempted first but its loader run could not reach Tailscale; the screenshots above come from the isolated local tagged app


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added freehand annotation capture in Design Mode, including ink feedback, native screenshot cards, scrolling support, and stable annotation references.
  * Added annotation lifecycle states, cancellation, retry handling, and localized capture-error messaging.
  * Improved context-token removal with hover feedback, accessibility actions, and more reliable selection updates.

* **Bug Fixes**
  * Improved capture stability and cleanup when captures are interrupted or page content changes.

* **Tests**
  * Added coverage for annotation capture, lifecycle transitions, viewport handling, accessibility, and overlay rendering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->