### PR TITLE
Fix new-surface targeting remote tmux panes

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -17655,9 +17655,7 @@ struct CMUXCLI {
         return parts.joined(separator: " ")
     }
 
-    /// Summary for surface.split / surface.create responses, which report
-    /// `accepted: true` (and no surface id) when the request was routed to a
-    /// remote tmux mirror — the new pane arrives asynchronously.
+    /// Summary for remote-tmux creations whose pane or window arrives asynchronously.
     func v2CreationSummary(_ payload: [String: Any], idFormat: CLIIDFormat, kinds: [String] = ["surface", "workspace"]) -> String {
         guard (payload["accepted"] as? Bool) == true else {
             return v2OKSummary(payload, idFormat: idFormat, kinds: kinds)
@@ -17666,7 +17664,9 @@ struct CMUXCLI {
         if let handle = formatHandle(payload, kind: "workspace", idFormat: idFormat) {
             parts.append(handle)
         }
-        parts.append("(routed to remote tmux; the new pane arrives asynchronously)")
+        parts.append((payload["remote_tmux_operation"] as? String) == "new-window"
+            ? String(localized: "cli.creation.remoteTmux.newWindow", defaultValue: "(routed to remote tmux; the new window arrives asynchronously)")
+            : String(localized: "cli.creation.remoteTmux.newPane", defaultValue: "(routed to remote tmux; the new pane arrives asynchronously)"))
         return parts.joined(separator: " ")
     }
 

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Pane/ControlCommandCoordinator+Pane.swift
@@ -377,7 +377,8 @@ extension ControlCommandCoordinator {
             return remoteRoutedCreationResult(
                 windowID: windowID,
                 workspaceID: workspaceID,
-                typeRawValue: typeRawValue
+                typeRawValue: typeRawValue,
+                operation: .splitWindow
             )
         case .createdDock(let windowID, let workspaceID, let dockPaneID, let dockSurfaceID, let typeRawValue):
             return .ok(.object([

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+MirrorRouting.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+MirrorRouting.swift
@@ -12,11 +12,13 @@ extension ControlCommandCoordinator {
     func remoteRoutedCreationResult(
         windowID: UUID?,
         workspaceID: UUID,
-        typeRawValue: String
+        typeRawValue: String,
+        operation: ControlRemoteTmuxCreationOperation
     ) -> ControlCallResult {
         .ok(.object([
             "accepted": .bool(true),
             "routed": .string("remote-tmux"),
+            "remote_tmux_operation": .string(operation.rawValue),
             "window_id": orNull(windowID?.uuidString),
             "window_ref": ref(.window, windowID),
             "workspace_id": .string(workspaceID.uuidString),

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlCommandCoordinator+Surface.swift
@@ -393,7 +393,8 @@ extension ControlCommandCoordinator {
             return remoteRoutedCreationResult(
                 windowID: windowID,
                 workspaceID: workspaceID,
-                typeRawValue: typeRawValue
+                typeRawValue: typeRawValue,
+                operation: .splitWindow
             )
         case .created(let windowID, let workspaceID, let paneID, let surfaceID, let typeRawValue):
             return .ok(.object([
@@ -537,6 +538,15 @@ extension ControlCommandCoordinator {
             return .err(code: "not_found", message: "Workspace not found", data: nil)
         case .paneNotFound:
             return .err(code: "not_found", message: "Pane not found", data: nil)
+        case .mirrorPaneTargetUnsupportedType(let typeRawValue, let message):
+            return .err(
+                code: "invalid_params",
+                message: message,
+                data: .object([
+                    "type": .string(typeRawValue),
+                    "target": .string("remote-tmux-pane"),
+                ])
+            )
         case .createFailed:
             return .err(code: "internal_error", message: "Failed to create surface", data: nil)
         case .mirrorUnsupportedOptions(let unsupported):
@@ -545,7 +555,8 @@ extension ControlCommandCoordinator {
             return remoteRoutedCreationResult(
                 windowID: windowID,
                 workspaceID: workspaceID,
-                typeRawValue: typeRawValue
+                typeRawValue: typeRawValue,
+                operation: .newWindow
             )
         case .createdDock(let windowID, let workspaceID, let dockPaneID, let dockSurfaceID, let typeRawValue):
             return .ok(.object([

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlRemoteTmuxCreationOperation.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlRemoteTmuxCreationOperation.swift
@@ -1,0 +1,5 @@
+/// The tmux command whose asynchronous topology event will materialize a routed creation.
+enum ControlRemoteTmuxCreationOperation: String, Sendable {
+    case newWindow = "new-window"
+    case splitWindow = "split-window"
+}

--- a/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceCreateResolution.swift
+++ b/Packages/macOS/CmuxControlSocket/Sources/CmuxControlSocket/Coordinator/Surface/ControlSurfaceCreateResolution.swift
@@ -35,12 +35,15 @@ public enum ControlSurfaceCreateResolution: Sendable, Equatable {
     /// The requested/focused pane did not resolve (legacy `not_found` / "Pane not
     /// found").
     case paneNotFound
+    /// A projected remote tmux pane resolved, but its owner cannot host this
+    /// surface type. Carries the wire type and app-bundle-localized explanation.
+    case mirrorPaneTargetUnsupportedType(typeRawValue: String, message: String)
     /// The surface creation failed (legacy `internal_error` / "Failed to create
     /// surface").
     case createFailed
-    /// The request carried options the routed remote tmux `new-window` cannot
-    /// honor; rejected BEFORE the remote session was mutated (an error after
-    /// the mutation invites retries that duplicate remote tabs).
+    /// The request carried options the routed remote tmux creation cannot honor;
+    /// rejected BEFORE the remote session was mutated (an error after the
+    /// mutation invites retries that duplicate remote panes or windows).
     case mirrorUnsupportedOptions([String])
     /// The create was routed to the remote tmux mirror backing the workspace
     /// (`new-window`); the tab arrives asynchronously via `%window-add`.

--- a/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
+++ b/Packages/macOS/CmuxControlSocket/Tests/CmuxControlSocketTests/ControlCommandCoordinatorSurfaceTests.swift
@@ -94,6 +94,32 @@ struct ControlCommandCoordinatorSurfaceTests {
         #expect(payload["type"] == .string("terminal"))
     }
 
+    @Test func surfaceCreateRemotePayloadIdentifiesTmuxNewWindow() throws {
+        let workspaceID = UUID()
+        let (coordinator, context) = coordinator(createResolution: .routedToRemote(
+            windowID: nil,
+            workspaceID: workspaceID,
+            typeRawValue: "terminal"
+        ))
+
+        let result = coordinator.handle(ControlRequest(
+            id: .int(1),
+            method: "surface.create",
+            params: ["type": .string("terminal")]
+        ))
+        _ = context
+
+        guard case .ok(.object(let payload)) = result else {
+            Issue.record("expected routed remote create payload")
+            return
+        }
+
+        #expect(payload["accepted"] == .bool(true))
+        #expect(payload["routed"] == .string("remote-tmux"))
+        #expect(payload["remote_tmux_operation"] == .string("new-window"))
+        #expect(payload["workspace_id"] == .string(workspaceID.uuidString))
+    }
+
     @Test func surfaceCreateDockUnsupportedTypeReturnsInvalidParams() throws {
         let (coordinator, context) = coordinator(createResolution: .dockUnsupportedType(
             typeRawValue: "agentSession",

--- a/Sources/RemoteTmuxController+Decisions.swift
+++ b/Sources/RemoteTmuxController+Decisions.swift
@@ -52,6 +52,35 @@ extension RemoteTmuxController {
             workingDirectory: commandWorkingDirectory,
             focus: focus
         )
+        return sendMirrorNewWindow(command, through: mirror, focus: focus)
+    }
+
+    /// Routes a projected control-pane target to a new tmux window immediately
+    /// after the window containing that pane. The target pane's authoritative
+    /// remote cwd is inherited when available.
+    func handleMirrorNewTabRequested(
+        workspaceId: UUID,
+        targetPaneId: Int,
+        focus: Bool
+    ) -> Bool {
+        guard let mirror = sessionMirror(workspaceId: workspaceId),
+              mirror.connection.connectionState == .connected,
+              let afterWindowId = mirror.windowIdByPane[targetPaneId] else {
+            return false
+        }
+        let command = Self.newWindowCommand(
+            afterWindowId: afterWindowId,
+            workingDirectory: mirror.cwdByPane[targetPaneId],
+            focus: focus
+        )
+        return sendMirrorNewWindow(command, through: mirror, focus: focus)
+    }
+
+    private func sendMirrorNewWindow(
+        _ command: String,
+        through mirror: RemoteTmuxSessionMirror,
+        focus: Bool
+    ) -> Bool {
         guard focus else { return mirror.connection.send(command) }
         return mirror.connection.sendNewWindow(command) { [weak mirror] windowId in
             guard let windowId else { return }

--- a/Sources/TerminalController+ControlSurfaceContext2.swift
+++ b/Sources/TerminalController+ControlSurfaceContext2.swift
@@ -337,7 +337,7 @@ extension TerminalController {
         }
         v2MaybeFocusWindow(for: tabManager)
         v2MaybeSelectWorkspace(tabManager, workspace: ws)
-
+        if let remote = controlRemoteTmuxSurfaceCreate(workspace: ws, tabManager: tabManager, inputs: inputs, panelType: panelType) { return remote }
         let paneId: PaneID? = {
             if let paneUUID = inputs.requestedPaneID {
                 return ws.bonsplitController.allPaneIds.first(where: { $0.id == paneUUID })

--- a/Sources/TerminalController+RemoteTmuxControlMutations.swift
+++ b/Sources/TerminalController+RemoteTmuxControlMutations.swift
@@ -140,6 +140,48 @@ extension TerminalController {
         )
     }
 
+    /// Interprets a projected pane handle according to the mirror topology:
+    /// surface tabs are tmux windows, anchored after the target pane's window.
+    func controlRemoteTmuxSurfaceCreate(
+        workspace: Workspace,
+        tabManager: TabManager,
+        inputs: ControlSurfaceCreateInputs,
+        panelType: PanelType
+    ) -> ControlSurfaceCreateResolution? {
+        guard let paneID = inputs.requestedPaneID,
+              let location = workspace.remoteTmuxControlPane(paneID: paneID) else {
+            return nil
+        }
+        guard panelType == .terminal else {
+            return .mirrorPaneTargetUnsupportedType(
+                typeRawValue: panelType.rawValue,
+                message: String(
+                    localized: "socket.surface.create.remoteTmuxPaneUnsupportedType",
+                    defaultValue: "Only terminal surfaces can target a remote tmux pane; the terminal is created as a new tmux window after the pane's window."
+                )
+            )
+        }
+        let unsupported = mirrorRoutedUnsupportedOptions(
+            workingDirectory: inputs.workingDirectory,
+            initialCommand: inputs.initialCommand,
+            tmuxStartCommand: inputs.tmuxStartCommand,
+            startupEnvironment: inputs.startupEnvironment,
+            remotePTYSessionID: inputs.remotePTYSessionID
+        )
+        guard unsupported.isEmpty else { return .mirrorUnsupportedOptions(unsupported) }
+        let routed = AppDelegate.shared?.remoteTmuxController.handleMirrorNewTabRequested(
+            workspaceId: workspace.id,
+            targetPaneId: location.pane.tmuxPaneID,
+            focus: v2FocusAllowed(requested: inputs.requestedFocus)
+        ) ?? false
+        guard routed else { return .createFailed }
+        return .routedToRemote(
+            windowID: v2ResolveWindowId(tabManager: tabManager),
+            workspaceID: workspace.id,
+            typeRawValue: panelType.rawValue
+        )
+    }
+
     func controlRemoteTmuxSurfaceRespawn(
         workspace: Workspace,
         tabManager: TabManager,

--- a/cmuxTests/RemoteTmuxMirrorCLIFailClosedTests.swift
+++ b/cmuxTests/RemoteTmuxMirrorCLIFailClosedTests.swift
@@ -310,9 +310,10 @@ extension RemoteTmuxMirrorCLIObservabilityTests {
                 )
             )
 
-            // tmux panes cannot host surface tabs; the projected pane handle is
-            // tombstoned rather than silently redirected.
-            #expect(result == .paneNotFound)
+            // A projected pane is a valid target. `new-surface` maps to a tmux
+            // window in a mirror, so the disconnected transport fails only
+            // after the handle has resolved and routing has been attempted.
+            #expect(result == .createFailed)
         }
 
         do {


### PR DESCRIPTION
## Summary

- Resolve explicit `new-surface --pane` targets through the existing projected remote-pane topology instead of searching only local Bonsplit pane IDs.
- Route a resolved remote pane to its containing tmux window and create the new surface after that window.
- Add `remote_tmux_operation` to routed creation responses so CLI output distinguishes tmux `new-window` from `split-window`.
- Localize the new remote creation summaries and unsupported-type error in English and Japanese.

## Semantics

`new-surface` creates another surface tab in a cmux pane. In an ssh-tmux mirror, tmux windows are the mirrored surface tabs, while tmux panes are native splits inside a window. Therefore the mirror operation is deliberately `new-window`, not `split-window`.

When `--pane` names a projected remote pane, the pane selects the containing tmux window. The new tmux window is inserted immediately after that window and inherits the targeted pane current directory when available. With `--focus false`, the current mirror selection is preserved.

The routed response now carries:

```json
"remote_tmux_operation": "new-window"
```

The human CLI summary accordingly says `the new window arrives asynchronously`. Split/pane creation routes carry `split-window` and continue to say `new pane`.

## Resolver boundary

This reuses the existing shared projected-pane resolver, `Workspace.remoteTmuxControlPane(paneID:)`, which already backs tree/list handle projection and other remote control mutations. The defect was the `surface.create` command path bypassing that resolver and searching only outer Bonsplit panes.

This PR does not change `reorder-surface` semantics for #7734 beyond keeping the shared resolver as the single handle-to-remote-pane boundary. The sibling #7734 work can rebase without reconciling a second registry or resolver.

## Regression coverage

The commits intentionally preserve the required red/green structure:

1. `3d6b2e1927 Test remote pane surface creation routing` adds the failing behavior test.
2. `0cc4fda53a Route new surfaces to remote tmux windows` implements the fix.

Verification:

- `/usr/bin/arch -arm64 swift test` in `Packages/macOS/CmuxControlSocket`: 270 tests passed.
- `git diff --check`: passed.
- `jq empty Resources/Localizable.xcstrings`: passed.
- English/Japanese presence check for all three changed localization keys: passed.
- `scripts/check-package-resolved-policy.py`: passed.
- `scripts/check-workspace-package-groups.py --check`: passed.
- `scripts/lint-pbxproj-test-wiring.sh`: passed.
- Tagged cloud build: https://github.com/manaflow-ai/cmux/actions/runs/29629677850

The branch does not contain `.github/swift-file-length-budget.tsv` or `scripts/swift_file_length_budget.py`; neither budget TSV was touched. The only touched pre-existing app Swift file above 500 lines remained at its original 538 lines. The tagged build completed without new Swift warnings.

## Real remote dogfood

Target: `cmux@cmux-mac-mini`, OpenSSH, tmux 3.5a. The fixture was isolated to `dogfood-8381-nspane` and removed afterward.

Build and socket identity:

```bash
CMUX_SKIP_ZIG_BUILD=1 /Users/austinwang/manaflow/cmuxterm-hq/scripts/reload-cloud.sh --tag issue-8381-new-surface-pane --launch
CMUX_TAG=issue-8381-new-surface-pane scripts/cmux-debug-cli.sh identify
```

`identify` reported bundle `com.cmuxterm.app.debug.issue.8381.new.surface.pane` and socket `/tmp/cmux-debug-issue-8381-new-surface-pane.sock`.

The remote fixture began with two tmux windows:

```text
0|@0|first|2
1|@1|second|1
```

After attaching through only the tagged CLI, `tree --json` listed projected panes `pane:2` and `pane:3` in `@0), and `pane:4` in `@1).

Explicit projected-pane request:

```bash
CMUX_TAG=issue-8381-new-surface-pane scripts/cmux-debug-cli.sh new-surface \
  --workspace workspace:2 --pane pane:3 --type terminal --focus false --json
```

Result:

```json
{
  "accepted": true,
  "remote_tmux_operation": "new-window",
  "routed": "remote-tmux",
  "workspace_ref": "workspace:2"
}
```

Remote order after targeting a pane in `@0`:

```text
0|@0|first|2|1
1|@2|zsh|1|0
2|@1|second|1|0
```

Targeting `pane:4` in `@1` inserted the new window after `@1`, proving the explicit pane chooses the correct remote tmux anchor. Both explicit and no-`--pane` non-JSON requests printed:

```text
OK accepted workspace:2 (routed to remote tmux; the new window arrives asynchronously)
```

Cleanup:

```bash
ssh cmux@cmux-mac-mini 'tmux kill-session -t dogfood-8381-nspane'
defaults delete com.cmuxterm.app.debug.issue.8381.new.surface.pane 'remoteTmux.beta.enabled'
```

## Localization audit

Changed user-facing surfaces:

- routed remote `new-window` success summary
- routed remote `split-window` success summary
- unsupported surface type error for an explicit remote pane target

`Resources/Localizable.xcstrings` contains translated English and Japanese values for:

- `cli.creation.remoteTmux.newWindow`
- `cli.creation.remoteTmux.newPane`
- `socket.surface.create.remoteTmuxPaneUnsupportedType`

The catalog parsed successfully, the locale keys were compared programmatically, and newly added Swift string literals were reviewed; all user-facing additions use `String(localized:defaultValue:)`.

Closes #8381
https://github.com/manaflow-ai/cmux/issues/8381

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8403"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786939495&installation_id=133855650&pr_number=8403&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8403&signature=db6645871f9635e1304337bd26e2700430fe2fa2b50915cf3ccb128b831eea61"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #8381 by resolving new-surface `--pane` targets through the remote-pane topology and creating a tmux `new-window` after the pane’s window. The CLI now reports the tmux operation, with localized messages.

- **Bug Fixes**
  - Resolve explicit `--pane` via `Workspace.remoteTmuxControlPane(paneID:)` instead of searching only local panes.
  - When targeting a projected remote pane, anchor to its tmux window, insert the new window right after it, inherit its cwd when available, and honor `--focus false`.
  - Return `invalid_params` with a localized message when a non-terminal surface targets a remote tmux pane.

- **New Features**
  - Responses include `remote_tmux_operation` (`"new-window"` or `"split-window"`); the CLI summary says “new window/pane arrives asynchronously” accordingly.
  - Added English and Japanese strings for remote `new-window`, `split-window`, and the unsupported-type error.

<sup>Written for commit 0cc4fda53af8aaf91d9718eb97239a9d984917ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8403?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for creating mirrored terminal surfaces in a remote tmux pane.
  - Remote creation now preserves whether the action creates a new window or splits a window.
  - New remote windows can be placed after the selected pane and optionally focused.

- **Bug Fixes**
  - Added clearer errors when unsupported surface types or options target remote tmux panes.
  - Improved handling of projected remote panes and disconnected sessions.

- **Documentation**
  - Added English and Japanese messages explaining remote creation behavior and limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->