### PR TITLE
ci: benchmark safe Nightly speedups

### DIFF
--- a/.github/workflows/nightly-perf-benchmark.yml
+++ b/.github/workflows/nightly-perf-benchmark.yml
@@ -1,0 +1,77 @@
+name: Nightly macOS performance benchmark
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - .github/workflows/nightly-perf-benchmark.yml
+      - scripts/ci/benchmark-nightly-build.sh
+      - tests/test_nightly_perf_benchmark.sh
+
+permissions:
+  contents: read
+
+concurrency:
+  group: nightly-perf-benchmark-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: ${{ matrix.scenario }}
+    runs-on: ${{ vars.MACOS_RUNNER_26_RELEASE || 'blacksmith-6vcpu-macos-26' }}
+    timeout-minutes: 55
+    env:
+      CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_26 }}
+      CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
+    strategy:
+      fail-fast: false
+      matrix:
+        scenario:
+          - universal-wmo
+          - universal-singlefile
+          - arm64-wmo
+          - x86_64-wmo
+    steps:
+      - name: Checkout benchmark ref
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - name: Select Xcode
+        run: ./scripts/select-ci-xcode.sh
+
+      - name: Install compilation dependencies
+        run: |
+          ./scripts/install-rust-ci.sh
+          ./scripts/download-prebuilt-ghosttykit.sh
+
+      - name: Cache Swift packages
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: .spm-cache
+          key: nightly-benchmark-spm-${{ hashFiles('cmux.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: nightly-benchmark-spm-
+
+      - name: Sanitize Swift package cache
+        run: python3 scripts/ci/sanitize-xcode-source-packages-cache.py .spm-cache
+
+      - name: Run benchmark
+        run: ./scripts/ci/benchmark-nightly-build.sh "${{ matrix.scenario }}"
+
+      - name: Publish benchmark summary
+        if: always()
+        run: |
+          summary="benchmark-results/${{ matrix.scenario }}/summary.md"
+          if [ -f "$summary" ]; then
+            cat "$summary" >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload benchmark evidence
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: nightly-benchmark-${{ matrix.scenario }}
+          path: benchmark-results/${{ matrix.scenario }}
+          if-no-files-found: warn
+          retention-days: 14

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -15,6 +15,14 @@ on:
         required: false
         default: false
         type: boolean
+      notarization_mode:
+        description: Branch-only experiment; main always requires app and DMG notarization
+        required: false
+        default: app-and-dmg
+        type: choice
+        options:
+          - app-and-dmg
+          - dmg-only-experiment
 
 concurrency:
   group: nightly-build-${{ github.ref_name }}
@@ -43,14 +51,20 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           FORCE_BUILD: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.force == 'true' && 'true' || 'false' }}
+          NOTARIZATION_MODE: ${{ github.event.inputs.notarization_mode || 'app-and-dmg' }}
         with:
           script: |
             const forceBuild = process.env.FORCE_BUILD === 'true';
+            const notarizationMode = process.env.NOTARIZATION_MODE;
             const { owner, repo } = context.repo;
             const requestedRef = context.ref.startsWith('refs/heads/')
               ? context.ref.replace('refs/heads/', '')
               : 'main';
             const isMainRef = requestedRef === 'main';
+            if (isMainRef && notarizationMode !== 'app-and-dmg') {
+              core.setFailed('DMG-only notarization experiment is forbidden on main');
+              return;
+            }
 
             // Pin every run to the revision that triggered it. In particular,
             // queued main pushes must each build their own merge commit instead
@@ -92,6 +106,7 @@ jobs:
                 [{data: 'build HEAD', header: true}, headSha],
                 [{data: 'nightly tag', header: true}, nightlySha ?? '(missing)'],
                 [{data: 'force build', header: true}, String(forceBuild)],
+                [{data: 'notarization mode', header: true}, notarizationMode],
                 [{data: 'should build', header: true}, String(shouldBuild)],
                 [{data: 'should publish', header: true}, String(isMainRef)],
               ])
@@ -379,6 +394,7 @@ jobs:
     env:
       CMUX_CI_XCODE_APP: ${{ vars.CMUX_CI_XCODE_APP_MACOS_26 }}
       CMUX_CI_REQUIRED_MACOS_SDK_MAJOR: "26"
+      DMG_ONLY_EXPERIMENT: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.notarization_mode == 'dmg-only-experiment' && 'true' || 'false' }}
     steps:
       - name: Clear stale git locks (self-hosted reused workspace)
         shell: bash
@@ -721,23 +737,25 @@ jobs:
             local dmg_tmp_dir
             local created_dmg
 
-            ditto -c -k --sequesterRsrc --keepParent "$app_path" "$zip_submit"
-            APP_SUBMIT_JSON="$(xcrun notarytool submit "$zip_submit" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
-            APP_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$APP_SUBMIT_JSON")"
-            APP_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$APP_SUBMIT_JSON")"
-            if [ "$APP_STATUS" != "Accepted" ]; then
-              echo "App notarization failed for $app_path with status: $APP_STATUS" >&2
-              xcrun notarytool log "$APP_SUBMIT_ID" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
-              exit 1
+            if [ "$DMG_ONLY_EXPERIMENT" != "true" ]; then
+              ditto -c -k --sequesterRsrc --keepParent "$app_path" "$zip_submit"
+              APP_SUBMIT_JSON="$(xcrun notarytool submit "$zip_submit" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" --wait --output-format json)"
+              APP_SUBMIT_ID="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["id"])' <<<"$APP_SUBMIT_JSON")"
+              APP_STATUS="$(python3 -c 'import json,sys; print(json.load(sys.stdin)["status"])' <<<"$APP_SUBMIT_JSON")"
+              if [ "$APP_STATUS" != "Accepted" ]; then
+                echo "App notarization failed for $app_path with status: $APP_STATUS" >&2
+                xcrun notarytool log "$APP_SUBMIT_ID" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
+                exit 1
+              fi
+              xcrun stapler staple "$app_path"
+              xcrun stapler validate "$app_path"
+              spctl -a -vv --type execute "$app_path"
+              CMUX_SMOKE_ALLOW_UNSUPPORTED_GUI=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
+              CMUX_SMOKE_DIRECT_EXEC=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
+              ./scripts/verify-app-bundle-channel-metadata.sh "$app_path" nightly
+              ./scripts/verify-app-bundle-licenses.sh "$app_path"
+              rm -f "$zip_submit"
             fi
-            xcrun stapler staple "$app_path"
-            xcrun stapler validate "$app_path"
-            spctl -a -vv --type execute "$app_path"
-            CMUX_SMOKE_ALLOW_UNSUPPORTED_GUI=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
-            CMUX_SMOKE_DIRECT_EXEC=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
-            ./scripts/verify-app-bundle-channel-metadata.sh "$app_path" nightly
-            ./scripts/verify-app-bundle-licenses.sh "$app_path"
-            rm -f "$zip_submit"
 
             dmg_tmp_dir="$(mktemp -d)"
             create-dmg \
@@ -763,6 +781,17 @@ jobs:
               echo "DMG notarization failed for $dmg_release with status: $DMG_STATUS" >&2
               xcrun notarytool log "$DMG_SUBMIT_ID" --apple-id "$APPLE_ID" --team-id "$APPLE_TEAM_ID" --password "$APPLE_APP_SPECIFIC_PASSWORD" || true
               exit 1
+            fi
+            if [ "$DMG_ONLY_EXPERIMENT" = "true" ]; then
+              # A DMG submission scans its nested app. Prove that Apple issued
+              # an independently usable app ticket before considering this path.
+              xcrun stapler staple "$app_path"
+              xcrun stapler validate "$app_path"
+              spctl -a -vv --type execute "$app_path"
+              CMUX_SMOKE_ALLOW_UNSUPPORTED_GUI=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
+              CMUX_SMOKE_DIRECT_EXEC=1 CMUX_SMOKE_DEBUG_LOGS=1 ./scripts/smoke-launch-macos-app.sh "$app_path"
+              ./scripts/verify-app-bundle-channel-metadata.sh "$app_path" nightly
+              ./scripts/verify-app-bundle-licenses.sh "$app_path"
             fi
             xcrun stapler staple "$dmg_release"
             xcrun stapler validate "$dmg_release"

--- a/scripts/ci/benchmark-nightly-build.sh
+++ b/scripts/ci/benchmark-nightly-build.sh
@@ -118,8 +118,8 @@ inspect_cold_artifact() {
   unstripped_bytes="$(stat -f %z "$archive")"
   binary_bytes="$(stat -f %z "$binary")"
 
-  uuid_before="$(dwarfdump --uuid "$binary" | sort)"
-  dsym_uuid="$(dwarfdump --uuid "$products/cmux.app.dSYM" | sort)"
+  uuid_before="$("$root/scripts/ci/macho-uuid-keys.sh" "$binary")"
+  dsym_uuid="$("$root/scripts/ci/macho-uuid-keys.sh" "$products/cmux.app.dSYM")"
   if ! comm -12 <(printf '%s\n' "$uuid_before") <(printf '%s\n' "$dsym_uuid") | grep -q UUID; then
     echo "error: app and dSYM UUIDs do not intersect" >&2
     exit 1
@@ -128,7 +128,7 @@ inspect_cold_artifact() {
   stripped_app="$RUNNER_TEMP/cmux-stripped-$scenario.app"
   ditto "$app" "$stripped_app"
   "$root/scripts/strip-release-bundle.sh" "$stripped_app"
-  uuid_after="$(dwarfdump --uuid "$stripped_app/Contents/MacOS/$executable" | sort)"
+  uuid_after="$("$root/scripts/ci/macho-uuid-keys.sh" "$stripped_app/Contents/MacOS/$executable")"
   if [ "$uuid_before" != "$uuid_after" ]; then
     echo "error: stripping changed the app Mach-O UUID" >&2
     exit 1

--- a/scripts/ci/benchmark-nightly-build.sh
+++ b/scripts/ci/benchmark-nightly-build.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 <universal-wmo|universal-singlefile|arm64-wmo|x86_64-wmo> [results-dir]" >&2
+}
+
+if [ "$#" -lt 1 ] || [ "$#" -gt 2 ]; then
+  usage
+  exit 2
+fi
+
+scenario="$1"
+results_dir="${2:-benchmark-results/$scenario}"
+case "$scenario" in
+  universal-wmo)
+    archs="arm64 x86_64"
+    compilation_mode="wholemodule"
+    phases="full"
+    ;;
+  universal-singlefile)
+    archs="arm64 x86_64"
+    compilation_mode="singlefile"
+    phases="full"
+    ;;
+  arm64-wmo)
+    archs="arm64"
+    compilation_mode="wholemodule"
+    phases="cold"
+    ;;
+  x86_64-wmo)
+    archs="x86_64"
+    compilation_mode="wholemodule"
+    phases="cold"
+    ;;
+  *)
+    usage
+    exit 2
+    ;;
+esac
+
+root="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$root"
+mkdir -p "$results_dir"
+results_dir="$(cd "$results_dir" && pwd)"
+derived_data="$RUNNER_TEMP/cmux-nightly-benchmark-$scenario"
+source_file="$root/Sources/CmuxEventBus.swift"
+source_backup="$RUNNER_TEMP/CmuxEventBus.swift.$scenario"
+cp "$source_file" "$source_backup"
+
+cleanup() {
+  cp "$source_backup" "$source_file"
+}
+trap cleanup EXIT
+
+summary="$results_dir/summary.md"
+metrics="$results_dir/metrics.tsv"
+printf 'phase\tseconds\n' > "$metrics"
+
+build_phase() {
+  local phase="$1"
+  local started elapsed
+  started="$(date +%s)"
+  CMUX_SKIP_ZIG_BUILD=1 xcodebuild \
+    -scheme cmux \
+    -configuration Release \
+    -derivedDataPath "$derived_data" \
+    -destination 'generic/platform=macOS' \
+    -clonedSourcePackagesDirPath .spm-cache \
+    -showBuildTimingSummary \
+    ARCHS="$archs" \
+    ONLY_ACTIVE_ARCH=NO \
+    SWIFT_COMPILATION_MODE="$compilation_mode" \
+    SWIFT_OPTIMIZATION_LEVEL=-O \
+    COMPILATION_CACHE_ENABLE_CACHING=YES \
+    COMPILATION_CACHE_LIMIT_SIZE=3221225472 \
+    COMPILER_INDEX_STORE_ENABLE=NO \
+    CODE_SIGNING_ALLOWED=NO \
+    ASSETCATALOG_COMPILER_APPICON_NAME=AppIcon-Nightly \
+    build 2>&1 | tee "$results_dir/$phase.log"
+  elapsed=$(( $(date +%s) - started ))
+  printf '%s\t%s\n' "$phase" "$elapsed" >> "$metrics"
+}
+
+assert_release_settings() {
+  local settings="$results_dir/build-settings.txt"
+  xcodebuild \
+    -scheme cmux \
+    -configuration Release \
+    -destination 'generic/platform=macOS' \
+    ARCHS="$archs" \
+    SWIFT_COMPILATION_MODE="$compilation_mode" \
+    SWIFT_OPTIMIZATION_LEVEL=-O \
+    -showBuildSettings > "$settings"
+  grep -Eq '^[[:space:]]*SWIFT_OPTIMIZATION_LEVEL = -O$' "$settings"
+  grep -Eq "^[[:space:]]*SWIFT_COMPILATION_MODE = $compilation_mode$" "$settings"
+}
+
+inspect_cold_artifact() {
+  local products app info executable binary actual_archs archive stripped_app
+  local uuid_before uuid_after dsym_uuid unstripped_bytes stripped_bytes binary_bytes
+  products="$derived_data/Build/Products/Release"
+  app="$products/cmux.app"
+  info="$app/Contents/Info.plist"
+  if [ ! -d "$app" ]; then
+    echo "error: expected app missing at $app" >&2
+    exit 1
+  fi
+  executable="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$info")"
+  binary="$app/Contents/MacOS/$executable"
+  actual_archs="$(lipo -archs "$binary")"
+  for arch in $archs; do
+    lipo "$binary" -verify_arch "$arch"
+  done
+
+  archive="$results_dir/unstripped-app.tar.gz"
+  tar -C "$products" -czf "$archive" cmux.app
+  unstripped_bytes="$(stat -f %z "$archive")"
+  binary_bytes="$(stat -f %z "$binary")"
+
+  uuid_before="$(dwarfdump --uuid "$binary" | sort)"
+  dsym_uuid="$(dwarfdump --uuid "$products/cmux.app.dSYM" | sort)"
+  if ! comm -12 <(printf '%s\n' "$uuid_before") <(printf '%s\n' "$dsym_uuid") | grep -q UUID; then
+    echo "error: app and dSYM UUIDs do not intersect" >&2
+    exit 1
+  fi
+
+  stripped_app="$RUNNER_TEMP/cmux-stripped-$scenario.app"
+  ditto "$app" "$stripped_app"
+  "$root/scripts/strip-release-bundle.sh" "$stripped_app"
+  uuid_after="$(dwarfdump --uuid "$stripped_app/Contents/MacOS/$executable" | sort)"
+  if [ "$uuid_before" != "$uuid_after" ]; then
+    echo "error: stripping changed the app Mach-O UUID" >&2
+    exit 1
+  fi
+  tar -C "$RUNNER_TEMP" -czf "$results_dir/stripped-app.tar.gz" "$(basename "$stripped_app")"
+  stripped_bytes="$(stat -f %z "$results_dir/stripped-app.tar.gz")"
+
+  {
+    printf 'actual_archs\t%s\n' "$actual_archs"
+    printf 'binary_bytes\t%s\n' "$binary_bytes"
+    printf 'unstripped_archive_bytes\t%s\n' "$unstripped_bytes"
+    printf 'stripped_archive_bytes\t%s\n' "$stripped_bytes"
+  } >> "$metrics"
+
+  if [ "$archs" = "arm64 x86_64" ]; then
+    CMUX_SMOKE_DIRECT_EXEC=1 \
+      CMUX_SMOKE_STARTUP_TIMEOUT_SECONDS=15 \
+      CMUX_SMOKE_STABLE_SECONDS=5 \
+      "$root/scripts/smoke-launch-macos-app.sh" "$app" | tee "$results_dir/smoke.log"
+  fi
+}
+
+rm -rf "$derived_data"
+assert_release_settings
+build_phase cold
+inspect_cold_artifact
+
+if [ "$phases" = "full" ]; then
+  build_phase noop-warm
+
+  cache_path="$derived_data/CompilationCache.noindex"
+  if [ ! -d "$cache_path" ]; then
+    echo "error: Xcode compilation cache was not produced" >&2
+    exit 1
+  fi
+  find "$derived_data" -mindepth 1 -maxdepth 1 ! -name CompilationCache.noindex -exec rm -rf {} +
+  printf '\n// nightly benchmark source change: %s\n' "$scenario" >> "$source_file"
+  build_phase one-file-cache-only
+fi
+
+{
+  echo "# Nightly build benchmark: $scenario"
+  echo
+  echo "- Xcode: $(xcodebuild -version | tr '\n' ' ')"
+  echo "- Architectures: $archs"
+  echo "- Swift compilation mode: $compilation_mode"
+  echo "- Swift optimization: -O"
+  echo
+  echo '| Phase | Seconds |'
+  echo '| --- | ---: |'
+  awk -F '\t' 'NR > 1 && $1 ~ /^(cold|noop-warm|one-file-cache-only)$/ { printf "| %s | %s |\n", $1, $2 }' "$metrics"
+  echo
+  echo '| Artifact | Value |'
+  echo '| --- | ---: |'
+  awk -F '\t' '$1 !~ /^(phase|cold|noop-warm|one-file-cache-only)$/ { printf "| %s | %s |\n", $1, $2 }' "$metrics"
+} > "$summary"
+
+cat "$summary"

--- a/scripts/ci/benchmark-nightly-build.sh
+++ b/scripts/ci/benchmark-nightly-build.sh
@@ -120,7 +120,7 @@ inspect_cold_artifact() {
 
   uuid_before="$("$root/scripts/ci/macho-uuid-keys.sh" "$binary")"
   dsym_uuid="$("$root/scripts/ci/macho-uuid-keys.sh" "$products/cmux.app.dSYM")"
-  if ! comm -12 <(printf '%s\n' "$uuid_before") <(printf '%s\n' "$dsym_uuid") | grep -q UUID; then
+  if [ -z "$(comm -12 <(printf '%s\n' "$uuid_before") <(printf '%s\n' "$dsym_uuid"))" ]; then
     echo "error: app and dSYM UUIDs do not intersect" >&2
     exit 1
   fi

--- a/scripts/ci/macho-uuid-keys.sh
+++ b/scripts/ci/macho-uuid-keys.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 1 ]; then
+  echo "usage: $0 <Mach-O-or-dSYM-path>" >&2
+  exit 2
+fi
+
+tool="${CMUX_DWARFDUMP_TOOL:-dwarfdump}"
+"$tool" --uuid "$1" | awk '
+  $1 == "UUID:" && NF >= 3 { print $2 "\t" $3 }
+' | sort

--- a/tests/test_nightly_perf_benchmark.sh
+++ b/tests/test_nightly_perf_benchmark.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/nightly-perf-benchmark.yml"
 RUNNER="$ROOT_DIR/scripts/ci/benchmark-nightly-build.sh"
+UUID_KEYS="$ROOT_DIR/scripts/ci/macho-uuid-keys.sh"
 NIGHTLY="$ROOT_DIR/.github/workflows/nightly.yml"
 
 if [ ! -f "$WORKFLOW" ] || [ ! -x "$RUNNER" ]; then
@@ -17,6 +18,26 @@ for scenario in universal-wmo universal-singlefile arm64-wmo x86_64-wmo; do
     exit 1
   fi
 done
+
+if [ ! -x "$UUID_KEYS" ]; then
+  echo "FAIL: normalized Mach-O UUID helper is required" >&2
+  exit 1
+fi
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+cat > "$tmp_dir/dwarfdump" <<'EOF'
+#!/usr/bin/env bash
+printf 'UUID: AAAA-BBBB (arm64) %s\n' "$2"
+printf 'UUID: CCCC-DDDD (x86_64) %s\n' "$2"
+EOF
+chmod +x "$tmp_dir/dwarfdump"
+CMUX_DWARFDUMP_TOOL="$tmp_dir/dwarfdump" "$UUID_KEYS" /one/cmux > "$tmp_dir/one"
+CMUX_DWARFDUMP_TOOL="$tmp_dir/dwarfdump" "$UUID_KEYS" /different/cmux > "$tmp_dir/two"
+if ! cmp -s "$tmp_dir/one" "$tmp_dir/two"; then
+  echo "FAIL: Mach-O UUID comparison must ignore differing file paths" >&2
+  exit 1
+fi
 
 for requirement in \
   'CMUX_CI_XCODE_APP_MACOS_26' \

--- a/tests/test_nightly_perf_benchmark.sh
+++ b/tests/test_nightly_perf_benchmark.sh
@@ -38,6 +38,10 @@ if ! cmp -s "$tmp_dir/one" "$tmp_dir/two"; then
   echo "FAIL: Mach-O UUID comparison must ignore differing file paths" >&2
   exit 1
 fi
+if grep -Fq "grep -q UUID" "$RUNNER"; then
+  echo "FAIL: normalized UUID intersections must not search for removed labels" >&2
+  exit 1
+fi
 
 for requirement in \
   'CMUX_CI_XCODE_APP_MACOS_26' \

--- a/tests/test_nightly_perf_benchmark.sh
+++ b/tests/test_nightly_perf_benchmark.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+WORKFLOW="$ROOT_DIR/.github/workflows/nightly-perf-benchmark.yml"
+RUNNER="$ROOT_DIR/scripts/ci/benchmark-nightly-build.sh"
+
+if [ ! -f "$WORKFLOW" ] || [ ! -x "$RUNNER" ]; then
+  echo "FAIL: nightly performance benchmark workflow and executable runner are required" >&2
+  exit 1
+fi
+
+for scenario in universal-wmo universal-singlefile arm64-wmo x86_64-wmo; do
+  if ! grep -Fq "$scenario" "$WORKFLOW"; then
+    echo "FAIL: missing benchmark scenario: $scenario" >&2
+    exit 1
+  fi
+done
+
+for requirement in \
+  'CMUX_CI_XCODE_APP_MACOS_26' \
+  'blacksmith-6vcpu-macos-26' \
+  './scripts/select-ci-xcode.sh' \
+  './scripts/download-prebuilt-ghosttykit.sh' \
+  './scripts/ci/benchmark-nightly-build.sh' \
+  'actions/upload-artifact@'; do
+  if ! grep -Fq "$requirement" "$WORKFLOW"; then
+    echo "FAIL: benchmark workflow missing: $requirement" >&2
+    exit 1
+  fi
+done
+
+for requirement in \
+  'SWIFT_COMPILATION_MODE=' \
+  'SWIFT_OPTIMIZATION_LEVEL=-O' \
+  'COMPILATION_CACHE_ENABLE_CACHING=YES' \
+  'COMPILER_INDEX_STORE_ENABLE=NO' \
+  'CODE_SIGNING_ALLOWED=NO' \
+  'lipo' \
+  'dwarfdump --uuid' \
+  'strip-release-bundle.sh' \
+  'smoke-launch-macos-app.sh'; do
+  if ! grep -Fq "$requirement" "$RUNNER"; then
+    echo "FAIL: benchmark runner missing safety or measurement check: $requirement" >&2
+    exit 1
+  fi
+done
+
+echo "PASS: nightly performance benchmark preserves release constraints"

--- a/tests/test_nightly_perf_benchmark.sh
+++ b/tests/test_nightly_perf_benchmark.sh
@@ -59,7 +59,7 @@ for requirement in \
   'COMPILER_INDEX_STORE_ENABLE=NO' \
   'CODE_SIGNING_ALLOWED=NO' \
   'lipo' \
-  'dwarfdump --uuid' \
+  'macho-uuid-keys.sh' \
   'strip-release-bundle.sh' \
   'smoke-launch-macos-app.sh'; do
   if ! grep -Fq "$requirement" "$RUNNER"; then

--- a/tests/test_nightly_perf_benchmark.sh
+++ b/tests/test_nightly_perf_benchmark.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 WORKFLOW="$ROOT_DIR/.github/workflows/nightly-perf-benchmark.yml"
 RUNNER="$ROOT_DIR/scripts/ci/benchmark-nightly-build.sh"
+NIGHTLY="$ROOT_DIR/.github/workflows/nightly.yml"
 
 if [ ! -f "$WORKFLOW" ] || [ ! -x "$RUNNER" ]; then
   echo "FAIL: nightly performance benchmark workflow and executable runner are required" >&2
@@ -42,6 +43,18 @@ for requirement in \
   'smoke-launch-macos-app.sh'; do
   if ! grep -Fq "$requirement" "$RUNNER"; then
     echo "FAIL: benchmark runner missing safety or measurement check: $requirement" >&2
+    exit 1
+  fi
+done
+
+for requirement in \
+  'notarization_mode:' \
+  'DMG_ONLY_EXPERIMENT' \
+  'DMG-only notarization experiment is forbidden on main' \
+  'if [ "$DMG_ONLY_EXPERIMENT" != "true" ]' \
+  'xcrun stapler staple "$app_path"'; do
+  if ! grep -Fq "$requirement" "$NIGHTLY"; then
+    echo "FAIL: nightly DMG-only notarization experiment missing safety check: $requirement" >&2
     exit 1
   fi
 done


### PR DESCRIPTION
Measures Nightly build optimizations before changing production behavior.

Experiments:
- Release whole-module versus single-file Swift compilation, with cold, warm, and one-file cache-only rebuilds
- universal versus separate arm64 and x86_64 builds
- pre-transfer stripping with dSYM UUID and architecture verification
- branch-only single-submission DMG notarization, blocked on main and required to produce a usable nested-app ticket

Every build keeps `-O`, verifies expected architectures, and runs the universal app launch smoke. This PR is experimental evidence collection; production settings stay unchanged until results prove equal artifacts and behavior.

Baseline: Swift-source Nightly compile steps currently take 19-22 minutes, while web-only cache-hit runs take 4 minutes to compile.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8395"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786933303&installation_id=133855650&pr_number=8395&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8395&signature=990d6fd82954761a554632c1ce4464f72195532354dc4e3df69b0d6322495e9e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a controlled Nightly CI benchmark to measure Swift build speedups, plus intersection-based, path-independent Mach-O UUID checks and a branch-only DMG-only notarization experiment. No production behavior changes.

- **New Features**
  - New `nightly-perf-benchmark` workflow runs 4 scenarios (universal WMO, universal single-file, arm64 WMO, x86_64 WMO) and publishes summaries and artifacts.
  - `scripts/ci/benchmark-nightly-build.sh` measures cold/warm/cache-only phases, enforces `-O`, verifies archs via `lipo`, compares the intersection of app/dSYM UUIDs using the normalized helper `scripts/ci/macho-uuid-keys.sh` (path-independent), ensures stripping preserves UUID, smoke-tests universal builds, and records metrics.
  - Nightly adds `notarization_mode` with a DMG-only experiment blocked on `main`; when enabled, skips app notarization and proves a usable nested-app ticket. Tests validate required scenarios, compilation and artifact safety gates, normalized UUID intersections, and notarization experiment guards.

<sup>Written for commit fd900ede7ab1d7a08fdbcdd086eb7a68540a3ca5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8395?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added nightly performance benchmarks covering four build scenarios, with timing, artifact, and architecture metrics.
  * Added an optional DMG-only notarization experiment mode for manually triggered nightly builds.
  * Added benchmark summaries and evidence artifacts for review.

* **Bug Fixes**
  * Added validation and safety checks for notarization, build outputs, Mach-O UUIDs, architectures, and caching.

* **Tests**
  * Added automated coverage for benchmark configuration, runner behavior, and notarization safeguards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->