### PR TITLE
Activate AppKit sidebar workspaces on mouseup

### DIFF
--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -88,7 +88,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
 
     var currentModelForMeasurement: SidebarWorkspaceRowModel? { model }
 
-    /// Paints the FULL selected treatment instantly on press by applying a
+    /// Paints the FULL selected treatment instantly on mouse-up by applying a
     /// selection-flipped copy of the model — every selection-derived color
     /// (background, title, secondary text, notification preview, badges)
     /// flips with the highlight instead of trailing in with the terminal
@@ -103,7 +103,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         needsLayout = true
     }
 
-    /// Counterpart for the row selection is LEAVING: applies the full
+    /// Counterpart for the row selection that is LEAVING: applies the full
     /// deselected treatment instantly so old and new selection never show
     /// together while the authoritative render sits behind the terminal-view
     /// swap. configure() reconciles right after.
@@ -114,12 +114,6 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         optimistic.isMultiSelected = false
         applyModel(optimistic)
         needsLayout = true
-    }
-
-    /// True when a press at this view should not repaint selection (the
-    /// close button closes without selecting).
-    func selectionPreviewShouldIgnore(_ hitView: NSView) -> Bool {
-        hitView === closeButton || hitView.isDescendant(of: closeButton)
     }
 
     private func applyBackgroundStyle(_ style: SidebarWorkspaceRowBackgroundStyle) {

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
@@ -14,7 +14,7 @@ struct SidebarWorkspaceRowModel: Equatable {
     let index: Int
     let snapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
     let settings: SidebarTabItemSettingsSnapshot
-    // `var` (not `let`) so the optimistic press/deselect paint can apply a
+    // `var` (not `let`) so the optimistic mouse-up/deselect paint can apply a
     // selection-flipped copy of the model; the stored model stays
     // authoritative and reconciles on the next configure.
     var isActive: Bool

--- a/Sources/Sidebar/AppKitList/SidebarSelectionCoalescer.swift
+++ b/Sources/Sidebar/AppKitList/SidebarSelectionCoalescer.swift
@@ -8,8 +8,8 @@ import QuartzCore
 /// full commit per click and later selections feel progressively slower.
 /// Leading edge applies immediately (single clicks keep their latency);
 /// clicks landing inside the window replace the pending request and one
-/// trailing fire applies only the newest. The row's optimistic press
-/// highlight still tracks every click instantly.
+/// trailing fire applies only the newest. The row's optimistic mouse-up
+/// highlight still tracks every completed click instantly.
 @MainActor
 final class SidebarSelectionCoalescer {
     private var pendingApply: (() -> Void)?

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableController.swift
@@ -4,6 +4,24 @@ import CmuxAppKitSupportUI
 import CmuxFoundation
 import SwiftUI
 
+enum SidebarWorkspaceSelectionPreviewEvent {
+    case mouseDown
+    case dragStarted
+    case recognizedClick
+}
+
+/// NSTableView sends its target/action only for a recognized click. Dragging
+/// starts through the pasteboard-writer path instead, so only the action event
+/// may paint a workspace as selected.
+enum SidebarWorkspaceSelectionPreviewPolicy {
+    static func shouldPreview(_ event: SidebarWorkspaceSelectionPreviewEvent) -> Bool {
+        switch event {
+        case .recognizedClick: true
+        case .mouseDown, .dragStarted: false
+        }
+    }
+}
+
 /// Main-actor owner of the default sidebar table lifecycle and its AppKit interactions.
 @MainActor
 final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NSTableViewDelegate {
@@ -177,9 +195,12 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
 #endif
         guard rows.indices.contains(row) else { return }
         if let actions = rows[row].appKitWorkspaceRowActions {
+            let modifiers = NSEvent.modifierFlags
+            // Paint at mouse-up, before a coalesced (trailing) model apply,
+            // so terminal loading cannot delay the completed click feedback.
+            previewSelection(row: row, modifiers: modifiers, event: .recognizedClick)
             // Capture modifiers at click time: a coalesced (trailing) apply
             // must not re-read the keyboard ~100ms later.
-            let modifiers = NSEvent.modifierFlags
             if modifiers.contains(.command) || modifiers.contains(.shift) {
                 // Multi-select mutations are order-dependent; apply in order,
                 // never dropping intermediates.
@@ -293,18 +314,22 @@ final class SidebarWorkspaceTableController: NSObject, NSTableViewDataSource, NS
         dropTargetGeometry.setReorderTargetCollectionActive(false, rows: rows)
     }
 
-    /// Optimistic press highlight: paints the clicked workspace cell as
+    /// Optimistic mouse-up highlight: paints a completed workspace click as
     /// selected immediately and, for a plain click, peels the highlight off
     /// the outgoing rows so old and new selection never show together while
     /// the authoritative render is queued behind the terminal-view swap.
     /// The authoritative apply reconciles right after.
-    func previewSelection(row: Int, modifiers: NSEvent.ModifierFlags, hitView: NSView?) {
+    func previewSelection(
+        row: Int,
+        modifiers: NSEvent.ModifierFlags,
+        event: SidebarWorkspaceSelectionPreviewEvent
+    ) {
+        guard SidebarWorkspaceSelectionPreviewPolicy.shouldPreview(event) else { return }
         guard rows.indices.contains(row),
               rows[row].appKitWorkspaceRowModel != nil,
               let table = containerView?.tableView,
               let cell = table.view(atColumn: 0, row: row, makeIfNecessary: false)
                 as? SidebarWorkspaceRowTableCellView else { return }
-        if let hitView, cell.selectionPreviewShouldIgnore(hitView) { return }
         let extendsSelection = modifiers.contains(.command) || modifiers.contains(.shift)
         if !extendsSelection {
             let visibleRows = table.rows(in: table.visibleRect)

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableViewImpl.swift
@@ -50,16 +50,6 @@ final class SidebarWorkspaceTableViewImpl: NSTableView {
     override func mouseDown(with event: NSEvent) {
         let point = convert(event.locationInWindow, from: nil)
         let clickedRow = row(at: point)
-        // Arc-feel: paint the selection highlight on press, before the
-        // click tracking loop and the model round trip confirm it.
-        if clickedRow >= 0 {
-            let hitView = superview.flatMap { hitTest($0.convert(event.locationInWindow, from: nil)) }
-            workspaceController?.previewSelection(
-                row: clickedRow,
-                modifiers: event.modifierFlags,
-                hitView: hitView
-            )
-        }
         super.mouseDown(with: event)
         if event.clickCount == 2, clickedRow < 0 {
             workspaceController?.doubleClickEmptyArea()

--- a/cmuxTests/SidebarWorkspaceTableTests.swift
+++ b/cmuxTests/SidebarWorkspaceTableTests.swift
@@ -11,6 +11,13 @@ import Testing
 @Suite
 struct SidebarWorkspaceTableTests {
     @Test
+    func workspaceSelectionPreviewOccursOnlyForRecognizedClick() {
+        #expect(!SidebarWorkspaceSelectionPreviewPolicy.shouldPreview(.mouseDown))
+        #expect(!SidebarWorkspaceSelectionPreviewPolicy.shouldPreview(.dragStarted))
+        #expect(SidebarWorkspaceSelectionPreviewPolicy.shouldPreview(.recognizedClick))
+    }
+
+    @Test
     @MainActor
     func containerHasNoStructuralHorizontalRowInsetAndAlwaysActiveHoverTracking() throws {
         let container = SidebarWorkspaceTableController().makeContainerView()


### PR DESCRIPTION
## Summary

- defer optimistic blue selection from mouse-down to the native NSTableView recognized-click action
- keep drag reorder on its existing pasteboard path without activating the dragged workspace
- preserve modifier clicks, close controls, and double-click rename behavior

## Tests

- regression test specifies no preview on mouse-down or drag start, and preview on recognized click
- Swift parser passed for all changed Swift and test files
- tagged macOS cloud build: https://github.com/manaflow-ai/cmux/actions/runs/29631140954
- tagged `mudrag` preflight: raw mouse click selected the inactive row and painted it blue
- tagged `mudrag` preflight: raw drag from an inactive row left the original workspace selected and blue

## Alternative

- Signal-owned implementation: https://github.com/manaflow-ai/cmux/pull/8383