### PR TITLE
Share workspace row presentation across SwiftUI and AppKit sidebars

### DIFF
--- a/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
+++ b/Packages/macOS/CmuxSettings/Sources/CmuxSettings/Keys/SidebarCatalogSection.swift
@@ -35,9 +35,10 @@ public struct SidebarCatalogSection: SettingCatalogSection {
         userDefaultsKey: "sidebarBranchVerticalLayout"
     )
 
+    /// Defaults to separate lines while preserving an explicitly stored inline preference.
     public let stackBranchDirectory = DefaultsKey<Bool>(
         id: "sidebar.stackBranchDirectory",
-        defaultValue: false,
+        defaultValue: true,
         userDefaultsKey: "sidebarBranchDirectoryStacked"
     )
 

--- a/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
+++ b/Packages/macOS/CmuxSettings/Tests/CmuxSettingsTests/UserDefaultsSettingsClientTests.swift
@@ -25,7 +25,7 @@ struct UserDefaultsSettingsClientTests {
         #expect(client.value(for: catalog.sidebar.showNotificationMessage) == true)
         #expect(client.value(for: catalog.sidebar.notificationMessageLineLimit) == 12)
         #expect(client.value(for: catalog.sidebar.branchVerticalLayout) == true)
-        #expect(client.value(for: catalog.sidebar.stackBranchDirectory) == false)
+        #expect(client.value(for: catalog.sidebar.stackBranchDirectory) == true)
         #expect(client.value(for: catalog.sidebar.pathLastSegmentOnly) == false)
         #expect(client.value(for: catalog.sidebar.makePullRequestsClickable) == true)
         #expect(client.value(for: catalog.app.keepWorkspaceOpenWhenClosingLastSurface) == true)
@@ -78,6 +78,10 @@ struct UserDefaultsSettingsClientTests {
         client.set(24, for: catalog.sidebar.notificationMessageLineLimit)
         #expect(defaults.object(forKey: "sidebarNotificationMessageLineLimit") as? Int == 24)
         #expect(client.value(for: catalog.sidebar.notificationMessageLineLimit) == 24)
+
+        client.set(false, for: catalog.sidebar.stackBranchDirectory)
+        #expect(defaults.object(forKey: "sidebarBranchDirectoryStacked") as? Bool == false)
+        #expect(client.value(for: catalog.sidebar.stackBranchDirectory) == false)
     }
 
     @Test func resetRestoresDefault() throws {

--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -11657,6 +11657,7 @@ struct VerticalTabsSidebar: View, Equatable {
             workspaceId: input.workspaceId,
             index: input.index,
             snapshot: input.workspace,
+            content: input.content,
             settings: input.settings,
             isActive: input.isActive,
             isMultiSelected: input.isMultiSelected,
@@ -13711,6 +13712,11 @@ struct VerticalTabsSidebar: View, Equatable {
                 showsAgentActivity: renderContext.showsAgentActivity
             )
         }
+        let content = SidebarWorkspaceRowContentModel(
+            workspace: workspaceSnapshot,
+            settings: settings,
+            latestNotificationText: liveLatestNotificationText
+        )
 
         let todoStatusResolution = WorkspaceTaskStatusOverride.effectiveStatus(
             override: tab.todoState.statusOverride,
@@ -13729,6 +13735,7 @@ struct VerticalTabsSidebar: View, Equatable {
             index: index,
             workspaceCount: renderContext.workspaceCount,
             workspace: workspaceSnapshot,
+            content: content,
             isActive: tabManager.selectedTabId == tab.id,
             isMultiSelected: selectedTabIds.contains(tab.id),
             hasUserCustomTitle: tab.effectiveCustomTitleSource == .user,
@@ -14654,10 +14661,8 @@ struct TabItemView: View, Equatable {
     @State private var renameDraft = ""
     @State private var renameBaselineHadUserCustomTitle = false
 
-    private static let maxWrappedTitleLines = 8
-    private static let maxDisplayedTitleCharacters = 2048
-
     var workspaceSnapshot: SidebarWorkspaceSnapshotBuilder.Snapshot { snapshot.workspace }
+    var content: SidebarWorkspaceRowContentModel { snapshot.content }
     var workspaceId: UUID { snapshot.workspaceId }
     var index: Int { snapshot.index }
     var isActive: Bool { snapshot.isActive }
@@ -14694,24 +14699,8 @@ struct TabItemView: View, Equatable {
         settings.alwaysShowShortcutHints
     }
 
-    private var sidebarShowGitBranch: Bool {
-        settings.showsGitBranch
-    }
-
-    private var sidebarBranchVerticalLayout: Bool {
-        settings.usesVerticalBranchLayout
-    }
-
-    private var sidebarStacksBranchAndDirectory: Bool {
-        settings.stacksBranchAndDirectory
-    }
-
     private var sidebarUsesLastSegmentPath: Bool {
         settings.usesLastSegmentPath
-    }
-
-    private var sidebarShowGitBranchIcon: Bool {
-        settings.showsGitBranchIcon
     }
 
     private var sidebarShowSSH: Bool {
@@ -14845,10 +14834,12 @@ struct TabItemView: View, Equatable {
     }
 
     private var showCloseButton: Bool {
-        isPointerHovering
-            && !contextMenuVisible
-            && canCloseWorkspace
-            && !(showsModifierShortcutHints || alwaysShowShortcutHints)
+        content.showsCloseButton(
+            isPointerHovering: isPointerHovering,
+            contextMenuVisible: contextMenuVisible,
+            canCloseWorkspace: canCloseWorkspace,
+            showsModifierShortcutHints: showsModifierShortcutHints
+        )
     }
 
     private var workspaceShortcutLabel: String? {
@@ -14990,20 +14981,7 @@ struct TabItemView: View, Equatable {
         let accessibilityHintText = String(localized: "sidebar.workspace.accessibilityHint", defaultValue: "Activate to focus this workspace. Drag to reorder, or use Move Up and Move Down actions.")
         let moveUpActionText = String(localized: "sidebar.workspace.moveUpAction", defaultValue: "Move Up")
         let moveDownActionText = String(localized: "sidebar.workspace.moveDownAction", defaultValue: "Move Down")
-        let latestNotificationSubtitle = latestNotificationText
-        let conversationMessageSubtitle = !settings.hidesAllDetails && settings.iMessageModeEnabled
-            ? workspaceSnapshot.latestConversationMessage?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
-            : nil
-        let effectiveSubtitle = latestNotificationSubtitle ?? conversationMessageSubtitle
-        let subtitleLineLimit = latestNotificationSubtitle == nil ? 2 : settings.notificationMessageLineLimit
-        // Bound notification payloads before shaping so pathological text stays cheap in lazy, Equatable rows.
-        let displayedSubtitle = effectiveSubtitle?.sidebarBoundedDisplayString(maxDisplayedLines: subtitleLineLimit, maxDisplayedCharacters: 4096)
         let detailVisibility = visibleAuxiliaryDetails
-        let titleLineLimit = settings.wrapsWorkspaceTitles ? Self.maxWrappedTitleLines : 1
-        let displayedTitle = workspaceSnapshot.title.sidebarBoundedDisplayString(
-            maxDisplayedLines: titleLineLimit,
-            maxDisplayedCharacters: Self.maxDisplayedTitleCharacters
-        )
         let scaledUnreadBadgeSize = 16 * fontScale
         let scaledLoadingSpinnerSize = max(10, 12 * fontScale)
         let titleFirstLineCenter = GlobalFontMagnification.scaledSize(
@@ -15102,10 +15080,10 @@ struct TabItemView: View, Equatable {
                     .alignmentGuide(.sidebarTitleFirstLineCenter) { _ in titleFirstLineCenter }
                     .layoutPriority(1)
                 } else {
-                    Text(displayedTitle)
+                    Text(content.title)
                         .font(magnifiedFont(scaledFontSize(12.5), weight: titleFontWeight))
                         .foregroundColor(activePrimaryTextColor)
-                        .lineLimit(titleLineLimit)
+                        .lineLimit(content.titleLineLimit)
                         .truncationMode(.tail)
                         .fixedSize(horizontal: false, vertical: true)
                         .frame(maxWidth: .infinity, alignment: .leading)
@@ -15127,11 +15105,11 @@ struct TabItemView: View, Equatable {
                 )
             }
 
-            if let subtitle = displayedSubtitle {
+            if let subtitle = content.subtitle {
                 Text(subtitle)
                     .font(magnifiedFont(scaledFontSize(10)))
                     .foregroundColor(activeSecondaryColor(0.8))
-                    .lineLimit(subtitleLineLimit)
+                    .lineLimit(content.subtitleLineLimit)
                     .truncationMode(.tail)
                     .multilineTextAlignment(.leading)
                     .fixedSize(horizontal: false, vertical: true)
@@ -15159,11 +15137,11 @@ struct TabItemView: View, Equatable {
             remoteWorkspaceSection(snapshot: workspaceSnapshot)
 
             if detailVisibility.showsMetadata {
-                let metadataEntries = workspaceSnapshot.metadataEntries
+                let statusRows = content.statusRows
                 let metadataBlocks = workspaceSnapshot.metadataBlocks
-                if !metadataEntries.isEmpty {
+                if !statusRows.isEmpty {
                     SidebarMetadataRows(
-                        entries: metadataEntries,
+                        rows: statusRows,
                         isActive: usesInvertedActiveForeground,
                         activeForegroundColor: activeSecondaryColor(0.95),
                         activeSecondaryForegroundColor: activeSecondaryColor(0.65),
@@ -15222,122 +15200,79 @@ struct TabItemView: View, Equatable {
             }
 
             // Branch + directory row
-            if detailVisibility.showsBranchDirectory {
-                if sidebarBranchVerticalLayout {
-                    if !workspaceSnapshot.branchDirectoryLines.isEmpty {
-                        HStack(alignment: .top, spacing: 3) {
-                            if sidebarShowGitBranchIcon, workspaceSnapshot.branchLinesContainBranch {
-                                CmuxSystemSymbolImage(magnified: "arrow.triangle.branch", pointSize: scaledFontSize(9))
-                                    .foregroundColor(activeSecondaryColor(0.6))
-                            }
-                            VStack(alignment: .leading, spacing: 1) {
-                                ForEach(Array(workspaceSnapshot.branchDirectoryLines.enumerated()), id: \.offset) { _, line in
-                                    if sidebarStacksBranchAndDirectory {
-                                        if let branch = line.branch {
-                                            Text(branch)
-                                                .font(magnifiedFont(scaledFontSize(10), design: .monospaced))
-                                                .foregroundColor(activeSecondaryColor(0.75))
-                                                .lineLimit(1)
-                                                .truncationMode(.tail)
-                                        }
-                                        if !line.directoryCandidates.isEmpty {
-                                            SidebarDirectoryText(
-                                                candidates: line.directoryCandidates,
-                                                color: activeSecondaryColor(0.75),
-                                                fontScale: fontScale
-                                            )
-                                        }
-                                    } else {
-                                        HStack(spacing: 3) {
-                                            if let branch = line.branch {
-                                                Text(branch)
-                                                    .font(magnifiedFont(scaledFontSize(10), design: .monospaced))
-                                                    .foregroundColor(activeSecondaryColor(0.75))
-                                                    .lineLimit(1)
-                                                    .truncationMode(.tail)
-                                            }
-                                            if line.branch != nil, !line.directoryCandidates.isEmpty {
-                                                CmuxSystemSymbolImage(magnified: "circle.fill", pointSize: scaledFontSize(3))
-                                                    .foregroundColor(activeSecondaryColor(0.6))
-                                                    .padding(.horizontal, 1)
-                                            }
-                                            if !line.directoryCandidates.isEmpty {
-                                                SidebarDirectoryText(
-                                                    candidates: line.directoryCandidates,
-                                                    color: activeSecondaryColor(0.75),
-                                                    fontScale: fontScale
-                                                )
-                                            }
-                                        }
+            if !content.branchDirectoryRows.isEmpty {
+                HStack(alignment: .top, spacing: 3) {
+                    if content.showsBranchIcon {
+                        CmuxSystemSymbolImage(magnified: "arrow.triangle.branch", pointSize: scaledFontSize(9))
+                            .foregroundColor(activeSecondaryColor(0.6))
+                    }
+                    VStack(alignment: .leading, spacing: 1) {
+                        ForEach(Array(content.branchDirectoryRows.enumerated()), id: \.offset) { _, line in
+                            if line.stacksBranchAndDirectory {
+                                if let branch = line.branch {
+                                    Text(branch)
+                                        .font(magnifiedFont(scaledFontSize(10), design: .monospaced))
+                                        .foregroundColor(activeSecondaryColor(0.75))
+                                        .lineLimit(1)
+                                        .truncationMode(.tail)
+                                }
+                                if !line.directoryCandidates.isEmpty {
+                                    SidebarDirectoryText(
+                                        candidates: line.directoryCandidates,
+                                        color: activeSecondaryColor(0.75),
+                                        fontScale: fontScale
+                                    )
+                                }
+                            } else {
+                                HStack(spacing: 3) {
+                                    if let branch = line.branch {
+                                        Text(branch)
+                                            .font(magnifiedFont(scaledFontSize(10), design: .monospaced))
+                                            .foregroundColor(activeSecondaryColor(0.75))
+                                            .lineLimit(1)
+                                            .truncationMode(.tail)
+                                    }
+                                    if line.branch != nil, !line.directoryCandidates.isEmpty {
+                                        CmuxSystemSymbolImage(magnified: "circle.fill", pointSize: scaledFontSize(3))
+                                            .foregroundColor(activeSecondaryColor(0.6))
+                                            .padding(.horizontal, 1)
+                                    }
+                                    if !line.directoryCandidates.isEmpty {
+                                        SidebarDirectoryText(
+                                            candidates: line.directoryCandidates,
+                                            color: activeSecondaryColor(0.75),
+                                            fontScale: fontScale
+                                        )
                                     }
                                 }
                             }
                         }
                     }
-                } else if sidebarStacksBranchAndDirectory,
-                          (workspaceSnapshot.compactGitBranchSummaryText != nil
-                           || !workspaceSnapshot.compactDirectoryCandidates.isEmpty) {
-                    HStack(alignment: .top, spacing: 3) {
-                        if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
-                            CmuxSystemSymbolImage(magnified: "arrow.triangle.branch", pointSize: scaledFontSize(9))
-                                .foregroundColor(activeSecondaryColor(0.6))
-                        }
-                        VStack(alignment: .leading, spacing: 1) {
-                            if let branchRow = workspaceSnapshot.compactGitBranchSummaryText {
-                                Text(branchRow)
-                                    .font(magnifiedFont(scaledFontSize(10), design: .monospaced))
-                                    .foregroundColor(activeSecondaryColor(0.75))
-                                    .lineLimit(1)
-                                    .truncationMode(.tail)
-                            }
-                            if !workspaceSnapshot.compactDirectoryCandidates.isEmpty {
-                                SidebarDirectoryText(
-                                    candidates: workspaceSnapshot.compactDirectoryCandidates,
-                                    color: activeSecondaryColor(0.75),
-                                    fontScale: fontScale
-                                )
-                            }
-                        }
-                    }
-                } else if !workspaceSnapshot.compactBranchDirectoryCandidates.isEmpty {
-                    HStack(spacing: 3) {
-                        if sidebarShowGitBranchIcon, workspaceSnapshot.compactGitBranchSummaryText != nil {
-                            CmuxSystemSymbolImage(magnified: "arrow.triangle.branch", pointSize: scaledFontSize(9))
-                                .foregroundColor(activeSecondaryColor(0.6))
-                        }
-                        SidebarDirectoryText(
-                            candidates: workspaceSnapshot.compactBranchDirectoryCandidates,
-                            color: activeSecondaryColor(0.75),
-                            fontScale: fontScale
-                        )
-                    }
                 }
             }
 
             // Pull request rows
-            if detailVisibility.showsPullRequests, !workspaceSnapshot.pullRequestRows.isEmpty {
+            if !content.pullRequestRows.isEmpty {
                 VStack(alignment: .leading, spacing: 1) {
-                    ForEach(workspaceSnapshot.pullRequestRows) { pullRequest in
-                        let pullRequestNumber = String(pullRequest.number)
-                        let pullRequestTitle = "\(pullRequest.label) #\(pullRequestNumber)"
+                    ForEach(content.pullRequestRows) { pullRequest in
                         let rowContent = HStack(alignment: .center, spacing: 4) {
                             PullRequestStatusIcon(
                                 status: pullRequest.status,
                                 color: pullRequestForegroundColor,
                                 fontScale: fontScale
                             )
-                            Text(pullRequestTitle).underline(settings.makesPullRequestsClickable).lineLimit(1).truncationMode(.tail)
-                            Text(pullRequestStatusLabel(pullRequest.status)).lineLimit(1)
+                            Text(pullRequest.title).underline(pullRequest.isClickable).lineLimit(1).truncationMode(.tail)
+                            Text(pullRequest.statusLabel).lineLimit(1)
                             Spacer(minLength: 0)
                         }
                         .font(magnifiedFont(scaledFontSize(10), weight: .semibold))
                         .foregroundColor(pullRequestForegroundColor)
                         .opacity(pullRequest.isStale ? 0.5 : 1)
-                        if settings.makesPullRequestsClickable {
+                        if pullRequest.isClickable {
                             Button(action: { openPullRequestLink(pullRequest.url) }) { rowContent }
                                 .buttonStyle(.plain)
                                 .tint(pullRequestForegroundColor)
-                                .safeHelp(String(localized: "sidebar.pullRequest.openTooltip", defaultValue: "Open \(pullRequestTitle)"))
+                                .safeHelp(pullRequest.openTooltip)
                                 .accessibilityIdentifier("SidebarPullRequestRow")
                         } else {
                             rowContent.accessibilityElement(children: .combine).accessibilityIdentifier("SidebarPullRequestRow")
@@ -15575,14 +15510,6 @@ struct TabItemView: View, Equatable {
 
     private func openPortLink(_ port: Int) {
         actions.openPort(port)
-    }
-
-    private func pullRequestStatusLabel(_ status: SidebarPullRequestStatus) -> String {
-        switch status {
-        case .open: return String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
-        case .merged: return String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
-        case .closed: return String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
-        }
     }
 
     private func logLevelIcon(_ level: SidebarLogLevel) -> String {
@@ -15913,7 +15840,7 @@ extension String {
 }
 
 private struct SidebarMetadataRows: View {
-    let entries: [SidebarStatusEntry]
+    let rows: [SidebarWorkspaceStatusRowContent]
     let isActive: Bool
     let activeForegroundColor: Color
     let activeSecondaryForegroundColor: Color
@@ -15925,9 +15852,9 @@ private struct SidebarMetadataRows: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 2) {
-            ForEach(visibleEntries, id: \.key) { entry in
+            ForEach(visibleRows) { row in
                 SidebarMetadataEntryRow(
-                    entry: entry,
+                    row: row,
                     isActive: isActive,
                     activeForegroundColor: activeForegroundColor,
                     fontScale: fontScale,
@@ -15951,30 +15878,28 @@ private struct SidebarMetadataRows: View {
         .safeHelp(helpText)
     }
 
-    private var visibleEntries: [SidebarStatusEntry] {
-        guard !isExpanded, entries.count > collapsedEntryLimit else { return entries }
-        return Array(entries.prefix(collapsedEntryLimit))
+    private var visibleRows: [SidebarWorkspaceStatusRowContent] {
+        guard !isExpanded, rows.count > collapsedEntryLimit else { return rows }
+        return Array(rows.prefix(collapsedEntryLimit))
     }
 
     private var helpText: String {
-        entries.map { entry in
-            let trimmed = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
-            return trimmed.isEmpty ? entry.key : trimmed
-        }
-        .joined(separator: "\n")
+        rows.map(\.text).joined(separator: "\n")
     }
 
     private var shouldShowToggle: Bool {
-        entries.count > collapsedEntryLimit
+        rows.count > collapsedEntryLimit
     }
 }
 
 private struct SidebarMetadataEntryRow: View {
-    let entry: SidebarStatusEntry
+    let row: SidebarWorkspaceStatusRowContent
     let isActive: Bool
     let activeForegroundColor: Color
     let fontScale: CGFloat
     let onFocus: () -> Void
+
+    private var entry: SidebarStatusEntry { row.entry }
 
     var body: some View {
         Group {
@@ -16050,18 +15975,16 @@ private struct SidebarMetadataEntryRow: View {
 
     @ViewBuilder
     private func metadataText(underlined: Bool) -> some View {
-        let trimmed = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
-        let display = trimmed.isEmpty ? entry.key : trimmed
         if entry.format == .markdown,
            let attributed = try? AttributedString(
-                markdown: display,
+                markdown: row.text,
                 options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
            ) {
             Text(attributed)
                 .underline(underlined)
                 .foregroundColor(foregroundColor)
         } else {
-            Text(display)
+            Text(row.text)
                 .underline(underlined)
                 .foregroundColor(foregroundColor)
         }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift
@@ -243,6 +243,7 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
         defer { CATransaction.commit() }
         let palette = palette(model)
         let snapshot = model.snapshot
+        let content = model.content
         let settings = model.settings
 
         // Chrome
@@ -304,22 +305,17 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             mediaCameraView.contentTintColor = .systemGreen
         }
 
-        let titleLineLimit = settings.wrapsWorkspaceTitles ? 8 : 1
-        titleView.maximumNumberOfLines = titleLineLimit
-        titleView.lineBreakMode = titleLineLimit == 1 ? .byTruncatingTail : .byWordWrapping
-        let boundedTitle = snapshot.title.sidebarBoundedDisplayString(
-            maxDisplayedLines: titleLineLimit,
-            maxDisplayedCharacters: 2048
-        )
+        titleView.maximumNumberOfLines = content.titleLineLimit
+        titleView.lineBreakMode = content.titleLineLimit == 1 ? .byTruncatingTail : .byWordWrapping
 #if DEBUG
-        if titleView.stringValue != boundedTitle {
+        if titleView.stringValue != content.title {
             cmuxDebugLog(
                 "sidebar.row.titlePaint workspace=\(model.workspaceId.uuidString.prefix(8)) " +
-                "title=\"\(boundedTitle.prefix(40))\""
+                "title=\"\(content.title.prefix(40))\""
             )
         }
 #endif
-        titleView.stringValue = boundedTitle
+        titleView.stringValue = content.title
         titleView.font = .systemFont(ofSize: model.scaled(12.5), weight: .semibold)
         titleView.textColor = palette.primaryText
 
@@ -359,20 +355,10 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
             }
         }
 
-        let conversationSubtitle: String? = {
-            guard !settings.hidesAllDetails, settings.iMessageModeEnabled else { return nil }
-            let trimmed = snapshot.latestConversationMessage?.trimmingCharacters(in: .whitespacesAndNewlines)
-            return (trimmed?.isEmpty == false) ? trimmed : nil
-        }()
-        let effectiveSubtitle = model.latestNotificationText ?? conversationSubtitle
-        let subtitleLineLimit = model.latestNotificationText == nil ? 2 : settings.notificationMessageLineLimit
-        subtitleView.isHidden = effectiveSubtitle == nil
-        if let effectiveSubtitle {
-            subtitleView.maximumNumberOfLines = subtitleLineLimit
-            subtitleView.stringValue = effectiveSubtitle.sidebarBoundedDisplayString(
-                maxDisplayedLines: subtitleLineLimit,
-                maxDisplayedCharacters: 4096
-            )
+        subtitleView.isHidden = content.subtitle == nil
+        if let subtitle = content.subtitle {
+            subtitleView.maximumNumberOfLines = content.subtitleLineLimit
+            subtitleView.stringValue = subtitle
             subtitleView.font = .systemFont(ofSize: model.scaled(10))
             subtitleView.textColor = palette.secondary(0.8)
         }
@@ -507,10 +493,12 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
 
     private var showsCloseNow: Bool {
         guard let model else { return false }
-        return isPointerHovering
-            && !contextMenuVisible
-            && model.canCloseWorkspace
-            && !(model.showsShortcutHints || model.settings.alwaysShowShortcutHints)
+        return model.content.showsCloseButton(
+            isPointerHovering: isPointerHovering,
+            contextMenuVisible: contextMenuVisible,
+            canCloseWorkspace: model.canCloseWorkspace,
+            showsModifierShortcutHints: model.showsShortcutHints
+        )
     }
 
     private func updateCloseVisibility() {
@@ -535,21 +523,20 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     }
 
     private func configureMetadata(model: SidebarWorkspaceRowModel, palette: SidebarRowPalette) {
-        let allEntries = model.settings.visibleAuxiliaryDetails.showsMetadata
-            ? model.snapshot.metadataEntries : []
-        let visible = model.isMetadataExpanded ? allEntries : Array(allEntries.prefix(3))
+        let allRows = model.content.statusRows
+        let visible = model.isMetadataExpanded ? allRows : Array(allRows.prefix(3))
         Self.pool(&metadataRows, count: visible.count, parent: self) { SidebarRowIconTextLine() }
-        for (index, entry) in visible.enumerated() {
+        for (index, row) in visible.enumerated() {
             metadataRows[index].configureMetadataEntry(
-                entry, model: model,
-                color: entry.color.flatMap { NSColor(hex: $0) } ?? (model.isActive ? palette.secondary(0.95).withAlphaComponent(0.84) : .secondaryLabelColor)
+                row, model: model,
+                color: row.color.flatMap { NSColor(hex: $0) } ?? (model.isActive ? palette.secondary(0.95).withAlphaComponent(0.84) : .secondaryLabelColor)
             )
         }
         let toggleFont = NSFont.systemFont(ofSize: model.scaled(10), weight: .semibold)
         let toggleColor = model.isActive
             ? palette.secondary(0.9)
             : NSColor.secondaryLabelColor.withAlphaComponent(0.9)
-        metadataToggleButton.isHidden = allEntries.count <= 3
+        metadataToggleButton.isHidden = allRows.count <= 3
         if !metadataToggleButton.isHidden {
             metadataToggleButton.configure(
                 title: model.isMetadataExpanded
@@ -613,38 +600,8 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     }
 
     private func configureBranchDirectory(model: SidebarWorkspaceRowModel, palette: SidebarRowPalette) {
-        let snapshot = model.snapshot
-        let settings = model.settings
-        let showsSection = settings.visibleAuxiliaryDetails.showsBranchDirectory
-        var lines: [SidebarRowIconTextLine.BranchLineContent] = []
-        if showsSection {
-            if settings.usesVerticalBranchLayout {
-                for line in snapshot.branchDirectoryLines {
-                    lines.append(.init(
-                        branch: settings.showsGitBranch ? line.branch : nil,
-                        directoryCandidates: line.directoryCandidates,
-                        stacked: settings.stacksBranchAndDirectory
-                    ))
-                }
-            } else if settings.stacksBranchAndDirectory {
-                if snapshot.compactGitBranchSummaryText != nil || !snapshot.compactDirectoryCandidates.isEmpty {
-                    lines.append(.init(
-                        branch: snapshot.compactGitBranchSummaryText,
-                        directoryCandidates: snapshot.compactDirectoryCandidates,
-                        stacked: true
-                    ))
-                }
-            } else if !snapshot.compactBranchDirectoryCandidates.isEmpty {
-                lines.append(.init(
-                    branch: nil,
-                    directoryCandidates: snapshot.compactBranchDirectoryCandidates,
-                    stacked: false
-                ))
-            }
-        }
-        let showsIcon = showsSection && settings.showsGitBranchIcon
-            && (settings.usesVerticalBranchLayout ? snapshot.branchLinesContainBranch : snapshot.compactGitBranchSummaryText != nil || !snapshot.compactBranchDirectoryCandidates.isEmpty)
-        branchIconView.isHidden = !(showsIcon && !lines.isEmpty)
+        let lines = model.content.branchDirectoryRows
+        branchIconView.isHidden = !model.content.showsBranchIcon
         if !branchIconView.isHidden {
             branchIconView.image = RenderableSystemSymbol.configuredAppKitImage(
                 systemName: "arrow.triangle.branch", pointSize: model.scaled(9), weight: nil
@@ -658,20 +615,17 @@ final class SidebarWorkspaceRowTableCellView: NSTableCellView {
     }
 
     private func configurePullRequestsAndPorts(model: SidebarWorkspaceRowModel, palette: SidebarRowPalette) {
-        let snapshot = model.snapshot
-        let settings = model.settings
-        let prs = settings.visibleAuxiliaryDetails.showsPullRequests ? snapshot.pullRequestRows : []
+        let prs = model.content.pullRequestRows
         Self.pool(&pullRequestRows, count: prs.count, parent: self) { SidebarRowPullRequestLine() }
         for (index, pr) in prs.enumerated() {
             pullRequestRows[index].configure(
-                pr, model: model, palette: palette,
-                clickable: settings.makesPullRequestsClickable
+                pr, model: model, palette: palette
             ) { [weak self] in
                 self?.actions?.commands.updateSelection()
                 self?.actions?.onOpenPullRequest(pr.url)
             }
         }
-        let ports = settings.visibleAuxiliaryDetails.showsPorts ? snapshot.listeningPorts : []
+        let ports = model.settings.visibleAuxiliaryDetails.showsPorts ? model.snapshot.listeningPorts : []
         Self.pool(&portButtons, count: ports.count, parent: self) { SidebarRowLinkButton() }
         for (index, port) in ports.enumerated() {
             portButtons[index].configure(

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift
@@ -13,6 +13,7 @@ struct SidebarWorkspaceRowModel: Equatable {
     let workspaceId: UUID
     let index: Int
     let snapshot: SidebarWorkspaceSnapshotBuilder.Snapshot
+    let content: SidebarWorkspaceRowContentModel
     let settings: SidebarTabItemSettingsSnapshot
     // `var` (not `let`) so the optimistic press/deselect paint can apply a
     // selection-flipped copy of the model; the stored model stays

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift
@@ -236,4 +236,9 @@ final class SidebarRowTextView: NSTextField {
         let size = cell?.cellSize(forBounds: NSRect(x: 0, y: 0, width: width, height: .greatestFiniteMagnitude)) ?? .zero
         return ceil(size.height)
     }
+
+    var unconstrainedContentSize: NSSize {
+        let size = cell?.cellSize ?? intrinsicContentSize
+        return NSSize(width: ceil(size.width), height: ceil(size.height))
+    }
 }

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -311,11 +311,11 @@ final class SidebarRowPullRequestLine: NSView {
             x: 0, y: (bounds.height - iconSize.height) / 2,
             width: iconSize.width, height: iconSize.height
         )
-        let statusSize = statusLabel.intrinsicContentSize
+        let statusSize = statusLabel.unconstrainedContentSize
         let titleX = iconSize.width + 4
         let titleWidth = max(10, bounds.width - titleX - statusSize.width - 8)
         let title: NSView = titleButton.isHidden ? titleLabel : titleButton
-        let titleSize = titleButton.isHidden ? titleLabel.intrinsicContentSize : titleButton.intrinsicContentSize
+        let titleSize = titleButton.isHidden ? titleLabel.unconstrainedContentSize : titleButton.intrinsicContentSize
         title.frame = NSRect(
             x: titleX, y: (bounds.height - titleSize.height) / 2,
             width: min(ceil(titleSize.width), titleWidth), height: titleSize.height

--- a/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
+++ b/Sources/Sidebar/AppKitList/Cells/SidebarWorkspaceRowSupportViews.swift
@@ -43,12 +43,6 @@ struct SidebarRowPalette {
 /// One "small icon + text" line (metadata entry, log line, branch/dir line).
 @MainActor
 final class SidebarRowIconTextLine: NSView {
-    struct BranchLineContent {
-        let branch: String?
-        let directoryCandidates: [String]
-        let stacked: Bool
-    }
-
     private let iconView = NSImageView()
     private let iconLabel = NSTextField(labelWithString: "")
     private let textView = SidebarRowTextView(lines: 1)
@@ -73,10 +67,11 @@ final class SidebarRowIconTextLine: NSView {
     }
 
     func configureMetadataEntry(
-        _ entry: SidebarStatusEntry,
+        _ row: SidebarWorkspaceStatusRowContent,
         model: SidebarWorkspaceRowModel,
         color: NSColor
     ) {
+        let entry = row.entry
         stacked = false
         secondTextView.isHidden = true
         iconLabel.isHidden = true
@@ -106,8 +101,7 @@ final class SidebarRowIconTextLine: NSView {
                 }
             }
         }
-        let text = entry.key.isEmpty ? entry.value : "\(entry.key): \(entry.value)"
-        textView.stringValue = text
+        textView.stringValue = row.text
         textView.font = .systemFont(ofSize: model.scaled(10))
         textView.textColor = color
         needsLayout = true
@@ -160,14 +154,16 @@ final class SidebarRowIconTextLine: NSView {
     /// Branch/dir line with width-adaptive directory candidate selection
     /// (manual ViewThatFits: longest candidate that fits wins).
     func configureBranchLine(
-        _ content: BranchLineContent,
+        _ content: SidebarWorkspaceBranchDirectoryRowContent,
         model: SidebarWorkspaceRowModel,
         palette: SidebarRowPalette
     ) {
         iconView.isHidden = true
         iconLabel.isHidden = true
         iconSize = 0
-        stacked = content.stacked && content.branch != nil && !content.directoryCandidates.isEmpty
+        stacked = content.stacksBranchAndDirectory
+            && content.branch != nil
+            && !content.directoryCandidates.isEmpty
         let font = NSFont.monospacedSystemFont(ofSize: model.scaled(10), weight: .regular)
         let color = palette.secondary(0.75)
         pendingCandidates = content.directoryCandidates
@@ -275,40 +271,32 @@ final class SidebarRowPullRequestLine: NSView {
     }
 
     func configure(
-        _ display: SidebarWorkspaceSnapshotBuilder.PullRequestDisplay,
+        _ content: SidebarWorkspacePullRequestRowContent,
         model: SidebarWorkspaceRowModel,
         palette: SidebarRowPalette,
-        clickable: Bool,
         onOpen: @escaping () -> Void
     ) {
         let color = model.isActive ? palette.secondary(0.75) : NSColor.secondaryLabelColor
         let font = NSFont.systemFont(ofSize: model.scaled(10), weight: .semibold)
-        iconView.configure(status: display.status, color: color, fontScale: model.fontScale)
-        iconSize = SidebarRowPullRequestIconView.size(status: display.status, fontScale: model.fontScale)
-        let title = "\(display.label) #\(display.number)"
-        titleButton.isHidden = !clickable
-        titleLabel.isHidden = clickable
-        if clickable {
+        iconView.configure(status: content.status, color: color, fontScale: model.fontScale)
+        iconSize = SidebarRowPullRequestIconView.size(status: content.status, fontScale: model.fontScale)
+        titleButton.isHidden = !content.isClickable
+        titleLabel.isHidden = content.isClickable
+        if content.isClickable {
             titleButton.configure(
-                title: title, font: font, color: color, underlined: true,
-                toolTip: String(localized: "sidebar.pullRequest.openTooltip", defaultValue: "Open pull request"),
+                title: content.title, font: font, color: color, underlined: true,
+                toolTip: content.openTooltip,
                 onClick: onOpen
             )
         } else {
-            titleLabel.stringValue = title
+            titleLabel.stringValue = content.title
             titleLabel.font = font
             titleLabel.textColor = color
         }
-        let statusText: String
-        switch display.status {
-        case .open: statusText = String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
-        case .merged: statusText = String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
-        case .closed: statusText = String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
-        }
-        statusLabel.stringValue = statusText
+        statusLabel.stringValue = content.statusLabel
         statusLabel.font = font
         statusLabel.textColor = color
-        alphaValue = display.isStale ? 0.5 : 1
+        alphaValue = content.isStale ? 0.5 : 1
         lineHeight = max(iconSize.height, ceil(font.ascender - font.descender + font.leading))
         needsLayout = true
     }

--- a/Sources/SidebarWorkspaceBranchDirectoryRowContent.swift
+++ b/Sources/SidebarWorkspaceBranchDirectoryRowContent.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// One normalized branch and working-directory row shared by both sidebar renderers.
+struct SidebarWorkspaceBranchDirectoryRowContent: Equatable {
+    let branch: String?
+    let directoryCandidates: [String]
+    let stacksBranchAndDirectory: Bool
+}

--- a/Sources/SidebarWorkspacePullRequestRowContent.swift
+++ b/Sources/SidebarWorkspacePullRequestRowContent.swift
@@ -1,0 +1,39 @@
+import CmuxSidebar
+import Foundation
+
+/// Immutable pull-request presentation shared by both sidebar renderers.
+struct SidebarWorkspacePullRequestRowContent: Equatable, Identifiable {
+    let id: String
+    let title: String
+    let url: URL
+    let status: SidebarPullRequestStatus
+    let statusLabel: String
+    let openTooltip: String
+    let isStale: Bool
+    let isClickable: Bool
+
+    init(
+        display: SidebarWorkspaceSnapshotBuilder.PullRequestDisplay,
+        isClickable: Bool
+    ) {
+        id = display.id
+        let resolvedTitle = "\(display.label) #\(display.number)"
+        title = resolvedTitle
+        url = display.url
+        status = display.status
+        statusLabel = switch display.status {
+        case .open:
+            String(localized: "sidebar.pullRequest.statusOpen", defaultValue: "open")
+        case .merged:
+            String(localized: "sidebar.pullRequest.statusMerged", defaultValue: "merged")
+        case .closed:
+            String(localized: "sidebar.pullRequest.statusClosed", defaultValue: "closed")
+        }
+        openTooltip = String(
+            localized: "sidebar.pullRequest.openTooltip",
+            defaultValue: "Open \(display.label) #\(display.number)"
+        )
+        isStale = display.isStale
+        self.isClickable = isClickable
+    }
+}

--- a/Sources/SidebarWorkspaceRowContentModel.swift
+++ b/Sources/SidebarWorkspaceRowContentModel.swift
@@ -1,0 +1,125 @@
+import CmuxFoundation
+import Foundation
+
+/// Shared immutable presentation model for SwiftUI and AppKit workspace rows.
+///
+/// The parent sidebar projection creates this value once from the authoritative
+/// workspace snapshot and settings. Renderers only choose native controls and
+/// geometry; they do not independently decide which content is visible.
+struct SidebarWorkspaceRowContentModel: Equatable {
+    let title: String
+    let titleLineLimit: Int
+    let subtitle: String?
+    let subtitleLineLimit: Int
+    let statusRows: [SidebarWorkspaceStatusRowContent]
+    let branchDirectoryRows: [SidebarWorkspaceBranchDirectoryRowContent]
+    let showsBranchIcon: Bool
+    let pullRequestRows: [SidebarWorkspacePullRequestRowContent]
+
+    private let alwaysShowsShortcutHints: Bool
+
+    init(
+        workspace: SidebarWorkspaceSnapshotBuilder.Snapshot,
+        settings: SidebarTabItemSettingsSnapshot,
+        latestNotificationText: String?
+    ) {
+        titleLineLimit = settings.wrapsWorkspaceTitles ? 8 : 1
+        title = workspace.title.sidebarBoundedDisplayString(
+            maxDisplayedLines: titleLineLimit,
+            maxDisplayedCharacters: 2048
+        )
+
+        let notificationSubtitle = settings.showsNotificationMessage
+            ? latestNotificationText
+            : nil
+        let conversationSubtitle: String? = {
+            guard !settings.hidesAllDetails, settings.iMessageModeEnabled else { return nil }
+            return workspace.latestConversationMessage?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .nilIfEmpty
+        }()
+        let effectiveSubtitle = notificationSubtitle ?? conversationSubtitle
+        subtitleLineLimit = notificationSubtitle == nil ? 2 : settings.notificationMessageLineLimit
+        subtitle = effectiveSubtitle?.sidebarBoundedDisplayString(
+            maxDisplayedLines: subtitleLineLimit,
+            maxDisplayedCharacters: 4096
+        )
+
+        statusRows = settings.visibleAuxiliaryDetails.showsMetadata
+            ? workspace.metadataEntries.map(SidebarWorkspaceStatusRowContent.init)
+            : []
+
+        branchDirectoryRows = Self.branchDirectoryRows(
+            workspace: workspace,
+            settings: settings
+        )
+        showsBranchIcon = settings.visibleAuxiliaryDetails.showsBranchDirectory
+            && settings.showsGitBranchIcon
+            && !branchDirectoryRows.isEmpty
+            && (settings.usesVerticalBranchLayout
+                ? branchDirectoryRows.contains { $0.branch != nil }
+                : workspace.compactGitBranchSummaryText != nil)
+
+        pullRequestRows = settings.visibleAuxiliaryDetails.showsPullRequests
+            ? workspace.pullRequestRows.map {
+                SidebarWorkspacePullRequestRowContent(
+                    display: $0,
+                    isClickable: settings.makesPullRequestsClickable
+                )
+            }
+            : []
+        alwaysShowsShortcutHints = settings.alwaysShowShortcutHints
+    }
+
+    func showsCloseButton(
+        isPointerHovering: Bool,
+        contextMenuVisible: Bool,
+        canCloseWorkspace: Bool,
+        showsModifierShortcutHints: Bool
+    ) -> Bool {
+        isPointerHovering
+            && !contextMenuVisible
+            && canCloseWorkspace
+            && !(showsModifierShortcutHints || alwaysShowsShortcutHints)
+    }
+
+    private static func branchDirectoryRows(
+        workspace: SidebarWorkspaceSnapshotBuilder.Snapshot,
+        settings: SidebarTabItemSettingsSnapshot
+    ) -> [SidebarWorkspaceBranchDirectoryRowContent] {
+        guard settings.visibleAuxiliaryDetails.showsBranchDirectory else { return [] }
+
+        if settings.usesVerticalBranchLayout {
+            return workspace.branchDirectoryLines.map {
+                SidebarWorkspaceBranchDirectoryRowContent(
+                    branch: settings.showsGitBranch ? $0.branch : nil,
+                    directoryCandidates: $0.directoryCandidates,
+                    stacksBranchAndDirectory: settings.stacksBranchAndDirectory
+                )
+            }
+        }
+
+        if settings.stacksBranchAndDirectory {
+            guard workspace.compactGitBranchSummaryText != nil
+                    || !workspace.compactDirectoryCandidates.isEmpty else {
+                return []
+            }
+            return [
+                SidebarWorkspaceBranchDirectoryRowContent(
+                    branch: workspace.compactGitBranchSummaryText,
+                    directoryCandidates: workspace.compactDirectoryCandidates,
+                    stacksBranchAndDirectory: true
+                ),
+            ]
+        }
+
+        guard !workspace.compactBranchDirectoryCandidates.isEmpty else { return [] }
+        return [
+            SidebarWorkspaceBranchDirectoryRowContent(
+                branch: nil,
+                directoryCandidates: workspace.compactBranchDirectoryCandidates,
+                stacksBranchAndDirectory: false
+            ),
+        ]
+    }
+}

--- a/Sources/SidebarWorkspaceRowInput.swift
+++ b/Sources/SidebarWorkspaceRowInput.swift
@@ -15,6 +15,7 @@ struct SidebarWorkspaceRowInput {
     let index: Int
     let workspaceCount: Int
     let workspace: SidebarWorkspaceSnapshotBuilder.Snapshot
+    let content: SidebarWorkspaceRowContentModel
     let isActive: Bool
     let isMultiSelected: Bool
     let hasUserCustomTitle: Bool
@@ -54,6 +55,7 @@ struct SidebarWorkspaceRowInput {
             index: index,
             workspaceCount: workspaceCount,
             workspace: workspace,
+            content: content,
             isActive: isActive,
             isMultiSelected: isMultiSelected,
             hasUserCustomTitle: hasUserCustomTitle,

--- a/Sources/SidebarWorkspaceRowSnapshot.swift
+++ b/Sources/SidebarWorkspaceRowSnapshot.swift
@@ -12,6 +12,7 @@ struct SidebarWorkspaceRowSnapshot: Equatable {
     let index: Int
     let workspaceCount: Int
     let workspace: SidebarWorkspaceSnapshotBuilder.Snapshot
+    let content: SidebarWorkspaceRowContentModel
     let isActive: Bool
     let isMultiSelected: Bool
     let hasUserCustomTitle: Bool

--- a/Sources/SidebarWorkspaceStatusRowContent.swift
+++ b/Sources/SidebarWorkspaceStatusRowContent.swift
@@ -1,0 +1,27 @@
+import CmuxSettings
+import CmuxSidebar
+import Foundation
+
+/// Immutable presentation for one workspace status row shared by both sidebar renderers.
+struct SidebarWorkspaceStatusRowContent: Equatable, Identifiable {
+    let entry: SidebarStatusEntry
+    let text: String
+
+    var id: String { entry.key }
+    var icon: String? { entry.icon }
+    var color: String? { entry.color }
+    var url: URL? { entry.url }
+    var format: SidebarMetadataFormat { entry.format }
+
+    init(entry: SidebarStatusEntry) {
+        self.entry = entry
+        let trimmedValue = entry.value.trimmingCharacters(in: .whitespacesAndNewlines)
+        text = trimmedValue.isEmpty ? Self.fallbackText(for: entry.key) : trimmedValue
+    }
+
+    private static func fallbackText(for key: String) -> String {
+        guard AgentHibernationLifecycleStatusKeys.isAllowed(key) else { return key }
+        let catalogSlug = key == "claude_code" ? "claude" : key
+        return AutoNamingAgentCatalog.displayName(forSlug: catalogSlug)
+    }
+}

--- a/cmux.xcodeproj/project.pbxproj
+++ b/cmux.xcodeproj/project.pbxproj
@@ -1533,6 +1533,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		F7216006000000000000001 /* SidebarTabItemContextMenuState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7216006000000000000002 /* SidebarTabItemContextMenuState.swift */; };
 		A6AC73F10000000000000001 /* SidebarTitleFirstLineCenterAlignment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73F10000000000000002 /* SidebarTitleFirstLineCenterAlignment.swift */; };
 		CA39C0304FE351A21C372429 /* SidebarWidthPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */; };
+		8409A0018409A0018409A001 /* SidebarWorkspaceBranchDirectoryRowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8409A0058409A0058409A005 /* SidebarWorkspaceBranchDirectoryRowContent.swift */; };
 		EDA24082C65B4E2A2A03F276 /* SidebarWorkspaceChecklistPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = BAC8DE2AF74EC2C272681A75 /* SidebarWorkspaceChecklistPopover.swift */; };
 		B290FAD92C810ACB2D9CD9C6 /* SidebarWorkspaceChecklistView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E9E7BB6EF7C9F8D2C681999D /* SidebarWorkspaceChecklistView.swift */; };
 		6707F0036707F0036707F003 /* SidebarWorkspaceContextMenuSnapshot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0046707F0046707F004 /* SidebarWorkspaceContextMenuSnapshot.swift */; };
@@ -1554,6 +1555,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 			A6AC73320000000000000001 /* SidebarWorkspaceLoadingSpinner.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73320000000000000002 /* SidebarWorkspaceLoadingSpinner.swift */; };
 		6707F0216707F0216707F021 /* SidebarWorkspaceNotificationIndex.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0226707F0226707F022 /* SidebarWorkspaceNotificationIndex.swift */; };
 		6707F0236707F0236707F023 /* SidebarWorkspaceNotificationIndexTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0246707F0246707F024 /* SidebarWorkspaceNotificationIndexTests.swift */; };
+		8409A0028409A0028409A002 /* SidebarWorkspacePullRequestRowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8409A0068409A0068409A006 /* SidebarWorkspacePullRequestRowContent.swift */; };
 		C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */; };
 		C9A57211C9A57211C9A57211 /* SidebarWorkspaceRenderItemID.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A57212C9A57212C9A57212 /* SidebarWorkspaceRenderItemID.swift */; };
 		C9A5760DC9A5760DC9A5760D /* SidebarWorkspaceReorderDropOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9A5760EC9A5760EC9A5760E /* SidebarWorkspaceReorderDropOverlay.swift */; };
@@ -1565,6 +1567,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		6707F0076707F0076707F007 /* SidebarWorkspaceRowActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0086707F0086707F008 /* SidebarWorkspaceRowActions.swift */; };
 		B804A0240000000000000024 /* SidebarWorkspaceRowCellView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0240000000000000024 /* SidebarWorkspaceRowCellView.swift */; };
 		B804A0220000000000000022 /* SidebarWorkspaceRowCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */; };
+		8409A0038409A0038409A003 /* SidebarWorkspaceRowContentModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8409A0078409A0078409A007 /* SidebarWorkspaceRowContentModel.swift */; };
 		6707F0116707F0116707F011 /* SidebarWorkspaceRowInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */; };
 		B804A0230000000000000023 /* SidebarWorkspaceRowModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0230000000000000023 /* SidebarWorkspaceRowModel.swift */; };
 		B804A0250000000000000025 /* SidebarWorkspaceRowSlotViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0250000000000000025 /* SidebarWorkspaceRowSlotViews.swift */; };
@@ -1582,6 +1585,7 @@ C0DE71B10000000000000001 /* AppDelegate+AgentChatNotifications.swift in Sources 
 		988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */; };
 		62270F3DCECB4787D789CCE3 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */; };
 		4F80E2D0A6377A1D8A97D411 /* SidebarWorkspaceStatusPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3896D9D4AD4D31A54882813E /* SidebarWorkspaceStatusPopover.swift */; };
+		8409A0048409A0048409A004 /* SidebarWorkspaceStatusRowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8409A0088409A0088409A008 /* SidebarWorkspaceStatusRowContent.swift */; };
 		A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */; };
 		B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */; };
 		B804A00E000000000000000E /* SidebarWorkspaceTableCellModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = B804B00E000000000000000E /* SidebarWorkspaceTableCellModel.swift */; };
@@ -3575,6 +3579,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		F7216006000000000000002 /* SidebarTabItemContextMenuState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabItemContextMenuState.swift; sourceTree = "<group>"; };
 		A6AC73F10000000000000002 /* SidebarTitleFirstLineCenterAlignment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarTitleFirstLineCenterAlignment.swift; sourceTree = "<group>"; };
 		EE0171AF1F49F7547191CEE5 /* SidebarWidthPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWidthPolicyTests.swift; sourceTree = "<group>"; };
+		8409A0058409A0058409A005 /* SidebarWorkspaceBranchDirectoryRowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceBranchDirectoryRowContent.swift; sourceTree = "<group>"; };
 		BAC8DE2AF74EC2C272681A75 /* SidebarWorkspaceChecklistPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SidebarWorkspaceChecklistPopover.swift"; sourceTree = "<group>"; };
 		E9E7BB6EF7C9F8D2C681999D /* SidebarWorkspaceChecklistView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceChecklistView.swift; sourceTree = "<group>"; };
 		6707F0046707F0046707F004 /* SidebarWorkspaceContextMenuSnapshot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceContextMenuSnapshot.swift; sourceTree = "<group>"; };
@@ -3596,6 +3601,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 			A6AC73320000000000000002 /* SidebarWorkspaceLoadingSpinner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceLoadingSpinner.swift; sourceTree = "<group>"; };
 		6707F0226707F0226707F022 /* SidebarWorkspaceNotificationIndex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceNotificationIndex.swift; sourceTree = "<group>"; };
 		6707F0246707F0246707F024 /* SidebarWorkspaceNotificationIndexTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceNotificationIndexTests.swift; sourceTree = "<group>"; };
+		8409A0068409A0068409A006 /* SidebarWorkspacePullRequestRowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspacePullRequestRowContent.swift; sourceTree = "<group>"; };
 		C9A57202C9A57202C9A57202 /* SidebarWorkspaceRenderItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRenderItem.swift; sourceTree = "<group>"; };
 		C9A57212C9A57212C9A57212 /* SidebarWorkspaceRenderItemID.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRenderItemID.swift; sourceTree = "<group>"; };
 		C9A5760EC9A5760EC9A5760E /* SidebarWorkspaceReorderDropOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceReorderDropOverlay.swift; sourceTree = "<group>"; };
@@ -3607,6 +3613,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		6707F0086707F0086707F008 /* SidebarWorkspaceRowActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowActions.swift; sourceTree = "<group>"; };
 		B804B0240000000000000024 /* SidebarWorkspaceRowCellView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCellView.swift; sourceTree = "<group>"; };
 		B804B0220000000000000022 /* SidebarWorkspaceRowCommands.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowCommands.swift; sourceTree = "<group>"; };
+		8409A0078409A0078409A007 /* SidebarWorkspaceRowContentModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowContentModel.swift; sourceTree = "<group>"; };
 		6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceRowInput.swift; sourceTree = "<group>"; };
 		B804B0230000000000000023 /* SidebarWorkspaceRowModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowModel.swift; sourceTree = "<group>"; };
 		B804B0250000000000000025 /* SidebarWorkspaceRowSlotViews.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/Cells/SidebarWorkspaceRowSlotViews.swift; sourceTree = "<group>"; };
@@ -3624,6 +3631,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 		D50D9BCE46701FBA91C2EFB6 /* SidebarWorkspaceSnapshotRefreshPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceSnapshotRefreshPolicy.swift; sourceTree = "<group>"; };
 		F016B5C09357B3226FA2E014 /* SidebarWorkspaceSnapshotRefreshPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceSnapshotRefreshPolicyTests.swift; sourceTree = "<group>"; };
 		3896D9D4AD4D31A54882813E /* SidebarWorkspaceStatusPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SidebarWorkspaceStatusPopover.swift"; sourceTree = "<group>"; };
+		8409A0088409A0088409A008 /* SidebarWorkspaceStatusRowContent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarWorkspaceStatusRowContent.swift; sourceTree = "<group>"; };
 		A6AC73010000000000000002 /* SidebarWorkspaceStatusSlots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/SidebarWorkspaceStatusSlots.swift; sourceTree = "<group>"; };
 		B804B0010000000000000001 /* SidebarWorkspaceTableActions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableActions.swift; sourceTree = "<group>"; };
 		B804B00E000000000000000E /* SidebarWorkspaceTableCellModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sidebar/AppKitList/SidebarWorkspaceTableCellModel.swift; sourceTree = "<group>"; };
@@ -4461,8 +4469,12 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					6707F0066707F0066707F006 /* SidebarWorkspaceGroupRowView.swift */,
 					6707F0106707F0106707F010 /* SidebarWorkspaceGroupRowSnapshot.swift */,
 					6707F0086707F0086707F008 /* SidebarWorkspaceRowActions.swift */,
+					8409A0058409A0058409A005 /* SidebarWorkspaceBranchDirectoryRowContent.swift */,
+					8409A0068409A0068409A006 /* SidebarWorkspacePullRequestRowContent.swift */,
+					8409A0078409A0078409A007 /* SidebarWorkspaceRowContentModel.swift */,
 					6707F0126707F0126707F012 /* SidebarWorkspaceRowInput.swift */,
 					6707F00A6707F00A6707F00A /* SidebarWorkspaceRowSnapshot.swift */,
+					8409A0088409A0088409A008 /* SidebarWorkspaceStatusRowContent.swift */,
 					6707F00C6707F00C6707F00C /* SidebarWorkspaceRowView.swift */,
 					6707F0146707F0146707F014 /* SidebarWorkspaceRowsSnapshot.swift */,
 					6707F0226707F0226707F022 /* SidebarWorkspaceNotificationIndex.swift */,
@@ -7629,6 +7641,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				D7344F010000000000000001 /* SidebarTabDragPayload.swift in Sources */,
 				F7216006000000000000001 /* SidebarTabItemContextMenuState.swift in Sources */,
 				A6AC73F10000000000000001 /* SidebarTitleFirstLineCenterAlignment.swift in Sources */,
+				8409A0018409A0018409A001 /* SidebarWorkspaceBranchDirectoryRowContent.swift in Sources */,
 				EDA24082C65B4E2A2A03F276 /* SidebarWorkspaceChecklistPopover.swift in Sources */,
 				B290FAD92C810ACB2D9CD9C6 /* SidebarWorkspaceChecklistView.swift in Sources */,
 				6707F0036707F0036707F003 /* SidebarWorkspaceContextMenuSnapshot.swift in Sources */,
@@ -7645,6 +7658,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 					A6AC73310000000000000001 /* SidebarWorkspaceLeadingStatusSlot.swift in Sources */,
 					A6AC73320000000000000001 /* SidebarWorkspaceLoadingSpinner.swift in Sources */,
 				6707F0216707F0216707F021 /* SidebarWorkspaceNotificationIndex.swift in Sources */,
+				8409A0028409A0028409A002 /* SidebarWorkspacePullRequestRowContent.swift in Sources */,
 				C9A57201C9A57201C9A57201 /* SidebarWorkspaceRenderItem.swift in Sources */,
 				C9A57211C9A57211C9A57211 /* SidebarWorkspaceRenderItemID.swift in Sources */,
 				C9A5760DC9A5760DC9A5760D /* SidebarWorkspaceReorderDropOverlay.swift in Sources */,
@@ -7655,6 +7669,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6707F0076707F0076707F007 /* SidebarWorkspaceRowActions.swift in Sources */,
 				B804A0240000000000000024 /* SidebarWorkspaceRowCellView.swift in Sources */,
 				B804A0220000000000000022 /* SidebarWorkspaceRowCommands.swift in Sources */,
+				8409A0038409A0038409A003 /* SidebarWorkspaceRowContentModel.swift in Sources */,
 				6707F0116707F0116707F011 /* SidebarWorkspaceRowInput.swift in Sources */,
 				B804A0230000000000000023 /* SidebarWorkspaceRowModel.swift in Sources */,
 				B804A0250000000000000025 /* SidebarWorkspaceRowSlotViews.swift in Sources */,
@@ -7667,6 +7682,7 @@ C0DE71B10000000000000002 /* AppDelegate+AgentChatNotifications.swift */ = {isa =
 				6707F0156707F0156707F015 /* SidebarWorkspaceSnapshotRefreshCoalescer.swift in Sources */,
 				988C6A036BA56EA5759A95A0 /* SidebarWorkspaceSnapshotRefreshPolicy.swift in Sources */,
 				4F80E2D0A6377A1D8A97D411 /* SidebarWorkspaceStatusPopover.swift in Sources */,
+				8409A0048409A0048409A004 /* SidebarWorkspaceStatusRowContent.swift in Sources */,
 		A6AC73010000000000000001 /* SidebarWorkspaceStatusSlots.swift in Sources */,
 				B804A0010000000000000001 /* SidebarWorkspaceTableActions.swift in Sources */,
 				B804A00E000000000000000E /* SidebarWorkspaceTableCellModel.swift in Sources */,

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -238,6 +238,41 @@ struct SidebarAppKitRowCellTests {
     }
 
     @Test
+    func pullRequestStatusKeepsEnoughWidthToRenderWithoutTruncation() throws {
+        let model = Self.makeModel()
+        let url = try #require(URL(string: "https://github.com/manaflow-ai/cmux/pull/8413"))
+        let content = SidebarWorkspacePullRequestRowContent(
+            display: .init(
+                id: "pr#8413",
+                number: 8413,
+                label: "PR",
+                url: url,
+                status: .open,
+                isStale: false
+            ),
+            isClickable: true
+        )
+        let row = SidebarRowPullRequestLine()
+        row.configure(
+            content,
+            model: model,
+            palette: SidebarRowPalette(model: model),
+            onOpen: {}
+        )
+        row.frame = NSRect(x: 0, y: 0, width: 300, height: row.measuredHeight(width: 300))
+        row.layoutSubtreeIfNeeded()
+
+        let statusLabel = try #require(
+            row.subviews
+                .compactMap { $0 as? SidebarRowTextView }
+                .first { $0.stringValue == content.statusLabel }
+        )
+        let requiredWidth = ceil(try #require(statusLabel.cell).cellSize.width)
+
+        #expect(statusLabel.frame.width >= requiredWidth)
+    }
+
+    @Test
     func explicitInlineBranchDirectoryPreferenceIsPreserved() throws {
         let settings = Self.makeSettings(stacksBranchAndDirectory: false)
         let content = SidebarWorkspaceRowContentModel(

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -7,10 +7,29 @@ import Testing
 @Suite
 @MainActor
 struct SidebarAppKitRowCellTests {
-    private static func makeSnapshot(title: String = "Workspace") -> SidebarWorkspaceSnapshotBuilder.Snapshot {
+    private static func makeSettings(hidesAllDetails: Bool = false) -> SidebarTabItemSettingsSnapshot {
+        let defaults = UserDefaults(suiteName: UUID().uuidString)!
+        defaults.set(hidesAllDetails, forKey: "sidebarHideAllDetails")
+        defaults.set(true, forKey: "sidebarShowNotificationMessage")
+        defaults.set(true, forKey: "sidebarShowStatusPills")
+        defaults.set(true, forKey: "sidebarShowBranchDirectory")
+        defaults.set(true, forKey: "sidebarShowGitBranchIcon")
+        defaults.set(true, forKey: "sidebarShowPullRequest")
+        defaults.set(true, forKey: "sidebarBranchVerticalLayout")
+        defaults.set(false, forKey: "sidebarBranchDirectoryStacked")
+        return SidebarTabItemSettingsSnapshot(defaults: defaults)
+    }
+
+    private static func makeSnapshot(
+        title: String = "Workspace",
+        latestConversationMessage: String? = nil,
+        metadataEntries: [SidebarStatusEntry] = [],
+        branchDirectoryLines: [SidebarWorkspaceSnapshotBuilder.VerticalBranchDirectoryLine] = [],
+        pullRequestRows: [SidebarWorkspaceSnapshotBuilder.PullRequestDisplay] = []
+    ) -> SidebarWorkspaceSnapshotBuilder.Snapshot {
         SidebarWorkspaceSnapshotBuilder.Snapshot(
             presentationKey: SidebarWorkspaceSnapshotFactory.presentationKey(
-                settings: SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!),
+                settings: makeSettings(),
                 showsAgentActivity: false
             ),
             title: title,
@@ -22,8 +41,8 @@ struct SidebarAppKitRowCellTests {
             remoteStateHelpText: "",
             showsRemoteReconnectAffordance: false,
             copyableSidebarSSHError: nil,
-            latestConversationMessage: nil,
-            metadataEntries: [],
+            latestConversationMessage: latestConversationMessage,
+            metadataEntries: metadataEntries,
             metadataBlocks: [],
             latestLog: nil,
             progress: nil,
@@ -31,9 +50,9 @@ struct SidebarAppKitRowCellTests {
             compactGitBranchSummaryText: nil,
             compactDirectoryCandidates: [],
             compactBranchDirectoryCandidates: [],
-            branchDirectoryLines: [],
-            branchLinesContainBranch: false,
-            pullRequestRows: [],
+            branchDirectoryLines: branchDirectoryLines,
+            branchLinesContainBranch: branchDirectoryLines.contains { $0.branch != nil },
+            pullRequestRows: pullRequestRows,
             listeningPorts: [],
             finderDirectoryPath: nil,
             mediaActivity: BrowserMediaActivity(),
@@ -52,11 +71,18 @@ struct SidebarAppKitRowCellTests {
         isActive: Bool = false,
         canClose: Bool = true
     ) -> SidebarWorkspaceRowModel {
+        let settings = makeSettings()
+        let snapshot = makeSnapshot()
         SidebarWorkspaceRowModel(
             workspaceId: workspaceId,
             index: 0,
-            snapshot: makeSnapshot(),
-            settings: SidebarTabItemSettingsSnapshot(defaults: UserDefaults(suiteName: UUID().uuidString)!),
+            snapshot: snapshot,
+            content: SidebarWorkspaceRowContentModel(
+                workspace: snapshot,
+                settings: settings,
+                latestNotificationText: nil
+            ),
+            settings: settings,
             isActive: isActive,
             isMultiSelected: false,
             canCloseWorkspace: canClose,
@@ -79,6 +105,158 @@ struct SidebarAppKitRowCellTests {
             isMetadataExpanded: false,
             isMarkdownExpanded: false
         )
+    }
+
+    @Test
+    func sharedContentUsesWorkspaceTitleInsteadOfAgentSurfaceTitle() {
+        let settings = Self.makeSettings()
+        let content = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(title: "cmux104: #7230 trusted manual host"),
+            settings: settings,
+            latestNotificationText: nil
+        )
+
+        #expect(content.title == "cmux104: #7230 trusted manual host")
+        #expect(content.title != "claude-ayw")
+        #expect(content.titleLineLimit == 1)
+    }
+
+    @Test
+    func sharedStatusRowsUseAuthoritativeValueWithoutRawAgentSlug() throws {
+        let settings = Self.makeSettings()
+        let needsInput = SidebarStatusEntry(
+            key: "claude_code",
+            value: "Needs input",
+            icon: "bell.fill",
+            color: "#FF9500"
+        )
+        let content = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(metadataEntries: [needsInput]),
+            settings: settings,
+            latestNotificationText: nil
+        )
+        let status = try #require(content.statusRows.first)
+
+        #expect(status.text == "Needs input")
+        #expect(status.icon == "bell.fill")
+        #expect(!status.text.contains("claude_code"))
+
+        let runningContent = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(metadataEntries: [
+                SidebarStatusEntry(
+                    key: "claude_code",
+                    value: "Running",
+                    icon: "bolt.fill",
+                    color: "#4C8DFF"
+                ),
+            ]),
+            settings: settings,
+            latestNotificationText: nil
+        )
+        #expect(runningContent.statusRows.first?.text == "Running")
+        #expect(runningContent.statusRows.first?.icon == "bolt.fill")
+    }
+
+    @Test
+    func emptyAgentStatusValueFallsBackToFriendlyAgentName() throws {
+        let settings = Self.makeSettings()
+        let content = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(metadataEntries: [
+                SidebarStatusEntry(key: "claude_code", value: "  "),
+            ]),
+            settings: settings,
+            latestNotificationText: nil
+        )
+        let status = try #require(content.statusRows.first)
+
+        #expect(status.text == "Claude Code")
+    }
+
+    @Test
+    func sharedSubtitleUsesNotificationVisibilityRules() {
+        let visibleSettings = Self.makeSettings()
+        let visible = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(latestConversationMessage: "older conversation"),
+            settings: visibleSettings,
+            latestNotificationText: "Claude is waiting for your input"
+        )
+        let hiddenSettings = Self.makeSettings(hidesAllDetails: true)
+        let hidden = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(latestConversationMessage: "older conversation"),
+            settings: hiddenSettings,
+            latestNotificationText: "Claude is waiting for your input"
+        )
+
+        #expect(visible.subtitle == "Claude is waiting for your input")
+        #expect(visible.subtitleLineLimit == visibleSettings.notificationMessageLineLimit)
+        #expect(hidden.subtitle == nil)
+    }
+
+    @Test
+    func sharedBranchDirectoryAndPullRequestRowsPreserveParityContent() throws {
+        let settings = Self.makeSettings()
+        let pullRequestURL = try #require(URL(string: "https://github.com/manaflow-ai/cmux/pull/7238"))
+        let content = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(
+                branchDirectoryLines: [
+                    .init(
+                        branch: "issue-7230-trusted-manual-host",
+                        directoryCandidates: ["~/manaflow/term/cmux104", "cmux104"]
+                    ),
+                ],
+                pullRequestRows: [
+                    .init(
+                        id: "pr#7238",
+                        number: 7238,
+                        label: "PR",
+                        url: pullRequestURL,
+                        status: .open,
+                        isStale: false
+                    ),
+                ]
+            ),
+            settings: settings,
+            latestNotificationText: nil
+        )
+        let branchRow = try #require(content.branchDirectoryRows.first)
+        let pullRequest = try #require(content.pullRequestRows.first)
+
+        #expect(branchRow.branch == "issue-7230-trusted-manual-host")
+        #expect(branchRow.directoryCandidates.first == "~/manaflow/term/cmux104")
+        #expect(content.showsBranchIcon)
+        #expect(pullRequest.title == "PR #7238")
+        #expect(pullRequest.statusLabel == "open")
+        #expect(pullRequest.url == pullRequestURL)
+        #expect(pullRequest.isClickable)
+    }
+
+    @Test
+    func sharedHoverCloseRuleMatchesShortcutAndContextMenuSuppression() {
+        let settings = Self.makeSettings()
+        let content = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(),
+            settings: settings,
+            latestNotificationText: nil
+        )
+
+        #expect(content.showsCloseButton(
+            isPointerHovering: true,
+            contextMenuVisible: false,
+            canCloseWorkspace: true,
+            showsModifierShortcutHints: false
+        ))
+        #expect(!content.showsCloseButton(
+            isPointerHovering: true,
+            contextMenuVisible: true,
+            canCloseWorkspace: true,
+            showsModifierShortcutHints: false
+        ))
+        #expect(!content.showsCloseButton(
+            isPointerHovering: true,
+            contextMenuVisible: false,
+            canCloseWorkspace: true,
+            showsModifierShortcutHints: true
+        ))
     }
 
     private static func makeActions(model: SidebarWorkspaceRowModel) -> SidebarAppKitRowActions {

--- a/cmuxTests/SidebarAppKitRowCellTests.swift
+++ b/cmuxTests/SidebarAppKitRowCellTests.swift
@@ -7,7 +7,10 @@ import Testing
 @Suite
 @MainActor
 struct SidebarAppKitRowCellTests {
-    private static func makeSettings(hidesAllDetails: Bool = false) -> SidebarTabItemSettingsSnapshot {
+    private static func makeSettings(
+        hidesAllDetails: Bool = false,
+        stacksBranchAndDirectory: Bool? = nil
+    ) -> SidebarTabItemSettingsSnapshot {
         let defaults = UserDefaults(suiteName: UUID().uuidString)!
         defaults.set(hidesAllDetails, forKey: "sidebarHideAllDetails")
         defaults.set(true, forKey: "sidebarShowNotificationMessage")
@@ -16,7 +19,9 @@ struct SidebarAppKitRowCellTests {
         defaults.set(true, forKey: "sidebarShowGitBranchIcon")
         defaults.set(true, forKey: "sidebarShowPullRequest")
         defaults.set(true, forKey: "sidebarBranchVerticalLayout")
-        defaults.set(false, forKey: "sidebarBranchDirectoryStacked")
+        if let stacksBranchAndDirectory {
+            defaults.set(stacksBranchAndDirectory, forKey: "sidebarBranchDirectoryStacked")
+        }
         return SidebarTabItemSettingsSnapshot(defaults: defaults)
     }
 
@@ -221,13 +226,36 @@ struct SidebarAppKitRowCellTests {
         let branchRow = try #require(content.branchDirectoryRows.first)
         let pullRequest = try #require(content.pullRequestRows.first)
 
+        #expect(settings.stacksBranchAndDirectory)
         #expect(branchRow.branch == "issue-7230-trusted-manual-host")
         #expect(branchRow.directoryCandidates.first == "~/manaflow/term/cmux104")
+        #expect(branchRow.stacksBranchAndDirectory)
         #expect(content.showsBranchIcon)
         #expect(pullRequest.title == "PR #7238")
         #expect(pullRequest.statusLabel == "open")
         #expect(pullRequest.url == pullRequestURL)
         #expect(pullRequest.isClickable)
+    }
+
+    @Test
+    func explicitInlineBranchDirectoryPreferenceIsPreserved() throws {
+        let settings = Self.makeSettings(stacksBranchAndDirectory: false)
+        let content = SidebarWorkspaceRowContentModel(
+            workspace: Self.makeSnapshot(
+                branchDirectoryLines: [
+                    .init(
+                        branch: "issue-7230-trusted-manual-host",
+                        directoryCandidates: ["~/manaflow/term/cmux104"]
+                    ),
+                ]
+            ),
+            settings: settings,
+            latestNotificationText: nil
+        )
+        let branchRow = try #require(content.branchDirectoryRows.first)
+
+        #expect(!settings.stacksBranchAndDirectory)
+        #expect(!branchRow.stacksBranchAndDirectory)
     }
 
     @Test

--- a/cmuxTests/SidebarWorkspaceContextMenuWindowTargetsTests.swift
+++ b/cmuxTests/SidebarWorkspaceContextMenuWindowTargetsTests.swift
@@ -60,12 +60,19 @@ struct SidebarWorkspaceContextMenuWindowTargetsTests {
         let suiteName = "SidebarWorkspaceContextMenuWindowTargetsTests.\(UUID().uuidString)"
         let defaults = try #require(UserDefaults(suiteName: suiteName))
         defer { defaults.removePersistentDomain(forName: suiteName) }
+        let workspace = SidebarWorkspaceSnapshotRefreshPolicyTests.snapshot()
+        let settings = SidebarTabItemSettingsSnapshot(defaults: defaults)
         return SidebarWorkspaceRowSnapshot(
             workspaceId: UUID(),
             groupId: nil,
             index: 0,
             workspaceCount: 1,
-            workspace: SidebarWorkspaceSnapshotRefreshPolicyTests.snapshot(),
+            workspace: workspace,
+            content: SidebarWorkspaceRowContentModel(
+                workspace: workspace,
+                settings: settings,
+                latestNotificationText: nil
+            ),
             isActive: true,
             isMultiSelected: false,
             hasUserCustomTitle: false,
@@ -85,7 +92,7 @@ struct SidebarWorkspaceContextMenuWindowTargetsTests {
             topDropIndicatorVisible: false,
             bottomDropIndicatorVisible: false,
             isBonsplitWorkspaceDropActive: false,
-            settings: SidebarTabItemSettingsSnapshot(defaults: defaults),
+            settings: settings,
             isChecklistExpanded: false,
             checklistAddFieldActivationToken: 0,
             isChecklistPopoverPresented: false,

--- a/cmuxTests/SidebarWorkspaceNotificationIndexTests.swift
+++ b/cmuxTests/SidebarWorkspaceNotificationIndexTests.swift
@@ -208,12 +208,18 @@ struct SidebarWorkspaceContextMenuTargetAggregateTests {
         remoteState: WorkspaceRemoteConnectionState,
         settings: SidebarTabItemSettingsSnapshot
     ) -> SidebarWorkspaceRowInput {
-        SidebarWorkspaceRowInput(
+        let workspace = SidebarWorkspaceSnapshotRefreshPolicyTests.snapshot()
+        return SidebarWorkspaceRowInput(
             workspaceId: workspaceId,
             groupId: groupId,
             index: 0,
             workspaceCount: 3,
-            workspace: SidebarWorkspaceSnapshotRefreshPolicyTests.snapshot(),
+            workspace: workspace,
+            content: SidebarWorkspaceRowContentModel(
+                workspace: workspace,
+                settings: settings,
+                latestNotificationText: nil
+            ),
             isActive: false,
             isMultiSelected: isMultiSelected,
             hasUserCustomTitle: false,


### PR DESCRIPTION
Closes #8409

Issue: https://github.com/manaflow-ai/cmux/issues/8409

## Summary
- derive one immutable workspace-row content model above both sidebar renderers
- render titles, human status text, lifecycle status rows, branch/cwd rows, PR rows, and hover-close rules from that shared model
- keep the AppKit row native, pooled, equality-gated, and free of per-row SwiftUI observation

## Verification
The first commit intentionally adds regression coverage before the shared types exist. Final tagged-build details and before/after screenshots will be added after the implementation commit is pushed.

## Coordination
Reviewed #8303 before implementation. This change builds on the flagged AppKit list already present on main and does not modify #8303 or its branch.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8413"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786954102&installation_id=133855650&pr_number=8413&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8413&signature=053b2f1dbb4b90543d0ce5cb6d932f6ea4329a1484ab5f2620292456195bdb3e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Share a single immutable workspace-row content model across SwiftUI and AppKit sidebars so titles, subtitles, status rows, branch/directory, PR rows, and close-button behavior match exactly. Switches branch + directory to stacked by default while preserving any existing inline preference, satisfying #8409; also prevents PR status labels from being truncated.

- **Refactors**
  - Introduced `SidebarWorkspaceRowContentModel` with `SidebarWorkspaceStatusRowContent`, `SidebarWorkspaceBranchDirectoryRowContent`, and `SidebarWorkspacePullRequestRowContent`.
  - SwiftUI and AppKit now read title/subtitle text and line limits from the model; empty agent status values fall back to friendly names.
  - Centralized branch icon visibility, stacked/inline branch–directory layout, and PR row title/status/tooltip/clickability.
  - Unified hover-close visibility rule in the model to match shortcut and context-menu suppression across both renderers.
  - Default `sidebar.stackBranchDirectory` is now true (stacked by default) and preserves an explicitly stored inline preference.

- **Bug Fixes**
  - Preserve full PR status label width in AppKit rows using `unconstrainedContentSize` in `SidebarRowTextView` and updated PR row layout.

<sup>Written for commit 8d65c927d67e9807bcb5795bb349c588d67a2b98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8413?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Refined sidebar workspace row rendering for titles, subtitles, metadata/status rows, branch+directory layout, and pull request rows for more consistent presentation.
  * Reworked close-button visibility to better match hover and context-menu/shortcut expectations.
* **Settings**
  * Enabled the default “stack branch directory” behavior in the sidebar.
* **Tests**
  * Expanded snapshot and interaction coverage for workspace titles, status indicators, metadata, branch and pull request details, subtitle handling, and close-button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->