### PR TITLE
Fix AppKit sidebar appearance-toggle flicker

### DIFF
--- a/Sources/ContentView.swift
+++ b/Sources/ContentView.swift
@@ -2471,11 +2471,29 @@ struct ContentView: View {
 
     private func contentAndSidebarLayout(appearance: WindowAppearanceSnapshot) -> AnyView {
         let layout: AnyView
-        // When matching terminal background, use HStack so both sidebar and terminal
-        // sit directly on the window background with no intermediate layers.
+        // The legacy SwiftUI path uses HStack while matching so both sidebar
+        // and terminal sit directly on the window background.
         let useWithinWindow = sidebarBlendMode == SidebarBlendModeOption.withinWindow.rawValue
             && !sidebarMatchTerminalBackground
-        if useWithinWindow {
+        if CmuxFeatureFlags.shared.isAppKitSidebarListEnabled {
+            // Appearance changes must not replace the NSViewRepresentable. Keep
+            // one structural parent for both backdrop policies and express the
+            // sidebar column as padding on the stable terminal/right-sidebar
+            // subtree. This lets SwiftUI commit the backdrop and any row palette
+            // updates together without remounting the native table at zero width.
+            layout = AnyView(
+                ZStack(alignment: .leading) {
+                    terminalContentWithRightSidebarPanel(appearance: appearance)
+                        .modifier(SidebarWidthLeadingPaddingModifier(
+                            layout: sidebarLayout,
+                            enabled: sidebarState.isVisible
+                        ))
+                    if sidebarState.isVisible {
+                        sidebarPanelWithBackdrop(appearance: appearance)
+                    }
+                }
+            )
+        } else if useWithinWindow {
             // Overlay mode keeps the left sidebar on top, but the right
             // sidebar stays in an HStack so terminal rows are clipped before
             // the sidebar backdrop samples the window.
@@ -10667,8 +10685,6 @@ struct VerticalTabsSidebar: View, Equatable {
         return CustomSidebarDataContextBuilder().dataContext(for: snapshot)
     }
 
-    @AppStorage("sidebarMatchTerminalBackground")
-    private var sidebarMatchTerminalBackground = false
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsLeadingInsetKey)
     private var titlebarLeftControlsLeadingInset = MinimalModeTitlebarDebugSettings.defaultLeftControlsLeadingInset
     @AppStorage(MinimalModeTitlebarDebugSettings.leftControlsTopInsetKey)

--- a/Sources/Debug/SidebarLazyContractProbe.swift
+++ b/Sources/Debug/SidebarLazyContractProbe.swift
@@ -12,6 +12,7 @@ struct SidebarLazyContractProbe {
     var workspaceRowBodyEnd: (() -> Void)?
     var groupHeaderRowBody: (() -> Void)?
     var workspaceSnapshotBuild: (() -> Void)?
+    var tableContainerMake: (() -> Void)?
     var tableRootViewReconfigure: (() -> Void)?
     var workspaceRowInputProjection: (() -> Void)?
 }

--- a/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
+++ b/Sources/Sidebar/AppKitList/SidebarWorkspaceTableView.swift
@@ -17,7 +17,10 @@ struct SidebarWorkspaceTableView: NSViewRepresentable {
     }
 
     func makeNSView(context: Context) -> SidebarWorkspaceTableContainerView {
-        context.coordinator.makeContainerView()
+#if DEBUG
+        sidebarLazyContractProbe.tableContainerMake?()
+#endif
+        return context.coordinator.makeContainerView()
     }
 
     func updateNSView(_ nsView: SidebarWorkspaceTableContainerView, context: Context) {

--- a/cmuxTests/WorkspaceContentViewVisibilityTests.swift
+++ b/cmuxTests/WorkspaceContentViewVisibilityTests.swift
@@ -25,6 +25,10 @@ final class WorkspaceContentViewVisibilityTests {
         }
     }
 
+    private final class AppKitSidebarMountProbeCounts {
+        var tableContainerMakes = 0
+    }
+
     @Test
     @MainActor
     func testMinimalModeToggleDoesNotReevaluateChromeHeavyBodies() async throws {
@@ -100,6 +104,75 @@ final class WorkspaceContentViewVisibilityTests {
         #expect(
             counts.verticalTabsSidebarBody == 0,
             "Minimal-mode toggles must not rebuild the vertical sidebar render context."
+        )
+    }
+
+    @Test
+    @MainActor
+    func testMatchTerminalBackgroundKeepsAppKitTableContainerMounted() async throws {
+        _ = NSApplication.shared
+
+        let suiteName = "WorkspaceContentViewVisibilityTests.AppKitSidebar.\(UUID().uuidString)"
+        let defaults = try #require(UserDefaults(suiteName: suiteName))
+        defaults.removePersistentDomain(forName: suiteName)
+        defer { defaults.removePersistentDomain(forName: suiteName) }
+        defaults.set(
+            CmuxExtensionSidebarSelection.defaultProviderId,
+            forKey: CmuxExtensionSidebarSelection.defaultsKey
+        )
+        defaults.set(SidebarBlendModeOption.withinWindow.rawValue, forKey: "sidebarBlendMode")
+        defaults.set(false, forKey: "sidebarMatchTerminalBackground")
+
+        let appKitSidebarFlag = CmuxFeatureFlags.allFlags[6]
+        let previousOverride = CmuxFeatureFlags.shared.overrideValue(for: appKitSidebarFlag)
+        CmuxFeatureFlags.shared.setOverride(true, for: appKitSidebarFlag)
+        defer { CmuxFeatureFlags.shared.setOverride(previousOverride, for: appKitSidebarFlag) }
+
+        let tabManager = TabManager()
+        for _ in 0..<3 {
+            tabManager.addWorkspace(autoWelcomeIfNeeded: false)
+        }
+        let notificationStore = TerminalNotificationStore.shared
+        let counts = AppKitSidebarMountProbeCounts()
+        let root = ContentView(updateViewModel: UpdateStateModel(), windowId: UUID())
+            .environmentObject(tabManager)
+            .environmentObject(notificationStore)
+            .environmentObject(notificationStore.sidebarUnread)
+            .environmentObject(SidebarState())
+            .environmentObject(SidebarSelectionState())
+            .environmentObject(FileExplorerState())
+            .environmentObject(CmuxConfigStore())
+            .environment(
+                \.sidebarLazyContractProbe,
+                SidebarLazyContractProbe(
+                    tableContainerMake: { counts.tableContainerMakes += 1 }
+                )
+            )
+            .defaultAppStorage(defaults)
+
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 900, height: 640),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = MainWindowHostingView(rootView: root)
+        defer {
+            window.contentView = nil
+            window.close()
+        }
+
+        await Self.drainMainRunLoop(for: window)
+        #expect(counts.tableContainerMakes == 1)
+
+        defaults.set(true, forKey: "sidebarMatchTerminalBackground")
+        await Self.drainMainRunLoop(for: window)
+        defaults.set(false, forKey: "sidebarMatchTerminalBackground")
+        await Self.drainMainRunLoop(for: window)
+
+        #expect(
+            counts.tableContainerMakes == 1,
+            "Appearance-only sidebar transitions must preserve the existing AppKit table container."
         )
     }
 


### PR DESCRIPTION
Closes #8412

Issue: https://github.com/manaflow-ai/cmux/issues/8412

## Problem
Toggling Match Terminal Background changes the outer sidebar layout structure. That remounts the AppKit table, briefly presents estimated title-only row heights, and then remeasures the secondary content. The result is a flickered frame with clipped/ghosted branch and PR text.

## Status
The current head is the required red regression-test commit only. It mounts the real ContentView with the AppKit sidebar enabled and asserts that appearance-only transitions preserve the table container. The implementation commit will follow after CI records the failure.

## Coordination
PR #8303 also touches the AppKit controller and mutation scheduling. Issue #8409 currently adds row-content parity coverage on its sibling branch. This PR stays on the outer appearance/layout identity path and does not restructure row models.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/manaflow-ai/codesmith/cmux/pr/8414"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786954934&installation_id=133855650&pr_number=8414&repository=manaflow-ai%2Fcmux&return_to=https%3A%2F%2Fgithub.com%2Fmanaflow-ai%2Fcmux%2Fpull%2F8414&signature=bf2580654c76aa63904383ae3bed25fb0477e6f8de3c12f46f33a5f5406dc56c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes AppKit sidebar flicker when toggling “Match Terminal Background” (issue #8412) by preserving the table container across appearance-only changes. Adds a regression test with a DEBUG probe to ensure the container is created once.

- **Bug Fixes**
  - Keep the AppKit sidebar `NSViewRepresentable` mounted using a stable `ZStack` parent with leading padding, preventing remounts during appearance changes.
  - Add `tableContainerMake` probe and a test that toggles `sidebarMatchTerminalBackground` to assert the container is not recreated.

<sup>Written for commit 23c3e74e3e2a07436b73c5e35ecd72443d9dec6b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/manaflow-ai/cmux/pull/8414?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

