### PR TITLE
Clear SSH auth marker after successful startup

### DIFF
--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10182,6 +10182,7 @@ struct CMUXCLI {
         }
         if authenticationLockPath != nil {
             authScriptLines += [
+                "cmux_ssh_clear_auth_inflight",
                 "zsystem flock -u \"$cmux_ssh_auth_lock_fd\" || exit 255",
                 "trap - EXIT HUP INT TERM",
             ]

--- a/CLI/cmux.swift
+++ b/CLI/cmux.swift
@@ -10142,7 +10142,8 @@ struct CMUXCLI {
             remoteShellCommand: remoteShellCommand
         )
         var authScriptLines: [String] = []
-        let authenticationLockPath = SSHConnectionSharingOptions().foregroundAuthenticationLockPath(
+        let sharingOptions = SSHConnectionSharingOptions()
+        let authenticationLockPath = sharingOptions.foregroundAuthenticationLockPath(
             destination: options.destination,
             port: options.port,
             options: effectiveSSHOptions(options.sshOptions, remoteRelayPort: options.remoteRelayPort)
@@ -10181,11 +10182,7 @@ struct CMUXCLI {
             authScriptLines.append(localCommandScript)
         }
         if authenticationLockPath != nil {
-            authScriptLines += [
-                "cmux_ssh_clear_auth_inflight",
-                "zsystem flock -u \"$cmux_ssh_auth_lock_fd\" || exit 255",
-                "trap - EXIT HUP INT TERM",
-            ]
+            authScriptLines += sharingOptions.successfulForegroundAuthenticationCleanupShellLines()
         }
         let authScriptBody = authScriptLines.joined(separator: "\n")
         let authScript = authenticationLockPath == nil

--- a/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHConnectionSharingOptions.swift
+++ b/Packages/macOS/CmuxFoundation/Sources/CmuxFoundation/SSHConnectionSharingOptions.swift
@@ -212,6 +212,21 @@ public struct SSHConnectionSharingOptions: Sendable {
             .path
     }
 
+    /// Returns the shell commands that finish successful foreground authentication.
+    ///
+    /// The marker must be cleared before the advisory lock is released so a
+    /// concurrent cleanup request cannot mistake a completed authentication
+    /// attempt for one that is still in flight.
+    ///
+    /// - Returns: Shell commands that clear the marker, release the lock, and disarm cleanup traps.
+    public func successfulForegroundAuthenticationCleanupShellLines() -> [String] {
+        [
+            "cmux_ssh_clear_auth_inflight",
+            "zsystem flock -u \"$cmux_ssh_auth_lock_fd\" || exit 255",
+            "trap - EXIT HUP INT TERM",
+        ]
+    }
+
     /// Builds a shell function that removes a stale cmux-owned control socket.
     ///
     /// The caller invokes the function only while holding the matching

--- a/Sources/SSHPTYAttachStartupCommandBuilder.swift
+++ b/Sources/SSHPTYAttachStartupCommandBuilder.swift
@@ -118,8 +118,9 @@ enum SSHPTYAttachStartupCommandBuilder {
     }
 
     private static func sshForegroundAuthCommand(_ auth: ForegroundAuth) -> String {
+        let sharingOptions = SSHConnectionSharingOptions()
         var arguments = ["ssh"]
-        let options = sshOptionsWithRestoreControlDefaults(auth.sshOptions)
+        let options = sharingOptions.mergingDefaults(into: auth.sshOptions)
         if !hasSSHOptionKey(options, key: "ConnectTimeout") {
             arguments += ["-o", "ConnectTimeout=6"]
         }
@@ -141,14 +142,14 @@ enum SSHPTYAttachStartupCommandBuilder {
         // The command-line `true` below conflicts with a host-configured
         // RemoteCommand unless overridden (issue #7246).
         arguments += SSHHostConfiguredRemoteCommand().overrideArguments
-        let preflight = SSHConnectionSharingOptions().controlPathPreflightShellFunction(
+        let preflight = sharingOptions.controlPathPreflightShellFunction(
             sshArguments: arguments,
             destination: auth.destination,
             options: options
         )
         arguments += ["-T", auth.destination, "true"]
         let command = arguments.map(shellQuote).joined(separator: " ")
-        guard let lockPath = SSHConnectionSharingOptions().foregroundAuthenticationLockPath(
+        guard let lockPath = sharingOptions.foregroundAuthenticationLockPath(
             destination: auth.destination,
             port: auth.port,
             options: options
@@ -156,7 +157,7 @@ enum SSHPTYAttachStartupCommandBuilder {
             return command
         }
         let inFlightPath = lockPath + ".inflight"
-        let lockedCommand = [
+        var lockedCommand = [
             "umask 077",
             "cmux_ssh_auth_inflight_path=\(shellQuote(inFlightPath))",
             "cmux_ssh_auth_lock_path=\(shellQuote(lockPath))",
@@ -174,11 +175,10 @@ enum SSHPTYAttachStartupCommandBuilder {
             "command \(command)",
             "cmux_ssh_auth_status=$?",
             "if [ \"$cmux_ssh_auth_status\" -ne 0 ]; then exit \"$cmux_ssh_auth_status\"; fi",
-            "zsystem flock -u \"$cmux_ssh_auth_lock_fd\" || exit 255",
-            "trap - EXIT HUP INT TERM",
-            "exit 0",
-        ].compactMap { $0 }.joined(separator: "\n")
-        return "/bin/zsh -fc \(shellQuote(lockedCommand))"
+        ].compactMap { $0 }
+        lockedCommand += sharingOptions.successfulForegroundAuthenticationCleanupShellLines()
+        lockedCommand.append("exit 0")
+        return "/bin/zsh -fc \(shellQuote(lockedCommand.joined(separator: "\n")))"
     }
 
     static func sshOptionsWithRestoreControlDefaults(_ options: [String], relayPort: Int? = nil) -> [String] {

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1643,6 +1643,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		A6AC72070000000000000001 /* SpinnerSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC72070000000000000002 /* SpinnerSpec.swift */; };
 		F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6724601A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift */; };
 		797800040000000000000001 /* SSHDeepSleepReattachTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797800040000000000000002 /* SSHDeepSleepReattachTests.swift */; };
+		8410A0020000000000000002 /* SSHForegroundAuthenticationMarkerCleanupTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8410A0010000000000000001 /* SSHForegroundAuthenticationMarkerCleanupTests.swift */; };
 		797800050000000000000001 /* SSHPersistentPTYRetryLifecycleTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 797800050000000000000002 /* SSHPersistentPTYRetryLifecycleTests.swift */; };
 			C77070000000000000000002 /* SSHPTYAttachExitCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77070000000000000000001 /* SSHPTYAttachExitCode.swift */; };
 			C77070000000000000000003 /* SSHPTYAttachExitCode.swift in Sources */ = {isa = PBXBuildFile; fileRef = C77070000000000000000001 /* SSHPTYAttachExitCode.swift */; };
@@ -3684,6 +3685,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		A6AC72070000000000000002 /* SpinnerSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpinnerSpec.swift; sourceTree = "<group>"; };
 		F6724601A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHConfiguredRemoteCommandHostTests.swift; sourceTree = "<group>"; };
 		797800040000000000000002 /* SSHDeepSleepReattachTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHDeepSleepReattachTests.swift; sourceTree = "<group>"; };
+		8410A0010000000000000001 /* SSHForegroundAuthenticationMarkerCleanupTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHForegroundAuthenticationMarkerCleanupTests.swift; sourceTree = "<group>"; };
 		797800050000000000000002 /* SSHPersistentPTYRetryLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPersistentPTYRetryLifecycleTests.swift; sourceTree = "<group>"; };
 			C77070000000000000000001 /* SSHPTYAttachExitCode.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachExitCode.swift; sourceTree = "<group>"; };
 			C77070000000000000000007 /* SSHPTYAttachExitCodeClassifierTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SSHPTYAttachExitCodeClassifierTests.swift; sourceTree = "<group>"; };
@@ -5841,6 +5843,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				0C4AD348F196FBBEE52D53A7 /* SSHPTYAttachReconnectInputFilterTests.swift */,
 				4F73A5C0BB93507E18261385 /* SSHStartupManualReconnectTests.swift */,
 				797800040000000000000002 /* SSHDeepSleepReattachTests.swift */,
+				8410A0010000000000000001 /* SSHForegroundAuthenticationMarkerCleanupTests.swift */,
 				797800050000000000000002 /* SSHPersistentPTYRetryLifecycleTests.swift */,
 				F6724603A1B2C3D4E5F67246 /* RemoteTmuxHostRemoteCommandOverrideTests.swift */,
 				F6724601A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift */,
@@ -8611,6 +8614,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 						F8000000A1B2C3D4E5F60718 /* SocketControlPasswordStoreTests.swift in Sources */,
 				F6724600A1B2C3D4E5F67246 /* SSHConfiguredRemoteCommandHostTests.swift in Sources */,
 				797800040000000000000001 /* SSHDeepSleepReattachTests.swift in Sources */,
+				8410A0020000000000000002 /* SSHForegroundAuthenticationMarkerCleanupTests.swift in Sources */,
 				797800050000000000000001 /* SSHPersistentPTYRetryLifecycleTests.swift in Sources */,
 						C77070000000000000000003 /* SSHPTYAttachExitCode.swift in Sources */,
 						C77070000000000000000006 /* SSHPTYAttachExitCodeClassifierTests.swift in Sources */,

--- a/cmuxTests/SSHForegroundAuthenticationMarkerCleanupTests.swift
+++ b/cmuxTests/SSHForegroundAuthenticationMarkerCleanupTests.swift
@@ -1,0 +1,112 @@
+import CmuxFoundation
+import Foundation
+import Testing
+
+#if canImport(cmux_DEV)
+@testable import cmux_DEV
+#elseif canImport(cmux)
+@testable import cmux
+#endif
+
+@Suite(.serialized)
+struct SSHForegroundAuthenticationMarkerCleanupTests {
+    @Test func restoredAttachRemovesForegroundAuthInflightMarkerAfterSuccess() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-restored-auth-\(UUID().uuidString)", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux")
+        let fakeSSH = root.appendingPathComponent("ssh")
+        let socketHash = UUID().uuidString
+            .replacingOccurrences(of: "-", with: "")
+            .lowercased() + "01234567"
+        let destination = "cleanup-\(socketHash.prefix(8)).example.test"
+        let controlPath = "/tmp/cmux-ssh-\(getuid())-\(socketHash)"
+        let sshOptions = [
+            "ControlMaster=auto",
+            "ControlPersist=600",
+            "ControlPath=\(controlPath)",
+        ]
+        let lockPath = try #require(SSHConnectionSharingOptions().foregroundAuthenticationLockPath(
+            destination: destination,
+            port: 2222,
+            options: sshOptions
+        ))
+        let inFlightPath = lockPath + ".inflight"
+
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: root)
+            unlink(lockPath)
+            unlink(inFlightPath)
+        }
+
+        try Self.writeShellFile(at: fakeCLI, lines: [
+            "#!/bin/sh",
+            "case \" $* \" in *\" ssh-pty-attach \"*) exit 253 ;; *) exit 0 ;; esac",
+        ])
+        try Self.writeShellFile(at: fakeSSH, lines: [
+            "#!/bin/sh",
+            "previous_arg=",
+            "for arg in \"$@\"; do",
+            "  if [ \"$arg\" = '-G' ]; then printf 'controlpath %s\\n' \"${CMUX_TEST_CONTROL_PATH}\"; exit 0; fi",
+            "  if [ \"$previous_arg\" = '-O' ] && [ \"$arg\" = 'check' ]; then exit 0; fi",
+            "  previous_arg=\"$arg\"",
+            "done",
+            "exit 0",
+        ])
+        for executable in [fakeCLI, fakeSSH] {
+            try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: executable.path)
+        }
+
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+        environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
+        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
+        environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        environment["CMUX_TEST_CONTROL_PATH"] = controlPath
+
+        let command = SSHPTYAttachStartupCommandBuilder.command(
+            sessionID: "ssh-test-session",
+            foregroundAuth: SSHPTYAttachStartupCommandBuilder.ForegroundAuth(
+                destination: destination,
+                port: 2222,
+                identityFile: nil,
+                sshOptions: sshOptions,
+                token: "foreground-auth-token"
+            )
+        )
+        let result = try Self.runProcess(command: command, environment: environment)
+
+        #expect(result.status == 253, Comment(rawValue: result.stderr))
+        #expect(
+            !fileManager.fileExists(atPath: inFlightPath),
+            "Successful restored authentication must remove its owned in-flight marker before releasing the lock"
+        )
+    }
+
+    private static func writeShellFile(at url: URL, lines: [String]) throws {
+        try (lines.joined(separator: "\n") + "\n").write(to: url, atomically: true, encoding: .utf8)
+    }
+
+    private static func runProcess(
+        command: String,
+        environment: [String: String]
+    ) throws -> (status: Int32, stderr: String) {
+        let process = Process()
+        let stderrPipe = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        process.environment = environment
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = stderrPipe
+        try process.run()
+        process.waitUntilExit()
+        let stderr = String(
+            data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
+            encoding: .utf8
+        ) ?? ""
+        return (process.terminationStatus, stderr)
+    }
+}

--- a/cmuxTests/SSHForegroundAuthenticationMarkerCleanupTests.swift
+++ b/cmuxTests/SSHForegroundAuthenticationMarkerCleanupTests.swift
@@ -102,11 +102,9 @@ struct SSHForegroundAuthenticationMarkerCleanupTests {
         process.standardOutput = FileHandle.nullDevice
         process.standardError = stderrPipe
         try process.run()
+        let stderrData = stderrPipe.fileHandleForReading.readDataToEndOfFile()
         process.waitUntilExit()
-        let stderr = String(
-            data: stderrPipe.fileHandleForReading.readDataToEndOfFile(),
-            encoding: .utf8
-        ) ?? ""
+        let stderr = String(data: stderrData, encoding: .utf8) ?? ""
         return (process.terminationStatus, stderr)
     }
 }

--- a/cmuxTests/SSHStartupSignalLifecycleTests.swift
+++ b/cmuxTests/SSHStartupSignalLifecycleTests.swift
@@ -1,4 +1,5 @@
 import XCTest
+import CmuxFoundation
 import Darwin
 
 extension CLINotifyProcessIntegrationRegressionTests {
@@ -292,6 +293,71 @@ extension CLINotifyProcessIntegrationRegressionTests {
         let sshLog = (try? String(contentsOf: logFile, encoding: .utf8)) ?? ""
         XCTAssertTrue(sshLog.contains("-G"), sshLog)
         XCTAssertTrue(sshLog.contains("-O check"), sshLog)
+    }
+
+    func testSSHStartupRemovesForegroundAuthInflightMarkerAfterSuccess() throws {
+        let fileManager = FileManager.default
+        let root = fileManager.temporaryDirectory
+            .appendingPathComponent("cmux-ssh-auth-inflight-\(UUID().uuidString)", isDirectory: true)
+        let fakeCLI = root.appendingPathComponent("cmux")
+        let fakeSSH = root.appendingPathComponent("ssh")
+        let controlPath = "/tmp/cmux-ssh-\(getuid())-0123456789abcdef0123456789abcdef01234567"
+        let sshOptions = [
+            "ControlMaster=auto",
+            "ControlPersist=600",
+            "ControlPath=\(controlPath)",
+        ]
+        let lockPath = try XCTUnwrap(SSHConnectionSharingOptions().foregroundAuthenticationLockPath(
+            destination: "cmux-macmini",
+            port: 2222,
+            options: sshOptions
+        ))
+        let inFlightPath = lockPath + ".inflight"
+
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        defer {
+            try? fileManager.removeItem(at: root)
+            unlink(lockPath)
+            unlink(inFlightPath)
+        }
+
+        try writeShellFile(at: fakeCLI, lines: ["#!/bin/sh", "exit 0"])
+        try writeShellFile(at: fakeSSH, lines: [
+            "#!/bin/sh",
+            "previous_arg=",
+            "for arg in \"$@\"; do",
+            "  if [ \"$arg\" = '-G' ]; then printf 'controlpath %s\\n' \"${CMUX_TEST_CONTROL_PATH}\"; exit 0; fi",
+            "  if [ \"$previous_arg\" = '-O' ] && [ \"$arg\" = 'check' ]; then exit 255; fi",
+            "  previous_arg=\"$arg\"",
+            "done",
+            "exit 0",
+        ])
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeCLI.path)
+        try fileManager.setAttributes([.posixPermissions: 0o700], ofItemAtPath: fakeSSH.path)
+
+        let startupCommand = try generatedSSHStartupCommand(sshOptions: sshOptions)
+        var environment = ProcessInfo.processInfo.environment
+        environment["PATH"] = "\(root.path):\(environment["PATH"] ?? "/usr/bin:/bin")"
+        environment["CMUX_BUNDLED_CLI_PATH"] = fakeCLI.path
+        environment["CMUX_SOCKET_PATH"] = "/tmp/cmux-debug-test.sock"
+        environment["CMUX_WORKSPACE_ID"] = "11111111-1111-1111-1111-111111111111"
+        environment["CMUX_SURFACE_ID"] = "22222222-2222-2222-2222-222222222222"
+        environment["CMUX_TEST_CONTROL_PATH"] = controlPath
+        environment["CMUX_SSH_RECONNECT_DELAY_SECONDS"] = "0"
+
+        let result = runProcess(
+            executablePath: "/bin/sh",
+            arguments: ["-c", startupCommand],
+            environment: environment,
+            timeout: 5
+        )
+
+        XCTAssertFalse(result.timedOut, result.stderr)
+        XCTAssertEqual(result.status, 0, result.stderr)
+        XCTAssertFalse(
+            fileManager.fileExists(atPath: inFlightPath),
+            "Successful foreground authentication must remove its owned in-flight marker before releasing the lock"
+        )
     }
 
     func testSSHStartupStopsAtConfiguredReconnectLimit() throws {
@@ -659,6 +725,7 @@ extension CLINotifyProcessIntegrationRegressionTests {
                     ok: true,
                     result: [
                         "workspace_id": workspaceID,
+                        "surface_id": "surface:1",
                     ]
                 )
             case "workspace.remote.configure":


### PR DESCRIPTION
## Summary

- remove the owned foreground-auth `.inflight` marker after successful native SSH authentication
- use one shared success-cleanup sequence for both CLI workspace startup and restored SSH PTY attach
- preserve cleanup order: clear marker, release the shared auth lock, then disable exit/signal traps
- cover both generated shell-command paths with executable regressions

## Context

Follow-up to #8308. That PR was squash-merged before its post-review marker-cleanup repair landed. Canonical review of this follow-up then found the same lifecycle bug in the app-side restored attach generator, so this PR fixes the duplicated behavior at its shared `SSHConnectionSharingOptions` owner.

## Red/green proof

### CLI startup

Test-only commit `ea95d3e35b` failed as expected:

```text
Executed 1 test, with 1 failure
XCTAssertFalse failed - Successful foreground authentication must remove its owned in-flight marker before releasing the lock
```

Fix commit `52869a58de` passes that path.

### Restored SSH PTY attach

Test-only commit `546f860fde` failed as expected:

```text
totalTestCount: 1
failedTests: 1
Expectation failed: the foreground-auth .inflight marker still existed
```

Shared fix commit `843336561f` makes both selected behavioral tests pass:

```text
totalTestCount: 2
passedTests: 2
failedTests: 0
result: Passed
```

Focused command:

```bash
xcodebuild test -quiet \
  -project cmux.xcodeproj \
  -scheme cmux-unit \
  -configuration Debug \
  -destination 'platform=macOS' \
  -derivedDataPath /tmp/cmux-issue-8300-autoreview-tests \
  -only-testing:cmuxTests/CLINotifyProcessIntegrationRegressionTests/testSSHStartupRemovesForegroundAuthInflightMarkerAfterSuccess \
  -only-testing:cmuxTests/SSHForegroundAuthenticationMarkerCleanupTests
```

## Verification

- focused generated-command behavior: 2 tests passed
- CmuxFoundation: 111 tests passed
- CmuxCore: 52 tests passed
- CmuxRemoteSession: 103 tests passed
- `scripts/check-pbxproj.sh`
- `scripts/check-package-resolved-policy.py`
- `scripts/check-workspace-package-groups.py --check`
- `scripts/lint-pbxproj-test-wiring.sh` (528 test files)
- `git diff --check`
- merge-conflict gate against current `origin/main`: clean

The Swift file-length budget script and TSV are absent on this branch; the new test is 112 lines and no budget file changed.

No app reload or launch was performed. No user-facing strings or localization catalogs changed.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SSH foreground authentication flow to consistently clear in-progress (“inflight”) marker files after a successful startup.
  * Enhanced SSH startup handling for workspace creation responses that include additional surface identifiers, improving marker lifecycle reliability.
* **Tests**
  * Added regression coverage to verify in-flight marker cleanup and startup behavior during restored foreground authentication scenarios.
  * Updated startup command test fixtures to better reflect the expanded workspace creation payload.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->