### PR TITLE
Own admitted Iroh connection lifetime

### DIFF
--- a/Sources/Mobile/MobileHostIrohConnectionSupervisor.swift
+++ b/Sources/Mobile/MobileHostIrohConnectionSupervisor.swift
@@ -1,0 +1,53 @@
+import CmuxIrohTransport
+
+/// Owns the legacy coupled lifetime of one admitted Iroh connection.
+enum MobileHostIrohConnectionSupervisor {
+    typealias Operation = @Sendable () async -> Void
+
+    static func runLegacyCoupled(
+        session: CmxIrohAdmittedServerSession,
+        isCurrent: @escaping CmxIrohHostRuntime.CurrentGeneration
+    ) async {
+        let eventWriter = MobileHostIrohServerEventWriter(session: session)
+        let laneRouter = MobileHostIrohApplicationLaneRouter(session: session)
+        await runLegacyCoupled(
+            runControl: {
+                await MobileHostService.acceptTransport(
+                    session.controlTransport,
+                    authorization: .irohAdmission(session.peer),
+                    independentEventWriter: eventWriter,
+                    isCurrent: isCurrent
+                )
+            },
+            runLanes: {
+                await laneRouter.run(isCurrent: isCurrent)
+            },
+            closeSession: {
+                await session.close()
+            },
+            stopLanes: {
+                await laneRouter.stop()
+            }
+        )
+    }
+
+    static func runLegacyCoupled(
+        runControl: @escaping Operation,
+        runLanes: @escaping Operation,
+        closeSession: @escaping Operation,
+        stopLanes: @escaping Operation
+    ) async {
+        await withTaskGroup(of: Void.self) { group in
+            group.addTask {
+                await runControl()
+            }
+            group.addTask {
+                await runLanes()
+            }
+            _ = await group.next()
+            group.cancelAll()
+            await closeSession()
+            await stopLanes()
+        }
+    }
+}

--- a/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
+++ b/Sources/Mobile/MobileHostIrohRuntime+Activation.swift
@@ -189,27 +189,10 @@ extension MobileHostIrohRuntime {
             pendingRevocations: pendingRevocations,
             protocolConfiguration: protocolConfiguration,
             handleTransport: { session, isCurrent in
-                let eventWriter = MobileHostIrohServerEventWriter(
-                    session: session
+                await MobileHostIrohConnectionSupervisor.runLegacyCoupled(
+                    session: session,
+                    isCurrent: isCurrent
                 )
-                let laneRouter = MobileHostIrohApplicationLaneRouter(session: session)
-                await withTaskGroup(of: Void.self) { group in
-                    group.addTask {
-                        await MobileHostService.acceptTransport(
-                            session.controlTransport,
-                            authorization: .irohAdmission(session.peer),
-                            independentEventWriter: eventWriter,
-                            isCurrent: isCurrent
-                        )
-                    }
-                    group.addTask {
-                        await laneRouter.run(isCurrent: isCurrent)
-                    }
-                    _ = await group.next()
-                    group.cancelAll()
-                    await session.close()
-                    await laneRouter.stop()
-                }
             },
             handleBinding: { [weak self] registration, discovery, attestation in
                 let binding = registration.binding

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1065,6 +1065,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		C1A071000000000000000001 /* MobileHostIrohAdmissionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A071000000000000000011 /* MobileHostIrohAdmissionTests.swift */; };
 		A17070900000000000000002 /* MobileHostIrohApplicationLaneRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A17070900000000000000001 /* MobileHostIrohApplicationLaneRouter.swift */; };
 		C1A070000000000000000002 /* MobileHostIrohAuthObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A070000000000000000012 /* MobileHostIrohAuthObserver.swift */; };
+		B7A1C0100000000000000002 /* MobileHostIrohConnectionSupervisor.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7A1C0100000000000000001 /* MobileHostIrohConnectionSupervisor.swift */; };
 		1B0B09020000000000000002 /* MobileHostIrohRuntime+Activation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0B09020000000000000001 /* MobileHostIrohRuntime+Activation.swift */; };
 		C1A070000000000000000003 /* MobileHostIrohRuntime+Lifecycle.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A070000000000000000013 /* MobileHostIrohRuntime+Lifecycle.swift */; };
 		1B0B09030000000000000002 /* MobileHostIrohRuntime+SettingsControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B0B09030000000000000001 /* MobileHostIrohRuntime+SettingsControl.swift */; };
@@ -3102,6 +3103,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		C1A071000000000000000011 /* MobileHostIrohAdmissionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohAdmissionTests.swift; sourceTree = "<group>"; };
 		A17070900000000000000001 /* MobileHostIrohApplicationLaneRouter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohApplicationLaneRouter.swift; sourceTree = "<group>"; };
 		C1A070000000000000000012 /* MobileHostIrohAuthObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohAuthObserver.swift; sourceTree = "<group>"; };
+		B7A1C0100000000000000001 /* MobileHostIrohConnectionSupervisor.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MobileHostIrohConnectionSupervisor.swift; sourceTree = "<group>"; };
 		1B0B09020000000000000001 /* MobileHostIrohRuntime+Activation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MobileHostIrohRuntime+Activation.swift"; sourceTree = "<group>"; };
 		C1A070000000000000000013 /* MobileHostIrohRuntime+Lifecycle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MobileHostIrohRuntime+Lifecycle.swift"; sourceTree = "<group>"; };
 		1B0B09030000000000000001 /* MobileHostIrohRuntime+SettingsControl.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = "MobileHostIrohRuntime+SettingsControl.swift"; sourceTree = "<group>"; };
@@ -4303,6 +4305,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				C1A070000000000000000012 /* MobileHostIrohAuthObserver.swift */,
 				C1A070000000000000000013 /* MobileHostIrohRuntime+Lifecycle.swift */,
 				A17070900000000000000001 /* MobileHostIrohApplicationLaneRouter.swift */,
+				B7A1C0100000000000000001 /* MobileHostIrohConnectionSupervisor.swift */,
 				C1A070000000000000000014 /* MobileHostIrohServerEventWriter.swift */,
 				C1A070000000000000000015 /* MobileHostTransportAuthorization.swift */,
 				C0DE00000000000000000C8C /* MobileHostService+TicketAuthorization.swift */,
@@ -7296,6 +7299,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				B8B056D90000000000000001 /* MobileHostIdentity.swift in Sources */,
 				A17070900000000000000002 /* MobileHostIrohApplicationLaneRouter.swift in Sources */,
 				C1A070000000000000000002 /* MobileHostIrohAuthObserver.swift in Sources */,
+				B7A1C0100000000000000002 /* MobileHostIrohConnectionSupervisor.swift in Sources */,
 				1B0B09020000000000000002 /* MobileHostIrohRuntime+Activation.swift in Sources */,
 				C1A070000000000000000003 /* MobileHostIrohRuntime+Lifecycle.swift in Sources */,
 				1B0B09030000000000000002 /* MobileHostIrohRuntime+SettingsControl.swift in Sources */,

--- a/cmuxTests/MobileHostConnectionLifecycleTests.swift
+++ b/cmuxTests/MobileHostConnectionLifecycleTests.swift
@@ -36,9 +36,40 @@ extension MobileHostAuthorizationTests {
 
         await transport.finishReceiving()
         await runTask.value
+        await session.close(reason: "duplicate close after remote EOF")
 
         #expect(await transport.observedConnectCount() == 1)
         #expect(await transport.observedCloseCount() == 1)
+        #expect(await closeRecorder.recordedIDs() == [connectionID])
+    }
+
+    @Test func testMobileHostConnectionCancellationClosesTransportExactlyOnce() async {
+        let connectionID = UUID()
+        let transport = GatedMobileHostByteTransport()
+        let closeRecorder = MobileHostConnectionCloseRecorder()
+        let session = MobileHostConnection(
+            id: connectionID,
+            transport: transport,
+            authorizeRequest: { _ in nil },
+            onAuthorizedRequest: { _ in },
+            handleRequest: { _ in .ok([:]) },
+            onClose: { id in
+                await closeRecorder.record(id)
+            }
+        )
+
+        let runTask = Task {
+            await session.run()
+        }
+        await transport.waitUntilReceiveStarted()
+
+        runTask.cancel()
+        await runTask.value
+        await session.close(reason: "duplicate close after cancellation")
+
+        #expect(await transport.observedConnectCount() == 1)
+        #expect(await transport.observedCloseCount() == 1)
+        #expect(await transport.observedReceiveCancellation())
         #expect(await closeRecorder.recordedIDs() == [connectionID])
     }
 
@@ -357,6 +388,7 @@ private actor GatedMobileHostByteTransport: CmxByteTransport {
     private var receiveContinuation: CheckedContinuation<Data?, Never>?
     private var connectCount = 0
     private var closeCount = 0
+    private var receiveCancellationObserved = false
 
     init() {
         let receiveStarted = AsyncStream<Void>.makeStream()
@@ -370,8 +402,19 @@ private actor GatedMobileHostByteTransport: CmxByteTransport {
 
     func receive() async -> Data? {
         receiveStartedContinuation.yield()
-        return await withCheckedContinuation { continuation in
-            receiveContinuation = continuation
+        return await withTaskCancellationHandler {
+            await withCheckedContinuation { continuation in
+                guard !Task.isCancelled else {
+                    receiveCancellationObserved = true
+                    continuation.resume(returning: nil)
+                    return
+                }
+                receiveContinuation = continuation
+            }
+        } onCancel: {
+            Task {
+                await self.cancelReceive()
+            }
         }
     }
 
@@ -401,6 +444,16 @@ private actor GatedMobileHostByteTransport: CmxByteTransport {
 
     func observedCloseCount() -> Int {
         closeCount
+    }
+
+    func observedReceiveCancellation() -> Bool {
+        receiveCancellationObserved
+    }
+
+    private func cancelReceive() {
+        receiveCancellationObserved = true
+        receiveContinuation?.resume(returning: nil)
+        receiveContinuation = nil
     }
 }
 

--- a/cmuxTests/MobileHostIrohAdmissionTests.swift
+++ b/cmuxTests/MobileHostIrohAdmissionTests.swift
@@ -253,6 +253,88 @@ extension MobileHostAuthorizationTests {
         #expect(tcpPayload["mac_device_id"] == nil)
     }
 
+    @Test func testLegacyIrohSupervisorClosesOnceWhenControlEnds() async throws {
+        try await assertLegacyIrohSupervisorCleanup(trigger: .controlEnds)
+    }
+
+    @Test func testLegacyIrohSupervisorClosesOnceWhenLaneTaskCompletes() async throws {
+        try await assertLegacyIrohSupervisorCleanup(trigger: .laneTaskEnds)
+    }
+
+    @Test func testLegacyIrohSupervisorClosesOnceWhenChildrenFinishTogether() async throws {
+        try await assertLegacyIrohSupervisorCleanup(trigger: .childrenFinishTogether)
+    }
+
+    @Test func testLegacyIrohSupervisorClosesOnceOnCallerCancellation() async throws {
+        try await assertLegacyIrohSupervisorCleanup(trigger: .callerCancellation)
+    }
+
+    private func assertLegacyIrohSupervisorCleanup(
+        trigger: LegacyIrohSupervisorTrigger
+    ) async throws {
+        let controlStarted = AsyncTestSignal()
+        let lanesStarted = AsyncTestSignal()
+        let (controlStream, controlContinuation) = AsyncStream<Void>.makeStream()
+        let (laneStream, laneContinuation) = AsyncStream<Void>.makeStream()
+        let cleanupRecorder = MobileHostConnectionCloseRecorder()
+        let childExitRecorder = MobileHostConnectionCloseRecorder()
+        let sessionCloseID = UUID()
+        let laneStopID = UUID()
+        let controlExitID = UUID()
+        let laneExitID = UUID()
+        let supervisorTask = Task {
+            await MobileHostIrohConnectionSupervisor.runLegacyCoupled(
+                runControl: {
+                    controlStarted.fulfill()
+                    for await _ in controlStream {}
+                    await childExitRecorder.record(controlExitID)
+                },
+                runLanes: {
+                    lanesStarted.fulfill()
+                    for await _ in laneStream {}
+                    await childExitRecorder.record(laneExitID)
+                },
+                closeSession: {
+                    await cleanupRecorder.record(sessionCloseID)
+                },
+                stopLanes: {
+                    await cleanupRecorder.record(laneStopID)
+                }
+            )
+        }
+        defer {
+            supervisorTask.cancel()
+            controlContinuation.finish()
+            laneContinuation.finish()
+        }
+
+        try await controlStarted.wait()
+        try await lanesStarted.wait()
+        switch trigger {
+        case .controlEnds:
+            controlContinuation.finish()
+        case .laneTaskEnds:
+            laneContinuation.finish()
+        case .childrenFinishTogether:
+            controlContinuation.finish()
+            laneContinuation.finish()
+        case .callerCancellation:
+            supervisorTask.cancel()
+        }
+        await supervisorTask.value
+
+        #expect(await cleanupRecorder.recordedIDs() == [sessionCloseID, laneStopID])
+        let childExits = await childExitRecorder.recordedIDs()
+        switch trigger {
+        case .controlEnds:
+            #expect(childExits.filter { $0 == laneExitID }.count == 1)
+        case .laneTaskEnds:
+            #expect(childExits.filter { $0 == controlExitID }.count == 1)
+        case .childrenFinishTogether, .callerCancellation:
+            #expect(childExits.count == 2)
+        }
+    }
+
     @Test func testIrohTerminalLaneInputFramingSurvivesQUICChunkBoundaries() throws {
         var buffer = Data([0, 0])
         #expect(try MobileHostIrohApplicationLaneRouter.decodeTerminalInputFrames(from: &buffer).isEmpty)
@@ -307,6 +389,13 @@ extension MobileHostAuthorizationTests {
         )
         return .irohAdmission(CmxIrohAdmittedPeer(peer: peer))
     }
+}
+
+private enum LegacyIrohSupervisorTrigger {
+    case controlEnds
+    case laneTaskEnds
+    case childrenFinishTogether
+    case callerCancellation
 }
 
 private actor MobileHostIrohPersistenceGate {


### PR DESCRIPTION
This is the behavior-preserving first slice of the mobile terminal protocol rebuild.

- Extracts the admitted Iroh control and application-lane task group into one connection supervisor.
- Preserves the current v1 wire format, authentication, cancellation, close ordering, and router behavior.
- Adds lifecycle coverage for remote EOF, caller cancellation, control-first exit, lane-first exit, and simultaneous child completion.

The supervisor is the ownership boundary required before protocol negotiation. This PR deliberately does not preserve a clean control EOF as a resumable session because v1 has no transcript-bound resume grammar and application lanes still carry ambient surface UUID authority.

Staged follow-ups:

1. Add an authenticated, transcript-bound negotiation and capability state machine over Iroh QUIC. Keep Tailscale as a route hint only.
2. Replace string input messages with binary sequenced input, cumulative acknowledgements, duplicate suppression, and bounded replay.
3. Add renderer epochs, base revisions, atomic theme and geometry state, explicit color space, and a full-snapshot recovery path before changing renderer implementation.
4. Give primary-screen scrollback stable line IDs and a bounded paged cache with velocity-aware prefetch. Keep alternate-screen scroll ownership on the terminal host.
5. Retire the legacy raw listener only after compatibility telemetry and downgrade tests prove it is safe.

Verification:

- Six focused lifecycle tests pass on the rebased head.
- Xcode project test wiring lint passes for 523 test files.
- Tagged macOS and isolated iOS Simulator builds pass with tag `irhown`.
- Simulator auto sign-in, pairing, terminal input, and navigate-out/back recovery pass end to end.
- The same head archives, signs, installs, auto-signs in, pairs, and launches on the physical iPhone. The Mac observed its admitted Iroh terminal lane.

Local unit-test compilation currently needs the unrelated one-line `instanceSerial` correction already missing on `main`; that temporary local correction is not included in this branch.