### PR TITLE
Fix ssh-tmux new-window no-focus routing

### DIFF
--- a/Sources/AppDelegate+SocketConfiguration.swift
+++ b/Sources/AppDelegate+SocketConfiguration.swift
@@ -6,7 +6,7 @@ extension AppDelegate {
     func reconcileSocketListenerConfiguration(source: String) {
         TerminalController.shared.reconcileSocketConfiguration(
             resolvedSocketListenerConfiguration(),
-            preferredTabManager: activeTabManagerForCommands(),
+            routingFallbackTabManager: activeTabManagerForCommands(),
             source: source
         )
     }
@@ -47,7 +47,7 @@ extension AppDelegate {
         ])
         TerminalController.shared.reconcileSocketConfiguration(
             config,
-            preferredTabManager: tabManager,
+            routingFallbackTabManager: tabManager,
             source: source
         )
     }
@@ -65,7 +65,7 @@ extension AppDelegate {
         guard !health.isHealthy else {
             TerminalController.shared.reconcileSocketConfiguration(
                 config,
-                preferredTabManager: tabManager,
+                routingFallbackTabManager: tabManager,
                 source: source
             )
             return
@@ -79,7 +79,7 @@ extension AppDelegate {
         ])
         TerminalController.shared.reconcileSocketConfiguration(
             config,
-            preferredTabManager: tabManager,
+            routingFallbackTabManager: tabManager,
             source: source
         )
     }
@@ -102,7 +102,7 @@ extension AppDelegate {
         TerminalController.shared.startSocketTransport(
             config,
             socketPath: restartPath,
-            preferredTabManager: manager
+            routingFallbackTabManager: manager
         )
     }
 }

--- a/Sources/TerminalController+SocketConfiguration.swift
+++ b/Sources/TerminalController+SocketConfiguration.swift
@@ -34,11 +34,14 @@ extension TerminalController {
     /// until normal window registration supplies their routing target.
     func reconcileSocketConfiguration(
         _ configuration: SocketControlServerConfiguration,
-        preferredTabManager: TabManager? = nil,
+        routingFallbackTabManager: TabManager? = nil,
         source: String
     ) {
-        if let preferredTabManager {
-            self.tabManager = preferredTabManager
+        // Listener configuration is transport state, not focus intent. A window
+        // registered in the background may seed routing only when no active
+        // manager exists; afterward key-window and explicit-focus paths own it.
+        if tabManager == nil, let routingFallbackTabManager {
+            tabManager = routingFallbackTabManager
         }
         let previousMode = socketServer.accessMode
         let wasRunning = socketServer.isRunning
@@ -54,7 +57,7 @@ extension TerminalController {
             startSocketTransport(
                 configuration,
                 socketPath: configuration.preferredSocketPath,
-                preferredTabManager: preferredTabManager
+                routingFallbackTabManager: routingFallbackTabManager
             )
         } else if wasRunning {
             let reconfigured = socketServer.reconfigure(accessMode: configuration.accessMode)
@@ -62,14 +65,14 @@ extension TerminalController {
                 startSocketTransport(
                     configuration,
                     socketPath: configuration.preferredSocketPath,
-                    preferredTabManager: preferredTabManager
+                    routingFallbackTabManager: routingFallbackTabManager
                 )
             }
         } else {
             startSocketTransport(
                 configuration,
                 socketPath: activeSocketPath(preferredPath: configuration.preferredSocketPath),
-                preferredTabManager: preferredTabManager
+                routingFallbackTabManager: routingFallbackTabManager
             )
         }
 
@@ -91,10 +94,10 @@ extension TerminalController {
     func startSocketTransport(
         _ configuration: SocketControlServerConfiguration,
         socketPath: String,
-        preferredTabManager: TabManager? = nil,
+        routingFallbackTabManager: TabManager? = nil,
         preserveAcceptFailureStreak: Bool = false
     ) {
-        if let manager = preferredTabManager ?? tabManager {
+        if let manager = tabManager ?? routingFallbackTabManager {
             start(
                 tabManager: manager,
                 socketPath: socketPath,

--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -289,6 +289,10 @@ import Testing
         harness.cacheConnection(host: host, session: "one")
         #expect(harness.appDelegate.focusMainWindow(windowId: harness.windowId))
         #expect(harness.appDelegate.tabManager === harness.manager)
+        #expect(TerminalController.shared.activeTabManagerForCallerNotification() === harness.manager)
+        let focusedBefore = try #require(
+            TerminalController.shared.v2Identify(params: [:])["focused"] as? [String: Any]
+        )
 
         let responseText = await Task.detached {
             TerminalController.shared.v2RemoteTmuxWindow(
@@ -304,6 +308,14 @@ import Testing
         )
 
         #expect(harness.appDelegate.tabManager === harness.manager)
+        #expect(TerminalController.shared.activeTabManagerForCallerNotification() === harness.manager)
+        let focusedAfter = try #require(
+            TerminalController.shared.v2Identify(params: [:])["focused"] as? [String: Any]
+        )
+        #expect(focusedAfter["window_id"] as? String == focusedBefore["window_id"] as? String)
+        #expect(focusedAfter["workspace_id"] as? String == focusedBefore["workspace_id"] as? String)
+        #expect(focusedAfter["pane_id"] as? String == focusedBefore["pane_id"] as? String)
+        #expect(focusedAfter["surface_id"] as? String == focusedBefore["surface_id"] as? String)
     }
 
     private func writeExecutable(at url: URL, contents: String) throws {

--- a/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCloseDetachTests.swift
@@ -293,6 +293,10 @@ import Testing
         let focusedBefore = try #require(
             TerminalController.shared.v2Identify(params: [:])["focused"] as? [String: Any]
         )
+        let windowIDBefore = try #require(focusedBefore["window_id"] as? String)
+        let workspaceIDBefore = try #require(focusedBefore["workspace_id"] as? String)
+        let paneIDBefore = try #require(focusedBefore["pane_id"] as? String)
+        let surfaceIDBefore = try #require(focusedBefore["surface_id"] as? String)
 
         let responseText = await Task.detached {
             TerminalController.shared.v2RemoteTmuxWindow(
@@ -312,10 +316,10 @@ import Testing
         let focusedAfter = try #require(
             TerminalController.shared.v2Identify(params: [:])["focused"] as? [String: Any]
         )
-        #expect(focusedAfter["window_id"] as? String == focusedBefore["window_id"] as? String)
-        #expect(focusedAfter["workspace_id"] as? String == focusedBefore["workspace_id"] as? String)
-        #expect(focusedAfter["pane_id"] as? String == focusedBefore["pane_id"] as? String)
-        #expect(focusedAfter["surface_id"] as? String == focusedBefore["surface_id"] as? String)
+        #expect(focusedAfter["window_id"] as? String == windowIDBefore)
+        #expect(focusedAfter["workspace_id"] as? String == workspaceIDBefore)
+        #expect(focusedAfter["pane_id"] as? String == paneIDBefore)
+        #expect(focusedAfter["surface_id"] as? String == surfaceIDBefore)
     }
 
     private func writeExecutable(at url: URL, contents: String) throws {

--- a/cmuxTests/SocketACLReloadRegressionTests.swift
+++ b/cmuxTests/SocketACLReloadRegressionTests.swift
@@ -115,7 +115,7 @@ struct SocketACLReloadRegressionTests {
                         accessMode: SocketControlSettings.migrateMode(rawMode),
                         preferredSocketPath: socketPath
                     ),
-                    preferredTabManager: tabManager,
+                    routingFallbackTabManager: tabManager,
                     source: source
                 )
                 reloadContinuation.yield(source)
@@ -126,7 +126,7 @@ struct SocketACLReloadRegressionTests {
                 accessMode: .allowAll,
                 preferredSocketPath: socketPath
             ),
-            preferredTabManager: tabManager,
+            routingFallbackTabManager: tabManager,
             source: "test.watcher_baseline"
         )
         #expect(controller.socketServer.isRunning)
@@ -155,7 +155,7 @@ struct SocketACLReloadRegressionTests {
                 accessMode: .cmuxOnly,
                 preferredSocketPath: firstPath
             ),
-            preferredTabManager: TabManager(),
+            routingFallbackTabManager: TabManager(),
             source: "test.path_baseline"
         )
         #expect(controller.socketServer.currentSocketPath == firstPath)
@@ -165,7 +165,7 @@ struct SocketACLReloadRegressionTests {
                 accessMode: .automation,
                 preferredSocketPath: secondPath
             ),
-            preferredTabManager: TabManager(),
+            routingFallbackTabManager: TabManager(),
             source: "test.path_change"
         )
 
@@ -200,7 +200,7 @@ struct SocketACLReloadRegressionTests {
                 accessMode: .automation,
                 preferredSocketPath: configuredPath
             ),
-            preferredTabManager: TabManager(),
+            routingFallbackTabManager: TabManager(),
             source: "test.pending_rearm_path_change"
         )
 
@@ -241,7 +241,7 @@ struct SocketACLReloadRegressionTests {
                 accessMode: .automation,
                 preferredSocketPath: preferredPath
             ),
-            preferredTabManager: TabManager(),
+            routingFallbackTabManager: TabManager(),
             source: "test.fallback_reconcile"
         )
 
@@ -268,7 +268,7 @@ struct SocketACLReloadRegressionTests {
                 accessMode: .cmuxOnly,
                 preferredSocketPath: socketPath
             ),
-            preferredTabManager: tabManager,
+            routingFallbackTabManager: tabManager,
             source: "test.missing_path_baseline"
         )
         #expect(controller.socketServer.isRunning)
@@ -279,7 +279,7 @@ struct SocketACLReloadRegressionTests {
                 accessMode: .automation,
                 preferredSocketPath: socketPath
             ),
-            preferredTabManager: tabManager,
+            routingFallbackTabManager: tabManager,
             source: "test.missing_path_reconfigure"
         )
 

--- a/cmuxTests/SocketConfigurationLifecycleTests.swift
+++ b/cmuxTests/SocketConfigurationLifecycleTests.swift
@@ -349,7 +349,7 @@ extension SocketACLReloadRegressionTests {
                 accessMode: .cmuxOnly,
                 preferredSocketPath: socketPath
             ),
-            preferredTabManager: tabManager,
+            routingFallbackTabManager: tabManager,
             source: "test.headless_attach"
         )
 


### PR DESCRIPTION
## Summary

- preserve the active command-routing owner while `ssh-tmux --new-window --no-focus` creates and populates a dedicated mirror window
- make listener reconciliation focus-neutral across every deferred window-registration / mirror-attach pass, instead of restoring a focus snapshot after the fact
- add identify-level regression coverage for the window, workspace, pane, and surface selection

## Root cause and architecture

`RemoteTmuxController.attachHost` already creates the dedicated window with `shouldActivate: false`, and the mirror mutation coordinator keeps topology attachment itself focus-neutral. The focus theft came from a different owner: every `registerMainWindow` call runs `ensureSocketListenerIfEnabled`, whose socket reconciliation unconditionally replaced `TerminalController.tabManager` with the newly registered window's manager. The new window stayed non-key, but subsequent `system.identify` and untargeted socket commands routed through it.

Socket transport configuration and active-window command routing are now separate responsibilities. A newly registered manager is a `routingFallbackTabManager`: it may seed routing only when no active manager exists. Listener restarts prefer the existing routing owner. After that seed, only key-window or explicit focus-intent paths may replace the active manager.

This is the shared focus-suppression mechanism in the mirror attach path, not a `ssh-tmux`-specific snapshot/restore race. The sibling working on #7733 can rebase on this ownership boundary; this PR remains scoped to the dedicated `--new-window --no-focus` contract.

## Verification

- [x] Test-first regression proof
  - [red, test-only ref](https://github.com/manaflow-ai/cmux/actions/runs/29630435239): 6 tests executed; `dedicatedWindowSocketDefaultsToFocusNeutral` failed because the active manager and all four focused IDs changed
  - [green, fix ref](https://github.com/manaflow-ai/cmux/actions/runs/29630436248): the same 6 tests passed
  - Both isolated refs include the same one-line `DockPortalReconcileTests` compile repair from #8390 because current `main` otherwise cannot compile the test target; that repair is not in this PR.
- [x] Tagged cloud build: [run 29629762947](https://github.com/manaflow-ai/cmux/actions/runs/29629762947)

  ```bash
  CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-8379-sshtmux-nofocus --launch
  ```

- [x] Real-remote dogfood against `ec2-user@cmux-aws-m4pro` (tmux 3.6b), using only the tagged socket

  ```bash
  cmux-dev --socket /tmp/cmux-debug-issue-8379-sshtmux-nofocus.sock identify
  cmux-dev --socket /tmp/cmux-debug-issue-8379-sshtmux-nofocus.sock ssh-tmux ec2-user@cmux-aws-m4pro --new-window --no-focus
  cmux-dev --socket /tmp/cmux-debug-issue-8379-sshtmux-nofocus.sock workspace list --window window:2 --json
  cmux-dev --socket /tmp/cmux-debug-issue-8379-sshtmux-nofocus.sock identify
  ```

  Before and after both reported `window:1 / workspace:1 / pane:1 / surface:1`; the deferred mirror population completed in `window:2` with workspace title `dogfood-8379-nofocus`. The remote fixture was then killed and no `dogfood-8379-nofocus` session remains.
- [x] `./scripts/lint-pbxproj-test-wiring.sh`
- [x] `git diff --check`
- [x] Swift budget audit: production files are 129 and 108 lines; neither budget TSV is touched. `scripts/swift_file_length_budget.py` and `.github/swift-file-length-budget.tsv` do not exist on current `main`, so that requested script could not be run; `.github/swift-warning-budget.tsv` is unchanged and the tagged build introduced no new warning.
- [x] Localization audit: no user-facing surfaces, message keys, or localization catalogs changed; the added production text is comments/parameter naming only, and an added-string scan found no new production UI text.

Closes #8379
https://github.com/manaflow-ai/cmux/issues/8379
