### PR TITLE
Exclude production crons from docs channels

### DIFF
--- a/.github/workflows/docs-deploy-reusable.yml
+++ b/.github/workflows/docs-deploy-reusable.yml
@@ -32,6 +32,7 @@ jobs:
           mkdir -p .vercel
           printf '{"orgId":"%s","projectId":"%s"}' "$VERCEL_ORG_ID" "$VERCEL_PROJECT_ID" > .vercel/project.json
           bunx vercel@56.3.1 deploy --prod --yes \
+            --local-config web/vercel.docs-channel.json \
             --build-env "CMUX_DOCS_CHANNEL=$DOCS_CHANNEL" \
             --env "CMUX_DOCS_CHANNEL=$DOCS_CHANNEL"
         env:

--- a/.github/workflows/docs-deploy-reusable.yml
+++ b/.github/workflows/docs-deploy-reusable.yml
@@ -31,8 +31,9 @@ jobs:
       - run: |
           mkdir -p .vercel
           printf '{"orgId":"%s","projectId":"%s"}' "$VERCEL_ORG_ID" "$VERCEL_PROJECT_ID" > .vercel/project.json
+          # Vercel reloads config from the linked project's web root.
+          cp web/vercel.docs-channel.json web/vercel.json
           bunx vercel@56.3.1 deploy --prod --yes \
-            --local-config web/vercel.docs-channel.json \
             --build-env "CMUX_DOCS_CHANNEL=$DOCS_CHANNEL" \
             --env "CMUX_DOCS_CHANNEL=$DOCS_CHANNEL"
         env:

--- a/tests/test_docs_deploy_auth_guard.py
+++ b/tests/test_docs_deploy_auth_guard.py
@@ -1,9 +1,11 @@
+import json
 from pathlib import Path
 import unittest
 
 
 ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_WORKFLOW = ROOT / ".github/workflows/docs-deploy-reusable.yml"
+DOCS_VERCEL_CONFIG = ROOT / "web/vercel.docs-channel.json"
 HEALTH_WORKFLOW = ROOT / ".github/workflows/vercel-auth-health.yml"
 
 
@@ -15,6 +17,14 @@ class DocsDeployAuthGuardTests(unittest.TestCase):
         self.assertIn("bunx vercel@56.3.1 deploy", workflow)
         self.assertNotIn("bunx vercel deploy", workflow)
         self.assertNotIn("--token", workflow)
+
+    def test_docs_deploy_excludes_production_crons(self) -> None:
+        workflow = DEPLOY_WORKFLOW.read_text()
+        config = json.loads(DOCS_VERCEL_CONFIG.read_text())
+
+        self.assertIn("--local-config web/vercel.docs-channel.json", workflow)
+        self.assertNotIn("crons", config)
+        self.assertEqual(config["regions"], ["pdx1"])
 
     def test_vercel_auth_is_checked_daily(self) -> None:
         workflow = HEALTH_WORKFLOW.read_text()

--- a/tests/test_docs_deploy_auth_guard.py
+++ b/tests/test_docs_deploy_auth_guard.py
@@ -22,7 +22,11 @@ class DocsDeployAuthGuardTests(unittest.TestCase):
         workflow = DEPLOY_WORKFLOW.read_text()
         config = json.loads(DOCS_VERCEL_CONFIG.read_text())
 
-        self.assertIn("--local-config web/vercel.docs-channel.json", workflow)
+        self.assertIn(
+            "cp web/vercel.docs-channel.json web/vercel.json",
+            workflow,
+        )
+        self.assertNotIn("--local-config", workflow)
         self.assertNotIn("crons", config)
         self.assertEqual(config["regions"], ["pdx1"])
 

--- a/tests/test_docs_deploy_auth_guard.py
+++ b/tests/test_docs_deploy_auth_guard.py
@@ -6,6 +6,7 @@ import unittest
 ROOT = Path(__file__).resolve().parents[1]
 DEPLOY_WORKFLOW = ROOT / ".github/workflows/docs-deploy-reusable.yml"
 DOCS_VERCEL_CONFIG = ROOT / "web/vercel.docs-channel.json"
+PRODUCTION_VERCEL_CONFIG = ROOT / "web/vercel.json"
 HEALTH_WORKFLOW = ROOT / ".github/workflows/vercel-auth-health.yml"
 
 
@@ -21,6 +22,7 @@ class DocsDeployAuthGuardTests(unittest.TestCase):
     def test_docs_deploy_excludes_production_crons(self) -> None:
         workflow = DEPLOY_WORKFLOW.read_text()
         config = json.loads(DOCS_VERCEL_CONFIG.read_text())
+        production_config = json.loads(PRODUCTION_VERCEL_CONFIG.read_text())
 
         self.assertIn(
             "cp web/vercel.docs-channel.json web/vercel.json",
@@ -28,7 +30,10 @@ class DocsDeployAuthGuardTests(unittest.TestCase):
         )
         self.assertNotIn("--local-config", workflow)
         self.assertNotIn("crons", config)
-        self.assertEqual(config["regions"], ["pdx1"])
+        self.assertEqual(
+            config,
+            {key: value for key, value in production_config.items() if key != "crons"},
+        )
 
     def test_vercel_auth_is_checked_daily(self) -> None:
         workflow = HEALTH_WORKFLOW.read_text()

--- a/web/vercel.docs-channel.json
+++ b/web/vercel.docs-channel.json
@@ -1,0 +1,12 @@
+{
+  "$schema": "https://openapi.vercel.sh/vercel.json",
+  "git": {
+    "deploymentEnabled": {
+      "main": true,
+      "*": false
+    }
+  },
+  "regions": [
+    "pdx1"
+  ]
+}


### PR DESCRIPTION
Docs-only Vercel projects inherited the production Cloud VM cron schedule, causing periodic 503s because those projects intentionally lack production secrets.

This adds a dedicated docs-channel Vercel config without crons and makes the reusable docs deployment select it explicitly. The production app keeps its existing cron config.

Verification:
- regression test fails before the fix and passes after it
- `python3 -m unittest tests.test_docs_deploy_auth_guard`
- `actionlint .github/workflows/docs-deploy-reusable.yml`
- `jq empty web/vercel.docs-channel.json`
- structured autoreview clean

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8407"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786944258&installation_id=133855650&pr_number=8407&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8407&signature=5470dfbdbe93b405379c0e82bf88b42c61f7ff9ae7ad382dcb187b20d2160408"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop docs-only deployments from inheriting production cron schedules to prevent 503s from missing secrets. Adds a dedicated docs Vercel config and updates the deploy workflow to install it at the project root.

- **Bug Fixes**
  - Added `web/vercel.docs-channel.json` with no `crons` and `regions: ["pdx1"]`; restrict `git.deploymentEnabled` to `main`.
  - Updated `docs-deploy-reusable.yml` to copy the docs config to `web/vercel.json` using `vercel@56.3.1`, with tests guarding root config usage, cron exclusion, and preventing drift vs production (equal to production minus `crons`).

<sup>Written for commit 03e2a88cdcf7fe1c732f79f0adb3888540608fc9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8407?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added dedicated Vercel configuration for the documentation site.
  * Documentation deployments are region-pinned and omit production cron jobs.
  * Git deployments are enabled for the main branch and disabled for other branches.

* **Tests**
  * Added a unit test to confirm the docs deployment workflow copies the docs config into `web/vercel.json`, avoids local-config behavior, and excludes the `crons` setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->